### PR TITLE
rust: add `anyhow` dependency

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
 name = "rustboard"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-stream 0.3.0",
  "async-trait",
  "byteorder",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.34"
 async-stream = "0.3.0"
 async-trait = "0.1.41"
 byteorder = "1.3.4"

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -13,6 +13,15 @@ licenses([
 
 # Aliased targets
 alias(
+    name = "anyhow",
+    actual = "@raze__anyhow__1_0_34//:anyhow",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "async_stream",
     actual = "@raze__async_stream__0_3_0//:async_stream",
     tags = [


### PR DESCRIPTION
Summary:
The [`anyhow`] crate facilitates returning *unstructured* error values
in applications. It makes it easy to define freeform errors and add
context to them. It’s a sibling to [`thiserror`], by the same author.

[`anyhow`]: https://crates.io/crates/anyhow
[`thiserror`]: https://crates.io/crates/thiserror

Test Plan:
It builds: `bazel build //third_party/rust:anyhow`.

wchargin-branch: rust-dep-anyhow
