### PR TITLE
cleanup: remove TypeScript build from tf_web_library

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -14,12 +14,6 @@
 
 """Same as web_library but supports TypeScript."""
 
-load("//third_party:clutz.bzl",
-     "DEPRECATED_CLUTZ_ATTRIBUTES",
-     "DEPRECATED_CLUTZ_OUTPUTS",
-     "deprecated_clutz_aspect",
-     "deprecated_extract_dts_from_closure_libraries")
-
 load("@io_bazel_rules_closure//closure:defs.bzl",
      "closure_js_aspect")
 
@@ -57,38 +51,12 @@ def _tf_web_library(ctx):
   # process what came before
   deps = unfurl(ctx.attr.deps, provider="webfiles")
   webpaths = depset()
-  ts_typings = depset(ctx.files._default_typings)
-  ts_typings_paths = depset(
-      [long_path(ctx, f) for f in ctx.files._default_typings])
-  ts_typings_execroots = depset()
   for dep in deps:
     webpaths = depset(transitive=[webpaths, dep.webfiles.webpaths])
-    if hasattr(dep.webfiles, "ts_typings"):
-      ts_typings = depset(transitive=[ts_typings, dep.webfiles.ts_typings])
-    if hasattr(dep.webfiles, "ts_typings_paths"):
-      ts_typings_paths = depset(transitive=[
-          ts_typings_paths,
-          dep.webfiles.ts_typings_paths,
-      ])
-    if hasattr(dep.webfiles, "ts_typings_execroots"):
-      ts_typings_execroots = depset(transitive=[
-          ts_typings_execroots,
-          dep.webfiles.ts_typings_execroots,
-      ])
 
   # process what comes now
   manifest_srcs = []
   new_webpaths = []
-  ts_inputs = depset()
-  ts_outputs = []
-  ts_files = ts_typings_paths.to_list()
-  new_typings = []
-  new_typings_paths = []
-  new_typings_execroot = struct(inputs=[])
-  execroot = struct(
-      inputs=[(long_path(ctx, f), f.path) for f in ctx.files._default_typings],
-      outputs=[],
-      program=[ctx.executable._tsc.path, "-p"])
   web_srcs = []
   path = ctx.attr.path
   strip = _get_strip(ctx)
@@ -101,93 +69,15 @@ def _tf_web_library(ctx):
     webpath = "%s/%s" % ("" if path == "/" else path, suffix)
     _add_webpath(ctx, src, webpath, webpaths, new_webpaths, manifest_srcs)
     if suffix.endswith(".d.ts"):
-      web_srcs.append(src)
-      entry = (webpath[1:], src.path)
-      new_typings.append(src)
-      new_typings_paths.append(entry[0])
-      new_typings_execroot.inputs.append(entry)
-      ts_inputs = depset([src], transitive=[ts_inputs])
-      ts_files.append(entry[0])
-      execroot.inputs.append(entry)
+      # Polymer v1 fork still specifies d.ts in tf_web_library.
+      pass
     elif suffix.endswith(".ts"):
-      noext = suffix[:-3]
-      js = ctx.actions.declare_file("%s.js" % noext)
-      dts = ctx.actions.declare_file("%s.d.ts" % noext)
-      webpath_js = webpath[:-3] + ".js"
-      webpath_dts = webpath[:-3] + ".d.ts"
-      _add_webpath(ctx, js, webpath_js, webpaths, new_webpaths, manifest_srcs)
-      _add_webpath(ctx, dts, webpath_dts, webpaths, new_webpaths, manifest_srcs)
-      ts_inputs = depset([src], transitive=[ts_inputs])
-      ts_outputs.append(js)
-      ts_outputs.append(dts)
-      web_srcs.append(dts)
-      web_srcs.append(js)
-      ts_files.append(webpath[1:])
-      execroot.inputs.append((webpath[1:], src.path))
-      execroot.outputs.append((webpath_js[1:], js.path))
-      execroot.outputs.append((webpath_dts[1:], dts.path))
-      new_typings.append(dts)
-      new_typings_paths.append(webpath_dts[1:])
-      new_typings_execroot.inputs.append((webpath_dts[1:], dts.path))
+      fail(
+          "tf_web_library no longer can build TypeScript. Please use " +
+          "tf_ts_library instead."
+      )
     else:
       web_srcs.append(src)
