### PR TITLE
scalar card: implement full tooltip

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -131,8 +131,9 @@ limitations under the License.
               <span [style.backgroundColor]="datum.metadata.color"></span>
             </td>
             <td class="name">{{ datum.metadata.displayName }}</td>
-            <td>{{ datum.point.y }}</td>
-            <td *ngIf="smoothingEnabled">{{ datum.point.value }}</td>
+            <td *ngIf="smoothingEnabled">{{ datum.point.y }}</td>
+            <td>{{ datum.point.value }}</td>
+            <!-- Print the step with comma for readability. -->
             <td>{{ datum.point.step | number }}</td>
             <td>{{ datum.point.wallTime | date: 'short' }}</td>
           </tr>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -90,6 +90,7 @@ limitations under the License.
     [seriesMetadataMap]="chartMetadataMap"
     [yScaleType]="newYAxisType"
     [ignoreYOutliers]="ignoreOutliers"
+    [tooltipTemplate]="tooltip"
   ></line-chart>
 
   <ng-template #legacyChart>
@@ -107,5 +108,36 @@ limitations under the License.
       [resizeEventDebouncePeriodInMs]="RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS"
       (onResize)="redraw()"
     ></tb-line-chart>
+  </ng-template>
+
+  <ng-template #tooltip let-tooltipData="data">
+    <table class="tooltip">
+      <thead>
+        <tr>
+          <th class="circle-header"></th>
+          <th>Run</th>
+          <th *ngIf="smoothingEnabled">Smoothed</th>
+          <th>Value</th>
+          <th>Step</th>
+          <th>Time</th>
+        </tr>
+      </thead>
+      <tbody>
+        <ng-container
+          *ngFor="let datum of tooltipData; trackBy: trackByTooltipDatum"
+        >
+          <tr class="tooltip-row">
+            <td class="tooltip-row-circle">
+              <span [style.backgroundColor]="datum.metadata.color"></span>
+            </td>
+            <td class="name">{{ datum.metadata.displayName }}</td>
+            <td>{{ datum.point.y }}</td>
+            <td *ngIf="smoothingEnabled">{{ datum.point.value }}</td>
+            <td>{{ datum.point.step | number }}</td>
+            <td>{{ datum.point.wallTime | date: 'short' }}</td>
+          </tr>
+        </ng-container>
+      </tbody>
+    </table>
   </ng-template>
 </div>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -79,3 +79,29 @@ $_title-to-heading-gap: 12px;
     height: 100%;
   }
 }
+
+.tooltip {
+  border-spacing: 4px;
+  font-size: 13px;
+
+  th {
+    text-align: left;
+  }
+
+  $_circle-size: 12px;
+
+  .tooltip-row-circle {
+    align-items: center;
+    height: $_circle-size;
+    width: $_circle-size;
+  }
+
+  .tooltip-row-circle > span {
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    display: inline-block;
+    // Subtract by border width (1px on both sides)
+    height: $_circle-size - 2px;
+    width: $_circle-size - 2px;
+  }
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -37,12 +37,18 @@ import {
   XAxisType as ChartXAxisType,
   YAxisType,
 } from '../../../widgets/line_chart/line_chart_types';
-import {RendererType, ScaleType} from '../../../widgets/line_chart_v2/types';
+import {
+  RendererType,
+  ScaleType,
+  TooltipDatum,
+} from '../../../widgets/line_chart_v2/types';
 import {ScalarStepDatum} from '../../data_source';
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardDataSeries,
+  ScalarCardSeriesMetadata,
   ScalarCardSeriesMetadataMap,
+  SeriesType,
 } from './scalar_card_types';
 
 const RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS = 50;
@@ -125,8 +131,11 @@ export class ScalarCardComponent {
   @Input() seriesDataList!: SeriesDataList;
 
   // gpu chart related props.
+  @Input() smoothingEnabled!: boolean;
   @Input() gpuLineChartEnabled!: boolean;
   @Input() dataSeries!: ScalarCardDataSeries[];
+  // For tooltip search.
+  @Input() dataSeriesMap!: Map<string, ScalarCardDataSeries>;
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
@@ -178,5 +187,9 @@ export class ScalarCardComponent {
         this.lineChart.redraw();
       }
     }
