### PR TITLE
infra: persist experimentalPlugin to URL

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -40,6 +40,7 @@ tf_ng_module(
         "//tensorboard/webapp/alert/store",
         "//tensorboard/webapp/app_routing/store",
         "//tensorboard/webapp/experiments/store:selectors",
+        "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/metrics/store",
         "//tensorboard/webapp/runs/store:selectors",
         "//tensorboard/webapp/util:ui_selectors",

--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -31,7 +31,7 @@ tf_ts_library(
         "types.ts",
     ],
     deps = [
-        "//tensorboard/webapp/metrics/data_source",
+        "//tensorboard/webapp/metrics/data_source:types",
         "//tensorboard/webapp/widgets/histogram:types",
         "//tensorboard/webapp/widgets/line_chart",
     ],

--- a/tensorboard/webapp/metrics/types.ts
+++ b/tensorboard/webapp/metrics/types.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {HistogramMode} from '../widgets/histogram/histogram_types';
 import {TooltipSortingMethod} from '../widgets/line_chart/polymer_interop_types';
 
-import {PluginType} from './data_source';
+import {PluginType} from './data_source/types';
 
 export {HistogramMode};
 export {TooltipSortingMethod as TooltipSort};

--- a/tensorboard/webapp/routes/BUILD
+++ b/tensorboard/webapp/routes/BUILD
@@ -19,11 +19,22 @@ tf_ts_library(
 )
 
 tf_ts_library(
+    name = "core_deeplink_provider_types",
+    srcs = [
+        "core_deeplink_provider_types.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/metrics:types",
+    ],
+)
+
+tf_ts_library(
     name = "core_deeplink_provider",
     srcs = [
         "core_deeplink_provider.ts",
     ],
     deps = [
+        ":core_deeplink_provider_types",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/app_routing:deep_link_provider",
@@ -32,6 +43,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/metrics/data_source:types",
         "//tensorboard/webapp/tb_wrapper",
+        "//tensorboard/webapp/webapp_data_source:feature_flag_types",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//rxjs",

--- a/tensorboard/webapp/routes/core_deeplink_provider_types.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider_types.ts
@@ -12,20 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Injectable} from '@angular/core';
+import {URLDeserializedState as MetricsURLDeserializedState} from '../metrics/types';
 
-import {FeatureFlags} from '../feature_flag/types';
-
-@Injectable()
-export abstract class TBFeatureFlagDataSource {
-  /**
-   * Gets feature flags defined.
-   *
-   * The "feature" is very loosely defined so other applications can define more
-   * flags. It is up to the application to better type the flags and create necessary
-   * facilities (e.g., strongly typed selector).
-   */
-  abstract getFeatures(): FeatureFlags;
-}
-
-export const EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY = 'experimentalPlugin';
+// No need to deserialize the Experimental Plugins as it is immutable and is only read at
+// the start of the application.
+export type DeserializedState = MetricsURLDeserializedState;

--- a/tensorboard/webapp/selectors.ts
+++ b/tensorboard/webapp/selectors.ts
@@ -12,9 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+export * from './alert/store/alert_selectors';
 export * from './app_routing/store/app_routing_selectors';
 export * from './experiments/store/experiments_selectors';
-export * from './alert/store/alert_selectors';
+export * from './feature_flag/store/feature_flag_selectors';
 export * from './metrics/store/metrics_selectors';
 export * from './runs/store/runs_selectors';
 export * from './util/ui_selectors';

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -74,14 +74,24 @@ tf_ng_module(
 )
 
 tf_ng_module(
-    name = "feature_flag",
+    name = "feature_flag_types",
     srcs = [
-        "tb_feature_flag_data_source.ts",
         "tb_feature_flag_data_source_types.ts",
-        "tb_feature_flag_module.ts",
     ],
     deps = [
         "//tensorboard/webapp/feature_flag:types",
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ng_module(
+    name = "feature_flag",
+    srcs = [
+        "tb_feature_flag_data_source.ts",
+        "tb_feature_flag_module.ts",
+    ],
+    deps = [
+        ":feature_flag_types",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -14,7 +14,10 @@ limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
 
-import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
+import {
+  EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
+  TBFeatureFlagDataSource,
+} from './tb_feature_flag_data_source_types';
 
 /**
  * Save the initial URL query params, before the AppRoutingEffects initialize.
@@ -32,7 +35,9 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
   getFeatures() {
     const params = util.getParams();
     return {
-      enabledExperimentalPlugins: params.getAll('experimentalPlugin'),
+      enabledExperimentalPlugins: params.getAll(
+        EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY
+      ),
       inColab: params.get('tensorboardColab') === 'true',
       enableGpuChart: params.get('fastChart') === 'true',
     };


### PR DESCRIPTION
This change reads the state from the store and use our DeepLinkProvider
to add the query parameter to the URL.

Note that no navigation will cause the state to change since we want to
keep it immutable.
