### PR TITLE
py3: remove `__future__` imports

### DIFF
--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """TensorBoard is a webapp for understanding TensorFlow runs and graphs."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import lazy as _lazy
 from tensorboard import version as _version

--- a/tensorboard/__main__.py
+++ b/tensorboard/__main__.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Module that allows the user to run `python -m tensorboard`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import main as _main
 

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Unit tests for application package."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 

--- a/tensorboard/backend/empty_path_redirect.py
+++ b/tensorboard/backend/empty_path_redirect.py
@@ -25,10 +25,6 @@ This middleware respects `SCRIPT_NAME` as described by the WSGI spec. If
 the actual path "/foo", and so will be redirected to "/foo/".
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 class EmptyPathRedirectMiddleware(object):
     """WSGI middleware to redirect from "" to "/"."""

--- a/tensorboard/backend/empty_path_redirect_test.py
+++ b/tensorboard/backend/empty_path_redirect_test.py
@@ -14,10 +14,6 @@
 # ==============================================================================
 """Tests for `tensorboard.backend.empty_path_redirect`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 import werkzeug
 from werkzeug import test as werkzeug_test

--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Bridge from event multiplexer storage to generic data APIs."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import base64
 import json

--- a/tensorboard/backend/event_processing/data_provider_test.py
+++ b/tensorboard/backend/event_processing/data_provider_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Unit tests for `tensorboard.backend.event_processing.data_provider`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/backend/event_processing/directory_loader.py
+++ b/tensorboard/backend/event_processing/directory_loader.py
@@ -15,9 +15,6 @@
 
 """Implementation for a multi-file directory loader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import io_wrapper

--- a/tensorboard/backend/event_processing/directory_loader_test.py
+++ b/tensorboard/backend/event_processing/directory_loader_test.py
@@ -15,9 +15,6 @@
 
 """Tests for directory_loader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import glob

--- a/tensorboard/backend/event_processing/directory_watcher.py
+++ b/tensorboard/backend/event_processing/directory_watcher.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 
 """Contains the implementation for the DirectoryWatcher class."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import bisect
 

--- a/tensorboard/backend/event_processing/directory_watcher_test.py
+++ b/tensorboard/backend/event_processing/directory_watcher_test.py
@@ -15,9 +15,6 @@
 
 """Tests for directory_watcher."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import shutil

--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Takes a generator of values, and accumulates them for a frontend."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import threading

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/backend/event_processing/event_file_inspector.py
+++ b/tensorboard/backend/event_processing/event_file_inspector.py
@@ -108,9 +108,6 @@ histograms
    outoforder_steps     []
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import itertools

--- a/tensorboard/backend/event_processing/event_file_inspector_test.py
+++ b/tensorboard/backend/event_processing/event_file_inspector_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import shutil

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 
 """Functionality for loading events from a record file."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import contextlib
 

--- a/tensorboard/backend/event_processing/event_file_loader_test.py
+++ b/tensorboard/backend/event_processing/event_file_loader_test.py
@@ -15,9 +15,6 @@
 
 """Tests for event_file_loader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import abc
 import io

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Provides an interface for working with multiple event files."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import threading

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import os.path

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """IO helper functions."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import os

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import tempfile

--- a/tensorboard/backend/event_processing/plugin_asset_util.py
+++ b/tensorboard/backend/event_processing/plugin_asset_util.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Load plugin assets from disk."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os.path
 

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Takes a generator of values, and accumulates them for a frontend."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import threading

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Provides an interface for working with multiple event files."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import threading

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import os.path

--- a/tensorboard/backend/event_processing/reservoir.py
+++ b/tensorboard/backend/event_processing/reservoir.py
@@ -15,9 +15,6 @@
 
 """A key-value[] store that implements reservoir sampling on the values."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import random

--- a/tensorboard/backend/event_processing/reservoir_test.py
+++ b/tensorboard/backend/event_processing/reservoir_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf

--- a/tensorboard/backend/experiment_id.py
+++ b/tensorboard/backend/experiment_id.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Application-level experiment ID support."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import re
 

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for `tensorboard.backend.experiment_id`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 

--- a/tensorboard/backend/experimental_plugin.py
+++ b/tensorboard/backend/experimental_plugin.py
@@ -17,10 +17,6 @@
 Contains the mechanism for marking plugins as experimental.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 class ExperimentalPlugin(object):
     """A marker class used to annotate a plugin as experimental.

--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -14,10 +14,6 @@
 # ==============================================================================
 """TensorBoard HTTP utilities."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import gzip
 import json

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -15,10 +15,6 @@
 # ==============================================================================
 """Tests HTTP utilities."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import gzip
 import struct

--- a/tensorboard/backend/json_util.py
+++ b/tensorboard/backend/json_util.py
@@ -23,9 +23,6 @@ Neither subclassing JSONEncoder nor passing a function in the |default|
 keyword argument overrides this.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import math

--- a/tensorboard/backend/json_util_test.py
+++ b/tensorboard/backend/json_util_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import string

--- a/tensorboard/backend/path_prefix.py
+++ b/tensorboard/backend/path_prefix.py
@@ -19,9 +19,6 @@ Using a path prefix of `/foo/bar` enables TensorBoard to serve from
 See the `--path_prefix` flag docs for more details.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import errors
 

--- a/tensorboard/backend/path_prefix_test.py
+++ b/tensorboard/backend/path_prefix_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for `tensorboard.backend.path_prefix`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 

--- a/tensorboard/backend/process_graph.py
+++ b/tensorboard/backend/process_graph.py
@@ -18,11 +18,6 @@ Used by both TensorBoard and mldash.
 """
 
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-
 def prepare_graph_for_ui(
     graph, limit_attr_size=1024, large_attrs_key="_too_large_attrs"
 ):

--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Validates responses and their security features."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 

