### PR TITLE
workspace: upgrade to Bazel 3.5.0, rules_rust latest (1/n)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
   # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
   # bazel-0.20.0-linux-x86_64.sha256
   global:
-    - BAZEL=2.1.0
-    - BAZEL_SHA256SUM=e13581d44faad6ac807dd917e682fef20359d26728166ac35dadd8ee653a580d
+    - BAZEL=3.5.0
+    - BAZEL_SHA256SUM=7ecb6f51c02dad0c343aa8dca804cf07b42b56e5ce4521092d83fe1dbd6a6581
   matrix:
     - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,13 +93,14 @@ script:
   - elapsed "script"
   # Note: bazel test implies fetch+build, but this gives us timing.
   - elapsed && bazel fetch //tensorboard/...
-  - elapsed && bazel build //tensorboard/...
-  - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
-  - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
-  # Run manual S3 test
-  - elapsed && bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
-  - elapsed && bazel test //tensorboard/summary/writer:event_file_writer_s3_test
-  - elapsed "script (done)"
+  # TODO: Re-enable full tests as CI populates cache.
+  # - elapsed && bazel build //tensorboard/...
+  # - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
+  # - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
+  # # Run manual S3 test
+  # - elapsed && bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
+  # - elapsed && bazel test //tensorboard/summary/writer:event_file_writer_s3_test
+  # - elapsed "script (done)"
 
 after_script:
   # Bazel launches daemons unless --batch is used.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,7 +89,7 @@ tf_workspace()
 load("@bazel_skylib//lib:versions.bzl", "versions")
 # Keep this version in sync with the BAZEL environment variable defined
 # in our .travis.yml config.
-versions.check(minimum_bazel_version = "2.1.0")
+versions.check(minimum_bazel_version = "3.5.0")
 
 load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
 
@@ -109,12 +109,12 @@ bazel_version_repository(name = "bazel_version")
 
 http_archive(
     name = "io_bazel_rules_rust",
-    sha256 = "9beda941ab076d15428d8615475329bd65002a13a26c2837932af0fb3dc582c5",
-    strip_prefix = "rules_rust-9426a3820093e75ea07d14f875e42f789632507f",
+    sha256 = "17dbf791f4dab0fd4496ce5345af35e9ce2f6d011c1c8423436da517d019a3ea",
+    strip_prefix = "rules_rust-2f97db595b05b1ee8cc44bde5bdf03c00bd169fb",
     urls = [
-        # Master branch as of 2020-10-23
-        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_rust/archive/9426a3820093e75ea07d14f875e42f789632507f.tar.gz",
-        "https://github.com/bazelbuild/rules_rust/archive/9426a3820093e75ea07d14f875e42f789632507f.tar.gz",
+        # Master branch as of 2020-11-05
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_rust/archive/2f97db595b05b1ee8cc44bde5bdf03c00bd169fb.tar.gz",
+        "https://github.com/bazelbuild/rules_rust/archive/2f97db595b05b1ee8cc44bde5bdf03c00bd169fb.tar.gz",
     ],
 )
 

--- a/ci/bazelrc
+++ b/ci/bazelrc
@@ -1,5 +1,6 @@
 # Limit resources since Travis Trusty GCE VMs have 2 cores and 7.5 GB RAM.
-build --local_resources=4000,2,1.0
+build --local_cpu_resources=2
+build --local_ram_resources=4000
 build --worker_max_instances=2
 
 # Ensure sandboxing is on to increase hermeticity.


### PR DESCRIPTION
Summary:
Bazel rule repositories (Go, Rust, protobuf, …) are migrating to a new
linker API introduced as a breaking Bazel change:
<https://github.com/bazelbuild/bazel/issues/10860>

This API requires Bazel 3.0.0, which is fine for us. We also need to
upgrade to 3.5.0 for incoming Node changes, so we do that now, too.

Because we can’t manage to build our whole test suite at once on CI
resources, this patch also disables all the builds. We’ll re-enable them
incrementally. See #4092, et al. for prior art.

Test Plan:
Locally, everything builds, all tests pass, and TensorBoard looks okay
enough.

wchargin-branch: bazel-3.5.0
