### PR TITLE
data: make `downsample` required, but permit zero

### DIFF
--- a/tensorboard/data/proto/data_provider.proto
+++ b/tensorboard/data/proto/data_provider.proto
@@ -56,7 +56,7 @@ message TagFilter {
 }
 
 message Downsample {
-  // Maximum number of points to return. Must be positive.
+  // Maximum number of points to return. Must be non-negative. Zero means zero.
   int64 num_points = 1;
 }
 
@@ -120,8 +120,8 @@ message ReadScalarsRequest {
   PluginFilter plugin_filter = 2;
   // Optional filter for time series. If omitted, all time series match.
   RunTagFilter run_tag_filter = 3;
-  // Downsampling specification describing how many points to return per time
-  // series. It is an error if `downsample.num_points <= 0`.
+  // Required downsampling specification describing how many points to return
+  // per time series.
   Downsample downsample = 4;
 }
 
@@ -187,8 +187,8 @@ message ReadTensorsRequest {
   PluginFilter plugin_filter = 2;
   // Optional filter for time series. If omitted, all time series match.
   RunTagFilter run_tag_filter = 3;
-  // Downsampling specification describing how many points to return per time
-  // series. It is an error if `downsample.num_points <= 0`.
+  // Required downsampling specification describing how many points to return
+  // per time series.
   Downsample downsample = 4;
 }
 
@@ -257,8 +257,8 @@ message ReadBlobSequencesRequest {
   PluginFilter plugin_filter = 2;
   // Optional filter for time series. If omitted, all time series match.
   RunTagFilter run_tag_filter = 3;
-  // Downsampling specification describing how many points to return per time
-  // series. It is an error if `downsample.num_points <= 0`.
+  // Required downsampling specification describing how many points to return
+  // per time series.
   Downsample downsample = 4;
 }
 

--- a/tensorboard/data/server/tensorboard.data.pb.rs
+++ b/tensorboard/data/server/tensorboard.data.pb.rs
@@ -46,7 +46,7 @@ pub struct TagFilter {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Downsample {
-    /// Maximum number of points to return. Must be positive.
+    /// Maximum number of points to return. Must be non-negative. Zero means zero.
     #[prost(int64, tag="1")]
     pub num_points: i64,
 }
@@ -129,8 +129,8 @@ pub struct ReadScalarsRequest {
     /// Optional filter for time series. If omitted, all time series match.
     #[prost(message, optional, tag="3")]
     pub run_tag_filter: ::std::option::Option<RunTagFilter>,
-    /// Downsampling specification describing how many points to return per time
-    /// series. It is an error if `downsample.num_points <= 0`.
+    /// Required downsampling specification describing how many points to return
+    /// per time series.
     #[prost(message, optional, tag="4")]
     pub downsample: ::std::option::Option<Downsample>,
 }
@@ -227,8 +227,8 @@ pub struct ReadTensorsRequest {
     /// Optional filter for time series. If omitted, all time series match.
     #[prost(message, optional, tag="3")]
     pub run_tag_filter: ::std::option::Option<RunTagFilter>,
-    /// Downsampling specification describing how many points to return per time
-    /// series. It is an error if `downsample.num_points <= 0`.
+    /// Required downsampling specification describing how many points to return
+    /// per time series.
     #[prost(message, optional, tag="4")]
     pub downsample: ::std::option::Option<Downsample>,
 }
@@ -329,8 +329,8 @@ pub struct ReadBlobSequencesRequest {
     /// Optional filter for time series. If omitted, all time series match.
     #[prost(message, optional, tag="3")]
     pub run_tag_filter: ::std::option::Option<RunTagFilter>,
-    /// Downsampling specification describing how many points to return per time
-    /// series. It is an error if `downsample.num_points <= 0`.
+    /// Required downsampling specification describing how many points to return
+    /// per time series.
     #[prost(message, optional, tag="4")]
     pub downsample: ::std::option::Option<Downsample>,
 }


### PR DESCRIPTION
Summary:
Suggested by @nfelt on #4314. This hits a flexibility/usability middle
ground between “omitted messages are implied to be empty” (which makes
it easy to accidentally set `num_points: 0` and wonder why the result is
empty) and “you may not set `num_points: 0`” (which excludes legitimate
use cases).

Test Plan:
None needed; this is just a doc update for now, as the service does not
yet have any clients or servers.

wchargin-branch: data-downsample-required
