### PR TITLE
perf: improve graph build performance

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -273,6 +273,11 @@ export const template = html`
 
     /* --- Node label --- */
 
+    #root,
+    .node {
+      will-change: transform;
+    }
+
     .node > text.nodelabel {
       cursor: pointer;
       fill: #444;

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {html} from '@polymer/polymer';
 
+// Please keep node font-size/classnames in sync with tf-graph-common/common.ts
 export const template = html`
   <style>
     :host {

--- a/tensorboard/plugins/graph/tf_graph_common/common.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common.ts
@@ -88,6 +88,22 @@ export let Class = {
   ELLIPSISNODE: 'ellipsis',
 };
 
+// Please keep this in sync with tf-graph-scene.html.ts.
+export const FontSizeInPx: Record<string, Record<string, number>> = {
+  Edge: {
+    LABEL: 3.5,
+  },
+  Annotation: {
+    LABEL: 5,
+  },
+  Node: {
+    EXPANDED_LABEL: 9,
+    SERIES_LABEL: 8,
+    OP_LABEL: 6,
+    HEALTH_PILL_STAT_LABEL: 4,
+  },
+};
+
 export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 
 /**

--- a/tensorboard/plugins/graph/tf_graph_common/layout.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/layout.ts
@@ -187,7 +187,7 @@ export const PARAMS = {
     /** X-space between each annotation-node and its label. */
     labelOffset: 2,
     /** Defines the max width for annotation label */
-    maxLabelWidth: 120,
+    maxLabelWidth: 40,
   },
   constant: {size: {width: 4, height: 4}},
   series: {

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import * as d3 from 'd3';
 import * as _ from 'lodash';
 
-import {Class, selectChild, selectOrCreateChild} from './common';
+import {Class, FontSizeInPx, selectChild, selectOrCreateChild} from './common';
 import * as tf_graph_common from './common';
 import * as contextmenu from './contextmenu';
 import * as edge from './edge';
@@ -432,9 +432,21 @@ function labelBuild(
   // duplicated in styles, we are rounding it to 8px which does not cause any visible
   // jank.
   let fontSize = 8;
+
+  switch (renderNodeInfo.node.type) {
+    case NodeType.META:
+      fontSize = renderNodeInfo.expanded
+        ? FontSizeInPx.Node.EXPANDED_LABEL
+        : FontSizeInPx.Node.SERIES_LABEL;
+      break;
+    case NodeType.OP:
+      fontSize = FontSizeInPx.Node.OP_LABEL;
+      break;
+  }
+
   if (useFontScale) {
     if (text.length > sceneElement.maxMetanodeLabelLength) {
-      text = text.substr(0, sceneElement.maxMetanodeLabelLength - 2) + '...';
+      text = text.substr(0, sceneElement.maxMetanodeLabelLength - 2) + '…';
     }
     let scale = getLabelFontScale(sceneElement);
     label.attr('font-size', scale(text.length) + 'px');
@@ -1399,7 +1411,7 @@ function addAnnotationLabel(
     .attr('dy', '.35em')
     .attr('text-anchor', a.isIn ? 'end' : 'start')
     .text(label);
-  return enforceLabelWidth(txtElement, -1, 8);
+  return enforceLabelWidth(txtElement, -1, FontSizeInPx.Annotation.LABEL);
 }
 function addInteractionForAnnotation(
   selection,

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -320,3 +320,40 @@ export function computeHumanFriendlyTime(timeInMicroseconds: number) {
   }
   return Math.floor(timeDifferenceInMs / 86400000) + ' days ago';
 }
+
+const canvas = document.createElement('canvas');
+const measurerContext = canvas.getContext('2d');
+
+/**
+ * Returns width of `text` rendered with Roboto at provided fontSize.
+ */
+export function measureTextWidth(text: string, fontSize: number): number {
+  measurerContext.font = `${fontSize}px Roboto, sans-serif`;
+  return measurerContext.measureText(text).width;
+}
+
+/**
+ * Returns, if rendered `text` does not fit into maxWidth, truncated string with trailing
+ * ellipsis.
+ */
+export function maybeTruncateString(
+  text: string,
+  fontSize: number,
+  maxWidth: number
+): string {
+  if (measureTextWidth(text, fontSize) <= maxWidth) return text;
+
+  let start = 0;
+  let end = text.length;
+  while (start < end) {
+    const middle = Math.round(start + (end - start) / 2);
+    const substring = text.slice(0, middle) + '…';
+    if (measureTextWidth(substring, fontSize) <= maxWidth) {
+      start = middle;
+    } else {
+      end = middle - 1;
+    }
+  }
+
+  return start === 0 ? text[0] : text.slice(0, start) + '…';
+}

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -346,7 +346,7 @@ export function maybeTruncateString(
   let start = 0;
   let end = text.length;
   while (start < end) {
-    const middle = Math.round(start + (end - start) / 2);
+    const middle = start + Math.round((end - start) / 2);
     const substring = text.slice(0, middle) + '…';
     if (measureTextWidth(substring, fontSize) <= maxWidth) {
       start = middle;

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -341,6 +341,7 @@ export function maybeTruncateString(
   fontSize: number,
   maxWidth: number
 ): string {
+  if (!text) return '';
   if (measureTextWidth(text, fontSize) <= maxWidth) return text;
 
   let start = 0;


### PR DESCRIPTION
Background: since SVG text does not support CSS's
text-overflow:ellipsis, we manually measure the text dimension using
`SVGTextElement.prototype.getComputedTextLength`.

Problem: `getComputedTextLength` causes relayout/restyle which ends up
spending nearly 10ms per operation which is prohibited expensive. This
process is repeated with O(n) and causes larger graph rendering to take
~160s in a text set.

Fix: instead of using SVG's getComputedTextLength, we now use canvas and
its measureText. Do note that we need to know the fontSize and, to
prevent invoking `computedStyle` (which will invoke restyle), we
estimate the fontSize which may cause less than ideal layout.

After the change, we no longer see restyle or relayout in performance
profiling and saw the last render step ("build scene") reduced from 160s
to 700ms (tested with graph.pbtxt that is ~250 MiB).

Do note that we still spend considerable amount of time (80s) on "normalizing
names " which we intend to fix later.

Before:
![image](https://user-images.githubusercontent.com/2547313/102577175-59cb9980-40ac-11eb-92a0-53bdc0de3bc6.png)

After:
![image](https://user-images.githubusercontent.com/2547313/102581972-7bca1980-40b6-11eb-8c89-bb5d14ac8339.png)
