### PR TITLE
bug: fix requests to absolute paths under path_prefix

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -41,6 +41,7 @@ tf_ng_module(
     name = "app_root",
     srcs = [
         "app_root.ts",
+        "app_root_module.ts",
     ],
     deps = [
         ":location",

--- a/tensorboard/webapp/app_routing/app_root_module.ts
+++ b/tensorboard/webapp/app_routing/app_root_module.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,12 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
-import {HttpClientModule} from '@angular/common/http';
-import {AppRootModule} from '../app_routing/app_root_module';
-import {TBHttpClient} from './tb_http_client';
+
+import {AppRootProvider} from './app_root';
+import {LocationModule} from './location_module';
 
 @NgModule({
-  imports: [HttpClientModule, AppRootModule],
-  providers: [TBHttpClient],
+  imports: [LocationModule],
+  providers: [AppRootProvider],
 })
-export class TBHttpClientModule {}
+export class AppRootModule {}

--- a/tensorboard/webapp/app_routing/app_routing_module.ts
+++ b/tensorboard/webapp/app_routing/app_routing_module.ts
@@ -16,7 +16,7 @@ import {NgModule} from '@angular/core';
 import {EffectsModule} from '@ngrx/effects';
 import {StoreModule} from '@ngrx/store';
 
-import {AppRootProvider} from './app_root';
+import {AppRootModule} from './app_root_module';
 import {AppRoutingEffects} from './effects';
 import {LocationModule} from './location_module';
 import {ProgrammaticalNavigationModule} from './programmatical_navigation_module';
@@ -27,8 +27,9 @@ import {APP_ROUTING_FEATURE_KEY} from './store/app_routing_types';
   imports: [
     StoreModule.forFeature(APP_ROUTING_FEATURE_KEY, reducers),
     EffectsModule.forFeature([AppRoutingEffects]),
+    AppRootModule,
     LocationModule,
   ],
-  providers: [ProgrammaticalNavigationModule, AppRootProvider],
+  providers: [ProgrammaticalNavigationModule],
 })
 export class AppRoutingModule {}

--- a/tensorboard/webapp/app_routing/views/app_routing_view_module.ts
+++ b/tensorboard/webapp/app_routing/views/app_routing_view_module.ts
@@ -21,16 +21,15 @@ import {RouterLinkDirectiveContainer} from './router_link_directive_container';
 import {RouterOutletComponent} from './router_outlet_component';
 import {RouterOutletContainer} from './router_outlet_container';
 import {LocationModule} from '../location_module';
-import {AppRootProvider} from '../app_root';
+import {AppRootModule} from '../app_root_module';
 
 @NgModule({
-  imports: [CommonModule, LocationModule, RouteRegistryModule],
+  imports: [CommonModule, AppRootModule, LocationModule, RouteRegistryModule],
   exports: [RouterOutletContainer, RouterLinkDirectiveContainer],
   declarations: [
     RouterOutletContainer,
     RouterOutletComponent,
     RouterLinkDirectiveContainer,
   ],
-  providers: [AppRootProvider],
 })
 export class AppRoutingViewModule {}

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -42,6 +42,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/angular:expect_angular_common_http",
+        "//tensorboard/webapp/app_routing:app_root",
         "//tensorboard/webapp/feature_flag",
         "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/store",
@@ -65,6 +66,7 @@ tf_ng_module(
         ":http_client_testing",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/app_routing:app_root",
         "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/feature_flag/store:types",


### PR DESCRIPTION
Some frontend components, including the Time Series dashboard, make
HTTP requests using absolute paths, which fail under --path_prefix, since
the TensorBoard application may not be served under '/'.

This change amends TBHttpClient to add the 'app root' as a prefix when
the requested resource is an absolute path. Internal schemes of the form
'/experiment/some_dynamic_id/...' (e.g. TB.dev) should be compatible, if
the 'app root' is '/' in those cases.

Manually tested with/without `--path_prefix=/foo/bar` that the Time Series
dashboard loads data. Pointing the logdir at npmi demo data did not load
anything in the dashboard, so I was not able to confirm that it works as
intended.

Note that Debugger V2's code viewer still fails to load Monaco under path
prefix. It does not use TBHttpClient for fetching Monaco assets.

No sync changes should be required.  Googlers, see test sync cl/351684147.