### PR TITLE
feat: add an ability to enable gpu line chart

### DIFF
--- a/tensorboard/webapp/feature_flag/effects/BUILD
+++ b/tensorboard/webapp/feature_flag/effects/BUILD
@@ -27,6 +27,7 @@ tf_ng_module(
         ":effects",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/feature_flag:testing",
         "//tensorboard/webapp/feature_flag/actions",
         "//tensorboard/webapp/feature_flag/store:types",
         "//tensorboard/webapp/webapp_data_source:feature_flag_testing",

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -14,19 +14,19 @@ limitations under the License.
 ==============================================================================*/
 
 import {TestBed} from '@angular/core/testing';
-
 import {provideMockActions} from '@ngrx/effects/testing';
 import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {ReplaySubject} from 'rxjs';
 
-import {State} from '../store/feature_flag_types';
 import {
   TBFeatureFlagTestingModule,
   TestingTBFeatureFlagDataSource,
 } from '../../webapp_data_source/tb_feature_flag_testing';
-import {FeatureFlagEffects} from './feature_flag_effects';
 import {featuresLoaded} from '../actions/feature_flag_actions';
+import {State} from '../store/feature_flag_types';
+import {buildFeatureFlag} from '../testing';
+import {FeatureFlagEffects} from './feature_flag_effects';
 
 describe('feature_flag_effects', () => {
   let actions: ReplaySubject<Action>;
@@ -60,19 +60,21 @@ describe('feature_flag_effects', () => {
     });
 
     it('loads features from the data source on init', () => {
-      spyOn(dataSource, 'getFeatures').and.returnValue({
-        enabledExperimentalPlugins: ['foo', 'bar'],
-        inColab: false,
-      });
+      spyOn(dataSource, 'getFeatures').and.returnValue(
+        buildFeatureFlag({
+          enabledExperimentalPlugins: ['foo', 'bar'],
+          inColab: false,
+        })
+      );
 
       actions.next(effects.ngrxOnInitEffects());
 
       expect(recordedActions).toEqual([
         featuresLoaded({
-          features: {
+          features: buildFeatureFlag({
             enabledExperimentalPlugins: ['foo', 'bar'],
             inColab: false,
-          },
+          }),
         }),
       ]);
     });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -24,6 +24,7 @@ const initialState: FeatureFlagState = {
   features: {
     enabledExperimentalPlugins: [],
     inColab: false,
+    enableGpuChart: false,
   },
 };
 

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -21,6 +21,7 @@ export function buildFeatureFlag(
   return {
     enabledExperimentalPlugins: [],
     inColab: false,
+    enableGpuChart: false,
     ...override,
   };
 }

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -18,4 +18,6 @@ export interface FeatureFlags {
   enabledExperimentalPlugins: string[];
   // Whether the TensorBoard is being run inside Colab output cell.
   inColab: boolean;
+  // Whether to enable our experimental GPU line chart.
+  enableGpuChart: boolean;
 }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -34,6 +34,7 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
     return {
       enabledExperimentalPlugins: params.getAll('experimentalPlugin'),
       inColab: params.get('tensorboardColab') === 'true',
+      enableGpuChart: params.get('fastChart') === 'true',
     };
   }
 }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -38,6 +38,7 @@ describe('tb_feature_flag_data_source', () => {
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: ['a', 'b'],
           inColab: false,
+          enableGpuChart: false,
         });
       });
 
@@ -48,6 +49,7 @@ describe('tb_feature_flag_data_source', () => {
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: [],
           inColab: true,
+          enableGpuChart: false,
         });
       });
 
@@ -58,7 +60,29 @@ describe('tb_feature_flag_data_source', () => {
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: [],
           inColab: false,
+          enableGpuChart: false,
         });
+      });
+
+      it("returns enableGpuChart=false when 'fastChart' is empty", () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('fastChart=')
+        );
+        expect(dataSource.getFeatures().enableGpuChart).toEqual(false);
+      });
+
+      it('returns enableGpuChart=true when "true"', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('fastChart=true')
+        );
+        expect(dataSource.getFeatures().enableGpuChart).toEqual(true);
+      });
+
+      it('returns enableGpuChart=false when explicitly "false"', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('fastChart=false')
+        );
+        expect(dataSource.getFeatures().enableGpuChart).toEqual(false);
       });
 
       it('returns empty enabledExperimentalPlugins when empty', () => {
@@ -68,6 +92,7 @@ describe('tb_feature_flag_data_source', () => {
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: [],
           inColab: false,
+          enableGpuChart: false,
         });
       });
     });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -31,37 +31,46 @@ describe('tb_feature_flag_data_source', () => {
     });
 
     describe('getFeatures', () => {
+      it('returns default values when params are empty', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('')
+        );
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: [],
+          inColab: false,
+          enableGpuChart: false,
+        });
+      });
+
       it('returns enabledExperimentalPlugins from the query params', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('experimentalPlugin=a&experimentalPlugin=b')
         );
-        expect(dataSource.getFeatures()).toEqual({
-          enabledExperimentalPlugins: ['a', 'b'],
-          inColab: false,
-          enableGpuChart: false,
-        });
+        expect(dataSource.getFeatures().enabledExperimentalPlugins).toEqual([
+          'a',
+          'b',
+        ]);
+      });
+
+      it('returns empty enabledExperimentalPlugins when empty', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('')
+        );
+        expect(dataSource.getFeatures().enabledExperimentalPlugins).toEqual([]);
       });
 
       it('returns isInColab when true', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('tensorboardColab=true')
         );
-        expect(dataSource.getFeatures()).toEqual({
-          enabledExperimentalPlugins: [],
-          inColab: true,
-          enableGpuChart: false,
-        });
+        expect(dataSource.getFeatures().inColab).toEqual(true);
       });
 
       it('returns isInColab when false', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('tensorboardColab=false')
         );
-        expect(dataSource.getFeatures()).toEqual({
-          enabledExperimentalPlugins: [],
-          inColab: false,
-          enableGpuChart: false,
-        });
+        expect(dataSource.getFeatures().inColab).toEqual(false);
       });
 
       it("returns enableGpuChart=false when 'fastChart' is empty", () => {
@@ -83,17 +92,6 @@ describe('tb_feature_flag_data_source', () => {
           new URLSearchParams('fastChart=false')
         );
         expect(dataSource.getFeatures().enableGpuChart).toEqual(false);
-      });
-
-      it('returns empty enabledExperimentalPlugins when empty', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
-          new URLSearchParams('')
-        );
-        expect(dataSource.getFeatures()).toEqual({
-          enabledExperimentalPlugins: [],
-          inColab: false,
-          enableGpuChart: false,
-        });
       });
     });
   });


### PR DESCRIPTION
This change adds a new unconnected flag `fastChart`.  The flag is intended to used for enabling
new GPU based line chart in time series in the future.