### PR TITLE
core: cache on JS resources when hash is present

### DIFF
--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -377,9 +377,9 @@ class CorePluginTestBase(object):
             )
 
 
-class CorePluginResourceTEst(tf.test.TestCase):
+class CorePluginResourceTest(tf.test.TestCase):
     def setUp(self):
-        super(CorePluginResourceTEst, self).setUp()
+        super(CorePluginResourceTest, self).setUp()
         self.logdir = self.get_temp_dir()
         self.multiplexer = event_multiplexer.EventMultiplexer()
         provider = data_provider.MultiplexerDataProvider(


### PR DESCRIPTION
Previously, TensorBoard never cached the resource even when its contents
never change in a given pip package. While this is tolerable in the
local instance setting, it is not the best especially when we start to
use worker where the resources would have to be fetched per worker
instance,

This change enables caching for one day (for now) when JavaScript
resources with `_file_hash` query parameter is requested. While this
approach works for any resources, there is no strong reason to do so and
we will start with restrictive caching at first. In the future, we may
apply the query parameter to more resources and enable caching of SVG
and other resources.

