### PR TITLE
cleanup: debugger to use tf_ng_module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - run: |
           ! git grep -E '"@npm//d3"|"@npm//@types/d3"' 'tensorboard/webapp/**/*BUILD' ':!tensorboard/webapp/third_party/**'
       - run: |
-          ! git grep -E '"@npm_angular_bazel//:index.bzl"' 'tensorboard/webapp/**/*BUILD'
+          ! git grep -E '"@npm_angular_bazel//:index.bzl"' 'tensorboard/**/BUILD'
 
   lint-build:
     runs-on: ubuntu-16.04

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
@@ -1,9 +1,8 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-ng_module(
+tf_ng_module(
     name = "store",
     srcs = [
         "debugger_reducers.ts",
@@ -20,7 +19,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "debugger_store_helpers",
     srcs = [
         "debugger_store_helpers.ts",
@@ -33,7 +32,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "types",
     srcs = [
         "debugger_types.ts",
@@ -45,7 +44,7 @@ ng_module(
     ],
 )
 
-ng_module(
+tf_ng_module(
     name = "debug_tensor_value",
     srcs = [
         "debug_tensor_value.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "alerts",
     srcs = [
         "alerts_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "execution_data",
     srcs = [
         "execution_data_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "graph",
     srcs = [
         "graph_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "graph_executions",
     srcs = [
         "graph_executions_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "source_code",
     srcs = [
         "source_code_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "source_files",
     srcs = [
         "source_files_component.ts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
@@ -1,11 +1,10 @@
-load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-ng_module(
+tf_ng_module(
     name = "stack_trace",
     srcs = [
         "stack_trace_component.ts",


### PR DESCRIPTION
ng_module will change shortly and we require some indirection for our
convenience. This change makes changes to the debugger_v2 code and
change our CI lint check to guard against any usages of ng_module.
