### PR TITLE
Update protos for TF v2.4.0-rc1

### DIFF
--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -568,6 +568,9 @@ message ConfigProto {
     // Session::Extend() may not be supported.
     bool optimize_for_static_graph = 12;
 
+    // This field will eventually be deprecated and replaced by
+    // mlir_bridge_rollout (b/166038521).
+    //
     // Whether to enable the MLIR-based TF->XLA bridge.
     //
     // This is a replacement to the existing bridge, and not ready for
@@ -580,6 +583,22 @@ message ConfigProto {
     // to an "execute" operation. The kernel for these operations is responsible
     // to lower the encapsulated graph to a particular device.
     bool enable_mlir_bridge = 13;
+
+    // An enum that describes the state of the MLIR bridge rollout.
+    enum MlirBridgeRollout {
+      // If this field is left unspecified, the MLIR bridge may be selectively
+      // enabled on a per graph basis.
+      MLIR_BRIDGE_ROLLOUT_UNSPECIFIED = 0;
+      // Enabling the MLIR bridge enables it for all graphs in this session.
+      MLIR_BRIDGE_ROLLOUT_ENABLED = 1;
+      // Disabling the MLIR bridge disables it for all graphs in this session.
+      MLIR_BRIDGE_ROLLOUT_DISABLED = 2;
+    }
+    // This field is underdevelopment, for now use enable_mlir_bridge
+    // (b/166038521).
+    //
+    // Whether to enable the MLIR-based TF->XLA bridge.
+    MlirBridgeRollout mlir_bridge_rollout = 17;
 
     // Whether to enable the MLIR-based Graph optimizations.
     //

--- a/tensorboard/compat/proto/cpp_shape_inference.proto
+++ b/tensorboard/compat/proto/cpp_shape_inference.proto
@@ -11,6 +11,10 @@ message CppShapeInferenceResult {
   message HandleShapeAndType {
     TensorShapeProto shape = 1;
     DataType dtype = 2;
+    // For dtype==DT_VARIANT, specialized_type may indicate a more specific
+    // type. For other dtypes or when the information is unavailable it is set
+    // to ST_INVALID.
+    SpecializedType specialized_type = 3;
   }
   message HandleData {
     bool is_set = 1;

--- a/tensorboard/compat/proto/saved_object_graph.proto
+++ b/tensorboard/compat/proto/saved_object_graph.proto
@@ -76,6 +76,9 @@ message SavedUserObject {
   string identifier = 1;
   // Version information from the producer of this SavedUserObject.
   VersionDef version = 2;
+  // Deprecated! At the time of deprecation, Keras was the only user of this
+  // field, and its saving and loading code will be updated shortly.
+  // Please save your application-specific metadata to separate file
   // Initialization-related metadata.
   string metadata = 3;
 }
@@ -124,6 +127,13 @@ message SavedBareConcreteFunction {
   repeated string argument_keywords = 2;
   // The prefix of `argument_keywords` which may be identified by position.
   int64 allowed_positional_arguments = 3;
+  // The spec of the function that this ConcreteFunction is traced from. This
+  // allows the ConcreteFunction to be called with nest structure inputs. This
+  // field may not be populated. If this field is absent, the concrete function
+  // can only be called with flat inputs.
+  // TODO(b/169361281): support calling saved ConcreteFunction with structured
+  // inputs in C++ SavedModel API.
+  FunctionSpec function_spec = 4;
 }
 
 message SavedConstant {
@@ -141,7 +151,15 @@ message SavedVariable {
   VariableAggregation aggregation = 5;
   string name = 6;
   string device = 7;
+  // List of component variables for a distributed variable.
+  //
+  // When this field is non-empty, the SavedVariable will be assumed
+  // to be a distributed variable defined by the components listed here.
+  //
+  // This is only supported by experimental loaders at the moment.
+  repeated SavedVariable experimental_distributed_variable_components = 8;
 }
+
 
 // Represents `FunctionSpec` used in `Function`. This represents a
 // function that has been wrapped as a TensorFlow `Function`.
@@ -152,6 +170,21 @@ message FunctionSpec {
   bool is_method = 2;
   // The input signature, if specified.
   StructuredValue input_signature = 5;
+
+  // Whether the function should be compiled by XLA.
+  //
+  // The public interface to `tf.function` uses an optional boolean to
+  // represent three distinct states for this field.  Unfortunately, proto3
+  // removes the ability to explicitly check for the presence or absence of a
+  // field, so we instead map to an enum.
+  //
+  // See `tf.function` for details.
+  enum ExperimentalCompile {
+    DEFAULT = 0;
+    ON = 1;
+    OFF = 2;
+  }
+  ExperimentalCompile experimental_compile = 6;
 
   reserved 3, 4;
 }

--- a/tensorboard/compat/proto/types.proto
+++ b/tensorboard/compat/proto/types.proto
@@ -74,3 +74,14 @@ enum DataType {
 //    https://www.tensorflow.org/code/tensorboard/compat/proto/types.cc,
 //    https://www.tensorflow.org/code/tensorboard/compat/proto/dtypes.py,
 //    https://www.tensorflow.org/code/tensorboard/compat/proto/function.py)
+
+// For identifying the underlying type of a variant. For variants, the types
+// listed here are a subset of the types in the variant type registry,
+// corresponding to commonly used variants which must occasionally be
+// special-cased.
+enum SpecializedType {
+  // Invalid/unknown specialized type.
+  ST_INVALID = 0;
+  // "tensorflow::TensorList" in the variant type registry.
+  ST_TENSOR_LIST = 1;
+}


### PR DESCRIPTION
While testing the pip candidate locally for 2.4, it fails on the proto_test.

This change was created by checking out git checkout v2.4.0-rc1
in a TensorFlow local repo, and running
`./tensorboard/compat/proto/update.sh PATH_TO_TENSORFLOW_REPO`.