### PR TITLE
Do not specify default values in QueryParamsFeatureFlagDataSource. Rely on initialState defaults instead.

### DIFF
--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -27,8 +27,8 @@ import {FeatureFlags} from '../types';
  * does not have enough information to provide values. In that case, the
  * corresponding feature flag values should remain unchanged in the State.
  */
-export const featuresLoaded = createAction(
-  '[FEATURE FLAG] Features Loaded',
+export const partialFeatureFlagsLoaded = createAction(
+  '[FEATURE FLAG] Partial Feature Flags Loaded',
   props<{
     features: Partial<FeatureFlags>;
   }>()

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -20,9 +20,16 @@ import {FeatureFlags} from '../types';
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 /** @typehack */ import * as _typeHackStoreModel from '@ngrx/store/src/models';
 
+/**
+ * Signals that a data source has loaded feature flag values.
+ *
+ * Some or all feature flag properties can be unspecified if the data source
+ * does not have enough information to provide values. In that case, the
+ * corresponding feature flag values should remain unchanged in the State.
+ */
 export const featuresLoaded = createAction(
   '[FEATURE FLAG] Features Loaded',
   props<{
-    features: FeatureFlags;
+    features: Partial<FeatureFlags>;
   }>()
 );

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
@@ -19,7 +19,7 @@ import {Actions, ofType, createEffect} from '@ngrx/effects';
 import {map} from 'rxjs/operators';
 
 import {TBFeatureFlagDataSource} from '../../webapp_data_source/tb_feature_flag_data_source_types';
-import {featuresLoaded} from '../actions/feature_flag_actions';
+import {partialFeatureFlagsLoaded} from '../actions/feature_flag_actions';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 /** @typehack */ import * as _typeHackNgrx from '@ngrx/store/src/models';
@@ -36,7 +36,7 @@ export class FeatureFlagEffects {
       ofType(effectsInitialized),
       map(() => {
         const features = this.dataSource.getFeatures();
-        return featuresLoaded({features});
+        return partialFeatureFlagsLoaded({features});
       })
     )
   );

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -23,7 +23,7 @@ import {
   TBFeatureFlagTestingModule,
   TestingTBFeatureFlagDataSource,
 } from '../../webapp_data_source/tb_feature_flag_testing';
-import {featuresLoaded} from '../actions/feature_flag_actions';
+import {partialFeatureFlagsLoaded} from '../actions/feature_flag_actions';
 import {State} from '../store/feature_flag_types';
 import {buildFeatureFlag} from '../testing';
 import {FeatureFlagEffects} from './feature_flag_effects';
@@ -70,7 +70,7 @@ describe('feature_flag_effects', () => {
       actions.next(effects.ngrxOnInitEffects());
 
       expect(recordedActions).toEqual([
-        featuresLoaded({
+        partialFeatureFlagsLoaded({
           features: buildFeatureFlag({
             enabledExperimentalPlugins: ['foo', 'bar'],
             inColab: false,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -31,6 +31,9 @@ const initialState: FeatureFlagState = {
 const reducer = createReducer<FeatureFlagState>(
   initialState,
   on(actions.featuresLoaded, (state, {features}) => {
+    // Feature flag values have been loaded from a data source. Override current
+    // flags with any values specified by the data source and leave values for
+    // unspecified properties unchanged.
     return {
       ...state,
       isFeatureFlagsLoaded: true,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -30,7 +30,7 @@ const initialState: FeatureFlagState = {
 
 const reducer = createReducer<FeatureFlagState>(
   initialState,
-  on(actions.featuresLoaded, (state, {features}) => {
+  on(actions.partialFeatureFlagsLoaded, (state, {features}) => {
     // Feature flag values have been loaded from a data source. Override current
     // flags with any values specified by the data source and leave values for
     // unspecified properties unchanged.

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -19,6 +19,20 @@ import {buildFeatureFlagState} from './testing';
 
 describe('feature_flag_reducers', () => {
   describe('featuresLoaded', () => {
+    it('sets isFeatureFlagsLoaded to true', () => {
+      const prevState = buildFeatureFlagState({
+        isFeatureFlagsLoaded: false,
+      });
+      const nextState = reducers(
+        prevState,
+        actions.featuresLoaded({features: {}})
+      );
+
+      expect(nextState).toEqual(buildFeatureFlagState({
+        isFeatureFlagsLoaded: true,
+      }));
+    });
+
     it('sets the new feature flags onto the state', () => {
       const prevState = buildFeatureFlagState({
         isFeatureFlagsLoaded: false,
@@ -29,16 +43,38 @@ describe('feature_flag_reducers', () => {
       const nextState = reducers(
         prevState,
         actions.featuresLoaded({
-          features: buildFeatureFlag({
+          features: {
             enabledExperimentalPlugins: ['foo', 'bar'],
-          }),
+          },
         })
       );
 
-      expect(nextState.features.enabledExperimentalPlugins).toEqual([
-        'foo',
-        'bar',
-      ]);
+      expect(nextState.features).toEqual(buildFeatureFlag({
+        enabledExperimentalPlugins: ['foo', 'bar']
+      }));
+    });
+
+    it('ignores unspecified feature flags', () => {
+      const prevState = buildFeatureFlagState({
+        isFeatureFlagsLoaded: false,
+        features: buildFeatureFlag({
+          enabledExperimentalPlugins: ['foo'],
+          inColab: true,
+        }),
+      });
+      const nextState = reducers(
+        prevState,
+        actions.featuresLoaded({
+          features: {
+            inColab: false
+          },
+        })
+      );
+
+      expect(nextState.features).toEqual(buildFeatureFlag({
+        enabledExperimentalPlugins: ['foo'],
+        inColab: false,
+      }));
     });
   });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -25,7 +25,7 @@ describe('feature_flag_reducers', () => {
       });
       const nextState = reducers(
         prevState,
-        actions.featuresLoaded({features: {}})
+        actions.partialFeatureFlagsLoaded({features: {}})
       );
 
       expect(nextState).toEqual(
@@ -44,7 +44,7 @@ describe('feature_flag_reducers', () => {
       });
       const nextState = reducers(
         prevState,
-        actions.featuresLoaded({
+        actions.partialFeatureFlagsLoaded({
           features: {
             enabledExperimentalPlugins: ['foo', 'bar'],
           },
@@ -68,7 +68,7 @@ describe('feature_flag_reducers', () => {
       });
       const nextState = reducers(
         prevState,
-        actions.featuresLoaded({
+        actions.partialFeatureFlagsLoaded({
           features: {
             inColab: false,
           },

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -28,9 +28,11 @@ describe('feature_flag_reducers', () => {
         actions.featuresLoaded({features: {}})
       );
 
-      expect(nextState).toEqual(buildFeatureFlagState({
-        isFeatureFlagsLoaded: true,
-      }));
+      expect(nextState).toEqual(
+        buildFeatureFlagState({
+          isFeatureFlagsLoaded: true,
+        })
+      );
     });
 
     it('sets the new feature flags onto the state', () => {
@@ -49,9 +51,11 @@ describe('feature_flag_reducers', () => {
         })
       );
 
-      expect(nextState.features).toEqual(buildFeatureFlag({
-        enabledExperimentalPlugins: ['foo', 'bar']
-      }));
+      expect(nextState.features).toEqual(
+        buildFeatureFlag({
+          enabledExperimentalPlugins: ['foo', 'bar'],
+        })
+      );
     });
 
     it('ignores unspecified feature flags', () => {
@@ -66,15 +70,17 @@ describe('feature_flag_reducers', () => {
         prevState,
         actions.featuresLoaded({
           features: {
-            inColab: false
+            inColab: false,
           },
         })
       );
 
-      expect(nextState.features).toEqual(buildFeatureFlag({
-        enabledExperimentalPlugins: ['foo'],
-        inColab: false,
-      }));
+      expect(nextState.features).toEqual(
+        buildFeatureFlag({
+          enabledExperimentalPlugins: ['foo'],
+          inColab: false,
+        })
+      );
     });
   });
 });

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -92,6 +92,7 @@ tf_ng_module(
     ],
     deps = [
         ":feature_flag_types",
+        "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -19,6 +19,7 @@ import {
   GPU_LINE_CHART_QUERY_PARAM_KEY,
   TBFeatureFlagDataSource,
 } from './tb_feature_flag_data_source_types';
+import {FeatureFlags} from '../feature_flag/types';
 
 /**
  * Save the initial URL query params, before the AppRoutingEffects initialize.
@@ -35,13 +36,22 @@ const util = {
 export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
   getFeatures() {
     const params = util.getParams();
-    return {
-      enabledExperimentalPlugins: params.getAll(
+    // Set feature flag value for query parameters that are explicitly
+    // specified. Feature flags for unspecified query parameters remain unset so
+    // their values in the underlying state are not inadvertently changed.
+    const featureFlags : Partial<FeatureFlags> = {};
+    if (params.has(EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY)) {
+      featureFlags.enabledExperimentalPlugins = params.getAll(
         EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY
-      ),
-      inColab: params.get('tensorboardColab') === 'true',
-      enableGpuChart: params.get(GPU_LINE_CHART_QUERY_PARAM_KEY) === 'true',
-    };
+      );
+    }
+    if (params.has('tensorboardColab')) {
+      featureFlags.inColab = params.get('tensorboardColab') === 'true';
+    }
+    if (params.has(GPU_LINE_CHART_QUERY_PARAM_KEY)) {
+      featureFlags.enableGpuChart = params.get(GPU_LINE_CHART_QUERY_PARAM_KEY) === 'true';
+    }
+    return featureFlags;
   }
 }
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -39,7 +39,7 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
     // Set feature flag value for query parameters that are explicitly
     // specified. Feature flags for unspecified query parameters remain unset so
     // their values in the underlying state are not inadvertently changed.
-    const featureFlags : Partial<FeatureFlags> = {};
+    const featureFlags: Partial<FeatureFlags> = {};
     if (params.has(EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY)) {
       featureFlags.enabledExperimentalPlugins = params.getAll(
         EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY
@@ -49,7 +49,8 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
       featureFlags.inColab = params.get('tensorboardColab') === 'true';
     }
     if (params.has(GPU_LINE_CHART_QUERY_PARAM_KEY)) {
-      featureFlags.enableGpuChart = params.get(GPU_LINE_CHART_QUERY_PARAM_KEY) === 'true';
+      featureFlags.enableGpuChart =
+        params.get(GPU_LINE_CHART_QUERY_PARAM_KEY) === 'true';
     }
     return featureFlags;
   }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -42,7 +42,9 @@ describe('tb_feature_flag_data_source', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('experimentalPlugin=a&experimentalPlugin=b')
         );
-        expect(dataSource.getFeatures()).toEqual({enabledExperimentalPlugins: ['a', 'b']});
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: ['a', 'b'],
+        });
       });
 
       it('returns inColab=false when `tensorboardColab` is empty', () => {
@@ -89,9 +91,15 @@ describe('tb_feature_flag_data_source', () => {
 
       it('returns all flag values when they are all set', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
-          new URLSearchParams('experimentalPlugin=a&tensorboardColab&fastChart=true')
+          new URLSearchParams(
+            'experimentalPlugin=a&tensorboardColab&fastChart=true'
+          )
         );
-        expect(dataSource.getFeatures()).toEqual({enabledExperimentalPlugins: ['a'], inColab: false, enableGpuChart: true});
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: ['a'],
+          inColab: false,
+          enableGpuChart: true,
+        });
       });
     });
   });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -31,67 +31,67 @@ describe('tb_feature_flag_data_source', () => {
     });
 
     describe('getFeatures', () => {
-      it('returns default values when params are empty', () => {
+      it('returns empy values when params are empty', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('')
         );
-        expect(dataSource.getFeatures()).toEqual({
-          enabledExperimentalPlugins: [],
-          inColab: false,
-          enableGpuChart: false,
-        });
+        expect(dataSource.getFeatures()).toEqual({});
       });
 
       it('returns enabledExperimentalPlugins from the query params', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('experimentalPlugin=a&experimentalPlugin=b')
         );
-        expect(dataSource.getFeatures().enabledExperimentalPlugins).toEqual([
-          'a',
-          'b',
-        ]);
+        expect(dataSource.getFeatures()).toEqual({enabledExperimentalPlugins: ['a', 'b']});
       });
 
-      it('returns empty enabledExperimentalPlugins when empty', () => {
+      it('returns inColab=false when `tensorboardColab` is empty', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
-          new URLSearchParams('')
+          new URLSearchParams('tensorboardColab')
         );
-        expect(dataSource.getFeatures().enabledExperimentalPlugins).toEqual([]);
+        expect(dataSource.getFeatures()).toEqual({inColab: false});
       });
 
-      it('returns isInColab when true', () => {
+      it('returns inColab=true when `tensorboardColab` is`true`', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('tensorboardColab=true')
         );
-        expect(dataSource.getFeatures().inColab).toEqual(true);
+        expect(dataSource.getFeatures()).toEqual({inColab: true});
       });
 
-      it('returns isInColab when false', () => {
+      it('returns inColab=false when `tensorboardColab` is `false`', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('tensorboardColab=false')
         );
-        expect(dataSource.getFeatures().inColab).toEqual(false);
+        expect(dataSource.getFeatures()).toEqual({inColab: false});
       });
 
-      it("returns enableGpuChart=false when 'fastChart' is empty", () => {
+      it('returns enableGpuChart=false when `fastChart` is empty', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('fastChart=')
         );
-        expect(dataSource.getFeatures().enableGpuChart).toEqual(false);
+        expect(dataSource.getFeatures()).toEqual({enableGpuChart: false});
       });
 
-      it('returns enableGpuChart=true when "true"', () => {
+      it('returns enableGpuChart=true when `fastChart` is `true`', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('fastChart=true')
         );
-        expect(dataSource.getFeatures().enableGpuChart).toEqual(true);
+        expect(dataSource.getFeatures()).toEqual({enableGpuChart: true});
       });
 
-      it('returns enableGpuChart=false when explicitly "false"', () => {
+      it('returns enableGpuChart=false when `fastChart` is "false"', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('fastChart=false')
         );
-        expect(dataSource.getFeatures().enableGpuChart).toEqual(false);
+        expect(dataSource.getFeatures()).toEqual({enableGpuChart: false});
+      });
+
+      it('returns all flag values when they are all set', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('experimentalPlugin=a&tensorboardColab&fastChart=true')
+        );
+        expect(dataSource.getFeatures()).toEqual({enabledExperimentalPlugins: ['a'], inColab: false, enableGpuChart: true});
       });
     });
   });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -24,8 +24,11 @@ export abstract class TBFeatureFlagDataSource {
    * The "feature" is very loosely defined so other applications can define more
    * flags. It is up to the application to better type the flags and create necessary
    * facilities (e.g., strongly typed selector).
+   *
+   * The data source may leave some or all feature flags unspecified if it does
+   * not have enough information to provide values.
    */
-  abstract getFeatures(): FeatureFlags;
+  abstract getFeatures(): Partial<FeatureFlags>;
 }
 
 export const EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY = 'experimentalPlugin';


### PR DESCRIPTION
* Motivation for features / changes

  In the near future we will want feature flag default values to be customizable by different flavors of Tensorboard (TensorBoard.dev vs OSS TensorBoard vs TensorBoard.corp).

  Currently default values are, in practice, set by the QueryParamsFeatureFlagDataSource. This is not the mechanism that we want to use to specify default values so we remove this responsibility out of the DataSource.

* Technical description of changes

  * Change TBFeatureFlagDataSource interface so that a Partial<FeatureFlags> can be returned. 
  * QueryParamsFeatureFlagDataSource returns Partial<FeatureFlags> only if corresponding query parameter was specified on URL.
  * Reducers ignore unspecified FeatureFlag properties from the data source and instead fall back to those already in State. In practice, for the moment, this is just the reducer initialState.

* Detailed steps to verify changes work correctly (as executed by you)

  * Wrote tests.
  * Bring up a tensorboard and load scalars dashboard.  Ensure default value for inColab is used (by looking at Time Series dashboard requests).
  * Override with `tensorboardColab=true` query param and see that Time Series dashboard now uses GET instead of POST for requests.
  * Override with `tensorboardColab` query param and see that Time Series dashboard again uses POST.
