### PR TITLE
Use `nonlocal` rather than `box[0]` in tests

### DIFF
--- a/tensorboard/auth_test.py
+++ b/tensorboard/auth_test.py
@@ -20,25 +20,27 @@ from tensorboard import test as tb_test
 
 class AuthContextTest(tb_test.TestCase):
     def test_cache_success(self):
-        call_count_box = [0]
+        call_count = 0
 
         class UsernameProvider(auth.AuthProvider):
             def authenticate(self, environ):
-                call_count_box[0] += 1
+                nonlocal call_count
+                call_count += 1
                 return environ["username"]
 
         providers = {UsernameProvider: UsernameProvider()}
         auth_ctx = auth.AuthContext(providers, {"username": "whoami"})
         self.assertEqual(auth_ctx.get(UsernameProvider), "whoami")
         self.assertEqual(auth_ctx.get(UsernameProvider), "whoami")
-        self.assertEqual(call_count_box[0], 1)
+        self.assertEqual(call_count, 1)
 
     def test_cache_failure(self):
-        call_count_box = [0]
+        call_count = 0
 
         class FailureProvider(auth.AuthProvider):
             def authenticate(self, environ):
-                call_count_box[0] += 1
+                nonlocal call_count
+                call_count += 1
                 raise RuntimeError()
 
         providers = {FailureProvider: FailureProvider()}
@@ -47,7 +49,7 @@ class AuthContextTest(tb_test.TestCase):
             auth_ctx.get(FailureProvider)
         with self.assertRaises(RuntimeError):
             auth_ctx.get(FailureProvider)
-        self.assertEqual(call_count_box[0], 2)
+        self.assertEqual(call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -53,7 +53,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
         )
 
         real_popen = subprocess.Popen
-        port_file_box = [None]  # value of `--port-file` to be stashed here
+        port_file = None  # value of `--port-file` to be stashed here
 
         # Stub out `subprocess.Popen` to write the port file.
         def fake_popen(subprocess_args, *args, **kwargs):
@@ -63,8 +63,8 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
                     port_file_prefix = "--port-file="
                     if not arg.startswith(port_file_prefix):
                         continue
+                    nonlocal port_file
                     port_file = arg[len(port_file_prefix) :]
-                    port_file_box[0] = port_file
                     with open(port_file, "w") as outfile:
                         outfile.write("23456\n")
 
@@ -88,7 +88,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
             fake_binary,
             "--logdir=/tmp/logs",
             "--port=0",
-            "--port-file=%s" % port_file_box[0],
+            "--port-file=%s" % port_file,
             "--die-after-stdin",
             "--verbose",  # logging is enabled in tests
         ]

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -103,16 +103,17 @@ class LazyTest(unittest.TestCase):
             def __eq__(self, other):
                 return True
 
-        count_box = [0]
+        count = 0
 
         @lazy.lazy_load("foo")
         def foo():
-            count_box[0] += 1
+            nonlocal count
+            count += 1
             return EqualToEverything()
 
         dir(foo)
         dir(foo)
-        self.assertEqual(count_box[0], 1)
+        self.assertEqual(count, 1)
 
 
 if __name__ == "__main__":

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -744,12 +744,13 @@ class TensorboardUploaderTest(tf.test.TestCase):
             pass
 
         mock_rate_limiter = mock.create_autospec(util.RateLimiter)
-        upload_call_count_box = [0]
+        upload_call_count = 0
 
         def mock_upload_once():
-            upload_call_count_box[0] += 1
+            nonlocal upload_call_count
+            upload_call_count += 1
             tick_count = mock_rate_limiter.tick.call_count
-            self.assertEqual(tick_count, upload_call_count_box[0])
+            self.assertEqual(tick_count, upload_call_count)
             if tick_count >= 3:
                 raise Success()
 
@@ -1352,13 +1353,14 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         event_2 = event_pb2.Event(step=2)
         event_2.summary.value.add(tag="bar", simple_value=-2.0)
 
-        add_point_call_count_box = [0]
+        add_point_call_count = 0
 
         def mock_add_point(byte_budget_manager_self, point):
             # Simulate out-of-space error the first time that we try to store
             # the second point.
-            add_point_call_count_box[0] += 1
-            if add_point_call_count_box[0] == 2:
+            nonlocal add_point_call_count
+            add_point_call_count += 1
+            if add_point_call_count == 2:
                 raise uploader_lib._OutOfSpaceError()
 
         with mock.patch.object(
@@ -1798,13 +1800,14 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             ),
         )
 
-        add_point_call_count_box = [0]
+        add_point_call_count = 0
 
         def mock_add_point(byte_budget_manager_self, point):
             # Simulate out-of-space error the first time that we try to store
             # the second point.
-            add_point_call_count_box[0] += 1
-            if add_point_call_count_box[0] == 2:
+            nonlocal add_point_call_count
+            add_point_call_count += 1
+            if add_point_call_count == 2:
                 raise uploader_lib._OutOfSpaceError()
 
         with mock.patch.object(


### PR DESCRIPTION
Summary:
To set a value in an outer scope from within a nested function, we’ve
historically used the pattern of “boxing” the value in a length-1 list:

```python
count_box = [0]

def foo():
    count_box[0] += 1
    ...

foo()
assert count_box[0] == 1
```

Now that we use Python 3 everywhere, we can avoid the box and just use
the `nonlocal` keyword instead:

```python
count = 0

def foo():
    nonlocal count
    count += 1
    ...

foo()
assert count == 1
```

This patch fixes up uses of this pattern, all of which are in tests.

Part of #4488.

Test Plan:
Running `git grep -F '_box = ['` no longer matches any results.

wchargin-branch: box-to-nonlocal
