### PR TITLE
ci: add nightly scheduled GitHub Actions job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ on:
       - '[0-9]+.*'
       - 'ci-*'
   pull_request: {}
+  schedule:
+    # 13:00 UTC is 05:00 in Pacific standard time (UTC-8), which is well
+    # after nightly TensorFlow wheels are released (around 2--3 AM) and
+    # just after nightly TensorBoard wheels are released (around 04:15).
+    # (cron syntax: minute hour day-of-month month day-of-week)
+    - cron: '0 13 * * *'
 
 env:
   # Keep this Bazel version in sync with the `versions.check` directive


### PR DESCRIPTION
Summary:
This extends our current GitHub Actions CI workflow to run nightly at
05:00 PST (06:00 PDT, 13:00 UTC). The [docs for scheduled events][1]
indicate that such a job will run on the default (master) branch. This
job should run with write access to the build cache.

[1]: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events

Test Plan:
Note that the workflow parses and normal CI still runs on this job.
We’ll wait for tomorrow to see if it actually runs.

wchargin-branch: ci-gh-nightly
