### PR TITLE
Fix unnecessary scroller bar in firefox and chrome

### DIFF
--- a/tensorboard/plugins/projector/tf_projector_plugin/index.js
+++ b/tensorboard/plugins/projector/tf_projector_plugin/index.js
@@ -19,6 +19,7 @@ html,
 body,
 iframe {
   border: 0;
+  display: block;
   height: 100%;
   margin: 0;
   width: 100%;

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.ts
@@ -20,7 +20,7 @@ import {customElement, property} from '@polymer/decorators';
 class VzProjectorDashboard extends PolymerElement {
   static readonly template = html`
     <template is="dom-if" if="[[dataNotFound]]">
-      <div style="max-width: 540px; margin: 80px auto 0 auto;">
+      <div style="max-width: 540px; margin: 0 auto; padding: 80px 0 0">
         <h3>No checkpoint was found.</h3>
         <p>Probable causes:</p>
         <ul>

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -87,6 +87,7 @@ export enum PluginLoadState {
       }
       .plugins ::ng-deep iframe {
         border: 0;
+        display: block;
         height: 100%;
         width: 100%;
       }


### PR DESCRIPTION
* Motivation for features / changes
https://github.com/tensorflow/tensorboard/issues/4313
Unnecessary scrollers in Chrome and firefox 

* Technical description of changes
1. Replace margin with padding for the content of projector text block to prevent the body height exceeds the iframe
2. The script tag ahead of nested iframe creates a small extra height for firefox. Apply line-heigh 0 to the body 

* Screenshots of UI changes
* Chrome
![chrome](https://user-images.githubusercontent.com/1131010/104054962-da108680-51a2-11eb-8acf-0f5dd89db1e1.png)
Firefox
![firefox](https://user-images.githubusercontent.com/1131010/104054977-e0066780-51a2-11eb-9130-5eda9a35718a.png)
