### PR TITLE
webapp: add noscript message

### DIFF
--- a/tensorboard/webapp/index_polymer3.uninlined.html
+++ b/tensorboard/webapp/index_polymer3.uninlined.html
@@ -50,9 +50,19 @@ limitations under the License.
 
     -webkit-font-smoothing: antialiased;
   }
+  noscript {
+    display: block;
+    margin: 0 auto;
+    max-width: 600px;
+    padding: 10px;
+  }
 </style>
 
 <body>
+  <noscript>
+    <h1>TensorBoard requires JavaScript</h1>
+    <p>Please enable JavaScript and reload this page.</p>
+  </noscript>
   <script jscomp-nocompile src="tf-imports/require.js"></script>
   <script jscomp-nocompile src="polymer3_lib_binary.js"></script>
   <script jscomp-nocompile src="tb-webapp/tb_webapp_binary.js"></script>


### PR DESCRIPTION
Summary:
Since TensorBoard is rendered entirely client-side with Angular and
Polymer, the screen is entirely blank when JavaScript is disabled. This
patch adds a simple “please enable JavaScript” `<noscript>` message.
Fixes #4401.

Test Plan:
In both Chrome and Firefox, the message appears when JavaScript is
disabled but not otherwise. It’s properly centered at wide window sizes
and doesn’t create a horizontal scrollbar at narrow ones. Looks like:

![Screenshot of a blank page with a header “TensorBoard requires
JavaScript”, followed by a message, “Please enable JavaScript and
reload this page.” Both are rendered in Roboto, and appear to be
centered in the screenshot.][ss]

[ss]: https://user-images.githubusercontent.com/4317806/100648627-0b6d7b00-32f6-11eb-9781-68af70d7cb1f.png

wchargin-branch: noscript-message