+  }
+
+  trackByTooltipDatum(index: number, datum: TooltipDatum) {
+    return datum.id;
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -46,9 +46,7 @@ import {ScalarStepDatum} from '../../data_source';
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardDataSeries,
-  ScalarCardSeriesMetadata,
   ScalarCardSeriesMetadataMap,
-  SeriesType,
 } from './scalar_card_types';
 
 const RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS = 50;
@@ -134,8 +132,6 @@ export class ScalarCardComponent {
   @Input() smoothingEnabled!: boolean;
   @Input() gpuLineChartEnabled!: boolean;
   @Input() dataSeries!: ScalarCardDataSeries[];
-  // For tooltip search.
-  @Input() dataSeriesMap!: Map<string, ScalarCardDataSeries>;
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -144,6 +144,7 @@ function areSeriesEqual(
         (gpuLineChartEnabled$ | async) ? (chartMetadataMap$ | async) : {}
       "
       [gpuLineChartEnabled]="gpuLineChartEnabled$ | async"
+      [smoothingEnabled]="smoothingEnabled$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
     ></scalar-card-component>
@@ -278,10 +279,22 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
     }
 
     this.dataSeries$ = runIdAndPoints$.pipe(
-      combineLatestWith(this.store.select(getMetricsScalarSmoothing)),
-      switchMap(([runsData, smoothing]) => {
+      combineLatestWith(
+        this.store.select(getMetricsScalarSmoothing),
+        this.store.select(getMetricsXAxisType)
+      ),
+      switchMap(([runsData, smoothing, xType]) => {
         const dataSeriesList = runsData.map(({runId, points}) => {
-          return {id: runId, points};
+          return {
+            id: runId,
+            points: points.map((point) => {
+              return {
+                ...point,
+                x: xType === XAxisType.WALL_TIME ? point.x * 1000 : point.x,
+                wallTime: point.wallTime * 1000,
+              };
+            }),
+          };
         });
 
         if (smoothing === 0) {
@@ -304,7 +317,8 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
           })
         );
       }),
-      startWith([])
+      startWith([]),
+      shareReplay(1)
     );
 
     this.chartMetadataMap$ = runIdAndPoints$.pipe(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -290,6 +290,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
             points: points.map((point) => {
               return {
                 ...point,
+                // Convert time in seconds to milliseconds.
+                // TODO(stephanwlee): when the legacy line chart is removed, do the
+                // conversion at either effects or at `stepSeriesToLineSeries`.
                 x: xType === XAxisType.WALL_TIME ? point.x * 1000 : point.x,
                 wallTime: point.wallTime * 1000,
               };

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -95,7 +95,7 @@ class TestableLineChart {
     <ng-container
       *ngIf="tooltipTemplate"
       [ngTemplateOutlet]="tooltipTemplate"
-      [ngTemplateOutletContext]="{data: tooltipData}"
+      [ngTemplateOutletContext]="{data: tooltipDataForTesting}"
     ></ng-container>
   `,
 })
@@ -107,7 +107,10 @@ class TestableGpuLineChart {
   @Input() ignoreYOutliers!: boolean;
   @Input()
   tooltipTemplate!: TemplateRef<{data: TooltipDatum[]}>;
-  @Input() tooltipData: TooltipDatum[] = [];
+
+  // This input does not exist on real line-chart and is devised to make tooltipTemplate
+  // testable without using the real implementation.
+  @Input() tooltipDataForTesting: TooltipDatum[] = [];
 
   constructor(public readonly changeDetectorRef: ChangeDetectorRef) {}
 }
@@ -1014,7 +1017,8 @@ describe('scalar card', () => {
         {
           id: 'run1',
           points: [
-            // Keeps the data structure as is but requires "x" and "y" props.
+            // Keeps the data structure as is but do notice adjusted wallTime and
+            // line_chart_v2 required "x" and "y" props.
             {wallTime: 2000, value: 1, step: 1, x: 1, y: 1},
             {wallTime: 4000, value: 10, step: 2, x: 2, y: 10},
           ],
@@ -1159,7 +1163,7 @@ describe('scalar card', () => {
       ) {
         const lineChart = fixture.debugElement.query(Selector.GPU_LINE_CHART);
 
-        lineChart.componentInstance.tooltipData = tooltipData;
+        lineChart.componentInstance.tooltipDataForTesting = tooltipData;
         lineChart.componentInstance.changeDetectorRef.markForCheck();
       }
 
@@ -1219,8 +1223,6 @@ describe('scalar card', () => {
 
         expect(tableContent).toEqual([
           ['', 'Row 1', '1000', '10', '1/1/20, 12:00 AM'],
-          // Print the step with comma for readability. The value is yet optimize for
-          // readability (we may use the scientific formatting).
           ['', 'Row 2', '-1000', '1,000', '12/31/20, 12:00 AM'],
         ]);
       }));

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -13,29 +13,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {OverlayContainer} from '@angular/cdk/overlay';
-import {Component, Input} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
-import {ComponentFixture, fakeAsync, flush, tick} from '@angular/core/testing';
+import {ChangeDetectorRef, Component, Input, TemplateRef} from '@angular/core';
+import {
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {State} from '../../../app_state';
-import {DataLoadState} from '../../../types/data';
 import {of, ReplaySubject} from 'rxjs';
 
+import {State} from '../../../app_state';
 import {Run} from '../../../runs/store/runs_types';
 import {buildRun} from '../../../runs/store/testing';
 import * as selectors from '../../../selectors';
 import {MatIconTestingModule} from '../../../testing/mat_icon_module';
+import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
 import {
   XAxisType as ChartXAxisType,
   YAxisType,
 } from '../../../widgets/line_chart/line_chart_types';
 import {TooltipSortingMethod} from '../../../widgets/line_chart/polymer_interop_types';
+import {
+  DataSeries,
+  DataSeriesMetadataMap,
+  RendererType,
+  ScaleType,
+  TooltipDatum,
+} from '../../../widgets/line_chart_v2/types';
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {PluginType} from '../../data_source';
@@ -45,7 +57,6 @@ import {
   provideMockCardRunToSeriesData,
 } from '../../testing';
 import {TooltipSort, XAxisType} from '../../types';
-
 import {
   ScalarCardComponent,
   ScalarChartEvalPoint,
@@ -54,12 +65,10 @@ import {
 } from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
 import {
-  DataSeries,
-  DataSeriesMetadataMap,
-  RendererType,
-  ScaleType,
-} from '../../../widgets/line_chart_v2/types';
-import {SeriesType} from './scalar_card_types';
+  ScalarCardPoint,
+  ScalarCardSeriesMetadata,
+  SeriesType,
+} from './scalar_card_types';
 
 @Component({
   selector: 'tb-line-chart',
@@ -81,14 +90,26 @@ class TestableLineChart {
 
 @Component({
   selector: 'line-chart',
-  template: '',
+  template: `
+    {{ tooltipData | json }}
+    <ng-container
+      *ngIf="tooltipTemplate"
+      [ngTemplateOutlet]="tooltipTemplate"
+      [ngTemplateOutletContext]="{data: tooltipData}"
+    ></ng-container>
+  `,
 })
 class TestableGpuLineChart {
   @Input() preferredRendererType!: RendererType;
   @Input() seriesData!: DataSeries[];
   @Input() seriesMetadataMap!: DataSeriesMetadataMap;
   @Input() yScaleType!: ScaleType;
-  @Input() ignoreYOutliers: boolean = false;
+  @Input() ignoreYOutliers!: boolean;
+  @Input()
+  tooltipTemplate!: TemplateRef<{data: TooltipDatum[]}>;
+  @Input() tooltipData: TooltipDatum[] = [];
+
+  constructor(public readonly changeDetectorRef: ChangeDetectorRef) {}
 }
 
 describe('scalar card', () => {
@@ -951,6 +972,8 @@ describe('scalar card', () => {
     const Selector = {
       GPU_LINE_CHART: By.directive(TestableGpuLineChart),
       SVG_LINE_CHART: By.directive(TestableLineChart),
+      TOOLTIP_HEADER_COLUMN: By.css('table.tooltip th'),
+      TOOLTIP_ROW: By.css('table.tooltip .tooltip-row'),
     };
 
     it('renders the gpu line chart instead of svg one', fakeAsync(() => {
@@ -992,22 +1015,22 @@ describe('scalar card', () => {
           id: 'run1',
           points: [
             // Keeps the data structure as is but requires "x" and "y" props.
-            {wallTime: 2, value: 1, step: 1, x: 1, y: 1},
-            {wallTime: 4, value: 10, step: 2, x: 2, y: 10},
+            {wallTime: 2000, value: 1, step: 1, x: 1, y: 1},
+            {wallTime: 4000, value: 10, step: 2, x: 2, y: 10},
           ],
         },
-        {id: 'run2', points: [{wallTime: 2, value: 1, step: 1, x: 1, y: 1}]},
+        {id: 'run2', points: [{wallTime: 2000, value: 1, step: 1, x: 1, y: 1}]},
         {
           id: '["smoothed","run1"]',
           points: [
-            {wallTime: 2, value: 1, step: 1, x: 1, y: 1},
+            {wallTime: 2000, value: 1, step: 1, x: 1, y: 1},
             // Exact smoothed value is not too important.
-            {wallTime: 4, value: 10, step: 2, x: 2, y: jasmine.any(Number)},
+            {wallTime: 4000, value: 10, step: 2, x: 2, y: jasmine.any(Number)},
           ],
         },
         {
           id: '["smoothed","run2"]',
-          points: [{wallTime: 2, value: 1, step: 1, x: 1, y: 1}],
+          points: [{wallTime: 2000, value: 1, step: 1, x: 1, y: 1}],
         },
       ]);
       expect(lineChart.componentInstance.seriesMetadataMap).toEqual({
@@ -1082,11 +1105,11 @@ describe('scalar card', () => {
           id: 'run1',
           points: [
             // Keeps the data structure as is but requires "x" and "y" props.
-            {wallTime: 2, value: 1, step: 1, x: 1, y: 1},
-            {wallTime: 4, value: 10, step: 2, x: 2, y: 10},
+            {wallTime: 2000, value: 1, step: 1, x: 1, y: 1},
+            {wallTime: 4000, value: 10, step: 2, x: 2, y: 10},
           ],
         },
-        {id: 'run2', points: [{wallTime: 2, value: 1, step: 1, x: 1, y: 1}]},
+        {id: 'run2', points: [{wallTime: 2000, value: 1, step: 1, x: 1, y: 1}]},
       ]);
       expect(lineChart.componentInstance.seriesMetadataMap).toEqual({
         run1: {
@@ -1109,5 +1132,171 @@ describe('scalar card', () => {
         },
       });
     }));
+
+    describe('tooltip', () => {
+      function buildTooltipDatum(
+        metadata?: ScalarCardSeriesMetadata,
+        point: Partial<ScalarCardPoint> = {}
+      ): TooltipDatum<ScalarCardSeriesMetadata, ScalarCardPoint> {
+        return {
+          id: metadata?.id ?? 'a',
+          metadata: {
+            type: SeriesType.ORIGINAL,
+            id: 'a',
+            displayName: 'A name',
+            visible: true,
+            color: '#f00',
+            ...metadata,
+          },
+          closestPointIndex: 0,
+          point: {x: 0, y: 0, value: 0, step: 0, wallTime: 0, ...point},
+        };
+      }
+
+      function setTooltipData(
+        fixture: ComponentFixture<ScalarCardContainer>,
+        tooltipData: TooltipDatum[]
+      ) {
+        const lineChart = fixture.debugElement.query(Selector.GPU_LINE_CHART);
+
+        lineChart.componentInstance.tooltipData = tooltipData;
+        lineChart.componentInstance.changeDetectorRef.markForCheck();
+      }
+
+      it('renders the tooltip using the custom template (no smooth)', fakeAsync(() => {
+        store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
+        const fixture = createComponent('card1');
+        setTooltipData(fixture, [
+          buildTooltipDatum(
+            {
+              id: 'row1',
+              type: SeriesType.ORIGINAL,
+              displayName: 'Row 1',
+              visible: true,
+              color: '#00f',
+            },
+            {
+              x: 10,
+              step: 10,
+              y: 1000,
+              value: 1000,
+              wallTime: new Date('2020-01-01').getTime(),
+            }
+          ),
+          buildTooltipDatum(
+            {
+              id: 'row2',
+              type: SeriesType.ORIGINAL,
+              displayName: 'Row 2',
+              visible: true,
+              color: '#0f0',
+            },
+            {
+              x: 1000,
+              step: 1000,
+              y: -1000,
+              value: -1000,
+              wallTime: new Date('2020-12-31').getTime(),
+            }
+          ),
+        ]);
+        fixture.detectChanges();
+
+        const headerCols = fixture.debugElement.queryAll(
+          Selector.TOOLTIP_HEADER_COLUMN
+        );
+        const headerText = headerCols.map(
+          (col) => col.nativeElement.textContent
+        );
+        expect(headerText).toEqual(['', 'Run', 'Value', 'Step', 'Time']);
+
+        const rows = fixture.debugElement.queryAll(Selector.TOOLTIP_ROW);
+        const tableContent = rows.map((row) => {
+          return row
+            .queryAll(By.css('td'))
+            .map((td) => td.nativeElement.textContent);
+        });
+
+        expect(tableContent).toEqual([
+          ['', 'Row 1', '1000', '10', '1/1/20, 12:00 AM'],
+          // Print the step with comma for readability. The value is yet optimize for
+          // readability (we may use the scientific formatting).
+          ['', 'Row 2', '-1000', '1,000', '12/31/20, 12:00 AM'],
+        ]);
+      }));
+
+      it('renders the tooltip using the custom template (smooth)', fakeAsync(() => {
+        store.overrideSelector(selectors.getMetricsScalarSmoothing, 0.5);
+        const fixture = createComponent('card1');
+        setTooltipData(fixture, [
+          buildTooltipDatum(
+            {
+              id: 'smoothed_row1',
+              type: SeriesType.DERIVED,
+              displayName: 'Row 1',
+              visible: true,
+              color: '#00f',
+              aux: false,
+              originalSeriesId: 'row1',
+            },
+            {
+              x: 10,
+              step: 10,
+              y: 500,
+              value: 1000,
+              wallTime: new Date('2020-01-01').getTime(),
+            }
+          ),
+          buildTooltipDatum(
+            {
+              id: 'smoothed_row2',
+              type: SeriesType.DERIVED,
+              displayName: 'Row 2',
+              visible: true,
+              color: '#0f0',
+              aux: false,
+              originalSeriesId: 'row2',
+            },
+            {
+              x: 1000,
+              step: 1000,
+              y: -500,
+              value: -1000,
+              wallTime: new Date('2020-12-31').getTime(),
+            }
+          ),
+        ]);
+        fixture.detectChanges();
+
+        const headerCols = fixture.debugElement.queryAll(
+          Selector.TOOLTIP_HEADER_COLUMN
+        );
+        const headerText = headerCols.map(
+          (col) => col.nativeElement.textContent
+        );
+        expect(headerText).toEqual([
+          '',
+          'Run',
+          'Smoothed',
+          'Value',
+          'Step',
+          'Time',
+        ]);
+
+        const rows = fixture.debugElement.queryAll(Selector.TOOLTIP_ROW);
+        const tableContent = rows.map((row) => {
+          return row
+            .queryAll(By.css('td'))
+            .map((td) => td.nativeElement.textContent);
+        });
+
+        expect(tableContent).toEqual([
+          ['', 'Row 1', '500', '1000', '10', '1/1/20, 12:00 AM'],
+          // Print the step with comma for readability. The value is yet optimize for
+          // readability (we may use the scientific formatting).
+          ['', 'Row 2', '-500', '-1000', '1,000', '12/31/20, 12:00 AM'],
+        ]);
+      }));
+    });
   });
 });

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
@@ -56,35 +56,37 @@ limitations under the License.
   [cdkConnectedOverlayGrowAfterOpen]="true"
   (detach)="onTooltipDisplayDetached()"
 >
-  <table class="tooltip-container">
+  <div class="tooltip-container">
+    <ng-container
+      [ngTemplateOutlet]="tooltipTemplate ? tooltipTemplate : defaultTooltip"
+      [ngTemplateOutletContext]="{data: cursoredData}"
+    ></ng-container>
+  </div>
+</ng-template>
+
+<ng-template #defaultTooltip let-tooltipData="data">
+  <table>
     <thead>
       <tr>
         <th class="circle-header"></th>
-        <th>Run</th>
-        <th>Value</th>
-        <th>Step</th>
+        <th>Name</th>
+        <th>Y</th>
+        <th>X</th>
       </tr>
     </thead>
     <tbody>
       <ng-container
-        *ngFor="let datum of cursoredData; trackBy: trackBySeriesName"
+        *ngFor="let datum of tooltipData; trackBy: trackBySeriesName"
       >
-        <ng-container
-          [ngTemplateOutlet]="tooltipTemplate ? tooltipTemplate : defaultTooltipRow"
-          [ngTemplateOutletContext]="{data: datum}"
-        ></ng-container>
+        <tr class="tooltip-row">
+          <td class="tooltip-row-circle">
+            <span [style.backgroundColor]="datum.metadata.color"></span>
+          </td>
+          <td class="name">{{ datum.metadata.displayName }}</td>
+          <td>{{ datum.point.y }}</td>
+          <td>{{ datum.point.x }}</td>
+        </tr>
       </ng-container>
     </tbody>
   </table>
-</ng-template>
-
-<ng-template #defaultTooltipRow let-rowData="data">
-  <tr class="tooltip-row">
-    <td class="tooltip-row-circle">
-      <span [style.backgroundColor]="rowData.metadata.color"></span>
-    </td>
-    <td class="name">{{ rowData.metadata.displayName }}</td>
-    <td>{{ rowData.point.y }}</td>
-    <td>{{ rowData.point.x }}</td>
-  </tr>
 </ng-template>

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.scss
@@ -49,8 +49,11 @@ $_circle-size: 12px;
 }
 
 .tooltip-container {
-  background: rgba(50, 50, 50, 0.85);
+  background: rgba(0, 0, 0, 0.85);
+  border-radius: 4px;
   color: #fff;
+  contain: paint style layout;
+  font-size: 0.9em;
   overflow: auto;
   padding: 5px;
   pointer-events: none;
@@ -61,7 +64,6 @@ th,
 td {
   padding: 2px 5px;
   text-align: left;
-  font-size: 0.9em;
 }
 
 th {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -52,11 +52,14 @@ import {
   getProposedViewExtentOnZoom,
 } from './line_chart_interactive_utils';
 
-export interface TooltipDatum {
+export interface TooltipDatum<
+  Metadata extends DataSeriesMetadata = DataSeriesMetadata,
+  PointDatum extends Point = Point
+> {
   id: string;
-  metadata: DataSeriesMetadata;
+  metadata: Metadata;
   closestPointIndex: number | null;
-  point: {x: number; y: number} | null;
+  point: PointDatum | null;
 }
 
 enum InteractionState {
@@ -75,7 +78,7 @@ export function scrollStrategyFactory(
 }
 
 export interface TooltipTemplateContext {
-  data: TooltipDatum;
+  data: TooltipDatum[];
 }
 
 export type TooltipTemplate = TemplateRef<TooltipTemplateContext>;

--- a/tensorboard/webapp/widgets/line_chart_v2/types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/types.ts
@@ -22,3 +22,4 @@ export {
   RendererType,
   ScaleType,
 } from './lib/public_types';
+export {TooltipDatum} from './sub_view/line_chart_interactive_view';


### PR DESCRIPTION
This change implements tooltip for the new line chart. The line chart by
default only provide very high level information and does not contain
any information about smoothed value, original value, and wall time.
This change attempts to reach some feature parity with the existing
scalar card.