### PR TITLE
line chart: draw NaN with triangle

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -117,6 +117,7 @@ tf_ts_library(
     ],
     deps = [
         ":drawable",
+        ":internal_types",
     ],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -131,6 +131,7 @@ tf_ts_library(
     ],
     deps = [
         ":internal_types",
+        "@npm//@types/jasmine",
     ],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
@@ -115,7 +115,7 @@ export abstract class DataDrawable {
     this.layout = layout;
   }
 
-  private getLayoutRect(): Rect {
+  protected getLayoutRect(): Rect {
     return this.layout;
   }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/integration_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/integration_test.ts
@@ -395,5 +395,39 @@ describe('line_chart_v2/lib/integration test', () => {
       expect(circle.getAttribute('cx')).toBe('2');
       expect(circle.getAttribute('cy')).toBe('5');
     });
+
+    it('renders circle for aux but not NaNs', () => {
+      chart.resize({width: 10, height: 10});
+      chart.setViewBox({x: [0, 10], y: [0, 10]});
+      chart.setMetadata({
+        aux: buildMetadata({id: 'aux', visible: true, aux: true}),
+      });
+      chart.setData([
+        buildSeries({
+          id: 'aux',
+          points: [
+            {x: -1, y: 5},
+            {x: 0, y: 5},
+            {x: 1, y: NaN},
+            {x: 2, y: 5},
+            {x: 3, y: NaN},
+          ],
+        }),
+      ]);
+
+      const children = getDomChildren();
+      expect(children.length).toBe(2);
+      const [line, circle] = children;
+
+      expect(isTriangle(line)).toBe(false);
+      expect(isTriangle(circle)).toBe(false);
+      assertSvgPathD(line, [
+        [-1, 5],
+        [0, 5],
+      ]);
+      expect(circle.nodeName).toBe('circle');
+      expect(circle.getAttribute('cx')).toBe('2');
+      expect(circle.getAttribute('cy')).toBe('5');
+    });
   });
 });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/BUILD
@@ -45,6 +45,7 @@ tf_ts_library(
         ":types",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:coordinator",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:internal_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:testing",
         "@npm//@types/jasmine",
         "@npm//three",
     ],

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -14,8 +14,9 @@ limitations under the License.
 ==============================================================================*/
 import * as THREE from 'three';
 
+import {Polyline} from '../internal_types';
+import {assertSvgPathD} from '../testing';
 import {ThreeCoordinator} from '../threejs_coordinator';
-import {Point, Polyline} from '../internal_types';
 import {SvgRenderer} from './svg_renderer';
 import {ThreeRenderer} from './threejs_renderer';
 
