### PR TITLE
proto: split `protos_all` into individual targets

### DIFF
--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -12,43 +12,289 @@ filegroup(
     srcs = glob(["*.proto"]),
 )
 
+tb_proto_library(
+    name = "allocation_description",
+    srcs = ["allocation_description.proto"],
+)
+
+tb_proto_library(
+    name = "api_def",
+    srcs = ["api_def.proto"],
+    deps = [
+        ":attr_value",
+    ],
+)
+
+tb_proto_library(
+    name = "attr_value",
+    srcs = ["attr_value.proto"],
+    deps = [
+        ":tensor",
+        ":tensor_shape",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "cluster",
+    srcs = ["cluster.proto"],
+)
+
+tb_proto_library(
+    name = "config",
+    srcs = ["config.proto"],
+    deps = [
+        ":cluster",
+        ":cost_graph",
+        ":debug",
+        ":graph",
+        ":rewriter_config",
+        ":step_stats",
+    ],
+)
+
+tb_proto_library(
+    name = "cost_graph",
+    srcs = ["cost_graph.proto"],
+    deps = [
+        ":tensor_shape",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "cpp_shape_inference",
+    srcs = ["cpp_shape_inference.proto"],
+    deps = [
+        ":tensor_shape",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "debug",
+    srcs = ["debug.proto"],
+)
+
+tb_proto_library(
+    name = "event",
+    srcs = ["event.proto"],
+    deps = [
+        ":summary",
+    ],
+)
+
+tb_proto_library(
+    name = "function",
+    srcs = ["function.proto"],
+    deps = [
+        ":attr_value",
+        ":node_def",
+        ":op_def",
+    ],
+)
+
+tb_proto_library(
+    name = "graph",
+    srcs = ["graph.proto"],
+    deps = [
+        ":function",
+        ":node_def",
+        ":versions",
+    ],
+)
+
+tb_proto_library(
+    name = "meta_graph",
+    srcs = ["meta_graph.proto"],
+    deps = [
+        ":graph",
+        ":op_def",
+        ":saved_object_graph",
+        ":saver",
+        ":struct",
+        ":tensor_shape",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "node_def",
+    srcs = ["node_def.proto"],
+    deps = [
+        ":attr_value",
+    ],
+)
+
+tb_proto_library(
+    name = "op_def",
+    srcs = ["op_def.proto"],
+    deps = [
+        ":attr_value",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "resource_handle",
+    srcs = ["resource_handle.proto"],
+    deps = [
+        ":tensor_shape",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "rewriter_config",
+    srcs = ["rewriter_config.proto"],
+    deps = [
+        ":attr_value",
+        ":verifier_config",
+    ],
+)
+
+tb_proto_library(
+    name = "saved_object_graph",
+    srcs = ["saved_object_graph.proto"],
+    deps = [
+        ":struct",
+        ":tensor_shape",
+        ":trackable_object_graph",
+        ":types",
+        ":variable",
+        ":versions",
+    ],
+)
+
+tb_proto_library(
+    name = "saver",
+    srcs = ["saver.proto"],
+)
+
+tb_proto_library(
+    name = "step_stats",
+    srcs = ["step_stats.proto"],
+    deps = [
+        ":allocation_description",
+        ":tensor_description",
+    ],
+)
+
+tb_proto_library(
+    name = "struct",
+    srcs = ["struct.proto"],
+    deps = [
+        ":tensor",
+        ":tensor_shape",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "summary",
+    srcs = ["summary.proto"],
+    deps = [
+        ":tensor",
+    ],
+)
+
+tb_proto_library(
+    name = "tensor_description",
+    srcs = ["tensor_description.proto"],
+    deps = [
+        ":allocation_description",
+        ":tensor_shape",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "tensor",
+    srcs = ["tensor.proto"],
+    deps = [
+        ":resource_handle",
+        ":tensor_shape",
+        ":types",
+    ],
+)
+
+tb_proto_library(
+    name = "tensor_shape",
+    srcs = ["tensor_shape.proto"],
+)
+
+tb_proto_library(
+    name = "tfprof_log",
+    srcs = ["tfprof_log.proto"],
+    deps = [
+        ":attr_value",
+        ":step_stats",
+    ],
+)
+
+tb_proto_library(
+    name = "trackable_object_graph",
+    srcs = ["trackable_object_graph.proto"],
+)
+
+tb_proto_library(
+    name = "types",
+    srcs = ["types.proto"],
+)
+
+tb_proto_library(
+    name = "variable",
+    srcs = ["variable.proto"],
+)
+
+tb_proto_library(
+    name = "verifier_config",
+    srcs = ["verifier_config.proto"],
+)
+
+tb_proto_library(
+    name = "versions",
+    srcs = ["versions.proto"],
+)
+
 # Protobuf files copied from the main TensorFlow repository.
 # Keep this list synced with proto_test.py
 tb_proto_library(
     name = "protos_all",
-    srcs = [
-        "allocation_description.proto",
-        "api_def.proto",
-        "attr_value.proto",
-        "cluster.proto",
-        "config.proto",
-        "cost_graph.proto",
-        "cpp_shape_inference.proto",
-        "debug.proto",
-        "event.proto",
-        "function.proto",
-        "graph.proto",
-        "meta_graph.proto",
-        "node_def.proto",
-        "op_def.proto",
-        "resource_handle.proto",
-        "rewriter_config.proto",
-        "saved_object_graph.proto",
-        "saver.proto",
-        "step_stats.proto",
-        "struct.proto",
-        "summary.proto",
-        "tensor.proto",
-        "tensor_description.proto",
-        "tensor_shape.proto",
-        "tfprof_log.proto",
-        "trackable_object_graph.proto",
-        "types.proto",
-        "variable.proto",
-        "verifier_config.proto",
-        "versions.proto",
-    ],
+    srcs = [],
     visibility = ["//visibility:public"],
+    deps = [
+        ":allocation_description",
+        ":api_def",
+        ":attr_value",
+        ":cluster",
+        ":config",
+        ":cost_graph",
+        ":cpp_shape_inference",
+        ":debug",
+        ":event",
+        ":function",
+        ":graph",
+        ":meta_graph",
+        ":node_def",
+        ":op_def",
+        ":resource_handle",
+        ":rewriter_config",
+        ":saved_object_graph",
+        ":saver",
+        ":step_stats",
+        ":struct",
+        ":summary",
+        ":tensor",
+        ":tensor_description",
+        ":tensor_shape",
+        ":tfprof_log",
+        ":trackable_object_graph",
+        ":types",
+        ":variable",
+        ":verifier_config",
+        ":versions",
+    ],
 )
 
 py_test(


### PR DESCRIPTION
Summary:
The Bazel Go proto rules require that each proto file have its own Go
package and its own build target. This patch splits up `protos_all`
accordingly, retaining an hourglass target for Python code.

Generated by running

```sh
(
    cd tensorboard/compat/proto/ &&
    for f in *.proto; do
        printf 'tb_proto_library(\n'
        printf '\tname = "%s",\n' "${f%.proto}"
        printf '\tsrcs = ["%s"],\n' "$f"
        if grep -q '^import "tensorboard/' "$f"; then
            printf '\tdeps = [\n'
            grep '^import "tensorboard/' "$f" |
                sed -e 's#.*compat/proto/\([^.]*\).*#\t\t":\1",#'
            printf '\t],\n'
        fi
        printf ')\n\n'
    done | expand -t4
)
```

and copying the output into `tensorboard/compat/proto/BUILD`, then
replacing `protos_all`’s `srcs` with `deps` and running Buildifier.

Test Plan:
All targets build and all tests pass. After a test sync, tests still
pass, and Go proto libraries can be built internally.

wchargin-branch: protos-split-compat
