### PR TITLE
ci: persist Rust caches for Pip package build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           python-version: '3.8'
           architecture: 'x64'
-      - name: 'Cache Cargo home directory'
+      - name: 'Cache Cargo artifacts'
         uses: actions/cache@v2
         with:
           path: |
@@ -126,7 +126,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            # Needed for installing binaries with cache
+            # Needed if we `cargo install` binaries (at time of writing, this
+            # job doesn't but the files are tiny, and this will mitigate
+            # confusion if we need to `cargo install` later)
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
           key: build-data-server-pip-${{ runner.os }}-cargo-${{ matrix.rust_version }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}
@@ -215,7 +217,7 @@ jobs:
         cargo_raze_version: ['0.7.0']
     steps:
       - uses: actions/checkout@v1
-      - name: 'Cache Cargo home directory'
+      - name: 'Cache Cargo artifacts'
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,20 @@ jobs:
         with:
           python-version: '3.8'
           architecture: 'x64'
+      - name: 'Cache Cargo home directory'
+        uses: actions/cache@v2
+        with:
+          path: |
+            tensorboard/data/server/target/
+            # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            # Needed for installing binaries with cache
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: build-data-server-pip-${{ runner.os }}-cargo-${{ matrix.rust_version }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}
       - name: 'Install Rust toolchain'
         uses: actions-rs/toolchain@v1
         with:
@@ -214,7 +228,7 @@ jobs:
             # Needed for installing binaries (`cargo-raze`) with cache
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-          key: ${{ runner.os }}-cargo-${{ matrix.rust_version }}-${{ matrix.cargo_raze_version }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}
+          key: lint-rust-${{ runner.os }}-cargo-${{ matrix.rust_version }}-${{ matrix.cargo_raze_version }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}
       - name: 'Install Rust toolchain'
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Summary:
The `build-data-server-pip` job runs on two platforms on every push, and
each run takes about 5 minutes. The vast majority of this time (85%) is
spent building all dependencies from scratch. Since [macOS minutes are
priced at 10× the rate of Linux minutes][pricing] and this is our only
macOS job, we may as well spend a modicum of effort to improve this.

[pricing]: https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions#about-billing-for-github-actions

The docs at <https://github.com/actions/cache> say that a repository can
have up to 5 GB of caches. The cache for our other Rust job is ~200 MB,
and we don’t have any other caches, so adding two more of those caches
seems okay. The caches are also invalidated infrequently: only when we
update Rust dependencies or update the workflow file itself.

Adding a cache should speed up these builds. We already do this for the
Rust lint job, and it works well. This is a separate cache because the
job builds in release mode rather than debug mode.

Rust builds generally have good hermeticity properties, so this should
be fairly safe. If we want to be extra safe, we could turn this off for
builds that will be published in an actual stable release.

Test Plan:
Note that the second run of the checks for this PR spends less time in
the “Build” and “Test” phases. It appears to still spend about a minute
total building, even though it hits cache. I’m not sure why—this is not
the case for normal, local, incremental builds—but this is still an
improvement of about 65%, so I’m okay with it for now.

wchargin-branch: ci-cache-rust-pip
