### PR TITLE
Remove `frame-ancestors *` CSP directive

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -222,7 +222,6 @@ def Respond(
                 "default-src 'self'",
                 "font-src %s"
                 % _create_csp_string("'self'", *_CSP_FONT_DOMAINS_WHITELIST),
-                "frame-ancestors *",
                 # Dynamic plugins are rendered inside an iframe.
                 "frame-src %s"
                 % _create_csp_string("'self'", *_CSP_FRAME_DOMAINS_WHITELIST),

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -239,7 +239,7 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=["abcdefghi"]
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;frame-ancestors *;"
+            "default-src 'self';font-src 'self' data:;"
             "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'self' 'unsafe-eval' 'sha256-abcdefghi'"
@@ -253,7 +253,7 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;frame-ancestors *;"
+            "default-src 'self';font-src 'self' data:;"
             "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'unsafe-eval'"
@@ -268,7 +268,7 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;frame-ancestors *;"
+            "default-src 'self';font-src 'self' data:;"
             "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'none'"
@@ -283,7 +283,7 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;frame-ancestors *;"
+            "default-src 'self';font-src 'self' data:;"
             "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'self'"
@@ -297,7 +297,7 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=["abcdefghi"]
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;frame-ancestors *;"
+            "default-src 'self';font-src 'self' data:;"
             "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'self' 'sha256-abcdefghi'"
@@ -324,7 +324,7 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=["abcd"]
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;frame-ancestors *;"
+            "default-src 'self';font-src 'self' data:;"
             "frame-src 'self' https://myframe.com;"
             "img-src 'self' data: blob: https://example.com;"
             "object-src 'none';style-src 'self' https://www.gstatic.com data: "

--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -34,8 +34,6 @@ _HTML_MIME_TYPE = "text/html"
 _CSP_DEFAULT_SRC = "default-src"
 # Whitelist of allowed CSP violations.
 _CSP_IGNORE = {
-    # Allow TensorBoard to be iframed.
-    "frame-ancestors": ["*"],
     # Polymer-based code uses unsafe-inline.
     "style-src": ["'unsafe-inline'", "data:"],
     # Used in canvas


### PR DESCRIPTION
# Motivation for features / changes

Hi! I'm a dev working on adding TensorBoard support to the [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) extensions for [VS Code](https://code.visualstudio.com/). We'd like to enable users to view TensorBoard inline in our[ Jupyter notebook experience within VS Code](https://code.visualstudio.com/docs/python/jupyter-support).

Currently this doesn't work because the `frame-ancestors *` directive prevents VS Code from framing TensorBoard. This is because VS Code is an Electron application, and Electron appears to be unable to frame websites which set `frame-ancestors *` in its response headers: https://github.com/electron/electron/issues/26369

# Technical description of changes
This PR essentially reverses https://github.com/tensorflow/tensorboard/pull/2797.

If I'm reading the CSP specification correctly, omitting the frame-ancestors directive altogether is equivalent to setting `frame-ancestors *`, so to my knowledge this PR should not result in a behavior change for environments which correctly implement the CSP spec. From https://w3c.github.io/webappsec-csp/2/#directive-frame-ancestors:

> The term allowed frame ancestors refers to the result of parsing the frame-ancestors directive’s value as a source list. If a frame-ancestors directive is not explicitly included in the policy, then allowed frame ancestors is "*".
 
# Screenshots of UI changes
With this PR, users can now display TensorBoard inline in a Jupyter notebook in VS Code:
![image](https://user-images.githubusercontent.com/30305945/99320395-64321380-2820-11eb-8588-bddf75aa98fd.png)
![image](https://user-images.githubusercontent.com/30305945/99321010-b1fb4b80-2821-11eb-80df-acfae6d0c778.png)

# Detailed steps to verify changes work correctly (as executed by you)
1. Remove line 223 which sets `frame-ancestors *` from backend/http_util.py
1. Install tensorboard package locally
1. Install Visual Studio Code from https://code.visualstudio.com/download and add it to your PATH during the installation stage
1. Install the Python extension for VS Code by running `code --install-extension ms-python.python` in your shell
1. Open VS Code
1. Hit 'Cmd/Ctrl + Shift + P' to bring up the command palette. Type 'Jupyter: Create New Blank Jupyter Notebook' and press enter. This will create a blank Jupyter notebook
1. In a cell, run 
> from IPython.display import IFrame
IFrame('http://localhost:6060', width=700, height=350)

8. tensorboard should now be rendered inline in the cell output


Thank you and please let me know if you have questions about this proposed change!