### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -598,7 +598,7 @@ def _auth_context_middleware(wsgi_app, auth_providers):
 def _clean_path(path):
     """Removes a trailing slash from a non-root path.
 
-    Arguments:
+    Args:
       path: The path of a request.
 
     Returns:

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -977,7 +977,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
     def _writeMetadata(self, logdir, summary_metadata, nonce=""):
         """Write to disk a summary with the given metadata.
 
-        Arguments:
+        Args:
           logdir: a string
           summary_metadata: a `SummaryMetadata` protobuf object
           nonce: optional; will be added to the end of the event file name

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -792,7 +792,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
     def _writeMetadata(self, logdir, summary_metadata, nonce=""):
         """Write to disk a summary with the given metadata.
 
-        Arguments:
+        Args:
           logdir: a string
           summary_metadata: a `SummaryMetadata` protobuf object
           nonce: optional; will be added to the end of the event file name

--- a/tensorboard/data_compat.py
+++ b/tensorboard/data_compat.py
@@ -55,7 +55,7 @@ def migrate_value(value):
     disk; this method converts them to new-style values so that further
     code need only deal with one data format.
 
-    Arguments:
+    Args:
       value: A `Summary.Value` object. This argument is not modified.
 
     Returns:

--- a/tensorboard/encode_png_benchmark.py
+++ b/tensorboard/encode_png_benchmark.py
@@ -93,7 +93,7 @@ def _image_of_size(image_size):
 def _format_line(headers, fields):
     """Format a line of a table.
 
-    Arguments:
+    Args:
       headers: A list of strings that are used as the table headers.
       fields: A list of the same length as `headers` where `fields[i]` is
         the entry for `headers[i]` in this row. Elements can be of

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/summary_v2.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/summary_v2.py
@@ -27,7 +27,7 @@ from tensorboard_plugin_example import metadata
 def greeting(name, guest, step=None, description=None):
     """Write a "greeting" summary.
 
-    Arguments:
+    Args:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.
       guest: A rank-0 string `Tensor`.

--- a/tensorboard/functionaltests/wct_test_driver.py
+++ b/tensorboard/functionaltests/wct_test_driver.py
@@ -40,7 +40,7 @@ _SUITE_FAILED_RE = re.compile(r".*failing test.*")
 def create_test_class(binary_path, web_path):
     """Create a unittest.TestCase class to run WebComponentTester tests.
 
-    Arguments:
+    Args:
       binary_path: relative path to a `tf_web_library` target;
           e.g.: "tensorboard/components/vz_foo/test/test_web_library"
       web_path: absolute web path to the tests page in the above web

--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -91,7 +91,7 @@ _CLEANER_STORE = _CleanerStore()
 def markdown_to_safe_html(markdown_string):
     """Convert Markdown to HTML that's safe to splice into the DOM.
 
-    Arguments:
+    Args:
       markdown_string: A Unicode string or UTF-8--encoded bytestring
         containing Markdown source. Markdown tables are supported.
 

--- a/tensorboard/plugins/audio/audio_demo.py
+++ b/tensorboard/plugins/audio/audio_demo.py
@@ -60,7 +60,7 @@ def run(logdir, run_name, wave_name, wave_constructor):
 
     Waves will be generated at frequencies ranging from A4 to A5.
 
-    Arguments:
+    Args:
       logdir: the top-level directory into which to write summary data
       run_name: the name of this run; will be created as a subdirectory
         under logdir
@@ -258,7 +258,7 @@ def bisine_wahwah_wave(frequency):
 def run_all(logdir, verbose=False):
     """Generate waves of the shapes defined above.
 
-    Arguments:
+    Args:
       logdir: the directory into which to store all the runs' data
       verbose: if true, print out each run's name as it begins
     """

--- a/tensorboard/plugins/audio/metadata.py
+++ b/tensorboard/plugins/audio/metadata.py
@@ -56,7 +56,7 @@ def create_summary_metadata(display_name, description, encoding):
 def parse_plugin_metadata(content):
     """Parse summary metadata to a Python object.
 
-    Arguments:
+    Args:
       content: The `content` field of a `SummaryMetadata` proto
         corresponding to the audio plugin.
 

