### PR TITLE
graph: disallow double click to select text

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -38,6 +38,10 @@ export const template = html`
       visibility: hidden;
     }
 
+    text {
+      user-select: none;
+    }
+
     /* --- Node and annotation-node for Metanode --- */
 
     .meta > .nodeshape > rect,


### PR DESCRIPTION
Graph plugin's main UI affordance is double click a node to
expand/collapse. This, without this change, by browser default selects
text in a node which is often not user's intention and offers less than
ideal user experience. This change disables that.
