### PR TITLE
line chart: add temporal scale

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -10,6 +10,9 @@ tf_ts_library(
         "internal_types.ts",
         "scale_types.ts",
     ],
+    deps = [
+        ":formatter",
+    ],
 )
 
 tf_ts_library(
@@ -82,6 +85,7 @@ tf_ts_library(
     ],
     visibility = ["//tensorboard:internal"],
     deps = [
+        ":formatter",
         ":internal_types",
         "//tensorboard/webapp/third_party:d3",
     ],

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -12,7 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {scaleLinear, scaleLog} from '../../../third_party/d3';
+import {scaleLinear, scaleLog, scaleTime} from '../../../third_party/d3';
+import {numberFormatter, relativeTimeFormatter} from './formatter';
 import {Scale, ScaleType} from './scale_types';
 
 export {ScaleType} from './scale_types';
@@ -23,6 +24,8 @@ export function createScale(type: ScaleType): Scale {
       return new LinearScale();
     case ScaleType.LOG10:
       return new Log10Scale();
+    case ScaleType.TIME:
+      return new TemporalScale();
     default:
       const _: never = type;
       throw new RangeError(`ScaleType ${_} not supported.`);
@@ -93,6 +96,8 @@ class LinearScale implements Scale {
   isSafeNumber(x: number): boolean {
     return Number.isFinite(x);
   }
+
+  defaultFormatter = numberFormatter;
 }
 
 class Log10Scale implements Scale {
@@ -174,4 +179,44 @@ class Log10Scale implements Scale {
   isSafeNumber(x: number): boolean {
     return Number.isFinite(x) && x > 0;
   }
+
+  defaultFormatter = numberFormatter;
+}
+
+export class TemporalScale implements Scale {
+  private readonly scale = scaleTime();
+
+  forward(
+    domain: [number, number],
+    range: [number, number],
+    x: number
+  ): number {
+    return this.scale.domain(domain).range(range)(x);
+  }
+
+  reverse(
+    domain: [number, number],
+    range: [number, number],
+    x: number
+  ): number {
+    return this.scale.domain(domain).range(range).invert(x).getTime();
+  }
+
+  niceDomain(domain: [number, number]): [number, number] {
+    const [minDate, maxDate] = this.scale.domain(domain).nice().domain();
+    return [minDate.getTime(), maxDate.getTime()];
+  }
+
+  ticks(domain: [number, number], sizeGuidance: number): number[] {
+    return this.scale
+      .domain(domain)
+      .ticks(sizeGuidance)
+      .map((date) => date.getTime());
+  }
+
+  isSafeNumber(x: number): boolean {
+    return Number.isFinite(x);
+  }
+
+  defaultFormatter = relativeTimeFormatter;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {scaleLinear, scaleLog, scaleTime} from '../../../third_party/d3';
-import {numberFormatter, relativeTimeFormatter} from './formatter';
+import {numberFormatter, wallTimeFormatter} from './formatter';
 import {Scale, ScaleType} from './scale_types';
 
 export {ScaleType} from './scale_types';
@@ -218,5 +218,5 @@ export class TemporalScale implements Scale {
     return Number.isFinite(x);
   }
 
-  defaultFormatter = relativeTimeFormatter;
+  defaultFormatter = wallTimeFormatter;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_types.ts
@@ -13,9 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {Formatter} from './formatter';
+
 export enum ScaleType {
   LINEAR,
   LOG10,
+  TIME,
 }
 
 /**
@@ -70,4 +73,6 @@ export interface Scale {
    * *: e.g., f(1) = 2 and f'(2) = 1 vs. f(1) = NaN and f'(NaN) = ?.
    */
   isSafeNumber(x: number): boolean;
+
+  defaultFormatter: Formatter;
 }


### PR DESCRIPTION
This change implements temporal scale using d3.scaleTime.

While it _can_ be a performance hotspot, transforming data in temporal
dimension is non-trivial so, for now, we decided to adopt d3.scaleTime
as is.
