### PR TITLE
line chart: refactor worker typing

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_pool.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_pool.ts
@@ -55,9 +55,9 @@ export interface WorkerProxy {
 export class WorkerPool {
   private readonly workers: WorkerProxy[] = [];
   constructor(
-    private readonly workerResourcePath: string,
-    private readonly maxPoolSize = 10,
-    private readonly workerFactory: (resourcePath: string) => Worker = getWorker
+    private readonly workerResourcePath: Parameters<typeof getWorker>[0],
+    private readonly maxPoolSize: number = 10,
+    private readonly workerFactory: typeof getWorker = getWorker
   ) {
     // TODO(tensorboard-team): consider pre-allocating with the IdleCallback.
   }


### PR DESCRIPTION
Internally, we cannot create Worker with string. As such, we need to
alter the types of parameter of Worker factory and this change allows
there to be different type signatures of the WorkerPool.
