### PR TITLE
line chart: transfer data with 64 bit precision

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series.ts
@@ -34,7 +34,7 @@ export function compactDataSeries(
     return len + data.points.length;
   }, 0);
   let seriesIndex = 0;
-  const flattenedSeries = new Float32Array(totalLength * 2);
+  const flattenedSeries = new Float64Array(totalLength * 2);
   const idsAndLengths: Array<{id: string; length: number}> = [];
 
   for (const series of dataSeriesArr) {
@@ -57,7 +57,7 @@ export function decompactDataSeries(
   compactDataSeries: CompactDataSeries
 ): DataSeries[] {
   const {flattenedSeries, idsAndLengths} = compactDataSeries;
-  const rawData = new Float32Array(flattenedSeries);
+  const rawData = new Float64Array(flattenedSeries);
   const data: DataSeries[] = [];
 
   if (rawData.length % 2 !== 0) {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series.ts
@@ -17,7 +17,7 @@ import {DataSeries} from '../internal_types';
 
 export interface CompactDataSeries {
   idsAndLengths: Array<{id: string; length: number}>;
-  // buffer of packed f64s
+  // buffer of packed f64s that represents 2d coordinates, [x1, y1, x2, y2, ..., xn, yn].
   flattenedSeries: ArrayBuffer;
 }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series.ts
@@ -17,6 +17,7 @@ import {DataSeries} from '../internal_types';
 
 export interface CompactDataSeries {
   idsAndLengths: Array<{id: string; length: number}>;
+  // buffer of packed f64s
   flattenedSeries: ArrayBuffer;
 }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series_test.ts
@@ -104,29 +104,12 @@ describe('line_chart_v2/lib/compact_data_series', () => {
       );
     });
 
-    it('rounds to float 32', () => {
-      const dataSeries = [
-        {
-          id: 'foo',
-          points: [{x: 1, y: Number.MIN_VALUE}],
-        },
-      ];
-
-      const actual = decompactDataSeries(compactDataSeries(dataSeries));
-      expect(actual).not.toEqual(dataSeries);
-      expect(actual).toEqual([
-        {
-          id: 'foo',
-          points: [{x: 1, y: 0}],
-        },
-      ]);
-    });
-
-    it('does not round fractiional numbers', () => {
+    it('transfers without losing precision', () => {
       const dataSeries = [
         {
           id: 'foo',
           points: [
+            {x: 1, y: Number.MIN_VALUE},
             {x: 1, y: 0.3},
             {x: 1, y: 1e-10},
           ],
@@ -134,19 +117,20 @@ describe('line_chart_v2/lib/compact_data_series', () => {
       ];
 
       const actual = decompactDataSeries(compactDataSeries(dataSeries));
-      expect(actual).not.toEqual(dataSeries);
-      expect(actual).toEqual([
+      expect(actual).toEqual(dataSeries);
+    });
+
+    it('transfers date', () => {
+      const time = new Date('2020-01-01').getTime();
+      const dataSeries = [
         {
           id: 'foo',
-          points: [
-            {x: 1, y: jasmine.any(Number)},
-            {x: 1, y: jasmine.any(Number)},
-          ],
+          points: [{x: 1, y: time}],
         },
-      ]);
-      // When converting to Float32, there are error due to missing precision.
-      expect(actual[0].points[0].y).toBeCloseTo(0.3, 6);
-      expect(actual[0].points[1].y).toBeCloseTo(1e-10, 12);
+      ];
+
+      const actual = decompactDataSeries(compactDataSeries(dataSeries));
+      expect(actual).toEqual(dataSeries);
     });
 
     it('fails when decompacting wrong message (odd number of data points', () => {


### PR DESCRIPTION
We premature optimized thinking that we should allocate less memory
using Float32Array where possible instead of Float64Array. The thing
is, with 32 bit precision, it is not possible to represent the date
serialized to integer.

This changes the data transfer layer only. We will diagnose and change
other places where we use Float32Array as needed (for instance, WebGL
uses 32 bit precision and threejs internally uses Float32Array a lot.
Having more precision does not help in all cases)