### PR TITLE
feat: persist fastChart feature flag to url

### DIFF
--- a/tensorboard/webapp/routes/core_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider_test.ts
@@ -44,6 +44,7 @@ describe('core deeplink provider', () => {
     store.overrideSelector(selectors.getPinnedCardsWithMetadata, []);
     store.overrideSelector(selectors.getUnresolvedImportedPinnedCards, []);
     store.overrideSelector(selectors.getEnabledExperimentalPlugins, []);
+    store.overrideSelector(selectors.getIsGpuChartEnabled, false);
 
     queryParamsSerialized = [];
 
@@ -247,6 +248,15 @@ describe('core deeplink provider', () => {
         {key: 'experimentalPlugin', value: 'foo'},
         {key: 'experimentalPlugin', value: 'bar'},
         {key: 'experimentalPlugin', value: 'baz'},
+      ]);
+    });
+
+    it('serializes enabled fast chart state', () => {
+      store.overrideSelector(selectors.getIsGpuChartEnabled, true);
+      store.refreshState();
+
+      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
+        {key: 'fastChart', value: 'true'},
       ]);
     });
   });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -16,6 +16,7 @@ import {Injectable} from '@angular/core';
 
 import {
   EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
+  GPU_LINE_CHART_QUERY_PARAM_KEY,
   TBFeatureFlagDataSource,
 } from './tb_feature_flag_data_source_types';
 
@@ -39,7 +40,7 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
         EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY
       ),
       inColab: params.get('tensorboardColab') === 'true',
-      enableGpuChart: params.get('fastChart') === 'true',
+      enableGpuChart: params.get(GPU_LINE_CHART_QUERY_PARAM_KEY) === 'true',
     };
   }
 }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -29,3 +29,5 @@ export abstract class TBFeatureFlagDataSource {
 }
 
 export const EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY = 'experimentalPlugin';
+
+export const GPU_LINE_CHART_QUERY_PARAM_KEY = 'fastChart';


### PR DESCRIPTION
This change builds on top of already existing feature of deep linking to
persist a state in the feature flag reducer for convenience of a user.

With this change, when launching tensorboard with `?fastChart=true`, it
will stay in the URL across navigations.
