### PR TITLE
line chart: add utility for smoothing line chart

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -83,14 +83,26 @@ tf_web_library(
 )
 
 tf_ts_library(
+    name = "line_chart_utils",
+    srcs = [
+        "data_transformer.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+    ],
+)
+
+tf_ts_library(
     name = "line_chart_v2_tests",
     testonly = True,
     srcs = [
+        "data_transformer_test.ts",
         "line_chart_component_test.ts",
         "line_chart_internal_utils_test.ts",
     ],
     deps = [
         ":internal_utils",
+        ":line_chart_utils",
         ":line_chart_v2",
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "//tensorboard/webapp/angular:expect_angular_core_testing",

--- a/tensorboard/webapp/widgets/line_chart_v2/data_transformer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/data_transformer.ts
@@ -1,0 +1,99 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {DataSeries} from './lib/public_types';
+
+/**
+ * Smoothes data series in y axis using smoothing algorithm from classical TensorBoard
+ * circa 2019-2020. 1st-order IIR low-pass filter to attenuate the higher-frequency
+ * components of the time-series.
+ * @param data DataSeries to smooth
+ * @param smoothingWeight Degree of smoothing. Number between 0 and 1, inclusive.
+ */
+export async function classicSmoothing(
+  data: DataSeries[],
+  smoothingWeight: number
+): Promise<Array<{srcId: string; points: DataSeries['points']}>> {
+  if (!data.length) [];
+
+  if (!Number.isFinite(smoothingWeight)) {
+    smoothingWeight = 0;
+  }
+  smoothingWeight = Math.max(0, Math.min(smoothingWeight, 1));
+
+  const results: Array<{srcId: string; points: DataSeries['points']}> = [];
+
+  for (const series of data) {
+    if (!series.points.length) {
+      results.push({
+        srcId: series.id,
+        points: [],
+      });
+      continue;
+    }
+
+    let last = series.points.length > 0 ? 0 : NaN;
+    let numAccum = 0;
+
+    const initialYVal = series.points[0].y;
+    const isConstant = series.points.every((point) => point.y == initialYVal);
+
+    // See #786.
+    if (isConstant) {
+      // No need to prepend smoothed data.
+      results.push({
+        srcId: series.id,
+        points: series.points,
+      });
+      continue;
+    }
+
+    const smoothedPoints = series.points.map((point) => {
+      const nextVal = point.y;
+      if (!Number.isFinite(nextVal)) {
+        return {
+          x: point.x,
+          y: nextVal,
+        };
+      } else {
+        last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;
+        numAccum++;
+        // The uncorrected moving average is biased towards the initial value.
+        // For example, if initialized with `0`, with smoothingWeight `s`, where
+        // every data point is `c`, after `t` steps the moving average is
+        // ```
+        //   EMA = 0*s^(t) + c*(1 - s)*s^(t-1) + c*(1 - s)*s^(t-2) + ...
+        //       = c*(1 - s^t)
+        // ```
+        // If initialized with `0`, dividing by (1 - s^t) is enough to debias
+        // the moving average. We count the number of finite data points and
+        // divide appropriately before storing the data.
+        const debiasWeight =
+          smoothingWeight === 1 ? 1 : 1 - Math.pow(smoothingWeight, numAccum);
+
+        return {
+          x: point.x,
+          y: last / debiasWeight,
+        };
+      }
+    });
+    results.push({
+      srcId: series.id,
+      points: smoothedPoints,
+    });
+  }
+
+  return results;
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/data_transformer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/data_transformer_test.ts
@@ -44,7 +44,7 @@ describe('line_chart_v2/data_transformer test', () => {
       const actual = await classicSmoothing(dataSeries, 0.6);
       expect(actual).toEqual([
         {
-          srcId: 's1',
+          id: 's1',
           points: [
             // 0.4 * 1 / (1 - 0.6^1) = 1
             {x: 0, y: 1},
@@ -60,7 +60,7 @@ describe('line_chart_v2/data_transformer test', () => {
           ],
         },
         {
-          srcId: 's2',
+          id: 's2',
           points: [
             {x: 0, y: 0},
             // (0.5 * 0.4) / (1 - 0.6^2) = 0.3125
@@ -70,7 +70,7 @@ describe('line_chart_v2/data_transformer test', () => {
           ],
         },
         {
-          srcId: 's3',
+          id: 's3',
           points: [],
         },
       ]);
@@ -98,7 +98,7 @@ describe('line_chart_v2/data_transformer test', () => {
       const actual = await classicSmoothing(dataSeries, 0.0);
       expect(actual).toEqual([
         {
-          srcId: 's1',
+          id: 's1',
           points: [
             {x: 0, y: 1},
             {x: 1, y: 0.5},
@@ -106,7 +106,7 @@ describe('line_chart_v2/data_transformer test', () => {
           ],
         },
         {
-          srcId: 's2',
+          id: 's2',
           points: [
             {x: 0, y: 0},
             {x: 1, y: 0.5},
@@ -134,7 +134,7 @@ describe('line_chart_v2/data_transformer test', () => {
       );
       expect(actual).toEqual([
         {
-          srcId: 's1',
+          id: 's1',
           points: [
             {x: 0, y: -Infinity},
             {x: 0, y: 1},
@@ -163,7 +163,7 @@ describe('line_chart_v2/data_transformer test', () => {
       );
       expect(actual).toEqual([
         {
-          srcId: 's1',
+          id: 's1',
           points: [
             {x: 0, y: 0},
             {x: 1, y: 0},
@@ -189,7 +189,7 @@ describe('line_chart_v2/data_transformer test', () => {
       );
       expect(actual).toEqual([
         {
-          srcId: 's1',
+          id: 's1',
           points: [
             {x: 0, y: 0.3},
             {x: 1, y: 0.3},
@@ -216,7 +216,7 @@ describe('line_chart_v2/data_transformer test', () => {
           );
           expect(actual).toEqual([
             {
-              srcId: 's1',
+              id: 's1',
               points: [
                 {x: 0, y: 1},
                 {x: 1, y: 0.5},
@@ -241,7 +241,7 @@ describe('line_chart_v2/data_transformer test', () => {
         );
         expect(actual).toEqual([
           {
-            srcId: 's1',
+            id: 's1',
             points: [
               {x: 0, y: 0},
               {x: 1, y: 0},

--- a/tensorboard/webapp/widgets/line_chart_v2/data_transformer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/data_transformer_test.ts
@@ -1,0 +1,254 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {classicSmoothing} from './data_transformer';
+import {buildSeries} from './lib/testing';
+
+describe('line_chart_v2/data_transformer test', () => {
+  describe('#classicSmoothing', () => {
+    it('smoothes data series', async () => {
+      const dataSeries = [
+        buildSeries({
+          id: 's1',
+          points: [
+            {x: 0, y: 1},
+            {x: 1, y: 0.5},
+            {x: 2, y: 0},
+          ],
+        }),
+        buildSeries({
+          id: 's2',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 0.5},
+            {x: 2, y: 1},
+          ],
+        }),
+        buildSeries({
+          id: 's3',
+          points: [],
+        }),
+      ];
+      const actual = await classicSmoothing(dataSeries, 0.6);
+      expect(actual).toEqual([
+        {
+          srcId: 's1',
+          points: [
+            // 0.4 * 1 / (1 - 0.6^1) = 1
+            {x: 0, y: 1},
+            // (0.5 * 0.4 + 0.4 * 1 * 0.6) / (1 - 0.6^2) = 0.6875
+            {x: 1, y: 0.6875},
+            // ~ 0.33673
+            {
+              x: 2,
+              y:
+                ((0.5 * 0.4 + 0.4 * 1 * 0.6) * 0.6 + 0) /
+                (1 - Math.pow(0.6, 3)),
+            },
+          ],
+        },
+        {
+          srcId: 's2',
+          points: [
+            {x: 0, y: 0},
+            // (0.5 * 0.4) / (1 - 0.6^2) = 0.3125
+            {x: 1, y: 0.3125},
+            // ~0.6633
+            {x: 2, y: (1 * 0.4 + 0.5 * 0.4 * 0.6) / (1 - Math.pow(0.6, 3))},
+          ],
+        },
+        {
+          srcId: 's3',
+          points: [],
+        },
+      ]);
+    });
+
+    it('does not smooth at all when weight is 0', async () => {
+      const dataSeries = [
+        buildSeries({
+          id: 's1',
+          points: [
+            {x: 0, y: 1},
+            {x: 1, y: 0.5},
+            {x: 2, y: 0},
+          ],
+        }),
+        buildSeries({
+          id: 's2',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 0.5},
+            {x: 2, y: 1},
+          ],
+        }),
+      ];
+      const actual = await classicSmoothing(dataSeries, 0.0);
+      expect(actual).toEqual([
+        {
+          srcId: 's1',
+          points: [
+            {x: 0, y: 1},
+            {x: 1, y: 0.5},
+            {x: 2, y: 0},
+          ],
+        },
+        {
+          srcId: 's2',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 0.5},
+            {x: 2, y: 1},
+          ],
+        },
+      ]);
+    });
+
+    it('omits not finite values in smoothing', async () => {
+      const actual = await classicSmoothing(
+        [
+          buildSeries({
+            id: 's1',
+            points: [
+              {x: 0, y: -Infinity},
+              {x: 0, y: 1},
+              {x: 0.5, y: NaN},
+              {x: 0.75, y: Infinity},
+              {x: 1, y: 0.5},
+            ],
+          }),
+        ],
+        0.6
+      );
+      expect(actual).toEqual([
+        {
+          srcId: 's1',
+          points: [
+            {x: 0, y: -Infinity},
+            {x: 0, y: 1},
+            {x: 0.5, y: NaN},
+            {x: 0.75, y: Infinity},
+            // Please refer to the "smoothes data series" spec for details of this value.
+            {x: 1, y: 0.6875},
+          ],
+        },
+      ]);
+    });
+
+    it('returns 0 when smoothing weight is 1', async () => {
+      const actual = await classicSmoothing(
+        [
+          buildSeries({
+            id: 's1',
+            points: [
+              {x: 0, y: 1},
+              {x: 1, y: 0.5},
+              {x: 2, y: 0},
+            ],
+          }),
+        ],
+        1
+      );
+      expect(actual).toEqual([
+        {
+          srcId: 's1',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 0},
+            {x: 2, y: 0},
+          ],
+        },
+      ]);
+    });
+
+    it('does not inject floating point noise when numbers are constant', async () => {
+      const actual = await classicSmoothing(
+        [
+          buildSeries({
+            id: 's1',
+            points: [
+              {x: 0, y: 0.3},
+              {x: 1, y: 0.3},
+              {x: 2, y: 0.3},
+            ],
+          }),
+        ],
+        0.1
+      );
+      expect(actual).toEqual([
+        {
+          srcId: 's1',
+          points: [
+            {x: 0, y: 0.3},
+            {x: 1, y: 0.3},
+            {x: 2, y: 0.3},
+          ],
+        },
+      ]);
+    });
+
+    describe('smoothing weight clipping', () => {
+      for (const smoothingWeight of [NaN, -1, -Infinity, Infinity]) {
+        it(`clips smoothing weight=${smoothingWeight} to 0`, async () => {
+          const actual = await classicSmoothing(
+            [
+              buildSeries({
+                id: 's1',
+                points: [
+                  {x: 0, y: 1},
+                  {x: 1, y: 0.5},
+                ],
+              }),
+            ],
+            smoothingWeight
+          );
+          expect(actual).toEqual([
+            {
+              srcId: 's1',
+              points: [
+                {x: 0, y: 1},
+                {x: 1, y: 0.5},
+              ],
+            },
+          ]);
+        });
+      }
+
+      it('clips smoothing weight larger than 1 to 1', async () => {
+        const actual = await classicSmoothing(
+          [
+            buildSeries({
+              id: 's1',
+              points: [
+                {x: 0, y: 1},
+                {x: 1, y: 0.5},
+              ],
+            }),
+          ],
+          2
+        );
+        expect(actual).toEqual([
+          {
+            srcId: 's1',
+            points: [
+              {x: 0, y: 0},
+              {x: 1, y: 0},
+            ],
+          },
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This change ports logic in the vz_line_chart for our consumption in new
GpuLineChart.

Future integration note: unlike vz_line_chart, smoothing is not built-in
to the line chart; previous pattern made the line chart more logic-ful
and made it harder to adopt other smoothing strategies or data
transformation logic. Instead, we decided to have a notion of `aux` or
auxiliary data series and let the consumer pass the smoothed data
series.
