### PR TITLE
rust: add `thiserror` dependency

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "prost-build",
  "rand",
  "rand_chacha",
+ "thiserror",
  "tokio",
  "tonic",
  "tonic-build",
@@ -673,6 +674,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -30,6 +30,7 @@ futures-core = "0.3.6"
 prost = "0.6.1"
 rand = "0.7.3"
 rand_chacha = "0.2.2"
+thiserror = "1.0.21"
 tokio = { version = "0.2.2", features = ["macros"] }
 tonic = "0.3.1"
 

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -94,6 +94,15 @@ alias(
 )
 
 alias(
+    name = "thiserror",
+    actual = "@raze__thiserror__1_0_22//:thiserror",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "tokio",
     actual = "@raze__tokio__0_2_22//:tokio",
     tags = [

--- a/third_party/rust/crates.bzl
+++ b/third_party/rust/crates.bzl
@@ -733,6 +733,26 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__thiserror__1_0_22",
+        url = "https://crates.io/api/v1/crates/thiserror/1.0.22/download",
+        type = "tar.gz",
+        sha256 = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e",
+        strip_prefix = "thiserror-1.0.22",
+        build_file = Label("//third_party/rust/remote:BUILD.thiserror-1.0.22.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__thiserror_impl__1_0_22",
+        url = "https://crates.io/api/v1/crates/thiserror-impl/1.0.22/download",
+        type = "tar.gz",
+        sha256 = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56",
+        strip_prefix = "thiserror-impl-1.0.22",
+        build_file = Label("//third_party/rust/remote:BUILD.thiserror-impl-1.0.22.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__tokio__0_2_22",
         url = "https://crates.io/api/v1/crates/tokio/0.2.22/download",
         type = "tar.gz",

--- a/third_party/rust/remote/BUILD.thiserror-1.0.22.bazel
+++ b/third_party/rust/remote/BUILD.thiserror-1.0.22.bazel
@@ -1,0 +1,79 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "thiserror",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__thiserror_impl__1_0_22//:thiserror_impl",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.22",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "test_backtrace" with type "test" omitted
+
+# Unsupported target "test_deprecated" with type "test" omitted
+
+# Unsupported target "test_display" with type "test" omitted
+
+# Unsupported target "test_error" with type "test" omitted
+
+# Unsupported target "test_expr" with type "test" omitted
+
+# Unsupported target "test_from" with type "test" omitted
+
+# Unsupported target "test_lints" with type "test" omitted
+
+# Unsupported target "test_option" with type "test" omitted
+
+# Unsupported target "test_path" with type "test" omitted
+
+# Unsupported target "test_source" with type "test" omitted
+
+# Unsupported target "test_transparent" with type "test" omitted

--- a/third_party/rust/remote/BUILD.thiserror-impl-1.0.22.bazel
+++ b/third_party/rust/remote/BUILD.thiserror-impl-1.0.22.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "thiserror_impl",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "proc-macro",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.22",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_24//:proc_macro2",
+        "@raze__quote__1_0_7//:quote",
+        "@raze__syn__1_0_48//:syn",
+    ],
+)


### PR DESCRIPTION
Summary:
The [`thiserror`] crate facilitates defining structured error types for
libraries. It makes it easy to specify how errors are converted from
other errors (e.g., an underlying I/O error) and how they are converted
to strings for display.

[`thiserror`]: https://crates.io/crates/thiserror

Test Plan:
It builds: `bazel build //third_party/rust:thiserror`.

wchargin-branch: rust-dep-thiserror
