### PR TITLE
Provide and consume FeatureFlagState StoreConfig, allowing other Tensorboards to override default feature flag values.

### DIFF
--- a/tensorboard/webapp/feature_flag/feature_flag_module.ts
+++ b/tensorboard/webapp/feature_flag/feature_flag_module.ts
@@ -30,7 +30,11 @@ import {FeatureFlagEffects} from './effects/feature_flag_effects';
 @NgModule({
   imports: [
     TBFeatureFlagModule,
-    StoreModule.forFeature(FEATURE_FLAG_FEATURE_KEY, reducers, FEATURE_FLAG_STORE_CONFIG_TOKEN),
+    StoreModule.forFeature(
+      FEATURE_FLAG_FEATURE_KEY,
+      reducers,
+      FEATURE_FLAG_STORE_CONFIG_TOKEN
+    ),
     EffectsModule.forFeature([FeatureFlagEffects]),
   ],
   providers: [

--- a/tensorboard/webapp/feature_flag/feature_flag_module.ts
+++ b/tensorboard/webapp/feature_flag/feature_flag_module.ts
@@ -20,14 +20,24 @@ import {EffectsModule} from '@ngrx/effects';
 import {TBFeatureFlagModule} from '../webapp_data_source/tb_feature_flag_module';
 
 import {FEATURE_FLAG_FEATURE_KEY} from './store/feature_flag_types';
+import {
+  FEATURE_FLAG_STORE_CONFIG_TOKEN,
+  getConfig,
+} from './store/feature_flag_store_config_provider';
 import {reducers} from './store/feature_flag_reducers';
 import {FeatureFlagEffects} from './effects/feature_flag_effects';
 
 @NgModule({
   imports: [
     TBFeatureFlagModule,
-    StoreModule.forFeature(FEATURE_FLAG_FEATURE_KEY, reducers),
+    StoreModule.forFeature(FEATURE_FLAG_FEATURE_KEY, reducers, FEATURE_FLAG_STORE_CONFIG_TOKEN),
     EffectsModule.forFeature([FeatureFlagEffects]),
+  ],
+  providers: [
+    {
+      provide: FEATURE_FLAG_STORE_CONFIG_TOKEN,
+      useFactory: getConfig,
+    },
   ],
 })
 export class FeatureFlagModule {}

--- a/tensorboard/webapp/feature_flag/store/BUILD
+++ b/tensorboard/webapp/feature_flag/store/BUILD
@@ -7,12 +7,14 @@ tf_ng_module(
     srcs = [
         "feature_flag_reducers.ts",
         "feature_flag_selectors.ts",
+        "feature_flag_store_config_provider.ts",
     ],
     deps = [
         ":types",
         "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/actions",
         "//tensorboard/webapp/webapp_data_source:feature_flag",
+        "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//rxjs",
     ],

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -15,18 +15,9 @@ limitations under the License.
 import {Action, createReducer, on} from '@ngrx/store';
 
 import * as actions from '../actions/feature_flag_actions';
-import {FeatureFlagState} from './feature_flag_types';
+import {FeatureFlagState, initialState} from './feature_flag_types';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
-
-const initialState: FeatureFlagState = {
-  isFeatureFlagsLoaded: false,
-  features: {
-    enabledExperimentalPlugins: [],
-    inColab: false,
-    enableGpuChart: false,
-  },
-};
 
 const reducer = createReducer<FeatureFlagState>(
   initialState,
@@ -42,6 +33,6 @@ const reducer = createReducer<FeatureFlagState>(
   })
 );
 
-export function reducers(state: FeatureFlagState, action: Action) {
+export function reducers(state: FeatureFlagState | undefined, action: Action) {
   return reducer(state, action);
 }

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -15,7 +15,8 @@ limitations under the License.
 import {Action, createReducer, on} from '@ngrx/store';
 
 import * as actions from '../actions/feature_flag_actions';
-import {FeatureFlagState, initialState} from './feature_flag_types';
+import {initialState} from './feature_flag_store_config_provider';
+import {FeatureFlagState} from './feature_flag_types';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -15,9 +15,17 @@ limitations under the License.
 import {InjectionToken} from '@angular/core';
 import {StoreConfig} from '@ngrx/store';
 
-import {FeatureFlagState, initialState} from './feature_flag_types';
+import {FeatureFlagState} from './feature_flag_types';
 
-// /** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+export const initialState: FeatureFlagState = {
+  isFeatureFlagsLoaded: false,
+  features: {
+    enabledExperimentalPlugins: [],
+    inColab: false,
+    enableGpuChart: false,
+  },
+};
 
 /**
  * Injection token for providing feature flag StoreConfig.
@@ -25,7 +33,7 @@ import {FeatureFlagState, initialState} from './feature_flag_types';
 export const FEATURE_FLAG_STORE_CONFIG_TOKEN: InjectionToken<StoreConfig<
   FeatureFlagState
 >> = new InjectionToken<StoreConfig<FeatureFlagState>>(
-  'Feature Flag Store Config'
+  '[Feature Flag] Store Config'
 );
 
 /**

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -20,7 +20,7 @@ import {FeatureFlagState, initialState} from './feature_flag_types';
 // /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 /**
- * Injection token for providing feature flag defaults values.
+ * Injection token for providing feature flag StoreConfig.
  */
 export const FEATURE_FLAG_STORE_CONFIG_TOKEN: InjectionToken<StoreConfig<
   FeatureFlagState
@@ -34,7 +34,7 @@ export const FEATURE_FLAG_STORE_CONFIG_TOKEN: InjectionToken<StoreConfig<
  *
  * Other instances of TensorBoard can override these default values by
  * providing their own StoreConfig using the FEATURE_FLAG_STORE_CONFIG_TOKEN
- * injection token and providing their own initialState.
+ * injection token.
  */
 export function getConfig(): StoreConfig<FeatureFlagState> {
   return {initialState};

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -22,11 +22,11 @@ import {FeatureFlagState, initialState} from './feature_flag_types';
 /**
  * Injection token for providing feature flag defaults values.
  */
-export const FEATURE_FLAG_STORE_CONFIG_TOKEN : InjectionToken<
-StoreConfig<FeatureFlagState>
->= new InjectionToken<
-  StoreConfig<FeatureFlagState>
->('Feature Flag Store Config');
+export const FEATURE_FLAG_STORE_CONFIG_TOKEN: InjectionToken<StoreConfig<
+  FeatureFlagState
+>> = new InjectionToken<StoreConfig<FeatureFlagState>>(
+  'Feature Flag Store Config'
+);
 
 /**
  * Returns initialState for feature flags with sensible default values for

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -1,0 +1,41 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {InjectionToken} from '@angular/core';
+import {StoreConfig} from '@ngrx/store';
+
+import {FeatureFlagState, initialState} from './feature_flag_types';
+
+// /** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+/**
+ * Injection token for providing feature flag defaults values.
+ */
+export const FEATURE_FLAG_STORE_CONFIG_TOKEN : InjectionToken<
+StoreConfig<FeatureFlagState>
+>= new InjectionToken<
+  StoreConfig<FeatureFlagState>
+>('Feature Flag Store Config');
+
+/**
+ * Returns initialState for feature flags with sensible default values for
+ * OSS TensorBoard.
+ *
+ * Other instances of TensorBoard can override these default values by
+ * providing their own StoreConfig using the FEATURE_FLAG_STORE_CONFIG_TOKEN
+ * injection token and providing their own initialState.
+ */
+export function getConfig(): StoreConfig<FeatureFlagState> {
+  return {initialState};
+}

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -17,7 +17,6 @@ import {StoreConfig} from '@ngrx/store';
 
 import {FeatureFlagState} from './feature_flag_types';
 
-
 export const initialState: FeatureFlagState = {
   isFeatureFlagsLoaded: false,
   features: {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -25,12 +25,3 @@ export interface FeatureFlagState {
 export interface State {
   [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagState;
 }
-
-export const initialState: FeatureFlagState = {
-  isFeatureFlagsLoaded: false,
-  features: {
-    enabledExperimentalPlugins: [],
-    inColab: false,
-    enableGpuChart: false,
-  },
-};

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -25,3 +25,12 @@ export interface FeatureFlagState {
 export interface State {
   [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagState;
 }
+
+export const initialState: FeatureFlagState = {
+  isFeatureFlagsLoaded: false,
+  features: {
+    enabledExperimentalPlugins: [],
+    inColab: false,
+    enableGpuChart: false,
+  },
+};


### PR DESCRIPTION
* Motivation for features / changes

  Some instances of TensorBoard (notably, TensorBoard.dev), might want to provide different default
  values for feature flags.

* Technical description of changes

  Define injection token that allows us to provide and consume a StoreConfig<FeatureFlagState>. StoreConfig
  allows an initialState value to be specified for the state.

  Provide a fallback StoreConfig that simply defines initialState to be. . . the initialState we already use.

* Detailed steps to verify changes work correctly (as executed by you)

  * Load local TensorBoard and ensure Scalars and TimeSeries dashboards successfully load scalar data.
  * Test that tensorboardColab query parameter impacts how TimeSeries dashboard loads scalar data.
  * Patch changes into internal repo and modify TensorBoard.dev to provide its own StoreConfig with an initial state
     that includes a non-empty value for enabledExperimentalPlugins. Load the TensorBoard.dev and ensure those
     experimental plugins appear by default.