### PR TITLE
rust: fix panic when reading explicit tensors/blobs

### DIFF
--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -105,8 +105,28 @@ impl StageTimeSeries {
         use pb::DataClass;
         match self.data_class {
             DataClass::Scalar => self.commit_to(tag, &mut run.scalars, EventValue::into_scalar),
-            DataClass::Tensor => todo!("tensor time series not yet supported"),
-            DataClass::BlobSequence => todo!("blob sequence time series not yet supported"),
+            DataClass::Tensor => {
+                warn!(
+                    "tensor time series not yet supported (tag: {:?}, plugin: {:?})",
+                    tag.0,
+                    self.metadata
+                        .plugin_data
+                        .as_ref()
+                        .map(|p| p.plugin_name.as_str())
+                        .unwrap_or("")
+                );
+            }
+            DataClass::BlobSequence => {
+                warn!(
+                    "blob sequence time series not yet supported (tag: {}, plugin: {})",
+                    tag.0,
+                    self.metadata
+                        .plugin_data
+                        .as_ref()
+                        .map(|p| p.plugin_name.as_str())
+                        .unwrap_or("")
+                );
+            }
             _ => (),
         };
     }

--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -107,7 +107,7 @@ impl StageTimeSeries {
             DataClass::Scalar => self.commit_to(tag, &mut run.scalars, EventValue::into_scalar),
             DataClass::Tensor => {
                 warn!(
-                    "tensor time series not yet supported (tag: {:?}, plugin: {:?})",
+                    "Tensor time series not yet supported (tag: {:?}, plugin: {:?})",
                     tag.0,
                     self.metadata
                         .plugin_data
@@ -118,7 +118,7 @@ impl StageTimeSeries {
             }
             DataClass::BlobSequence => {
                 warn!(
-                    "blob sequence time series not yet supported (tag: {}, plugin: {})",
+                    "Blob sequence time series not yet supported (tag: {}, plugin: {})",
                     tag.0,
                     self.metadata
                         .plugin_data


### PR DESCRIPTION
Summary:
We don’t yet apply data-compat conversions to tensor and blob type
summaries, so we usually don’t see `data_class` set to anything other
than “unknown” or “scalar”. But @psybuzz points out in #4436 that nPMI
data is explicitly `DATA_CLASS_TENSOR`, which triggers a panic in the
data server. This patch replaces that panic with a warning. Of course,
the warning will go away entirely when tensor support is implemented;
for now, this just prevents crashing, which is nice.

Test Plan:
Run `//tensorboard/plugins/npmi:npmi_demo` to get test data if you don’t
have it already, then point the server at that logdir and note that it
successfully finishes a load cycle:

```
$ bazel run //tensorboard/data/server -- --logdir /tmp/npmi_demo -v
listening on [::]:6806
[2020-12-09T06:52:29Z INFO  rustboard_core::cli] Starting load cycle
[2020-12-09T06:52:29Z WARN  rustboard_core::run] Tensor time series not yet supported (tag: "_npmi_/metrics", plugin: "npmi")
[2020-12-09T06:52:29Z WARN  rustboard_core::run] Tensor time series not yet supported (tag: "_npmi_/values", plugin: "npmi")
[2020-12-09T06:52:29Z WARN  rustboard_core::run] Tensor time series not yet supported (tag: "_npmi_/annotations", plugin: "npmi")
[2020-12-09T06:52:29Z WARN  rustboard_core::run] Tensor time series not yet supported (tag: "_npmi_/values", plugin: "npmi")
[2020-12-09T06:52:29Z WARN  rustboard_core::run] Tensor time series not yet supported (tag: "_npmi_/annotations", plugin: "npmi")
[2020-12-09T06:52:29Z WARN  rustboard_core::run] Tensor time series not yet supported (tag: "_npmi_/metrics", plugin: "npmi")
[2020-12-09T06:52:29Z INFO  rustboard_core::cli] Finished load cycle (1.032345ms)
```

Also, note that `git grep 'todo!'` shows no further panic-todos.

wchargin-branch: rust-nopanic-blob-tensor
