### PR TITLE
graph: use data provider if no multiplexer available

### DIFF
--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -61,7 +61,9 @@ class GraphsPlugin(base_plugin.TBPlugin):
           context: A base_plugin.TBContext instance.
         """
         self._multiplexer = context.multiplexer
-        if context.flags and context.flags.generic_data == "true":
+        if not self._multiplexer or (
+            context.flags and context.flags.generic_data == "true"
+        ):
             self._data_provider = context.data_provider
         else:
             self._data_provider = None


### PR DESCRIPTION
Summary:
The graph plugin still defaults to the multiplexer code path, since not
all functionality is implemented in the data provide code path (only run
graphs are implemented). But when a data provider is available and a
multiplexer is not, it should still try to use the data provider. Now,
it does so. This fixes a failure in `is_active`, which previously tried
to call `PluginRunToTagToContent` on `None`.

Test Plan:
Run TensorBoard with `--load_fast` (causing it to provide a gRPC data
provider but no multiplexer) and launch the web server to trigger a
request to `/plugins_listing`. Note that this no longer prints an error
that “is_active() for graphs failed”.

wchargin-branch: graph-data-provider-fallback
