### PR TITLE
Fix mouse interaction in hparam parallel coords, scatter plot

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
@@ -218,10 +218,10 @@ class TfHparamsParallelCoordsPlot extends LegacyElementMixin(PolymerElement) {
     this.redrawCount++;
   }
   closestSessionGroupChanged(sessionGroup) {
-    (this as any)._setClosestSessionGroup(sessionGroup);
+    this.closestSessionGroup = sessionGroup;
   }
   selectedSessionGroupChanged(sessionGroup) {
-    (this as any)._setSelectedSessionGroup(sessionGroup);
+    this.selectedSessionGroup = sessionGroup;
   }
   // computes validSessionGroups: Filters out the session groups in the
   // sessionGroups that have one or more of their column values undefined.

--- a/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
@@ -736,18 +736,16 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
           closestMarkers.classed('closest-marker', true);
           // All elements in closestMarkers should have the same
           // sessionGroup.
-          (_this as any)._setClosestSessionGroup(
-            closestMarkers.datum().sessionGroup
-          );
+          _this.closestSessionGroup = closestMarkers.datum().sessionGroup;
         } else {
-          (_this as any)._setClosestSessionGroup(null);
+          _this.closestSessionGroup = null;
         }
       })
       .on('mouseleave', function ([col, metric]) {
         if (closestMarkers !== null) {
           closestMarkers.classed('closest-marker', false);
           closestMarkers = null;
-          (_this as any)._setClosestSessionGroup(null);
+          _this.closestSessionGroup = null;
         }
       });
     // Finds a closest visible marker in the [col,metric] cell to the point


### PR DESCRIPTION
During the Polymer 2 to 3 migration, we missed this case in the
hparams dashboard and improperly migrated a property setting
site. Properties with the `notify: true` config do not get Polymer's
implicit `_setPropertyName(value)` method defined. Instead, they must
be set the regular way: `this.propertyName = value`.

Note that, unlike some other properties with `notify: true; readonly: true`,
these *SessionGroup properties may be set from outside the element
via bindings, so they should not use `readonly`.

Manually tested that hovering/clicking over lines in the parallel
coordinates view and dots in the scatter plot properly show the table
of params for the current session group.

Fixes #4309