### PR TITLE
line chart: improve interaction

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -22,6 +22,7 @@ tf_ng_module(
         "line_chart_interactive_view.ng.html",
     ],
     deps = [
+        ":internal_types",
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "//tensorboard/webapp/third_party:d3",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
@@ -33,6 +34,12 @@ tf_ng_module(
 )
 
 tf_ts_library(
+    name = "internal_types",
+    srcs = ["internal_types.ts"],
+    visibility = ["//visibility:private"],
+)
+
+tf_ts_library(
     name = "sub_view_tests",
     testonly = True,
     srcs = [
@@ -40,8 +47,10 @@ tf_ts_library(
         "line_chart_grid_view_test.ts",
         "line_chart_interactive_utils_test.ts",
         "line_chart_interactive_view_test.ts",
+        "testing.ts",
     ],
     deps = [
+        ":internal_types",
         ":sub_view",
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "//tensorboard/webapp/angular:expect_angular_core_testing",

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/internal_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/internal_types.ts
@@ -1,0 +1,22 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export enum MouseEventButtons {
+  LEFT = 0b1,
+  RIGHT = 0b10,
+  MIDDLE = 0b100,
+  FOURTH = 0b1000, // often 'back' button, but can differ by mouse controller.
+  FIFTH = 0b100000, // often 'forward' button, but can differ by mouse controller.
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/internal_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/internal_types.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+// From: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
 export enum MouseEventButtons {
   LEFT = 0b1,
   RIGHT = 0b10,

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
@@ -14,7 +14,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<svg #dots class="dots">
+<svg
+  #dots
+  class="dots"
+  [class.pannable]="specialKeyPressed"
+  [class.draggable]="state === InteractionState.NONE || state === InteractionState.DRAG_ZOOMING"
+  [class.panning]="state === InteractionState.PANNING"
+>
   <ng-container *ngIf="state === InteractionState.NONE">
     <ng-container
       *ngFor="let datum of cursoredData; trackBy: trackBySeriesName"

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.scss
@@ -21,6 +21,18 @@ limitations under the License.
 .dots {
   height: 100%;
   width: 100%;
+
+  &.draggable {
+    cursor: crosshair;
+  }
+
+  &.pannable {
+    cursor: grab;
+  }
+
+  &.panning {
+    cursor: grabbing;
+  }
 }
 
 $_circle-size: 12px;

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -234,8 +234,9 @@ export class LineChartInteractiveViewComponent
           ? InteractionState.PANNING
           : InteractionState.DRAG_ZOOMING;
 
-        // In case left down -> middle down, don't override the initial
-        // zoomBoxInUiCoordinate and dragStartCoord.
+        // Override the dragStartCoord and zoomBox only when started to zoom.
+        // For instance, if you press left button then right, drag zoom should start at
+        // the left button down so the second mousedown is ignored.
         if (
           prevState === InteractionState.NONE &&
           nextState === InteractionState.DRAG_ZOOMING

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -47,6 +47,7 @@ import {
   Scale,
 } from '../lib/public_types';
 import {getScaleRangeFromDomDim} from './chart_view_utils';
+import {MouseEventButtons} from './internal_types';
 import {
   findClosestIndex,
   getProposedViewExtentOnZoom,
@@ -138,6 +139,9 @@ export class LineChartInteractiveViewComponent
 
   state: InteractionState = InteractionState.NONE;
 
+  // Whether alt or shiftKey is pressed down.
+  specialKeyPressed: boolean = false;
+
   // Gray box that shows when user drags with mouse down
   zoomBoxInUiCoordinate: Rect = {x: 0, width: 0, height: 0, y: 0};
 
@@ -196,17 +200,47 @@ export class LineChartInteractiveViewComponent
         this.changeDetector.markForCheck();
       });
 
+    fromEvent<MouseEvent>(window, 'keydown', {
+      passive: true,
+    })
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe((event) => {
+        const newState = this.shouldPan(event);
+        if (newState !== this.specialKeyPressed) {
+          this.specialKeyPressed = newState;
+          this.changeDetector.markForCheck();
+        }
+      });
+
+    fromEvent<MouseEvent>(window, 'keyup', {
+      passive: true,
+    })
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe((event) => {
+        const newState = this.shouldPan(event);
+        if (newState !== this.specialKeyPressed) {
+          this.specialKeyPressed = newState;
+          this.changeDetector.markForCheck();
+        }
+      });
+
     fromEvent<MouseEvent>(this.dotsContainer.nativeElement, 'mousedown', {
       passive: true,
     })
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe((event) => {
-        this.state = event.shiftKey
+        const prevState = this.state;
+        const nextState = this.shouldPan(event)
           ? InteractionState.PANNING
           : InteractionState.DRAG_ZOOMING;
-        this.dragStartCoord = {x: event.offsetX, y: event.offsetY};
 
-        if (this.state === InteractionState.DRAG_ZOOMING) {
+        // In case left down -> middle down, don't override the initial
+        // zoomBoxInUiCoordinate and dragStartCoord.
+        if (
+          prevState === InteractionState.NONE &&
+          nextState === InteractionState.DRAG_ZOOMING
+        ) {
+          this.dragStartCoord = {x: event.offsetX, y: event.offsetY};
           this.zoomBoxInUiCoordinate = {
             x: event.offsetX,
             width: 0,
@@ -215,18 +249,24 @@ export class LineChartInteractiveViewComponent
           };
         }
 
-        this.changeDetector.markForCheck();
+        if (prevState !== nextState) {
+          this.state = nextState;
+          this.changeDetector.markForCheck();
+        }
       });
 
     fromEvent<MouseEvent>(this.dotsContainer.nativeElement, 'mouseup', {
       passive: true,
     })
       .pipe(takeUntil(this.ngUnsubscribe))
-      .subscribe(() => {
+      .subscribe((event) => {
+        const leftClicked =
+          (event.buttons & MouseEventButtons.LEFT) === MouseEventButtons.LEFT;
         this.dragStartCoord = null;
 
         const zoomBox = this.zoomBoxInUiCoordinate;
         if (
+          !leftClicked &&
           this.state === InteractionState.DRAG_ZOOMING &&
           zoomBox.width > 0 &&
           zoomBox.height > 0
@@ -371,6 +411,25 @@ export class LineChartInteractiveViewComponent
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  private shouldPan(event: MouseEvent | KeyboardEvent): boolean {
+    const specialKeyEngaged = event.shiftKey || event.altKey;
+
+    if (event instanceof KeyboardEvent) {
+      return specialKeyEngaged;
+    }
+
+    const leftClicked =
+      (event.buttons & MouseEventButtons.LEFT) === MouseEventButtons.LEFT;
+    const middleClicked =
+      (event.buttons & MouseEventButtons.MIDDLE) === MouseEventButtons.MIDDLE;
+
+    // Ignore right/forward/back clicks.
+    if (!leftClicked && !middleClicked) return false;
+    // At this point, either left or middle is clicked, but if both are clicked, left
+    // takes precedence.
+    return (middleClicked && !leftClicked) || specialKeyEngaged;
   }
 
   trackBySeriesName(index: number, datum: TooltipDatum) {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/testing.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/testing.ts
@@ -23,6 +23,11 @@ export enum MouseEventButton {
   FIFTH = 4, // often 'forward' button, but can differ by mouse controller.
 }
 
+/**
+ * Emulates MouseEvent's `button` and `buttons`. When multiple buttons are pressed, do
+ * note that `buttons` have bit-wise union of the keys while `button` has a value
+ * corresponding to the last button pressed.
+ */
 export function createPartialMouseEvent(
   buttonList: MouseEventButtons[]
 ): Partial<MouseEventInit> {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/testing.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/testing.ts
@@ -1,0 +1,56 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {MouseEventButtons} from './internal_types';
+
+export enum MouseEventButton {
+  LEFT = 0,
+  MIDDLE = 1,
+  RIGHT = 2,
+  FOURTH = 3, // often 'back' button, but can differ by mouse controller.
+  FIFTH = 4, // often 'forward' button, but can differ by mouse controller.
+}
+
+export function createPartialMouseEvent(
+  buttonList: MouseEventButtons[]
+): Partial<MouseEventInit> {
+  const lastButton = buttonList[buttonList.length - 1];
+
+  let buttons = 0;
+  for (const button of buttonList) {
+    buttons |= button;
+  }
+
+  let button: number;
+  switch (lastButton) {
+    case MouseEventButtons.LEFT:
+      button = MouseEventButton.LEFT;
+      break;
+    case MouseEventButtons.RIGHT:
+      button = MouseEventButton.RIGHT;
+      break;
+    case MouseEventButtons.MIDDLE:
+      button = MouseEventButton.MIDDLE;
+      break;
+    case MouseEventButtons.FOURTH:
+      button = MouseEventButton.FOURTH;
+      break;
+    case MouseEventButtons.FIFTH:
+      button = MouseEventButton.FIFTH;
+      break;
+  }
+
+  return {button, buttons};
+}


### PR DESCRIPTION
We now allow:
- middle click drag to pan around
- altKey to pan (used to be only shift)
- show cursor according to the internal state
