### PR TITLE
ui: allow disabled dropdown options

### DIFF
--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -18,8 +18,7 @@ export interface DropdownOption {
   value: any;
   displayText: string;
   /**
-   * Whether the option should appear non-interactable. All options are
-   * 'enabled' by default.
+   * Whether the option should appear non-interactable. 'enabled' by default.
    */
   disabled?: boolean;
 }

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -17,8 +17,16 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 export interface DropdownOption {
   value: any;
   displayText: string;
+  /**
+   * Whether the option should appear non-interactable. All options are
+   * 'enabled' by default.
+   */
+  disabled?: boolean;
 }
 
+/**
+ * A generic dropdown with options, similar to <select>.
+ */
 @Component({
   selector: 'tb-dropdown',
   template: `
@@ -26,7 +34,11 @@ export interface DropdownOption {
       [value]="value"
       (selectionChange)="selectionChange.emit($event.value)"
     >
-      <mat-option *ngFor="let option of options" [value]="option.value">
+      <mat-option
+        *ngFor="let option of options"
+        [value]="option.value"
+        [disabled]="option.disabled"
+      >
         {{ option.displayText }}
       </mat-option>
     </mat-select>


### PR DESCRIPTION
This introduces a new field on the `DropdownOption` public interface
to let clients of the `<tb-dropdown>` component specify options that
are non-interactable.

![image](https://user-images.githubusercontent.com/2322480/100935741-57125700-34a5-11eb-906f-98afba55ca4e.png)
