### PR TITLE
Rename FEAUTURE_FLAG_FEATURE_KEY to FEATURE_FLAG_FEATURE_KEY.

### DIFF
--- a/tensorboard/webapp/feature_flag/feature_flag_module.ts
+++ b/tensorboard/webapp/feature_flag/feature_flag_module.ts
@@ -19,14 +19,14 @@ import {EffectsModule} from '@ngrx/effects';
 
 import {TBFeatureFlagModule} from '../webapp_data_source/tb_feature_flag_module';
 
-import {FEAUTURE_FLAG_FEATURE_KEY} from './store/feature_flag_types';
+import {FEATURE_FLAG_FEATURE_KEY} from './store/feature_flag_types';
 import {reducers} from './store/feature_flag_reducers';
 import {FeatureFlagEffects} from './effects/feature_flag_effects';
 
 @NgModule({
   imports: [
     TBFeatureFlagModule,
-    StoreModule.forFeature(FEAUTURE_FLAG_FEATURE_KEY, reducers),
+    StoreModule.forFeature(FEATURE_FLAG_FEATURE_KEY, reducers),
     EffectsModule.forFeature([FeatureFlagEffects]),
   ],
 })

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -17,14 +17,14 @@ import {createSelector, createFeatureSelector} from '@ngrx/store';
 
 import {
   FeatureFlagState,
-  FEAUTURE_FLAG_FEATURE_KEY,
+  FEATURE_FLAG_FEATURE_KEY,
   State,
 } from './feature_flag_types';
 
 /** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store';
 
 const selectFeatureFlagState = createFeatureSelector<State, FeatureFlagState>(
-  FEAUTURE_FLAG_FEATURE_KEY
+  FEATURE_FLAG_FEATURE_KEY
 );
 
 export const getIsFeatureFlagsLoaded = createSelector(

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import {FeatureFlags} from '../types';
 
-export const FEAUTURE_FLAG_FEATURE_KEY = 'feature';
+export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 
 export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;
@@ -23,5 +23,5 @@ export interface FeatureFlagState {
 }
 
 export interface State {
-  [FEAUTURE_FLAG_FEATURE_KEY]?: FeatureFlagState;
+  [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagState;
 }

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -16,7 +16,7 @@ limitations under the License.
 import {buildFeatureFlag} from '../testing';
 import {
   FeatureFlagState,
-  FEAUTURE_FLAG_FEATURE_KEY,
+  FEATURE_FLAG_FEATURE_KEY,
 } from './feature_flag_types';
 
 export function buildFeatureFlagState(
@@ -32,6 +32,6 @@ export function buildFeatureFlagState(
 
 export function buildState(featureFlagState: FeatureFlagState) {
   return {
-    [FEAUTURE_FLAG_FEATURE_KEY]: featureFlagState,
+    [FEATURE_FLAG_FEATURE_KEY]: featureFlagState,
   };
 }

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -14,10 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {buildFeatureFlag} from '../testing';
-import {
-  FeatureFlagState,
-  FEATURE_FLAG_FEATURE_KEY,
-} from './feature_flag_types';
+import {FeatureFlagState, FEATURE_FLAG_FEATURE_KEY} from './feature_flag_types';
 
 export function buildFeatureFlagState(
   override: Partial<FeatureFlagState> = {}


### PR DESCRIPTION
* Motivation for features / changes

  Code cleanup.

* Technical description of changes

  Use vscode to rename FEAUTURE_FLAG_FEATURE_KEY to FEATURE_FLAG_FEATURE_KEY.

* Detailed steps to verify changes work correctly (as executed by you)

  Ran server after rename and ensured that tensorboardColab query parameter still impacted behavior of the scalars dashboard.