### PR TITLE
line chart: implement ignoreOutlier

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -89,6 +89,7 @@ limitations under the License.
     [seriesData]="dataSeries"
     [seriesMetadataMap]="chartMetadataMap"
     [yScaleType]="newYAxisType"
+    [ignoreYOutliers]="ignoreOutliers"
   ></line-chart>
 
   <ng-template #legacyChart>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -88,6 +88,7 @@ class TestableGpuLineChart {
   @Input() seriesData!: DataSeries[];
   @Input() seriesMetadataMap!: DataSeriesMetadataMap;
   @Input() yScaleType!: ScaleType;
+  @Input() ignoreYOutliers: boolean = false;
 }
 
 describe('scalar card', () => {

--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -43,6 +43,7 @@ tf_ts_library(
     ],
     visibility = ["//visibility:private"],
     deps = [
+        "//tensorboard/webapp/third_party:d3",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:utils",
     ],


### PR DESCRIPTION
This change backports some logic from vz-chart-helpers to ignore y
dimension outliers when computing the default viewBox.
