### PR TITLE
infra: upgrade Bazel to 3.7.0 (1 of 4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,6 @@ node_js:
   - "11"
 
 env:
-  # Keep this Bazel version in sync with the `versions.check` directive
-  # near the top of our WORKSPACE file.
-  #
-  # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
-  # bazel-0.20.0-linux-x86_64.sha256
-  global:
-    - BAZEL=2.1.0
-    - BAZEL_SHA256SUM=e13581d44faad6ac807dd917e682fef20359d26728166ac35dadd8ee653a580d
   matrix:
     - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
@@ -43,6 +35,13 @@ cache:
 before_install:
   - elapsed() { TZ=UTC printf "Time %(%T)T %s\n" "$SECONDS" "$1"; }
   - elapsed "before_install"
+  # Keep this Bazel version in sync with the `versions.check` directive
+  # near the top of our WORKSPACE file.
+  #
+  # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
+  # bazel-0.20.0-linux-x86_64.sha256
+  - export BAZEL=3.7.0
+  - export BAZEL_SHA256SUM=b7583eec83cc38302997098a40b8c870c37e0ab971a83cb3364c754a178b74ec
   - ci/download_bazel.sh "${BAZEL}" "${BAZEL_SHA256SUM}" ~/bazel
   - sudo mv ~/bazel /usr/local/bin/bazel
   - cp ci/bazelrc ~/.bazelrc
@@ -93,10 +92,13 @@ script:
   - elapsed "script"
   # Note: bazel test implies fetch+build, but this gives us timing.
   - elapsed && bazel fetch //tensorboard/...
-  - elapsed && bazel build //tensorboard/...
-  - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
-  - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
-  # Run manual S3 test
+  # - elapsed && bazel build //tensorboard/plugins/...
+  # - elapsed && bazel build //tensorboard/components/...
+  # - elapsed && bazel build //tensorboard/webapp/...
+  # - elapsed && bazel build //tensorboard/...
+  # - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
+  # - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
+  # # Run manual S3 test
   - elapsed && bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
   - elapsed && bazel test //tensorboard/summary/writer:event_file_writer_s3_test
   - elapsed "script (done)"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,7 +89,7 @@ tf_workspace()
 load("@bazel_skylib//lib:versions.bzl", "versions")
 # Keep this version in sync with the BAZEL environment variable defined
 # in our .travis.yml config.
-versions.check(minimum_bazel_version = "2.1.0")
+versions.check(minimum_bazel_version = "3.7.0")
 
 load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
 

--- a/ci/bazelrc
+++ b/ci/bazelrc
@@ -1,5 +1,6 @@
 # Limit resources since Travis Trusty GCE VMs have 2 cores and 7.5 GB RAM.
-build --local_resources=4000,2,1.0
+build --local_cpu_resources=2
+build --local_ram_resources=4000
 build --worker_max_instances=2
 
 # Ensure sandboxing is on to increase hermeticity.


### PR DESCRIPTION
This change disables large part of CI so we can safely populate the
Travis cache to unblock other infrastructural upgrade.

Note that there are total of 4 PRs to be submitted.
