### PR TITLE
rust: bind server to `::1` by default

### DIFF
--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -48,7 +48,7 @@ struct Opts {
     ///
     /// IP address to bind this server to. May be an IPv4 address (e.g., 127.0.0.1 or 0.0.0.0) or
     /// an IPv6 address (e.g., ::1 or ::0).
-    #[clap(long, default_value = "::0")]
+    #[clap(long, default_value = "::1")]
     host: IpAddr,
 
     /// Bind to this port


### PR DESCRIPTION
Summary:
Previously, the data server defaulted to host `::0`, the IPv6 wildcard
address and analogue of `0.0.0.0`, ~a.k.a. `--bind_all`. But we can
safely restrict this to just `::1`, the loopback address and analogue of
`127.0.0.1`, allowing localhost connections only. @psybuzz reports that
macOS shows a security dialog about incoming connections to the data
server, and that this fixes it.

Test Plan:
Running `tensorboard --load_fast` still works fine, since TensorBoard is
connecting to a data server running on the same machine.

wchargin-branch: rust-default-bind-loopback
