### PR TITLE
line chart: make sure tooltip repositions when scrolled

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -78,6 +78,7 @@ tf_ng_module(
     deps = [
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/angular:expect_angular_cdk_scrolling",
         "//tensorboard/webapp/angular:expect_angular_material_autocomplete",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_icon",

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
@@ -34,7 +34,7 @@ limitations under the License.
   </div>
 </div>
 <div class="split-content">
-  <div class="main">
+  <div cdkScrollable class="main">
     <metrics-filtered-view
       *ngIf="showFilteredView"
       [cardObserver]="cardObserver"

--- a/tensorboard/webapp/metrics/views/main_view/main_view_module.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_module.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
@@ -52,13 +53,14 @@ import {PinnedViewContainer} from './pinned_view_container';
   ],
   exports: [MainViewContainer],
   imports: [
-    CommonModule,
     CardRendererModule,
+    CommonModule,
     MatAutocompleteModule,
     MatButtonModule,
     MatIconModule,
     MatInputModule,
     RightPaneModule,
+    ScrollingModule,
   ],
 })
 export class MainViewModule {}


### PR DESCRIPTION
The new line chart uses cdk overlay to render the tooltip. It currently
has three strategies it can take when scrolled in the scroll container.
Strategies aside, we need a way for the overlay to be able to detect a
scroll event in a scroll container and adding `cdkScrollable` is one way
to register a scrollable container to the cdk library.

