### PR TITLE
rust: fix test warning on macOS

### DIFF
--- a/tensorboard/data/server/logdir.rs
+++ b/tensorboard/data/server/logdir.rs
@@ -256,7 +256,6 @@ impl<'a> LogdirLoader<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsStr;
     use std::fs::{self, File};
 
     use crate::types::{Step, Tag, WallTime};
@@ -410,6 +409,7 @@ mod tests {
     #[cfg(target_os = "linux")] // macOS seems to sometimes give EILSEQ on non-UTF-8 filenames
     #[test]
     fn test_bad_unicode_collision() -> Result<(), Box<dyn std::error::Error>> {
+        use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 
         // Generate a bad-Unicode collision.


### PR DESCRIPTION
Summary:
We import `OsStr` but only use it in tests that don’t run on macOS,
which causes an `unused_imports` warning: harmless, but should be fixed.

Test Plan:
Note that the `build-data-server-pip` macOS CI job’s “Test” step emits a
warning before this patch but not after it.

wchargin-branch: rust-unused-import-macos
