### PR TITLE
rust: run Clippy on tests and fix existing errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --manifest-path tensorboard/data/server/Cargo.toml
+          args: --tests --manifest-path tensorboard/data/server/Cargo.toml
       - name: 'Check cargo-raze freshness'
         run: |
           rm -rf third_party/rust/

--- a/tensorboard/data/server/downsample.rs
+++ b/tensorboard/data/server/downsample.rs
@@ -59,8 +59,8 @@ mod tests {
     use super::*;
 
     /// Clones `xs` and [`downsample`]s the result to `k` elements.
-    fn downsample_cloned<T: Clone>(xs: &Vec<T>, k: usize) -> Vec<T> {
-        let mut ys = xs.clone();
+    fn downsample_cloned<T: Clone>(xs: &[T], k: usize) -> Vec<T> {
+        let mut ys = Vec::from(xs);
         downsample(&mut ys, k);
         ys
     }
@@ -84,9 +84,9 @@ mod tests {
 
     #[test]
     fn test_inorder_plus_last() {
-        let xs: Vec<u32> = downsample_cloned(&(0..10000).collect(), 100);
+        let xs: Vec<u32> = downsample_cloned(&(0..10000).collect::<Vec<_>>(), 100);
         let mut ys = xs.clone();
-        ys.sort();
+        ys.sort_unstable();
         assert_eq!(xs, ys);
         assert_eq!(xs.last(), Some(&9999));
     }

--- a/tensorboard/data/server/event_file.rs
+++ b/tensorboard/data/server/event_file.rs
@@ -167,10 +167,7 @@ mod tests {
         assert_eq!(reader.last_wall_time(), &Some(1234.5));
         match reader.read_event() {
             Err(ReadEventError::InvalidRecord(ChecksumError { got, want: _ }))
-                if got == MaskedCrc::compute(&encode_event(&good_event)) =>
-            {
-                ()
-            }
+                if got == MaskedCrc::compute(&encode_event(&good_event)) => {}
             other => panic!("{:?}", other),
         };
         assert_eq!(reader.last_wall_time(), &Some(1234.5));

--- a/tensorboard/data/server/lib.rs
+++ b/tensorboard/data/server/lib.rs
@@ -17,10 +17,6 @@ limitations under the License.
 
 #![allow(clippy::needless_update)] // https://github.com/rust-lang/rust-clippy/issues/6323
 
-pub fn zero(x: f32) -> bool {
-    x == 0.0
-}
-
 pub mod cli;
 pub mod commit;
 pub mod data_compat;

--- a/tensorboard/data/server/lib.rs
+++ b/tensorboard/data/server/lib.rs
@@ -17,6 +17,10 @@ limitations under the License.
 
 #![allow(clippy::needless_update)] // https://github.com/rust-lang/rust-clippy/issues/6323
 
+pub fn zero(x: f32) -> bool {
+    x == 0.0
+}
+
 pub mod cli;
 pub mod commit;
 pub mod data_compat;

--- a/tensorboard/data/server/logdir.rs
+++ b/tensorboard/data/server/logdir.rs
@@ -385,7 +385,7 @@ mod tests {
             let first_point = run_data.scalars[&Tag("accuracy".to_string())]
                 .valid_values()
                 .map(|(_step, _wall_time, &value)| value.0)
-                .nth(0);
+                .next();
             first_point
         };
 

--- a/tensorboard/data/server/server.rs
+++ b/tensorboard/data/server/server.rs
@@ -320,6 +320,9 @@ impl<T: Hash + Eq> Filter<T> {
 }
 
 #[cfg(test)]
+// Allow comparing raw wall times on responses. Wall times are always passed through as opaque
+// values (we don't do arithmetic on them), so comparing them for exact equality is okay.
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
     use tonic::Code;

--- a/tensorboard/data/server/types.rs
+++ b/tensorboard/data/server/types.rs
@@ -116,6 +116,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_wall_time() {
         assert_eq!(WallTime::new(f64::INFINITY), None);
         assert_eq!(WallTime::new(-f64::INFINITY), None);

--- a/tensorboard/data/server/writer.rs
+++ b/tensorboard/data/server/writer.rs
@@ -74,7 +74,7 @@ mod tests {
             match reader.read_event() {
                 Ok(event) => result.push(event),
                 Err(ReadRecordError(Truncated)) => return Ok(result),
-                Err(e) => return Err(e.into()),
+                Err(e) => return Err(e),
             }
         }
     }


### PR DESCRIPTION
Summary:
We run Clippy to catch common errors, but by default Clippy only runs on
non-test code. We noticed this in #4487, when Clippy would have caught a
real error (test doing nothing due to `unit_cmp`). This patch adds the
`--tests` flag to our Clippy invocation and fixes all existing warnings.

Test Plan:
The first draft of this PR included only the workflow change, and thus
properly failed on CI. Once the fixes were included, CI passed.

wchargin-branch: rust-clippy-tests
