### PR TITLE
rust: add `byteorder` dependency

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -7,6 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
+name = "byteorder"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,5 +25,6 @@ dependencies = [
 name = "rustboard"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "crc",
 ]

--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -7,17 +7,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
-<<<<<<< HEAD
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-=======
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
->>>>>>> eb4cfd1082009b1f9dcf7c4c6ac14e04a513de3e
 
 [[package]]
 name = "crc"

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+byteorder = "1.3.4"
 crc = "1.8.1"
 
 [[bin]]

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -13,6 +13,15 @@ licenses([
 
 # Aliased targets
 alias(
+    name = "byteorder",
+    actual = "@raze__byteorder__1_3_4//:byteorder",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "crc",
     actual = "@raze__crc__1_8_1//:crc",
     tags = [

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -29,3 +29,21 @@ alias(
         "manual",
     ],
 )
+
+alias(
+    name = "rand",
+    actual = "@raze__rand__0_7_3//:rand",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "rand_chacha",
+    actual = "@raze__rand_chacha__0_2_2//:rand_chacha",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)

--- a/third_party/rust/crates.bzl
+++ b/third_party/rust/crates.bzl
@@ -33,10 +33,100 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__cfg_if__0_1_10",
+        url = "https://crates.io/api/v1/crates/cfg-if/0.1.10/download",
+        type = "tar.gz",
+        sha256 = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
+        strip_prefix = "cfg-if-0.1.10",
+        build_file = Label("//third_party/rust/remote:BUILD.cfg-if-0.1.10.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__crc__1_8_1",
         url = "https://crates.io/api/v1/crates/crc/1.8.1/download",
         type = "tar.gz",
         sha256 = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb",
         strip_prefix = "crc-1.8.1",
         build_file = Label("//third_party/rust/remote:BUILD.crc-1.8.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__getrandom__0_1_15",
+        url = "https://crates.io/api/v1/crates/getrandom/0.1.15/download",
+        type = "tar.gz",
+        sha256 = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6",
+        strip_prefix = "getrandom-0.1.15",
+        build_file = Label("//third_party/rust/remote:BUILD.getrandom-0.1.15.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__libc__0_2_80",
+        url = "https://crates.io/api/v1/crates/libc/0.2.80/download",
+        type = "tar.gz",
+        sha256 = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614",
+        strip_prefix = "libc-0.2.80",
+        build_file = Label("//third_party/rust/remote:BUILD.libc-0.2.80.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ppv_lite86__0_2_10",
+        url = "https://crates.io/api/v1/crates/ppv-lite86/0.2.10/download",
+        type = "tar.gz",
+        sha256 = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857",
+        strip_prefix = "ppv-lite86-0.2.10",
+        build_file = Label("//third_party/rust/remote:BUILD.ppv-lite86-0.2.10.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand__0_7_3",
+        url = "https://crates.io/api/v1/crates/rand/0.7.3/download",
+        type = "tar.gz",
+        sha256 = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03",
+        strip_prefix = "rand-0.7.3",
+        build_file = Label("//third_party/rust/remote:BUILD.rand-0.7.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_chacha__0_2_2",
+        url = "https://crates.io/api/v1/crates/rand_chacha/0.2.2/download",
+        type = "tar.gz",
+        sha256 = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402",
+        strip_prefix = "rand_chacha-0.2.2",
+        build_file = Label("//third_party/rust/remote:BUILD.rand_chacha-0.2.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_core__0_5_1",
+        url = "https://crates.io/api/v1/crates/rand_core/0.5.1/download",
+        type = "tar.gz",
+        sha256 = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19",
+        strip_prefix = "rand_core-0.5.1",
+        build_file = Label("//third_party/rust/remote:BUILD.rand_core-0.5.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_hc__0_2_0",
+        url = "https://crates.io/api/v1/crates/rand_hc/0.2.0/download",
+        type = "tar.gz",
+        sha256 = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c",
+        strip_prefix = "rand_hc-0.2.0",
+        build_file = Label("//third_party/rust/remote:BUILD.rand_hc-0.2.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__wasi__0_9_0_wasi_snapshot_preview1",
+        url = "https://crates.io/api/v1/crates/wasi/0.9.0+wasi-snapshot-preview1/download",
+        type = "tar.gz",
+        sha256 = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519",
+        strip_prefix = "wasi-0.9.0+wasi-snapshot-preview1",
+        build_file = Label("//third_party/rust/remote:BUILD.wasi-0.9.0+wasi-snapshot-preview1.bazel"),
     )

--- a/third_party/rust/crates.bzl
+++ b/third_party/rust/crates.bzl
@@ -23,6 +23,16 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__byteorder__1_3_4",
+        url = "https://crates.io/api/v1/crates/byteorder/1.3.4/download",
+        type = "tar.gz",
+        sha256 = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de",
+        strip_prefix = "byteorder-1.3.4",
+        build_file = Label("//third_party/rust/remote:BUILD.byteorder-1.3.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__crc__1_8_1",
         url = "https://crates.io/api/v1/crates/crc/1.8.1/download",
         type = "tar.gz",

--- a/third_party/rust/remote/BUILD.byteorder-1.3.4.bazel
+++ b/third_party/rust/remote/BUILD.byteorder-1.3.4.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "byteorder",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.3.4",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)


### PR DESCRIPTION
Summary:
The [`byteorder`] crate facilitates working with fixed-endian values.
For TFRecords, we need to read little-endian numbers from a data stream.

[`byteorder`]: https://crates.io/crates/byteorder

Test Plan:
It builds: `bazel build //third_party/rust:byteorder`.

wchargin-branch: rust-dep-byteorder
