### PR TITLE
chore: typecheck 'monaco' types in source code component

### DIFF
--- a/tensorboard/webapp/widgets/source_code/BUILD
+++ b/tensorboard/webapp/widgets/source_code/BUILD
@@ -19,6 +19,7 @@ tf_ng_module(
         ":load_monaco",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//monaco-editor-core",
         "@npm//rxjs",
     ],
 )

--- a/tensorboard/webapp/widgets/source_code/source_code_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_component.ts
@@ -46,9 +46,8 @@ export class SourceCodeComponent implements OnInit, OnChanges, OnDestroy {
   @Input()
   focusedLineno: number | null = null;
 
-  // TODO(cais): Explore better typing by depending on external libraries.
   @Input()
-  monaco: any | null = null;
+  monaco: typeof monaco | null = null;
 
   @ViewChild('codeViewerContainer', {static: true, read: ElementRef})
   private readonly codeViewerContainer!: ElementRef<HTMLDivElement>;

--- a/tensorboard/webapp/widgets/source_code/source_code_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container.ts
@@ -52,9 +52,7 @@ export class SourceCodeContainer implements OnInit {
   monaco$: Observable<typeof monaco> | null = null;
 
   ngOnInit(): void {
-    this.monaco$ = from(loadMonaco()).pipe(
-      map(() => window.monaco)
-    );
+    this.monaco$ = from(loadMonaco()).pipe(map(() => window.monaco));
   }
 
   constructor() {}

--- a/tensorboard/webapp/widgets/source_code/source_code_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container.ts
@@ -12,14 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {from} from 'rxjs';
+import {Component, Input, OnInit} from '@angular/core';
+import {from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 import {loadMonaco} from './load_monaco_shim';
-
-// TODO(cais): Explore better typing by depending on external libraries.
-const windowWithRequireAndMonaco: any = window;
 
 /**
  * SourceCodeContainer displays the content of a source-code file.
@@ -43,7 +40,7 @@ const windowWithRequireAndMonaco: any = window;
     ></source-code-component>
   `,
 })
-export class SourceCodeContainer {
+export class SourceCodeContainer implements OnInit {
   // Lines of the source-code file, split at line breaks.
   @Input()
   lines: string[] | null = null; // TODO(cais): Add spinner for `null`.
@@ -52,11 +49,11 @@ export class SourceCodeContainer {
   @Input()
   focusedLineno: number | null = null;
 
-  monaco$: any | null = null;
+  monaco$: Observable<typeof monaco> | null = null;
 
   ngOnInit(): void {
     this.monaco$ = from(loadMonaco()).pipe(
-      map(() => windowWithRequireAndMonaco.monaco)
+      map(() => window.monaco)
     );
   }
 


### PR DESCRIPTION
This updates a few type annotations in the SourceCode component,
mainly relating to the use of `monaco`. Now, Monaco editor uses are
typechecked.

Test plan:
Manually changed an instance of `this.monaco.editor.create` to
`this.monaco.editor.create2` and saw that `bazel build tensorboard`
fails.

Googlers, see associated Copybara change: cl/347056094.