### PR TITLE
Revert "Add a lengths argument to tensorboard.summary.audio."

### DIFF
--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -246,35 +246,6 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
             # Reset to default state for other tests.
             tf2.summary.experimental.set_step(None)
 
-    def test_lengths(self):
-        data = np.array(
-            [[[1.0], [0.0]], [[1.0], [-1.0]], [[0.0], [0.0]]]
-        ).astype(np.float32)
-        lengths = np.array([1, 2, 0]).astype(np.int32)
-        pb = self.audio(
-            "a", data, 44100, step=333, lengths=lengths, max_outputs=2
-        )
-        results = tensor_util.make_ndarray(pb.value[0].tensor)
-
-        self.assertEqual(results.shape, (2, 2))
-        # If lengths are respected, the first example will be 2 bytes shorter
-        # than the second.
-        self.assertLen(results[0, 0], 46)
-        self.assertLen(results[1, 0], 48)
-
-    def test_no_lengths(self):
-        data = np.array(
-            [[[1.0], [0.0]], [[1.0], [-1.0]], [[0.0], [0.0]]]
-        ).astype(np.float32)
-        pb = self.audio("a", data, 44100, step=333, lengths=None, max_outputs=2)
-        results = tensor_util.make_ndarray(pb.value[0].tensor)
-
-        self.assertEqual(results.shape, (2, 2))
-        # If no lengths are provided, both examples contain all samples in the
-        # dense tensor.
-        self.assertLen(results[0, 0], 48)
-        self.assertLen(results[1, 0], 48)
-
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -37,7 +37,6 @@ def audio(
     max_outputs=3,
     encoding=None,
     description=None,
-    lengths=None,
 ):
     """Write an audio summary.
 
@@ -46,15 +45,14 @@ def audio(
         be this name prefixed by any active name scopes.
       data: A `Tensor` representing audio data with shape `[k, t, c]`,
         where `k` is the number of audio clips, `t` is the number of
-        frames, and `c` is the number of channels. To pass batches of data where
-        the frame count is variable, use the `lengths` parameter. Elements
-        should be floating-point values in `[-1.0, 1.0]`. Any of the dimensions
-        may be statically unknown (i.e., `None`).
+        frames, and `c` is the number of channels. Elements should be
+        floating-point values in `[-1.0, 1.0]`. Any of the dimensions may
+        be statically unknown (i.e., `None`).
       sample_rate: An `int` or rank-0 `int32` `Tensor` that represents the
         sample rate, in Hz. Must be positive.
       step: Explicit `int64`-castable monotonic step value for this summary. If
-        omitted, this defaults to `tf.summary.experimental.get_step()`, which
-        must not be None.
+        omitted, this defaults to `tf.summary.experimental.get_step()`, which must
+        not be None.
       max_outputs: Optional `int` or rank-0 integer `Tensor`. At most this
         many audio clips will be emitted at each step. When more than
         `max_outputs` many clips are provided, the first `max_outputs`
@@ -64,11 +62,6 @@ def audio(
         default, so if you want "wav" in particular, set this explicitly.
       description: Optional long-form description for this summary, as a
         constant `str`. Markdown is supported. Defaults to empty.
-      lengths: Optional lengths `Tensor`, shaped `[k]`, where each entry
-        indicates the length of the k'th example in frames. Useful when `data`
-        should be interpreted as ragged rather than fixed-length; each example
-        will be truncated accordingly prior to audio encoding. k may be
-        statically unknown (i.e., `None`).
 
     Returns:
       True on success, or false if no summary was emitted because no default
@@ -92,7 +85,7 @@ def audio(
         description=description,
         encoding=metadata.Encoding.Value("WAV"),
     )
-    inputs = [data, sample_rate, max_outputs, step, lengths]
+    inputs = [data, sample_rate, max_outputs, step]
     # TODO(https://github.com/tensorflow/tensorboard/issues/2109): remove fallback
     summary_scope = (
         getattr(tf.summary.experimental, "summary_scope", None)
@@ -107,31 +100,15 @@ def audio(
             tf.debugging.assert_rank(data, 3)
             tf.debugging.assert_non_negative(max_outputs)
             limited_audio = data[:max_outputs]
-
             encode_fn = functools.partial(
                 audio_ops.encode_wav, sample_rate=sample_rate
             )
-            if lengths is not None:
-                tf.debugging.assert_rank(lengths, 1)
-                limited_lengths = lengths[:max_outputs]
-
-                def encode_with_length(datum_and_length):
-                    datum, length = datum_and_length
-                    return encode_fn(datum[:length])
-
-                encoded_audio = tf.map_fn(
-                    encode_with_length,
-                    (limited_audio, limited_lengths),
-                    dtype=tf.string,
-                    name="encode_each_audio",
-                )
-            else:
-                encoded_audio = tf.map_fn(
-                    encode_fn,
-                    limited_audio,
-                    dtype=tf.string,
-                    name="encode_each_audio",
-                )
+            encoded_audio = tf.map_fn(
+                encode_fn,
+                limited_audio,
+                dtype=tf.string,
+                name="encode_each_audio",
+            )
             # Workaround for map_fn returning float dtype for an empty elems input.
             encoded_audio = tf.cond(
                 tf.shape(input=encoded_audio)[0] > 0,


### PR DESCRIPTION
Reverts tensorflow/tensorboard#4502

We need to pass this through an internal review process first since the change affects the TensorFlow API, and that can take up to a week, so reverting for now to avoid blocking our internal sync.