### PR TITLE
rust: upgrade to Rust 1.48.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        rust_version: ['1.47.0']
+        rust_version: ['1.48.0']
         cargo_raze_version: ['0.7.0']
     steps:
       - uses: actions/checkout@v1

--- a/third_party/rust.bzl
+++ b/third_party/rust.bzl
@@ -22,6 +22,6 @@ load("//third_party/rust:crates.bzl", "raze_fetch_remote_crates")
 
 def tensorboard_rust_workspace():
     """TensorBoard Rust dependencies."""
-    rust_repositories()
+    rust_repositories(version = "1.48.0")
     rust_workspace()
     raze_fetch_remote_crates()


### PR DESCRIPTION
Summary:
Rust 1.48 is out today! I’ve been eagerly awaiting one feature in
particular: intra-doc links. As of this release of rustdoc, you can link
to other doc items as Markdown links:

```markdown
<!-- autolinks -->
Each reservoir has an associated [`Basin`].

<!-- named links -->
This contains a [`summary::value::Value`], which represents the
underlying `oneof value` field (a `simple_value`, `tensor`, etc.). It is
not to be confused with a [`summary::Value`], which is….

[`summary::Value`]: `pb::summary::Value`
[`summary::value::Value`]: `pb::summary::value::Value`
```

Full [release announcement here][announce].

If you have local toolchains installed, you can update them by running
`rustup update stable`.

[announce]: https://blog.rust-lang.org/2020/11/19/Rust-1.48.html

Test Plan:
I’ve already been using this syntax in our docs, so run the doc server:

```
ibazel run //tensorboard/data/server:rustboard_core_doc_server
```

…and navigate to the docs for `reservoir::StageReservoir`, and note
that the links to `Basin` and `std::sync::RwLock` are live and working.

wchargin-branch: rust-v1.48.0
