### PR TITLE
line chart: use yScale for y-axis in grid

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view.ts
@@ -93,7 +93,7 @@ export class LineChartGridView {
   }
 
   getDomY(dataY: number): number {
-    return this.xScale.forward(
+    return this.yScale.forward(
       this.viewExtent.y,
       getScaleRangeFromDomDim(this.domDim, 'y'),
       dataY
@@ -108,7 +108,7 @@ export class LineChartGridView {
   }
 
   getYTicks() {
-    return this.xScale.ticks(
+    return this.yScale.ticks(
       this.viewExtent.y,
       getDomSizeInformedTickCount(this.domDim.height, this.yGridCount)
     );


### PR DESCRIPTION
Due to the bug, we were using xScale when calculating y-positions of the
grid. This change fixes that and adds a test.

