### PR TITLE
Add a lengths argument to tensorboard.summary.audio.

### DIFF
--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -251,37 +251,33 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
             tf2.summary.experimental.set_step(None)
 
     def test_lengths(self):
-        data = np.array([[[1.0], [0.0]], [[1.0], [-1.0]]]).astype(np.float32)
-        lengths = np.array([1, 2]).astype(np.int32)
-        event = self.audio_event("a", data, 44100, step=333, lengths=lengths)
-        self.assertEqual(event.step, 333)
-        self.assertLen(event.summary.value, 1)
-        tensor = tf.io.parse_tensor(
-            event.summary.value[0].tensor.SerializeToString(),
-            out_type=tf.string,
+        data = np.array(
+            [[[1.0], [0.0]], [[1.0], [-1.0]], [[0.0], [0.0]]]
+        ).astype(np.float32)
+        lengths = np.array([1, 2, 0]).astype(np.int32)
+        pb = self.audio(
+            "a", data, 44100, step=333, lengths=lengths, max_outputs=2
         )
+        results = tensor_util.make_ndarray(pb.value[0].tensor)
 
-        self.assertEqual(tensor.shape, [2, 2])
+        self.assertEqual(results.shape, (2, 2))
         # If lengths are respected, the first example will be 2 bytes shorter
         # than the second.
-        self.assertLen(tensor[0, 0].numpy(), 46)
-        self.assertLen(tensor[1, 0].numpy(), 48)
+        self.assertLen(results[0, 0], 46)
+        self.assertLen(results[1, 0], 48)
 
     def test_no_lengths(self):
-        data = np.array([[[1.0], [0.0]], [[1.0], [-1.0]]]).astype(np.float32)
-        event = self.audio_event("a", data, 44100, step=333, lengths=None)
-        self.assertEqual(event.step, 333)
-        self.assertLen(event.summary.value, 1)
-        tensor = tf.io.parse_tensor(
-            event.summary.value[0].tensor.SerializeToString(),
-            out_type=tf.string,
-        )
+        data = np.array(
+            [[[1.0], [0.0]], [[1.0], [-1.0]], [[0.0], [0.0]]]
+        ).astype(np.float32)
+        pb = self.audio("a", data, 44100, step=333, lengths=None, max_outputs=2)
+        results = tensor_util.make_ndarray(pb.value[0].tensor)
 
-        self.assertEqual(tensor.shape, [2, 2])
+        self.assertEqual(results.shape, (2, 2))
         # If no lengths are provided, both examples contain all samples in the
         # dense tensor.
-        self.assertLen(tensor[0, 0].numpy(), 48)
-        self.assertLen(tensor[1, 0].numpy(), 48)
+        self.assertLen(results[0, 0], 48)
+        self.assertLen(results[1, 0], 48)
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -49,14 +49,15 @@ def audio(
         be this name prefixed by any active name scopes.
       data: A `Tensor` representing audio data with shape `[k, t, c]`,
         where `k` is the number of audio clips, `t` is the number of
-        frames, and `c` is the number of channels. Elements should be
-        floating-point values in `[-1.0, 1.0]`. Any of the dimensions may
-        be statically unknown (i.e., `None`).
+        frames, and `c` is the number of channels. To pass batches of data where
+        the frame count is variable, use the `lengths` parameter. Elements
+        should be floating-point values in `[-1.0, 1.0]`. Any of the dimensions
+        may be statically unknown (i.e., `None`).
       sample_rate: An `int` or rank-0 `int32` `Tensor` that represents the
         sample rate, in Hz. Must be positive.
       step: Explicit `int64`-castable monotonic step value for this summary. If
-        omitted, this defaults to `tf.summary.experimental.get_step()`, which must
-        not be None.
+        omitted, this defaults to `tf.summary.experimental.get_step()`, which
+        must not be None.
       max_outputs: Optional `int` or rank-0 integer `Tensor`. At most this
         many audio clips will be emitted at each step. When more than
         `max_outputs` many clips are provided, the first `max_outputs`
@@ -67,8 +68,10 @@ def audio(
       description: Optional long-form description for this summary, as a
         constant `str`. Markdown is supported. Defaults to empty.
       lengths: Optional lengths `Tensor`, shaped `[k]`, where each entry
-        indicates the length of the k'th example in frames. k may be statically
-        unknown (i.e., `None`).
+        indicates the length of the k'th example in frames. Useful when `data`
+        should be interpreted as ragged rather than fixed-length; each example
+        will be truncated accordingly prior to audio encoding. k may be
+        statically unknown (i.e., `None`).
 
     Returns:
       True on success, or false if no summary was emitted because no default

--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -115,8 +115,8 @@ def audio(
                 tf.debugging.assert_rank(lengths, 1)
                 limited_lengths = lengths[:max_outputs]
 
-                def encode_with_length(datum_length):
-                    datum, length = datum_length
+                def encode_with_length(datum_and_length):
+                    datum, length = datum_and_length
                     return encode_fn(datum[:length])
 
                 encoded_audio = tf.map_fn(

--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -40,6 +40,7 @@ def audio(
     max_outputs=3,
     encoding=None,
     description=None,
+    lengths=None,
 ):
     """Write an audio summary.
 
@@ -65,6 +66,9 @@ def audio(
         default, so if you want "wav" in particular, set this explicitly.
       description: Optional long-form description for this summary, as a
         constant `str`. Markdown is supported. Defaults to empty.
+      lengths: Optional lengths `Tensor`, shaped `[k]`, where each entry
+        indicates the length of the k'th example in frames. k may be statically
+        unknown (i.e., `None`).
 
     Returns:
       True on success, or false if no summary was emitted because no default
@@ -88,7 +92,7 @@ def audio(
         description=description,
         encoding=metadata.Encoding.Value("WAV"),
     )
-    inputs = [data, sample_rate, max_outputs, step]
+    inputs = [data, sample_rate, max_outputs, step, lengths]
     # TODO(https://github.com/tensorflow/tensorboard/issues/2109): remove fallback
     summary_scope = (
         getattr(tf.summary.experimental, "summary_scope", None)
@@ -103,15 +107,31 @@ def audio(
             tf.debugging.assert_rank(data, 3)
             tf.debugging.assert_non_negative(max_outputs)
             limited_audio = data[:max_outputs]
+
             encode_fn = functools.partial(
                 audio_ops.encode_wav, sample_rate=sample_rate
             )
-            encoded_audio = tf.map_fn(
-                encode_fn,
-                limited_audio,
-                dtype=tf.string,
-                name="encode_each_audio",
-            )
+            if lengths is not None:
+                tf.debugging.assert_rank(lengths, 1)
+                limited_lengths = lengths[:max_outputs]
+
+                def encode_with_length(datum_length):
+                    datum, length = datum_length
+                    return encode_fn(datum[:length])
+
+                encoded_audio = tf.map_fn(
+                    encode_with_length,
+                    (limited_audio, limited_lengths),
+                    dtype=tf.string,
+                    name="encode_each_audio",
+                )
+            else:
+                encoded_audio = tf.map_fn(
+                    encode_fn,
+                    limited_audio,
+                    dtype=tf.string,
+                    name="encode_each_audio",
+                )
             # Workaround for map_fn returning float dtype for an empty elems input.
             encoded_audio = tf.cond(
                 tf.shape(input=encoded_audio)[0] > 0,


### PR DESCRIPTION
* Motivation for features / changes

Audio summaries have always assumed that examples in the dense
tensor shaped [batch_size, num_frames, num_channels] all have the same
length. This is frequently not the case when building audio models, such as
text-to-speech models, where the output length of the model varies per batch
item. When ragged tensors of substantially different shapes are batched
together, this can be wasteful. Additionally, the padding after the end of each
record is included in the resulting WAV file, which is misleading because these
samples were not present in the source signal. The consumer of the audio summary
has no way to determine what the original true lengths of each example were.

* Technical description of changes

This change adds a lengths keyword argument to tensorboard.summary.audio, which
allows the caller to indicate the per-batch-item lengths of each signal in the
dense input tensor.

* Screenshots of UI changes

No UI changes -- adds keyword argument to tensorboard.summary.audio.

* Detailed steps to verify changes work correctly (as executed by you)

Run unit tests.

* Alternate designs / implementations considered

Support `tf.RaggedTensor` instead of adding a lengths argument. RaggedTensor is fairly new and adoption is low, so it would be nice to meet users where they are. I think RaggedTensor support would be a great future improvement.