### PR TITLE
chore: redirection for ng_module

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """External-only delegates for various BUILD rules."""
 
+load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("@npm_bazel_rollup//:index.bzl", "rollup_bundle")
 load("@npm_bazel_karma//:index.bzl", "karma_web_test_suite")
 load("@npm_bazel_typescript//:index.bzl", "ts_config", "ts_devserver", "ts_library")
@@ -139,3 +140,7 @@ def tf_sass_library(**kwargs):
     sass_library(
         **kwargs
     )
+
+def tf_ng_module(**kwargs):
+    """TensorBoard wrapper for Angular modules."""
+    ng_module(**kwargs)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ng_web_test_suite", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_web_test_suite", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -8,7 +7,7 @@ licenses(["notice"])
 # TODO(cais): Consider replacing old debuger plugin with this before launch,
 # instead of having two versions of debugger co-exist, which may be confusing to
 # users.
-ng_module(
+tf_ng_module(
     name = "debugger_v2",
     srcs = [
         "debugger_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "data_source",
     srcs = [
         "tfdbg2_data_source.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/BUILD
@@ -1,9 +1,8 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = [
         "debugger_effects.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "debug_tensor_value",
     srcs = [
         "debug_tensor_value_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/BUILD
@@ -1,4 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -19,7 +19,7 @@ genrule(
     exec_tools = [":inline_images"],
 )
 
-ng_module(
+tf_ng_module(
     name = "inactive",
     srcs = [
         "inactive_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "timeline",
     srcs = [
         "timeline_component.ts",

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_web_test_suite", "tf_sass_binary", "tf_sass_library", "tf_svg_bundle")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_sass_library", "tf_svg_bundle")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
@@ -7,7 +6,7 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "oss_plugins_module",
     srcs = [
         "oss_plugins_module.ts",
@@ -21,7 +20,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "reducer_config",
     srcs = [
         "reducer_config.ts",
@@ -32,7 +31,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "selectors",
     srcs = [
         "selectors.ts",
@@ -47,7 +46,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "mat_icon",
     srcs = [
         "mat_icon_module.ts",
@@ -61,7 +60,7 @@ ng_module(
 
 # Angular module for the top-level app component together with all of its
 # injectable dependencies.  I.e., the entire Angular app.
-ng_module(
+tf_ng_module(
     name = "app",
     srcs = [
         "app_container.ts",
@@ -103,7 +102,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "app_state",
     srcs = [
         "app_state.ts",
@@ -123,7 +122,7 @@ ng_module(
 # TODO(stephanwlee): at the moment, there is no development build. Reinstate it.
 # Wrapper that prepares Angular app for deployment, dealing with browser
 # compatibility, Vulcanization, and configuration (e.g. prod vs. dev).
-ng_module(
+tf_ng_module(
     name = "ng_main",
     srcs = [
         "bootstrap.ts",

--- a/tensorboard/webapp/alert/BUILD
+++ b/tensorboard/webapp/alert/BUILD
@@ -1,9 +1,8 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "alert",
     srcs = [
         "alert_module.ts",
@@ -20,7 +19,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "alert_action",
     srcs = [
         "alert_action_module.ts",

--- a/tensorboard/webapp/alert/effects/BUILD
+++ b/tensorboard/webapp/alert/effects/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = [
         "index.ts",

--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -8,7 +7,7 @@ tf_sass_binary(
     src = "alert_display_snackbar_container.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "alert_snackbar",
     srcs = [
         "alert_display_snackbar_container.ts",

--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -1,11 +1,10 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "app_routing",
     srcs = [
         "app_routing_module.ts",
@@ -23,7 +22,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "location",
     srcs = [
         "location.ts",
@@ -37,7 +36,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "route_registry",
     srcs = [
         "route_registry_module.ts",
@@ -57,7 +56,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "programmatical_navigation_module",
     srcs = [
         "programmatical_navigation_module.ts",
@@ -70,7 +69,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "deep_link_provider",
     srcs = [
         "deep_link_provider.ts",
@@ -84,7 +83,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "route_config",
     srcs = [
         "route_config.ts",
@@ -97,7 +96,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "route_config_test",
     testonly = True,
     srcs = [
@@ -134,7 +133,7 @@ tf_ts_library(
     deps = [":types"],
 )
 
-ng_module(
+tf_ng_module(
     name = "testing",
     testonly = True,
     srcs = [
@@ -149,7 +148,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "app_routing_test",
     testonly = True,
     srcs = [

--- a/tensorboard/webapp/app_routing/effects/BUILD
+++ b/tensorboard/webapp/app_routing/effects/BUILD
@@ -1,10 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = [
         "app_routing_effects.ts",
@@ -27,7 +27,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "effects_tests",
     testonly = True,
     srcs = ["app_routing_effects_test.ts"],

--- a/tensorboard/webapp/app_routing/views/BUILD
+++ b/tensorboard/webapp/app_routing/views/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "views",
     srcs = [
         "app_routing_view_module.ts",

--- a/tensorboard/webapp/core/BUILD
+++ b/tensorboard/webapp/core/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "core",
     srcs = [
         "core_module.ts",
@@ -19,7 +19,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "types",
     srcs = [
         "types.ts",

--- a/tensorboard/webapp/core/effects/BUILD
+++ b/tensorboard/webapp/core/effects/BUILD
@@ -1,9 +1,8 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = [
         "core_effects.ts",

--- a/tensorboard/webapp/core/store/BUILD
+++ b/tensorboard/webapp/core/store/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "store",
     srcs = [
         "core_initial_state_provider.ts",

--- a/tensorboard/webapp/core/views/BUILD
+++ b/tensorboard/webapp/core/views/BUILD
@@ -1,5 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/webapp/core/views/BUILD
+++ b/tensorboard/webapp/core/views/BUILD
@@ -1,9 +1,9 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "hash_storage",
     srcs = [
         "hash_storage_component.ts",
@@ -20,7 +20,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "page_title",
     srcs = [
         "page_title_component.ts",

--- a/tensorboard/webapp/deeplink/BUILD
+++ b/tensorboard/webapp/deeplink/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "deeplink",
     srcs = [
         "deeplink_module.ts",
@@ -15,7 +15,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "deeplink_test_lib",
     testonly = True,
     srcs = [

--- a/tensorboard/webapp/experiments/BUILD
+++ b/tensorboard/webapp/experiments/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "experiments",
     srcs = [
         "experiments_module.ts",

--- a/tensorboard/webapp/feature_flag/BUILD
+++ b/tensorboard/webapp/feature_flag/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "feature_flag",
     srcs = [
         "feature_flag_module.ts",
@@ -18,7 +18,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "types",
     srcs = [
         "types.ts",

--- a/tensorboard/webapp/feature_flag/actions/BUILD
+++ b/tensorboard/webapp/feature_flag/actions/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "actions",
     srcs = [
         "feature_flag_actions.ts",

--- a/tensorboard/webapp/feature_flag/effects/BUILD
+++ b/tensorboard/webapp/feature_flag/effects/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = [
         "feature_flag_effects.ts",
@@ -17,7 +17,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "effects_test_lib",
     testonly = True,
     srcs = [

--- a/tensorboard/webapp/feature_flag/store/BUILD
+++ b/tensorboard/webapp/feature_flag/store/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "store",
     srcs = [
         "feature_flag_reducers.ts",
@@ -18,7 +18,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "types",
     srcs = [
         "feature_flag_types.ts",
@@ -28,7 +28,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "store_test_lib",
     testonly = True,
     srcs = [

--- a/tensorboard/webapp/header/BUILD
+++ b/tensorboard/webapp/header/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "plugin_selector_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "header",
     srcs = [
         "header_component.ts",

--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "metrics",
     srcs = [
         "metrics_module.ts",

--- a/tensorboard/webapp/metrics/data_source/BUILD
+++ b/tensorboard/webapp/metrics/data_source/BUILD
@@ -1,11 +1,10 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "data_source",
     srcs = [
         "index.ts",

--- a/tensorboard/webapp/metrics/effects/BUILD
+++ b/tensorboard/webapp/metrics/effects/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = ["index.ts"],
     deps = [

--- a/tensorboard/webapp/metrics/views/BUILD
+++ b/tensorboard/webapp/metrics/views/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_sass_library", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_sass_library", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -15,7 +14,7 @@ tf_sass_binary(
     src = "metrics_container.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "views",
     srcs = [
         "metrics_container.ts",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -1,5 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -8,7 +7,7 @@ tf_sass_binary(
     src = "card_view_container.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "card_renderer",
     srcs = [
         "card_lazy_loader.ts",
@@ -45,7 +44,7 @@ tf_sass_binary(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "histogram_card",
     srcs = [
         "histogram_card_component.ts",
@@ -88,7 +87,7 @@ tf_sass_binary(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "image_card",
     srcs = [
         "image_card_component.ts",
@@ -121,7 +120,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "run_name",
     srcs = [
         "run_name_component.ts",
@@ -156,7 +155,7 @@ tf_sass_binary(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "scalar_card",
     srcs = [
         "scalar_card_component.ts",

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -48,7 +47,7 @@ tf_sass_binary(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "main_view",
     srcs = [
         "card_grid_component.ts",

--- a/tensorboard/webapp/metrics/views/right_pane/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -8,7 +7,7 @@ tf_sass_binary(
     src = "settings_view_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "right_pane",
     srcs = [
         "right_pane_component.ts",

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "plugins",
     srcs = [
         "plugins_component.ts",
@@ -28,7 +27,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "plugin_registry",
     srcs = [
         "plugin_registry_module.ts",

--- a/tensorboard/webapp/plugins/npmi/BUILD
+++ b/tensorboard/webapp/plugins/npmi/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "npmi_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "npmi",
     srcs = [
         "npmi_component.ts",

--- a/tensorboard/webapp/plugins/npmi/data_source/BUILD
+++ b/tensorboard/webapp/plugins/npmi/data_source/BUILD
@@ -1,9 +1,8 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "data_source",
     srcs = [
         "npmi_data_source.ts",

--- a/tensorboard/webapp/plugins/npmi/effects/BUILD
+++ b/tensorboard/webapp/plugins/npmi/effects/BUILD
@@ -1,9 +1,8 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = [
         "index.ts",

--- a/tensorboard/webapp/plugins/npmi/store/BUILD
+++ b/tensorboard/webapp/plugins/npmi/store/BUILD
@@ -1,9 +1,8 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "store",
     srcs = [
         "index.ts",
@@ -19,7 +18,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "types",
     srcs = [
         "npmi_types.ts",

--- a/tensorboard/webapp/plugins/npmi/util/BUILD
+++ b/tensorboard/webapp/plugins/npmi/util/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "metric_type",
     srcs = [
         "metric_type.ts",
@@ -27,7 +26,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "filter_annotations",
     srcs = [
         "filter_annotations.ts",
@@ -57,7 +56,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "violin_data",
     srcs = [
         "violin_data.ts",
@@ -88,7 +87,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "sort_annotations",
     srcs = [
         "sort_annotations.ts",
@@ -119,7 +118,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "coordinate_data",
     srcs = [
         "coordinate_data.ts",
@@ -148,7 +147,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "csv_result",
     srcs = [
         "csv_result.ts",

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "annotations_list_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "annotations_list",
     srcs = [
         "annotations_list_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "annotation_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "annotation",
     srcs = [
         "annotation_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "annotations_list_toolbar_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "annotations_list_toolbar",
     srcs = [
         "annotations_list_toolbar_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "annotations_search_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "annotations_search",
     srcs = [
         "annotations_search_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "header_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "header",
     srcs = [
         "header_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/legend/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/legend/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "legend_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "legend",
     srcs = [
         "legend_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/legend/legend_element/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/legend/legend_element/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "legend_element_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "legend_element",
     srcs = [
         "legend_element_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "data_selection_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "data_selection",
     srcs = [
         "data_selection_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "metric_arithmetic_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "metric_arithmetic",
     srcs = [
         "metric_arithmetic_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "metric_arithmetic_element_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "metric_arithmetic_element",
     srcs = [
         "metric_arithmetic_element_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "metric_arithmetic_operator",
     srcs = [
         "metric_arithmetic_operator_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "metric_search_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "metric_search",
     srcs = [
         "metric_search_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "results_download_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "results_download",
     srcs = [
         "results_download_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/inactive/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/inactive/BUILD
@@ -1,10 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "inactive",
     srcs = [
         "inactive_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/main/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/main/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "main_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "main",
     srcs = [
         "main_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "selected_annotations_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "selected_annotations",
     srcs = [
         "selected_annotations_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "parallel_coordinates_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "parallel_coordinates",
     srcs = [
         "parallel_coordinates_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "violin_filters_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "violin_filters",
     srcs = [
         "violin_filters_component.ts",

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "violin_filter_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "violin_filter",
     srcs = [
         "violin_filter_component.ts",

--- a/tensorboard/webapp/plugins/testing/BUILD
+++ b/tensorboard/webapp/plugins/testing/BUILD
@@ -1,10 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "testing",
     testonly = True,
     srcs = [

--- a/tensorboard/webapp/plugins/text_v2/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "text_v2",
     srcs = [
         "text_v2_module.ts",

--- a/tensorboard/webapp/plugins/text_v2/data_source/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/data_source/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "data_source",
     srcs = [
         "index.ts",

--- a/tensorboard/webapp/plugins/text_v2/effects/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/effects/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = [
         "index.ts",

--- a/tensorboard/webapp/plugins/text_v2/store/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/store/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "store",
     srcs = [
         "index.ts",
@@ -18,7 +17,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "types",
     srcs = [
         "text_types.ts",

--- a/tensorboard/webapp/plugins/text_v2/views/text_dashboard/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/views/text_dashboard/BUILD
@@ -1,10 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "text_dashboard",
     srcs = [
         "text_dashboard_component.ts",

--- a/tensorboard/webapp/reloader/BUILD
+++ b/tensorboard/webapp/reloader/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "reloader",
     srcs = [
         "reloader_component.ts",

--- a/tensorboard/webapp/runs/BUILD
+++ b/tensorboard/webapp/runs/BUILD
@@ -1,11 +1,10 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "runs",
     srcs = [
         "runs_module.ts",

--- a/tensorboard/webapp/runs/data_source/BUILD
+++ b/tensorboard/webapp/runs/data_source/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "data_source",
     srcs = [
         "runs_data_source.ts",
@@ -28,7 +27,7 @@ tf_ts_library(
     visibility = ["//visibility:private"],
 )
 
-ng_module(
+tf_ng_module(
     name = "testing",
     testonly = True,
     srcs = [

--- a/tensorboard/webapp/runs/effects/BUILD
+++ b/tensorboard/webapp/runs/effects/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "effects",
     srcs = [
         "index.ts",

--- a/tensorboard/webapp/runs/views/runs_selector/BUILD
+++ b/tensorboard/webapp/runs/views/runs_selector/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "runs_selector",
     srcs = [
         "runs_selector_component.ts",

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "runs_table_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "runs_table",
     srcs = [
         "runs_table_component.ts",

--- a/tensorboard/webapp/runs_legacy/BUILD
+++ b/tensorboard/webapp/runs_legacy/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "runs_legacy",
     srcs = [
         "runs_module.ts",

--- a/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/BUILD
+++ b/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "legacy_runs_selector",
     srcs = [
         "legacy_runs_selector_component.ts",

--- a/tensorboard/webapp/settings/BUILD
+++ b/tensorboard/webapp/settings/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "settings",
     srcs = [
         "dialog_component.ts",

--- a/tensorboard/webapp/tb_wrapper/BUILD
+++ b/tensorboard/webapp/tb_wrapper/BUILD
@@ -1,10 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "tb_wrapper",
     srcs = [
         "tb_wrapper_component.ts",

--- a/tensorboard/webapp/tbdev_upload/BUILD
+++ b/tensorboard/webapp/tbdev_upload/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "tbdev_upload",
     srcs = [
         "tbdev_upload_button_component.ts",

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(
     default_testonly = True,
@@ -28,7 +27,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "mat_icon",
     srcs = [
         "mat_icon_module.ts",
@@ -38,7 +37,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "dom",
     srcs = [
         "dom.ts",
@@ -56,7 +55,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "material",
     srcs = [
         "material.ts",

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -1,8 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "webapp_data_source",
     srcs = [
         "tb_server_data_source.ts",
@@ -18,7 +18,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "webapp_data_source_test_lib",
     testonly = True,
     srcs = [
@@ -33,7 +33,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "http_client",
     srcs = [
         "tb_http_client.ts",
@@ -53,7 +53,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "http_client_test",
     testonly = True,
     srcs = [
@@ -73,7 +73,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "feature_flag",
     srcs = [
         "tb_feature_flag_data_source.ts",
@@ -88,7 +88,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "feature_flag_testing",
     testonly = True,
     srcs = [
@@ -100,7 +100,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "feature_flag_test_lib",
     testonly = True,
     srcs = [
@@ -114,7 +114,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "http_client_testing",
     testonly = True,
     srcs = [

--- a/tensorboard/webapp/widgets/BUILD
+++ b/tensorboard/webapp/widgets/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "resize_detector",
     srcs = [
         "resize_detector_directive.ts",
@@ -33,7 +32,7 @@ tf_ts_library(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "resize_detector_testing",
     testonly = True,
     srcs = [

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "dropdown_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "dropdown",
     srcs = [
         "dropdown_component.ts",

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "histogram",
     srcs = [
         "histogram_component.ts",

--- a/tensorboard/webapp/widgets/line_chart/BUILD
+++ b/tensorboard/webapp/widgets/line_chart/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "line_chart",
     srcs = [
         "line_chart_component.ts",

--- a/tensorboard/webapp/widgets/range_input/BUILD
+++ b/tensorboard/webapp/widgets/range_input/BUILD
@@ -1,5 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -8,7 +7,7 @@ tf_sass_binary(
     src = "range_input_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "range_input",
     srcs = [
         "range_input_component.ts",

--- a/tensorboard/webapp/widgets/text/BUILD
+++ b/tensorboard/webapp/widgets/text/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "truncated_path_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "truncated_path",
     srcs = [
         "truncated_path_component.ts",
@@ -25,7 +24,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "text_tests",
     testonly = True,
     srcs = ["truncated_path_test.ts"],


### PR DESCRIPTION
In the newer version of rules_nodejs, they deprecated ng_module. There
still is a way to use rules_nodejs and this is the abstraction that
makes it work in a way that is compatible with an internal rule.


