### PR TITLE
Pass FeatureFlags to CUSTOM_ELEMENT dashboards; use in Scalars dashboard for inColab and scalarsBatchSize.

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -23,6 +23,7 @@ tf_ts_library(
         "//tensorboard/components/tf_storage",
         "//tensorboard/components/tf_utils",
         "//tensorboard/components/vz_chart_helpers",
+        "//tensorboard/webapp/feature_flag:types",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
         "@npm//@types/lodash",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
@@ -334,7 +334,7 @@ export class TfScalarCard extends PolymerElement {
       runs.push(run);
     }
 
-    const batchSize = this.batchSize || DEFAULT_BATCH_SIZE;
+    const batchSize = this.batchSize ?? DEFAULT_BATCH_SIZE;
 
     const requestGroups = [];
     for (const [tag, runs] of runsByTag) {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.ts
@@ -31,6 +31,7 @@ import '../../../components/tf_runs_selector/tf-runs-selector';
 import * as tf_storage from '../../../components/tf_storage/storage';
 import * as tf_utils from '../../../components/tf_utils/utils';
 import * as vz_chart_helpers from '../../../components/vz_chart_helpers/vz-chart-helpers';
+import {FeatureFlags} from '../../../webapp/feature_flag/types';
 import './tf-scalar-card';
 import {TfScalarCard} from './tf-scalar-card';
 import './tf-smoothing-input';
@@ -166,6 +167,8 @@ class TfScalarDashboard extends LegacyElementMixin(ArrayUpdateHelper) {
                   tag="[[item.tag]]"
                   tooltip-sorting-method="[[_tooltipSortingMethod]]"
                   x-type="[[_xType]]"
+                  batch-size="[[featureFlags.scalarsBatchSize]]"
+                  in-colab="[[featureFlags.inColab]]"
                 ></tf-scalar-card>
               </template>
             </tf-category-paginated-view>
@@ -205,6 +208,9 @@ class TfScalarDashboard extends LegacyElementMixin(ArrayUpdateHelper) {
 
   @property({type: Boolean})
   reloadOnReady: boolean = true;
+
+  @property({type: Object})
+  featureFlags?: FeatureFlags;
 
   @property({
     type: Boolean,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -25,6 +25,7 @@ const initialState: FeatureFlagState = {
     enabledExperimentalPlugins: [],
     inColab: false,
     enableGpuChart: false,
+    scalarsBatchSize: undefined,
   },
 };
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -34,20 +34,24 @@ export const getIsFeatureFlagsLoaded = createSelector(
   }
 );
 
+export const getFeatureFlags = createSelector(selectFeatureFlagState, (state)=> {
+  return state.features;
+});
+
 export const getEnabledExperimentalPlugins = createSelector(
   selectFeatureFlagState,
   (state) => {
-    return state.features.enabledExperimentalPlugins || [];
+    return state.features.enabledExperimentalPlugins;
   }
 );
 
 export const getIsInColab = createSelector(selectFeatureFlagState, (state) => {
-  return !!state.features.inColab;
+  return state.features.inColab;
 });
 
 export const getIsGpuChartEnabled = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): boolean => {
-    return !!state.features.enableGpuChart;
+    return state.features.enableGpuChart;
   }
 );

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -34,9 +34,12 @@ export const getIsFeatureFlagsLoaded = createSelector(
   }
 );
 
-export const getFeatureFlags = createSelector(selectFeatureFlagState, (state)=> {
-  return state.features;
-});
+export const getFeatureFlags = createSelector(
+  selectFeatureFlagState,
+  (state) => {
+    return state.features;
+  }
+);
 
 export const getEnabledExperimentalPlugins = createSelector(
   selectFeatureFlagState,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -17,6 +17,22 @@ import * as selectors from './feature_flag_selectors';
 import {buildFeatureFlagState, buildState} from './testing';
 
 describe('feature_flag_selectors', () => {
+  describe('#getFeatureFlags', () => {
+    it('returns value in the store', () => {
+      const state = buildState(
+        buildFeatureFlagState({
+          features: buildFeatureFlag({
+            enableGpuChart: true,
+          }),
+        })
+      );
+
+      expect(selectors.getFeatureFlags(state)).toEqual(
+        buildFeatureFlag({enableGpuChart: true})
+      );
+    });
+  });
+
   describe('#getEnabledExperimentalPlugins', () => {
     it('returns value in array', () => {
       const state = buildState(

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -22,6 +22,7 @@ export function buildFeatureFlag(
     enabledExperimentalPlugins: [],
     inColab: false,
     enableGpuChart: false,
+    scalarsBatchSize: undefined,
     ...override,
   };
 }

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -20,4 +20,10 @@ export interface FeatureFlags {
   inColab: boolean;
   // Whether to enable our experimental GPU line chart.
   enableGpuChart: boolean;
+  // Maximum number of runs to include in a request to get scalar data.
+  // `undefined` indicates that we should rely on defaults defined in the
+  // dashboards code.
+  //
+  // See: https://github.com/tensorflow/tensorboard/blob/master/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
+  scalarsBatchSize: number | undefined;
 }

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -16,9 +16,12 @@ tf_ng_module(
     ],
     deps = [
         ":plugin_registry",
+        "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/core",
         "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/core/store",
+        "//tensorboard/webapp/feature_flag:types",
+        "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -58,6 +58,8 @@ tf_ts_library(
         "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/core/testing",
+        "//tensorboard/webapp/feature_flag:testing",
+        "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/plugins/testing",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -24,8 +24,7 @@ limitations under the License.
 
 <div
   *ngIf="pluginLoadState !== PluginLoadState.LOADED
-      && pluginLoadState !== PluginLoadState.LOADING
-      && isFeatureFlagsLoaded"
+      && pluginLoadState !== PluginLoadState.LOADING"
   [ngSwitch]="pluginLoadState"
   class="warning"
 >

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -24,7 +24,8 @@ limitations under the License.
 
 <div
   *ngIf="pluginLoadState !== PluginLoadState.LOADED
-      && pluginLoadState !== PluginLoadState.LOADING"
+      && pluginLoadState !== PluginLoadState.LOADING
+      && isFeatureFlagsLoaded"
   [ngSwitch]="pluginLoadState"
   class="warning"
 >

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -148,6 +148,10 @@ export class PluginsComponent implements OnChanges {
   private readonly pluginInstances = new Map<string, HTMLElement>();
 
   ngOnChanges(change: SimpleChanges): void {
+    // TODO: Handle case where this.activeKnownPlugin goes from truthy to falsy.
+    //       It might happen when users are navigating between experiments and
+    //       the new experiment does not have data for the active dashboard?
+
     if (!this.isFeatureFlagsLoaded || !this.activeKnownPlugin) {
       return;
     }

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -31,6 +31,8 @@ import {
   TemplateRef,
 } from '@angular/core';
 
+import {FeatureFlags} from '../feature_flag/types';
+
 import {UiPluginMetadata} from './plugins_container';
 import {
   LoadingMechanismType,
@@ -121,6 +123,12 @@ export class PluginsComponent implements OnChanges {
   dataLocation!: string;
 
   @Input()
+  isFeatureFlagsLoaded!: boolean;
+
+  @Input()
+  featureFlags!: FeatureFlags;
+
+  @Input()
   lastUpdated?: number;
 
   @Input()
@@ -207,6 +215,7 @@ export class PluginsComponent implements OnChanges {
           customElementPlugin.element_name
         );
         (pluginElement as any).reloadOnReady = false;
+        (pluginElement as any).featureFlags = this.featureFlags;
         this.pluginsContainer.nativeElement.appendChild(pluginElement);
         break;
       }

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -125,6 +125,11 @@ export class PluginsComponent implements OnChanges {
   @Input()
   isFeatureFlagsLoaded!: boolean;
 
+  /**
+   * Feature flags to pass to underlying plugins. Currently only passed to
+   * plugins of type CUSTOM_ELEMENT. The feature flags are set directly on
+   * the element as the featureFlags property.
+   */
   @Input()
   featureFlags!: FeatureFlags;
 

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -148,13 +148,17 @@ export class PluginsComponent implements OnChanges {
   private readonly pluginInstances = new Map<string, HTMLElement>();
 
   ngOnChanges(change: SimpleChanges): void {
+    if (!this.isFeatureFlagsLoaded || !this.activeKnownPlugin) {
+      return;
+    }
+
     const shouldCreatePlugin = Boolean(
       this.activeKnownPlugin &&
         !this.pluginInstances.has(this.activeKnownPlugin.id)
     );
 
-    if (change['activeKnownPlugin'] && this.activeKnownPlugin) {
-      const prevActiveKnownPlugin = change['activeKnownPlugin'].previousValue;
+    if (change['activeKnownPlugin'] || change['isFeatureFlagsLoaded']) {
+      const prevActiveKnownPlugin = change['activeKnownPlugin']?.previousValue;
       if (
         prevActiveKnownPlugin &&
         prevActiveKnownPlugin.id !== this.activeKnownPlugin.id
@@ -170,10 +174,7 @@ export class PluginsComponent implements OnChanges {
         this.showPlugin(this.activeKnownPlugin);
       }
     }
-    if (
-      this.activeKnownPlugin &&
-      (shouldCreatePlugin || change['lastUpdated'])
-    ) {
+    if (shouldCreatePlugin || change['lastUpdated']) {
       this.reload(this.activeKnownPlugin, shouldCreatePlugin);
     }
   }

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -32,7 +32,10 @@ import {PluginsListFailureCode} from '../core/types';
 import {PluginMetadata} from '../types/api';
 import {LoadState, DataLoadState} from '../types/data';
 import {State} from '../app_state';
-import {getFeatureFlags, getIsFeatureFlagsLoaded} from '../feature_flag/store/feature_flag_selectors';
+import {
+  getFeatureFlags,
+  getIsFeatureFlagsLoaded,
+} from '../feature_flag/store/feature_flag_selectors';
 
 import {PluginLoadState} from './plugins_component';
 

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -67,7 +67,7 @@ const lastLoadedTimeInMs = createSelector(
       [dataLocation]="dataLocation$ | async"
       [lastUpdated]="lastLoadedTimeInMs$ | async"
       [pluginLoadState]="pluginLoadState$ | async"
-      [isFeatureFlagsLoaded]="isFeatureFlagsLoaded | async"
+      [isFeatureFlagsLoaded]="isFeatureFlagsLoaded$ | async"
       [featureFlags]="featureFlags$ | async"
       [environmentFailureNotFoundTemplate]="environmentFailureNotFoundTemplate"
       [environmentFailureUnknownTemplate]="environmentFailureUnknownTemplate"
@@ -128,7 +128,7 @@ export class PluginsContainer {
       return env.data_location;
     })
   );
-  readonly isFeatureFlagsLoaded = this.store.select(getIsFeatureFlagsLoaded);
+  readonly isFeatureFlagsLoaded$ = this.store.select(getIsFeatureFlagsLoaded);
   readonly featureFlags$ = this.store.select(getFeatureFlags);
 
   constructor(private readonly store: Store<State>) {}

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -31,7 +31,8 @@ import {
 import {PluginsListFailureCode} from '../core/types';
 import {PluginMetadata} from '../types/api';
 import {LoadState, DataLoadState} from '../types/data';
-import {State} from '../core/store/core_types';
+import {State} from '../app_state';
+import {getFeatureFlags, getIsFeatureFlagsLoaded} from '../feature_flag/store/feature_flag_selectors';
 
 import {PluginLoadState} from './plugins_component';
 
@@ -66,6 +67,8 @@ const lastLoadedTimeInMs = createSelector(
       [dataLocation]="dataLocation$ | async"
       [lastUpdated]="lastLoadedTimeInMs$ | async"
       [pluginLoadState]="pluginLoadState$ | async"
+      [isFeatureFlagsLoaded]="isFeatureFlagsLoaded | async"
+      [featureFlags]="featureFlags$ | async"
       [environmentFailureNotFoundTemplate]="environmentFailureNotFoundTemplate"
       [environmentFailureUnknownTemplate]="environmentFailureUnknownTemplate"
     ></plugins-component>
@@ -125,6 +128,8 @@ export class PluginsContainer {
       return env.data_location;
     })
   );
+  readonly isFeatureFlagsLoaded = this.store.select(getIsFeatureFlagsLoaded);
+  readonly featureFlags$ = this.store.select(getFeatureFlags);
 
   constructor(private readonly store: Store<State>) {}
 }

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -185,6 +185,24 @@ describe('plugins_component', () => {
       expect(el.nativeElement.childElementCount).toBe(0);
     });
 
+    it('creates no plugin when feature flags are not loaded', async () => {
+      store.overrideSelector(getIsFeatureFlagsLoaded, false);
+      store.overrideSelector(getActivePlugin, 'foo');
+
+      const fixture = TestBed.createComponent(PluginsContainer);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const plugins1 = fixture.debugElement.query(By.css('.plugins'));
+      expect(plugins1.nativeElement.childElementCount).toBe(0);
+
+      store.overrideSelector(getIsFeatureFlagsLoaded, true);
+      store.refreshState();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const plugins2 = fixture.debugElement.query(By.css('.plugins'));
+      expect(plugins2.nativeElement.childElementCount).toBe(1);
+    });
+
     it('creates an element for CUSTOM_ELEMENT type of plugin', async () => {
       const fixture = TestBed.createComponent(PluginsContainer);
       fixture.detectChanges();

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -41,6 +41,9 @@ import {
 } from '../core/store/core_selectors';
 import {PluginsListFailureCode} from '../core/types';
 import {TestingDebuggerModule} from '../../plugins/debugger_v2/tf_debugger_v2_plugin/testing';
+import {buildFeatureFlag} from '../feature_flag/testing';
+import {getFeatureFlags} from '../feature_flag/store/feature_flag_selectors';
+import {getIsFeatureFlagsLoaded} from '../feature_flag/store/feature_flag_selectors';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
@@ -154,6 +157,8 @@ describe('plugins_component', () => {
       data_location: 'foobar',
       window_title: 'Tests!',
     });
+    store.overrideSelector(getIsFeatureFlagsLoaded, true);
+    store.overrideSelector(getFeatureFlags, buildFeatureFlag());
 
     createElementSpy = spyOn(document, 'createElement').and.callThrough();
     createElementSpy

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -330,6 +330,23 @@ describe('plugins_component', () => {
         barElement.shadowRoot.firstElementChild.clientWidth
       ).toBeGreaterThan(0);
     });
+
+    it('assigns feature flags to CUSTOM_ELEMENT plugins', async () => {
+      store.overrideSelector(
+        getFeatureFlags,
+        buildFeatureFlag({inColab: true})
+      );
+      setActivePlugin('bar');
+
+      const fixture = TestBed.createComponent(PluginsContainer);
+      fixture.detectChanges();
+
+      const pluginElement = fixture.debugElement.query(By.css('.plugins'))
+        .children[0].nativeNode;
+      expect((pluginElement as any).featureFlags).toEqual(
+        buildFeatureFlag({inColab: true})
+      );
+    });
   });
 
   describe('reload', () => {

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -17,6 +17,7 @@ import {Injectable} from '@angular/core';
 import {
   EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
   GPU_LINE_CHART_QUERY_PARAM_KEY,
+  SCALARS_BATCH_SIZE_PARAM_KEY,
   TBFeatureFlagDataSource,
 } from './tb_feature_flag_data_source_types';
 import {FeatureFlags} from '../feature_flag/types';
@@ -51,6 +52,9 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
     if (params.has(GPU_LINE_CHART_QUERY_PARAM_KEY)) {
       featureFlags.enableGpuChart =
         params.get(GPU_LINE_CHART_QUERY_PARAM_KEY) === 'true';
+    }
+    if (params.has(SCALARS_BATCH_SIZE_PARAM_KEY)) {
+      featureFlags.scalarsBatchSize = Number(params.get(SCALARS_BATCH_SIZE_PARAM_KEY));
     }
     return featureFlags;
   }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -54,7 +54,9 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
         params.get(GPU_LINE_CHART_QUERY_PARAM_KEY) === 'true';
     }
     if (params.has(SCALARS_BATCH_SIZE_PARAM_KEY)) {
-      featureFlags.scalarsBatchSize = Number(params.get(SCALARS_BATCH_SIZE_PARAM_KEY));
+      featureFlags.scalarsBatchSize = Number(
+        params.get(SCALARS_BATCH_SIZE_PARAM_KEY)
+      );
     }
     return featureFlags;
   }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -89,16 +89,29 @@ describe('tb_feature_flag_data_source', () => {
         expect(dataSource.getFeatures()).toEqual({enableGpuChart: false});
       });
 
+      it('returns scalarsBatchSize from the query params', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('scalarsBatchSize=12')
+        );
+        expect(dataSource.getFeatures()).toEqual({
+          scalarsBatchSize: 12,
+        });
+      });
+
       it('returns all flag values when they are all set', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams(
-            'experimentalPlugin=a&tensorboardColab&fastChart=true'
+            'experimentalPlugin=a' +
+              '&tensorboardColab' +
+              '&fastChart=true' +
+              '&scalarsBatchSize=16'
           )
         );
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: ['a'],
           inColab: false,
           enableGpuChart: true,
+          scalarsBatchSize: 16,
         });
       });
     });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -34,3 +34,5 @@ export abstract class TBFeatureFlagDataSource {
 export const EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY = 'experimentalPlugin';
 
 export const GPU_LINE_CHART_QUERY_PARAM_KEY = 'fastChart';
+
+export const SCALARS_BATCH_SIZE_PARAM_KEY = 'scalarsBatchSize';


### PR DESCRIPTION
* Motivation for features / changes

  We want to be able to use the FeatureFlags mechanism to modify behavior in dashboards.
  The Scalars dashboard, for example, could use two FeatureFlags:
  * `isColab`, which maps to the `tensorboardColab`  query parameter. The Scalars dashboard already independently
     reads this query parameter but it is more consistent to get it from FeatureFlags.
  * `scalarsBatchSize`, which is new functionality. TensorBoard.dev will use FeatureFlags to modify the /scalars_multirun
     batch size.

* Technical description of changes

  * plugins_component on Angular side, which manages dashboard creation, now waits for FeatureFlags to be
     loaded before loading dashboards. It passes the featureFlags property of each dashboard, which can choose to
     use or ignore it as a polymer property.
  * introduce the `scalarsBatchSize` feature flag and map it to the query parameter of the same name.
  * scalars dashboard code uses the `featureFlags` property to read `isColab` and `scalarsBatchSize` feature flags
    and uses the values to modify behavior.

* Detailed steps to verify changes work correctly (as executed by you)

  * Wrote some tests.
  * Brought up a local tensorboard and ensured that `tensorboardColab` and `scalarsBatchSize` query parameters
     properly modify scalars dashboard behavior.
  * Temporarily synthetically delay query parameter loading by 10 seconds. Load tensorboard and observe that dashboards
     are not loaded until the 10 seconds elapses and that they load correctly.
