### PR TITLE
rust: add `tempfile` dependency

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "prost-build",
  "rand",
  "rand_chacha",
+ "tempfile",
  "thiserror",
  "tokio",
  "tonic",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -30,6 +30,7 @@ futures-core = "0.3.6"
 prost = "0.6.1"
 rand = "0.7.3"
 rand_chacha = "0.2.2"
+tempfile = "3.1.0"
 thiserror = "1.0.21"
 tokio = { version = "0.2.2", features = ["macros"] }
 tonic = "0.3.1"

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -30,13 +30,13 @@ futures-core = "0.3.6"
 prost = "0.6.1"
 rand = "0.7.3"
 rand_chacha = "0.2.2"
-tempfile = "3.1.0"
 thiserror = "1.0.21"
 tokio = { version = "0.2.2", features = ["macros"] }
 tonic = "0.3.1"
 
 [dev-dependencies]
 prost-build = "0.6.1"
+tempfile = "3.1.0"
 tonic-build = "0.3.1"
 
 [[bin]]

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -94,6 +94,15 @@ alias(
 )
 
 alias(
+    name = "tempfile",
+    actual = "@raze__tempfile__3_1_0//:tempfile",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "thiserror",
     actual = "@raze__thiserror__1_0_22//:thiserror",
     tags = [


### PR DESCRIPTION
Summary:
The [`tempfile`] crate is the standard Rust library for handling
temporary files and directories. We anticipate using this for tests that
want to set up a directory of event files.

[`tempfile`]: https://crates.io/crates/tempfile

Test Plan:
It builds: `bazel build //third_party/rust:tempfile`.

wchargin-branch: rust-dep-tempfile
