### PR TITLE
Allow SourceDiff clients to update 'renderSideBySide'

### DIFF
--- a/tensorboard/webapp/widgets/source_code/source_code_diff_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_component.ts
@@ -56,7 +56,6 @@ export class SourceCodeDiffComponent implements OnChanges {
   // When a diff is shown, the two versions can be rendered in one of 2 modes:
   // - side by side: 2 scrollable frames with a vertical separator
   // - inline: 1 scrollable frame showing modified and original lines
-  // This component does not respond to changes in this property.
   @Input()
   renderSideBySide: boolean = true;
 
@@ -101,6 +100,10 @@ export class SourceCodeDiffComponent implements OnChanges {
         original: this.monaco.editor.createModel(this.firstText || ''),
         modified: this.monaco.editor.createModel(this.secondText || ''),
       });
+    }
+
+    if (changes['renderSideBySide']) {
+      this.editor.updateOptions({renderSideBySide: this.renderSideBySide});
     }
   }
 }

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
@@ -21,6 +21,8 @@ import {loadMonaco} from './load_monaco_shim';
 /**
  * A component that renders a diff of 2 separate text contents. Diffs can be
  * viewed inline or side by side.
+ * - side by side: 2 scrollable frames with a vertical separator
+ * - inline: 1 scrollable frame showing modified and original lines
  */
 @Component({
   selector: 'source-code-diff',

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {ChangeDetectorRef, NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import * as loadMonacoShim from './load_monaco_shim';
@@ -69,6 +69,36 @@ describe('Source Code Diff', () => {
       spies.createDiffEditorSpy.calls.allArgs()[0][1].renderSideBySide
     ).toBe(false);
     expect(spies.diffEditorSpy.setModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates an existing editor when renderSideBySide changes', async () => {
+    const fixture = TestBed.createComponent(SourceCodeDiffContainer);
+    const changeDetector = fixture.debugElement.injector.get(ChangeDetectorRef);
+    const component = fixture.componentInstance;
+    component.firstText = 'foo';
+    component.secondText = 'bar';
+    component.renderSideBySide = false;
+    fixture.detectChanges();
+
+    // Simlulate loading monaco.
+    await loadMonacoShim.loadMonaco();
+    changeDetector.detectChanges();
+
+    expect(spies.diffEditorSpy.updateOptions).not.toHaveBeenCalled();
+
+    component.renderSideBySide = true;
+    changeDetector.detectChanges();
+
+    expect(spies.diffEditorSpy.updateOptions).toHaveBeenCalledWith(
+      jasmine.objectContaining({renderSideBySide: true})
+    );
+
+    component.renderSideBySide = false;
+    changeDetector.detectChanges();
+
+    expect(spies.diffEditorSpy.updateOptions).toHaveBeenCalledWith(
+      jasmine.objectContaining({renderSideBySide: false})
+    );
   });
 
   it('calls loadMonaco() on ngOnInit()', () => {

--- a/tensorboard/webapp/widgets/source_code/testing.ts
+++ b/tensorboard/webapp/widgets/source_code/testing.ts
@@ -61,6 +61,7 @@ export function setUpMonacoFakes() {
           spies.diffEditorSpy = jasmine.createSpyObj('diffEditorSpy', [
             'layout',
             'setModel',
+            'updateOptions',
           ]);
           return spies.diffEditorSpy;
         },


### PR DESCRIPTION
The SourceDiff component uses the Monaco editor for rendering a diff either
as side-by-side editors or as a unified, inline diff editor. Before, it did not
respect changes in the `renderSideBySide` input property. Now, it calls
Monaco's `updateOptions()` to allow changing the setting in an existing
editor.

https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditor.html#updateoptions