### PR TITLE
rust: add `grpc_cli` tips to DEVELOPMENT.md

### DIFF
--- a/tensorboard/data/server/DEVELOPMENT.md
+++ b/tensorboard/data/server/DEVELOPMENT.md
@@ -74,3 +74,64 @@ When done, commit the changes to `Cargo.toml`, `Cargo.lock`, and the
 
 [crates.io]: https://crates.io/
 [raze]: https://github.com/google/cargo-raze
+
+## `grpc_cli` development tips
+
+RustBoard implements a gRPC server. The [`grpc_cli`] tool can be handy for
+sending ad hoc requests to the server. To use the tool, make sure that a
+RustBoard server is running (`bazel run -c opt //tensorboard/data/server`),
+change into the root directory for the TensorBoard repository, and run:
+
+```
+grpc_cli \
+    --channel_creds_type=insecure \
+    --protofiles tensorboard/data/proto/data_provider.proto \
+    call localhost:6806 \
+    TensorBoardDataProvider.ListScalars '
+        experiment_id: "123"
+        plugin_filter { plugin_name: "scalars" }
+    '
+```
+
+The `localhost:6806` argument should point to your running server. The
+`ListRuns` identifier should name the RPC method that you want to invoke. And
+the quoted string is the text format encoding of the request message.
+
+You should know:
+
+-   The Tonic framework does not yet support gRPC reflection, so you need to
+    specify the `--protofiles` argument, and the `grpc_cli ls` subcommand will
+    not work. This is [under development in Prost and Tonic][reflection].
+
+-   You should be in the root directory of the repository to refer to the
+    `.proto` file, because it imports other protos under `tensorboard/compat/`
+    via relative path. If you really want to run at non-root, try setting
+    `--proto-path` to the path to the root repository (keep `--protofiles` as a
+    path relative to that directory).
+
+-   If your `grpc_cli` invocation fails because the response size is too large,
+    apply the following patch and rebuild `grpc_cli`:
+
+    ```diff
+    diff --git a/test/cpp/util/grpc_tool.cc b/test/cpp/util/grpc_tool.cc
+    index fceee0c82b..443d419c6e 100644
+    --- a/test/cpp/util/grpc_tool.cc
+    +++ b/test/cpp/util/grpc_tool.cc
+    @@ -226,6 +226,7 @@ void ReadResponse(CliCall* call, const std::string& method_name,
+     std::shared_ptr<grpc::Channel> CreateCliChannel(
+         const std::string& server_address, const CliCredentials& cred) {
+       grpc::ChannelArguments args;
+    +  args.SetMaxReceiveMessageSize(1024 * 1024 * 256);
+       if (!cred.GetSslTargetNameOverride().empty()) {
+         args.SetSslTargetNameOverride(cred.GetSslTargetNameOverride());
+       }
+    ```
+
+    If you want to not have to do this, upvote [grpc/grpc#24734].
+
+-   Googlers: use the open-source build of `grpc_cli`, not the Google-internal
+    one.
+
+[`grpc_cli`]: https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md
+[grpc/grpc#24734]: https://github.com/grpc/grpc/issues/24374
+[reflection]: https://github.com/hyperium/tonic/pull/340

--- a/tensorboard/data/server/DEVELOPMENT.md
+++ b/tensorboard/data/server/DEVELOPMENT.md
@@ -94,7 +94,7 @@ grpc_cli \
 ```
 
 The `localhost:6806` argument should point to your running server. The
-`ListRuns` identifier should name the RPC method that you want to invoke. And
+`ListScalars` identifier should name the RPC method that you want to invoke. And
 the quoted string is the text format encoding of the request message.
 
 You should know:


### PR DESCRIPTION
Summary:
This includes a valid example invocation, plus some miscellaneous
advice, especially for Googlers.

wchargin-branch: rust-grpc-cli-dev-guide
