### PR TITLE
rust: add `base64` dependency

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -92,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +754,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream 0.3.0",
  "async-trait",
+ "base64 0.13.0",
  "byteorder",
  "clap",
  "crc",
@@ -922,7 +929,7 @@ checksum = "74a5d6e7439ecf910463667080de772a9c7ddf26bc9fb4f3252ac3862e43337d"
 dependencies = [
  "async-stream 0.2.1",
  "async-trait",
- "base64",
+ "base64 0.12.3",
  "bytes",
  "futures-core",
  "futures-util",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -25,6 +25,7 @@ default-run = "rustboard"
 [dependencies]
 async-stream = "0.3.0"
 async-trait = "0.1.41"
+base64 = "0.13.0"
 byteorder = "1.3.4"
 clap = "3.0.0-beta.2"
 crc = "1.8.1"

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -31,6 +31,15 @@ alias(
 )
 
 alias(
+    name = "base64",
+    actual = "@raze__base64__0_13_0//:base64",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "byteorder",
     actual = "@raze__byteorder__1_3_4//:byteorder",
     tags = [

--- a/third_party/rust/crates.bzl
+++ b/third_party/rust/crates.bzl
@@ -113,6 +113,16 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__base64__0_13_0",
+        url = "https://crates.io/api/v1/crates/base64/0.13.0/download",
+        type = "tar.gz",
+        sha256 = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd",
+        strip_prefix = "base64-0.13.0",
+        build_file = Label("//third_party/rust/remote:BUILD.base64-0.13.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__bitflags__1_2_1",
         url = "https://crates.io/api/v1/crates/bitflags/1.2.1/download",
         type = "tar.gz",

--- a/third_party/rust/remote/BUILD.base64-0.13.0.bazel
+++ b/third_party/rust/remote/BUILD.base64-0.13.0.bazel
@@ -1,0 +1,68 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "benchmarks" with type "bench" omitted
+
+# Unsupported target "base64" with type "example" omitted
+
+# Unsupported target "make_tables" with type "example" omitted
+
+rust_library(
+    name = "base64",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.13.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "decode" with type "test" omitted
+
+# Unsupported target "encode" with type "test" omitted
+
+# Unsupported target "helpers" with type "test" omitted
+
+# Unsupported target "tests" with type "test" omitted


### PR DESCRIPTION
Summary:
The [`base64`] crate provides Base64 encoding and decoding, for a
variety of alphabets (including both [RFC 3548 alphabets][rfc]) and with
optional padding. We’ll use this to encode blob keys.

[`base64`]: https://crates.io/crates/base64
[rfc]: https://tools.ietf.org/html/rfc3548#section-3

Test Plan:
It builds: `bazel build //third_party/rust:base64`.

wchargin-branch: rust-dep-base64
