### PR TITLE
line chart: fix the nice domain for small constant

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -155,7 +155,7 @@ class Log10Scale implements Scale {
       return [Number.MIN_VALUE, 1];
     }
 
-    return [Math.max(Number.MIN_VALUE, adjustedMin * 0.5), adjustedMax * 1.5];
+    return [Math.max(Number.MIN_VALUE, adjustedMin * 0.5), adjustedMax * 2];
   }
 
   ticks(domain: [number, number], sizeGuidance: number): number[] {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -28,7 +28,6 @@ export function createScale(type: ScaleType): Scale {
 }
 
 const PADDING_RATIO = 0.05;
-const PADDING_FOR_ZERO = 0.01;
 
 class LinearScale implements Scale {
   private transform(
@@ -70,14 +69,14 @@ class LinearScale implements Scale {
       throw new Error('Unexpected input: min is larger than max');
     }
 
+    if (max === min) {
+      if (min === 0) return [-1, 1];
+      if (min < 0) return [2 * min, 0];
+      return [0, 2 * min];
+    }
+
     const scale = scaleLinear();
-    const padding =
-      max === min
-        ? // In case both `min` and `max` are 0, we want some padding.
-          min === 0
-          ? PADDING_FOR_ZERO
-          : Math.abs(min) * PADDING_RATIO
-        : (max - min + Number.EPSILON) * PADDING_RATIO;
+    const padding = (max - min + Number.EPSILON) * PADDING_RATIO;
     const [niceMin, niceMax] = scale
       .domain([min - padding, max + padding])
       .nice()
@@ -150,26 +149,13 @@ class Log10Scale implements Scale {
 
     const adjustedMin = Math.max(min, Number.MIN_VALUE);
     const adjustedMax = Math.max(max, Number.MIN_VALUE);
+
     if (max <= 0) {
-      // When both min and max are non-positive, clip to [1e-326, 1].
-      return [adjustedMin, 1];
+      // When both min and max are non-positive, clip to [Number.MIN_VALUE, 1].
+      return [Number.MIN_VALUE, 1];
     }
 
-    const numericMinLogValue = this.transform(Number.MIN_VALUE);
-    const minLogValue = this.transform(adjustedMin);
-    const maxLogValue = this.transform(adjustedMax);
-
-    const spreadInLog = maxLogValue - minLogValue;
-    const padInLog =
-      spreadInLog > 0
-        ? spreadInLog * PADDING_RATIO
-        : // In case `minLogValue` is 0 (i.e., log_10(1) = 0), we want some padding.
-          Math.max(Math.abs(minLogValue * PADDING_RATIO), PADDING_FOR_ZERO);
-
-    return [
-      this.untransform(Math.max(numericMinLogValue, minLogValue - padInLog)),
-      this.untransform(maxLogValue + padInLog),
-    ];
+    return [Math.max(Number.MIN_VALUE, adjustedMin * 0.5), adjustedMax * 1.5];
   }
 
   ticks(domain: [number, number], sizeGuidance: number): number[] {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -202,9 +202,9 @@ describe('line_chart_v2/lib/scale test', () => {
         let low: number;
         let high: number;
 
-        [low, high] = scale.niceDomain([0, 100]);
-        expect(low).toBe(Number.MIN_VALUE);
-        expect(high).toBeCloseTo(100, 0);
+        [low, high] = scale.niceDomain([1, 100]);
+        expect(low).toBeCloseTo(0.79, 2);
+        expect(high).toBeCloseTo(125.8, 0);
 
         [low, high] = scale.niceDomain([0.001, 75]);
         // spread is about log_10(75) - log_10(0.001) = 4.875

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -226,9 +226,7 @@ describe('line_chart_v2/lib/scale test', () => {
 
         [low, high] = scale.niceDomain([-1, 1]);
         expect(low).toBe(Number.MIN_VALUE);
-        // Because the spread is large from -326 to 0, upper bound is much larger, too.
-        // This may not be ideal and we may want to implement better logic in this case.
-        expect(high).toBeGreaterThanOrEqual(1e16);
+        expect(high).toBe(2);
       });
 
       it('throws an error when min is larger than max', () => {


### PR DESCRIPTION
Also, this change improves testing around `niceDomain` and we assert on
non-positive value clipping.

This change partially address #4362 for the new gpu line chart. We will later
integrate the new scale to the legacy vz_line_chart.