### PR TITLE
cleanup: refactor chai/mocha test to jasmine

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -1,5 +1,4 @@
-load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_web_test_suite", "tf_ts_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
@@ -84,16 +83,13 @@ tf_ts_library(
     ],
     deps = [
         ":tensor_widget_lib",
-        "@npm//@types/chai",
         "@npm//@types/jasmine",
-        "@npm//chai",
     ],
 )
 
-jasmine_node_test(
-    name = "test",
-    srcs = [":test_lib"],
+tf_ng_web_test_suite(
+    name = "karma_test",
     deps = [
-        "@npm//chai",
+        ":test_lib",
     ],
 )

--- a/tensorboard/components/tensor_widget/colormap-test.ts
+++ b/tensorboard/components/tensor_widget/colormap-test.ts
@@ -15,34 +15,41 @@ limitations under the License.
 
 /** Unit tests for colormaps. */
 
-import {expect} from 'chai';
-
 import {GrayscaleColorMap, JetColorMap} from './colormap';
 
 describe('GrayscaleColorMap', () => {
   it('max < min causes constructor error', () => {
     const min = 3;
     const max = 2;
-    expect(() => new GrayscaleColorMap({min, max})).to.throw(/max.*<.*min/);
+    expect(() => new GrayscaleColorMap({min, max})).toThrowError(
+      Error,
+      /max.*<.*min/
+    );
   });
 
   it('NaN or Infinity min or max causes constructor error', () => {
-    expect(() => new GrayscaleColorMap({min: 0, max: Infinity})).to.throw(
+    expect(() => new GrayscaleColorMap({min: 0, max: Infinity})).toThrowError(
+      Error,
       /max.*not finite/
     );
-    expect(() => new GrayscaleColorMap({min: 0, max: -Infinity})).to.throw(
+    expect(() => new GrayscaleColorMap({min: 0, max: -Infinity})).toThrowError(
+      Error,
       /max.*not finite/
     );
-    expect(() => new GrayscaleColorMap({min: 0, max: NaN})).to.throw(
+    expect(() => new GrayscaleColorMap({min: 0, max: NaN})).toThrowError(
+      Error,
       /max.*not finite/
     );
-    expect(() => new GrayscaleColorMap({min: Infinity, max: 0})).to.throw(
+    expect(() => new GrayscaleColorMap({min: Infinity, max: 0})).toThrowError(
+      Error,
       /min.*not finite/
     );
-    expect(() => new GrayscaleColorMap({min: -Infinity, max: 0})).to.throw(
+    expect(() => new GrayscaleColorMap({min: -Infinity, max: 0})).toThrowError(
+      Error,
       /min.*not finite/
     );
-    expect(() => new GrayscaleColorMap({min: NaN, max: 0})).to.throw(
+    expect(() => new GrayscaleColorMap({min: NaN, max: 0})).toThrowError(
+      Error,
       /min.*not finite/
     );
   });
@@ -51,34 +58,34 @@ describe('GrayscaleColorMap', () => {
     const min = 0;
     const max = 10;
     const colormap = new GrayscaleColorMap({min, max});
-    expect(colormap.getRGB(0)).to.eql([0, 0, 0]);
-    expect(colormap.getRGB(5)).to.eql([127.5, 127.5, 127.5]);
-    expect(colormap.getRGB(10)).to.eql([255, 255, 255]);
+    expect(colormap.getRGB(0)).toEqual([0, 0, 0]);
+    expect(colormap.getRGB(5)).toEqual([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(10)).toEqual([255, 255, 255]);
     // Over-limits.
-    expect(colormap.getRGB(-100)).to.eql([0, 0, 0]);
-    expect(colormap.getRGB(500)).to.eql([255, 255, 255]);
+    expect(colormap.getRGB(-100)).toEqual([0, 0, 0]);
+    expect(colormap.getRGB(500)).toEqual([255, 255, 255]);
   });
 
   it('max > min, non-finite values', () => {
     const min = 0;
     const max = 10;
     const colormap = new GrayscaleColorMap({min, max});
-    expect(colormap.getRGB(NaN)).to.eql([255, 0, 0]);
-    expect(colormap.getRGB(-Infinity)).to.eql([255, 255 / 2, 0]);
-    expect(colormap.getRGB(Infinity)).to.eql([0, 0, 255]);
+    expect(colormap.getRGB(NaN)).toEqual([255, 0, 0]);
+    expect(colormap.getRGB(-Infinity)).toEqual([255, 255 / 2, 0]);
+    expect(colormap.getRGB(Infinity)).toEqual([0, 0, 255]);
   });
 
   it('max === min, non-finite values', () => {
     const min = -3.2;
     const max = -3.2;
     const colormap = new GrayscaleColorMap({min, max});
-    expect(colormap.getRGB(-32)).to.eql([127.5, 127.5, 127.5]);
-    expect(colormap.getRGB(-3.2)).to.eql([127.5, 127.5, 127.5]);
-    expect(colormap.getRGB(0)).to.eql([127.5, 127.5, 127.5]);
-    expect(colormap.getRGB(32)).to.eql([127.5, 127.5, 127.5]);
-    expect(colormap.getRGB(NaN)).to.eql([255, 0, 0]);
-    expect(colormap.getRGB(-Infinity)).to.eql([255, 255 / 2, 0]);
-    expect(colormap.getRGB(Infinity)).to.eql([0, 0, 255]);
+    expect(colormap.getRGB(-32)).toEqual([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(-3.2)).toEqual([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(0)).toEqual([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(32)).toEqual([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(NaN)).toEqual([255, 0, 0]);
+    expect(colormap.getRGB(-Infinity)).toEqual([255, 255 / 2, 0]);
+    expect(colormap.getRGB(Infinity)).toEqual([0, 0, 255]);
   });
 });
 
@@ -86,26 +93,35 @@ describe('JetColormap', () => {
   it('max < min causes constructor error', () => {
     const min = 3;
     const max = 2;
-    expect(() => new JetColorMap({min, max})).to.throw(/max.*<.*min/);
+    expect(() => new JetColorMap({min, max})).toThrowError(
+      Error,
+      /max.*<.*min/
+    );
   });
 
   it('NaN or Infinity min or max causes constructor error', () => {
-    expect(() => new JetColorMap({min: 0, max: Infinity})).to.throw(
+    expect(() => new JetColorMap({min: 0, max: Infinity})).toThrowError(
+      Error,
       /max.*not finite/
     );
-    expect(() => new JetColorMap({min: 0, max: -Infinity})).to.throw(
+    expect(() => new JetColorMap({min: 0, max: -Infinity})).toThrowError(
+      Error,
       /max.*not finite/
     );
-    expect(() => new JetColorMap({min: 0, max: NaN})).to.throw(
+    expect(() => new JetColorMap({min: 0, max: NaN})).toThrowError(
+      Error,
       /max.*not finite/
     );
-    expect(() => new JetColorMap({min: Infinity, max: 0})).to.throw(
+    expect(() => new JetColorMap({min: Infinity, max: 0})).toThrowError(
+      Error,
       /min.*not finite/
     );
-    expect(() => new JetColorMap({min: -Infinity, max: 0})).to.throw(
+    expect(() => new JetColorMap({min: -Infinity, max: 0})).toThrowError(
+      Error,
       /min.*not finite/
     );
-    expect(() => new JetColorMap({min: NaN, max: 0})).to.throw(
+    expect(() => new JetColorMap({min: NaN, max: 0})).toThrowError(
+      Error,
       /min.*not finite/
     );
   });
@@ -114,25 +130,25 @@ describe('JetColormap', () => {
     const min = 0;
     const max = 10;
     const colormap = new JetColorMap({min, max});
-    expect(colormap.getRGB(0)).to.eql([0, 0, 255]);
-    expect(colormap.getRGB(5)).to.eql([127.5, 255, 127.5]);
-    expect(colormap.getRGB(10)).to.eql([255, 0, 0]);
+    expect(colormap.getRGB(0)).toEqual([0, 0, 255]);
+    expect(colormap.getRGB(5)).toEqual([127.5, 255, 127.5]);
+    expect(colormap.getRGB(10)).toEqual([255, 0, 0]);
     // Over-limits.
-    expect(colormap.getRGB(-100)).to.eql([0, 0, 255]);
-    expect(colormap.getRGB(500)).to.eql([255, 0, 0]);
+    expect(colormap.getRGB(-100)).toEqual([0, 0, 255]);
+    expect(colormap.getRGB(500)).toEqual([255, 0, 0]);
   });
 
   it('max > min, non-finite values', () => {
     const min = 0;
     const max = 10;
     const colormap = new JetColorMap({min, max});
-    expect(colormap.getRGB(NaN)).to.eql([255 * 0.25, 255 * 0.25, 255 * 0.25]);
-    expect(colormap.getRGB(-Infinity)).to.eql([
+    expect(colormap.getRGB(NaN)).toEqual([255 * 0.25, 255 * 0.25, 255 * 0.25]);
+    expect(colormap.getRGB(-Infinity)).toEqual([
       255 * 0.5,
       255 * 0.5,
       255 * 0.5,
     ]);
-    expect(colormap.getRGB(Infinity)).to.eql([
+    expect(colormap.getRGB(Infinity)).toEqual([
       255 * 0.75,
       255 * 0.75,
       255 * 0.75,

--- a/tensorboard/components/tensor_widget/dtype-utils-test.ts
+++ b/tensorboard/components/tensor_widget/dtype-utils-test.ts
@@ -13,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {expect} from 'chai';
-
 import {
   isBooleanDType,
   isFloatDType,
@@ -24,91 +22,91 @@ import {
 
 describe('isIntegerDType', () => {
   it('returns true for unsigned ints', () => {
-    expect(isIntegerDType('uint02')).to.be.true;
-    expect(isIntegerDType('uint2')).to.be.true;
-    expect(isIntegerDType('uint04')).to.be.true;
-    expect(isIntegerDType('uint4')).to.be.true;
-    expect(isIntegerDType('uint8')).to.be.true;
-    expect(isIntegerDType('uint16')).to.be.true;
-    expect(isIntegerDType('uint64')).to.be.true;
-    expect(isIntegerDType('uint128')).to.be.true;
+    expect(isIntegerDType('uint02')).toBe(true);
+    expect(isIntegerDType('uint2')).toBe(true);
+    expect(isIntegerDType('uint04')).toBe(true);
+    expect(isIntegerDType('uint4')).toBe(true);
+    expect(isIntegerDType('uint8')).toBe(true);
+    expect(isIntegerDType('uint16')).toBe(true);
+    expect(isIntegerDType('uint64')).toBe(true);
+    expect(isIntegerDType('uint128')).toBe(true);
   });
 
   it('returns true for signed ints', () => {
-    expect(isIntegerDType('int4')).to.be.true;
-    expect(isIntegerDType('int8')).to.be.true;
-    expect(isIntegerDType('int16')).to.be.true;
-    expect(isIntegerDType('int32')).to.be.true;
-    expect(isIntegerDType('int64')).to.be.true;
-    expect(isIntegerDType('int128')).to.be.true;
+    expect(isIntegerDType('int4')).toBe(true);
+    expect(isIntegerDType('int8')).toBe(true);
+    expect(isIntegerDType('int16')).toBe(true);
+    expect(isIntegerDType('int32')).toBe(true);
+    expect(isIntegerDType('int64')).toBe(true);
+    expect(isIntegerDType('int128')).toBe(true);
   });
 
   it('returns false for negative cases', () => {
-    expect(isIntegerDType('bool')).to.be.false;
-    expect(isIntegerDType('string')).to.be.false;
-    expect(isIntegerDType('float32')).to.be.false;
-    expect(isIntegerDType('complex64')).to.be.false;
-    expect(isIntegerDType('complex128')).to.be.false;
-    expect(isIntegerDType('resource')).to.be.false;
-    expect(isIntegerDType('interrupt')).to.be.false;
+    expect(isIntegerDType('bool')).toBe(false);
+    expect(isIntegerDType('string')).toBe(false);
+    expect(isIntegerDType('float32')).toBe(false);
+    expect(isIntegerDType('complex64')).toBe(false);
+    expect(isIntegerDType('complex128')).toBe(false);
+    expect(isIntegerDType('resource')).toBe(false);
+    expect(isIntegerDType('interrupt')).toBe(false);
   });
 });
 
 describe('isFloatDType', () => {
   it('returns true for floats', () => {
-    expect(isFloatDType('float32')).to.be.true;
-    expect(isFloatDType('float64')).to.be.true;
+    expect(isFloatDType('float32')).toBe(true);
+    expect(isFloatDType('float64')).toBe(true);
   });
 
   it('returns true for bfloat types', () => {
-    expect(isFloatDType('bfloat16')).to.be.true;
+    expect(isFloatDType('bfloat16')).toBe(true);
   });
 
   it('returns false for negative cases', () => {
-    expect(isFloatDType('bool')).to.be.false;
-    expect(isFloatDType('string')).to.be.false;
-    expect(isFloatDType('int32')).to.be.false;
-    expect(isFloatDType('uint32')).to.be.false;
-    expect(isFloatDType('complex64')).to.be.false;
-    expect(isFloatDType('complex128')).to.be.false;
-    expect(isFloatDType('resource')).to.be.false;
+    expect(isFloatDType('bool')).toBe(false);
+    expect(isFloatDType('string')).toBe(false);
+    expect(isFloatDType('int32')).toBe(false);
+    expect(isFloatDType('uint32')).toBe(false);
+    expect(isFloatDType('complex64')).toBe(false);
+    expect(isFloatDType('complex128')).toBe(false);
+    expect(isFloatDType('resource')).toBe(false);
   });
 });
 
 describe('isBooleanDType', () => {
   it('returns true for booleans', () => {
-    expect(isBooleanDType('bool')).to.be.true;
-    expect(isBooleanDType('boolean')).to.be.true;
-    expect(isBooleanDType('Boolean')).to.be.true;
+    expect(isBooleanDType('bool')).toBe(true);
+    expect(isBooleanDType('boolean')).toBe(true);
+    expect(isBooleanDType('Boolean')).toBe(true);
   });
 
   it('returns false for negative cases', () => {
-    expect(isBooleanDType('string')).to.be.false;
-    expect(isBooleanDType('int32')).to.be.false;
-    expect(isBooleanDType('uint32')).to.be.false;
-    expect(isBooleanDType('float32')).to.be.false;
-    expect(isBooleanDType('float64')).to.be.false;
-    expect(isBooleanDType('complex64')).to.be.false;
-    expect(isBooleanDType('complex128')).to.be.false;
-    expect(isBooleanDType('resource')).to.be.false;
+    expect(isBooleanDType('string')).toBe(false);
+    expect(isBooleanDType('int32')).toBe(false);
+    expect(isBooleanDType('uint32')).toBe(false);
+    expect(isBooleanDType('float32')).toBe(false);
+    expect(isBooleanDType('float64')).toBe(false);
+    expect(isBooleanDType('complex64')).toBe(false);
+    expect(isBooleanDType('complex128')).toBe(false);
+    expect(isBooleanDType('resource')).toBe(false);
   });
 });
 
 describe('isStringDType', () => {
   it('returns true for strings', () => {
-    expect(isStringDType('str')).to.be.true;
-    expect(isStringDType('string')).to.be.true;
-    expect(isStringDType('String')).to.be.true;
+    expect(isStringDType('str')).toBe(true);
+    expect(isStringDType('string')).toBe(true);
+    expect(isStringDType('String')).toBe(true);
   });
 
   it('returns false for negative cases', () => {
-    expect(isStringDType('bool')).to.be.false;
-    expect(isStringDType('int32')).to.be.false;
-    expect(isStringDType('uint32')).to.be.false;
-    expect(isStringDType('float32')).to.be.false;
-    expect(isStringDType('float64')).to.be.false;
-    expect(isStringDType('complex64')).to.be.false;
-    expect(isStringDType('complex128')).to.be.false;
-    expect(isStringDType('resource')).to.be.false;
+    expect(isStringDType('bool')).toBe(false);
+    expect(isStringDType('int32')).toBe(false);
+    expect(isStringDType('uint32')).toBe(false);
+    expect(isStringDType('float32')).toBe(false);
+    expect(isStringDType('float64')).toBe(false);
+    expect(isStringDType('complex64')).toBe(false);
+    expect(isStringDType('complex128')).toBe(false);
+    expect(isStringDType('resource')).toBe(false);
   });
 });

--- a/tensorboard/components/tensor_widget/selection-test.ts
+++ b/tensorboard/components/tensor_widget/selection-test.ts
@@ -15,8 +15,6 @@ limitations under the License.
 
 /** Unit tests for selection. */
 
-import {expect} from 'chai';
-
 import {MoveDirection, Shape, TensorViewSlicingSpec, TensorView} from './types';
 import {TensorElementSelection} from './selection';
 
@@ -37,7 +35,7 @@ describe('TensorElementSelection', () => {
       1,
       1
     );
-    expect(selection.getElementStatus([])).to.eql({
+    expect(selection.getElementStatus([])).toEqual({
       topEdge: true,
       bottomEdge: true,
       leftEdge: true,
@@ -63,26 +61,26 @@ describe('TensorElementSelection', () => {
       5,
       1
     );
-    expect(selection.getElementStatus([0])).to.eql({
+    expect(selection.getElementStatus([0])).toEqual({
       topEdge: true,
       bottomEdge: false,
       leftEdge: true,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([1])).to.eql({
+    expect(selection.getElementStatus([1])).toEqual({
       topEdge: false,
       bottomEdge: false,
       leftEdge: true,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([4])).to.eql({
+    expect(selection.getElementStatus([4])).toEqual({
       topEdge: false,
       bottomEdge: true,
       leftEdge: true,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([5])).to.eql(null);
-    expect(selection.getElementStatus([9])).to.eql(null);
+    expect(selection.getElementStatus([5])).toBeNull();
+    expect(selection.getElementStatus([9])).toBeNull();
   });
 
   it('2D shape: multiple rows and multiple columns', () => {
@@ -103,50 +101,50 @@ describe('TensorElementSelection', () => {
       3,
       4
     );
-    expect(selection.getElementStatus([0, 0])).to.eql({
+    expect(selection.getElementStatus([0, 0])).toEqual({
       topEdge: true,
       bottomEdge: false,
       leftEdge: true,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([0, 1])).to.eql({
+    expect(selection.getElementStatus([0, 1])).toEqual({
       topEdge: true,
       bottomEdge: false,
       leftEdge: false,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([1, 0])).to.eql({
+    expect(selection.getElementStatus([1, 0])).toEqual({
       topEdge: false,
       bottomEdge: false,
       leftEdge: true,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([1, 1])).to.eql({
+    expect(selection.getElementStatus([1, 1])).toEqual({
       topEdge: false,
       bottomEdge: false,
       leftEdge: false,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([2, 3])).to.eql({
+    expect(selection.getElementStatus([2, 3])).toEqual({
       topEdge: false,
       bottomEdge: true,
       leftEdge: false,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([1, 3])).to.eql({
+    expect(selection.getElementStatus([1, 3])).toEqual({
       topEdge: false,
       bottomEdge: false,
       leftEdge: false,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([2, 2])).to.eql({
+    expect(selection.getElementStatus([2, 2])).toEqual({
       topEdge: false,
       bottomEdge: true,
       leftEdge: false,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([3, 4])).to.eql(null);
-    expect(selection.getElementStatus([9, 9])).to.eql(null);
+    expect(selection.getElementStatus([3, 4])).toBeNull();
+    expect(selection.getElementStatus([9, 9])).toBeNull();
   });
 
   it('2D shape: single row, multiple columns', () => {
@@ -167,27 +165,27 @@ describe('TensorElementSelection', () => {
       1,
       4
     );
-    expect(selection.getElementStatus([0, 0])).to.eql(null);
-    expect(selection.getElementStatus([1, 0])).to.eql({
+    expect(selection.getElementStatus([0, 0])).toBeNull();
+    expect(selection.getElementStatus([1, 0])).toEqual({
       topEdge: true,
       bottomEdge: true,
       leftEdge: true,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([1, 1])).to.eql({
+    expect(selection.getElementStatus([1, 1])).toEqual({
       topEdge: true,
       bottomEdge: true,
       leftEdge: false,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([1, 3])).to.eql({
+    expect(selection.getElementStatus([1, 3])).toEqual({
       topEdge: true,
       bottomEdge: true,
       leftEdge: false,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([2, 0])).to.eql(null);
-    expect(selection.getElementStatus([2, 1])).to.eql(null);
+    expect(selection.getElementStatus([2, 0])).toBeNull();
+    expect(selection.getElementStatus([2, 1])).toBeNull();
   });
 
   it('2D shape: multiple rows, single column', () => {
@@ -208,20 +206,20 @@ describe('TensorElementSelection', () => {
       3,
       1
     );
-    expect(selection.getElementStatus([0, 0])).to.eql(null);
-    expect(selection.getElementStatus([5, 7])).to.eql({
+    expect(selection.getElementStatus([0, 0])).toBeNull();
+    expect(selection.getElementStatus([5, 7])).toEqual({
       topEdge: true,
       bottomEdge: false,
       leftEdge: true,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([7, 7])).to.eql({
+    expect(selection.getElementStatus([7, 7])).toEqual({
       topEdge: false,
       bottomEdge: true,
       leftEdge: true,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([8, 7])).to.eql(null);
+    expect(selection.getElementStatus([8, 7])).toBeNull();
   });
 
   it('2D shape: single row, single column', () => {
@@ -242,12 +240,12 @@ describe('TensorElementSelection', () => {
       1,
       1
     );
-    expect(selection.getElementStatus([0, 0])).to.eql(null);
-    expect(selection.getElementStatus([4, 7])).to.eql(null);
-    expect(selection.getElementStatus([6, 7])).to.eql(null);
-    expect(selection.getElementStatus([5, 6])).to.eql(null);
-    expect(selection.getElementStatus([5, 8])).to.eql(null);
-    expect(selection.getElementStatus([5, 7])).to.eql({
+    expect(selection.getElementStatus([0, 0])).toBeNull();
+    expect(selection.getElementStatus([4, 7])).toBeNull();
+    expect(selection.getElementStatus([6, 7])).toBeNull();
+    expect(selection.getElementStatus([5, 6])).toBeNull();
+    expect(selection.getElementStatus([5, 8])).toBeNull();
+    expect(selection.getElementStatus([5, 7])).toEqual({
       topEdge: true,
       bottomEdge: true,
       leftEdge: true,
@@ -278,29 +276,29 @@ describe('TensorElementSelection', () => {
       3,
       2
     );
-    expect(selection.getElementStatus([0, 0, 0])).to.eql(null);
-    expect(selection.getElementStatus([2, 0, 0])).to.eql(null);
-    expect(selection.getElementStatus([3, 5, 7])).to.eql(null);
-    expect(selection.getElementStatus([3, 5, 8])).to.eql(null);
-    expect(selection.getElementStatus([2, 5, 7])).to.eql({
+    expect(selection.getElementStatus([0, 0, 0])).toBeNull();
+    expect(selection.getElementStatus([2, 0, 0])).toBeNull();
+    expect(selection.getElementStatus([3, 5, 7])).toBeNull();
+    expect(selection.getElementStatus([3, 5, 8])).toBeNull();
+    expect(selection.getElementStatus([2, 5, 7])).toEqual({
       topEdge: true,
       bottomEdge: false,
       leftEdge: true,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([2, 5, 8])).to.eql({
+    expect(selection.getElementStatus([2, 5, 8])).toEqual({
       topEdge: true,
       bottomEdge: false,
       leftEdge: false,
       rightEdge: true,
     });
-    expect(selection.getElementStatus([2, 7, 7])).to.eql({
+    expect(selection.getElementStatus([2, 7, 7])).toEqual({
       topEdge: false,
       bottomEdge: true,
       leftEdge: true,
       rightEdge: false,
     });
-    expect(selection.getElementStatus([2, 7, 8])).to.eql({
+    expect(selection.getElementStatus([2, 7, 8])).toEqual({
       topEdge: false,
       bottomEdge: true,
       leftEdge: false,
@@ -318,7 +316,7 @@ describe('TensorElementSelection', () => {
     };
     expect(
       () => new TensorElementSelection(shape, slicingSpec, 0, 0, 0, 0)
-    ).to.throw(/doesn\'t support tensor with zero elements./);
+    ).toThrowError(Error, /doesn\'t support tensor with zero elements./);
   });
 });
 
@@ -340,26 +338,26 @@ describe('Moving selection', () => {
       1
     );
     // All movements on a scalar selection leads to no change.
-    expect(selection.move(MoveDirection.UP, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getRowCount()).to.equal(1);
-    expect(selection.getColStart()).to.equal(0);
-    expect(selection.getColCount()).to.equal(1);
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getRowCount()).to.equal(1);
-    expect(selection.getColStart()).to.equal(0);
-    expect(selection.getColCount()).to.equal(1);
-    expect(selection.move(MoveDirection.LEFT, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getRowCount()).to.equal(1);
-    expect(selection.getColStart()).to.equal(0);
-    expect(selection.getColCount()).to.equal(1);
-    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getRowCount()).to.equal(1);
-    expect(selection.getColStart()).to.equal(0);
-    expect(selection.getColCount()).to.equal(1);
+    expect(selection.move(MoveDirection.UP, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getRowCount()).toBe(1);
+    expect(selection.getColStart()).toBe(0);
+    expect(selection.getColCount()).toBe(1);
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getRowCount()).toBe(1);
+    expect(selection.getColStart()).toBe(0);
+    expect(selection.getColCount()).toBe(1);
+    expect(selection.move(MoveDirection.LEFT, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getRowCount()).toBe(1);
+    expect(selection.getColStart()).toBe(0);
+    expect(selection.getColCount()).toBe(1);
+    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getRowCount()).toBe(1);
+    expect(selection.getColStart()).toBe(0);
+    expect(selection.getColCount()).toBe(1);
   });
 
   it('1D moving', () => {
@@ -381,33 +379,33 @@ describe('Moving selection', () => {
       1
     );
     // Null effects from left-right movements.
-    expect(selection.move(MoveDirection.UP, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getColStart()).to.equal(0);
-    expect(selection.move(MoveDirection.LEFT, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getColStart()).to.equal(0);
-    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getColStart()).to.equal(0);
+    expect(selection.move(MoveDirection.UP, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getColStart()).toBe(0);
+    expect(selection.move(MoveDirection.LEFT, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getColStart()).toBe(0);
+    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getColStart()).toBe(0);
     // Effective movements without changing slicing spec.
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(1);
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(2);
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(3);
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(4);
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(1);
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(2);
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(3);
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(4);
     // Movement causes updates to slicing spec.
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.equal(
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBe(
       MoveDirection.DOWN
     );
-    expect(selection.getRowStart()).to.equal(5);
+    expect(selection.getRowStart()).toBe(5);
 
     // Cannnot move anymore.
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(5);
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(5);
   });
 
   it('2D moving', () => {
@@ -429,36 +427,36 @@ describe('Moving selection', () => {
       1
     );
     // Null effects from up and left movements.
-    expect(selection.move(MoveDirection.UP, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getColStart()).to.equal(0);
-    expect(selection.move(MoveDirection.LEFT, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getColStart()).to.equal(0);
+    expect(selection.move(MoveDirection.UP, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getColStart()).toBe(0);
+    expect(selection.move(MoveDirection.LEFT, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getColStart()).toBe(0);
     // Non-null effect from down movement.
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(1);
-    expect(selection.getColStart()).to.equal(0);
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(1);
+    expect(selection.getColStart()).toBe(0);
     // Non-null effect from right movement.
-    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(1);
-    expect(selection.getColStart()).to.equal(1);
+    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(1);
+    expect(selection.getColStart()).toBe(1);
     // Next down movement should cause a slicinng spec change.
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.equal(
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBe(
       MoveDirection.DOWN
     );
-    expect(selection.getRowStart()).to.equal(2);
-    expect(selection.getColStart()).to.equal(1);
+    expect(selection.getRowStart()).toBe(2);
+    expect(selection.getColStart()).toBe(1);
     // Next right movement should cause a slicing spec change.
-    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).to.equal(
+    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).toBe(
       MoveDirection.RIGHT
     );
-    expect(selection.getRowStart()).to.equal(2);
-    expect(selection.getColStart()).to.equal(2);
+    expect(selection.getRowStart()).toBe(2);
+    expect(selection.getColStart()).toBe(2);
     // Moving back up.
-    expect(selection.move(MoveDirection.UP, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(1);
-    expect(selection.getColStart()).to.equal(2);
+    expect(selection.move(MoveDirection.UP, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(1);
+    expect(selection.getColStart()).toBe(2);
   });
 
   it('2D moving with setSlicingSpec reflects new spec', () => {
@@ -488,8 +486,8 @@ describe('Moving selection', () => {
     };
     // With the new slicing spec set, the downward move should lead to no update
     // in the slicing spec, and neither should the rightward move.
-    expect(selection.move(MoveDirection.DOWN, newSlicingSpec)).to.be.null;
-    expect(selection.move(MoveDirection.RIGHT, newSlicingSpec)).to.be.null;
+    expect(selection.move(MoveDirection.DOWN, newSlicingSpec)).toBeNull();
+    expect(selection.move(MoveDirection.RIGHT, newSlicingSpec)).toBeNull();
   });
 
   it('3D moving', () => {
@@ -516,36 +514,36 @@ describe('Moving selection', () => {
       1
     );
     // Null effects from up and left movements.
-    expect(selection.move(MoveDirection.UP, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getColStart()).to.equal(0);
-    expect(selection.move(MoveDirection.LEFT, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(0);
-    expect(selection.getColStart()).to.equal(0);
+    expect(selection.move(MoveDirection.UP, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getColStart()).toBe(0);
+    expect(selection.move(MoveDirection.LEFT, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(0);
+    expect(selection.getColStart()).toBe(0);
     // Non-null effect from down movement.
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(1);
-    expect(selection.getColStart()).to.equal(0);
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(1);
+    expect(selection.getColStart()).toBe(0);
     // Non-null effect from right movement.
-    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(1);
-    expect(selection.getColStart()).to.equal(1);
+    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(1);
+    expect(selection.getColStart()).toBe(1);
     // Next down movement should cause a slicinng spec change.
-    expect(selection.move(MoveDirection.DOWN, slicingSpec)).to.equal(
+    expect(selection.move(MoveDirection.DOWN, slicingSpec)).toBe(
       MoveDirection.DOWN
     );
-    expect(selection.getRowStart()).to.equal(2);
-    expect(selection.getColStart()).to.equal(1);
+    expect(selection.getRowStart()).toBe(2);
+    expect(selection.getColStart()).toBe(1);
     // Next right movement should cause a slicing spec change.
-    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).to.equal(
+    expect(selection.move(MoveDirection.RIGHT, slicingSpec)).toBe(
       MoveDirection.RIGHT
     );
-    expect(selection.getRowStart()).to.equal(2);
-    expect(selection.getColStart()).to.equal(2);
+    expect(selection.getRowStart()).toBe(2);
+    expect(selection.getColStart()).toBe(2);
 
     // Moving back up.
-    expect(selection.move(MoveDirection.UP, slicingSpec)).to.be.null;
-    expect(selection.getRowStart()).to.equal(1);
-    expect(selection.getColStart()).to.equal(2);
+    expect(selection.move(MoveDirection.UP, slicingSpec)).toBeNull();
+    expect(selection.getRowStart()).toBe(1);
+    expect(selection.getColStart()).toBe(2);
   });
 });

--- a/tensorboard/components/tensor_widget/shape-utils-test.ts
+++ b/tensorboard/components/tensor_widget/shape-utils-test.ts
@@ -13,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {expect} from 'chai';
-
 import {
   formatShapeForDisplay,
   getDefaultSlicingSpec,
@@ -25,52 +23,50 @@ import {TensorViewSlicingSpec} from './types';
 
 describe('size', () => {
   it('scalar', () => {
-    expect(numElements([])).to.equal(1);
+    expect(numElements([])).toBe(1);
   });
 
   it('1D', () => {
-    expect(numElements([3])).to.equal(3);
-    expect(numElements([0])).to.equal(0);
+    expect(numElements([3])).toBe(3);
+    expect(numElements([0])).toBe(0);
   });
 
   it('2D', () => {
-    expect(numElements([3, 4])).to.equal(12);
-    expect(numElements([3, 0])).to.equal(0);
-    expect(numElements([0, 3])).to.equal(0);
+    expect(numElements([3, 4])).toBe(12);
+    expect(numElements([3, 0])).toBe(0);
+    expect(numElements([0, 3])).toBe(0);
   });
 
   it('3D', () => {
-    expect(numElements([3, 4, 5])).to.equal(60);
-    expect(numElements([3, 0, 5])).to.equal(0);
-    expect(numElements([0, 4, 5])).to.equal(0);
+    expect(numElements([3, 4, 5])).toBe(60);
+    expect(numElements([3, 0, 5])).toBe(0);
+    expect(numElements([0, 4, 5])).toBe(0);
   });
 
   it('4D', () => {
-    expect(numElements([2, 3, 4, 5])).to.equal(120);
-    expect(numElements([2, 3, 0, 5])).to.equal(0);
+    expect(numElements([2, 3, 4, 5])).toBe(120);
+    expect(numElements([2, 3, 0, 5])).toBe(0);
   });
 });
 
 describe('formatShapeForDisplay', () => {
   it('returns string scalar for []', () => {
-    expect(formatShapeForDisplay([])).to.equal('scalar');
+    expect(formatShapeForDisplay([])).toBe('scalar');
   });
 
   it('returns array strings for non-scalar shapes', () => {
-    expect(formatShapeForDisplay([0])).to.equal('[0]');
-    expect(formatShapeForDisplay([12])).to.equal('[12]');
-    expect(formatShapeForDisplay([4, 8])).to.equal('[4,8]');
-    expect(formatShapeForDisplay([1, 32, 8])).to.equal('[1,32,8]');
-    expect(formatShapeForDisplay([8, 32, 32, 128])).to.equal('[8,32,32,128]');
-    expect(formatShapeForDisplay([0, 8, 32, 32, 128])).to.equal(
-      '[0,8,32,32,128]'
-    );
+    expect(formatShapeForDisplay([0])).toBe('[0]');
+    expect(formatShapeForDisplay([12])).toBe('[12]');
+    expect(formatShapeForDisplay([4, 8])).toBe('[4,8]');
+    expect(formatShapeForDisplay([1, 32, 8])).toBe('[1,32,8]');
+    expect(formatShapeForDisplay([8, 32, 32, 128])).toBe('[8,32,32,128]');
+    expect(formatShapeForDisplay([0, 8, 32, 32, 128])).toBe('[0,8,32,32,128]');
   });
 });
 
 describe('getDefaultSlicingSpec', () => {
   it('returns correct result for scalar shape', () => {
-    expect(getDefaultSlicingSpec([])).to.eql({
+    expect(getDefaultSlicingSpec([])).toEqual({
       slicingDimsAndIndices: [],
       viewingDims: [],
       verticalRange: null,
@@ -79,7 +75,7 @@ describe('getDefaultSlicingSpec', () => {
   });
 
   it('returns correct result for 1D shape', () => {
-    expect(getDefaultSlicingSpec([10])).to.eql({
+    expect(getDefaultSlicingSpec([10])).toEqual({
       slicingDimsAndIndices: [],
       viewingDims: [0],
       verticalRange: null,
@@ -88,7 +84,7 @@ describe('getDefaultSlicingSpec', () => {
   });
 
   it('returns correct result for 2D shape', () => {
-    expect(getDefaultSlicingSpec([4, 5])).to.eql({
+    expect(getDefaultSlicingSpec([4, 5])).toEqual({
       slicingDimsAndIndices: [],
       viewingDims: [0, 1],
       verticalRange: null,
@@ -97,7 +93,7 @@ describe('getDefaultSlicingSpec', () => {
   });
 
   it('returns correct result for 3D shape', () => {
-    expect(getDefaultSlicingSpec([4, 5, 6])).to.eql({
+    expect(getDefaultSlicingSpec([4, 5, 6])).toEqual({
       slicingDimsAndIndices: [
         {
           dim: 0,
@@ -111,7 +107,7 @@ describe('getDefaultSlicingSpec', () => {
   });
 
   it('returns correct result for 4D shape', () => {
-    expect(getDefaultSlicingSpec([4, 5, 6, 7])).to.eql({
+    expect(getDefaultSlicingSpec([4, 5, 6, 7])).toEqual({
       slicingDimsAndIndices: [
         {
           dim: 0,
@@ -129,7 +125,7 @@ describe('getDefaultSlicingSpec', () => {
   });
 
   it('returns correct result for 5D shape', () => {
-    expect(getDefaultSlicingSpec([4, 5, 6, 7, 8])).to.eql({
+    expect(getDefaultSlicingSpec([4, 5, 6, 7, 8])).toEqual({
       slicingDimsAndIndices: [
         {
           dim: 0,
@@ -183,7 +179,7 @@ describe('dimensionsDiffer', () => {
       verticalRange: null,
       horizontalRange: null,
     };
-    expect(areSlicingSpecsCompatible(spec0, spec1)).to.be.true;
+    expect(areSlicingSpecsCompatible(spec0, spec1)).toBe(true);
   });
 
   it('Different slicing indices are ignored', () => {
@@ -217,7 +213,7 @@ describe('dimensionsDiffer', () => {
       verticalRange: null,
       horizontalRange: null,
     };
-    expect(areSlicingSpecsCompatible(spec0, spec1)).to.be.true;
+    expect(areSlicingSpecsCompatible(spec0, spec1)).toBe(true);
   });
 
   it('Different slicing and viewing dimensions are captured', () => {
@@ -251,6 +247,6 @@ describe('dimensionsDiffer', () => {
       verticalRange: null,
       horizontalRange: null,
     };
-    expect(areSlicingSpecsCompatible(spec0, spec1)).to.be.false;
+    expect(areSlicingSpecsCompatible(spec0, spec1)).toBe(false);
   });
 });

--- a/tensorboard/components/tensor_widget/string-utils-test.ts
+++ b/tensorboard/components/tensor_widget/string-utils-test.ts
@@ -13,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {expect} from 'chai';
-
 import {
   booleanValueToDisplayString,
   ELLIPSES,
@@ -34,34 +32,32 @@ function stringRepeat(str: string, times: number) {
 
 describe('formatTensorName', () => {
   it('returns original string for under-limit lengths', () => {
-    expect(formatTensorName('')).to.equal('');
-    expect(formatTensorName('a')).to.equal('a');
+    expect(formatTensorName('')).toBe('');
+    expect(formatTensorName('a')).toBe('a');
     const onLimitName = stringRepeat('A', TENSOR_NAME_LENGTH_CUTOFF);
-    expect(formatTensorName(onLimitName)).to.equal(onLimitName);
+    expect(formatTensorName(onLimitName)).toBe(onLimitName);
   });
 
   it('returns string with ellipses for over-limit lengths', () => {
     const longName = stringRepeat('A', TENSOR_NAME_LENGTH_CUTOFF + 10);
-    expect(formatTensorName(longName).length).to.equal(
-      TENSOR_NAME_LENGTH_CUTOFF
-    );
+    expect(formatTensorName(longName).length).toBe(TENSOR_NAME_LENGTH_CUTOFF);
   });
 
   it('includes ellipses, prefix and suffix', () => {
     const longName = stringRepeat('A', TENSOR_NAME_LENGTH_CUTOFF + 10);
     const output = formatTensorName(longName);
-    expect(output.indexOf(ELLIPSES)).to.equal(
+    expect(output.indexOf(ELLIPSES)).toBe(
       Math.floor(TENSOR_NAME_LENGTH_CUTOFF / 2)
     );
-    expect(output.slice(0, 1)).to.equal('A');
-    expect(output.slice(output.length - 1, output.length)).to.equal('A');
+    expect(output.slice(0, 1)).toBe('A');
+    expect(output.slice(output.length - 1, output.length)).toBe('A');
   });
 });
 
 describe('Constants for formatTensorName', () => {
   it('TENSOR_NAME_LENGTH_CUTOFF is long-enough positive integer', () => {
-    expect(TENSOR_NAME_LENGTH_CUTOFF).to.be.greaterThan(ELLIPSES.length);
-    expect(Math.floor(TENSOR_NAME_LENGTH_CUTOFF)).to.equal(
+    expect(TENSOR_NAME_LENGTH_CUTOFF).toBeGreaterThan(ELLIPSES.length);
+    expect(Math.floor(TENSOR_NAME_LENGTH_CUTOFF)).toBe(
       Math.floor(TENSOR_NAME_LENGTH_CUTOFF)
     );
   });
@@ -70,73 +66,69 @@ describe('Constants for formatTensorName', () => {
 describe('numericValueToString', () => {
   it('returns NaN string for NaN', () => {
     const isInteger = false;
-    expect(numericValueToString(NaN, isInteger)).to.equal('NaN');
+    expect(numericValueToString(NaN, isInteger)).toBe('NaN');
     const decimalPlaces = 4;
-    expect(numericValueToString(NaN, isInteger, decimalPlaces)).to.equal('NaN');
+    expect(numericValueToString(NaN, isInteger, decimalPlaces)).toBe('NaN');
     expect(
       numericValueToString(NaN, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('NaN');
+    ).toBe('NaN');
   });
 
   it('returns unicode infinity for +/- Infinity', () => {
     const isInteger = false;
-    expect(numericValueToString(-Infinity, isInteger)).to.equal('-∞');
-    expect(numericValueToString(Infinity, isInteger)).to.equal('+∞');
+    expect(numericValueToString(-Infinity, isInteger)).toBe('-∞');
+    expect(numericValueToString(Infinity, isInteger)).toBe('+∞');
     const decimalPlaces = 4;
-    expect(numericValueToString(-Infinity, isInteger, decimalPlaces)).to.equal(
+    expect(numericValueToString(-Infinity, isInteger, decimalPlaces)).toBe(
       '-∞'
     );
-    expect(numericValueToString(Infinity, isInteger, decimalPlaces)).to.equal(
-      '+∞'
-    );
+    expect(numericValueToString(Infinity, isInteger, decimalPlaces)).toBe('+∞');
     expect(
       numericValueToString(-Infinity, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('-∞');
+    ).toBe('-∞');
     expect(
       numericValueToString(Infinity, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('+∞');
+    ).toBe('+∞');
   });
 
   it('float zeros are formatted correctly', () => {
     const isInteger = false;
     const x = 0;
-    expect(numericValueToString(x, isInteger)).to.equal('0.00');
+    expect(numericValueToString(x, isInteger)).toBe('0.00');
 
     let decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('0');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('0');
 
     decimalPlaces = 1;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('0.0');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('0.0');
 
     decimalPlaces = 0;
     expect(
       numericValueToString(x, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('0e+0');
+    ).toBe('0e+0');
     decimalPlaces = 2;
     expect(
       numericValueToString(x, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('0.00e+0');
+    ).toBe('0.00e+0');
   });
 
   it('Large positive float values are formatted correctly', () => {
     const isInteger = false;
     const x = 12345;
-    expect(numericValueToString(x, isInteger)).to.equal('1.23e+4');
+    expect(numericValueToString(x, isInteger)).toBe('1.23e+4');
 
     let decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('1e+4');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('1e+4');
 
     decimalPlaces = 1;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal(
-      '1.2e+4'
-    );
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('1.2e+4');
 
     decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).to.equal(
+    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).toBe(
       '12345'
     );
     decimalPlaces = 2;
-    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).to.equal(
+    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).toBe(
       '12345.00'
     );
   });
@@ -144,22 +136,20 @@ describe('numericValueToString', () => {
   it('Large negative float values are formatted correctly', () => {
     const isInteger = false;
     const x = -12345;
-    expect(numericValueToString(x, isInteger)).to.equal('-1.23e+4');
+    expect(numericValueToString(x, isInteger)).toBe('-1.23e+4');
 
     let decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('-1e+4');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('-1e+4');
 
     decimalPlaces = 1;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal(
-      '-1.2e+4'
-    );
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('-1.2e+4');
 
     decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).to.equal(
+    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).toBe(
       '-12345'
     );
     decimalPlaces = 2;
-    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).to.equal(
+    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).toBe(
       '-12345.00'
     );
   });
@@ -167,64 +157,62 @@ describe('numericValueToString', () => {
   it('Medium magnitude positive float values are formatted correctly', () => {
     const isInteger = false;
     const x = 42.6;
-    expect(numericValueToString(x, isInteger)).to.equal('42.60');
+    expect(numericValueToString(x, isInteger)).toBe('42.60');
 
     let decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('43');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('43');
 
     decimalPlaces = 1;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('42.6');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('42.6');
 
     decimalPlaces = 0;
     expect(
       numericValueToString(x, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('4e+1');
+    ).toBe('4e+1');
     decimalPlaces = 2;
     expect(
       numericValueToString(x, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('4.26e+1');
+    ).toBe('4.26e+1');
   });
 
   it('Medium magnitude negative float values are formatted correctly', () => {
     const isInteger = false;
     const x = -42.6;
-    expect(numericValueToString(x, isInteger)).to.equal('-42.60');
+    expect(numericValueToString(x, isInteger)).toBe('-42.60');
 
     let decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('-43');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('-43');
 
     decimalPlaces = 1;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('-42.6');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('-42.6');
 
     decimalPlaces = 0;
     expect(
       numericValueToString(x, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('-4e+1');
+    ).toBe('-4e+1');
     decimalPlaces = 2;
     expect(
       numericValueToString(x, isInteger, decimalPlaces, 'exponential')
-    ).to.equal('-4.26e+1');
+    ).toBe('-4.26e+1');
   });
 
   it('Small magnitude positive float values are formatted correctly', () => {
     const isInteger = false;
     const x = 1.337e-8;
-    expect(numericValueToString(x, isInteger)).to.equal('1.34e-8');
+    expect(numericValueToString(x, isInteger)).toBe('1.34e-8');
 
     let decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('1e-8');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('1e-8');
 
     decimalPlaces = 1;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal(
-      '1.3e-8'
-    );
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('1.3e-8');
 
     decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).to.equal(
+    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).toBe(
       '0'
     );
     decimalPlaces = 2;
-    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).to.equal(
+    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).toBe(
       '0.00'
     );
   });
@@ -232,88 +220,86 @@ describe('numericValueToString', () => {
   it('Small magnitude negative float values are formatted correctly', () => {
     const isInteger = false;
     const x = -1.337e-8;
-    expect(numericValueToString(x, isInteger)).to.equal('-1.34e-8');
+    expect(numericValueToString(x, isInteger)).toBe('-1.34e-8');
 
     let decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal('-1e-8');
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('-1e-8');
 
     decimalPlaces = 1;
-    expect(numericValueToString(x, isInteger, decimalPlaces)).to.equal(
-      '-1.3e-8'
-    );
+    expect(numericValueToString(x, isInteger, decimalPlaces)).toBe('-1.3e-8');
 
     decimalPlaces = 0;
-    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).to.equal(
+    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).toBe(
       '-0'
     );
     decimalPlaces = 2;
-    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).to.equal(
+    expect(numericValueToString(x, isInteger, decimalPlaces, 'fixed')).toBe(
       '-0.00'
     );
   });
 
   it('Zero integer is formatted correctly', () => {
     const isInteger = true;
-    expect(numericValueToString(0, isInteger)).to.equal('0');
+    expect(numericValueToString(0, isInteger)).toBe('0');
   });
 
   it('Small magnitude positive integers are formatted correctly', () => {
     const isInteger = true;
-    expect(numericValueToString(42, isInteger)).to.equal('42');
+    expect(numericValueToString(42, isInteger)).toBe('42');
   });
 
   it('Small magnitude negative integers are formatted correctly', () => {
     const isInteger = true;
-    expect(numericValueToString(-42, isInteger)).to.equal('-42');
+    expect(numericValueToString(-42, isInteger)).toBe('-42');
   });
 
   it('Large magnitude positive integers are formatted correctly', () => {
     const isInteger = true;
-    expect(numericValueToString(12345678, isInteger)).to.equal('1.23e+7');
+    expect(numericValueToString(12345678, isInteger)).toBe('1.23e+7');
   });
 
   it('Large magnitude negative integers are formatted correctly', () => {
     const isInteger = true;
-    expect(numericValueToString(-12345678, isInteger)).to.equal('-1.23e+7');
+    expect(numericValueToString(-12345678, isInteger)).toBe('-1.23e+7');
   });
 });
 
 describe('booleanValueToString', () => {
   it('correct return values for boolean arguments', () => {
-    expect(booleanValueToDisplayString(true)).to.eql('T');
-    expect(booleanValueToDisplayString(false)).to.eql('F');
+    expect(booleanValueToDisplayString(true)).toBe('T');
+    expect(booleanValueToDisplayString(false)).toBe('F');
     const shortForm = false;
-    expect(booleanValueToDisplayString(true, shortForm)).to.eql('True');
-    expect(booleanValueToDisplayString(false, shortForm)).to.eql('False');
+    expect(booleanValueToDisplayString(true, shortForm)).toBe('True');
+    expect(booleanValueToDisplayString(false, shortForm)).toBe('False');
   });
 
   it('correct return values for number arguments', () => {
-    expect(booleanValueToDisplayString(1)).to.eql('T');
-    expect(booleanValueToDisplayString(0)).to.eql('F');
+    expect(booleanValueToDisplayString(1)).toBe('T');
+    expect(booleanValueToDisplayString(0)).toBe('F');
     const shortForm = false;
-    expect(booleanValueToDisplayString(1, shortForm)).to.eql('True');
-    expect(booleanValueToDisplayString(0, shortForm)).to.eql('False');
+    expect(booleanValueToDisplayString(1, shortForm)).toBe('True');
+    expect(booleanValueToDisplayString(0, shortForm)).toBe('False');
   });
 });
 
 describe('stringValueToString', () => {
   it('cutoff with default length limit', () => {
-    expect(stringValueToDisplayString('')).to.eql('');
-    expect(stringValueToDisplayString('ABC')).to.eql('ABC');
-    expect(stringValueToDisplayString('ABCDE')).to.eql('ABC…');
+    expect(stringValueToDisplayString('')).toBe('');
+    expect(stringValueToDisplayString('ABC')).toBe('ABC');
+    expect(stringValueToDisplayString('ABCDE')).toBe('ABC…');
   });
 
   it('cutoff with custom length limit', () => {
     const lengthLimit = 2;
-    expect(stringValueToDisplayString('', lengthLimit)).to.eql('');
-    expect(stringValueToDisplayString('ABC', lengthLimit)).to.eql('A…');
+    expect(stringValueToDisplayString('', lengthLimit)).toBe('');
+    expect(stringValueToDisplayString('ABC', lengthLimit)).toBe('A…');
   });
 
   it('cutoff with explicitly disabled limit', () => {
-    expect(stringValueToDisplayString('', null)).to.eql('');
-    expect(stringValueToDisplayString('ABC', null)).to.eql('ABC');
-    expect(stringValueToDisplayString('ABCDE', null)).to.eql('ABCDE');
-    expect(stringValueToDisplayString(stringRepeat('V', 1000), null)).to.eql(
+    expect(stringValueToDisplayString('', null)).toBe('');
+    expect(stringValueToDisplayString('ABC', null)).toBe('ABC');
+    expect(stringValueToDisplayString('ABCDE', null)).toBe('ABCDE');
+    expect(stringValueToDisplayString(stringRepeat('V', 1000), null)).toBe(
       stringRepeat('V', 1000)
     );
   });


### PR DESCRIPTION
Angular works the best when using jasmine and most of our codebase
already adopted jasmine. To avoid using multiple libraries, we decided
to refactor existing tests into jasmine.
