### PR TITLE
make TF deps include //tensorboard/summary:tf_summary

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -16,10 +16,6 @@ package_group(
 )
 
 # The standard TensorBoard binary that serves the webapp.
-# The two //tensorboard/summary lines are to suppress an
-# annoying startup warning emitted by TensorFlow that
-# "Limited tf.compat.v2.summary API due to missing TensorBoard
-# installation.
 py_binary(
     name = "tensorboard",
     srcs = ["main.py"],
@@ -32,8 +28,6 @@ py_binary(
         ":program",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins:base_plugin",
-        "//tensorboard/summary",  # Suppress TF startup warning
-        "//tensorboard/summary:tf_summary",  # Suppress TF startup warning
         "//tensorboard/uploader:uploader_subcommand",
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:timing",  # non-strict dep, for patching convenience
@@ -370,7 +364,20 @@ py_library(name = "expect_grpc_testing_installed")
 # This is a dummy rule used as a TensorFlow dependency in open-source.
 # We expect TensorFlow to already be installed on the system, e.g. via
 # `pip install tensorflow`
-py_library(name = "expect_tensorflow_installed")
+#
+# NOTE: we include the dep on //tensorboard/summary:tf_summary so that
+# any TensorBoard code that depends on TF also depends on the tf.summary
+# implementation code hosted by TensorBoard itself. This prevents the
+# "Limited tf.compat.v2.summary API due to missing TensorBoard installation."
+# warning that would otherwise be emitted when running via `bazel run` due
+# to the bazel runfiles containing a `tensorboard` module that lacks that
+# code, which hides the pip installation module that does have it.
+py_library(
+    name = "expect_tensorflow_installed",
+    deps = [
+        "//tensorboard/summary:tf_summary",
+    ],
+)
 
 # This is a dummy rule used as a TensorFlow Datasets dependency in open-source.
 # We expect TensorFlow Datasets to already be installed on the system, e.g. via

--- a/tensorboard/plugins/metrics/BUILD
+++ b/tensorboard/plugins/metrics/BUILD
@@ -49,7 +49,6 @@ py_test(
         "//tensorboard/data:provider",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/plugins/image:metadata",
-        "//tensorboard/summary:tf_summary",
         "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
     ],

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -88,8 +88,6 @@ py_binary(
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
-        "//tensorboard/summary",
-        "//tensorboard/summary:tf_summary",
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -85,7 +85,6 @@ py_library(
     ],
     deps = [
         ":summary_v2",
-        "//tensorboard:expect_tensorflow_installed",
     ],
 )
 


### PR DESCRIPTION
This makes our `//tensorboard:expect_tensorflow_installed` placeholder target (reflecting a dep on the TF pip package from the virtualenv) include a dep on `//tensorboard/summary:tf_summary`.

This fixes "for once and for all" the problem wherein code within TensorBoard that depends on TF but not on our `tf_summary` shim logic prints the annoying `Limited tf.compat.v2.summary API due to missing TensorBoard installation.` message, and then fails to actually include the `tf.compat.v2.summary.scalar` endpoint.  Consequently we can remove ad-hoc additions of `tf_summary` deps from a few places.

This arrangement is also a better analog to the internal situation.

Confirmed that this syncs internally with a copybara change - see cl/346894347.