--- a/tensorboard/backend/security_validator_test.py
+++ b/tensorboard/backend/security_validator_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for `tensorboard.backend.security_validator`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 try:
     # python version >= 3.3

--- a/tensorboard/compat/__init__.py
+++ b/tensorboard/compat/__init__.py
@@ -19,10 +19,6 @@ APIs, as lazily loaded imports to help avoid circular dependency issues
 and defer the search and loading of the module until necessary.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 import tensorboard.lazy as _lazy
 

--- a/tensorboard/compat/proto/proto_test.py
+++ b/tensorboard/compat/proto/proto_test.py
@@ -19,9 +19,6 @@ as those available directly from TensorFlow. Local protos are used to
 build `tensorboard-notf` without a TensorFlow dependency.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import difflib
 import importlib

--- a/tensorboard/compat/tensorflow_stub/__init__.py
+++ b/tensorboard/compat/tensorflow_stub/__init__.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto.config_pb2 import *  # noqa
 from tensorboard.compat.proto.event_pb2 import *  # noqa

--- a/tensorboard/compat/tensorflow_stub/app.py
+++ b/tensorboard/compat/tensorflow_stub/app.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 
 """Generic entry point script."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import errno as _errno
 import sys as _sys

--- a/tensorboard/compat/tensorflow_stub/compat/__init__.py
+++ b/tensorboard/compat/tensorflow_stub/compat/__init__.py
@@ -27,9 +27,6 @@ The compatibility module also provides the following types:
 * `real_types`
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numbers as _numbers
 import numpy as _np

--- a/tensorboard/compat/tensorflow_stub/compat/v1/__init__.py
+++ b/tensorboard/compat/tensorflow_stub/compat/v1/__init__.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # Set this in tensorboard/compat/tensorflow_stub/__init__.py to eliminate
 # any cycles on import

--- a/tensorboard/compat/tensorflow_stub/dtypes.py
+++ b/tensorboard/compat/tensorflow_stub/dtypes.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Library of dtypes (Tensor element types)."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/compat/tensorflow_stub/errors.py
+++ b/tensorboard/compat/tensorflow_stub/errors.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Exception types for TensorFlow errors."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import traceback
 import warnings

--- a/tensorboard/compat/tensorflow_stub/flags.py
+++ b/tensorboard/compat/tensorflow_stub/flags.py
@@ -17,9 +17,6 @@
 
 See https://github.com/abseil/abseil-py.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import logging as _logging
 import sys as _sys

--- a/tensorboard/compat/tensorflow_stub/io/__init__.py
+++ b/tensorboard/compat/tensorflow_stub/io/__init__.py
@@ -13,8 +13,5 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from . import gfile  # noqa

--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -19,9 +19,6 @@ pure Python implementation, limited to the features required for
 TensorBoard.  This allows running TensorBoard without depending on
 TensorFlow for file operations.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple
 import glob as py_glob

--- a/tensorboard/compat/tensorflow_stub/io/gfile_s3_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_s3_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import boto3
 import os

--- a/tensorboard/compat/tensorflow_stub/io/gfile_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import io
 import os

--- a/tensorboard/compat/tensorflow_stub/io/gfile_tf_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_tf_test.py
@@ -15,9 +15,6 @@
 # =============================================================================
 """Testing File IO operations in gfile.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os.path
 

--- a/tensorboard/compat/tensorflow_stub/pywrap_tensorflow.py
+++ b/tensorboard/compat/tensorflow_stub/pywrap_tensorflow.py
@@ -14,9 +14,6 @@
 # =============================================================================
 """A wrapper for TensorFlow SWIG-generated bindings."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import array
 import struct

--- a/tensorboard/compat/tensorflow_stub/tensor_shape.py
+++ b/tensorboard/compat/tensorflow_stub/tensor_shape.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Helper classes for tensor shape inference."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from . import compat, dtypes
 from tensorboard.compat.proto import tensor_shape_pb2

--- a/tensorboard/data/__init__.py
+++ b/tensorboard/data/__init__.py
@@ -13,8 +13,5 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.data import experimental  # noqa: F401

--- a/tensorboard/data/experimental/__init__.py
+++ b/tensorboard/data/experimental/__init__.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.data.experimental.experiment_from_dev import (  # noqa: F401
     ExperimentFromDev,

--- a/tensorboard/data/experimental/base_experiment.py
+++ b/tensorboard/data/experimental/base_experiment.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Base Class of Experiment Data Access API."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import abc
 

--- a/tensorboard/data/experimental/experiment_from_dev.py
+++ b/tensorboard/data/experimental/experiment_from_dev.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Experiment Data Access API for tensorboard.dev."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import sys
 import time

--- a/tensorboard/data/experimental/experiment_from_dev_test.py
+++ b/tensorboard/data/experimental/experiment_from_dev_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.exporter."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from unittest import mock
 

--- a/tensorboard/data/experimental/test_binary.py
+++ b/tensorboard/data/experimental/test_binary.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """A test binary that can be used to test ExperimentFromDev features."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Experimental framework for generic TensorBoard data providers."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import abc
 

--- a/tensorboard/data/provider_test.py
+++ b/tensorboard/data/provider_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Unit tests for `tensorboard.data.provider`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import six

--- a/tensorboard/data_compat.py
+++ b/tensorboard/data_compat.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Utilities to migrate legacy protos to their modern equivalents."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf

--- a/tensorboard/dataclass_compat.py
+++ b/tensorboard/dataclass_compat.py
@@ -21,9 +21,6 @@ field and makes any necessary transformations to the tensor value. For
 This should be effected after the `data_compat` transformation.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import summary_pb2

--- a/tensorboard/dataclass_compat_test.py
+++ b/tensorboard/dataclass_compat_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for `tensorboard.dataclass_compat`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -24,9 +24,6 @@ automatically inherit the centrally-maintained list of standard plugins,
 for less repetition.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import logging
 

