### PR TITLE
py3: run `whitespace_hygiene_test.py` in Python 3

### DIFF
--- a/tensorboard/tools/whitespace_hygiene_test.py
+++ b/tensorboard/tools/whitespace_hygiene_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Summary:
Noticed in the original, failed CI run of #4507 that this script ran in
Python 2, since its `print()` caused an extra `()` to be printed (since
we turned off `print_function` in #4503). This happens because its
shebang specifies the system’s default `python` and the CI job that
invokes it doesn’t set up a Python 3 virtualenv. The script still works,
since it’s effectively bicompatible, but for consistency we should still
make sure that everything runs on Python 3 only (else the tasks in #4488
are not necessarily sound).

Test Plan:
`git grep bin/python` only matches this line, and we have no uses of
`/usr/bin/env python`, either.

wchargin-branch: py3-whitespace-test
