### PR TITLE
sync: fix missing material dependency

### DIFF
--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/BUILD
@@ -23,6 +23,7 @@ tf_ng_module(
     deps = [
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_checkbox",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/core/store",


### PR DESCRIPTION
In OSS, we can depend on `@angular/material` but we cannot do the same
internally. As such, we have a redirection module
(`tensorboard/webapp/angular:expect_*`) and this change uses that.
