### PR TITLE
sync: fix strict_deps on feature_flag_testing

### DIFF
--- a/tensorboard/webapp/feature_flag/effects/BUILD
+++ b/tensorboard/webapp/feature_flag/effects/BUILD
@@ -9,7 +9,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/feature_flag/actions",
-        "//tensorboard/webapp/webapp_data_source:feature_flag",
+        "//tensorboard/webapp/webapp_data_source:feature_flag_types",
         "@npm//@angular/core",
         "@npm//@ngrx/effects",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -106,7 +106,7 @@ tf_ng_module(
         "tb_feature_flag_testing.ts",
     ],
     deps = [
-        ":feature_flag",
+        ":feature_flag_types",
         "//tensorboard/webapp/feature_flag:testing",
         "@npm//@angular/core",
     ],


### PR DESCRIPTION
With the recent changes in the feature flag typing and because of inadequate strict_deps checking,
our sync is blocked again. This change corrects the dependency.

This time, we have tested the sync manually to make sure it no longer is borked (cl/342383238).