### PR TITLE
projector: fix cannot find module 'd3'

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -63,6 +63,7 @@ tf_ts_library(
         "//tensorboard/webapp/third_party:tfjs",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
+        "@npm//@types/d3",
         "@npm//d3",
         "@npm//numeric",
         "@npm//three",


### PR DESCRIPTION
[snip]
$ bazel run tensorboard/plugins/projector/vz_projector:standalone
tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts:16:21 - error TS2307: Cannot find module 'd3'.

16 import * as d3 from 'd3';
[snip]

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

* Motivation for features / changes

* Technical description of changes

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
