### PR TITLE
mesh: fix `is_active` without multiplexer

### DIFF
--- a/tensorboard/plugins/mesh/mesh_plugin.py
+++ b/tensorboard/plugins/mesh/mesh_plugin.py
@@ -116,21 +116,7 @@ class MeshPlugin(base_plugin.TBPlugin):
         }
 
     def is_active(self):
-        """Determines whether this plugin is active.
-
-        This plugin is only active if TensorBoard sampled any summaries
-        relevant to the mesh plugin.
-
-        Returns:
-          Whether this plugin is active.
-        """
-        all_runs = self._multiplexer.PluginRunToTagToContent(
-            MeshPlugin.plugin_name
-        )
-
-        # The plugin is active if any of the runs has a tag relevant
-        # to the plugin.
-        return bool(self._multiplexer and any(six.itervalues(all_runs)))
+        return False  # `list_plugins` as called by TB core suffices
 
     def frontend_metadata(self):
         return base_plugin.FrontendMetadata(element_name="mesh-dashboard")

--- a/tensorboard/plugins/mesh/mesh_plugin_test.py
+++ b/tensorboard/plugins/mesh/mesh_plugin_test.py
@@ -23,6 +23,7 @@ import shutil
 import numpy as np
 import tensorflow as tf
 import time
+from unittest import mock
 
 from werkzeug import test as werkzeug_test
 from werkzeug import wrappers
@@ -36,13 +37,6 @@ from tensorboard.plugins.mesh import summary
 from tensorboard.plugins.mesh import plugin_data_pb2
 from tensorboard.plugins.mesh import test_utils
 from tensorboard.util import test_util as tensorboard_test_util
-from mock import patch
-
-try:
-    # python version >= 3.3
-    from unittest import mock
-except ImportError:
-    import mock  # pylint: disable=unused-import
 
 
 class MeshPluginTest(tf.test.TestCase):
@@ -129,7 +123,7 @@ class MeshPluginTest(tf.test.TestCase):
                         if step % 2 == 0
                         else mesh_no_color_extended
                     )
-                    with patch.object(time, "time", return_value=step):
+                    with mock.patch.object(time, "time", return_value=step):
                         writer.add_summary(
                             sess.run(
                                 merged_summary_op,

--- a/tensorboard/plugins/mesh/mesh_plugin_test.py
+++ b/tensorboard/plugins/mesh/mesh_plugin_test.py
@@ -264,14 +264,6 @@ class MeshPluginTest(tf.test.TestCase):
             self.assertLessEqual(metadata[i - 1]["step"], metadata[i]["step"])
 
     def testIsActive(self):
-        self.assertTrue(self.plugin.is_active())
-
-    @mock.patch.object(
-        event_multiplexer.EventMultiplexer,
-        "PluginRunToTagToContent",
-        return_value={},
-    )
-    def testIsInactive(self, get_random_mesh_stub):
         self.assertFalse(self.plugin.is_active())
 
 


### PR DESCRIPTION
Summary:
The mesh plugin’s `is_active` method had a hard dependency on the event
multiplexer, which is not always available, as `TBContext` documents.
In fact, the entire `is_active` method can just be `return False`, since
TensorBoard core will treat the `"mesh"` plugin as active when `"mesh"`
data is available, and that’s all that it was checking, anyway.

Test Plan:
The mesh plugin appears active in a logdir with mesh data and inactive
in one without it, and when launching with `--load_fast` (and thus no
multiplexer) there’s no longer any log spam about “Plugin listing:
is_active() for mesh failed”.

wchargin-branch: mesh-isactive
