### PR TITLE
line chart: update only visible charts

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -86,6 +86,7 @@ limitations under the License.
   <ng-container *ngIf="isEverVisible">
     <line-chart
       *ngIf="gpuLineChartEnabled; else legacyChart"
+      [enableUpdate]="isCardVisible"
       [preferredRendererType]="RendererType.WEBGL"
       [seriesData]="dataSeries"
       [seriesMetadataMap]="chartMetadataMap"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -86,7 +86,7 @@ limitations under the License.
   <ng-container *ngIf="isEverVisible">
     <line-chart
       *ngIf="gpuLineChartEnabled; else legacyChart"
-      [enableUpdate]="isCardVisible"
+      [disableUpdate]="!isCardVisible"
       [preferredRendererType]="RendererType.WEBGL"
       [seriesData]="dataSeries"
       [seriesMetadataMap]="chartMetadataMap"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -140,6 +140,7 @@ export class ScalarCardComponent {
   @Input() seriesDataList!: SeriesDataList;
 
   // gpu chart related props.
+  @Input() isCardVisible!: boolean;
   @Input() smoothingEnabled!: boolean;
   @Input() gpuLineChartEnabled!: boolean;
   @Input() dataSeries!: ScalarCardDataSeries[];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -149,6 +149,7 @@ function areSeriesEqual(
       "
       [gpuLineChartEnabled]="gpuLineChartEnabled$ | async"
       [smoothingEnabled]="smoothingEnabled$ | async"
+      [isCardVisible]="isCardVisible$ | async"
       [isEverVisible]="isEverVisible$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
@@ -182,11 +183,13 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
   dataSeries$?: Observable<ScalarCardDataSeries[]>;
   chartMetadataMap$?: Observable<ScalarCardSeriesMetadataMap>;
 
-  readonly isEverVisible$ = this.store.select(getVisibleCardIdSet).pipe(
+  readonly isCardVisible$ = this.store.select(getVisibleCardIdSet).pipe(
     map((visibleSet) => {
       return visibleSet.has(this.cardId);
     }),
-    distinctUntilChanged(),
+    distinctUntilChanged()
+  );
+  readonly isEverVisible$ = this.isCardVisible$.pipe(
     takeWhile((visible) => !visible, true)
   );
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -111,6 +111,7 @@ class TestableGpuLineChart {
   @Input() xScaleType!: ScaleType;
   @Input() yScaleType!: ScaleType;
   @Input() ignoreYOutliers!: boolean;
+  @Input() disableUpdate?: boolean;
   @Input()
   tooltipTemplate!: TemplateRef<{data: TooltipDatum[]}>;
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -109,7 +109,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   /**
    * Optional parameter to tweak whether to propagate update to line chart implementation.
-   * When not specified, it defaults to `true`. When it is `false`, it remembers what has
+   * When not specified, it defaults to `false`. When it is `true`, it remembers what has
    * changed and applies the change when the update is enabled.
    */
   @Input()

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -108,6 +108,14 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
   tooltipTemplate?: TooltipTemplate;
 
   /**
+   * Optional parameter to tweak whether to propagate update to line chart implementation.
+   * When not specified, it defaults to `true`. When it is `false`, it remembers what has
+   * changed and applies the change when the update is enabled.
+   */
+  @Input()
+  enableUpdate?: boolean;
+
+  /**
    * Whether to ignore outlier when computing default viewBox from the dataSeries.
    *
    * Do note that we only take values in between approxmiately 5th to 95th percentiles.
@@ -167,7 +175,8 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
     }
 
     this.isViewBoxChanged =
-      !this.isViewBoxOverriden && this.shouldUpdateDefaultViewBox(changes);
+      this.isViewBoxChanged ||
+      (!this.isViewBoxOverriden && this.shouldUpdateDefaultViewBox(changes));
 
     this.updateLineChart();
   }
@@ -307,7 +316,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
    * Minimally and imperatively updates the chart library depending on prop changed.
    */
   private updateLineChart() {
-    if (!this.lineChart) return;
+    if (!this.lineChart || this.enableUpdate === false) return;
 
     if (this.scaleUpdated) {
       this.scaleUpdated = false;

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -113,7 +113,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
    * changed and applies the change when the update is enabled.
    */
   @Input()
-  enableUpdate?: boolean;
+  disableUpdate?: boolean;
 
   /**
    * Whether to ignore outlier when computing default viewBox from the dataSeries.
@@ -316,7 +316,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
    * Minimally and imperatively updates the chart library depending on prop changed.
    */
   private updateLineChart() {
-    if (!this.lineChart || this.enableUpdate === false) return;
+    if (!this.lineChart || this.disableUpdate === true) return;
 
     if (this.scaleUpdated) {
       this.scaleUpdated = false;

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -316,7 +316,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
    * Minimally and imperatively updates the chart library depending on prop changed.
    */
   private updateLineChart() {
-    if (!this.lineChart || this.disableUpdate === true) return;
+    if (!this.lineChart || this.disableUpdate) return;
 
     if (this.scaleUpdated) {
       this.scaleUpdated = false;

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -34,6 +34,7 @@ import {LineChartComponent} from './line_chart_component';
   template: `
     <line-chart
       #chart
+      [enableUpdate]="enableUpdate"
       [preferredRendererType]="preferredRendererType"
       [seriesData]="seriesData"
       [seriesMetadataMap]="seriesMetadataMap"
@@ -66,6 +67,9 @@ class TestableComponent {
 
   @Input()
   fixedViewBox?: Extent;
+
+  @Input()
+  enableUpdate?: boolean;
 
   // WebGL one is harder to test.
   preferredRendererType = RendererType.SVG;
@@ -105,6 +109,7 @@ describe('line_chart_v2/line_chart test', () => {
     seriesMetadataMap: DataSeriesMetadataMap;
     yScaleType: ScaleType;
     fixedViewBox?: Extent;
+    enableUpdate?: boolean;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
     fixture.componentInstance.seriesData = input.seriesData;
@@ -113,6 +118,10 @@ describe('line_chart_v2/line_chart test', () => {
 
     if (input.fixedViewBox) {
       fixture.componentInstance.fixedViewBox = input.fixedViewBox;
+    }
+
+    if (input.enableUpdate !== undefined) {
+      fixture.componentInstance.enableUpdate = input.enableUpdate;
     }
 
     return fixture;
@@ -348,6 +357,121 @@ describe('line_chart_v2/line_chart test', () => {
     expect(updateViewBoxSpy).toHaveBeenCalledWith({
       x: [-0.1, 1.1],
       y: [-0.1, 1.1],
+    });
+  });
+
+  describe('enableUpdate=false', () => {
+    it('disables any update', () => {
+      const fixture = createComponent({
+        enableUpdate: false,
+        seriesData: [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 0, y: 0},
+              {x: 1, y: -1},
+              {x: 2, y: 1},
+            ],
+          }),
+        ],
+        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.detectChanges();
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(0);
+
+      fixture.componentInstance.seriesMetadataMap = {};
+      fixture.detectChanges();
+
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('sets update when enableUpdate changes to true', () => {
+      const fixture = createComponent({
+        enableUpdate: false,
+        seriesData: [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 0, y: 0},
+              {x: 1, y: -1},
+              {x: 2, y: 1},
+            ],
+          }),
+        ],
+        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.detectChanges();
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(0);
+      expect(updateMetadataSpy).toHaveBeenCalledTimes(0);
+      expect(updateDataSpy).toHaveBeenCalledTimes(0);
+
+      fixture.componentInstance.enableUpdate = true;
+      fixture.detectChanges();
+
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
+      expect(updateMetadataSpy).toHaveBeenCalledTimes(1);
+      expect(updateDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('queues up viewBox changes and updates default viewBox when update is enabled', () => {
+      const fixture = createComponent({
+        enableUpdate: true,
+        seriesData: [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 0, y: 0},
+              {x: 1, y: -1},
+              {x: 2, y: 1},
+            ],
+          }),
+        ],
+        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.detectChanges();
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
+      expect(updateViewBoxSpy.calls.argsFor(0)).toEqual([
+        {
+          x: [-0.2, 2.2],
+          y: [-1.2, 1.2],
+        },
+      ]);
+
+      fixture.componentInstance.enableUpdate = false;
+      fixture.detectChanges();
+
+      fixture.componentInstance.seriesData = [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+            {x: 3, y: 1},
+          ],
+        }),
+      ];
+      fixture.detectChanges();
+
+      fixture.componentInstance.seriesMetadataMap = {
+        foo: buildMetadata({id: 'foo', visible: false}),
+      };
+      fixture.detectChanges();
+
+      fixture.componentInstance.enableUpdate = true;
+      fixture.detectChanges();
+
+      expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);
+      // No runs are current visible so we set the default view extent.
+      expect(updateViewBoxSpy.calls.argsFor(1)).toEqual([
+        {
+          x: [-0.1, 1.1],
+          y: [-0.1, 1.1],
+        },
+      ]);
     });
   });
 });

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -34,7 +34,7 @@ import {LineChartComponent} from './line_chart_component';
   template: `
     <line-chart
       #chart
-      [enableUpdate]="enableUpdate"
+      [disableUpdate]="disableUpdate"
       [preferredRendererType]="preferredRendererType"
       [seriesData]="seriesData"
       [seriesMetadataMap]="seriesMetadataMap"
@@ -69,7 +69,7 @@ class TestableComponent {
   fixedViewBox?: Extent;
 
   @Input()
-  enableUpdate?: boolean;
+  disableUpdate?: boolean;
 
   // WebGL one is harder to test.
   preferredRendererType = RendererType.SVG;
@@ -109,7 +109,7 @@ describe('line_chart_v2/line_chart test', () => {
     seriesMetadataMap: DataSeriesMetadataMap;
     yScaleType: ScaleType;
     fixedViewBox?: Extent;
-    enableUpdate?: boolean;
+    disableUpdate?: boolean;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
     fixture.componentInstance.seriesData = input.seriesData;
@@ -120,8 +120,8 @@ describe('line_chart_v2/line_chart test', () => {
       fixture.componentInstance.fixedViewBox = input.fixedViewBox;
     }
 
-    if (input.enableUpdate !== undefined) {
-      fixture.componentInstance.enableUpdate = input.enableUpdate;
+    if (input.disableUpdate !== undefined) {
+      fixture.componentInstance.disableUpdate = input.disableUpdate;
     }
 
     return fixture;
@@ -360,10 +360,10 @@ describe('line_chart_v2/line_chart test', () => {
     });
   });
 
-  describe('enableUpdate=false', () => {
+  describe('disableUpdate=true', () => {
     it('disables any update', () => {
       const fixture = createComponent({
-        enableUpdate: false,
+        disableUpdate: true,
         seriesData: [
           buildSeries({
             id: 'foo',
@@ -386,9 +386,9 @@ describe('line_chart_v2/line_chart test', () => {
       expect(updateViewBoxSpy).toHaveBeenCalledTimes(0);
     });
 
-    it('sets update when enableUpdate changes to true', () => {
+    it('sets update when disableUpdate changes to false', () => {
       const fixture = createComponent({
-        enableUpdate: false,
+        disableUpdate: true,
         seriesData: [
           buildSeries({
             id: 'foo',
@@ -407,7 +407,7 @@ describe('line_chart_v2/line_chart test', () => {
       expect(updateMetadataSpy).toHaveBeenCalledTimes(0);
       expect(updateDataSpy).toHaveBeenCalledTimes(0);
 
-      fixture.componentInstance.enableUpdate = true;
+      fixture.componentInstance.disableUpdate = false;
       fixture.detectChanges();
 
       expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
@@ -417,7 +417,7 @@ describe('line_chart_v2/line_chart test', () => {
 
     it('queues up viewBox changes and updates default viewBox when update is enabled', () => {
       const fixture = createComponent({
-        enableUpdate: true,
+        disableUpdate: false,
         seriesData: [
           buildSeries({
             id: 'foo',
@@ -440,7 +440,7 @@ describe('line_chart_v2/line_chart test', () => {
         },
       ]);
 
-      fixture.componentInstance.enableUpdate = false;
+      fixture.componentInstance.disableUpdate = true;
       fixture.detectChanges();
 
       fixture.componentInstance.seriesData = [
@@ -461,7 +461,7 @@ describe('line_chart_v2/line_chart test', () => {
       };
       fixture.detectChanges();
 
-      fixture.componentInstance.enableUpdate = true;
+      fixture.componentInstance.disableUpdate = false;
       fixture.detectChanges();
 
       expect(updateViewBoxSpy).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
In the timeseries dashboard, we keep track of cards that are in the
view. With this information, we can opt out of updating the charts that
are outside of the viewport and save CPU cycles.

This change propagates the visibility information via `enableUpdate`
flag and make sure to apply changes only when the card is visible in the
viewport.
