### PR TITLE
line chart: temporal axis

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -24,8 +24,8 @@ tf_ng_module(
     deps = [
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "//tensorboard/webapp/third_party:d3",
-        "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:scale",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//rxjs",

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -45,18 +45,10 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
       <ng-container *ngFor="let tick of getTicks()">
         <g>
           <text [attr.x]="textXPosition(tick)" [attr.y]="textYPosition(tick)">
-            {{
-              customFormatter
-                ? customFormatter.formatTick(tick)
-                : scale.defaultFormatter.formatTick(tick)
-            }}
+            {{ getFormatter().formatTick(tick) }}
           </text>
           <title>
-            {{
-              customFormatter
-                ? customFormatter.formatReadable(tick)
-                : scale.defaultFormatter.formatReadable(tick)
-            }}
+            {{ getFormatter().formatReadable(tick) }}
           </title>
         </g>
       </ng-container>
@@ -64,18 +56,10 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
     <svg *ngIf="shouldShowMajorTicks()" class="major">
       <g *ngFor="let tick of getMajorTicks()">
         <text [attr.x]="textXPosition(tick)" [attr.y]="textYPosition(tick)">
-          {{
-            customFormatter
-              ? customFormatter.formatShort(tick)
-              : scale.defaultFormatter.formatShort(tick)
-          }}
+          {{ getFormatter().formatShort(tick) }}
         </text>
         <title>
-          {{
-            customFormatter
-              ? customFormatter.formatReadable(tick)
-              : scale.defaultFormatter.formatReadable(tick)
-          }}
+          {{ getFormatter().formatReadable(tick) }}
         </title>
       </g>
     </svg>`,
@@ -142,6 +126,10 @@ export class LineChartAxisComponent {
   @Input()
   customFormatter?: Formatter;
 
+  getFormatter(): Formatter {
+    return this.customFormatter ?? this.scale.defaultFormatter;
+  }
+
   /**
    * Returns true if the major ticks must be shown.
    *
@@ -156,11 +144,11 @@ export class LineChartAxisComponent {
       this.scale instanceof TemporalScale &&
       this.axisExtent[1] - this.axisExtent[0] < DAY_IN_MS &&
       minorTickCount > majorTickCount &&
-      this.getMajorTicks().length <= 2
+      majorTickCount <= 2
     );
   }
 
-  getMajorTicks() {
+  getMajorTicks(): number[] {
     return this.scale.ticks(this.axisExtent, 2);
   }
 


### PR DESCRIPTION
This change treats time axis a bit specially and hardcodes logic for
rendering times. Time ticks, unlike simple numbers, can result in
massive confusion if we encode one to fit into 50px. For instance, if I
were representing 2020/12/31 12:31:12.442 as "12.442", you lose all the
important date, hour, and minute. We are definitely using `<title>` so
user can see more complete information but we lose the "glance-ability".

To mitigate the issue (not perfectly solving the issue), show a major
tick only for date which shows a bit higher level information (datetime)
when certain conditions are right. This business logic definitely is not
perfect but it is a great start and found it to be helpful.

I find special treatment for time scale encoded in line_chart_v2 a bit
unfortunate but it is the easiest way out for now.