--- a/tensorboard/plugins/audio/summary.py
+++ b/tensorboard/plugins/audio/summary.py
@@ -61,7 +61,7 @@ def op(
 ):
     """Create a legacy audio summary op for use in a TensorFlow graph.
 
-    Arguments:
+    Args:
       name: A unique name for the generated summary node.
       audio: A `Tensor` representing audio data with shape `[k, t, c]`,
         where `k` is the number of audio clips, `t` is the number of
@@ -155,7 +155,7 @@ def pb(
     (wrapped with constant tensors where appropriate) and then execute
     that summary op in a TensorFlow session.
 
-    Arguments:
+    Args:
       name: A unique name for the generated summary node.
       audio: An `np.array` representing audio data with shape `[k, t, c]`,
         where `k` is the number of audio clips, `t` is the number of

--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -43,7 +43,7 @@ def audio(
 ):
     """Write an audio summary.
 
-    Arguments:
+    Args:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.
       data: A `Tensor` representing audio data with shape `[k, t, c]`,

--- a/tensorboard/plugins/histogram/metadata.py
+++ b/tensorboard/plugins/histogram/metadata.py
@@ -50,7 +50,7 @@ def create_summary_metadata(display_name, description):
 def parse_plugin_metadata(content):
     """Parse summary metadata to a Python object.
 
-    Arguments:
+    Args:
       content: The `content` field of a `SummaryMetadata` proto
         corresponding to the histogram plugin.
 

--- a/tensorboard/plugins/histogram/summary.py
+++ b/tensorboard/plugins/histogram/summary.py
@@ -46,7 +46,7 @@ histogram_pb = summary_v2.histogram_pb
 def _buckets(data, bucket_count=None):
     """Create a TensorFlow op to group data into histogram buckets.
 
-    Arguments:
+    Args:
       data: A `Tensor` of any shape. Must be castable to `float64`.
       bucket_count: Optional positive `int` or scalar `int32` `Tensor`.
     Returns:
@@ -122,7 +122,7 @@ def op(
 ):
     """Create a legacy histogram summary op.
 
-    Arguments:
+    Args:
       name: A unique name for the generated summary node.
       data: A `Tensor` of any shape. Must be castable to `float64`.
       bucket_count: Optional positive `int`. The output will have this
@@ -162,7 +162,7 @@ def op(
 def pb(name, data, bucket_count=None, display_name=None, description=None):
     """Create a legacy histogram summary protobuf.
 
-    Arguments:
+    Args:
       name: A unique name for the generated summary, including any desired
         name scopes.
       data: A `np.array` or array-like form of any shape. Must have type

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -44,7 +44,7 @@ DEFAULT_BUCKET_COUNT = 30
 def histogram(name, data, step=None, buckets=None, description=None):
     """Write a histogram summary.
 
-    Arguments:
+    Args:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.
       data: A `Tensor` of any shape. Must be castable to `float64`.
@@ -111,7 +111,7 @@ def histogram(name, data, step=None, buckets=None, description=None):
 def _buckets(data, bucket_count=None):
     """Create a TensorFlow op to group data into histogram buckets.
 
-    Arguments:
+    Args:
       data: A `Tensor` of any shape. Must be castable to `float64`.
       bucket_count: Optional positive `int` or scalar `int32` `Tensor`.
     Returns:
@@ -178,7 +178,7 @@ def _buckets(data, bucket_count=None):
 def histogram_pb(tag, data, buckets=None, description=None):
     """Create a histogram summary protobuf.
 
-    Arguments:
+    Args:
       tag: String tag for the summary.
       data: A `np.array` or array-like form of any shape. Must have type
         castable to `float`.

--- a/tensorboard/plugins/hparams/hparams_demo.py
+++ b/tensorboard/plugins/hparams/hparams_demo.py
@@ -204,7 +204,7 @@ def prepare_data():
 def run_all(logdir, verbose=False):
     """Perform random search over the hyperparameter space.
 
-    Arguments:
+    Args:
       logdir: The top-level directory into which to write data. This
         directory should be empty or nonexistent.
       verbose: If true, print out each run's name as it begins.

--- a/tensorboard/plugins/hparams/hparams_minimal_demo.py
+++ b/tensorboard/plugins/hparams/hparams_minimal_demo.py
@@ -162,7 +162,7 @@ def run(logdir, session_id, hparams, group_name):
     how far it is from the room's temperature, and how much it changes at
     each time step.
 
-    Arguments:
+    Args:
       logdir: the top-level directory into which to write summary data
       session_id: an id for the session.
       hparams: A dictionary mapping a hyperparameter name to its value.
@@ -252,7 +252,7 @@ def run(logdir, session_id, hparams, group_name):
 def run_all(logdir, verbose=False):
     """Run simulations on a reasonable set of parameters.
 
-    Arguments:
+    Args:
       logdir: the directory into which to store all the runs' data
       verbose: if true, print out each run's name as it begins.
     """

