### PR TITLE
line chart: calc extent without illegal values

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -75,6 +75,7 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:chart",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:scale",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:testing",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:utils",
         "@npm//@angular/common",

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -87,6 +87,10 @@ class LinearScale implements Scale {
   ticks(domain: [number, number], sizeGuidance: number): number[] {
     return scaleLinear().domain(domain).ticks(sizeGuidance);
   }
+
+  isSafeNumber(x: number): boolean {
+    return Number.isFinite(x);
+  }
 }
 
 class Log10Scale implements Scale {
@@ -163,5 +167,9 @@ class Log10Scale implements Scale {
     const high = domain[1] <= 0 ? Number.MIN_VALUE : domain[1];
     const ticks = scaleLog().domain([low, high]).ticks(sizeGuidance);
     return ticks.length ? ticks : domain;
+  }
+
+  isSafeNumber(x: number): boolean {
+    return Number.isFinite(x) && x > 0;
   }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -116,6 +116,22 @@ describe('line_chart_v2/lib/scale test', () => {
         ]);
       });
     });
+
+    describe('#isSafeNumber', () => {
+      it('returns true for numbers', () => {
+        expect(scale.isSafeNumber(0.1)).toBe(true);
+        expect(scale.isSafeNumber(1)).toBe(true);
+        expect(scale.isSafeNumber(1e100)).toBe(true);
+        expect(scale.isSafeNumber(-1e100)).toBe(true);
+        expect(scale.isSafeNumber(1e-100)).toBe(true);
+      });
+
+      it('returns false for infinities and NaN', () => {
+        expect(scale.isSafeNumber(NaN)).toBe(false);
+        expect(scale.isSafeNumber(Infinity)).toBe(false);
+        expect(scale.isSafeNumber(-Infinity)).toBe(false);
+      });
+    });
   });
 
   describe('log10', () => {
@@ -288,6 +304,26 @@ describe('line_chart_v2/lib/scale test', () => {
       it('handles non-positive values correctly', () => {
         expect(scale.ticks([0, 0.01], 3)).toEqual([1e-300, 1e-200, 1e-100]);
         expect(scale.ticks([-100, 0.01], 3)).toEqual([1e-300, 1e-200, 1e-100]);
+      });
+    });
+
+    describe('#isSafeNumber', () => {
+      it('returns true for positive finite numbers', () => {
+        expect(scale.isSafeNumber(Number.MIN_VALUE)).toBe(true);
+        expect(scale.isSafeNumber(1e-100)).toBe(true);
+        expect(scale.isSafeNumber(0.1)).toBe(true);
+        expect(scale.isSafeNumber(1)).toBe(true);
+        expect(scale.isSafeNumber(1e100)).toBe(true);
+      });
+
+      it('returns non-positive values', () => {
+        expect(scale.isSafeNumber(Infinity)).toBe(false);
+        expect(scale.isSafeNumber(-Infinity)).toBe(false);
+        expect(scale.isSafeNumber(NaN)).toBe(false);
+        expect(scale.isSafeNumber(0)).toBe(false);
+        expect(scale.isSafeNumber(-0)).toBe(false);
+        expect(scale.isSafeNumber(-0.001)).toBe(false);
+        expect(scale.isSafeNumber(-1000)).toBe(false);
       });
     });
   });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -316,7 +316,7 @@ describe('line_chart_v2/lib/scale test', () => {
         expect(scale.isSafeNumber(1e100)).toBe(true);
       });
 
-      it('returns non-positive values', () => {
+      it('returns false for non-positive values', () => {
         expect(scale.isSafeNumber(Infinity)).toBe(false);
         expect(scale.isSafeNumber(-Infinity)).toBe(false);
         expect(scale.isSafeNumber(NaN)).toBe(false);

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_types.ts
@@ -62,4 +62,12 @@ export interface Scale {
    *    may return less or more ticks.
    */
   ticks(domain: [number, number], sizeGuidance: number): number[];
+
+  /**
+   * Returns true when a value, x, is a value, can be safely transformed symmetrically*,
+   * and is not an extremum.
+   *
+   * *: e.g., f(1) = 2 and f'(2) = 1 vs. f(1) = NaN and f'(NaN) = ?.
+   */
+  isSafeNumber(x: number): boolean;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -324,7 +324,9 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
       const dataExtent = computeDataSeriesExtent(
         this.seriesData,
         this.seriesMetadataMap,
-        this.ignoreYOutliers
+        this.ignoreYOutliers,
+        this.xScale.isSafeNumber,
+        this.yScale.isSafeNumber
       );
       this.viewBox = {
         x: this.xScale.niceDomain(dataExtent.x ?? DEFAULT_EXTENT.x),

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils.ts
@@ -31,7 +31,9 @@ import {isWebGl2Supported} from './lib/utils';
 export function computeDataSeriesExtent(
   data: DataSeries[],
   metadataMap: DataSeriesMetadataMap,
-  ignoreYOutliers: boolean
+  ignoreYOutliers: boolean,
+  isXSafeNumber: (x: number) => boolean,
+  isYSafeNumber: (x: number) => boolean
 ): {x: [number, number] | undefined; y: [number, number] | undefined} {
   let xMin: number | null = null;
   let xMax: number | null = null;
@@ -44,11 +46,11 @@ export function computeDataSeriesExtent(
 
     for (let index = 0; index < points.length; index++) {
       const {x, y} = points[index];
-      if (Number.isFinite(x)) {
+      if (isXSafeNumber(x)) {
         xMin = xMin === null || x < xMin ? x : xMin;
         xMax = xMax === null || x > xMax ? x : xMax;
       }
-      if (Number.isFinite(y)) {
+      if (isYSafeNumber(y)) {
         yPoints.push(y);
       }
       pointIndex++;


### PR DESCRIPTION
Illegal value is defined by a scale where, in some situation, we can
support all finite values while, in other cases, we can only support
positive finite numbers.

This change takes predicate on the extent calculation code and properly
calculate extent of log scale.
