### PR TITLE
TensorBoard 2.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tf_version_id: ['tf-nightly', 'notf']
+        tf_version_id: ['tensorflow==2.4.0', 'notf']
         python_version: ['3.7']
     steps:
       - uses: actions/checkout@v1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,11 @@
+# Release 2.4.1
+
+## Bug fixes
+
+- Fixed `--path_prefix` handling (#4423)
+- Removed `frame-ancestors *` CSP directive for compatibility with Electron
+  embeds (#4332) - thanks [@joyceerhl](https://github.com/joyceerhl)
+
 # Release 2.4.0
 
 The 2.4 minor series tracks TensorFlow 2.4.

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = "2.4.0"
+VERSION = "2.4.1"


### PR DESCRIPTION
Cherrypicks:

  - #4423: ng: support path_prefix at router level
  - #4332: Remove `frame-ancestors *` CSP directive

To be merged with rebase. Closes #4547.
