### PR TITLE
sync: fix build

### DIFF
--- a/tensorboard/webapp/feature_flag/actions/BUILD
+++ b/tensorboard/webapp/feature_flag/actions/BUILD
@@ -8,6 +8,7 @@ tf_ng_module(
         "feature_flag_actions.ts",
     ],
     deps = [
+        "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/store:types",
         "@npm//@ngrx/store",
     ],


### PR DESCRIPTION
feature_flags action requires types but BUILD file is lacking the
dependency

