### PR TITLE
cleanup: remove dev print for graph

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -341,7 +341,6 @@ export class RenderGraphInfo {
         proportion: histogram[key] / numItems,
       }));
     }
-    console.info('no pairs found!');
     return null;
   }
   /**


### PR DESCRIPTION
color histograms method spammed "no pairs found" onto console which
makes console quite unusable for a large graph. This change removes it.
