### PR TITLE
cleanup: remove duplicate requirejs dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "ngx-color-picker": "^9.0.0",
     "numeric": "^1.2.6",
     "plottable": "^3.9.0",
-    "requirejs": "^2.3.6",
     "rxjs": "7.0.0-beta.0",
     "three": "~0.108.0",
     "umap-js": "^1.3.2",


### PR DESCRIPTION
package.json had requirejs in both devDep and dep. `yarn` is supposed to autoclean
but it does not seem to do a great job there.