@@ -128,25 +129,6 @@ describe('line_chart_v2/lib/renderer test', () => {
     });
 
     describe('triangle', () => {
-      /**
-       * Asserts `d` attribute on a SVGPathElement.
-       *
-       * @param path An SVGPathElement with `d` attribute of format with absolute
-       *    coordinates: M, L, and Zs. e.g., "M1,2L2,3L3,4Z".
-       * @param roundedCoords Coordinates expected rounded to nearest integer.
-       */
-      function assertPath(path: SVGPathElement, roundedCoords: Point[]) {
-        expect(roundedCoords.length).toBe(3);
-        const dPath = path.getAttribute('d')!;
-        const parts = dPath.split(/[MLZ]/);
-        expect(parts.length).toBe(5);
-        for (const [index, {x, y}] of roundedCoords.entries()) {
-          const [actualX, actualY] = parts[index + 1].split(',');
-          expect(Number(actualX)).toBeCloseTo(x, 0);
-          expect(Number(actualY)).toBeCloseTo(y, 0);
-        }
-      }
-
       it('creates a path with fill', () => {
         renderer.createOrUpdateTriangleObject(
           null,
@@ -158,10 +140,10 @@ describe('line_chart_v2/lib/renderer test', () => {
         const path = el.children[0] as SVGPathElement;
         expect(path.tagName).toBe('path');
         expect(path.style.display).toBe('');
-        assertPath(path, [
-          {x: 7, y: 102},
-          {x: 13, y: 102},
-          {x: 10, y: 97},
+        assertSvgPathD(path, [
+          [7, 102],
+          [13, 102],
+          [10, 97],
         ]);
         expect(path.style.fill).toBe('rgb(255, 0, 0)');
       });
@@ -183,10 +165,10 @@ describe('line_chart_v2/lib/renderer test', () => {
         const path = el.children[0] as SVGPathElement;
         expect(path.tagName).toBe('path');
         expect(path.style.display).toBe('');
-        assertPath(path, [
-          {x: 15, y: 53},
-          {x: 25, y: 53},
-          {x: 20, y: 44},
+        assertSvgPathD(path, [
+          [15, 53],
+          [25, 53],
+          [20, 44],
         ]);
         expect(path.style.fill).toBe('rgb(0, 255, 0)');
       });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -148,6 +148,8 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
           'http://www.w3.org/2000/svg',
           'path'
         );
+
+        dom.classList.add('triangle');
         dom.style.fill = 'none';
         const data = this.createPathDString(vertices);
         dom.setAttribute('d', data + 'Z');

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
@@ -15,19 +15,140 @@ limitations under the License.
 
 import {DataDrawable} from './drawable';
 
+enum PartitionType {
+  NUMBER,
+  NAN,
+}
+
 export class SeriesLineView extends DataDrawable {
+  private partitionPolyline(
+    polyline: Float32Array
+  ): Array<{polyline: Float32Array; type: PartitionType}> {
+    if (polyline.length % 2 !== 0) {
+      throw new Error(`Cannot have odd length-ed polyline: ${polyline.length}`);
+    }
+
+    const partition = [];
+    let partitionStartInd: number = 0;
+    let isPrevValueNaN = false;
+    const zeroCoord = this.coordinator.transformDataToUiCoord(
+      this.getLayoutRect(),
+      [0, 0]
+    );
+    const zeroPoint = {x: zeroCoord[0], y: zeroCoord[1]};
+
+    let lastLegalNumber: {
+      x: number;
+      y: number;
+    } | null = null;
+
+    function recordPartition(
+      isNumberPartition: boolean,
+      slice: Float32Array,
+      nanSubstitude: {x: number; y: number}
+    ) {
+      if (isNumberPartition) {
+        return {type: PartitionType.NUMBER, polyline: slice};
+      } else {
+        return {
+          type: PartitionType.NAN,
+          polyline: slice.map((x, ind) => {
+            if (!isNaN(x)) return x;
+            return ind % 2 === 0 ? nanSubstitude.x : nanSubstitude.y;
+          }),
+        };
+      }
+    }
+
+    for (let index = 0; index < polyline.length; index += 2) {
+      const x = polyline[index];
+      const y = polyline[index + 1];
+      const hasNaN = isNaN(x) || isNaN(y);
+      if (hasNaN !== isPrevValueNaN && partitionStartInd !== index) {
+        partition.push(
+          recordPartition(
+            !isPrevValueNaN,
+            polyline.slice(partitionStartInd, index),
+            lastLegalNumber === null ? {x, y} : lastLegalNumber
+          )
+        );
+        partitionStartInd = index;
+      }
+
+      if (!hasNaN) {
+        lastLegalNumber = {x, y};
+      }
+
+      isPrevValueNaN = hasNaN;
+    }
+
+    if (partitionStartInd !== polyline.length - 1) {
+      partition.push(
+        recordPartition(
+          !isPrevValueNaN,
+          polyline.slice(partitionStartInd, polyline.length),
+          lastLegalNumber ?? zeroPoint
+        )
+      );
+    }
+
+    return partition;
+  }
+
   redraw() {
     for (const series of this.series) {
       const map = this.getMetadataMap();
       const metadata = map[series.id];
       if (!metadata) continue;
 
-      this.paintBrush.setLine(series.id, series.polyline, {
-        color: metadata.color,
-        visible: metadata.visible || false,
-        opacity: metadata.opacity ?? 1,
-        width: 1,
-      });
+      const partitionedPolyline = this.partitionPolyline(series.polyline);
+
+      for (const [
+        partitionInd,
+        {type, polyline},
+      ] of partitionedPolyline.entries()) {
+        if (type === PartitionType.NUMBER) {
+          if (polyline.length === 2) {
+            if (metadata.aux) continue;
+
+            this.paintBrush.setCircle(
+              `circle_${series.id}_${partitionInd}`,
+              {x: polyline[0], y: polyline[1]},
+              {
+                color: metadata.color,
+                visible: metadata.visible || false,
+                opacity: metadata.opacity ?? 1,
+                radius: 4,
+              }
+            );
+          } else {
+            this.paintBrush.setLine(
+              `line_${series.id}_${partitionInd}`,
+              polyline,
+              {
+                color: metadata.color,
+                visible: metadata.visible || false,
+                opacity: metadata.opacity ?? 1,
+                width: 1,
+              }
+            );
+          }
+          // Should not render triangles to mark NaNs for auxiliary lines.
+        } else if (!metadata.aux) {
+          for (let index = 0; index < polyline.length; index += 2) {
+            this.paintBrush.setTriangle(
+              `NaN_${series.id}_${polyline[index]}_${polyline[index + 1]}`,
+              {x: polyline[index], y: polyline[index + 1]},
+              {
+                color: metadata.color,
+                visible: metadata.visible || false,
+                opacity: metadata.opacity ?? 1,
+                size: 12,
+              }
+            );
+          }
+        }
+      }
     }
   }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
@@ -38,13 +38,13 @@ export class SeriesLineView extends DataDrawable {
         };
   }
 
+  /**
+   * @param polyline Expects the polyline to have even length and encode two-dimensional
+   *   coordinates.
+   */
   private partitionPolyline(
     polyline: Polyline
   ): Array<{polyline: Float32Array; type: PartitionType}> {
-    if (polyline.length % 2 !== 0) {
-      throw new Error(`Cannot have odd length-ed polyline: ${polyline.length}`);
-    }
-
     const partition = [];
     let partitionStartInd: number = 0;
     let isPrevValueNaN = false;
@@ -99,6 +99,11 @@ export class SeriesLineView extends DataDrawable {
       const map = this.getMetadataMap();
       const metadata = map[series.id];
       if (!metadata) continue;
+      if (series.polyline.length % 2 !== 0) {
+        throw new Error(
+          `Cannot have odd length-ed polyline: ${series.polyline.length}`
+        );
+      }
 
       const partitionedPolyline = this.partitionPolyline(series.polyline);
 
@@ -108,8 +113,6 @@ export class SeriesLineView extends DataDrawable {
       ] of partitionedPolyline.entries()) {
         if (type === PartitionType.NUMBER) {
           if (polyline.length === 2) {
-            if (metadata.aux) continue;
-
             this.paintBrush.setCircle(
               JSON.stringify(['circle', series.id, partitionInd]),
               {x: polyline[0], y: polyline[1]},

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/testing.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/testing.ts
@@ -48,3 +48,27 @@ export function buildMetadata(metadata: Partial<DataSeriesMetadata>) {
     ...metadata,
   };
 }
+
+/**
+ * Asserts `d` attribute on a SVGPathElement.
+ *
+ * @param path An SVGPathElement with `d` attribute of format with absolute
+ *    coordinates: M, L, and Zs. e.g., "M1,2L2,3L3,4Z".
+ * @param roundedCoords Coordinates expected rounded to nearest integer.
+ */
+export function assertSvgPathD(
+  path: SVGElement,
+  roundedCoords: Array<[number, number]>
+) {
+  expect(path.nodeName).toBe('path');
+  const dPath = path.getAttribute('d')!;
+  const parts = dPath.replace(/[MZ]/g, '').split('L');
+  expect(parts.length).toBe(roundedCoords.length);
+  for (const [index, [x, y]] of roundedCoords.entries()) {
+    const coordParts = parts[index].split(',');
+    expect(coordParts.length).toBe(2);
+    const [actualX, actualY] = coordParts;
+    expect(Number(actualX)).toBeCloseTo(x, 0);
+    expect(Number(actualY)).toBeCloseTo(y, 0);
+  }
+}


### PR DESCRIPTION
This change adds the feature of vz-line-chart of rendering null values
as triangles.

Business logic:
- for non-first NaNs: carry the y value from the last non-NaN value
- for starting NaNs with non-NaN values in the series: assign y values
  from the first non-NaN value.
- for all NaNs: assign 0 to y.
