### PR TITLE
line chart: set cache when object is returned

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
@@ -23,15 +23,26 @@ import {
 import {PaintBrush} from './paint_brush';
 import {ObjectRenderer} from './renderer/renderer_types';
 
-class RenderCacheContainer {
-  private prevFrameCache = new Map<string, any>();
-  private currFrameCache = new Map<string, any>();
+type Cacheable = {};
 
-  getFromPreviousFrame(key: string): any {
-    return this.prevFrameCache.get(key);
+export interface RenderCachePublicApi {
+  getFromPreviousFrame(key: string): Cacheable | null;
+  setToCurrentFrame(key: string, value: Cacheable): void;
+}
+
+class RenderCacheContainer implements RenderCachePublicApi {
+  private prevFrameCache = new Map<string, Cacheable>();
+  private currFrameCache = new Map<string, Cacheable>();
+
+  getFromPreviousFrame(key: string): Cacheable | null {
+    const value = this.prevFrameCache.get(key);
+    return value ?? null;
   }
 
-  setToCurrentFrame(key: string, value: any) {
+  setToCurrentFrame(key: string, value: Cacheable) {
+    if (!value) {
+      console.log(key);
+    }
     this.currFrameCache.set(key, value);
   }
 
@@ -41,7 +52,7 @@ class RenderCacheContainer {
    *
    * It returns cached objects that got removed from the new frame.
    */
-  finalizeFrameAndGetRemoved(): ReadonlyArray<any> {
+  finalizeFrameAndGetRemoved(): ReadonlyArray<Cacheable> {
     const removed = [];
 
     for (const [key, value] of this.prevFrameCache.entries()) {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {RenderCachePublicApi} from './drawable';
 import {Point} from './internal_types';
 import {
   CirclePaintOption,
@@ -21,11 +22,8 @@ import {
   TrianglePaintOption,
 } from './renderer/renderer_types';
 
-export interface PaintBrushContext<T = any> {
-  renderCache: {
-    getFromPreviousFrame(cacheKey: string): T;
-    setToCurrentFrame(cacheKey: string, obj: T): void;
-  };
+export interface PaintBrushContext {
+  renderCache: RenderCachePublicApi;
 }
 
 export class PaintBrush {
@@ -40,7 +38,9 @@ export class PaintBrush {
       polyline,
       paintOpt
     );
-    this.context.renderCache.setToCurrentFrame(cacheId, newCacheValue);
+    if (newCacheValue) {
+      this.context.renderCache.setToCurrentFrame(cacheId, newCacheValue);
+    }
   }
 
   setTriangle(cacheId: string, loc: Point, paintOpt: TrianglePaintOption) {
@@ -49,7 +49,9 @@ export class PaintBrush {
       loc,
       paintOpt
     );
-    this.context.renderCache.setToCurrentFrame(cacheId, newCacheValue);
+    if (newCacheValue) {
+      this.context.renderCache.setToCurrentFrame(cacheId, newCacheValue);
+    }
   }
 
   setCircle(cacheId: string, loc: Point, paintOpt: CirclePaintOption) {
@@ -58,6 +60,8 @@ export class PaintBrush {
       loc,
       paintOpt
     );
-    this.context.renderCache.setToCurrentFrame(cacheId, newCacheValue);
+    if (newCacheValue) {
+      this.context.renderCache.setToCurrentFrame(cacheId, newCacheValue);
+    }
   }
 }


### PR DESCRIPTION
There was a bug where when we tried to remove a line while the data is
not yet fetched, the line chart threw a JSE for trying to access
`null.obj3d` in the remove object function. This happened since renderer
can, in some case, early exit by returning null and we populated the
cache with null values. With this change, we disallow adding null value
to the cache with better typing. We previously had the bug because it
was typed to take `any` which includes `null`. Now, we type it to extend
an object which is an okay constraint since it is an Object drawer.