--- a/tensorboard/default_test.py
+++ b/tensorboard/default_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Unit tests for `tensorboard.default`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 try:
     # python version >= 3.3

--- a/tensorboard/defs/tb_proto_library_test.py
+++ b/tensorboard/defs/tb_proto_library_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for the `tb_proto_library` build macro."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import test as tb_test
 from tensorboard.defs import test_base_pb2

--- a/tensorboard/encode_png_benchmark.py
+++ b/tensorboard/encode_png_benchmark.py
@@ -41,9 +41,6 @@ twelve threads.
 The above numbers are consistent across runs, within about 5%.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import datetime
 import threading

--- a/tensorboard/errors.py
+++ b/tensorboard/errors.py
@@ -24,10 +24,6 @@ response with the error message.
 [1]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 class PublicError(RuntimeError):
     """An error whose text does not contain sensitive information.

--- a/tensorboard/errors_test.py
+++ b/tensorboard/errors_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.errors."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import errors
 from tensorboard import test as tb_test

--- a/tensorboard/examples/plugins/example_basic/setup.py
+++ b/tensorboard/examples/plugins/example_basic/setup.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import setuptools
 

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/demo.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/demo.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Demo code."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl import app
 import tensorflow as tf

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/metadata.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/metadata.py
@@ -14,9 +14,5 @@
 # ==============================================================================
 """Plugin-specific global metadata."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 PLUGIN_NAME = "example_basic"

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """A sample plugin to demonstrate dynamic loading."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 import os

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/summary_v2.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/summary_v2.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Summaries for the example_basic plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow.compat.v2 as tf
 from tensorboard.compat.proto import summary_pb2

--- a/tensorboard/examples/plugins/example_raw_scalars/setup.py
+++ b/tensorboard/examples/plugins/example_raw_scalars/setup.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import setuptools
 

--- a/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/demo.py
+++ b/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/demo.py
@@ -19,9 +19,6 @@ After installing the plugin (`python setup.py develop`), you can run TensorBoard
 with logdir set to the `demo_logs` directory.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import math
 

--- a/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/plugin.py
+++ b/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """A sample plugin to demonstrate reading scalars."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import mimetypes
 import os

--- a/tensorboard/functionaltests/core_test.py
+++ b/tensorboard/functionaltests/core_test.py
@@ -14,9 +14,6 @@
 
 """Basic TensorBoard functional tests using WebDriver."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import os

--- a/tensorboard/lazy.py
+++ b/tensorboard/lazy.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """TensorBoard is a webapp for understanding TensorFlow runs and graphs."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import threading

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Unit tests for the `tensorboard.lazy` module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import six
 import unittest

--- a/tensorboard/lib_test.py
+++ b/tensorboard/lib_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from six import moves
 import sys

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -21,10 +21,6 @@ wishing to customize the set of plugins or static assets that
 TensorBoard uses can swap out this file with their own.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 import os
 

--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Private utilities for managing multiple TensorBoard processes."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import base64
 import collections

--- a/tensorboard/manager_e2e_test.py
+++ b/tensorboard/manager_e2e_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """End-to-end tests for `tensorboard.manager`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import contextlib
 import datetime

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Unit tests for `tensorboard.manager`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import datetime
 import errno

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -16,9 +16,6 @@
 These APIs are experimental and subject to change.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import datetime
 import errno

--- a/tensorboard/pip_package/deterministic_tar_gz.py
+++ b/tensorboard/pip_package/deterministic_tar_gz.py
@@ -32,9 +32,6 @@ Some differences from `tar czf ARCHIVE [FILES]...`:
 See <https://reproducible-builds.org/docs/archives/>.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import gzip

--- a/tensorboard/pip_package/deterministic_tar_gz_test.py
+++ b/tensorboard/pip_package/deterministic_tar_gz_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """End-to-end tests for the `deterministic_tar_gz` tool."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import gzip
 import os

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from setuptools import find_packages, setup
 

--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Provides utilities that may be especially useful to plugins."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import threading
 

--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import textwrap
 

--- a/tensorboard/plugins/audio/audio_demo.py
+++ b/tensorboard/plugins/audio/audio_demo.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Sample data exhibiting audio summaries, via a waveform generator."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import inspect
 import math

--- a/tensorboard/plugins/audio/audio_plugin.py
+++ b/tensorboard/plugins/audio/audio_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The TensorBoard Audio plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from six.moves import urllib
 from werkzeug import wrappers

--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests the Tensorboard audio plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import json

--- a/tensorboard/plugins/audio/metadata.py
+++ b/tensorboard/plugins/audio/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Internal information about the audio plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.audio import plugin_data_pb2

--- a/tensorboard/plugins/audio/summary.py
+++ b/tensorboard/plugins/audio/summary.py
@@ -24,9 +24,6 @@ NOTE: This module is in beta, and its API is subject to change, but the
 data that it stores to disk will be supported forever.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import warnings

--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Tests for the audio plugin summary generation functions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import glob
 import os

--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -21,9 +21,6 @@ a binary string whose encoding is specified in the summary metadata, and
 `label` is a UTF-8 encoded Markdown string describing the audio clip.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -18,9 +18,6 @@ Every plugin in TensorBoard must extend and implement the abstract
 methods of this base class.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import six
 

