### PR TITLE
infra: error on dep on ng_module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
         # `//tensorboard/webapp/third_party:d3` instead.
       - run: |
           ! git grep -E '"@npm//d3"|"@npm//@types/d3"' 'tensorboard/webapp/**/*BUILD' ':!tensorboard/webapp/third_party/**'
+      - run: |
+          ! git grep -E '"@npm_angular_bazel//:index.bzl"' 'tensorboard/webapp/**/*BUILD'
 
   lint-build:
     runs-on: ubuntu-16.04

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -1,5 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
-load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -8,7 +7,7 @@ tf_sass_binary(
     src = "line_chart_interactive_view.scss",
 )
 
-ng_module(
+tf_ng_module(
     name = "sub_view",
     srcs = [
         "axis_formatter.ts",


### PR DESCRIPTION
This change disallows direct usage of ng_module and fixes one regression that we incurred recently.

We require indirection since in newer version of the rules_nodejs, they deprecated ng_module and 
dependency upgrade causes larger change than intended when there is no such indirection exists.