### PR TITLE
line chart: export types for consumer of line chart

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -14,6 +14,7 @@ tf_ng_module(
     srcs = [
         "line_chart_component.ts",
         "line_chart_module.ts",
+        "types.ts",
     ],
     assets = [
         "line_chart_component.ng.html",

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -17,7 +17,7 @@ tf_ts_library(
     srcs = [
         "public_types.ts",
     ],
-    visibility = ["//tensorboard:internal"],
+    visibility = ["//tensorboard/webapp/widgets/line_chart_v2:__subpackages__"],
     deps = [
         ":chart_types",
         ":internal_types",

--- a/tensorboard/webapp/widgets/line_chart_v2/types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/types.ts
@@ -1,0 +1,23 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Only selectively export types that would be used by the user of the line chart.
+export {
+  DataSeries,
+  RendererType,
+  ScaleType,
+  DataSeriesMetadataMap,
+  DataSeriesMetadata,
+} from './lib/public_types';


### PR DESCRIPTION
lib/public_types.ts is not really meant to be imported by consumer of
the line chart as (1) peeking into `lib` folder is a bit messy and (2)
it exports more types than what consumers really need.

The new `types` module is provided as part of the line_chart_v2
dependency and it only contains the types that consumers would need.