--- a/tensorboard/plugins/image/images_demo.py
+++ b/tensorboard/plugins/image/images_demo.py
@@ -71,7 +71,7 @@ def image_data(verbose=False):
 def convolve(image, pixel_filter, channels=3, name=None):
     """Perform a 2D pixel convolution on the given image.
 
-    Arguments:
+    Args:
       image: A 3D `float32` `Tensor` of shape `[height, width, channels]`,
         where `channels` is the third argument to this function and the
         first two dimensions are arbitrary.
@@ -121,7 +121,7 @@ def run_box_to_gaussian(logdir, verbose=False):
 
     See the summary description for more details.
 
-    Arguments:
+    Args:
       logdir: Directory into which to write event logs.
       verbose: Boolean; whether to log any output.
     """
@@ -218,7 +218,7 @@ def run_sobel(logdir, verbose=False):
 
     See the summary description for more details.
 
-    Arguments:
+    Args:
       logdir: Directory into which to write event logs.
       verbose: Boolean; whether to log any output.
     """
@@ -304,7 +304,7 @@ def run_sobel(logdir, verbose=False):
 def run_all(logdir, verbose=False):
     """Run simulations on a reasonable set of parameters.
 
-    Arguments:
+    Args:
       logdir: the directory into which to store all the runs' data
       verbose: if true, print out each run's name as it begins
     """

--- a/tensorboard/plugins/image/metadata.py
+++ b/tensorboard/plugins/image/metadata.py
@@ -51,7 +51,7 @@ def create_summary_metadata(display_name, description):
 def parse_plugin_metadata(content):
     """Parse summary metadata to a Python object.
 
-    Arguments:
+    Args:
       content: The `content` field of a `SummaryMetadata` proto
         corresponding to the image plugin.
 

--- a/tensorboard/plugins/image/summary.py
+++ b/tensorboard/plugins/image/summary.py
@@ -46,7 +46,7 @@ def op(
 ):
     """Create a legacy image summary op for use in a TensorFlow graph.
 
-    Arguments:
+    Args:
       name: A unique name for the generated summary node.
       images: A `Tensor` representing pixel data with shape `[k, h, w, c]`,
         where `k` is the number of images, `h` and `w` are the height and
@@ -114,7 +114,7 @@ def pb(name, images, max_outputs=3, display_name=None, description=None):
     (wrapped with constant tensors where appropriate) and then execute
     that summary op in a TensorFlow session.
 
-    Arguments:
+    Args:
       name: A unique name for the generated summary, including any desired
         name scopes.
       images: An `np.array` representing pixel data with shape

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -30,7 +30,7 @@ from tensorboard.util import lazy_tensor_creator
 def image(name, data, step=None, max_outputs=3, description=None):
     """Write an image summary.
 
-    Arguments:
+    Args:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.
       data: A `Tensor` representing pixel data with shape `[k, h, w, c]`,

--- a/tensorboard/plugins/mesh/metadata.py
+++ b/tensorboard/plugins/mesh/metadata.py
@@ -74,7 +74,7 @@ def create_summary_metadata(
 ):
     """Creates summary metadata which defined at MeshPluginData proto.
 
-    Arguments:
+    Args:
       name: Original merged (summaries of different types) summary name.
       display_name: The display name used in TensorBoard.
       content_type: Value from MeshPluginData.ContentType enum describing data.
@@ -115,7 +115,7 @@ def create_summary_metadata(
 def parse_plugin_metadata(content):
     """Parse summary metadata to a Python object.
 
-    Arguments:
+    Args:
       content: The `content` field of a `SummaryMetadata` proto
         corresponding to the mesh plugin.
 

--- a/tensorboard/plugins/npmi/metadata.py
+++ b/tensorboard/plugins/npmi/metadata.py
@@ -50,7 +50,7 @@ def create_summary_metadata(description):
 
 def parse_plugin_metadata(content):
     """Parse summary metadata to a Python object.
-    Arguments:
+    Args:
       content: The `content` field of a `SummaryMetadata` proto
         corresponding to the scalar plugin.
     Returns:

--- a/tensorboard/plugins/npmi/summary.py
+++ b/tensorboard/plugins/npmi/summary.py
@@ -25,7 +25,7 @@ from tensorboard.plugins.npmi import metadata
 def npmi_metrics(tensor, step=None, description=None):
     """Write the list of calculated metrics for this run.
 
