### PR TITLE
line chart: tooltip UX improvements

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -90,8 +90,13 @@ $_title-to-heading-gap: 12px;
 
   $_circle-size: 12px;
 
+  .tooltip-row {
+    white-space: nowrap;
+  }
+
   .tooltip-row-circle {
     align-items: center;
+    display: inline-flex;
     height: $_circle-size;
     width: $_circle-size;
   }

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -150,6 +150,14 @@ export class LineChartInteractiveViewComponent
       originY: 'bottom',
       overlayY: 'top',
     },
+    // bottom, right aligned
+    {
+      offsetY: 5,
+      originX: 'end',
+      overlayX: 'end',
+      originY: 'bottom',
+      overlayY: 'top',
+    },
     // Then top
     {
       offsetY: 5,
@@ -158,11 +166,27 @@ export class LineChartInteractiveViewComponent
       originY: 'top',
       overlayY: 'bottom',
     },
+    // then top, right aligned
+    {
+      offsetX: 5,
+      originX: 'end',
+      overlayX: 'end',
+      originY: 'top',
+      overlayY: 'bottom',
+    },
     // then right
     {
       offsetX: 5,
       originX: 'end',
       overlayX: 'start',
+      originY: 'top',
+      overlayY: 'top',
+    },
+    // then left
+    {
+      offsetX: 5,
+      originX: 'start',
+      overlayX: 'end',
       originY: 'top',
       overlayY: 'top',
     },


### PR DESCRIPTION
- do not wrap tooltip content when there isn't enough space
- vertical align the fob
- reposition tooltip and optionally right align against the chart when
  inconvenient.
