### PR TITLE
rust: add logdir loading benchmark

### DIFF
--- a/tensorboard/data/server/BUILD
+++ b/tensorboard/data/server/BUILD
@@ -68,6 +68,18 @@ rust_test(
     ],
 )
 
+rust_binary(
+    name = "bench",
+    srcs = ["bench.rs"],
+    edition = "2018",
+    deps = [
+        ":rustboard_core",
+        "//third_party/rust:clap",
+        "//third_party/rust:env_logger",
+        "//third_party/rust:log",
+    ],
+)
+
 rust_doc_test(
     name = "rustboard_core_doc_test",
     dep = ":rustboard_core",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -18,6 +18,7 @@ name = "rustboard"
 version = "0.1.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 edition = "2018"
+default-run = "rustboard"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -46,6 +47,10 @@ tonic-build = "0.3.1"
 [[bin]]
 name = "rustboard"
 path = "main.rs"
+
+[[bin]]
+name = "bench"
+path = "bench.rs"
 
 [lib]
 name = "rustboard_core"

--- a/tensorboard/data/server/bench.rs
+++ b/tensorboard/data/server/bench.rs
@@ -1,0 +1,53 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+//! Simple benchmark to completely load a logdir and then exit.
+
+use clap::Clap;
+use log::info;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use rustboard_core::commit::Commit;
+use rustboard_core::logdir::LogdirLoader;
+
+#[derive(Clap)]
+struct Opts {
+    #[clap(long)]
+    logdir: PathBuf,
+    #[clap(long, default_value = "info")]
+    log_level: String,
+}
+
+fn main() {
+    let opts: Opts = Opts::parse();
+    init_logging(&opts);
+
+    let commit = Commit::new();
+    let mut loader = LogdirLoader::new(&commit, opts.logdir);
+
+    info!("Starting load cycle");
+    let start = Instant::now();
+    loader.reload();
+    let end = Instant::now();
+    info!("Finished load cycle ({:?})", end - start);
+}
+
+fn init_logging(opts: &Opts) {
+    use env_logger::{Builder, Env};
+    Builder::from_env(Env::default().default_filter_or(&opts.log_level))
+        .format_timestamp_micros()
+        .init();
+}


### PR DESCRIPTION
Summary:
A new `bench` binary takes a `--logdir` parameter, loads the logdir to
completion, and then exits. This should report similar times to those
given by the info logs on the server itself, but is useful as a
standalone target because it exits upon completion. This makes it easier
to use with tools like `time(1)` or `hyperfine(1)` for automated studies
of performance over time.

I looked into using [`criterion`], which provides nice statistical
analysis over time. It works as advertised, but we want to be able to
point this benchmark at arbitrary logdirs and use it as a benchmarking
*tool* rather than just a fixed benchmark of a function. Same
justification for not using `cargo bench`.

The difference between the time reported in the `info!` logs and the
process runtime as reported by `time(1)` or `hyperfine(1)` tends to be
on the order of 5 ms on my machine, which I consider negligible enough
to not merit further investigation.

[`criterion`]: https://crates.io/crates/criterion

Test Plan:
To run with Cargo:

```
$ cargo run --release --bin bench -- --logdir ~/tensorboard_data/mnist/
```

To run with Bazel:

```
$ bazel run -c opt :bench -- --logdir ~/tensorboard_data/mnist/
```

For example, the gs://tensorboard-bench-logs/edge_cgan dataset completes
in 10.12 ± 0.04 seconds on my machine (Xeon W-2135 CPU, 64 GB RAM).

Note that these both run and report similar times. Note that `cargo run`
without `--bin` still runs the server.

wchargin-branch: rust-bench
