### PR TITLE
timeseries: stamp scalar only when first visible

### DIFF
--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -148,15 +148,15 @@ export class MetricsEffects implements OnInitEffects {
   );
 
   private getVisibleCardFetchInfos(): Observable<CardFetchInfo[]> {
-    const visibleCardIds$ = this.store.select(selectors.getVisibleCardIds);
+    const visibleCardIds$ = this.store.select(selectors.getVisibleCardIdSet);
     return visibleCardIds$.pipe(
       switchMap((cardIds) => {
         // Explicitly notify subscribers that there are no visible cards,
         // since `forkJoin` does not emit when passed an empty array.
-        if (!cardIds.length) {
+        if (!cardIds.size) {
           return of([]);
         }
-        const observables = cardIds.map((cardId) => {
+        const observables = [...cardIds].map((cardId) => {
           return this.store.select(getCardFetchInfo, cardId).pipe(take(1));
         });
         return forkJoin(observables);

--- a/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
+++ b/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
@@ -244,7 +244,10 @@ describe('metrics effects', () => {
           DataLoadState.LOADED
         );
         store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-        store.overrideSelector(selectors.getVisibleCardIds, ['card1', 'card2']);
+        store.overrideSelector(
+          selectors.getVisibleCardIdSet,
+          new Set(['card1', 'card2'])
+        );
         provideCardFetchInfo([{id: 'card1'}, {id: 'card2'}]);
         store.refreshState();
         fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
@@ -289,7 +292,10 @@ describe('metrics effects', () => {
           DataLoadState.LOADING
         );
         store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-        store.overrideSelector(selectors.getVisibleCardIds, ['card1', 'card2']);
+        store.overrideSelector(
+          selectors.getVisibleCardIdSet,
+          new Set(['card1', 'card2'])
+        );
         provideCardFetchInfo([
           {id: 'card1', loadState: DataLoadState.LOADED},
           {id: 'card2', loadState: DataLoadState.LOADING},
@@ -323,7 +329,10 @@ describe('metrics effects', () => {
         DataLoadState.LOADING
       );
       store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.overrideSelector(selectors.getVisibleCardIds, ['card1', 'card2']);
+      store.overrideSelector(
+        selectors.getVisibleCardIdSet,
+        new Set(['card1', 'card2'])
+      );
       provideCardFetchInfo([
         {id: 'card1', loadState: DataLoadState.LOADING},
         {id: 'card2', loadState: DataLoadState.LOADING},
@@ -352,7 +361,7 @@ describe('metrics effects', () => {
 
     it('does not re-fetch time series, if no cards are visible', () => {
       store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.overrideSelector(selectors.getVisibleCardIds, []);
+      store.overrideSelector(selectors.getVisibleCardIdSet, new Set([]));
       store.refreshState();
       fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
 
@@ -367,7 +376,7 @@ describe('metrics effects', () => {
       store.resetSelectors();
       store.overrideSelector(selectors.getRouteId, 'route1');
       store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.overrideSelector(selectors.getVisibleCardIds, ['card1']);
+      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
       provideCardFetchInfo([{id: 'card1', loadState: DataLoadState.LOADED}]);
       store.overrideSelector(selectors.getExperimentIdsFromRoute, null);
       store.refreshState();
@@ -442,7 +451,10 @@ describe('metrics effects', () => {
         loadState: DataLoadState.NOT_LOADED,
       });
 
-      store.overrideSelector(selectors.getVisibleCardIds, []);
+      store.overrideSelector(
+        selectors.getVisibleCardIdSet,
+        new Set<string>([])
+      );
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
@@ -454,7 +466,7 @@ describe('metrics effects', () => {
       expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
       expect(actualActions).toEqual([]);
 
-      store.overrideSelector(selectors.getVisibleCardIds, ['card1']);
+      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
@@ -491,7 +503,7 @@ describe('metrics effects', () => {
       });
 
       // Initial load.
-      store.overrideSelector(selectors.getVisibleCardIds, ['card1']);
+      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
@@ -504,7 +516,7 @@ describe('metrics effects', () => {
       expect(actualActions).toEqual([]);
 
       // Exit.
-      store.overrideSelector(selectors.getVisibleCardIds, []);
+      store.overrideSelector(selectors.getVisibleCardIdSet, new Set([]));
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
@@ -517,7 +529,7 @@ describe('metrics effects', () => {
       expect(actualActions).toEqual([]);
 
       // Re-enter.
-      store.overrideSelector(selectors.getVisibleCardIds, ['card1']);
+      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
@@ -576,7 +588,10 @@ describe('metrics effects', () => {
         .withArgs([expectedRequests[1]])
         .and.returnValue(of([sampleBackendResponses[1]]));
 
-      store.overrideSelector(selectors.getVisibleCardIds, ['card1', 'card2']);
+      store.overrideSelector(
+        selectors.getVisibleCardIdSet,
+        new Set(['card1', 'card2'])
+      );
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
@@ -616,7 +631,10 @@ describe('metrics effects', () => {
         );
         fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries');
 
-        store.overrideSelector(selectors.getVisibleCardIds, ['card1']);
+        store.overrideSelector(
+          selectors.getVisibleCardIdSet,
+          new Set(['card1'])
+        );
         store.refreshState();
         actions$.next(
           actions.cardVisibilityChanged({

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -140,11 +140,18 @@ export const getCardMetadata = createSelector(
   }
 );
 
-// A cheap identity selector to skip recomputing selectors.
-const getVisibleCardIdSet = createSelector(
+// A cheap identity selector to skip recomputing selectors when `state` changes.
+const selectVisibleCardIdSet = createSelector(
   selectMetricsState,
   (state): Set<CardId> => {
     return state.visibleCards;
+  }
+);
+
+export const getVisibleCardIdSet = createSelector(
+  selectVisibleCardIdSet,
+  (cardIdSet): Set<CardId> => {
+    return cardIdSet;
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -155,13 +155,6 @@ export const getVisibleCardIdSet = createSelector(
   }
 );
 
-export const getVisibleCardIds = createSelector(
-  getVisibleCardIdSet,
-  (cardIdSet: Set<CardId>): CardId[] => {
-    return [...cardIdSet];
-  }
-);
-
 /**
  * Returns current list of card data whose metadata is loaded.
  */

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -290,9 +290,9 @@ describe('metrics selectors', () => {
     });
   });
 
-  describe('getVisibleCardIds', () => {
+  describe('getVisibleCardIdSet', () => {
     beforeEach(() => {
-      selectors.getVisibleCardIds.release();
+      selectors.getVisibleCardIdSet.release();
     });
 
     it('returns an emtpy array', () => {
@@ -301,7 +301,7 @@ describe('metrics selectors', () => {
           visibleCards: new Set(),
         })
       );
-      expect(selectors.getVisibleCardIds(state)).toEqual([]);
+      expect(selectors.getVisibleCardIdSet(state)).toEqual(new Set<string>([]));
     });
 
     it('returns a non-empty array', () => {
@@ -310,7 +310,9 @@ describe('metrics selectors', () => {
           visibleCards: new Set(['card1', 'card2']),
         })
       );
-      expect(selectors.getVisibleCardIds(state)).toEqual(['card1', 'card2']);
+      expect(selectors.getVisibleCardIdSet(state)).toEqual(
+        new Set(['card1', 'card2'])
+      );
     });
   });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -83,34 +83,36 @@ limitations under the License.
     *ngIf="loadState === DataLoadState.LOADING"
   ></mat-spinner>
 
-  <line-chart
-    *ngIf="gpuLineChartEnabled; else legacyChart"
-    [preferredRendererType]="RendererType.WEBGL"
-    [seriesData]="dataSeries"
-    [seriesMetadataMap]="chartMetadataMap"
-    [xScaleType]="newXScaleType"
-    [yScaleType]="newYScaleType"
-    [customXFormatter]="xAxisType === XAxisType.RELATIVE ? relativeXFormatter : undefined"
-    [ignoreYOutliers]="ignoreOutliers"
-    [tooltipTemplate]="tooltip"
-  ></line-chart>
-
-  <ng-template #legacyChart>
-    <tb-line-chart
-      [colorScale]="runColorScale"
-      [seriesDataList]="seriesDataList"
-      [tooltipColumns]="tooltipColumns"
-      [tooltipSortingMethod]="tooltipSort"
+  <ng-container *ngIf="isEverVisible">
+    <line-chart
+      *ngIf="gpuLineChartEnabled; else legacyChart"
+      [preferredRendererType]="RendererType.WEBGL"
+      [seriesData]="dataSeries"
+      [seriesMetadataMap]="chartMetadataMap"
+      [xScaleType]="newXScaleType"
+      [yScaleType]="newYScaleType"
+      [customXFormatter]="xAxisType === XAxisType.RELATIVE ? relativeXFormatter : undefined"
       [ignoreYOutliers]="ignoreOutliers"
-      [xAxisType]="chartXAxisType()"
-      [smoothingEnabled]="scalarSmoothing > 0"
-      [smoothingWeight]="scalarSmoothing"
-      [yAxisType]="yAxisType"
-      detectResize
-      [resizeEventDebouncePeriodInMs]="RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS"
-      (onResize)="redraw()"
-    ></tb-line-chart>
-  </ng-template>
+      [tooltipTemplate]="tooltip"
+    ></line-chart>
+
+    <ng-template #legacyChart>
+      <tb-line-chart
+        [colorScale]="runColorScale"
+        [seriesDataList]="seriesDataList"
+        [tooltipColumns]="tooltipColumns"
+        [tooltipSortingMethod]="tooltipSort"
+        [ignoreYOutliers]="ignoreOutliers"
+        [xAxisType]="chartXAxisType()"
+        [smoothingEnabled]="scalarSmoothing > 0"
+        [smoothingWeight]="scalarSmoothing"
+        [yAxisType]="yAxisType"
+        detectResize
+        [resizeEventDebouncePeriodInMs]="RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS"
+        (onResize)="redraw()"
+      ></tb-line-chart>
+    </ng-template>
+  </ng-container>
 
   <ng-template
     #tooltip

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -144,6 +144,7 @@ export class ScalarCardComponent {
   @Input() gpuLineChartEnabled!: boolean;
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
+  @Input() isEverVisible!: boolean;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -31,6 +31,7 @@ import {
   shareReplay,
   startWith,
   switchMap,
+  takeWhile,
 } from 'rxjs/operators';
 
 import {State} from '../../../app_state';
@@ -42,6 +43,7 @@ import {
   getIsGpuChartEnabled,
   getRun,
   getRunColorMap,
+  getVisibleCardIdSet,
 } from '../../../selectors';
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
@@ -147,6 +149,7 @@ function areSeriesEqual(
       "
       [gpuLineChartEnabled]="gpuLineChartEnabled$ | async"
       [smoothingEnabled]="smoothingEnabled$ | async"
+      [isEverVisible]="isEverVisible$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
     ></scalar-card-component>
@@ -178,6 +181,14 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
   isPinned$?: Observable<boolean>;
   dataSeries$?: Observable<ScalarCardDataSeries[]>;
   chartMetadataMap$?: Observable<ScalarCardSeriesMetadataMap>;
+
+  readonly isEverVisible$ = this.store.select(getVisibleCardIdSet).pipe(
+    map((visibleSet) => {
+      return visibleSet.has(this.cardId);
+    }),
+    distinctUntilChanged(),
+    takeWhile((visible) => !visible, true)
+  );
 
   readonly tooltipSort$ = this.store.select(getMetricsTooltipSort);
   readonly ignoreOutliers$ = this.store.select(getMetricsIgnoreOutliers);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -216,7 +216,49 @@ describe('scalar card', () => {
     store.overrideSelector(selectors.getRun, null);
     store.overrideSelector(selectors.getIsGpuChartEnabled, false);
     store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
+    store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
   });
+
+  it('stamps line chart impl only when card is first visible', fakeAsync(() => {
+    const cardMetadata = {
+      plugin: PluginType.SCALARS,
+      tag: 'tagA',
+      run: null,
+    };
+    provideMockCardRunToSeriesData(
+      selectSpy,
+      PluginType.SCALARS,
+      'card1',
+      cardMetadata,
+      null /* runToSeries */
+    );
+    store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['unknown']));
+
+    const fixture = createComponent('card1');
+
+    const lineChart1 = fixture.debugElement.query(
+      By.directive(TestableLineChart)
+    );
+    expect(lineChart1).toBeNull();
+
+    store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
+    store.refreshState();
+    fixture.detectChanges();
+
+    const lineChart2 = fixture.debugElement.query(
+      By.directive(TestableLineChart)
+    );
+    expect(lineChart2).not.toBeNull();
+
+    store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['gone']));
+    store.refreshState();
+    fixture.detectChanges();
+
+    const lineChart3 = fixture.debugElement.query(
+      By.directive(TestableLineChart)
+    );
+    expect(lineChart3).not.toBeNull();
+  }));
 
   it('renders empty chart when there is no data', fakeAsync(() => {
     const cardMetadata = {


### PR DESCRIPTION
In the new gpu line chart, we have an option to use Worker process to
render the line chart but its initialization can be heavy as it requires
to download the worker resources (or even parse script and create a
process). To make the AFT better, we only stamp and create line chart
component when it is actually visible on the screen.
