### PR TITLE
line chart: Angular entry point to line chart

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -282,6 +282,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/widgets:resize_detector_testing",
         "//tensorboard/webapp/widgets/histogram:histogram_test",
         "//tensorboard/webapp/widgets/line_chart:line_chart_test",
+        "//tensorboard/webapp/widgets/line_chart_v2:line_chart_v2_tests",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:lib_tests",
         "//tensorboard/webapp/widgets/line_chart_v2/lib/renderer:renderer_test",
         "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:worker_test",

--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -1,0 +1,69 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])
+
+tf_sass_binary(
+    name = "line_chart_styles",
+    src = "line_chart_component.scss",
+)
+
+ng_module(
+    name = "line_chart_v2",
+    srcs = [
+        "line_chart_component.ts",
+        "line_chart_module.ts",
+    ],
+    assets = [
+        "line_chart_component.ng.html",
+        ":line_chart_styles",
+    ],
+    deps = [
+        ":internal_utils",
+        "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
+        "//tensorboard/webapp/widgets:resize_detector",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:chart",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:scale",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:worker_chart",
+        "//tensorboard/webapp/widgets/line_chart_v2/sub_view",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ts_library(
+    name = "internal_utils",
+    srcs = [
+        "line_chart_internal_utils.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:utils",
+    ],
+)
+
+tf_ts_library(
+    name = "line_chart_v2_tests",
+    testonly = True,
+    srcs = [
+        "line_chart_component_test.ts",
+        "line_chart_internal_utils_test.ts",
+    ],
+    deps = [
+        ":internal_utils",
+        ":line_chart_v2",
+        "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:chart",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:testing",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:utils",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -1,5 +1,4 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -10,7 +9,7 @@ tf_sass_binary(
     src = "line_chart_component.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "line_chart_v2",
     srcs = [
         "line_chart_component.ts",
@@ -39,6 +38,7 @@ tf_ts_library(
     srcs = [
         "line_chart_internal_utils.ts",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:utils",

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -79,11 +79,7 @@ tf_ts_library(
     srcs = [
         "scale.ts",
     ],
-    visibility = [
-        "//tensorboard/webapp/widgets/line_chart_v2/lib:__subpackages__",
-        # test uses it
-        "//tensorboard/webapp/widgets/line_chart_v2/sub_view:__pkg__",
-    ],
+    visibility = ["//tensorboard:internal"],
     deps = [
         ":internal_types",
         "//tensorboard/webapp/third_party:d3",
@@ -95,6 +91,7 @@ tf_ts_library(
     srcs = [
         "utils.ts",
     ],
+    visibility = ["//tensorboard:internal"],
     deps = [
         ":internal_types",
     ],

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/testing.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/testing.ts
@@ -15,16 +15,28 @@ limitations under the License.
 
 import {DataSeries, DataSeriesMetadata} from './internal_types';
 
+export function buildSeries(override: Partial<DataSeries>): DataSeries {
+  return {
+    id: 'foo',
+    points: [
+      {x: 1, y: 0},
+      {x: 2, y: -1},
+      {x: 2, y: 1},
+    ],
+    ...override,
+  };
+}
+
 export function createSeries(
   id: string,
   pointFn: (index: number) => number = Math.sin
 ): DataSeries {
-  return {
+  return buildSeries({
     id,
-    points: new Array(10).fill({x: 0, y: 0}).map((data, index) => {
+    points: [...new Array(10)].map((_, index) => {
       return {x: index, y: pointFn(index)};
     }),
-  };
+  });
 }
 
 export function buildMetadata(metadata: Partial<DataSeriesMetadata>) {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/utils.ts
@@ -47,3 +47,12 @@ export function arePolylinesEqual(lineA: Polyline, lineB: Polyline) {
   }
   return true;
 }
+
+export function areExtentsEqual(extentA: Extent, extentB: Extent): boolean {
+  return (
+    extentA.x[0] === extentB.x[0] &&
+    extentA.x[1] === extentB.x[1] &&
+    extentA.y[0] === extentB.y[0] &&
+    extentA.y[1] === extentB.y[1]
+  );
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -1,0 +1,68 @@
+<!--
+@license
+Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div
+  class="container"
+  detectResize
+  (onResize)="onViewResize()"
+  [resizeEventDebouncePeriodInMs]="0"
+  #overlayTarget="cdkOverlayOrigin"
+  cdkOverlayOrigin
+>
+  <div class="series-view" #main>
+    <line-chart-grid-view
+      [viewExtent]="viewBox"
+      [xScale]="xScale"
+      [yScale]="yScale"
+      [xGridCount]="10"
+      [yGridCount]="6"
+      [domDim]="domDimensions.main"
+    ></line-chart-grid-view>
+    <svg #chartEl *ngIf="getRendererType() === RendererType.SVG"></svg>
+    <canvas #chartEl *ngIf="getRendererType() === RendererType.WEBGL"></canvas>
+    <line-chart-interactive-view
+      [seriesData]="seriesData"
+      [seriesMetadataMap]="seriesMetadataMap"
+      [viewExtent]="viewBox"
+      [xScale]="xScale"
+      [yScale]="yScale"
+      [tooltipOriginEl]="overlayTarget"
+      [domDim]="domDimensions.main"
+      [tooltipTemplate]="tooltipTemplate"
+      (onViewExtentChange)="onViewBoxChanged($event)"
+      (onViewExtentReset)="onViewBoxReset()"
+    ></line-chart-interactive-view>
+  </div>
+  <line-chart-axis
+    #yAxis
+    class="y-axis"
+    axis="y"
+    [axisExtent]="viewBox.y"
+    [scale]="yScale"
+    [gridCount]="6"
+    [domDim]="domDimensions.yAxis"
+  ></line-chart-axis>
+  <line-chart-axis
+    #xAxis
+    class="x-axis"
+    axis="x"
+    [axisExtent]="viewBox.x"
+    [scale]="xScale"
+    [gridCount]="10"
+    [domDim]="domDimensions.xAxis"
+  ></line-chart-axis>
+</div>

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -23,13 +23,13 @@ limitations under the License.
   #overlayTarget="cdkOverlayOrigin"
   cdkOverlayOrigin
 >
-  <div class="series-view" #main>
+  <div class="series-view" #seriesView>
     <line-chart-grid-view
       [viewExtent]="viewBox"
       [xScale]="xScale"
       [yScale]="yScale"
-      [xGridCount]="10"
-      [yGridCount]="6"
+      [xGridCount]="X_GRID_COUNT"
+      [yGridCount]="Y_GRID_COUNT"
       [domDim]="domDimensions.main"
     ></line-chart-grid-view>
     <svg #chartEl *ngIf="getRendererType() === RendererType.SVG"></svg>
@@ -53,7 +53,7 @@ limitations under the License.
     axis="y"
     [axisExtent]="viewBox.y"
     [scale]="yScale"
-    [gridCount]="6"
+    [gridCount]="Y_GRID_COUNT"
     [domDim]="domDimensions.yAxis"
   ></line-chart-axis>
   <line-chart-axis
@@ -62,7 +62,7 @@ limitations under the License.
     axis="x"
     [axisExtent]="viewBox.x"
     [scale]="xScale"
-    [gridCount]="10"
+    [gridCount]="X_GRID_COUNT"
     [domDim]="domDimensions.xAxis"
   ></line-chart-axis>
 </div>

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -1,0 +1,57 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+:host {
+  contain: strict;
+  height: 100%;
+  width: 100%;
+}
+
+.container {
+  background: #fff;
+  display: grid;
+  height: 100%;
+  overflow: hidden;
+  width: 100%;
+  grid-template-areas:
+    'yaxis series'
+    '. xaxis';
+  grid-template-columns: 50px 1fr;
+  grid-auto-rows: 1fr 30px;
+}
+
+.series-view {
+  grid-area: series;
+  position: relative;
+  overflow: hidden;
+
+  canvas,
+  svg,
+  line-chart-grid-view,
+  line-chart-interactive-layer {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+}
+
+.x-axis {
+  grid-area: xaxis;
+}
+
+.y-axis {
+  grid-area: yaxis;
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -14,8 +14,7 @@ limitations under the License.
 ==============================================================================*/
 :host {
   contain: strict;
-  height: 100%;
-  width: 100%;
+  display: inline-block;
 }
 
 .container {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -1,0 +1,348 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+
+import {MainThreadChart} from './lib/chart';
+import {Chart} from './lib/chart_types';
+import {
+  ChartCallbacks,
+  ChartOptions,
+  DataSeries,
+  DataSeriesMetadataMap,
+  Extent,
+  RendererType,
+  Scale,
+  ScaleType,
+} from './lib/public_types';
+import {createScale} from './lib/scale';
+import {
+  areExtentsEqual,
+  isOffscreenCanvasSupported,
+  isWebGl2Supported,
+} from './lib/utils';
+import {WorkerChart} from './lib/worker/worker_chart';
+import {
+  computeDataSeriesExtent,
+  getRendererType,
+} from './line_chart_internal_utils';
+import {TooltipTemplate} from './sub_view/line_chart_interactive_view';
+
+export {TooltipTemplate} from './sub_view/line_chart_interactive_view';
+
+const DEFAULT_EXTENT: Extent = {x: [0, 1], y: [0, 1]};
+
+interface DomDimensions {
+  main: {width: number; height: number};
+  yAxis: {width: number; height: number};
+  xAxis: {width: number; height: number};
+}
+
+@Component({
+  selector: 'line-chart',
+  templateUrl: 'line_chart_component.ng.html',
+  styleUrls: ['line_chart_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
+  readonly RendererType = RendererType;
+
+  @ViewChild('main', {static: true, read: ElementRef})
+  private main!: ElementRef<HTMLElement>;
+
+  @ViewChild('xAxis', {static: true, read: ElementRef})
+  private xAxis!: ElementRef<HTMLElement>;
+
+  @ViewChild('yAxis', {static: true, read: ElementRef})
+  private yAxis!: ElementRef<HTMLElement>;
+
+  @ViewChild('chartEl', {static: false, read: ElementRef})
+  private chartEl?: ElementRef<HTMLCanvasElement | SVGElement>;
+
+  @Input()
+  preferredRendererType: RendererType = isWebGl2Supported()
+    ? RendererType.WEBGL
+    : RendererType.SVG;
+
+  @Input()
+  seriesData!: DataSeries[];
+
+  // In case of PR curve line chart, we do not want to compute the viewBox based on the
+  // data.
+  @Input()
+  fixedViewBox?: Extent;
+
+  @Input()
+  seriesMetadataMap!: DataSeriesMetadataMap;
+
+  @Input()
+  xScaleType: ScaleType = ScaleType.LINEAR;
+
+  @Input()
+  yScaleType: ScaleType = ScaleType.LINEAR;
+
+  @Input()
+  tooltipTemplate?: TooltipTemplate;
+
+  xScale: Scale = createScale(this.xScaleType);
+  yScale: Scale = createScale(this.xScaleType);
+  viewBox: Extent = DEFAULT_EXTENT;
+
+  domDimensions: DomDimensions = {
+    main: {width: 0, height: 0},
+    xAxis: {width: 0, height: 0},
+    yAxis: {width: 0, height: 0},
+  };
+
+  private lineChart?: Chart;
+  private dataExtent: Extent = DEFAULT_EXTENT;
+  private isDataUpdated = false;
+  private isMetadataUpdated = false;
+  // Must set the default view extent since it is an optional input.
+  private isViewBoxUpdated = true;
+  private isFixedViewBoxUpdataed = false;
+  private maybeSetViewBoxToDefault = true;
+  private scaleUpdated = false;
+
+  constructor(private readonly changeDetector: ChangeDetectorRef) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    // OnChanges only decides whether props need to be updated and do not directly update
+    // the line chart.
+
+    if (changes['xScaleType']) {
+      this.xScale = createScale(this.xScaleType);
+      this.scaleUpdated = true;
+    }
+
+    if (changes['yScaleType']) {
+      this.yScale = createScale(this.yScaleType);
+      this.scaleUpdated = true;
+    }
+
+    if (changes['seriesData']) {
+      this.isDataUpdated = true;
+    }
+
+    if (changes['defaultViewExtent']) {
+      this.isFixedViewBoxUpdataed = true;
+    }
+
+    if (changes['seriesMetadataMap']) {
+      this.isMetadataUpdated = true;
+    }
+
+    this.maybeSetViewBoxToDefault = this.shouldResetViewExtent(changes);
+
+    this.updateLineChart();
+  }
+
+  ngAfterViewInit() {
+    this.initializeChart();
+    this.updateLineChart();
+  }
+
+  onViewResize() {
+    if (!this.lineChart) return;
+
+    this.readAndUpdateDomDimensions();
+    this.lineChart.resize(this.domDimensions.main);
+    this.changeDetector.detectChanges();
+  }
+
+  private shouldResetViewExtent(changes: SimpleChanges): boolean {
+    if (changes['xScaleType'] || changes['yScaleType']) {
+      return true;
+    }
+
+    const prevDefaultExtent = this.getDefaultViewBox();
+    const wasViewExtentChanged = !areExtentsEqual(
+      prevDefaultExtent,
+      this.viewBox
+    );
+
+    // Don't modify view extent if user has manually changed the view box.
+    if (wasViewExtentChanged) {
+      return false;
+    }
+
+    if (changes['seriesData']) {
+      return true;
+    }
+
+    const seriesMetadataChange = changes['seriesMetadataMap'];
+    if (seriesMetadataChange) {
+      const prevMetadataMap = seriesMetadataChange.previousValue;
+      for (const [id, metadata] of Object.entries(this.seriesMetadataMap)) {
+        const prevMetadata = prevMetadataMap && prevMetadataMap[id];
+        if (!prevMetadata || metadata.visible !== prevMetadata.visible) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private initializeChart() {
+    if (this.lineChart) {
+      throw new Error('LineChart should not be initialized multiple times.');
+    }
+
+    const rendererType = this.getRendererType();
+    // Do not yet need to subscribe to the `onDrawEnd`.
+    const callbacks: ChartCallbacks = {onDrawEnd: () => {}};
+    let params: ChartOptions | null = null;
+
+    this.readAndUpdateDomDimensions();
+
+    switch (rendererType) {
+      case RendererType.SVG: {
+        params = {
+          type: RendererType.SVG,
+          container: this.chartEl!.nativeElement as SVGElement,
+          callbacks,
+          domDimension: this.domDimensions.main,
+        };
+        break;
+      }
+      case RendererType.WEBGL:
+        params = {
+          type: RendererType.WEBGL,
+          container: this.chartEl!.nativeElement as HTMLCanvasElement,
+          devicePixelRatio: window.devicePixelRatio,
+          callbacks,
+          domDimension: this.domDimensions.main,
+        };
+        break;
+      default:
+        const neverRendererType = rendererType as never;
+        throw new Error(
+          `<line-chart> does not yet support rendererType: ${neverRendererType}`
+        );
+    }
+
+    const useWorker =
+      rendererType !== RendererType.SVG && isOffscreenCanvasSupported();
+    const klass = useWorker ? WorkerChart : MainThreadChart;
+    this.lineChart = new klass(params);
+  }
+
+  ngOnDestroy() {
+    if (this.lineChart) this.lineChart.dispose();
+  }
+
+  getRendererType(): RendererType {
+    return getRendererType(this.preferredRendererType);
+  }
+
+  private readAndUpdateDomDimensions(): void {
+    this.domDimensions = {
+      main: {
+        width: this.main.nativeElement.clientWidth,
+        height: this.main.nativeElement.clientHeight,
+      },
+      xAxis: {
+        width: this.xAxis.nativeElement.clientWidth,
+        height: this.xAxis.nativeElement.clientHeight,
+      },
+      yAxis: {
+        width: this.yAxis.nativeElement.clientWidth,
+        height: this.yAxis.nativeElement.clientHeight,
+      },
+    };
+  }
+
+  /**
+   * Minimally and imperatively updates the chart library depending on prop changed.
+   */
+  private updateLineChart() {
+    if (!this.lineChart) return;
+
+    if (this.scaleUpdated) {
+      this.scaleUpdated = false;
+      this.lineChart.setXScaleType(this.xScaleType);
+      this.lineChart.setYScaleType(this.yScaleType);
+    }
+
+    if (this.isMetadataUpdated) {
+      this.isMetadataUpdated = false;
+      this.lineChart.setMetadata(this.seriesMetadataMap);
+    }
+
+    if (this.isDataUpdated) {
+      this.isDataUpdated = false;
+      this.lineChart.setData(this.seriesData);
+    }
+
+    // There are below conditions in which the viewExtent changes.
+    const viewBoxChange =
+      this.isFixedViewBoxUpdataed ||
+      this.isViewBoxUpdated ||
+      this.maybeSetViewBoxToDefault;
+
+    if (this.isFixedViewBoxUpdataed && this.fixedViewBox) {
+      this.viewBox = this.fixedViewBox;
+    } else if (this.maybeSetViewBoxToDefault) {
+      const dataExtent = computeDataSeriesExtent(
+        this.seriesData,
+        this.seriesMetadataMap
+      );
+
+      this.dataExtent = {
+        x: dataExtent.x ?? DEFAULT_EXTENT.x,
+        y: dataExtent.y ?? DEFAULT_EXTENT.y,
+      };
+      this.viewBox = this.getDefaultViewBox();
+    }
+
+    if (viewBoxChange) {
+      this.isFixedViewBoxUpdataed = false;
+      this.isViewBoxUpdated = false;
+      this.maybeSetViewBoxToDefault = false;
+      this.lineChart.setViewBox(this.viewBox);
+    }
+  }
+
+  onViewBoxChanged({dataExtent}: {dataExtent: Extent}) {
+    this.isViewBoxUpdated = true;
+    this.viewBox = dataExtent;
+    this.updateLineChart();
+  }
+
+  onViewBoxReset() {
+    this.maybeSetViewBoxToDefault = true;
+    this.updateLineChart();
+  }
+
+  private getDefaultViewBox(): Extent {
+    return this.fixedViewBox
+      ? this.fixedViewBox
+      : {
+          x: this.xScale.niceDomain(this.dataExtent.x),
+          y: this.yScale.niceDomain(this.dataExtent.y),
+        };
+  }
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -117,8 +117,9 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
   private isDataUpdated = false;
   private isMetadataUpdated = false;
   private isFixedViewBoxUpdated = false;
-  // Must set the default view box since it is an optional input.
   private isViewBoxOverriden = false;
+  // Must set the default view box since it is an optional input and won't trigger
+  // onChanges.
   private isViewBoxChanged = true;
   private scaleUpdated = true;
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -38,7 +38,7 @@ import {
   ScaleType,
 } from './lib/public_types';
 import {createScale} from './lib/scale';
-import {areExtentsEqual, isOffscreenCanvasSupported} from './lib/utils';
+import {isOffscreenCanvasSupported} from './lib/utils';
 import {WorkerChart} from './lib/worker/worker_chart';
 import {
   computeDataSeriesExtent,

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -1,0 +1,329 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {OverlayModule} from '@angular/cdk/overlay';
+import {CommonModule} from '@angular/common';
+import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {MainThreadChart} from './lib/chart';
+import {
+  DataSeries,
+  DataSeriesMetadataMap,
+  Extent,
+  RendererType,
+  ScaleType,
+} from './lib/public_types';
+import {buildMetadata, buildSeries} from './lib/testing';
+import {LineChartComponent} from './line_chart_component';
+
+@Component({
+  selector: 'testable-comp',
+  template: `
+    <line-chart
+      #chart
+      [preferredRendererType]="preferredRendererType"
+      [seriesData]="seriesData"
+      [seriesMetadataMap]="seriesMetadataMap"
+      [yScaleType]="yScaleType"
+      [fixedViewBox]="fixedViewBox"
+    ></line-chart>
+  `,
+  styles: [
+    `
+      line-chart {
+        height: 100px;
+        position: fixed;
+        width: 200px;
+      }
+    `,
+  ],
+})
+class TestableComponent {
+  @ViewChild(LineChartComponent)
+  chart!: LineChartComponent;
+
+  @Input()
+  seriesData!: DataSeries[];
+
+  @Input()
+  seriesMetadataMap!: DataSeriesMetadataMap;
+
+  @Input()
+  yScaleType!: ScaleType;
+
+  @Input()
+  fixedViewBox?: Extent;
+
+  // WebGL one is harder to test.
+  preferredRendererType = RendererType.SVG;
+
+  triggerViewBoxChange(viewBox: Extent) {
+    this.chart.onViewBoxChanged({dataExtent: viewBox});
+  }
+}
+
+describe('line_chart_v2/line_chart test', () => {
+  let resizeSpy: jasmine.Spy;
+  let disposeSpy: jasmine.Spy;
+  let setXScaleTypeSpy: jasmine.Spy;
+  let setYScaleTypeSpy: jasmine.Spy;
+  let updateMetadataSpy: jasmine.Spy;
+  let updateDataSpy: jasmine.Spy;
+  let updateViewBoxSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestableComponent, LineChartComponent],
+      imports: [CommonModule, OverlayModule],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    resizeSpy = spyOn(MainThreadChart.prototype, 'resize');
+    disposeSpy = spyOn(MainThreadChart.prototype, 'dispose');
+    setXScaleTypeSpy = spyOn(MainThreadChart.prototype, 'setXScaleType');
+    setYScaleTypeSpy = spyOn(MainThreadChart.prototype, 'setYScaleType');
+    updateMetadataSpy = spyOn(MainThreadChart.prototype, 'setMetadata');
+    updateDataSpy = spyOn(MainThreadChart.prototype, 'setData');
+    updateViewBoxSpy = spyOn(MainThreadChart.prototype, 'setViewBox');
+  });
+
+  function createComponent(input: {
+    seriesData: DataSeries[];
+    seriesMetadataMap: DataSeriesMetadataMap;
+    yScaleType: ScaleType;
+    fixedViewBox?: Extent;
+  }): ComponentFixture<TestableComponent> {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.componentInstance.seriesData = input.seriesData;
+    fixture.componentInstance.seriesMetadataMap = input.seriesMetadataMap;
+    fixture.componentInstance.yScaleType = input.yScaleType;
+
+    if (input.fixedViewBox) {
+      fixture.componentInstance.fixedViewBox = input.fixedViewBox;
+    }
+
+    return fixture;
+  }
+
+  it('sets axis, data, metadata, viewBox, and resize when created', () => {
+    const fixture = createComponent({
+      seriesData: [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+          ],
+        }),
+      ],
+      seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+      yScaleType: ScaleType.LINEAR,
+    });
+    fixture.detectChanges();
+
+    expect(disposeSpy).toHaveBeenCalledTimes(0);
+    // line chart DOM dimensions are measured as the component is created.
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+
+    expect(setXScaleTypeSpy).toHaveBeenCalledTimes(1);
+    expect(setXScaleTypeSpy).toHaveBeenCalledWith(ScaleType.LINEAR);
+
+    expect(setYScaleTypeSpy).toHaveBeenCalledTimes(1);
+    expect(setYScaleTypeSpy).toHaveBeenCalledWith(ScaleType.LINEAR);
+
+    expect(updateMetadataSpy).toHaveBeenCalledTimes(1);
+    expect(updateMetadataSpy).toHaveBeenCalledWith({
+      foo: buildMetadata({id: 'foo', visible: true}),
+    });
+
+    expect(updateDataSpy).toHaveBeenCalledTimes(1);
+    expect(updateDataSpy).toHaveBeenCalledWith([
+      buildSeries({
+        id: 'foo',
+        points: [
+          {x: 0, y: 0},
+          {x: 1, y: -1},
+          {x: 2, y: 1},
+        ],
+      }),
+    ]);
+
+    expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
+    expect(updateViewBoxSpy).toHaveBeenCalledWith({
+      x: [-0.2, 2.2],
+      y: [-1.2, 1.2],
+    });
+  });
+
+  it('uses the fixedViewBox when configured', () => {
+    const fixture = createComponent({
+      seriesData: [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+          ],
+        }),
+      ],
+      seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+      yScaleType: ScaleType.LINEAR,
+      fixedViewBox: {
+        x: [-100, 100],
+        y: [0, 1],
+      },
+    });
+    fixture.detectChanges();
+
+    expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
+    expect(updateViewBoxSpy).toHaveBeenCalledWith({
+      x: [-100, 100],
+      y: [0, 1],
+    });
+  });
+
+  it('updates only scaleType when updating scaleType', () => {
+    const fixture = createComponent({
+      seriesData: [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+          ],
+        }),
+      ],
+      seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+      yScaleType: ScaleType.LINEAR,
+    });
+    fixture.detectChanges();
+
+    fixture.componentInstance.yScaleType = ScaleType.LOG10;
+    fixture.detectChanges();
+
+    expect(setXScaleTypeSpy).toHaveBeenCalledTimes(2);
+    expect(setYScaleTypeSpy).toHaveBeenCalledTimes(2);
+    // `niceDomain` logic can change depending on the scale change.
+    expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
+
+    expect(disposeSpy).toHaveBeenCalledTimes(0);
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+    expect(updateMetadataSpy).toHaveBeenCalledTimes(1);
+    expect(updateDataSpy).toHaveBeenCalledTimes(1);
+  });
+
+  describe('data change', () => {
+    it('updates data and viewBox when data changes', () => {
+      const fixture = createComponent({
+        seriesData: [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 0, y: 0},
+              {x: 1, y: -1},
+              {x: 2, y: 1},
+            ],
+          }),
+        ],
+        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.detectChanges();
+
+      fixture.componentInstance.seriesData = [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+            {x: 3, y: 0},
+            {x: 4, y: 2},
+          ],
+        }),
+      ];
+      fixture.detectChanges();
+
+      expect(disposeSpy).toHaveBeenCalledTimes(0);
+      expect(setXScaleTypeSpy).toHaveBeenCalledTimes(1);
+      expect(setYScaleTypeSpy).toHaveBeenCalledTimes(1);
+      expect(resizeSpy).toHaveBeenCalledTimes(1);
+      expect(updateMetadataSpy).toHaveBeenCalledTimes(1);
+
+      expect(updateDataSpy).toHaveBeenCalledTimes(2);
+      // when data changes, we want to recompute the domain and fit it.
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not change the viewBox when it was modified manually', () => {
+      const fixture = createComponent({
+        seriesData: [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 0, y: 0},
+              {x: 1, y: -1},
+              {x: 2, y: 1},
+            ],
+          }),
+        ],
+        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.detectChanges();
+
+      fixture.componentInstance.triggerViewBoxChange({
+        x: [-5, 5],
+        y: [0, 10],
+      });
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
+
+      fixture.componentInstance.seriesData = [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+            {x: 3, y: 0},
+            {x: 4, y: 2},
+          ],
+        }),
+      ];
+      fixture.detectChanges();
+
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('sets [0, 1] viewBox when seriesData is empty', () => {
+    const fixture = createComponent({
+      seriesData: [],
+      seriesMetadataMap: {},
+      yScaleType: ScaleType.LINEAR,
+    });
+    fixture.detectChanges();
+
+    expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
+    expect(updateViewBoxSpy).toHaveBeenCalledWith({
+      x: [-0.1, 1.1],
+      y: [-0.1, 1.1],
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -75,7 +75,7 @@ class TestableComponent {
   }
 }
 
-fdescribe('line_chart_v2/line_chart test', () => {
+describe('line_chart_v2/line_chart test', () => {
   let resizeSpy: jasmine.Spy;
   let disposeSpy: jasmine.Spy;
   let setXScaleTypeSpy: jasmine.Spy;

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -75,7 +75,7 @@ class TestableComponent {
   }
 }
 
-describe('line_chart_v2/line_chart test', () => {
+fdescribe('line_chart_v2/line_chart test', () => {
   let resizeSpy: jasmine.Spy;
   let disposeSpy: jasmine.Spy;
   let setXScaleTypeSpy: jasmine.Spy;
@@ -268,6 +268,30 @@ describe('line_chart_v2/line_chart test', () => {
 
       expect(updateDataSpy).toHaveBeenCalledTimes(2);
       // when data changes, we want to recompute the domain and fit it.
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('updates viewBox when metadata map updates', () => {
+      const fixture = createComponent({
+        seriesData: [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 0, y: 0},
+              {x: 1, y: -1},
+              {x: 2, y: 1},
+            ],
+          }),
+        ],
+        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.detectChanges();
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
+
+      fixture.componentInstance.seriesMetadataMap = {};
+      fixture.detectChanges();
+
       expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
     });
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils.ts
@@ -1,0 +1,78 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  DataSeries,
+  DataSeriesMetadataMap,
+  RendererType,
+} from './lib/public_types';
+import {isWebGl2Supported} from './lib/utils';
+
+/**
+ * Returns extent, min and max values of each dimensions, of all data series points.
+ *
+ * Note that it excludes auxillary data points and invisible data series.
+ *
+ * TODO(stephanwlee): add support for ignoreOutlier.
+ */
+export function computeDataSeriesExtent(
+  data: DataSeries[],
+  metadataMap: DataSeriesMetadataMap
+): {x: [number, number] | undefined; y: [number, number] | undefined} {
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+
+  let xExtentChanged = false;
+  let yExtentChanged = false;
+
+  for (const {id, points} of data) {
+    const meta = metadataMap[id];
+    if (!meta || meta.aux || !meta.visible) continue;
+
+    for (let index = 0; index < points.length; index++) {
+      const {x, y} = points[index];
+      if (!Number.isNaN(x)) {
+        xMin = Math.min(xMin, x);
+        xMax = Math.max(xMax, x);
+        xExtentChanged = true;
+      }
+      if (!Number.isNaN(y)) {
+        yMin = Math.min(yMin, y);
+        yMax = Math.max(yMax, y);
+        yExtentChanged = true;
+      }
+    }
+  }
+
+  return {
+    x: xExtentChanged ? [xMin, xMax] : undefined,
+    y: yExtentChanged ? [yMin, yMax] : undefined,
+  };
+}
+
+export function getRendererType(
+  preferredRendererType: RendererType
+): RendererType {
+  switch (preferredRendererType) {
+    case RendererType.SVG:
+      return RendererType.SVG;
+    case RendererType.WEBGL:
+      return isWebGl2Supported() ? RendererType.WEBGL : RendererType.SVG;
+    default:
+      const _ = preferredRendererType as never;
+      throw new Error(`Unknown rendererType: ${preferredRendererType}`);
+  }
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils_test.ts
@@ -1,0 +1,246 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {
+  computeDataSeriesExtent,
+  getRendererType,
+} from './line_chart_internal_utils';
+import * as libUtils from './lib/utils';
+import {RendererType} from './lib/public_types';
+import {buildSeries, buildMetadata} from './lib/testing';
+
+describe('line_chart_v2/line_chart_internal_utils test', () => {
+  describe('#computeDataSeriesExtent', () => {
+    it('returns min and max from all series', () => {
+      const actual = computeDataSeriesExtent(
+        [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 1, y: -1},
+              {x: 2, y: -10},
+              {x: 3, y: 100},
+            ],
+          }),
+          buildSeries({
+            id: 'bar',
+            points: [
+              {x: -100, y: 0},
+              {x: 0, y: -1},
+              {x: -1000, y: 1},
+            ],
+          }),
+        ],
+        {
+          foo: buildMetadata({id: 'foo', visible: true}),
+          bar: buildMetadata({id: 'bar', visible: true}),
+        }
+      );
+
+      expect(actual).toEqual({x: [-1000, 3], y: [-10, 100]});
+    });
+
+    it('handles single dataSeries point', () => {
+      const actual = computeDataSeriesExtent(
+        [
+          buildSeries({
+            id: 'foo',
+            points: [{x: 1, y: -1}],
+          }),
+        ],
+        {
+          foo: buildMetadata({id: 'foo', visible: true}),
+        }
+      );
+
+      expect(actual).toEqual({x: [1, 1], y: [-1, -1]});
+    });
+
+    it('ignores dataseries that is visibility=false', () => {
+      const actual = computeDataSeriesExtent(
+        [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 1, y: -1},
+              {x: 2, y: -10},
+              {x: 3, y: 100},
+            ],
+          }),
+          buildSeries({
+            id: 'bar',
+            points: [
+              {x: -100, y: 0},
+              {x: -1000, y: 1},
+            ],
+          }),
+        ],
+        {
+          foo: buildMetadata({id: 'foo', visible: true}),
+          bar: buildMetadata({id: 'bar', visible: false}),
+        }
+      );
+
+      expect(actual).toEqual({x: [1, 3], y: [-10, 100]});
+    });
+
+    it('ignores dataseries that is aux', () => {
+      const actual = computeDataSeriesExtent(
+        [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 1, y: -1},
+              {x: 2, y: -10},
+              {x: 3, y: 100},
+            ],
+          }),
+          buildSeries({
+            id: 'bar',
+            points: [
+              {x: -100, y: 0},
+              {x: -1000, y: 1},
+            ],
+          }),
+        ],
+        {
+          foo: buildMetadata({id: 'foo', visible: true, aux: true}),
+          bar: buildMetadata({id: 'bar'}),
+        }
+      );
+
+      expect(actual).toEqual({x: [-1000, -100], y: [0, 1]});
+    });
+
+    it('ignores dataseries without metadata', () => {
+      const actual = computeDataSeriesExtent(
+        [
+          buildSeries({id: 'foo', points: [{x: 1, y: -1}]}),
+          buildSeries({
+            id: 'bar',
+            points: [
+              {x: -100, y: 0},
+              {x: -1000, y: 1},
+            ],
+          }),
+        ],
+        {
+          bar: buildMetadata({id: 'bar'}),
+        }
+      );
+
+      expect(actual).toEqual({x: [-1000, -100], y: [0, 1]});
+    });
+
+    it('filters out NaN and keeps infinity', () => {
+      const actual = computeDataSeriesExtent(
+        [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 1, y: -1},
+              {x: 2, y: Infinity},
+              {x: 3, y: NaN},
+              {x: 4, y: -1},
+            ],
+          }),
+        ],
+        {
+          foo: buildMetadata({id: 'foo'}),
+        }
+      );
+
+      expect(actual).toEqual({x: [1, 4], y: [-1, Infinity]});
+    });
+
+    it('returns infinities when nothing is visible', () => {
+      const actual = computeDataSeriesExtent(
+        [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 1, y: -1},
+              {x: 2, y: -10},
+              {x: 3, y: 100},
+            ],
+          }),
+          buildSeries({
+            id: 'bar',
+            points: [
+              {x: -100, y: 0},
+              {x: -1000, y: 1},
+            ],
+          }),
+        ],
+        {
+          foo: buildMetadata({id: 'foo', visible: false}),
+          bar: buildMetadata({id: 'bar', visible: false}),
+        }
+      );
+
+      expect(actual).toEqual({
+        x: undefined,
+        y: undefined,
+      });
+    });
+
+    it('returns infinities when dataSeries is empty', () => {
+      const actual = computeDataSeriesExtent([], {});
+
+      expect(actual).toEqual({
+        x: undefined,
+        y: undefined,
+      });
+    });
+
+    it('returns infinities when dataSeries is all NaN', () => {
+      const actual = computeDataSeriesExtent(
+        [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: NaN, y: NaN},
+              {x: NaN, y: NaN},
+            ],
+          }),
+        ],
+        {
+          foo: buildMetadata({id: 'foo', visible: true}),
+        }
+      );
+
+      expect(actual).toEqual({
+        x: undefined,
+        y: undefined,
+      });
+    });
+  });
+
+  describe('#getRendererType', () => {
+    it('returns svg when preferred svg', () => {
+      expect(getRendererType(RendererType.SVG)).toBe(RendererType.SVG);
+    });
+
+    it('returns webgl if webgl2 is supported', () => {
+      spyOn(libUtils, 'isWebGl2Supported').and.returnValue(true);
+      expect(getRendererType(RendererType.WEBGL)).toBe(RendererType.WEBGL);
+    });
+
+    it('returns svg if webgl2 is not supported', () => {
+      spyOn(libUtils, 'isWebGl2Supported').and.returnValue(false);
+      expect(getRendererType(RendererType.WEBGL)).toBe(RendererType.SVG);
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils_test.ts
@@ -165,7 +165,7 @@ describe('line_chart_v2/line_chart_internal_utils test', () => {
       expect(actual).toEqual({x: [1, 4], y: [-1, Infinity]});
     });
 
-    it('returns infinities when nothing is visible', () => {
+    it('returns undefined when nothing is visible', () => {
       const actual = computeDataSeriesExtent(
         [
           buildSeries({

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils_test.ts
@@ -196,7 +196,7 @@ describe('line_chart_v2/line_chart_internal_utils test', () => {
       });
     });
 
-    it('returns infinities when dataSeries is empty', () => {
+    it('returns undefined when dataSeries is empty', () => {
       const actual = computeDataSeriesExtent([], {});
 
       expect(actual).toEqual({
@@ -205,7 +205,7 @@ describe('line_chart_v2/line_chart_internal_utils test', () => {
       });
     });
 
-    it('returns infinities when dataSeries is all NaN', () => {
+    it('returns undefined when dataSeries is all NaN', () => {
       const actual = computeDataSeriesExtent(
         [
           buildSeries({

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_module.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_module.ts
@@ -1,0 +1,28 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {OverlayModule} from '@angular/cdk/overlay';
+
+import {LineChartComponent} from './line_chart_component';
+import {SubViewModule} from './sub_view/sub_view_module';
+import {ResizeDetectorModule} from '../resize_detector_module';
+
+@NgModule({
+  declarations: [LineChartComponent],
+  exports: [LineChartComponent],
+  imports: [CommonModule, OverlayModule, SubViewModule, ResizeDetectorModule],
+})
+export class LineChartModule {}


### PR DESCRIPTION
This change adds the Angular entry point for rendering a line chart using the
GPU line chart framework; it composes sub views and the charting library we've
been working on.

The major complexity lies in two aspects:
- detecting condition in which it should reset the viewBox
- making the minimal imperative API calls to the chart library depending on prop
  changed.

