### PR TITLE
metrics: gracefully degrade without tensors/blobs

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -105,6 +105,8 @@ class DataProvider(object):
 
     Unless otherwise noted, any methods on this class may raise errors
     defined in `tensorboard.errors`, like `tensorboard.errors.NotFoundError`.
+
+    If not implemented, optional methods may return `None`.
     """
 
     def data_location(self, ctx=None, *, experiment_id):

--- a/tensorboard/plugins/metrics/metrics_plugin.py
+++ b/tensorboard/plugins/metrics/metrics_plugin.py
@@ -321,6 +321,11 @@ class MetricsPlugin(base_plugin.TBPlugin):
             experiment_id=experiment,
             plugin_name=image_metadata.PLUGIN_NAME,
         )
+        # Not all data providers support tensors and/or blob sequences.
+        if histogram_mapping is None:
+            histogram_mapping = {}
+        if image_mapping is None:
+            image_mapping = {}
 
         result = {}
         result["scalars"] = _format_basic_mapping(scalar_mapping)


### PR DESCRIPTION
Summary:
Not all data providers support tensors and blob sequences. The methods
are optional in the `DataProvider` interface, and (e.g.) the gRPC data
provider does not yet implement them, nor does the RustBoard server.
This patch teaches the time series dashboard to gracefully omit image
and histogram data if the needed data classes aren’t available.

Test Plan:
Point TensorBoard at an MNIST dataset with all three kinds of data, and
note that scalars appear if `--load_fast` is passed, and all data
appears otherwise. Prior to this patch, the requests would 500 under
`--load_fast`, and so nothing would be displayed at all.

wchargin-branch: metrics-degrade-tensors-blobs