-
-  # get typings for closure code
-  clutz_dts = deprecated_extract_dts_from_closure_libraries(ctx)
-  if clutz_dts:
-    entry = (long_path(ctx, clutz_dts), clutz_dts.path)
-    ts_inputs = depset([clutz_dts], transitive=[ts_inputs])
-    ts_files.append(entry[0])
-    execroot.inputs.append(entry)
-
-  # compile typescript
-  if execroot.outputs:
-    ts_config = _new_file(ctx, "-tsc.json")
-    execroot.inputs.append(("tsconfig.json", ts_config.path))
-    ctx.actions.write(
-        output=ts_config,
-        content=struct(
-            compilerOptions=struct(
-                baseUrl=".",
-                declaration=True,
-                inlineSourceMap=True,
-                inlineSources=True,
-                module="es6",
-                moduleResolution="node",
-                skipLibCheck=True,
-                noResolve=True,
-                target="es6",
-            ),
-            files=ts_files,
-        ).to_json())
-    er_config = _new_file(ctx, "-tsc-execroot.json")
-    ctx.actions.write(output=er_config, content=execroot.to_json())
-    ts_inputs = depset(
-        [ts_config, er_config],
-        transitive=[
-            ts_inputs,
-            # TODO(@wchargin): Because `_tsc` is passed as `tools`
-            # below, collecting its runfiles should in principle be
-            # unnecessary, but without this line the two deps of `_tsc`
-            # (`tsc.js` and `@org_nodejs//:bin/node`) are in fact not
-            # included, and so execrooter fails at runtime.
-            collect_runfiles([ctx.attr._tsc]),
-            ts_typings,
-            ts_typings_execroots,
-        ],
-    )
-    ctx.actions.run(
-        tools=ctx.files._tsc,
-        inputs=ts_inputs,
-        outputs=ts_outputs,
-        executable=ctx.executable._execrooter,
-        arguments=(
-            [er_config.path] +
-            [f.path for f in ts_typings_execroots.to_list()]
-        ),
-        mnemonic="Tsc",
-        progress_message="Compiling %d TypeScript files %s" % (
-            len(ts_files), ctx.label))
 
   # perform strict dependency checking
   manifest = _make_manifest(ctx, manifest_srcs)
@@ -225,20 +115,6 @@ def _tf_web_library(ctx):
           ctx.executable._WebfilesServer.short_path,
           long_path(ctx, params_file)))
 
-  if new_typings:
-    er_config = _new_file(ctx, "-typings-execroot.json")
-    ctx.actions.write(output=er_config, content=new_typings_execroot.to_json())
-    ts_typings = depset(new_typings, transitive=[ts_typings])
-    ts_typings_paths = depset(new_typings_paths, transitive=[ts_typings_paths])
-    ts_typings_execroots = depset(
-        [er_config],
-        transitive=[ts_typings_execroots],
-    )
-  else:
-    ts_typings = depset()
-    ts_typings_paths = depset()
-    ts_typings_execroots = depset()
-
   # Export data to parent rules. This uses the legacy, string-based
   # provider mechanism for compatibility with the base `web_library`
   # rule from rules_closure: because `tf_web_library`s may depend on
@@ -254,16 +130,13 @@ def _tf_web_library(ctx):
           manifests=manifests,
           webpaths=webpaths,
           dummy=dummy,
-          ts_typings=ts_typings,
-          ts_typings_paths=ts_typings_paths,
-          ts_typings_execroots=ts_typings_execroots),
+      ),
       closure_js_library=collect_js(
           unfurl(ctx.attr.deps, provider="closure_js_library"),
           ctx.files._closure_library_base),
       runfiles=ctx.runfiles(
           files=(ctx.files.srcs +
                  ctx.files.data +
-                 ts_outputs +
                  ctx.files._closure_library_base + [
                      manifest,
                      params_file,
@@ -382,37 +255,22 @@ def _get_strip(ctx):
 tf_web_library = rule(
     implementation=_tf_web_library,
     executable=True,
-    attrs=dict(DEPRECATED_CLUTZ_ATTRIBUTES.items() + {
+    attrs={
         "path": attr.string(),
         "srcs": attr.label_list(allow_files=True),
         "deps": attr.label_list(
-            aspects=[
-                deprecated_clutz_aspect,
-                closure_js_aspect,
-            ]),
+            aspects=[closure_js_aspect]
+        ),
         "exports": attr.label_list(),
         "data": attr.label_list(allow_files=True),
         "suppress": attr.string_list(),
         "strip_prefix": attr.string(),
         "external_assets": attr.string_dict(default={"/_/runfiles": "."}),
-        "clutz_entry_points": attr.string_list(),
-        "_execrooter": attr.label(
-            default=Label("//tensorboard/scripts:execrooter"),
-            executable=True,
-            cfg="host"),
-        "_tsc": attr.label(
-            default=Label("@com_microsoft_typescript//:tsc"),
-            allow_files=True,
-            executable=True,
-            cfg="host"),
-        "_default_typings": attr.label(
-            default=Label("//tensorboard:tf_web_library_default_typings"),
-            allow_files=True),
         "_WebfilesServer": attr.label(
             default=Label("@io_bazel_rules_closure//java/io/bazel/rules/closure/webfiles/server:WebfilesServer"),
             executable=True,
             cfg="host"),
         "_ClosureWorker": CLOSURE_WORKER_ATTR,
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
-    }.items()),
-    outputs=DEPRECATED_CLUTZ_OUTPUTS)
+    },
+)


### PR DESCRIPTION
After our build system upgrade, we no longer use tf_web_library to build
the TypeScript files. Instead, we use the rules based on rules_nodejs
and ts_library.

Test CL: cl/344187444