### PR TITLE
rust: run `libc` build script

### DIFF
--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -59,9 +59,7 @@ targets = [
 gen_buildrs = true
 
 [package.metadata.raze.crates.libc.'0.2.80']
-additional_flags = [
-    "--cfg=libc_align",
-]
+gen_buildrs = true
 
 [package.metadata.raze.crates.indexmap.'1.6.0']
 additional_flags = [

--- a/third_party/rust/remote/BUILD.libc-0.2.80.bazel
+++ b/third_party/rust/remote/BUILD.libc-0.2.80.bazel
@@ -28,9 +28,37 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated Targets
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+cargo_build_script(
+    name = "libc_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "align",
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.80",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
 
 rust_library(
     name = "libc",
@@ -45,7 +73,6 @@ rust_library(
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
-        "--cfg=libc_align",
     ],
     tags = [
         "cargo-raze",
@@ -54,6 +81,7 @@ rust_library(
     version = "0.2.80",
     # buildifier: leave-alone
     deps = [
+        ":libc_build_script",
     ],
 )
 


### PR DESCRIPTION
Summary:
When setting up the transitive dep on `libc` in #4316, I had originally
passed `--cfg=libc_align`, because that fixed the build for me and on
CI, and I couldn’t figure out the right cross-platform fix. But @faern
[helpfully points out that we just need to run the build script][1],
which detects the OS and Rust compiler version to determine the
appropriate flags. Bazel `rules_rust` can handle this, if we just ask.

(I should have followed my own `DEVELOPMENT.md` suggestions!)

[1]: https://github.com/rust-lang/socket2-rs/issues/130#issuecomment-726741410

Test Plan:
It still builds—`bazel build @raze__libc__0_2_80//:libc`—and the demo
server still works and accepts requests following #4318’s test plan.

wchargin-branch: rust-libc-gen-buildrs
