### PR TITLE
Introduce a source code diff view component

### DIFF
--- a/tensorboard/webapp/widgets/source_code/BUILD
+++ b/tensorboard/webapp/widgets/source_code/BUILD
@@ -7,8 +7,11 @@ licenses(["notice"])
 tf_ng_module(
     name = "source_code",
     srcs = [
+        "editor_options.ts",
         "source_code_component.ts",
         "source_code_container.ts",
+        "source_code_diff_component.ts",
+        "source_code_diff_container.ts",
         "source_code_module.ts",
     ],
     assets = [
@@ -63,6 +66,7 @@ tf_ts_library(
     testonly = True,
     srcs = [
         "source_code_container_test.ts",
+        "source_code_diff_container_test.ts",
     ],
     deps = [
         ":load_monaco",

--- a/tensorboard/webapp/widgets/source_code/BUILD
+++ b/tensorboard/webapp/widgets/source_code/BUILD
@@ -20,6 +20,7 @@ tf_ng_module(
     ],
     deps = [
         ":load_monaco",
+        "//tensorboard/webapp/widgets:resize_detector",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//monaco-editor-core",

--- a/tensorboard/webapp/widgets/source_code/editor_options.ts
+++ b/tensorboard/webapp/widgets/source_code/editor_options.ts
@@ -12,23 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
-import {CommonModule} from '@angular/common';
-import {NgModule} from '@angular/core';
-
-import {SourceCodeComponent} from './source_code_component';
-import {SourceCodeContainer} from './source_code_container';
-import {SourceCodeDiffComponent} from './source_code_diff_component';
-import {SourceCodeDiffContainer} from './source_code_diff_container';
-
-@NgModule({
-  declarations: [
-    SourceCodeComponent,
-    SourceCodeContainer,
-    SourceCodeDiffComponent,
-    SourceCodeDiffContainer,
-  ],
-  imports: [CommonModule],
-  exports: [SourceCodeContainer, SourceCodeDiffContainer],
-})
-export class SourceCodeModule {}
+/**
+ * Options for source code editors.
+ */
+export const DEFAULT_CODE_LANGUAGE = 'python';
+export const DEFAULT_CODE_FONT_SIZE = 10;
+export const RESIZE_DEBOUNCE_INTERVAL_MS = 50;

--- a/tensorboard/webapp/widgets/source_code/source_code_component.ng.html
+++ b/tensorboard/webapp/widgets/source_code/source_code_component.ng.html
@@ -15,4 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div #codeViewerContainer class="code-viewer-container"></div>
+<div
+  #codeViewerContainer
+  class="code-viewer-container"
+  detectResize
+  [resizeEventDebouncePeriodInMs]="RESIZE_DEBOUNCE_INTERVAL_MS"
+  (onResize)="onResize()"
+></div>

--- a/tensorboard/webapp/widgets/source_code/source_code_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_component.ts
@@ -17,22 +17,15 @@ import {
   Component,
   ElementRef,
   Input,
+  OnChanges,
   SimpleChanges,
   ViewChild,
-  OnChanges,
-  OnDestroy,
-  OnInit,
 } from '@angular/core';
-import {fromEvent, interval, Subject} from 'rxjs';
-import {debounce, takeUntil, tap} from 'rxjs/operators';
-
 import {
-  DEFAULT_CODE_LANGUAGE,
   DEFAULT_CODE_FONT_SIZE,
+  DEFAULT_CODE_LANGUAGE,
   RESIZE_DEBOUNCE_INTERVAL_MS,
 } from './editor_options';
-
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'source-code-component',
@@ -40,7 +33,7 @@ import {
   styleUrls: ['./source_code_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SourceCodeComponent implements OnInit, OnChanges, OnDestroy {
+export class SourceCodeComponent implements OnChanges {
   @Input()
   lines: string[] | null = null; // TODO(cais): Add spinner for `null`.
 
@@ -54,32 +47,13 @@ export class SourceCodeComponent implements OnInit, OnChanges, OnDestroy {
   private readonly codeViewerContainer!: ElementRef<HTMLDivElement>;
 
   private editor: any = null;
-
   private decorations: string[] = [];
+  readonly RESIZE_DEBOUNCE_INTERVAL_MS = RESIZE_DEBOUNCE_INTERVAL_MS;
 
-  private readonly ngUnsubscribe = new Subject();
-
-  ngOnInit(): void {
-    // Listen to window resize event. When resize happens, re-layout
-    // monaco editor, so its width is always up-to-date with respect to
-    // the window size. Do this with `debounce()` to prevent re-layouting
-    // at too high a rate.
-    const resizePipe = fromEvent(window, 'resize')
-      .pipe(
-        takeUntil(this.ngUnsubscribe),
-        debounce(() => interval(RESIZE_DEBOUNCE_INTERVAL_MS)),
-        tap(() => {
-          if (this.editor !== null) {
-            this.editor.layout();
-          }
-        })
-      )
-      .subscribe();
-  }
-
-  ngOnDestroy(): void {
-    this.ngUnsubscribe.next();
-    this.ngUnsubscribe.complete();
+  onResize() {
+    if (this.editor) {
+      this.editor.layout();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -150,7 +124,3 @@ export class SourceCodeComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 }
-
-export const TEST_ONLY = {
-  RESIZE_DEBOUNCE_INTERVAL_MS,
-};

--- a/tensorboard/webapp/widgets/source_code/source_code_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_component.ts
@@ -26,12 +26,13 @@ import {
 import {fromEvent, interval, Subject} from 'rxjs';
 import {debounce, takeUntil, tap} from 'rxjs/operators';
 
+import {
+  DEFAULT_CODE_LANGUAGE,
+  DEFAULT_CODE_FONT_SIZE,
+  RESIZE_DEBOUNCE_INTERVAL_MS,
+} from './editor_options';
+
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
-
-const DEFAULT_CODE_LANGUAGE = 'python';
-const DEFAULT_CODE_FONT_SIZE = 10;
-
-const RESIZE_DEBOUNCE_INTERAVL_MS = 50;
 
 @Component({
   selector: 'source-code-component',
@@ -66,7 +67,7 @@ export class SourceCodeComponent implements OnInit, OnChanges, OnDestroy {
     const resizePipe = fromEvent(window, 'resize')
       .pipe(
         takeUntil(this.ngUnsubscribe),
-        debounce(() => interval(RESIZE_DEBOUNCE_INTERAVL_MS)),
+        debounce(() => interval(RESIZE_DEBOUNCE_INTERVAL_MS)),
         tap(() => {
           if (this.editor !== null) {
             this.editor.layout();
@@ -151,5 +152,5 @@ export class SourceCodeComponent implements OnInit, OnChanges, OnDestroy {
 }
 
 export const TEST_ONLY = {
-  RESIZE_DEBOUNCE_INTERAVL_MS,
+  RESIZE_DEBOUNCE_INTERVAL_MS,
 };

--- a/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
@@ -148,7 +148,7 @@ describe('Source Code Component', () => {
     });
 
     window.dispatchEvent(new Event('resize'));
-    await sleep(TEST_ONLY.RESIZE_DEBOUNCE_INTERAVL_MS);
+    await sleep(TEST_ONLY.RESIZE_DEBOUNCE_INTERVAL_MS);
     expect(spies.editorSpy!.layout).toHaveBeenCalledTimes(1);
   });
 });

--- a/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
@@ -18,7 +18,7 @@ limitations under the License.
 import {SimpleChange} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-import {SourceCodeComponent, TEST_ONLY} from './source_code_component';
+import {SourceCodeComponent} from './source_code_component';
 import {SourceCodeContainer} from './source_code_container';
 import {
   fakes,
@@ -121,35 +121,6 @@ describe('Source Code Component', () => {
       1,
       fakes.fakeMonaco.editor.ScrollType.Smooth
     );
-  });
-
-  function sleep(durationMs: number): Promise<void> {
-    return new Promise((resolve) => {
-      setInterval(() => {
-        resolve();
-      }, durationMs);
-    });
-  }
-
-  it('calls monaco editor layout() on resize', async () => {
-    const fixture = TestBed.createComponent(SourceCodeComponent);
-    const component = fixture.componentInstance;
-    component.ngOnInit();
-    component.lines = lines1;
-    component.focusedLineno = 3;
-    await component.ngOnChanges({
-      lines: new SimpleChange(null, lines1, true),
-      focusedLineno: new SimpleChange(null, 3, true),
-    });
-    await loadMonacoShim.loadMonaco();
-    component.monaco = windowWithRequireAndMonaco.monaco;
-    await component.ngOnChanges({
-      monaco: new SimpleChange(null, windowWithRequireAndMonaco.monaco, true),
-    });
-
-    window.dispatchEvent(new Event('resize'));
-    await sleep(TEST_ONLY.RESIZE_DEBOUNCE_INTERVAL_MS);
-    expect(spies.editorSpy!.layout).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_component.ts
@@ -1,0 +1,122 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
+import {Subject} from 'rxjs';
+import {debounceTime, takeUntil} from 'rxjs/operators';
+
+import {
+  DEFAULT_CODE_LANGUAGE,
+  DEFAULT_CODE_FONT_SIZE,
+  RESIZE_DEBOUNCE_INTERVAL_MS,
+} from './editor_options';
+
+@Component({
+  selector: 'source-code-diff-component',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SourceCodeDiffComponent implements OnInit, OnChanges, OnDestroy {
+  @Input()
+  firstText: string | null = null;
+
+  @Input()
+  secondText: string | null = null;
+
+  // When a diff is shown, the two versions can be rendered in one of 2 modes:
+  // - side by side: 2 scrollable frames with a vertical separator
+  // - inline: 1 scrollable frame showing modified and original lines
+  // This component does not respond to changes in this property.
+  @Input()
+  renderSideBySide: boolean = true;
+
+  @Input()
+  monaco: any;
+
+  private editor: any = null;
+  private readonly ngUnsubscribe$ = new Subject();
+  private readonly onResize$ = new Subject<void>();
+
+  constructor(private readonly ref: ElementRef) {
+    const resizeObserver = new ResizeObserver(() => {
+      this.onResize$.next();
+    });
+    resizeObserver.observe(ref.nativeElement);
+    this.ngUnsubscribe$.subscribe(() => {
+      resizeObserver.unobserve(ref.nativeElement);
+    });
+  }
+
+  ngOnInit() {
+    // When the element resizes, notify Monaco that it can recalculate layout.
+    this.onResize$
+      .pipe(
+        debounceTime(RESIZE_DEBOUNCE_INTERVAL_MS),
+        takeUntil(this.ngUnsubscribe$)
+      )
+      .subscribe(() => {
+        if (this.editor) {
+          this.editor.layout();
+        }
+      });
+  }
+
+  ngOnDestroy() {
+    this.ngUnsubscribe$.next();
+    this.ngUnsubscribe$.complete();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    // All changes depend on Monaco.
+    if (!this.monaco) {
+      return;
+    }
+
+    const willCreateEditor = !this.editor;
+    if (willCreateEditor) {
+      this.editor = this.monaco.editor.createDiffEditor(
+        this.ref.nativeElement,
+        {
+          language: DEFAULT_CODE_LANGUAGE,
+          readOnly: true,
+          fontSize: DEFAULT_CODE_FONT_SIZE,
+          minimap: {
+            enabled: true,
+          },
+          renderSideBySide: this.renderSideBySide,
+        }
+      );
+    }
+
+    if (willCreateEditor || changes['firstText'] || changes['secondText']) {
+      this.editor.setModel({
+        original: this.monaco.editor.createModel(this.firstText || ''),
+        modified: this.monaco.editor.createModel(this.secondText || ''),
+      });
+    }
+  }
+}
+
+export const TEST_ONLY = {
+  RESIZE_DEBOUNCE_INTERVAL_MS,
+};

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
@@ -1,0 +1,60 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {from} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+import {loadMonaco} from './load_monaco_shim';
+
+/**
+ * A component that renders a diff of 2 separate text contents. Diffs can be
+ * viewed inline or side by side.
+ */
+@Component({
+  selector: 'source-code-diff',
+  template: `
+    <source-code-diff-component
+      [firstText]="firstText"
+      [secondText]="secondText"
+      [renderSideBySide]="renderSideBySide"
+      [monaco]="monaco$ | async"
+    ></source-code-diff-component>
+  `,
+  styles: [
+    `
+      source-code-diff-component {
+        display: block;
+        height: 100%;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SourceCodeDiffContainer {
+  @Input()
+  firstText: string | null = null;
+
+  @Input()
+  secondText: string | null = null;
+
+  @Input()
+  renderSideBySide: boolean = true;
+
+  monaco$: any | null = null;
+
+  ngOnInit() {
+    this.monaco$ = from(loadMonaco()).pipe(map(() => (window as any).monaco));
+  }
+}

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
-import {from} from 'rxjs';
+import {from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 import {loadMonaco} from './load_monaco_shim';
@@ -52,9 +52,9 @@ export class SourceCodeDiffContainer {
   @Input()
   renderSideBySide: boolean = true;
 
-  monaco$: any | null = null;
+  monaco$: Observable<typeof monaco> | null = null;
 
-  ngOnInit() {
-    this.monaco$ = from(loadMonaco()).pipe(map(() => (window as any).monaco));
+  ngOnInit(): void {
+    this.monaco$ = from(loadMonaco()).pipe(map(() => window.monaco));
   }
 }

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
@@ -1,0 +1,78 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+
+import * as loadMonacoShim from './load_monaco_shim';
+import {SourceCodeDiffComponent} from './source_code_diff_component';
+import {SourceCodeDiffContainer} from './source_code_diff_container';
+import {setUpMonacoFakes, spies, tearDownMonacoFakes} from './testing';
+
+describe('Source Code Diff', () => {
+  beforeEach(async () => {
+    setUpMonacoFakes();
+    await TestBed.configureTestingModule({
+      declarations: [SourceCodeDiffComponent, SourceCodeDiffContainer],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    tearDownMonacoFakes();
+  });
+
+  it('renders a side-by-side diff using monaco', async () => {
+    const fixture = TestBed.createComponent(SourceCodeDiffContainer);
+    const component = fixture.componentInstance;
+    component.firstText = 'foo';
+    component.secondText = 'bar';
+    component.renderSideBySide = true;
+    fixture.detectChanges();
+
+    // Simlulate loading monaco.
+    await loadMonacoShim.loadMonaco();
+    fixture.detectChanges();
+
+    expect(spies.createDiffEditorSpy).toHaveBeenCalledTimes(1);
+    expect(
+      spies.createDiffEditorSpy.calls.allArgs()[0][1].renderSideBySide
+    ).toBe(true);
+    expect(spies.diffEditorSpy.setModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an inline diff using monaco', async () => {
+    const fixture = TestBed.createComponent(SourceCodeDiffContainer);
+    const component = fixture.componentInstance;
+    component.firstText = 'foo';
+    component.secondText = 'bar';
+    component.renderSideBySide = false;
+    fixture.detectChanges();
+
+    // Simlulate loading monaco.
+    await loadMonacoShim.loadMonaco();
+    fixture.detectChanges();
+
+    expect(spies.createDiffEditorSpy).toHaveBeenCalledTimes(1);
+    expect(
+      spies.createDiffEditorSpy.calls.allArgs()[0][1].renderSideBySide
+    ).toBe(false);
+    expect(spies.diffEditorSpy.setModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls loadMonaco() on ngOnInit()', () => {
+    const fixture = TestBed.createComponent(SourceCodeDiffContainer);
+    const component = fixture.componentInstance;
+    component.ngOnInit();
+    expect(spies.loadMonacoSpy!).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tensorboard/webapp/widgets/source_code/source_code_module.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_module.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
+import {ResizeDetectorModule} from '../resize_detector_module';
 import {SourceCodeComponent} from './source_code_component';
 import {SourceCodeContainer} from './source_code_container';
 import {SourceCodeDiffComponent} from './source_code_diff_component';
@@ -28,7 +29,7 @@ import {SourceCodeDiffContainer} from './source_code_diff_container';
     SourceCodeDiffComponent,
     SourceCodeDiffContainer,
   ],
-  imports: [CommonModule],
+  imports: [CommonModule, ResizeDetectorModule],
   exports: [SourceCodeContainer, SourceCodeDiffContainer],
 })
 export class SourceCodeModule {}

--- a/tensorboard/webapp/widgets/source_code/testing.ts
+++ b/tensorboard/webapp/widgets/source_code/testing.ts
@@ -33,6 +33,9 @@ export class FakeRange {
 export const spies: {
   loadMonacoSpy?: jasmine.Spy;
   editorSpy?: jasmine.SpyObj<any>;
+  createDiffEditorSpy?: jasmine.SpyObj<any>;
+  diffEditorSpy?: jasmine.SpyObj<any>;
+  createModelSpy?: jasmine.SpyObj<any>;
 } = {};
 
 export const fakes: {
@@ -54,6 +57,17 @@ export function setUpMonacoFakes() {
           ]);
           return spies.editorSpy;
         },
+        createDiffEditor: () => {
+          spies.diffEditorSpy = jasmine.createSpyObj('diffEditorSpy', [
+            'layout',
+            'setModel',
+          ]);
+          return spies.diffEditorSpy;
+        },
+        createModel: () => {
+          spies.createModelSpy = jasmine.createSpy();
+          return spies.createModelSpy;
+        },
         ScrollType: {
           Immediate: 1,
           Smooth: 0,
@@ -61,6 +75,10 @@ export function setUpMonacoFakes() {
       },
       Range: FakeRange,
     };
+    spies.createDiffEditorSpy = spyOn(
+      fakes.fakeMonaco.editor,
+      'createDiffEditor'
+    ).and.callThrough();
     windowWithRequireAndMonaco.monaco = fakes.fakeMonaco;
   }
   spies.loadMonacoSpy = spyOn(loadMonacoShim, 'loadMonaco').and.callFake(


### PR DESCRIPTION
The existing SourceCode components are used in the Debugger V2 dashboard
to provide a readonly view of source code. This change branches the
NgComponent into a variant used solely for rendering a diff view. Source code
diffs may render 2 text contents side-by-side or as 1 unified inline diff.

Drive-by: migrated the existing (non-diff) SourceCode component to also
use the ResizeDetector.

Manually tested that resizing the Debugger V2 plugin still works:
![image](https://user-images.githubusercontent.com/2322480/101960425-41471500-3bbc-11eb-8f53-d132ddbc6d86.png)


Notes:

Why isn't this just part of the existing SourceCodeComponent?

The underlying Monaco classes are different. While they share common
functionality (autoresize, scrolling text into view, selecting regions [1]), the
2 subclasses have some fundamental differences.
- DiffEditor manages 2 source code models, each of which can have its
  own separate gutters, settings, etc.  A unified SourceCodeComponent
  supporting diff/non-diff would need all inputs to specify which editor
  it applies to.
- Diff editor has unique input options, e.g. renderSideBySide.

Until there is a stronger use case to benefit from reuse, I think keeping
these separate for now makes sense.

[1] https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditor.html