-    Arguments:
+    Args:
       tensor: A `Tensor` of shape (num_metrics) and dtype string.
       step: Explicit `int64`-castable monotonic step value for this summary. If
         omitted, this defaults to `tf.summary.experimental.get_step()`, which
@@ -57,7 +57,7 @@ def npmi_metrics(tensor, step=None, description=None):
 def npmi_annotations(tensor, step=None, description=None):
     """Write the annotations for this run.
 
-    Arguments:
+    Args:
       tensor: A `Tensor` of shape (num_annotations) and dtype string.
       step: Explicit `int64`-castable monotonic step value for this summary. If
         omitted, this defaults to `tf.summary.experimental.get_step()`, which
@@ -89,7 +89,7 @@ def npmi_annotations(tensor, step=None, description=None):
 def npmi_values(tensor, step=None, description=None):
     """Write the actual npmi values.
 
-    Arguments:
+    Args:
       tensor: A `Tensor` of shape (num_annotations, num_metrics) and dtype
         float.
       step: Explicit `int64`-castable monotonic step value for this summary. If
@@ -122,7 +122,7 @@ def npmi_values(tensor, step=None, description=None):
 def npmi_embeddings(tensor, step=None, description=None):
     """Write the embedding representations for the annotations in the dataset.
 
-    Arguments:
+    Args:
       tensor: A `Tensor` of shape (num_annotations, embedding_dimension) and dtype
         float.
       step: Explicit `int64`-castable monotonic step value for this summary. If

--- a/tensorboard/plugins/pr_curve/metadata.py
+++ b/tensorboard/plugins/pr_curve/metadata.py
@@ -42,7 +42,7 @@ PROTO_VERSION = 0
 def create_summary_metadata(display_name, description, num_thresholds):
     """Create a `summary_pb2.SummaryMetadata` proto for pr_curves plugin data.
 
-    Arguments:
+    Args:
       display_name: The display name used in TensorBoard.
       description: The description to show in TensorBoard.
       num_thresholds: The number of thresholds to use for PR curves.
@@ -66,7 +66,7 @@ def create_summary_metadata(display_name, description, num_thresholds):
 def parse_plugin_metadata(content):
     """Parse summary metadata to a Python object.
 
-    Arguments:
+    Args:
       content: The `content` field of a `SummaryMetadata` proto
         corresponding to the pr_curves plugin.
 

--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -58,7 +58,7 @@ def start_runs(
 ):
     """Generate a PR curve with precision and recall evenly weighted.
 
-    Arguments:
+    Args:
       logdir: The directory into which to store all the runs' data.
       steps: The number of steps to run for.
       run_name: The name of the run.
