### PR TITLE
rust: add documentation server

### DIFF
--- a/tensorboard/data/server/BUILD
+++ b/tensorboard/data/server/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary", "rust_doc_test", "rust_library", "rust_test")
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary", "rust_doc", "rust_doc_test", "rust_library", "rust_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -24,6 +24,22 @@ rust_test(
 rust_doc_test(
     name = "rustboard_core_doc_test",
     dep = ":rustboard_core",
+)
+
+rust_doc(
+    name = "rustboard_core_doc",
+    dep = ":rustboard_core",
+)
+
+py_binary(
+    name = "rustboard_core_doc_server",
+    srcs = ["rustboard_core_doc_server.py"],
+    data = [":rustboard_core_doc.zip"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        "@org_pocoo_werkzeug",
+    ],
 )
 
 rust_binary(

--- a/tensorboard/data/server/rustboard_core_doc_server.py
+++ b/tensorboard/data/server/rustboard_core_doc_server.py
@@ -1,0 +1,57 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Documentation server for TensorBoard Rust code."""
+
+import mimetypes
+import os
+import zipfile
+
+from werkzeug import exceptions
+from werkzeug import serving
+from werkzeug import utils
+from werkzeug import wrappers
+
+
+def main():
+    webfiles = os.path.join(os.path.dirname(__file__), "rustboard_core_doc.zip")
+    data = {}
+
+    pfx = (
+        "bazel-out/k8-fastbuild/bin/tensorboard/data/server/rustboard_core_doc/"
+    )
+    with open(webfiles, "rb") as fp:
+        with zipfile.ZipFile(fp) as zp:
+            for path in zp.namelist():
+                if not path.startswith(pfx):
+                    continue
+                data[path[len(pfx) :]] = zp.read(path)
+
+    @wrappers.Request.application
+    def app(request):
+        p = request.path.lstrip("/")
+        if not p:
+            return utils.redirect("/rustboard_core/index.html")
+        if p.endswith("/"):
+            p += "index.html"
+        blob = data.get(p)
+        if not blob:
+            raise exceptions.NotFound()
+        return wrappers.Response(blob, content_type=mimetypes.guess_type(p)[0])
+
+    serving.run_simple("0.0.0.0", 6005, app)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
The Rust Bazel rules provide a `rust_doc` rule for documentation, but it
generates a zipfile with long file paths, which is inconvenient to
consume. This patch adds a simple Werkzeug server to serve from the
generated documentation. It’s compatible with `ibazel run`: just change
a Rust source file and refresh your browser tab to see your changes.

I have a [pending upstream patch for this][upstream], but I’m still
working on it, and it’s on my back burner. In the meantime, this is
helpful for both Rust authors and Rust reviewers on TensorBoard.

[upstream]: https://github.com/bazelbuild/rules_rust/pull/475

Test Plan:
Run `bazel run //tensorboard/data/server:rustboard_core_doc_server` and
navigate to port 6005:

![Screenshot of the docs for `rustboard_core::masked_crc::MaskedCrc` in
a standard rustdoc output format][ss]

[ss]: https://user-images.githubusercontent.com/4317806/98600750-e788bd80-2292-11eb-9f09-fd51ed5e5996.png

wchargin-branch: rust-doc-server
