### PR TITLE
line chart: fix layout in Safari

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -48,7 +48,7 @@ import {
   styles: [
     `
       :host {
-        display: block;
+        display: flex;
         overflow: hidden;
       }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view.ts
@@ -43,7 +43,7 @@ import {
   styles: [
     `
       :host {
-        display: block;
+        display: flex;
         overflow: hidden;
       }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.scss
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 :host {
-  display: block;
+  display: flex;
   position: relative;
   user-select: none;
 }


### PR DESCRIPTION
In FF and Chrome, block element under grid takes the full height with
`height: 100%` but it seems to behave a bit differently with Safari.
This change changes block to flex which fixes short axes, small grid,
and weird interactivity.