@@ -240,7 +240,7 @@ def start_runs(
 def run_all(logdir, steps, thresholds, verbose=False):
     """Generate PR curve summaries.
 
-    Arguments:
+    Args:
       logdir: The directory into which to store all the runs' data.
       steps: The number of steps to run for.
       verbose: Whether to print the names of runs into stdout during execution.

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -86,7 +86,7 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
         """Creates the JSON object for the PR curves response for a run-tag
         combo.
 
-        Arguments:
+        Args:
           runs: A list of runs to fetch the curves for.
           tag: The tag to fetch the curves for.
 

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -107,7 +107,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
     def computeCorrectDescription(self, standard_deviation):
         """Generates a correct description.
 
-        Arguments:
+        Args:
           standard_deviation: An integer standard deviation value.
 
         Returns:

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -190,7 +190,7 @@ def pb(
 ):
     """Create a PR curves summary protobuf.
 
-    Arguments:
+    Args:
       name: A name for the generated node. Will also serve as a series name in
           TensorBoard.
       labels: The ground truth values. A bool numpy array.

--- a/tensorboard/plugins/scalar/metadata.py
+++ b/tensorboard/plugins/scalar/metadata.py
@@ -51,7 +51,7 @@ def create_summary_metadata(display_name, description):
 def parse_plugin_metadata(content):
     """Parse summary metadata to a Python object.
 
-    Arguments:
+    Args:
       content: The `content` field of a `SummaryMetadata` proto
         corresponding to the scalar plugin.
 

--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -50,7 +50,7 @@ def run(
     how far it is from the room's temperature, and how much it changes at
     each time step.
 
-    Arguments:
+    Args:
       logdir: the top-level directory into which to write summary data
       run_name: the name of this run; will be created as a subdirectory
         under logdir
@@ -132,7 +132,7 @@ def run(
 def run_all(logdir, verbose=False):
     """Run simulations on a reasonable set of parameters.
 
-    Arguments:
+    Args:
       logdir: the directory into which to store all the runs' data
       verbose: if true, print out each run's name as it begins
     """

--- a/tensorboard/plugins/scalar/summary.py
+++ b/tensorboard/plugins/scalar/summary.py
@@ -36,7 +36,7 @@ scalar_pb = summary_v2.scalar_pb
 def op(name, data, display_name=None, description=None, collections=None):
     """Create a legacy scalar summary op.
 
-    Arguments:
+    Args:
       name: A unique name for the generated summary node.
       data: A real numeric rank-0 `Tensor`. Must have `dtype` castable
         to `float32`.
@@ -72,7 +72,7 @@ def op(name, data, display_name=None, description=None, collections=None):
 def pb(name, data, display_name=None, description=None):
     """Create a legacy scalar summary protobuf.
 
-    Arguments:
+    Args:
       name: A unique name for the generated summary, including any desired
         name scopes.
       data: A rank-0 `np.array` or array-like form (so raw `int`s and

--- a/tensorboard/plugins/scalar/summary_v2.py
+++ b/tensorboard/plugins/scalar/summary_v2.py
@@ -33,7 +33,7 @@ from tensorboard.util import tensor_util
 def scalar(name, data, step=None, description=None):
     """Write a scalar summary.
 
-    Arguments:
+    Args:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.
       data: A real numeric scalar value, convertible to a `float32` Tensor.
@@ -72,7 +72,7 @@ def scalar(name, data, step=None, description=None):
 def scalar_pb(tag, data, description=None):
     """Create a scalar summary_pb2.Summary protobuf.
 
-    Arguments:
+    Args:
       tag: String tag for the summary.
       data: A 0-dimensional `np.array` or a compatible python number type.
       description: Optional long-form description for this summary, as a

--- a/tensorboard/plugins/text/metadata.py
+++ b/tensorboard/plugins/text/metadata.py
@@ -51,7 +51,7 @@ def create_summary_metadata(display_name, description):
 def parse_plugin_metadata(content):
     """Parse summary metadata to a Python object.
 
-    Arguments:
+    Args:
       content: The `content` field of a `SummaryMetadata` proto corresponding to
         the text plugin.
     Returns:

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -78,7 +78,7 @@ def op(name, data, display_name=None, description=None, collections=None):
 def pb(name, data, display_name=None, description=None):
     """Create a legacy text summary protobuf.
 
-    Arguments:
+    Args:
       name: A name for the generated node. Will also serve as a series name in
         TensorBoard.
       data: A Python bytestring (of type bytes), or Unicode string. Or a numpy

--- a/tensorboard/plugins/text/summary_v2.py
+++ b/tensorboard/plugins/text/summary_v2.py
@@ -29,7 +29,7 @@ from tensorboard.util import tensor_util
 def text(name, data, step=None, description=None):
     """Write a text summary.
 
-    Arguments:
+    Args:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.
       data: A UTF-8 string tensor value.
@@ -65,7 +65,7 @@ def text(name, data, step=None, description=None):
 def text_pb(tag, data, description=None):
     """Create a text tf.Summary protobuf.
 
-    Arguments:
+    Args:
       tag: String tag for the summary.
       data: A Python bytestring (of type bytes), a Unicode string, or a numpy data
         array of those types.

--- a/tensorboard/util/encoder.py
+++ b/tensorboard/util/encoder.py
@@ -32,7 +32,7 @@ class _TensorFlowPngEncoder(op_evaluator.PersistentOpEvaluator):
     This function is thread-safe, and has high performance when run in
     parallel. See `encode_png_benchmark.py` for details.
 
-    Arguments:
+    Args:
       image: A numpy array of shape `[height, width, channels]`, where
         `channels` is 1, 3, or 4, and of dtype uint8.
 
@@ -72,7 +72,7 @@ class _TensorFlowWavEncoder(op_evaluator.PersistentOpEvaluator):
 
     This function is thread-safe and exhibits good parallel performance.
 
-    Arguments:
+    Args:
       audio: A numpy array of shape `[samples, channels]`.
       samples_per_second: A positive `int`, in Hz.
 

--- a/tensorboard/util/op_evaluator.py
+++ b/tensorboard/util/op_evaluator.py
@@ -42,7 +42,7 @@ class PersistentOpEvaluator(object):
         class FluxCapacitanceEvaluator(PersistentOpEvaluator):
           \"\"\"Compute the flux capacitance required for a system.
 
-          Arguments:
+          Args:
             x: Available power input, as a `float`, in jigawatts.
 
           Returns:


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420