--- a/tensorboard/plugins/base_plugin_test.py
+++ b/tensorboard/plugins/base_plugin_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for `tensorboard.plugins.base_plugin`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import test as tb_test
 from tensorboard.plugins import base_plugin

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """TensorBoard core plugin package."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import gzip

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests the TensorBoard core endpoints."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import contextlib

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -18,9 +18,6 @@ The logic below logs scalar data and then lays out the custom scalars
 dashboard.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -21,9 +21,6 @@ See `http_api.md` in this directory for specifications of the routes for
 this plugin.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import re
 

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the Custom Scalars Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import csv
 import io

--- a/tensorboard/plugins/custom_scalar/metadata.py
+++ b/tensorboard/plugins/custom_scalar/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Information on the custom scalars plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 

--- a/tensorboard/plugins/custom_scalar/summary.py
+++ b/tensorboard/plugins/custom_scalar/summary.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Contains summaries related to laying out the custom scalars dashboard."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.plugins.custom_scalar import layout_pb2
 from tensorboard.plugins.custom_scalar import metadata

--- a/tensorboard/plugins/custom_scalar/summary_test.py
+++ b/tensorboard/plugins/custom_scalar/summary_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for the layout module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow as tf
 

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """A wrapper around DebugDataReader used for retrieving tfdbg v2 data."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import threading
 

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer_test.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import threading
 import time

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The TensorBoard Debugger V2 plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from werkzeug import wrappers
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for Debugger V2 Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import json

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/extract_dtypes_from_python.py
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/extract_dtypes_from_python.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Used in genrule to convert dtype type info from Python to TypeScript."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 import sys

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inline_images.py
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inline_images.py
@@ -19,9 +19,6 @@ base64-encoded image content of the corresopnding .png files in the images/
 subdirectory.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import base64
 import os

--- a/tensorboard/plugins/distribution/compressor.py
+++ b/tensorboard/plugins/distribution/compressor.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Package for histogram compression."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 

--- a/tensorboard/plugins/distribution/compressor_test.py
+++ b/tensorboard/plugins/distribution/compressor_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow as tf
 

--- a/tensorboard/plugins/distribution/distributions_plugin.py
+++ b/tensorboard/plugins/distribution/distributions_plugin.py
@@ -18,9 +18,6 @@ See `http_api.md` in this directory for specifications of the routes for
 this plugin.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from werkzeug import wrappers
 

--- a/tensorboard/plugins/distribution/distributions_plugin_test.py
+++ b/tensorboard/plugins/distribution/distributions_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the Distributions Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import os.path

--- a/tensorboard/plugins/distribution/metadata.py
+++ b/tensorboard/plugins/distribution/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Information on the distributions plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # This name is used as the plugin prefix route and to identify this plugin
 # generally.

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The TensorBoard Graphs plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 from werkzeug import wrappers

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the Graphs Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import math

--- a/tensorboard/plugins/graph/graphs_plugin_v2_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_v2_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Integration tests for the Graphs Plugin for TensorFlow v2."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import os.path

--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for Keras Utility."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 

--- a/tensorboard/plugins/graph/metadata.py
+++ b/tensorboard/plugins/graph/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Information on the graph plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # This name is used as the plugin prefix route and to identify this plugin
 # generally, and is also the `plugin_name` for run graphs after data-compat

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Sample data exhibiting histogram summaries."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -18,9 +18,6 @@ See `http_api.md` in this directory for specifications of the routes for
 this plugin.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import random
 

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the Histograms Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import os.path

--- a/tensorboard/plugins/histogram/metadata.py
+++ b/tensorboard/plugins/histogram/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Information about histogram summaries."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.histogram import plugin_data_pb2

--- a/tensorboard/plugins/histogram/summary.py
+++ b/tensorboard/plugins/histogram/summary.py
@@ -28,9 +28,6 @@ NOTE: This module is in beta, and its API is subject to change, but the
 data that it stores to disk will be supported forever.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Tests for the histogram plugin summary generation functions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import glob
 import os

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -25,9 +25,6 @@ have the same value, then there is one bucket whose left and right
 endpoints are the same (the shape is `[1, 3]`).
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -128,8 +128,5 @@ hparams_config_pb = summary_v2.hparams_config_pb
 KerasCallback = keras.Callback
 
 
-del absolute_import
-del division
 del keras
-del print_function
 del summary_v2

--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -109,9 +109,6 @@ for API specifications. Consult the `hparams_demo.py` script in the
 TensorBoard repository for an end-to-end MNIST example.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.plugins.hparams import keras
 from tensorboard.plugins.hparams import summary_v2

--- a/tensorboard/plugins/hparams/api_test.py
+++ b/tensorboard/plugins/hparams/api_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import test
 from tensorboard.plugins.hparams import api

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -15,9 +15,6 @@
 """Wraps the base_plugin.TBContext to stores additional data shared across API
 handlers for the HParams plugin backend."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import os

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for backend_context."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import operator
 

--- a/tensorboard/plugins/hparams/download_data.py
+++ b/tensorboard/plugins/hparams/download_data.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Classes and functions for handling the DownloadData API call."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import csv
 import math

--- a/tensorboard/plugins/hparams/download_data_test.py
+++ b/tensorboard/plugins/hparams/download_data_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for download_data."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 try:
     # python version >= 3.3

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -14,10 +14,6 @@
 # ==============================================================================
 """Classes and functions for handling the GetExperiment API call."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 from tensorboard.plugins.hparams import error
 

--- a/tensorboard/plugins/hparams/hparams_demo.py
+++ b/tensorboard/plugins/hparams/hparams_demo.py
@@ -19,9 +19,6 @@ runs much faster, using synthetic data instead of actually training
 MNIST models.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os.path
 import random

--- a/tensorboard/plugins/hparams/hparams_minimal_demo.py
+++ b/tensorboard/plugins/hparams/hparams_minimal_demo.py
@@ -25,9 +25,6 @@ trains real MNIST models instead of using synthetic data, at the cost of
 taking much longer to run.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import hashlib
 import math

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -18,9 +18,6 @@ See `http_api.md` in this directory for specifications of the routes for
 this plugin.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 

