### PR TITLE
Limit max scalar smoothing to 0.99 / 0.999

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -197,9 +197,13 @@ describe('metrics right_pane', () => {
       scalarSmoothingInput.nativeElement.dispatchEvent(new Event('input'));
       tick(TEST_ONLY.SLIDER_AUDIT_TIME_MS);
 
-      expect(scalarSmoothingInput.nativeElement.value).toBe('1');
+      expect(scalarSmoothingInput.nativeElement.value).toBe(
+        TEST_ONLY.MAX_SMOOTHING_VALUE.toString()
+      );
       expect(dispatchSpy).toHaveBeenCalledWith(
-        actions.metricsChangeScalarSmoothing({smoothing: 1})
+        actions.metricsChangeScalarSmoothing({
+          smoothing: TEST_ONLY.MAX_SMOOTHING_VALUE,
+        })
       );
     }));
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -37,7 +37,7 @@ limitations under the License.
       <mat-slider
         aria-labelledby="scalars-smoothing-label"
         color="primary"
-        [max]="MAX_SMOOTHING_VALUE"
+        [max]="MAX_SMOOTHING_SLIDER_VALUE"
         [min]="0"
         [step]="0.01"
         [value]="scalarSmoothing"
@@ -50,7 +50,7 @@ limitations under the License.
         type="number"
         [max]="MAX_SMOOTHING_VALUE"
         min="0"
-        step="0.01"
+        step="0.001"
         [value]="scalarSmoothing"
         (input)="onScalarSmoothingInput($event)"
       />

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -39,10 +39,9 @@ limitations under the License.
         color="primary"
         [max]="MAX_SMOOTHING_VALUE"
         [min]="0"
-        [step]="0.001"
+        [step]="0.01"
         [value]="scalarSmoothing"
         [thumbLabel]="true"
-        [displayWith]="formatSmoothingThumbLabel"
         (input)="scalarSmoothingControlChanged$.emit($event.value)"
       ></mat-slider>
       <input
@@ -51,7 +50,7 @@ limitations under the License.
         type="number"
         [max]="MAX_SMOOTHING_VALUE"
         min="0"
-        step="0.001"
+        step="0.01"
         [value]="scalarSmoothing"
         (input)="onScalarSmoothingInput($event)"
       />

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -37,20 +37,21 @@ limitations under the License.
       <mat-slider
         aria-labelledby="scalars-smoothing-label"
         color="primary"
-        [max]="1"
+        [max]="MAX_SMOOTHING_VALUE"
         [min]="0"
-        [step]="0.01"
+        [step]="0.001"
         [value]="scalarSmoothing"
         [thumbLabel]="true"
+        [displayWith]="formatSmoothingThumbLabel"
         (input)="scalarSmoothingControlChanged$.emit($event.value)"
       ></mat-slider>
       <input
         class="slider-input"
         aria-labelledby="scalars-smoothing-label"
         type="number"
+        [max]="MAX_SMOOTHING_VALUE"
         min="0"
-        max="1"
-        step="0.01"
+        step="0.001"
         [value]="scalarSmoothing"
         (input)="onScalarSmoothingInput($event)"
       />

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -35,7 +35,7 @@ const SLIDER_AUDIT_TIME_MS = 250;
  * When smoothing === 1, all lines become flat on the x-axis, which is not
  * useful at all. Use a maximum smoothing value < 1.
  */
