### PR TITLE
py3: remove `six` from requirements

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,7 +26,6 @@ numpy >= 1.12.0
 protobuf >= 3.6.0
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
-six >= 1.10.0
 tensorboard-plugin-wit >= 1.6.0
 werkzeug >= 0.11.15
 # python3 specifically requires wheel 0.26


### PR DESCRIPTION
Summary:
As of #4510, we don’t need `six`, so we can remove it from the Pip
package requirements.

Part of #4488.

Test Plan:
Running `:extract_pip_package` and installing it into a virtualenv still
installs `six` as a transitive dep, so this is actually no functional
change for now. Maybe one day.

wchargin-branch: py3-norequire-six
