### PR TITLE
ng: dispatch coreLoaded after router is initialized

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -115,6 +115,7 @@ tf_ng_module(
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
+        "@npm//rxjs",
     ],
 )
 

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -86,8 +86,10 @@ tf_ng_module(
         "app_container.ng.html",
     ],
     deps = [
+        ":app_state",
         ":mat_icon",
         ":oss_plugins_module",
+        ":selectors",
         ":store_module",
         "//tensorboard/webapp/alert",
         "//tensorboard/webapp/alert/views:alert_snackbar",
@@ -113,6 +115,25 @@ tf_ng_module(
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
+    ],
+)
+
+tf_ng_module(
+    name = "app_test",
+    testonly = True,
+    srcs = [
+        "app_test.ts",
+    ],
+    deps = [
+        ":app",
+        ":app_state",
+        ":selectors",
+        "//tensorboard/webapp/app_routing:testing",
+        "//tensorboard/webapp/core/actions",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
     ],
 )
 
@@ -239,6 +260,7 @@ tf_resource_digest_suffixer(
 tf_ng_web_test_suite(
     name = "karma_test",
     deps = [
+        ":app_test",
         "//tensorboard/webapp/alert:test_lib",
         "//tensorboard/webapp/alert/store:test_lib",
         "//tensorboard/webapp/alert/views:views_test",

--- a/tensorboard/webapp/app_container.ts
+++ b/tensorboard/webapp/app_container.ts
@@ -12,26 +12,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, OnInit, ViewContainerRef} from '@angular/core';
+import {Component, ViewContainerRef} from '@angular/core';
 import {Store} from '@ngrx/store';
+import {filter, take} from 'rxjs/operators';
+
+import {getActiveRoute} from './selectors';
 import {coreLoaded} from './core/actions';
-import {State} from './core/store';
+import {State} from './app_state';
 
 @Component({
   selector: 'tb-webapp',
   templateUrl: './app_container.ng.html',
   styleUrls: ['./app_container.css'],
 })
-export class AppContainer implements OnInit {
+export class AppContainer {
   // vcRef is required by ngx-color-picker in order for it to place the popup
   // in the root node in a modal mode.
   // https://github.com/zefoy/ngx-color-picker/blob/94a7c862bb61d7207f21281526fcd94453219b54/projects/lib/src/lib/color-picker.directive.ts#L168-L175
   constructor(
     private readonly store: Store<State>,
     readonly vcRef: ViewContainerRef
-  ) {}
-
-  ngOnInit() {
-    this.store.dispatch(coreLoaded());
+  ) {
+    // Wait for route to be initialized before dispatching a coreLoaded.
+    this.store
+      .select(getActiveRoute)
+      .pipe(
+        filter((route) => Boolean(route)),
+        take(1)
+      )
+      .subscribe(() => {
+        // TODO(stephanwlee): deprecated coreLoaded and use the router actions when all
+        // apps are using the router.s
+        this.store.dispatch(coreLoaded());
+      });
   }
 }

--- a/tensorboard/webapp/app_test.ts
+++ b/tensorboard/webapp/app_test.ts
@@ -1,0 +1,71 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {Action, Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+
+import {AppContainer} from './app_container';
+import {State} from './app_state';
+import {coreLoaded} from './core/actions';
+import {getActiveRoute} from './selectors';
+import {buildRoute} from './app_routing/testing';
+
+describe('app test', () => {
+  let actualDispatches: Action[];
+  let store: MockStore<State>;
+
+  beforeEach(async () => {
+    actualDispatches = [];
+    await TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+      declarations: [AppContainer],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+      actualDispatches.push(action);
+    });
+  });
+
+  it('dispatches coreLoaded once after route is initialized', () => {
+    store.overrideSelector(getActiveRoute, null);
+    const fixture = TestBed.createComponent(AppContainer);
+    fixture.detectChanges();
+
+    expect(actualDispatches).toEqual([]);
+
+    store.overrideSelector(
+      getActiveRoute,
+      buildRoute({
+        pathname: '/bar',
+      })
+    );
+    store.refreshState();
+
+    expect(actualDispatches).toEqual([coreLoaded()]);
+
+    store.overrideSelector(
+      getActiveRoute,
+      buildRoute({
+        pathname: '/foo',
+      })
+    );
+    store.refreshState();
+    expect(actualDispatches).toEqual([coreLoaded()]);
+  });
+});


### PR DESCRIPTION
Only after the router is initialized, we can make sure we are at the
correct routes only at which point we should start to initialize and
make requests. Otherwise, we can make requests at the wrong paths which
may/may-not be correct.

With this change, we fire the coreLoaded after router is initialized
which is confirmed by checking for non-nullness of the activeRoute.