--- a/tensorboard/plugins/hparams/hparams_util.py
+++ b/tensorboard/plugins/hparams/hparams_util.py
@@ -39,9 +39,6 @@ hparams_util \
      --status=<A string containing a member of the Status protobuffer enum>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import getpass
 import time

--- a/tensorboard/plugins/hparams/keras.py
+++ b/tensorboard/plugins/hparams/keras.py
@@ -18,9 +18,6 @@ Most users should use `tensorboard.plugins.hparams.api` to access this
 module's contents.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow as tf
 

--- a/tensorboard/plugins/hparams/keras_test.py
+++ b/tensorboard/plugins/hparams/keras_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/plugins/hparams/list_metric_evals.py
+++ b/tensorboard/plugins/hparams/list_metric_evals.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Classes and functions for handling the ListMetricEvals API call."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.plugins.hparams import metrics
 from tensorboard.plugins.scalar import scalars_plugin

--- a/tensorboard/plugins/hparams/list_metric_evals_test.py
+++ b/tensorboard/plugins/hparams/list_metric_evals_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for list_metric_evals."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 try:
     # python version >= 3.3

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Classes and functions for handling the ListSessionGroups API call."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import operator

--- a/tensorboard/plugins/hparams/list_session_groups_test.py
+++ b/tensorboard/plugins/hparams/list_session_groups_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for list_session_groups."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import operator
 

--- a/tensorboard/plugins/hparams/metadata.py
+++ b/tensorboard/plugins/hparams/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Constants used in the HParams plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.compat.proto import types_pb2

--- a/tensorboard/plugins/hparams/metrics.py
+++ b/tensorboard/plugins/hparams/metrics.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Functions for dealing with metrics."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/plugins/hparams/summary.py
+++ b/tensorboard/plugins/hparams/summary.py
@@ -31,9 +31,6 @@ Typical usage for exporting summaries in a hyperparameters-tuning experiment:
    summary into the same session run <session_name>.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import time
 

--- a/tensorboard/plugins/hparams/summary_test.py
+++ b/tensorboard/plugins/hparams/summary_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for summary."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow as tf
 from google.protobuf import struct_pb2

--- a/tensorboard/plugins/hparams/summary_v2.py
+++ b/tensorboard/plugins/hparams/summary_v2.py
@@ -17,9 +17,6 @@
 These are porcelain on top of `api_pb2` (`api.proto`) and `summary.py`.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import abc
 import hashlib

--- a/tensorboard/plugins/hparams/summary_v2_test.py
+++ b/tensorboard/plugins/hparams/summary_v2_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import random

--- a/tensorboard/plugins/image/images_demo.py
+++ b/tensorboard/plugins/image/images_demo.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Sample image summaries exhibiting some interesting convolutions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl import app
 from absl import logging

--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The TensorBoard Images plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import imghdr
 

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests the Tensorboard images plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import json

--- a/tensorboard/plugins/image/metadata.py
+++ b/tensorboard/plugins/image/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Internal information about the images plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.image import plugin_data_pb2

--- a/tensorboard/plugins/image/summary.py
+++ b/tensorboard/plugins/image/summary.py
@@ -21,9 +21,6 @@ NOTE: This module is in beta, and its API is subject to change, but the
 data that it stores to disk will be supported forever.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Tests for the image plugin summary generation functions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import glob
 import os

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -18,9 +18,6 @@ An image summary stores the width, height, and PNG-encoded data for zero
 or more images in a rank-1 string array: `[w, h, png0, png1, ...]`.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat import tf2 as tf
 from tensorboard.plugins.image import metadata

--- a/tensorboard/plugins/mesh/demo_utils.py
+++ b/tensorboard/plugins/mesh/demo_utils.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Utils used for the mesh demo."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf

--- a/tensorboard/plugins/mesh/demo_utils_test.py
+++ b/tensorboard/plugins/mesh/demo_utils_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for demo utils functions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/plugins/mesh/mesh_demo.py
+++ b/tensorboard/plugins/mesh/mesh_demo.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Simple demo which displays constant 3D mesh."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 
 from absl import app

--- a/tensorboard/plugins/mesh/mesh_demo_v2.py
+++ b/tensorboard/plugins/mesh/mesh_demo_v2.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Simple demo which displays constant 3D mesh."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 
 from absl import app

--- a/tensorboard/plugins/mesh/mesh_plugin.py
+++ b/tensorboard/plugins/mesh/mesh_plugin.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """TensorBoard 3D mesh visualizer plugin."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import six

--- a/tensorboard/plugins/mesh/mesh_plugin_test.py
+++ b/tensorboard/plugins/mesh/mesh_plugin_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Tests the Tensorboard mesh plugin."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import os

--- a/tensorboard/plugins/mesh/metadata.py
+++ b/tensorboard/plugins/mesh/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Internal information about the mesh plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 from tensorboard.compat.proto import summary_pb2

--- a/tensorboard/plugins/mesh/metadata_test.py
+++ b/tensorboard/plugins/mesh/metadata_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for util functions to create/parse mesh plugin metadata."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from mock import patch
 import six

--- a/tensorboard/plugins/mesh/summary.py
+++ b/tensorboard/plugins/mesh/summary.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Mesh summaries and TensorFlow operations to create them."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 import tensorflow as tf

--- a/tensorboard/plugins/mesh/summary_test.py
+++ b/tensorboard/plugins/mesh/summary_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for tensorboard.plugins.mesh.summary."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 import tensorflow as tf

--- a/tensorboard/plugins/mesh/summary_v2.py
+++ b/tensorboard/plugins/mesh/summary_v2.py
@@ -16,9 +16,6 @@
 
 V2 versions
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 

--- a/tensorboard/plugins/mesh/summary_v2_test.py
+++ b/tensorboard/plugins/mesh/summary_v2_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for tensorboard.plugins.mesh.summary."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import glob
 import json

--- a/tensorboard/plugins/mesh/test_utils.py
+++ b/tensorboard/plugins/mesh/test_utils.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Test utils for mesh plugin tests."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import json

--- a/tensorboard/plugins/metrics/metadata.py
+++ b/tensorboard/plugins/metrics/metadata.py
@@ -14,9 +14,5 @@
 # ==============================================================================
 """Internal information about the metrics plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 PLUGIN_NAME = "timeseries"

