### PR TITLE
infra: better type Map

### DIFF
--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -151,7 +151,7 @@ export function categorizeTags(
 }
 
 function createTagToRuns(runToTag: RunToTag): Map<string, string[]> {
-  const tagToRun = new Map();
+  const tagToRun = new Map<string, string[]>();
   Object.keys(runToTag).forEach((run) => {
     runToTag[run].forEach((tag) => {
       const runs = tagToRun.get(tag) || [];

--- a/tensorboard/components/tf_paginated_view/tf-dom-repeat.ts
+++ b/tensorboard/components/tf_paginated_view/tf-dom-repeat.ts
@@ -76,7 +76,7 @@ export class TfDomRepeat<T extends {}> extends ArrayUpdateHelper {
    * removed when LRU grows more than size of the 2x_limit.
    */
   @property({type: Object})
-  _lruCachedItems = new Map();
+  _lruCachedItems = new Map<any, any>();
 
   @property({type: Number})
   _cacheSize = 10;

--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -1,5 +1,6 @@
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+load("@npm//@bazel/typescript:index.bzl", "ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -34,7 +35,14 @@ tb_proto_library(
     ],
 )
 
-exports_files(["rollup_config.js"])
+exports_files([
+    "rollup_config.js",
+])
+
+ts_library(
+    name = "strict_types",
+    srcs = ["strict_type_check.d.ts"],
+)
 
 # Custom ts_library compiler that runs tsc_wrapped with angular/compiler-cli statically linked
 # This can be used with worker mode because we don't need the linker at runtime to make

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -64,10 +64,7 @@ def tf_ts_library(strict_checks = True, **kwargs):
         tsconfig = "//:tsconfig-lax"
     elif "test_only" in kwargs and kwargs.get("test_only"):
         tsconfig = "//:tsconfig-test"
-    kwargs.setdefault("deps", []).append("@npm//tslib")
-
-    if strict_checks:
-        kwargs.setdefault("deps", []).append("//tensorboard/defs:strict_types")
+    kwargs.setdefault("deps", []).extend(["@npm//tslib", "//tensorboard/defs:strict_types"])
 
     ts_library(tsconfig = tsconfig, supports_workers = True, **kwargs)
 

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -66,6 +66,9 @@ def tf_ts_library(strict_checks = True, **kwargs):
         tsconfig = "//:tsconfig-test"
     kwargs.setdefault("deps", []).append("@npm//tslib")
 
+    if strict_checks:
+        kwargs.setdefault("deps", []).append("//tensorboard/defs:strict_types")
+
     ts_library(tsconfig = tsconfig, supports_workers = True, **kwargs)
 
 def tf_ts_devserver(**kwargs):

--- a/tensorboard/defs/strict_type_check.d.ts
+++ b/tensorboard/defs/strict_type_check.d.ts
@@ -1,0 +1,20 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Type override of lib.es2015.collection.d.ts.
+// Make sure value is not inferred and take anything.
+interface MapConstructor {
+  new <K, V>(): Map<K, V>;
+}

--- a/tensorboard/defs/strict_type_check.d.ts
+++ b/tensorboard/defs/strict_type_check.d.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 // Type override of lib.es2015.collection.d.ts.
-// Make sure value is not inferred and take anything.
+// Make sure key/value types are not inferred as any.
 interface MapConstructor {
   new <K, V>(): Map<K, V>;
 }

--- a/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
@@ -490,7 +490,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
         .attr('cy', ({y}) => y)
         .attr('r', 2)
         .attr('fill', fill);
-      const sessionGroupMarkersMap = new Map();
+      const sessionGroupMarkersMap = new Map<any, any[]>();
       _this.sessionGroups.forEach((sessionGroup) => {
         sessionGroupMarkersMap.set(sessionGroup, []);
       });

--- a/tensorboard/plugins/hparams/tf_hparams_table_view/tf-hparams-table-view.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_table_view/tf-hparams-table-view.ts
@@ -159,7 +159,7 @@ class TfHparamsTableView extends LegacyElementMixin(PolymerElement) {
     (this.$.sessionGroupsTable as any).set('detailsOpenedItems', []);
     PolymerDom.flush();
     // Index sessionGroups by name.
-    const sessionGroupsByName = new Map();
+    const sessionGroupsByName = new Map<string, any>();
     this.sessionGroups.forEach((sg: any) => {
       sessionGroupsByName.set(sg.name, sg);
     });

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/array-buffer-data-provider.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/array-buffer-data-provider.ts
@@ -219,7 +219,7 @@ export class ArrayBufferDataProvider {
    */
   _processMetadata(data: any[] | undefined): unknown[] {
     if (!data) return;
-    const stepToData = new Map();
+    const stepToData = new Map<any, any>();
     for (let i = 0; i < data.length; i++) {
       let dataEntry = data[i];
       if (!stepToData.has(dataEntry.step)) {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -207,7 +207,10 @@ describe('scalar card', () => {
     selectSpy = spyOn(store, 'select').and.callThrough();
     overlayContainer = TestBed.inject(OverlayContainer);
     resizeTester = TestBed.inject(ResizeDetectorTestingModule);
-    store.overrideSelector(selectors.getCurrentRouteRunSelection, new Map());
+    store.overrideSelector(
+      selectors.getCurrentRouteRunSelection,
+      new Map<string, boolean>()
+    );
     store.overrideSelector(selectors.getExperimentIdForRunId, null);
     store.overrideSelector(selectors.getExperimentIdToAliasMap, {});
     store.overrideSelector(selectors.getRun, null);

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -170,7 +170,10 @@ describe('metrics main view', () => {
     store.overrideSelector(getPageSize, 10);
     store.overrideSelector(selectors.getMetricsTagFilter, '');
     store.overrideSelector(getMetricsTagGroupExpansionState, false);
-    store.overrideSelector(selectors.getCurrentRouteRunSelection, new Map());
+    store.overrideSelector(
+      selectors.getCurrentRouteRunSelection,
+      new Map<string, boolean>()
+    );
     store.overrideSelector(selectors.getRunColorMap, {});
   });
 

--- a/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
@@ -42,7 +42,10 @@ describe('Npmi Container', () => {
   });
 
   it('renders npmi component initially with inactive component', () => {
-    store.overrideSelector(getCurrentRouteRunSelection, new Map());
+    store.overrideSelector(
+      getCurrentRouteRunSelection,
+      new Map<string, boolean>()
+    );
     const fixture = TestBed.createComponent(NpmiContainer);
     fixture.detectChanges();
 

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
@@ -53,7 +53,10 @@ describe('Npmi Annotations List Container', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    store.overrideSelector(selectors.getCurrentRouteRunSelection, new Map());
+    store.overrideSelector(
+      selectors.getCurrentRouteRunSelection,
+      new Map<string, boolean>()
+    );
   });
 
   it('renders expanded annotations list', () => {

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
@@ -54,7 +54,10 @@ describe('Npmi Results Download', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    store.overrideSelector(selectors.getCurrentRouteRunSelection, new Map());
+    store.overrideSelector(
+      selectors.getCurrentRouteRunSelection,
+      new Map<string, boolean>()
+    );
   });
 
   it('renders disabled button when no annotations are flagged', () => {

--- a/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
@@ -61,7 +61,10 @@ describe('Npmi Main Container', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    store.overrideSelector(getCurrentRouteRunSelection, new Map());
+    store.overrideSelector(
+      getCurrentRouteRunSelection,
+      new Map<string, boolean>()
+    );
 
     dispatchedActions = [];
     spyOn(store, 'dispatch').and.callFake((action: Action) => {
@@ -70,7 +73,10 @@ describe('Npmi Main Container', () => {
   });
 
   it('renders npmi main component without runs', () => {
-    store.overrideSelector(getCurrentRouteRunSelection, new Map());
+    store.overrideSelector(
+      getCurrentRouteRunSelection,
+      new Map<string, boolean>()
+    );
     const fixture = TestBed.createComponent(MainContainer);
     fixture.detectChanges();
 

--- a/tensorboard/webapp/plugins/text_v2/data_source/text_v2_server_data_source.ts
+++ b/tensorboard/webapp/plugins/text_v2/data_source/text_v2_server_data_source.ts
@@ -44,7 +44,7 @@ export class TextV2ServerDataSource implements TextV2DataSource {
       .get<BackendRunToTagsMap>(this.httpPathPrefix + '/tags')
       .pipe(
         map((runToTagObject) => {
-          const runToTag = new Map();
+          const runToTag = new Map<string, string[]>();
           Object.entries(runToTagObject).forEach(([runName, tags]) => {
             runToTag.set(runName, tags);
           });

--- a/tensorboard/webapp/plugins/text_v2/store/testing.ts
+++ b/tensorboard/webapp/plugins/text_v2/store/testing.ts
@@ -13,13 +13,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {StepDatum} from '../data_source';
 import {TextState, TEXT_FEATURE_KEY} from './text_types';
 
-export function buildTextState(override: Partial<TextState>) {
+type RunId = string;
+type TagId = string;
+
+export function buildTextState(override: Partial<TextState>): TextState {
   return {
-    runToTags: new Map(),
-    data: new Map(),
-    visibleRunTags: new Map(),
+    runToTags: new Map<RunId, TagId[]>(),
+    data: new Map<RunId, Map<TagId, StepDatum[]>>(),
+    visibleRunTags: new Map<string, Array<{run: string; tag: string}>>(),
     ...override,
   };
 }

--- a/tensorboard/webapp/plugins/text_v2/store/text_v2_reducers.ts
+++ b/tensorboard/webapp/plugins/text_v2/store/text_v2_reducers.ts
@@ -81,7 +81,7 @@ const initialState = {
       ]),
     ],
   ]),
-  visibleRunTags: new Map(),
+  visibleRunTags: new Map<string, Array<{run: string; tag: string}>>(),
 };
 
 const reducer = createReducer(initialState);

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -49,7 +49,7 @@ const dataInitialState: RunsDataState = {
   runMetadata: {},
   runsLoadState: {},
   hparamAndMetricSpec: {},
-  selectionState: new Map(),
+  selectionState: new Map<string, Map<string, boolean>>(),
 };
 
 const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
@@ -101,7 +101,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
 
     const eidsBasedKey = serializeExperimentIds(action.experimentIds);
     if (!nextSelectionState.has(eidsBasedKey)) {
-      const selectionMap = new Map();
+      const selectionMap = new Map<string, boolean>();
       const runSelected =
         action.runsForAllExperiments.length <=
         MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT;
@@ -371,8 +371,8 @@ const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(
       return state;
     }
 
-    const newHparamFilters = new Map();
-    const newMetricFilters = new Map();
+    const newHparamFilters = new Map<string, DiscreteFilter | IntervalFilter>();
+    const newMetricFilters = new Map<string, IntervalFilter>();
 
     const discreteHparams = new Map<string, Set<DiscreteHparamValue>>();
     const intervalHparams = new Map<
@@ -438,7 +438,7 @@ const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(
         includeUndefined: true,
         possibleValues: [...values],
         filterValues: [...values],
-      });
+      } as DiscreteFilter);
     }
 
     for (const [name, {minValue, maxValue}] of intervalHparams) {
@@ -449,7 +449,7 @@ const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(
         maxValue,
         filterLowerValue: minValue,
         filterUpperValue: maxValue,
-      });
+      } as IntervalFilter);
     }
 
     for (const metricTag of metricTags) {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -197,7 +197,10 @@ describe('runs_table', () => {
       lastLoadedTimeInMs: null,
     });
     store.overrideSelector(getExperiment, null);
-    store.overrideSelector(getCurrentRouteRunSelection, new Map());
+    store.overrideSelector(
+      getCurrentRouteRunSelection,
+      new Map() as ReturnType<typeof getCurrentRouteRunSelection>
+    );
     store.overrideSelector(getRunSelectorPaginationOption, {
       pageIndex: 0,
       pageSize: 10,
@@ -212,8 +215,14 @@ describe('runs_table', () => {
       rowling: 'Harry Potter',
       tolkien: 'The Lord of the Rings',
     });
-    store.overrideSelector(getRunHparamFilterMap, new Map());
-    store.overrideSelector(getRunMetricFilterMap, new Map());
+    store.overrideSelector(
+      getRunHparamFilterMap,
+      new Map() as ReturnType<typeof getRunHparamFilterMap>
+    );
+    store.overrideSelector(
+      getRunMetricFilterMap,
+      new Map() as ReturnType<typeof getRunMetricFilterMap>
+    );
     store.overrideSelector(getExperimentsHparamsAndMetrics, {
       hparams: [],
       metrics: [],


### PR DESCRIPTION
When you create a Map without values, TypeScript has to infer the type
and, sometimes, it is imperfect and types cannot unsafe. This change
forces valueless Map constructor to specify the types so we rely less on
the inference.

To emulate the internal enforcement, we are making a necessary changes
to `tf_ts_library` but do note that it is imperfect and sometimes misses the
cases. Also do note that it somehow leaks its way into targets with
`strict_check = False` which is unintended but bearable.

Do note that this requires sync changes.
Test CL with necessary change patched: cl/350867815