### PR TITLE
line chart: improve worker doc and check for assumption

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker.ts
@@ -20,7 +20,7 @@ limitations under the License.
  *
  * @param workerJsFilename Worker JavaScript resource file name. Exact resource path
  *   depends on context. It can be relative or absolute depending on a app and its
- *   configuration (internally, it is absolute; i.e., served at "/<resource_name.js>").
+ *   configuration. Please see the internal version of this module for details.
  */
 export function getWorker(workerJsFilename: string): Worker {
   if (workerJsFilename.includes('/')) {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker.ts
@@ -18,10 +18,15 @@ limitations under the License.
  *
  * This module exists to conform to internal requirements.
  *
- * @param workerResourcePath URL pathanme to the JavaScript resource served by
- *   TensorBoard. TensorBoard disallows fetching JavaScript resources from a differnt
- *   origin.
+ * @param workerJsFilename Worker JavaScript resource file name. Exact resource path
+ *   depends on context. It can be relative or absolute depending on a app and its
+ *   configuration (internally, it is absolute; i.e., served at "/<resource_name.js>").
  */
-export function getWorker(workerResourcePath: string): Worker {
-  return new Worker(workerResourcePath);
+export function getWorker(workerJsFilename: string): Worker {
+  if (workerJsFilename.includes('/')) {
+    throw new RangeError(
+      'Worker factory only allows file name and no resource path.'
+    );
+  }
+  return new Worker(workerJsFilename);
 }


### PR DESCRIPTION
Internally, due to conformance reasons, we cannot support a relative
path for the worker resource. As such, we are now modifying the contract
and accompany the change with a check.
