### PR TITLE
refactor: feature flag typing remove key-value

### DIFF
--- a/tensorboard/webapp/feature_flag/BUILD
+++ b/tensorboard/webapp/feature_flag/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -18,12 +18,16 @@ tf_ng_module(
     ],
 )
 
-tf_ng_module(
+tf_ts_library(
     name = "types",
     srcs = [
         "types.ts",
     ],
-    deps = [
-        "//tensorboard/webapp/webapp_data_source:feature_flag",
-    ],
+)
+
+tf_ts_library(
+    name = "testing",
+    testonly = True,
+    srcs = ["testing.ts"],
+    deps = [":types"],
 )

--- a/tensorboard/webapp/feature_flag/actions/BUILD
+++ b/tensorboard/webapp/feature_flag/actions/BUILD
@@ -8,7 +8,6 @@ tf_ng_module(
         "feature_flag_actions.ts",
     ],
     deps = [
-        "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/store:types",
         "@npm//@ngrx/store",
     ],

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -15,8 +15,7 @@ limitations under the License.
 
 import {createAction, props} from '@ngrx/store';
 
-import {FeatureFlags} from '../store/feature_flag_types';
-import {FeatureValue} from '../types';
+import {FeatureFlags} from '../types';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
 /** @typehack */ import * as _typeHackStoreModel from '@ngrx/store/src/models';

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -62,6 +62,7 @@ describe('feature_flag_effects', () => {
     it('loads features from the data source on init', () => {
       spyOn(dataSource, 'getFeatures').and.returnValue({
         enabledExperimentalPlugins: ['foo', 'bar'],
+        inColab: false,
       });
 
       actions.next(effects.ngrxOnInitEffects());
@@ -70,6 +71,7 @@ describe('feature_flag_effects', () => {
         featuresLoaded({
           features: {
             enabledExperimentalPlugins: ['foo', 'bar'],
+            inColab: false,
           },
         }),
       ]);

--- a/tensorboard/webapp/feature_flag/store/BUILD
+++ b/tensorboard/webapp/feature_flag/store/BUILD
@@ -39,6 +39,7 @@ tf_ng_module(
     deps = [
         ":store",
         ":types",
+        "//tensorboard/webapp/feature_flag:testing",
         "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/actions",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
+
 import * as actions from '../actions/feature_flag_actions';
 import {FeatureFlagState} from './feature_flag_types';
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import * as actions from '../actions/feature_flag_actions';
+import {buildFeatureFlag} from '../testing';
 import {reducers} from './feature_flag_reducers';
 import {buildFeatureFlagState} from './testing';
 
@@ -21,16 +22,16 @@ describe('feature_flag_reducers', () => {
     it('sets the new feature flags onto the state', () => {
       const prevState = buildFeatureFlagState({
         isFeatureFlagsLoaded: false,
-        features: {
+        features: buildFeatureFlag({
           enabledExperimentalPlugins: ['foo'],
-        },
+        }),
       });
       const nextState = reducers(
         prevState,
         actions.featuresLoaded({
-          features: {
+          features: buildFeatureFlag({
             enabledExperimentalPlugins: ['foo', 'bar'],
-          },
+          }),
         })
       );
 
@@ -38,25 +39,6 @@ describe('feature_flag_reducers', () => {
         'foo',
         'bar',
       ]);
-    });
-
-    it('sets the feature value of other features', () => {
-      const prevState = buildFeatureFlagState({
-        features: {
-          enabledExperimentalPlugins: [],
-        },
-      });
-      const nextState = reducers(
-        prevState,
-        actions.featuresLoaded({
-          features: {
-            enabledExperimentalPlugins: [],
-            enableMagicalFeature: true,
-          },
-        })
-      );
-
-      expect(nextState.features['enableMagicalFeature']).toBe(true);
     });
   });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -16,12 +16,10 @@ limitations under the License.
 import {createSelector, createFeatureSelector} from '@ngrx/store';
 
 import {
-  FeatureFlags,
   FeatureFlagState,
   FEAUTURE_FLAG_FEATURE_KEY,
   State,
 } from './feature_flag_types';
-import {FeatureValue} from '../types';
 
 /** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store';
 
@@ -33,16 +31,6 @@ export const getIsFeatureFlagsLoaded = createSelector(
   selectFeatureFlagState,
   (state) => {
     return state.isFeatureFlagsLoaded;
-  }
-);
-
-export const getFeature = createSelector(
-  selectFeatureFlagState,
-  (
-    state: FeatureFlagState,
-    featureId: keyof FeatureFlags
-  ): FeatureValue | null => {
-    return state.features[featureId] || null;
   }
 );
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -12,48 +12,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {buildFeatureFlag} from '../testing';
 import * as selectors from './feature_flag_selectors';
 import {buildFeatureFlagState, buildState} from './testing';
 
 describe('feature_flag_selectors', () => {
-  describe('getFeature', () => {
-    it('returns a current feature', () => {
-      const state = buildState(
-        buildFeatureFlagState({
-          features: {
-            enableMagicFeature: true,
-          },
-        })
-      );
-      const actual = selectors.getFeature(state, 'enableMagicFeature');
-
-      expect(actual).toBe(true);
-    });
-
-    it('returns null if the value is not present', () => {
-      const state = buildState(
-        buildFeatureFlagState({
-          features: {
-            enabledExperimentalPlugins: ['foo'],
-          },
-        })
-      );
-      const actual = selectors.getFeature(state, 'bar');
-
-      expect(actual).toBeNull();
-    });
-  });
-
   describe('getEnabledExperimentalPlugins', () => {
     it('returns value in array', () => {
       const state = buildState(
         buildFeatureFlagState({
-          features: {
+          features: buildFeatureFlag({
             enabledExperimentalPlugins: ['bar'],
-          },
+          }),
         })
       );
-      const actual = selectors.getFeature(state, 'enabledExperimentalPlugins');
+      const actual = selectors.getEnabledExperimentalPlugins(state);
 
       expect(actual).toEqual(['bar']);
     });
@@ -63,18 +36,18 @@ describe('feature_flag_selectors', () => {
     it('returns the proper value', () => {
       let state = buildState(
         buildFeatureFlagState({
-          features: {
+          features: buildFeatureFlag({
             inColab: true,
-          },
+          }),
         })
       );
       expect(selectors.getIsInColab(state)).toEqual(true);
 
       state = buildState(
         buildFeatureFlagState({
-          features: {
+          features: buildFeatureFlag({
             inColab: false,
-          },
+          }),
         })
       );
       expect(selectors.getIsInColab(state)).toEqual(false);

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -13,15 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {FeatureValue} from '../types';
+import {FeatureFlags} from '../types';
 
 export const FEAUTURE_FLAG_FEATURE_KEY = 'feature';
-
-export interface FeatureFlags {
-  enabledExperimentalPlugins?: string[];
-  inColab?: boolean;
-  [featureId: string]: FeatureValue | undefined;
-}
 
 export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {buildFeatureFlag} from '../testing';
 import {
   FeatureFlagState,
   FEAUTURE_FLAG_FEATURE_KEY,
@@ -25,11 +26,7 @@ export function buildFeatureFlagState(
   return {
     isFeatureFlagsLoaded: false,
     ...restOverride,
-    features: {
-      enabledExperimentalPlugins: ['foo'],
-      inColab: false,
-      ...featuresOverride,
-    },
+    features: buildFeatureFlag(featuresOverride),
   };
 }
 

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,18 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Injectable} from '@angular/core';
 
-import {FeatureFlags} from '../feature_flag/types';
+import {FeatureFlags} from './types';
 
-@Injectable()
-export abstract class TBFeatureFlagDataSource {
-  /**
-   * Gets feature flags defined.
-   *
-   * The "feature" is very loosely defined so other applications can define more
-   * flags. It is up to the application to better type the flags and create necessary
-   * facilities (e.g., strongly typed selector).
-   */
-  abstract getFeatures(): FeatureFlags;
+export function buildFeatureFlag(
+  override: Partial<FeatureFlags> = {}
+): FeatureFlags {
+  return {
+    enabledExperimentalPlugins: [],
+    inColab: false,
+    ...override,
+  };
 }

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -13,4 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-export {FeatureValue} from '../webapp_data_source/tb_feature_flag_data_source_types';
+export interface FeatureFlags {
+  // experimental plugins to manually enable.
+  enabledExperimentalPlugins: string[];
+  // Whether the TensorBoard is being run inside Colab output cell.
+  inColab: boolean;
+}

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -81,6 +81,7 @@ tf_ng_module(
         "tb_feature_flag_module.ts",
     ],
     deps = [
+        "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -97,6 +97,7 @@ tf_ng_module(
     ],
     deps = [
         ":feature_flag",
+        "//tensorboard/webapp/feature_flag:testing",
         "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_testing.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_testing.ts
@@ -13,17 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {NgModule, Injectable} from '@angular/core';
+import {Injectable, NgModule} from '@angular/core';
 
+import {buildFeatureFlag} from '../feature_flag/testing';
 import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
 
 @Injectable()
 export class TestingTBFeatureFlagDataSource extends TBFeatureFlagDataSource {
   getFeatures() {
-    return {
-      enabledExperimentalPlugins: [] as string[],
-      inColab: false,
-    };
+    return buildFeatureFlag();
   }
 }
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_testing.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_testing.ts
@@ -22,6 +22,7 @@ export class TestingTBFeatureFlagDataSource extends TBFeatureFlagDataSource {
   getFeatures() {
     return {
       enabledExperimentalPlugins: [] as string[],
+      inColab: false,
     };
   }
 }


### PR DESCRIPTION
Key-value allows just about anything and it is not that great for
typing. This change removes the key-value part of the FeatureFlag and
forces all apps to strongly type it. We can reintroduce it when we
absolutely need it.
