### PR TITLE
line chart: make threejs coordinator match DOM size

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator.ts
@@ -62,21 +62,18 @@ export class Coordinator {
   }
 
   /**
-   * Returns directionality of the y axis of the output space.
+   * Returns whether y axis is pointing down in the output space.
    *
    * ↑
-   * | viewBoxYDirection = +1
+   * | isYAxisPointedDown = false (e.g., cartesian coordinates, 3d scene)
    * |
    * |-------------→
    * |
-   * | viewBoxYDirection = -1
+   * | isYAxisPointedDown = true (e.g., DOM)
    * ↓
-   *
-   * +1: Suitable in 3-D aware context where you have full cartesian coordinates.
-   * -1: Suitable for DOM where <0, 0> is top-left corner of a DOM.
    */
-  getYAxisDirection(): -1 | 1 {
-    return -1;
+  isYAxisPointedDown(): boolean {
+    return true;
   }
 
   setXScale(scale: Scale) {
@@ -121,9 +118,9 @@ export class Coordinator {
       ),
       this.yScale.forward(
         domain.y,
-        this.getYAxisDirection() === 1
-          ? [rect.y, rect.y + +rect.height]
-          : [rect.y + rect.height, rect.y],
+        this.isYAxisPointedDown()
+          ? [rect.y + rect.height, rect.y]
+          : [rect.y, rect.y + rect.height],
         dataCoordinate[1]
       ),
     ];

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator.ts
@@ -37,6 +37,7 @@ import {convertRectToExtent} from './utils';
 export class Coordinator {
   protected xScale: Scale = createScale(ScaleType.LINEAR);
   protected yScale: Scale = createScale(ScaleType.LINEAR);
+
   protected domContainerRect: Rect = {
     x: 0,
     width: 1,
@@ -44,7 +45,7 @@ export class Coordinator {
     height: 1,
   };
 
-  protected lastUpdated: number = 0;
+  private lastUpdated: number = 0;
   private currentViewBoxRect: Rect = {
     x: 0,
     width: 1,
@@ -58,6 +59,24 @@ export class Coordinator {
 
   private updateIdentifier() {
     this.lastUpdated++;
+  }
+
+  /**
+   * Returns directionality of the y axis of the output space.
+   *
+   * ↑
+   * | viewBoxYDirection = +1
+   * |
+   * |-------------→
+   * |
+   * | viewBoxYDirection = -1
+   * ↓
+   *
+   * +1: Suitable in 3-D aware context where you have full cartesian coordinates.
+   * -1: Suitable for DOM where <0, 0> is top-left corner of a DOM.
+   */
+  getYAxisDirection(): -1 | 1 {
+    return -1;
   }
 
   setXScale(scale: Scale) {
@@ -102,7 +121,9 @@ export class Coordinator {
       ),
       this.yScale.forward(
         domain.y,
-        [rect.y + rect.height, rect.y],
+        this.getYAxisDirection() === 1
+          ? [rect.y, rect.y + +rect.height]
+          : [rect.y + rect.height, rect.y],
         dataCoordinate[1]
       ),
     ];

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator_test.ts
@@ -159,7 +159,7 @@ describe('line_chart_v2/lib/coordinator test', () => {
     });
 
     describe('#transformDataToUiCoord', () => {
-      beforeEach(() => {
+      it('converts with y-axis pointing up', () => {
         coordinator.setViewBoxRect({
           x: 50,
           y: 0,
@@ -172,12 +172,6 @@ describe('line_chart_v2/lib/coordinator test', () => {
           width: 5,
           height: 5,
         });
-      });
-
-      // unlike the base class, y-axis is not flipped since we are not rendering onto the
-      // DOM where <0, 0> is top-left. Unlike DOM, threejs's scene looks like ordinary
-      // cartesian coordinate with z-axis pointing up.
-      it('converts into internal coordinate system [0, 1000], no y-axis flipped', () => {
         const layout = {
           x: 2,
           y: 0,
@@ -186,18 +180,18 @@ describe('line_chart_v2/lib/coordinator test', () => {
         };
 
         expect(coordinator.transformDataToUiCoord(layout, [50, 50])).toEqual([
-          400,
-          500,
+          2,
+          2.5,
         ]);
         expect(coordinator.transformDataToUiCoord(layout, [150, 100])).toEqual([
-          1000,
-          1000,
+          5,
+          5,
         ]);
 
         // Outside of the viewBox.
         expect(coordinator.transformDataToUiCoord(layout, [0, -100])).toEqual([
-          100,
-          -1000,
+          0.5,
+          -5,
         ]);
       });
     });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator_test.ts
@@ -113,7 +113,7 @@ describe('line_chart_v2/lib/coordinator test', () => {
 
       // y-axis is flipped since data's origin assumes bottom-left as opposed to DOM's
       // coordinate system that has origin at top-left.
-      it('converts the coordinate system but flips y-axis', () => {
+      it('converts the coordinate system with y-axis pointing down', () => {
         const layout = {
           x: 500,
           y: 250,

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/threejs_coordinator.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/threejs_coordinator.ts
@@ -29,8 +29,8 @@ import {convertRectToExtent} from './utils';
  * In this coordinator, the output coordinate system is static from [0, 1000].
  */
 export class ThreeCoordinator extends Coordinator {
-  getYAxisDirection(): 1 {
-    return 1;
+  isYAxisPointedDown() {
+    return false;
   }
 
   private readonly camera = new THREE.OrthographicCamera(

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/threejs_coordinator.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/threejs_coordinator.ts
@@ -17,8 +17,7 @@ import * as THREE from 'three';
 
 import {Coordinator} from './coordinator';
 import {Rect} from './internal_types';
-import {createScale} from './scale';
-import {ScaleType} from './scale_types';
+import {convertRectToExtent} from './utils';
 
 /**
  * Unlike Coordinator, ThreeCoordinator uses internal coordinate system.
@@ -30,39 +29,30 @@ import {ScaleType} from './scale_types';
  * In this coordinator, the output coordinate system is static from [0, 1000].
  */
 export class ThreeCoordinator extends Coordinator {
-  private readonly CAMERA_MIN = 0;
-  private readonly CAMERA_MAX = 1000;
-  private readonly domToCameraScale = createScale(ScaleType.LINEAR);
+  getYAxisDirection(): 1 {
+    return 1;
+  }
+
   private readonly camera = new THREE.OrthographicCamera(
-    this.CAMERA_MIN,
-    this.CAMERA_MAX,
-    this.CAMERA_MAX,
-    this.CAMERA_MIN,
+    0,
+    1000,
+    1000,
+    0,
     0,
     100
   );
 
-  transformDataToUiCoord(
-    rectInUiCoordinate: Rect,
-    dataCoordinate: [number, number]
-  ): [number, number] {
-    const containerRect = this.domContainerRect;
-    const uiCoordinates = super.transformDataToUiCoord(
-      rectInUiCoordinate,
-      dataCoordinate
-    );
-
-    const xInCamera = this.domToCameraScale.forward(
-      [containerRect.x, containerRect.x + containerRect.width],
-      [this.CAMERA_MIN, this.CAMERA_MAX],
-      uiCoordinates[0]
-    );
-    const yInCamera = this.domToCameraScale.forward(
-      [containerRect.y + containerRect.height, containerRect.y],
-      [this.CAMERA_MIN, this.CAMERA_MAX],
-      uiCoordinates[1]
-    );
-    return [xInCamera, yInCamera];
+  setDomContainerRect(rect: Rect) {
+    // We set the camera extent based on the dom container size so the dimensions in
+    // camera coordinate corresponds to dimensions in pixels. This way, in order to draw,
+    // for example a circle, we don't have to map a pixel size to camera dimensions
+    // (which may have different aspect ratio and can draw a circle as an oval).
+    super.setDomContainerRect(rect);
+    this.camera.left = rect.x;
+    this.camera.right = rect.x + rect.width;
+    this.camera.top = rect.y + rect.height;
+    this.camera.bottom = rect.y;
+    this.camera.updateProjectionMatrix();
   }
 
   getCamera() {


### PR DESCRIPTION
Previously, we had a camera coordinate system where we had a fixed camera
view point. This was great because irrespective of the actual DOM size,
we could keep the objects position static. However, this approach has a
major problem. Now that we want to render shapes like triangle and
circle, geometry that is defined in the camera coordinate system has to
account for mismatch in camera coordinate aspect ratio vs. DOM camera
coordinate aspect ratio.

We want circle that is not an oval in browser pixel location. To do
that, when creating a geometry in the camera coordinates, we need to
account for discrepancy in aspect ratio, which generally is harder than
just matching the camera view point to that of the DOM size. As such,
this change removes the camera coordinate system separate from DOM but
supports the y-axis flipping which is the only remaining difference in
the coordinate systems we support.
