### PR TITLE
Remove unnecessary type cast to CoreState.

### DIFF
--- a/tensorboard/webapp/core/store/core_initial_state_provider.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider.ts
@@ -30,6 +30,6 @@ export function getConfig(deepLinker: HashDeepLinker): StoreConfig<CoreState> {
     initialState: {
       ...initialState,
       activePlugin: deepLinker.getPluginId() || null,
-    } as CoreState,
+    },
   };
 }


### PR DESCRIPTION
* Motivation for features / changes

  Remove an unnecessary TypeScript type cast of the initial CoreState. Could lead to obscuring future problems that the compiler would normally catch.

* Technical description of changes

  Remove unnecessary TypeScript type cast.

* Detailed steps to verify changes work correctly (as executed by you)

  Ran tests. Launched UI and ensured Scalars dashboard loads.
