### PR TITLE
line chart: fix issues with line chart

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -335,6 +335,7 @@ tf_web_library(
         "//tensorboard/webapp:index.html",
         "//tensorboard/webapp:index.js",
         "//tensorboard/webapp:svg_bundle",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:chart_worker.js",
     ],
     path = "/",
     deps = [

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/chart.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/chart.ts
@@ -40,10 +40,11 @@ import {ThreeCoordinator} from './threejs_coordinator';
  * authoring more cumbersome.
  */
 const util = {
-  requestAnimationFrame: window.requestAnimationFrame,
+  requestAnimationFrame: (cb: FrameRequestCallback) =>
+    self.requestAnimationFrame(cb),
 };
 
-export class MainThreadChart implements Chart {
+export class ChartImpl implements Chart {
   private readonly renderer: ObjectRenderer;
   private readonly seriesLineView: SeriesLineView;
   private readonly coordinator: Coordinator;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/integration_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/integration_test.ts
@@ -13,14 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {MainThreadChart, TEST_ONLY} from './chart';
+import {ChartImpl, TEST_ONLY} from './chart';
 import {ChartCallbacks, RendererType, ScaleType} from './public_types';
 import {buildMetadata, createSeries} from './testing';
 
 describe('line_chart_v2/lib/integration test', () => {
   let dom: SVGElement;
   let callbacks: ChartCallbacks;
-  let chart: MainThreadChart;
+  let chart: ChartImpl;
   let rafSpy: jasmine.Spy;
 
   beforeEach(() => {
@@ -34,7 +34,7 @@ describe('line_chart_v2/lib/integration test', () => {
     callbacks = {
       onDrawEnd: jasmine.createSpy(),
     };
-    chart = new MainThreadChart({
+    chart = new ChartImpl({
       type: RendererType.SVG,
       container: dom,
       callbacks,

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_bridge.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_bridge.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {MainThreadChart} from '../chart';
+import {ChartImpl} from '../chart';
 import {ChartOptions} from '../chart_types';
 import {decompactDataSeries} from './compact_data_series';
 import {
@@ -56,7 +56,7 @@ function createPortHandler(port: MessagePort, initMessage: InitMessage) {
       );
   }
 
-  const lineChart = new MainThreadChart(chartOptions);
+  const lineChart = new ChartImpl(chartOptions);
 
   port.onmessage = function (event: MessageEvent) {
     const message = event.data as HostToGuestMessage;

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -38,7 +38,7 @@ limitations under the License.
   canvas,
   svg,
   line-chart-grid-view,
-  line-chart-interactive-layer {
+  line-chart-interactive-view {
     height: 100%;
     left: 0;
     position: absolute;

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -25,7 +25,7 @@ import {
   ViewChild,
 } from '@angular/core';
 
-import {MainThreadChart} from './lib/chart';
+import {ChartImpl} from './lib/chart';
 import {Chart} from './lib/chart_types';
 import {
   ChartCallbacks,
@@ -257,7 +257,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     const useWorker =
       rendererType !== RendererType.SVG && isOffscreenCanvasSupported();
-    const klass = useWorker ? WorkerChart : MainThreadChart;
+    const klass = useWorker ? WorkerChart : ChartImpl;
     this.lineChart = new klass(params);
   }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -18,7 +18,7 @@ import {CommonModule} from '@angular/common';
 import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
-import {MainThreadChart} from './lib/chart';
+import {ChartImpl} from './lib/chart';
 import {
   DataSeries,
   DataSeriesMetadataMap,
@@ -91,13 +91,13 @@ describe('line_chart_v2/line_chart test', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
-    resizeSpy = spyOn(MainThreadChart.prototype, 'resize');
-    disposeSpy = spyOn(MainThreadChart.prototype, 'dispose');
-    setXScaleTypeSpy = spyOn(MainThreadChart.prototype, 'setXScaleType');
-    setYScaleTypeSpy = spyOn(MainThreadChart.prototype, 'setYScaleType');
-    updateMetadataSpy = spyOn(MainThreadChart.prototype, 'setMetadata');
-    updateDataSpy = spyOn(MainThreadChart.prototype, 'setData');
-    updateViewBoxSpy = spyOn(MainThreadChart.prototype, 'setViewBox');
+    resizeSpy = spyOn(ChartImpl.prototype, 'resize');
+    disposeSpy = spyOn(ChartImpl.prototype, 'dispose');
+    setXScaleTypeSpy = spyOn(ChartImpl.prototype, 'setXScaleType');
+    setYScaleTypeSpy = spyOn(ChartImpl.prototype, 'setYScaleType');
+    updateMetadataSpy = spyOn(ChartImpl.prototype, 'setMetadata');
+    updateDataSpy = spyOn(ChartImpl.prototype, 'setData');
+    updateViewBoxSpy = spyOn(ChartImpl.prototype, 'setViewBox');
   });
 
   function createComponent(input: {


### PR DESCRIPTION
When the demo was exercised, it revealed several issues with the
GpuLineChart.

Issues are:
- worker resource files are not served by the app
- requestAnimationFrame used by chart.ts in context of worker misses
  reference to `window` and causes invocation error as is.
  - refactored the "MainThreadChart" to "ChartImpl" since it is not
    meant to only be used in the "main thread"
