### PR TITLE
feat: selector to read fastChart feature flag

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -44,3 +44,10 @@ export const getEnabledExperimentalPlugins = createSelector(
 export const getIsInColab = createSelector(selectFeatureFlagState, (state) => {
   return !!state.features.inColab;
 });
+
+export const getIsGpuChartEnabled = createSelector(
+  selectFeatureFlagState,
+  (state: FeatureFlagState): boolean => {
+    return !!state.features.enableGpuChart;
+  }
+);

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -65,7 +65,7 @@ describe('feature_flag_selectors', () => {
       );
       const actual1 = selectors.getIsGpuChartEnabled(state1);
 
-      expect(actual1).toEqual(false);
+      expect(actual1).toBe(false);
 
       const state2 = buildState(
         buildFeatureFlagState({
@@ -76,7 +76,7 @@ describe('feature_flag_selectors', () => {
       );
       const actual2 = selectors.getIsGpuChartEnabled(state2);
 
-      expect(actual2).toEqual(true);
+      expect(actual2).toBe(true);
     });
   });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -17,7 +17,7 @@ import * as selectors from './feature_flag_selectors';
 import {buildFeatureFlagState, buildState} from './testing';
 
 describe('feature_flag_selectors', () => {
-  describe('getEnabledExperimentalPlugins', () => {
+  describe('#getEnabledExperimentalPlugins', () => {
     it('returns value in array', () => {
       const state = buildState(
         buildFeatureFlagState({
@@ -32,7 +32,7 @@ describe('feature_flag_selectors', () => {
     });
   });
 
-  describe('getIsInColab', () => {
+  describe('#getIsInColab', () => {
     it('returns the proper value', () => {
       let state = buildState(
         buildFeatureFlagState({
@@ -51,6 +51,32 @@ describe('feature_flag_selectors', () => {
         })
       );
       expect(selectors.getIsInColab(state)).toEqual(false);
+    });
+  });
+
+  describe('#getIsGpuChartEnabled', () => {
+    it('returns value in the store', () => {
+      const state1 = buildState(
+        buildFeatureFlagState({
+          features: buildFeatureFlag({
+            enableGpuChart: false,
+          }),
+        })
+      );
+      const actual1 = selectors.getIsGpuChartEnabled(state1);
+
+      expect(actual1).toEqual(false);
+
+      const state2 = buildState(
+        buildFeatureFlagState({
+          features: buildFeatureFlag({
+            enableGpuChart: true,
+          }),
+        })
+      );
+      const actual2 = selectors.getIsGpuChartEnabled(state2);
+
+      expect(actual2).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
This change trivially adds a selector to already existing state in the
feature flag reducer. With this change, we are able to discern whether
user manually enabled the faster line chart implementation.
