### PR TITLE
rust: add `walkdir` dependency

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -715,6 +715,16 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "walkdir",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1145,6 +1155,17 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -34,6 +34,7 @@ rand_chacha = "0.2.2"
 thiserror = "1.0.21"
 tokio = { version = "0.2.2", features = ["macros"] }
 tonic = "0.3.1"
+walkdir = "2.3.1"
 
 [dev-dependencies]
 prost-build = "0.6.1"

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -146,3 +146,12 @@ alias(
         "manual",
     ],
 )
+
+alias(
+    name = "walkdir",
+    actual = "@raze__walkdir__2_3_1//:walkdir",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)

--- a/third_party/rust/crates.bzl
+++ b/third_party/rust/crates.bzl
@@ -763,6 +763,16 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__same_file__1_0_6",
+        url = "https://crates.io/api/v1/crates/same-file/1.0.6/download",
+        type = "tar.gz",
+        sha256 = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+        strip_prefix = "same-file-1.0.6",
+        build_file = Label("//third_party/rust/remote:BUILD.same-file-1.0.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__slab__0_4_2",
         url = "https://crates.io/api/v1/crates/slab/0.4.2/download",
         type = "tar.gz",
@@ -1139,6 +1149,16 @@ def raze_fetch_remote_crates():
         sha256 = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed",
         strip_prefix = "version_check-0.9.2",
         build_file = Label("//third_party/rust/remote:BUILD.version_check-0.9.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__walkdir__2_3_1",
+        url = "https://crates.io/api/v1/crates/walkdir/2.3.1/download",
+        type = "tar.gz",
+        sha256 = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d",
+        strip_prefix = "walkdir-2.3.1",
+        build_file = Label("//third_party/rust/remote:BUILD.walkdir-2.3.1.bazel"),
     )
 
     maybe(

--- a/third_party/rust/remote/BUILD.same-file-1.0.6.bazel
+++ b/third_party/rust/remote/BUILD.same-file-1.0.6.bazel
@@ -1,0 +1,66 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "is_same_file" with type "example" omitted
+
+# Unsupported target "is_stderr" with type "example" omitted
+
+rust_library(
+    name = "same_file",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.6",
+    # buildifier: leave-alone
+    deps = [
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@raze__winapi_util__0_1_5//:winapi_util",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/rust/remote/BUILD.walkdir-2.3.1.bazel
+++ b/third_party/rust/remote/BUILD.walkdir-2.3.1.bazel
@@ -1,0 +1,64 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "walkdir",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "2.3.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__same_file__1_0_6//:same_file",
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@raze__winapi__0_3_9//:winapi",
+            "@raze__winapi_util__0_1_5//:winapi_util",
+        ],
+        "//conditions:default": [],
+    }),
+)


### PR DESCRIPTION
Summary:
The [`walkdir`] crate facilitates recursively walking a directory.
We need this to find all event files under a log directory.

[`walkdir`]: https://crates.io/crates/walkdir

Test Plan:
It builds: `bazel build //third_party/rust:walkdir`.

wchargin-branch: rust-dep-walkdir
