### PR TITLE
line chart: omit nan from interactive view

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
@@ -20,7 +20,7 @@ limitations under the License.
       *ngFor="let datum of cursoredData; trackBy: trackBySeriesName"
     >
       <circle
-        *ngIf="datum.point"
+        *ngIf="shouldRenderTooltipPoint(datum.point)"
         [attr.cx]="getDomX(datum.point.x)"
         [attr.cy]="getDomY(datum.point.y)"
         [attr.fill]="datum.metadata.color"

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -406,8 +406,8 @@ export class LineChartInteractiveViewComponent
     );
   }
 
-  shouldRenderTooltipPoint(point: Point | undefined): boolean {
-    return point !== undefined && !isNaN(point.x) && !isNaN(point.y);
+  shouldRenderTooltipPoint(point: Point | null): boolean {
+    return point !== null && !isNaN(point.x) && !isNaN(point.y);
   }
 
   private updateTooltip(event: MouseEvent) {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -42,6 +42,7 @@ import {
   DataSeriesMetadataMap,
   Dimension,
   Extent,
+  Point,
   Rect,
   Scale,
 } from '../lib/public_types';
@@ -403,6 +404,10 @@ export class LineChartInteractiveViewComponent
       getScaleRangeFromDomDim(this.domDim, 'y'),
       uiCoord
     );
+  }
+
+  shouldRenderTooltipPoint(point: Point | undefined): boolean {
+    return point !== undefined && !isNaN(point.x) && !isNaN(point.y);
   }
 
   private updateTooltip(event: MouseEvent) {


### PR DESCRIPTION
Previously, we were trying to render NaN values on the line chart
interactive layer (circle to indicate where the tooltip is at). This
caused SVG to complain and populate error messages on the console.
