### PR TITLE
rust: build universal data server with no binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        mode: ['native']
         platform: ['ubuntu-16.04', 'macos-10.15']
         rust_version: ['1.48.0']
+        include:
+          - mode: 'universal'
+            platform: 'ubuntu-16.04'
+            rust_version: '1.48.0'
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
@@ -117,6 +122,7 @@ jobs:
           python-version: '3.8'
           architecture: 'x64'
       - name: 'Cache Cargo artifacts'
+        if: matrix.mode == 'native'
         uses: actions/cache@v2
         with:
           path: |
@@ -133,6 +139,7 @@ jobs:
             ~/.cargo/.crates2.json
           key: build-data-server-pip-${{ runner.os }}-cargo-${{ matrix.rust_version }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/ci.yml') }}
       - name: 'Install Rust toolchain'
+        if: matrix.mode == 'native'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust_version }}
@@ -144,20 +151,31 @@ jobs:
             -c ./tensorboard/pip_package/requirements_dev.txt \
             setuptools wheel
       - name: 'Build'
+        if: matrix.mode == 'native'
         run: cd tensorboard/data/server/ && cargo build --release
       - name: 'Test'
+        if: matrix.mode == 'native'
         run: cd tensorboard/data/server/ && cargo test --release
-      - name: 'Package'
+      - name: 'Package (native)'
+        if: matrix.mode == 'native'
         run: |
           rm -rf /tmp/pip_package && mkdir /tmp/pip_package
           python tensorboard/data/server/pip_package/build.py \
             --server-binary tensorboard/data/server/target/release/rustboard \
             --out-dir /tmp/pip_package \
             ;
+      - name: 'Package (universal)'
+        if: matrix.mode == 'universal'
+        run: |
+          rm -rf /tmp/pip_package && mkdir /tmp/pip_package
+          python tensorboard/data/server/pip_package/build.py \
+            --universal \
+            --out-dir /tmp/pip_package \
+            ;
       - name: 'Upload'
         uses: actions/upload-artifact@v2
         with:
-          name: rustboard-${{ matrix.platform }}
+          name: tensorboard-data-server
           path: /tmp/pip_package/*
 
   lint-python-flake8:

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -23,14 +23,13 @@ __version__ = "0.1.0a0"
 
 
 def server_binary():
-    """Return the path to a TensorBoard data server binary.
+    """Return the path to a TensorBoard data server binary, if possible.
 
-    Raises:
-      RuntimeError: If the binary cannot be found.
+    Returns:
+      A string path on disk, or `None` if there is no binary bundled
+      with this package.
     """
     path = os.path.join(os.path.dirname(__file__), "bin", "server")
     if not os.path.exists(path):
-        raise RuntimeError(
-            "TensorBoard data server binary missing: should be at %s" % path
-        )
+        return None
     return path

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.1.0a0"
+__version__ = "0.1.0a20210111"
 
 
 def server_binary():

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.1.0a20210111"
+__version__ = "0.1.0a0"
 
 
 def server_binary():


### PR DESCRIPTION
Summary:
The `tensorboard-data-server` package now supports a universal build
configuration. When built in this configuration, the package does not
actually contain a binary, and returns `None` when interrogated for its
path. But it can be installed on any platform, so it serves as a
fallback. Thus, `tensorboard` can depend on `tensorboard-data-server`
while maintaining install-time compatibility on all platforms.

Closes #4533; see that issue for details.

Test Plan:
Running `build.py` with `--universal` successfully creates a Pip package
called `tensorboard_data_server-0.1.0a0-py3-none-any.whl` that contains
no binary. Running TensorBoard with `--load_fast` prints the new error
message and exits. When re-installing the native wheel, TensorBoard can
still find it. The existing codepaths for a bundled server and a server
taken from environment variable also still work.

Uploaded the three wheels built in CI to Test PyPI as `0.1.0a20210111`,
in the order (1) macOS (2) universal (3) Linux, waiting a minute or so
in between each. When installing a patched TensorBoard wheel with a new
`tensorboard-data-server` dep, it behaved as expected per #4533.

wchargin-branch: rust-universal-pip
