### PR TITLE
ui: fix styles in dropdowns, smoothing input

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -62,6 +62,12 @@ section .control-row:not(:last-child) {
   }
 }
 
+.scalars-smoothing .slider-input {
+  flex: none;
+  // Wide enough to show 3 digits after a decimal.
+  width: 60px;
+}
+
 mat-slider {
   flex: 1;
   // Reset mat-slider's internal extra space on left/right sides

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -64,8 +64,9 @@ section .control-row:not(:last-child) {
 
 .scalars-smoothing .slider-input {
   flex: none;
-  // Wide enough to show 3 digits after a decimal.
-  width: 60px;
+  // Wide enough to show 3 digits after a decimal. Required since Firefox does
+  // not shrink input fields smaller than some intrinsic size.
+  width: 5em;
 }
 
 mat-slider {

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
@@ -20,3 +20,10 @@ mat-select {
   box-sizing: border-box;
   padding: 6px;
 }
+
+mat-select:focus {
+  // Bring back the focus ring, which was removed by Angular Material's styles.
+  // In Firefox, the `outline-style: auto` is sufficient.
+  outline-color: -webkit-focus-ring-color;
+  outline-style: auto;
+}


### PR DESCRIPTION
The Time Series settings panel uses dropdowns and text
input fields. This fixes 2 issues:
- When the dropdown is focused, there is no visual indication
- In Firefox, the smoothing input flows offscreen

Before
![image](https://user-images.githubusercontent.com/2322480/100936069-d2740880-34a5-11eb-9b44-d6e569836f55.png)

After
![image](https://user-images.githubusercontent.com/2322480/100936092-d99b1680-34a5-11eb-821e-f4ef1e7f0d42.png)
