### PR TITLE
ts: pass explicit args to promise resolvers

### DIFF
--- a/tensorboard/components/tf_backend/requestManager.ts
+++ b/tensorboard/components/tf_backend/requestManager.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 interface ResolveReject {
-  resolve: Function;
-  reject: Function;
+  resolve: (x: unknown) => void;
+  reject: (x: unknown) => void;
 }
 
 /**
@@ -203,7 +203,7 @@ export class RequestManager {
       this._queue.length > 0
     ) {
       this._nActiveRequests++;
-      this._queue.pop().resolve();
+      this._queue.pop().resolve(undefined);
     }
   }
   /**

--- a/tensorboard/components/vz_line_chart2/microbenchmark/async.ts
+++ b/tensorboard/components/vz_line_chart2/microbenchmark/async.ts
@@ -68,7 +68,7 @@ export function patchAsync(): Async {
       async.promises.set(
         stringId,
         new Promise((resolve) => {
-          idToResolve.set(stringId, {resolve});
+          idToResolve.set(stringId, {resolve: () => resolve(undefined)});
         })
       );
     }

--- a/tensorboard/components/vz_line_chart2/microbenchmark/async.ts
+++ b/tensorboard/components/vz_line_chart2/microbenchmark/async.ts
@@ -67,8 +67,8 @@ export function patchAsync(): Async {
     if (!(time > 0)) {
       async.promises.set(
         stringId,
-        new Promise((resolve) => {
-          idToResolve.set(stringId, {resolve: () => resolve(undefined)});
+        new Promise<void>((resolve) => {
+          idToResolve.set(stringId, {resolve});
         })
       );
     }

--- a/tensorboard/components/vz_line_chart2/microbenchmark/polymer_util.ts
+++ b/tensorboard/components/vz_line_chart2/microbenchmark/polymer_util.ts
@@ -17,7 +17,7 @@ export async function polymerFlush() {
   return new Promise((resolve) => {
     (Polymer as any).flush();
     (Polymer as any).RenderStatus.afterNextRender(null, () => {
-      resolve();
+      resolve(undefined);
     });
   });
 }

--- a/tensorboard/components/vz_line_chart2/microbenchmark/polymer_util.ts
+++ b/tensorboard/components/vz_line_chart2/microbenchmark/polymer_util.ts
@@ -14,10 +14,10 @@ limitations under the License.
 ==============================================================================*/
 
 export async function polymerFlush() {
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     (Polymer as any).flush();
     (Polymer as any).RenderStatus.afterNextRender(null, () => {
-      resolve(undefined);
+      resolve();
     });
   });
 }

--- a/tensorboard/plugins/projector/vz_projector/data-provider.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider.ts
@@ -193,7 +193,7 @@ function streamParse(
         if (data) {
           callback(data);
         }
-        resolve();
+        resolve(undefined);
         return;
       }
       readChunk(offset, chunkSize);

--- a/tensorboard/plugins/projector/vz_projector/data-provider.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider.ts
@@ -193,7 +193,7 @@ function streamParse(
         if (data) {
           callback(data);
         }
-        resolve(undefined);
+        resolve();
         return;
       }
       readChunk(offset, chunkSize);

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -401,7 +401,7 @@ export class DataSet {
     // Now, iterate through all epoch batches of the UMAP optimization, updating
     // the modal window with the progress rather than animating each step since
     // the UMAP animation is not nearly as informative as t-SNE.
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       const step = () => {
         // Compute a batch of epochs since we don't want to update the UI
         // on every epoch.
@@ -432,7 +432,7 @@ export class DataSet {
                 logging.setModalMessage(null, UMAP_MSG_ID);
                 this.hasUmapRun = true;
                 stepCallback(currentEpoch);
-                resolve(undefined);
+                resolve();
               }
             },
             UMAP_MSG_ID,

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -432,7 +432,7 @@ export class DataSet {
                 logging.setModalMessage(null, UMAP_MSG_ID);
                 this.hasUmapRun = true;
                 stepCallback(currentEpoch);
-                resolve();
+                resolve(undefined);
               }
             },
             UMAP_MSG_ID,


### PR DESCRIPTION
Summary:
When creating a new promise in JavaScript, calling `resolve()` is
equivalent to calling `resolve(undefined)`. But [TypeScript 4.1 forbids
the implicit form][ts-relnotes]:

> Expected 1 arguments, but got 0. Did you forget to include 'void' in
> your type argument to 'Promise'?

This patch updates our code to explicitly patch `Promise<void>` where
appropriate, which for some reason suppresses the error, and to
explicitly pass `undefined` in places where `Promise<void>` is wrong.
Call sites found by manual `git grep -F 'resolve()'` and filtering out
matches for `Promise.resolve`, which may still be invoked without
argument.

[ts-relnotes]: https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#resolves-parameters-are-no-longer-optional-in-promises

Googlers, see <http://cl/348490334> for context.

Test Plan:
Spot-checked the scalars, images, and projector dashboards, including
with `?fastChart=true`.

wchargin-branch: ts-promise-resolve-explicit