--- a/tensorboard/plugins/metrics/metrics_loader.py
+++ b/tensorboard/plugins/metrics/metrics_loader.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The TensorBoard metrics plugin loader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins import metrics_plugin

--- a/tensorboard/plugins/metrics/metrics_plugin.py
+++ b/tensorboard/plugins/metrics/metrics_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The TensorBoard metrics plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import imghdr

--- a/tensorboard/plugins/metrics/metrics_plugin_test.py
+++ b/tensorboard/plugins/metrics/metrics_plugin_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Integration tests for the Metrics Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import collections

--- a/tensorboard/plugins/npmi/csv_to_plugin_data_demo.py
+++ b/tensorboard/plugins/npmi/csv_to_plugin_data_demo.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Demo script for converting csv data to logs for the plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import csv
 import os.path

--- a/tensorboard/plugins/npmi/metadata.py
+++ b/tensorboard/plugins/npmi/metadata.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 

--- a/tensorboard/plugins/npmi/npmi_demo.py
+++ b/tensorboard/plugins/npmi/npmi_demo.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Sample data exhibiting npmi values."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/plugins/npmi/npmi_plugin.py
+++ b/tensorboard/plugins/npmi/npmi_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The nPMI visualization plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import six
 import math

--- a/tensorboard/plugins/npmi/npmi_plugin_test.py
+++ b/tensorboard/plugins/npmi/npmi_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the nPMI plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import os

--- a/tensorboard/plugins/npmi/npy_to_embedding_data_demo.py
+++ b/tensorboard/plugins/npmi/npy_to_embedding_data_demo.py
@@ -19,9 +19,6 @@ similarity-based analysis.
 To use this, provide a .npy file containing embeddings, which will be converted
 to a logfile alongside other logs for this run.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf

--- a/tensorboard/plugins/npmi/summary.py
+++ b/tensorboard/plugins/npmi/summary.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat import tf2 as tf
 

--- a/tensorboard/plugins/npmi/summary_test.py
+++ b/tensorboard/plugins/npmi/summary_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for the npmi plugin summary generation functions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import glob
 import os

--- a/tensorboard/plugins/pr_curve/metadata.py
+++ b/tensorboard/plugins/pr_curve/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Internal information about the pr_curves plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.pr_curve import plugin_data_pb2

--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -26,9 +26,6 @@ corner of the color triangle - RGB), we then compute the probability that each
 color belongs to the class. We use those probabilities to generate PR curves.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os.path
 

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import six

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Integration tests for the pr_curves plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import functools

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -18,9 +18,6 @@ NOTE: This module is in beta, and its API is subject to change, but the
 data that it stores to disk will be supported forever.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Tests the op that generates pr_curve summaries."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf

--- a/tensorboard/plugins/profile_redirect/profile_redirect_plugin.py
+++ b/tensorboard/plugins/profile_redirect/profile_redirect_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Plugin that only displays a message with installation instructions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.plugins import base_plugin
 

--- a/tensorboard/plugins/profile_redirect/profile_redirect_plugin_test.py
+++ b/tensorboard/plugins/profile_redirect/profile_redirect_plugin_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for `profile_redirect_plugin`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import contextlib
 import sys

--- a/tensorboard/plugins/projector/__init__.py
+++ b/tensorboard/plugins/projector/__init__.py
@@ -21,9 +21,6 @@
 @@SpriteMetadata
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/plugins/projector/metadata.py
+++ b/tensorboard/plugins/projector/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Internal information about the projector plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 PLUGIN_NAME = "projector"
 

--- a/tensorboard/plugins/projector/projector_api_test.py
+++ b/tensorboard/plugins/projector/projector_api_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """API tests for the projector plugin in TensorBoard."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tensorboard/plugins/projector/projector_demo.py
+++ b/tensorboard/plugins/projector/projector_demo.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import tensorflow as tf  # Requires Tensorflow >=2.1

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The Embedding Projector plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import functools

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the Embedding Projector."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import gzip
 import io

--- a/tensorboard/plugins/scalar/metadata.py
+++ b/tensorboard/plugins/scalar/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Internal information about the scalar plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.scalar import plugin_data_pb2

--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Sample data exhibiting scalar summaries, via a temperature simulation."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os.path
 

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -18,9 +18,6 @@ See `http_api.md` in this directory for specifications of the routes for
 this plugin.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import csv
 

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the Scalars Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import csv
 import json

--- a/tensorboard/plugins/scalar/summary.py
+++ b/tensorboard/plugins/scalar/summary.py
@@ -18,9 +18,6 @@ A scalar summary stores a single floating-point value, as a rank-0
 tensor.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Tests for the scalar plugin summary API."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import glob
 import os

--- a/tensorboard/plugins/scalar/summary_v2.py
+++ b/tensorboard/plugins/scalar/summary_v2.py
@@ -18,9 +18,6 @@ A scalar summary stores a single floating-point value, as a rank-0
 tensor.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/plugins/text/metadata.py
+++ b/tensorboard/plugins/text/metadata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Internal information about the text plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.text import plugin_data_pb2

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Text summaries and TensorFlow operations to create them."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.plugins.text import metadata
 from tensorboard.plugins.text import summary_v2

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Tests for the text plugin summary API."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import glob
 import os

--- a/tensorboard/plugins/text/summary_v2.py
+++ b/tensorboard/plugins/text/summary_v2.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Text summaries and TensorFlow operations to create them, V2 versions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """The TensorBoard Text plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import textwrap
 

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the Text Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import os

