### PR TITLE
line chart: add circle and triangle drawer

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -19,7 +19,7 @@ import {Point, Polyline} from '../internal_types';
 import {SvgRenderer} from './svg_renderer';
 import {ThreeRenderer} from './threejs_renderer';
 
-fdescribe('line_chart_v2/lib/renderer test', () => {
+describe('line_chart_v2/lib/renderer test', () => {
   const SVG_NS = 'http://www.w3.org/2000/svg';
   const DEFAULT_LINE_OPTIONS = {visible: true, color: '#f00', width: 6};
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -128,6 +128,13 @@ describe('line_chart_v2/lib/renderer test', () => {
     });
 
     describe('triangle', () => {
+      /**
+       * Asserts `d` attribute on a SVGPathElement.
+       *
+       * @param path An SVGPathElement with `d` attribute of format with absolute
+       *    coordinates: M, L, and Zs. e.g., "M1,2L2,3L3,4Z".
+       * @param roundedCoords Coordinates expected rounded to nearest integer.
+       */
       function assertPath(path: SVGPathElement, roundedCoords: Point[]) {
         expect(roundedCoords.length).toBe(3);
         const dPath = path.getAttribute('d')!;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Polyline, Rect} from '../internal_types';
+import {Point, Polyline, Rect} from '../internal_types';
 
 export enum RendererType {
   SVG,
@@ -35,8 +35,9 @@ export interface ObjectRenderer<CacheValue = {}> {
   onResize(domRect: Rect): void;
 
   /**
-   * Draws or enqueues drawing operations depending on a renderer. If the `cachedLine` is
-   * null, it will create a new line object. Otherwise, it will update the object.
+   * Draws or enqueues line drawing operations depending on a renderer. If the
+   * `cachedLine` is null, it will create a new line object. Otherwise, it will
+   * the object.
    *
    * @param cachedLine Previously created object. Can be a recycled instance to reduce
    *    memory operations.
@@ -49,14 +50,44 @@ export interface ObjectRenderer<CacheValue = {}> {
     paintOpt: LinePaintOption
   ): CacheValue | null;
 
+  /**
+   * Draws or enqueues triangle drawing operations depending on a renderer. If the `cached` is
+   * null, it will create a new triangle object. Otherwise, it will update the object.
+   */
+  createOrUpdateTriangleObject(
+    cached: CacheValue | null,
+    loc: Point,
+    paintOpt: TrianglePaintOption
+  ): CacheValue | null;
+
+  /**
+   * Draws or enqueues circle drawing operations depending on a renderer.
+   */
+  createOrUpdateCircleObject(
+    cached: CacheValue | null,
+    loc: Point,
+    paintOpt: CirclePaintOption
+  ): CacheValue | null;
+
   flush(): void;
 
   destroyObject(cachedValue: CacheValue): void;
 }
 
-export interface LinePaintOption {
+interface PaintOption {
   visible: boolean;
   color: string;
   opacity?: number;
+}
+
+export interface LinePaintOption extends PaintOption {
   width: number;
+}
+
+export interface TrianglePaintOption extends PaintOption {
+  size: number;
+}
+
+export interface CirclePaintOption extends PaintOption {
+  radius: number;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -41,21 +41,20 @@ function createOrUpdateObject<T extends SVGPathElement | SVGCircleElement>(
   paintOpt: {visible: boolean; color: string; opacity?: number}
 ): T | null {
   const {color, visible, opacity} = paintOpt;
-  const cssDisplayValue = visible ? '' : 'none';
   let dom: T | undefined = prevDom;
 
   if (!dom) {
-    // Skip if prevDom does not exist and is invisible.
+    // Skip if prevDom does not exist and Object is invisible
     if (!visible) return null;
 
     dom = creator();
   } else if (!visible) {
-    dom.style.display = cssDisplayValue;
+    dom.style.display = 'none';
     return dom;
   }
 
   dom = updater(dom);
-  dom.style.display = cssDisplayValue;
+  dom.style.display = '';
   dom.style.stroke = color;
   dom.style.opacity = String(opacity ?? 1);
   return dom;
@@ -135,9 +134,9 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
     const altitude = (size * Math.sqrt(3)) / 2;
     const vertices = new Float32Array([
       loc.x - size / 2,
-      loc.y + (altitude * 1) / 3,
+      loc.y + altitude / 3,
       loc.x + size / 2,
-      loc.y + (altitude * 1) / 3,
+      loc.y + altitude / 3,
       loc.x,
       loc.y - (altitude * 2) / 3,
     ]);
@@ -156,6 +155,7 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
         return dom;
       },
       (dom) => {
+        // Modifying/overwriting three vertices is cheap enough. Update always.
         const data = this.createPathDString(vertices);
         dom.setAttribute('d', data + 'Z');
         return dom;
@@ -194,6 +194,7 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
         return dom;
       },
       (dom) => {
+        // Modifying/overwriting x, y, and r is cheap enough. Update always.
         dom.style.fill = color;
         dom.setAttribute('cx', String(loc.x));
         dom.setAttribute('cy', String(loc.y));

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -246,9 +246,9 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
     const altitude = (size * Math.sqrt(3)) / 2;
     const vertices = new Float32Array([
       loc.x - size / 2,
-      loc.y - (altitude * 1) / 3,
+      loc.y - altitude / 3,
       loc.x + size / 2,
-      loc.y - (altitude * 1) / 3,
+      loc.y - altitude / 3,
       loc.x,
       loc.y + (altitude * 2) / 3,
     ]);
@@ -259,16 +259,13 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
       const mesh = this.createMesh(geom, paintOpt);
       if (mesh === null) return null;
       this.scene.add(mesh);
-      return {
-        type: CacheType.TRIANGLE,
-        data: loc,
-        obj3d: mesh,
-      };
+      return {type: CacheType.TRIANGLE, data: loc, obj3d: mesh};
     }
 
     const geomUpdated = updateObject(
       cached.obj3d,
       (geom) => {
+        // Updating a geometry with three vertices is cheap enough. Update always.
         updateGeometryWithVec2Array(geom, vertices);
         return geom;
       },
@@ -292,13 +289,11 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
       if (mesh === null) return null;
       mesh.position.set(loc.x, loc.y, 0);
       this.scene.add(mesh);
-      return {
-        type: CacheType.CIRCLE,
-        data: {loc, radius},
-        obj3d: mesh,
-      };
+      return {type: CacheType.CIRCLE, data: {loc, radius}, obj3d: mesh};
     }
 
+    // geometry/vertices are created by CircleBufferGeometry and it is quite complex.
+    // Since it has N vertices (N < 20), update always.
     const geomUpdated = updateObject(cached.obj3d, () => geom, paintOpt);
     if (!geomUpdated) return cached;
     cached.obj3d.position.set(loc.x, loc.y, 0);


### PR DESCRIPTION
This change adds a renderer's ability to draw circle and triangles.

Use cases:
- We need to draw triangles for NaN values in the line chart
- We need to draw circles to denote length 1 scalar points

This change:
- refactors the line drawer to share the common material/style
  modification code

What will be done:
- the direction of the triangle shape needs to be a function of
  coordinator or its y-direction. Will address it in a follow up.
