### PR TITLE
refactor: extract store provider to a separate module

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -32,6 +32,19 @@ tf_ng_module(
 )
 
 tf_ng_module(
+    name = "store_module",
+    srcs = [
+        "store_module.ts",
+    ],
+    deps = [
+        ":reducer_config",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ng_module(
     name = "selectors",
     srcs = [
         "selectors.ts",
@@ -74,7 +87,7 @@ tf_ng_module(
     deps = [
         ":mat_icon",
         ":oss_plugins_module",
-        ":reducer_config",
+        ":store_module",
         "//tensorboard/webapp/alert",
         "//tensorboard/webapp/alert/views:alert_snackbar",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
@@ -98,8 +111,6 @@ tf_ng_module(
         "//tensorboard/webapp/tb_wrapper",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
-        "@npm//@ngrx/effects",
-        "@npm//@ngrx/store",
     ],
 )
 

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -12,33 +12,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {NgModule} from '@angular/core';
-import {StoreModule, META_REDUCERS} from '@ngrx/store';
-import {EffectsModule} from '@ngrx/effects';
 
-import {AppContainer} from './app_container';
-import {AppRoutingModule} from './app_routing/app_routing_module';
-import {AppRoutingViewModule} from './app_routing/views/app_routing_view_module';
-import {CoreModule} from './core/core_module';
-import {ExperimentsModule} from './experiments/experiments_module';
 import {AlertModule} from './alert/alert_module';
 import {AlertSnackbarModule} from './alert/views/alert_snackbar_module';
+import {AppContainer} from './app_container';
+import {AppRoutingModule} from './app_routing/app_routing_module';
+import {RouteRegistryModule} from './app_routing/route_registry_module';
+import {AppRoutingViewModule} from './app_routing/views/app_routing_view_module';
+import {CoreModule} from './core/core_module';
 import {HashStorageModule} from './core/views/hash_storage_module';
 import {PageTitleModule} from './core/views/page_title_module';
+import {ExperimentsModule} from './experiments/experiments_module';
 import {FeatureFlagModule} from './feature_flag/feature_flag_module';
 import {HeaderModule} from './header/header_module';
 import {MatIconModule} from './mat_icon_module';
+import {OssPluginsModule} from './oss_plugins_module';
 import {PluginsModule} from './plugins/plugins_module';
-import {ROOT_REDUCERS, loggerMetaReducerFactory} from './reducer_config';
+import {routesFactory} from './routes';
 import {RunsModule} from './runs/runs_module';
 import {SettingsModule} from './settings/settings_module';
+import {StoreModule} from './store_module';
 import {TensorBoardWrapperModule} from './tb_wrapper/tb_wrapper_module';
-import {OssPluginsModule} from './oss_plugins_module';
-
-import {RouteRegistryModule} from './app_routing/route_registry_module';
-import {routesFactory} from './routes';
 
 @NgModule({
   declarations: [AppContainer],
@@ -62,21 +59,8 @@ import {routesFactory} from './routes';
     PluginsModule,
     RunsModule,
     SettingsModule,
-    StoreModule.forRoot(ROOT_REDUCERS, {
-      runtimeChecks: {
-        strictStateSerializability: false,
-        strictActionSerializability: true,
-      },
-    }),
-    EffectsModule.forRoot([]),
+    StoreModule,
     OssPluginsModule,
-  ],
-  providers: [
-    {
-      provide: META_REDUCERS,
-      useFactory: loggerMetaReducerFactory,
-      multi: true,
-    },
   ],
   bootstrap: [AppContainer],
 })

--- a/tensorboard/webapp/store_module.ts
+++ b/tensorboard/webapp/store_module.ts
@@ -1,0 +1,43 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+import {EffectsModule as NgrxEffectsModule} from '@ngrx/effects';
+import {META_REDUCERS, StoreModule as NgrxStoreModule} from '@ngrx/store';
+
+import {loggerMetaReducerFactory, ROOT_REDUCERS} from './reducer_config';
+
+@NgModule({
+  imports: [
+    NgrxStoreModule.forRoot(ROOT_REDUCERS, {
+      runtimeChecks: {
+        strictStateImmutability: true,
+        strictActionImmutability: true,
+        // We use `Map` and `Set`. Remember not to abuse it and
+        // introduce too many class instances with many instance methods.
+        strictActionSerializability: false,
+        strictStateSerializability: false,
+      },
+    }),
+    NgrxEffectsModule.forRoot([]),
+  ],
+  providers: [
+    {
+      provide: META_REDUCERS,
+      useFactory: loggerMetaReducerFactory,
+      multi: true,
+    },
+  ],
+})
+export class StoreModule {}


### PR DESCRIPTION
This modularization allows other applications to provide the crucial set
up code without importing the entire `AppModule`.
