### PR TITLE
line chart: improve color opacity interpolation

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -410,7 +410,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
           };
 
           metadata.aux = true;
-          metadata.opacity = 0.4;
+          metadata.opacity = 0.25;
         }
         return metadataMap;
       }),

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -1096,7 +1096,7 @@ describe('scalar card', () => {
           type: SeriesType.ORIGINAL,
           visible: false,
           color: '#f00',
-          opacity: 0.4,
+          opacity: 0.25,
           aux: true,
         },
         run2: {
@@ -1105,7 +1105,7 @@ describe('scalar card', () => {
           type: SeriesType.ORIGINAL,
           visible: false,
           color: '#0f0',
-          opacity: 0.4,
+          opacity: 0.25,
           aux: true,
         },
         '["smoothed","run1"]': {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import * as THREE from 'three';
 
-import {hsl} from '../../../../third_party/d3';
+import {hsl, interpolateHsl} from '../../../../third_party/d3';
 import {Point, Polyline, Rect} from '../internal_types';
 import {ThreeCoordinator} from '../threejs_coordinator';
 import {arePolylinesEqual, isOffscreenCanvasSupported} from '../utils';
@@ -31,10 +31,7 @@ function createOpacityAdjustedColor(hex: string, opacity: number): THREE.Color {
   if (!newD3Color) {
     throw new Error(`d3 failed to recognize the color: ${hex}`);
   }
-  // As per d3 doc, in HSL, lightness channel is multiplied by 0.7 ^ -k.
-  // 1.6 is a random number but 1 - opacity was "not enough" thus increased "k" with 0.6
-  // bias.
-  return new THREE.Color(newD3Color.brighter(1.6 - opacity).hex());
+  return new THREE.Color(interpolateHsl(newD3Color, '#fff')(1 - opacity));
 }
 
 enum CacheType {


### PR DESCRIPTION
Previously, we were using d3.color.brighter but its algorithm created
a bit too salient color for certain colors (low luminance like our slate
color) while being light enough for others.

To alleviate this unevenness in brightening, we decided to use the color
interpolation instead. It results in more visually correct result.

Note: changed opacity from 0.4 to 0.25. It is 0.2 in vz-line-chart but
it looked a bit too faint in GPU line chart so we up-ed it by 0.05

Old:
![image](https://user-images.githubusercontent.com/2547313/104642838-4a664e80-5660-11eb-99f0-e4581d47fb36.png)

New:
![image](https://user-images.githubusercontent.com/2547313/104642811-40dce680-5660-11eb-841c-e6d70c67c5c8.png)
