### PR TITLE
line chart: implement tooltip sort order

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -112,7 +112,11 @@ limitations under the License.
     ></tb-line-chart>
   </ng-template>
 
-  <ng-template #tooltip let-tooltipData="data">
+  <ng-template
+    #tooltip
+    let-tooltipData="data"
+    let-cursorLoc="cursorLocationInDataCoord"
+  >
     <table class="tooltip">
       <thead>
         <tr>
@@ -127,9 +131,12 @@ limitations under the License.
       </thead>
       <tbody>
         <ng-container
-          *ngFor="let datum of tooltipData; trackBy: trackByTooltipDatum"
+          *ngFor="
+            let datum of getCursorAwareTooltipData(tooltipData, cursorLoc);
+            trackBy: trackByTooltipDatum
+          "
         >
-          <tr class="tooltip-row">
+          <tr class="tooltip-row" [class.closest]="datum.metadata.closest">
             <td class="tooltip-row-circle">
               <span [style.backgroundColor]="datum.metadata.color"></span>
             </td>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -103,10 +103,15 @@ $_title-to-heading-gap: 12px;
 
   .tooltip-row-circle > span {
     border-radius: 50%;
-    border: 1px solid rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.4);
     display: inline-block;
     // Subtract by border width (1px on both sides)
     height: $_circle-size - 2px;
     width: $_circle-size - 2px;
+  }
+
+  .closest .tooltip-row-circle > span {
+    border-color: #fff;
+    box-shadow: inset 0 0 0 1px #fff;
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -214,9 +214,10 @@ export class ScalarCardComponent {
         metadata: {
           ...datum.metadata,
           closest: false,
-          distSqToCursor:
-            (datum.point.x - cursorLoc.x) ** 2 +
-            (datum.point.y - cursorLoc.y) ** 2,
+          distSqToCursor: Math.hypot(
+            datum.point.x - cursorLoc.x,
+            datum.point.y - cursorLoc.y
+          ),
         },
       };
     });

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
@@ -59,7 +59,10 @@ limitations under the License.
   <div class="tooltip-container">
     <ng-container
       [ngTemplateOutlet]="tooltipTemplate ? tooltipTemplate : defaultTooltip"
-      [ngTemplateOutletContext]="{data: cursoredData}"
+      [ngTemplateOutletContext]="{
+        data: cursoredData,
+        cursorLocationInDataCoord: cursorLocationInDataCoord
+      }"
     ></ng-container>
   </div>
 </ng-template>

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -58,8 +58,8 @@ export interface TooltipDatum<
 > {
   id: string;
   metadata: Metadata;
-  closestPointIndex: number | null;
-  point: PointDatum | null;
+  closestPointIndex: number;
+  point: PointDatum;
 }
 
 enum InteractionState {
@@ -78,6 +78,7 @@ export function scrollStrategyFactory(
 }
 
 export interface TooltipTemplateContext {
+  cursorLocationInDataCoord: {x: number; y: number};
   data: TooltipDatum[];
 }
 
@@ -192,7 +193,7 @@ export class LineChartInteractiveViewComponent
     },
   ];
 
-  cursorXLocation: number | null = null;
+  cursorLocationInDataCoord: {x: number; y: number} | null = null;
   cursoredData: TooltipDatum[] = [];
   tooltipDisplayAttached: boolean = false;
 
@@ -438,7 +439,10 @@ export class LineChartInteractiveViewComponent
   }
 
   private updateTooltip(event: MouseEvent) {
-    this.cursorXLocation = this.getDataX(event.offsetX);
+    this.cursorLocationInDataCoord = {
+      x: this.getDataX(event.offsetX),
+      y: this.getDataY(event.offsetY),
+    };
     this.updateCursoredDataAndTooltipVisibility();
   }
 
@@ -447,13 +451,12 @@ export class LineChartInteractiveViewComponent
   }
 
   private updateCursoredDataAndTooltipVisibility() {
-    if (this.cursorXLocation === null) {
+    const cursorLoc = this.cursorLocationInDataCoord;
+    if (cursorLoc === null) {
       this.cursoredData = [];
       this.tooltipDisplayAttached = false;
       return;
     }
-
-    const cursorXLocation = this.cursorXLocation;
 
     this.cursoredData = this.isCursorInside
       ? (this.seriesData
@@ -467,7 +470,7 @@ export class LineChartInteractiveViewComponent
             return metadata && metadata.visible && !Boolean(metadata.aux);
           })
           .map(({seriesDatum, metadata}) => {
-            const index = findClosestIndex(seriesDatum.points, cursorXLocation);
+            const index = findClosestIndex(seriesDatum.points, cursorLoc.x);
             return {
               id: seriesDatum.id,
               closestPointIndex: index,


### PR DESCRIPTION
This change re-implements a feature of vz-line-chart, tooltip sorting.
We sort the tooltip based on few criterions:
- ascending/descending of `y`
- nearest: distance to the cursor
- default: just the order of the runs from... (unclear and it confuses
  people)
