### PR TITLE
sync: add data-id to runs-table for testability

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -231,7 +231,7 @@ limitations under the License.
 </ng-template>
 
 <ng-template #row let-item="item">
-  <div role="row">
+  <div role="row" [attr.data-id]="item.run.id">
     <span
       *ngFor="let columnId of columns"
       role="cell"


### PR DESCRIPTION
This is a recent regression from previous mat-table implementation where
we used to have the data-id attribute per row.

This regression is blocking the sync which is currently relying on the data
attribute.