### PR TITLE
ci: don’t update Cargo lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: 'Check cargo-raze freshness'
         run: |
           rm -rf third_party/rust/
-          (cd tensorboard/data/server/ && cargo generate-lockfile && cargo raze)
+          (cd tensorboard/data/server/ && cargo raze)
           git add .
           git diff --staged --exit-code
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: 'Check cargo-raze freshness'
         run: |
           rm -rf third_party/rust/
-          (cd tensorboard/data/server/ && cargo raze)
+          (cd tensorboard/data/server/ && cargo fetch && cargo raze)
           git add .
           git diff --staged --exit-code
 

--- a/tensorboard/data/server/DEVELOPMENT.md
+++ b/tensorboard/data/server/DEVELOPMENT.md
@@ -50,9 +50,9 @@ dependency:
     should look like `rand = "0.7.3"`. You can find the most recent version of a
     package on <https://crates.io/>.
 3.  Change into the `tensorboard/data/server/` directory.
-4.  Run `cargo generate-lockfile` to update `Cargo.lock`. Running this before
-    `cargo raze` ensures that the `http_archive` workspace rules in the
-    generated build files will have `sha256` checksums.
+4.  Run `cargo fetch` to update `Cargo.lock`. Running this before `cargo raze`
+    ensures that the `http_archive` workspace rules in the generated build
+    files will have `sha256` checksums.
 5.  Run `cargo raze` to update `third_party/rust/...`.
 
 This will add a new target like `//third_party/rust:rand`. Manually build it


### PR DESCRIPTION
Summary:
I didn’t realize that this also updates locks for transitive deps, which
can cause the Raze check to fail as it pulls in new versions.

Test Plan:
At master, running `cargo generate-lockfile` is *not* clean, even though
it passed at submit time, because `tokio` has been updated. Running
`cargo fetch` does not change the lockfile, but does add to it if you
add a new dep (e.g., `anyhow = "1.0.33"`).

wchargin-branch: ci-no-generate-lockfile