--- a/tensorboard/plugins/text_v2/text_v2_plugin.py
+++ b/tensorboard/plugins/text_v2/text_v2_plugin.py
@@ -14,10 +14,6 @@
 # ==============================================================================
 """Angular Version of Text Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 # Necessary for an internal test with special behavior for numpy.
 import numpy as np

--- a/tensorboard/plugins/text_v2/text_v2_plugin_test.py
+++ b/tensorboard/plugins/text_v2/text_v2_plugin_test.py
@@ -15,9 +15,6 @@
 # ==============================================================================
 """Integration tests for the Text Plugin."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import os

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -25,9 +25,6 @@ This module does not depend on first-party plugins or the default web
 server assets. Those are defined in `tensorboard.default`.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from abc import ABCMeta
 from abc import abstractmethod

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Unit tests for program package."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import sys

--- a/tensorboard/scripts/execrooter.py
+++ b/tensorboard/scripts/execrooter.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 """Utility for running programs in a symlinked execroot."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 import os

--- a/tensorboard/scripts/generate_testdata.py
+++ b/tensorboard/scripts/generate_testdata.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Generate some standard test data for debugging TensorBoard."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import bisect
 import math

--- a/tensorboard/summary/__init__.py
+++ b/tensorboard/summary/__init__.py
@@ -29,6 +29,3 @@ try:
     from tensorboard.summary.v2 import *  # noqa: F401
 except ImportError:
     pass
-
-
-del absolute_import, division, print_function

--- a/tensorboard/summary/__init__.py
+++ b/tensorboard/summary/__init__.py
@@ -16,9 +16,6 @@
 
 This module exposes summary ops for the standard TensorBoard plugins.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # If the V1 summary API is accessible, load and re-export it here.
 try:

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -78,9 +78,6 @@ with tf.compat.v1.Graph().as_default():
 ```
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # Keep this import outside the function below for internal sync reasons.
 import tensorflow as tf

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -176,4 +176,4 @@ from tensorboard.summary.v2 import image  # noqa: F401
 from tensorboard.summary.v2 import scalar  # noqa: F401
 from tensorboard.summary.v2 import text  # noqa: F401
 
-del absolute_import, division, print_function, tf, reexport_tf_summary
+del tf, reexport_tf_summary

--- a/tensorboard/summary/summary_test.py
+++ b/tensorboard/summary/summary_test.py
@@ -19,9 +19,6 @@ public entry point for end users, so we should be as careful as possible
 to ensure that we export the right things.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections.abc
 import sys

--- a/tensorboard/summary/tf_summary_test.py
+++ b/tensorboard/summary/tf_summary_test.py
@@ -22,9 +22,6 @@ sequences) via our pip package build script. But that script is run only in
 our external CI, whereas this python test can run anywhere our normal tests run.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import sys
 import unittest

--- a/tensorboard/summary/v1.py
+++ b/tensorboard/summary/v1.py
@@ -50,6 +50,3 @@ scalar_pb = _scalar_summary.pb
 
 text = _text_summary.op
 text_pb = _text_summary.pb
-
-
-del absolute_import, division, print_function

--- a/tensorboard/summary/v1.py
+++ b/tensorboard/summary/v1.py
@@ -17,9 +17,6 @@
 This module simply offers a shorter way to access the members of modules
 like `tensorboard.plugins.scalar.summary`.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.plugins.audio import summary as _audio_summary
 from tensorboard.plugins.custom_scalar import summary as _custom_scalar_summary

--- a/tensorboard/summary/v2.py
+++ b/tensorboard/summary/v2.py
@@ -23,5 +23,3 @@ from tensorboard.plugins.histogram.summary_v2 import histogram  # noqa: F401
 from tensorboard.plugins.image.summary_v2 import image  # noqa: F401
 from tensorboard.plugins.scalar.summary_v2 import scalar  # noqa: F401
 from tensorboard.plugins.text.summary_v2 import text  # noqa: F401
-
-del absolute_import, division, print_function

--- a/tensorboard/summary/v2.py
+++ b/tensorboard/summary/v2.py
@@ -16,9 +16,6 @@
 
 This module exposes v2 summary ops for the standard TensorBoard plugins.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # pylint: disable=unused-import
 from tensorboard.plugins.audio.summary_v2 import audio  # noqa: F401

--- a/tensorboard/summary/writer/event_file_writer.py
+++ b/tensorboard/summary/writer/event_file_writer.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Writes events to disk in a logdir."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import socket

--- a/tensorboard/summary/writer/event_file_writer_s3_test.py
+++ b/tensorboard/summary/writer/event_file_writer_s3_test.py
@@ -15,9 +15,6 @@
 
 # """Tests for EventFileWriter and _AsyncWriter"""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import boto3
 import os

--- a/tensorboard/summary/writer/event_file_writer_test.py
+++ b/tensorboard/summary/writer/event_file_writer_test.py
@@ -15,10 +15,6 @@
 
 # """Tests for EventFileWriter and _AsyncWriter"""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 import glob
 import os

--- a/tensorboard/summary/writer/record_writer_test.py
+++ b/tensorboard/summary/writer/record_writer_test.py
@@ -15,9 +15,6 @@
 
 # """Tests for RecordWriter"""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import six
 import os

--- a/tensorboard/test.py
+++ b/tensorboard/test.py
@@ -19,10 +19,6 @@ with some of the niceties of tf.test, while only requiring that Abseil
 be installed (`pip install absl-py`).
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 from absl.testing import absltest
 

--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -19,9 +19,6 @@ the same environment (virtualenv, Conda, etc.) from which you normally
 run TensorBoard. Read the output and follow the directions.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # This script may only depend on the Python standard library. It is not
 # built with Bazel and should not assume any third-party dependencies.

--- a/tensorboard/tools/whitespace_hygiene_test.py
+++ b/tensorboard/tools/whitespace_hygiene_test.py
@@ -18,9 +18,6 @@
 
 Keeps diffs clean and persnickety developers happy.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import os

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -15,9 +15,6 @@
 # Lint as: python3
 """Provides authentication support for TensorBoardUploader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import errno
 import json

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -15,9 +15,6 @@
 # Lint as: python3
 """Tests for tensorboard.uploader.auth."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 import os

--- a/tensorboard/uploader/dry_run_stubs.py
+++ b/tensorboard/uploader/dry_run_stubs.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Dry-run stubs for various rpc services."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard.uploader.proto import write_service_pb2
 

--- a/tensorboard/uploader/dry_run_stubs_test.py
+++ b/tensorboard/uploader/dry_run_stubs_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for dry-run rpc servicers."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import test as tb_test
 from tensorboard.uploader import dry_run_stubs

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Downloads experiment data from TensorBoard.dev."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import base64
 import contextlib

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.exporter."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import base64
 import json

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Flags parser for TensorBoard.dev uploader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 

--- a/tensorboard/uploader/flags_parser_test.py
+++ b/tensorboard/uploader/flags_parser_test.py
@@ -14,10 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.flags_parser."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 from absl.flags import argparse_flags
 

--- a/tensorboard/uploader/formatters.py
+++ b/tensorboard/uploader/formatters.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Helpers that format the information about experiments as strings."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import abc
 import collections

--- a/tensorboard/uploader/formatters_test.py
+++ b/tensorboard/uploader/formatters_test.py
@@ -15,9 +15,6 @@
 # Lint as: python3
 """Tests for tensorboard.uploader.formatters."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import time

