### PR TITLE
Identify which tensor is too large, when dropping from upload

### DIFF
--- a/tensorboard/plugins/text/text_demo.py
+++ b/tensorboard/plugins/text/text_demo.py
@@ -24,7 +24,7 @@ tf.compat.v1.enable_v2_behavior()
 LOGDIR = "/tmp/text_demo"
 
 # Number of steps for which to write data.
-STEPS = 16
+STEPS = 160
 
 
 def simple_example(step):
@@ -123,8 +123,8 @@ def create_run(logdir, run_name):
                 markdown_table(step)
             with tf.name_scope("higher_order_tensors"):
                 higher_order_tensors(step)
-            with tf.name_scope("simple_example_with_pagination"):
-                simple_example_with_pagination(step)
+            #            with tf.name_scope("simple_example_with_pagination"):
+            #                simple_example_with_pagination(step)
 
     writer.close()
 

--- a/tensorboard/plugins/text/text_demo.py
+++ b/tensorboard/plugins/text/text_demo.py
@@ -24,7 +24,7 @@ tf.compat.v1.enable_v2_behavior()
 LOGDIR = "/tmp/text_demo"
 
 # Number of steps for which to write data.
-STEPS = 160
+STEPS = 16
 
 
 def simple_example(step):
@@ -123,8 +123,8 @@ def create_run(logdir, run_name):
                 markdown_table(step)
             with tf.name_scope("higher_order_tensors"):
                 higher_order_tensors(step)
-            #            with tf.name_scope("simple_example_with_pagination"):
-            #                simple_example_with_pagination(step)
+            with tf.name_scope("simple_example_with_pagination"):
+                simple_example_with_pagination(step)
 
     writer.close()
 

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -795,8 +795,10 @@ class _TensorBatchedRequestSender(object):
         self._tensor_bytes += point.value.ByteSize()
         if point.value.ByteSize() > self._max_tensor_point_size:
             logger.warning(
-                "Tensor too large; skipping. "
+                "Tensor (%s, step: %d) too large; skipping. "
                 "Size %d exceeds limit of %d bytes.",
+                tag_proto.name,
+                event.step,
                 point.value.ByteSize(),
                 self._max_tensor_point_size,
             )


### PR DESCRIPTION
* Motivation for features / changes
When tensor are dropped for being too long, the end-user has no way of identifying which tensor was dropped.  The user needs to know in case it is a critical tensor to their visualizations.  And we'd like to get concrete reports from users about if our current limits work or are too restrictive, so we need users able to say which tensors they needed, and which ones were ok to skip.

* Technical description of changes
Adding additional data to the log message.
Before: "Tensor too large; skipping.  Size NNNNN exceeds limit of 16384 byte."
After "Tensor (name, step: NNN) too large ...."

The line wraps,  it wrapped before though.


* Detailed steps to verify changes work correctly (as executed by you)
Ran a --dry-run before and after

* Alternate designs / implementations considered
None, simple change.