### PR TITLE
bug: apply new scale niceDomain to vz-line-chart

### DIFF
--- a/tensorboard/components/vz_line_chart2/BUILD
+++ b/tensorboard/components/vz_line_chart2/BUILD
@@ -36,6 +36,7 @@ tf_ts_library(
         "//tensorboard/components/polymer:plottable_style",
         "//tensorboard/components/polymer:register_style_dom_module",
         "//tensorboard/components/vz_chart_helpers",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:scale",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
         "@npm//@types/d3",

--- a/tensorboard/components/vz_line_chart2/linear-scale.ts
+++ b/tensorboard/components/vz_line_chart2/linear-scale.ts
@@ -15,7 +15,11 @@ limitations under the License.
 import * as d3 from 'd3';
 import * as Plottable from 'plottable';
 
-import {ValueProviderForDomain, ITfScale} from './tf-scale';
+import {
+  createScale,
+  ScaleType,
+} from '../../webapp/widgets/line_chart_v2/lib/scale';
+import {ITfScale, ValueProviderForDomain} from './tf-scale';
 
 export class LinearScale extends Plottable.Scales.Linear implements ITfScale {
   private _ignoreOutlier: boolean = false;
@@ -41,27 +45,8 @@ export class LinearScale extends Plottable.Scales.Linear implements ITfScale {
    */
   protected _niceDomain(domain: number[], count?: number): number[] {
     const [a, b] = domain;
-    let padding: number;
-    const span = b - a;
-    if (span === 0) {
-      // If b===a, we would create an empty range. We instead select the range
-      // [0, 2*a] if a > 0, or [-2*a, 0] if a < 0, plus a little bit of
-      // extra padding on the top and bottom of the plot.
-      padding = Math.abs(a) * 1.1 + 1.1;
-    } else {
-      padding = span * this.padProportion();
-    }
-    let lower: number;
-    if (a >= 0 && a < span) {
-      // [1]: We include the intercept (y = 0) if doing so less than doubles the
-      // span of the y-axis. (We actually select a lower bound that's slightly
-      // less than 0 so that 0.00 will clearly be written on the lower edge of
-      // the chart. The label on the lowest tick is often filtered out.)
-      lower = -0.1 * b;
-    } else {
-      lower = a - padding;
-    }
-    return super._niceDomain([lower, b + padding], count);
+
+    return createScale(ScaleType.LINEAR).niceDomain([a, b]);
   }
   /**
    * @override to remove default padding logic.

--- a/tensorboard/components/vz_line_chart2/linear-scale.ts
+++ b/tensorboard/components/vz_line_chart2/linear-scale.ts
@@ -33,14 +33,6 @@ export class LinearScale extends Plottable.Scales.Linear implements ITfScale {
     return this;
   }
   /**
-   * TODO(nickfelt): Examine whether we truly require `c`.
-   * Adds some padding to a given domain. Specifically, it:
-   * - returns about [-0.1a - c, 2.1a + c] when a = b and a >= 0.
-   * - returns about [-2.1|a| - c, -0.1|a| + c] when a = b and a < 0.
-   * - returns [-0.1b, b + padProportion * (b-a)] if b > 2a and a > 0
-   * - else, pads by `padProportion`
-   * Note that `c` is a constant offset which specifically is 1.1. Please refer
-   * to [1] for its rationale.
    * @override
    */
   protected _niceDomain(domain: number[], count?: number): number[] {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -15,6 +15,8 @@ limitations under the License.
 import {scaleLinear, scaleLog} from '../../../third_party/d3';
 import {Scale, ScaleType} from './scale_types';
 
+export {ScaleType} from './scale_types';
+
 export function createScale(type: ScaleType): Scale {
   switch (type) {
     case ScaleType.LINEAR:


### PR DESCRIPTION
We are in midst of working on the new version of the line chart. In
doing so, we rewrote a scale library with a bit more tests.

This change integrates the new scale library so small constant values do
not result (e.g., 0.05) in  [-1, 1] domain.

![image](https://user-images.githubusercontent.com/2547313/99870033-beb2d300-2b84-11eb-8032-1cb001997964.png)

Fixes #4362.