--- a/tensorboard/uploader/logdir_loader.py
+++ b/tensorboard/uploader/logdir_loader.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Loader for event file data for an entire TensorBoard log directory."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import os

--- a/tensorboard/uploader/logdir_loader_test.py
+++ b/tensorboard/uploader/logdir_loader_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.logdir_loader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os.path
 import shutil

--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Initial server communication to determine session parameters."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from google.protobuf import message
 import requests

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.server_info."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import errno
 import os

--- a/tensorboard/uploader/test_util.py
+++ b/tensorboard/uploader/test_util.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Utilities for testing."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import threading
 

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -14,10 +14,6 @@
 # ==============================================================================
 """Progress tracker for uploader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 import contextlib
 from datetime import datetime

--- a/tensorboard/uploader/upload_tracker_test.py
+++ b/tensorboard/uploader/upload_tracker_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.upload_tracker."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import sys
 

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Uploads a TensorBoard logdir to TensorBoard.dev."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import contextlib
 import functools

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Entry point and high-level logic for TensorBoard.dev uploader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import abc
 import json

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.uploader_subcommand."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import sys
 

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.uploader."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import itertools
 import os

--- a/tensorboard/uploader/util.py
+++ b/tensorboard/uploader/util.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Utilities for use by the uploader command line tool."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import datetime
 import errno

--- a/tensorboard/uploader/util_test.py
+++ b/tensorboard/uploader/util_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for tensorboard.uploader.util."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import datetime
 import os

--- a/tensorboard/util/encoder.py
+++ b/tensorboard/util/encoder.py
@@ -16,9 +16,6 @@
 
 Encoder depends on TensorFlow.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 
 import numpy as np

--- a/tensorboard/util/encoder_test.py
+++ b/tensorboard/util/encoder_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import six

--- a/tensorboard/util/grpc_util.py
+++ b/tensorboard/util/grpc_util.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Utilities for working with python gRPC stubs."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import random
 import time

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """Tests for `tensorboard.util.grpc_util`."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import contextlib
 import hashlib

--- a/tensorboard/util/lazy_tensor_creator_test.py
+++ b/tensorboard/util/lazy_tensor_creator_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow as tf
 

--- a/tensorboard/util/op_evaluator.py
+++ b/tensorboard/util/op_evaluator.py
@@ -17,9 +17,6 @@
 Requires TensorFlow.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import threading
 

--- a/tensorboard/util/op_evaluator_test.py
+++ b/tensorboard/util/op_evaluator_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
 

--- a/tensorboard/util/platform_util.py
+++ b/tensorboard/util/platform_util.py
@@ -14,10 +14,6 @@
 
 """TensorBoard helper routine for platform."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 
 def readahead_file_path(path, unused_readahead=None):
     """Readahead files not implemented; simply returns given path."""

--- a/tensorboard/util/platform_util_test.py
+++ b/tensorboard/util/platform_util_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensorboard import test as tb_test
 from tensorboard.util import platform_util

--- a/tensorboard/util/tensor_util.py
+++ b/tensorboard/util/tensor_util.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Utilities to manipulate TensorProtos."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import six

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -18,9 +18,6 @@ This module is basically a dumpster for really generic succinct helper
 routines that exist solely for test code.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import threading
 

--- a/tensorboard/version_test.py
+++ b/tensorboard/version_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import pkg_resources
 


### PR DESCRIPTION
Summary:
Generated with `git sed '/^from __future__ import /d' && black .` and
then fixing up `del` statements indicated by flake8, where [`git-sed`]
does what it says on the tin.

Part of #4488.

[`git-sed`]: https://gist.github.com/wchargin/ea868384294e26103b90ac42e0de82d9

Test Plan:
All the removed literals are [on by default in 3.0][docs]:

```
$ git show | grep '^-f' | sort -u
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
```

[docs]: https://docs.python.org/3/library/__future__.html

wchargin-branch: py3-no-future