-const MAX_SMOOTHING_VALUE = 0.999;
+const MAX_SMOOTHING_VALUE = 0.99;
 
 @Component({
   selector: 'metrics-dashboard-settings-component',
@@ -81,11 +81,6 @@ export class SettingsViewComponent {
   scalarSmoothingChanged = this.scalarSmoothingControlChanged$.pipe(
     auditTime(SLIDER_AUDIT_TIME_MS)
   );
-
-  formatSmoothingThumbLabel(value: number): string {
-    const stringValue = value + '';
-    return stringValue.startsWith('0.') ? stringValue.slice(1) : stringValue;
-  }
 
   onScalarSmoothingInput(event: Event) {
     const input = event.target as HTMLInputElement;

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -35,7 +35,15 @@ const SLIDER_AUDIT_TIME_MS = 250;
  * When smoothing === 1, all lines become flat on the x-axis, which is not
  * useful at all. Use a maximum smoothing value < 1.
  */
-const MAX_SMOOTHING_VALUE = 0.99;
+const MAX_SMOOTHING_VALUE = 0.999;
+
+/**
+ * The smoothing slider has a step size of 0.01. Angular's rounding logic makes
+ * the effective maximum value 1, even when the 'max' attribute is set to 0.999.
+ * Set this value to the nearest value less than MAX_SMOOTHING_VALUE that is
+ * representable as 'min' + k * 'step'.
+ */
+const MAX_SMOOTHING_SLIDER_VALUE = 0.99;
 
 @Component({
   selector: 'metrics-dashboard-settings-component',
@@ -74,6 +82,7 @@ export class SettingsViewComponent {
   @Output() histogramModeChanged = new EventEmitter<HistogramMode>();
 
   readonly MAX_SMOOTHING_VALUE = MAX_SMOOTHING_VALUE;
+  readonly MAX_SMOOTHING_SLIDER_VALUE = MAX_SMOOTHING_SLIDER_VALUE;
 
   readonly scalarSmoothingControlChanged$ = new EventEmitter<number>();
   @Input() scalarSmoothing!: number;

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -31,6 +31,12 @@ import {HistogramMode, TooltipSort, XAxisType} from '../../types';
 
 const SLIDER_AUDIT_TIME_MS = 250;
 
+/**
+ * When smoothing === 1, all lines become flat on the x-axis, which is not
+ * useful at all. Use a maximum smoothing value < 1.
+ */
+const MAX_SMOOTHING_VALUE = 0.999;
+
 @Component({
   selector: 'metrics-dashboard-settings-component',
   templateUrl: 'settings_view_component.ng.html',
@@ -67,6 +73,8 @@ export class SettingsViewComponent {
   @Input() histogramMode!: HistogramMode;
   @Output() histogramModeChanged = new EventEmitter<HistogramMode>();
 
+  readonly MAX_SMOOTHING_VALUE = MAX_SMOOTHING_VALUE;
+
   readonly scalarSmoothingControlChanged$ = new EventEmitter<number>();
   @Input() scalarSmoothing!: number;
   @Output()
@@ -74,12 +82,20 @@ export class SettingsViewComponent {
     auditTime(SLIDER_AUDIT_TIME_MS)
   );
 
+  formatSmoothingThumbLabel(value: number): string {
+    const stringValue = value + '';
+    return stringValue.startsWith('0.') ? stringValue.slice(1) : stringValue;
+  }
+
   onScalarSmoothingInput(event: Event) {
     const input = event.target as HTMLInputElement;
     if (!input.value) {
       return;
     }
-    const nextValue = Math.min(Math.max(0, parseFloat(input.value)), 1);
+    const nextValue = Math.min(
+      Math.max(0, parseFloat(input.value)),
+      MAX_SMOOTHING_VALUE
+    );
 
     // Rectify here in case Angular does not trigger ngOnChanges when expected.
     if (nextValue !== parseFloat(input.value)) {
@@ -120,4 +136,5 @@ export class SettingsViewComponent {
 
 export const TEST_ONLY = {
   SLIDER_AUDIT_TIME_MS,
+  MAX_SMOOTHING_VALUE,
 };


### PR DESCRIPTION
The smoothing slider setting affects line charts. In the Scalars
dashboard, the maximum value has traditionally been 0.999, not
1.0. The Time Series dashboard allows the slider to go all the way
to 1, which "flattens the curve" onto the x-axis, often much less
meaningful than a "close to 1" number, which still shows the
general shape of the curves.

This updates the Time Series' scalar cards to be use a max
smoothing of 0.99 when dragging the slider, and 0.999 when
entering a value in the input field.

Before:
![image](https://user-images.githubusercontent.com/2322480/99868594-b81e5e80-2b78-11eb-864a-5a333275cc84.png)

After:
![image](https://user-images.githubusercontent.com/2322480/99869179-d63a8d80-2b7d-11eb-8628-391c3d76d2e4.png)


