### PR TITLE
rust: load graphs into memory as blob sequences

### DIFF
--- a/tensorboard/data/server/commit.rs
+++ b/tensorboard/data/server/commit.rs
@@ -56,6 +56,9 @@ pub struct RunData {
 
     /// Scalar time series for this run.
     pub scalars: TagStore<ScalarValue>,
+
+    /// Blob sequence time series for this run.
+    pub blob_sequences: TagStore<BlobSequenceValue>,
 }
 
 pub type TagStore<V> = HashMap<Tag, TimeSeries<V>>;
@@ -104,6 +107,12 @@ pub struct DataLoss;
 /// The value of a scalar time series at a single point.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ScalarValue(pub f32);
+
+/// The value of a blob sequence time series at a single point.
+///
+/// This value is a sequence of zero or more blobs, stored in memory.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BlobSequenceValue(pub Vec<Vec<u8>>);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Summary:
The `Commit` structure now has a `blob_sequences` store in addition to
its `scalars` store. For now, we only actually load run graphs into
memory (since it’s trivial, and everything else is merely easy).

Test Plan:
Unit tests included. There are no user-facing changes to the RPC layer.
Loading an MNIST dataset with scalars, graphs, and images no longer
prints warnings about `graph_def`s, and still serves scalars properly.

wchargin-branch: rust-load-graphs
