### PR TITLE
rust: add `tokio-stream` dependency

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -366,7 +366,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.1",
  "socket2",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "want",
@@ -558,6 +558,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -769,7 +775,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
+ "tokio-stream",
  "tonic",
  "tonic-build",
  "walkdir",
@@ -930,9 +937,19 @@ dependencies = [
  "lazy_static",
  "memchr",
  "mio",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "slab",
  "tokio-macros",
+]
+
+[[package]]
+name = "tokio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
+dependencies = [
+ "autocfg",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -947,6 +964,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.4",
+ "tokio 1.0.2",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,8 +984,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.1.11",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -979,7 +1007,7 @@ dependencies = [
  "pin-project 0.4.27",
  "prost",
  "prost-derive",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tower",
  "tower-balance",
@@ -1032,7 +1060,7 @@ dependencies = [
  "pin-project 0.4.27",
  "rand",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tower-discover",
  "tower-layer",
  "tower-load",
@@ -1050,7 +1078,7 @@ checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1081,7 +1109,7 @@ checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
  "tower-layer",
  "tower-load",
  "tower-service",
@@ -1096,7 +1124,7 @@ dependencies = [
  "futures-core",
  "log",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
  "tower-discover",
  "tower-service",
 ]
@@ -1119,7 +1147,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
 ]
 
@@ -1133,7 +1161,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "log",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
 ]
 
@@ -1145,7 +1173,7 @@ checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
 dependencies = [
  "futures-core",
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
  "tower-layer",
  "tower-service",
 ]
@@ -1163,7 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
 dependencies = [
  "pin-project 0.4.27",
- "tokio",
+ "tokio 0.2.22",
  "tower-layer",
  "tower-service",
 ]
@@ -1188,7 +1216,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tracing-attributes",
  "tracing-core",
 ]

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -39,6 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.59"
 thiserror = "1.0.21"
 tokio = { version = "0.2.2", features = ["macros"] }
+tokio-stream = "0.1.2"
 tonic = "0.3.1"
 walkdir = "2.3.1"
 

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -175,6 +175,15 @@ alias(
 )
 
 alias(
+    name = "tokio_stream",
+    actual = "@raze__tokio_stream__0_1_2//:tokio_stream",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "tonic",
     actual = "@raze__tonic__0_3_1//:tonic",
     tags = [

--- a/third_party/rust/crates.bzl
+++ b/third_party/rust/crates.bzl
@@ -633,6 +633,16 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__pin_project_lite__0_2_4",
+        url = "https://crates.io/api/v1/crates/pin-project-lite/0.2.4/download",
+        type = "tar.gz",
+        sha256 = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827",
+        strip_prefix = "pin-project-lite-0.2.4",
+        build_file = Label("//third_party/rust/remote:BUILD.pin-project-lite-0.2.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__pin_utils__0_1_0",
         url = "https://crates.io/api/v1/crates/pin-utils/0.1.0/download",
         type = "tar.gz",
@@ -983,12 +993,32 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__tokio__1_0_2",
+        url = "https://crates.io/api/v1/crates/tokio/1.0.2/download",
+        type = "tar.gz",
+        sha256 = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec",
+        strip_prefix = "tokio-1.0.2",
+        build_file = Label("//third_party/rust/remote:BUILD.tokio-1.0.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__tokio_macros__0_2_6",
         url = "https://crates.io/api/v1/crates/tokio-macros/0.2.6/download",
         type = "tar.gz",
         sha256 = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a",
         strip_prefix = "tokio-macros-0.2.6",
         build_file = Label("//third_party/rust/remote:BUILD.tokio-macros-0.2.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__tokio_stream__0_1_2",
+        url = "https://crates.io/api/v1/crates/tokio-stream/0.1.2/download",
+        type = "tar.gz",
+        sha256 = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd",
+        strip_prefix = "tokio-stream-0.1.2",
+        build_file = Label("//third_party/rust/remote:BUILD.tokio-stream-0.1.2.bazel"),
     )
 
     maybe(

--- a/third_party/rust/remote/BUILD.pin-project-lite-0.2.4.bazel
+++ b/third_party/rust/remote/BUILD.pin-project-lite-0.2.4.bazel
@@ -1,0 +1,62 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "pin_project_lite",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.4",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "drop_order" with type "test" omitted
+
+# Unsupported target "lint" with type "test" omitted
+
+# Unsupported target "proper_unpin" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/rust/remote/BUILD.tokio-1.0.2.bazel
+++ b/third_party/rust/remote/BUILD.tokio-1.0.2.bazel
@@ -1,0 +1,257 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "tokio",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "default",
+        "sync",
+        "time",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.2",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__pin_project_lite__0_2_4//:pin_project_lite",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "_require_full" with type "test" omitted
+
+# Unsupported target "async_send_sync" with type "test" omitted
+
+# Unsupported target "buffered" with type "test" omitted
+
+# Unsupported target "fs" with type "test" omitted
+
+# Unsupported target "fs_copy" with type "test" omitted
+
+# Unsupported target "fs_dir" with type "test" omitted
+
+# Unsupported target "fs_file" with type "test" omitted
+
+# Unsupported target "fs_file_mocked" with type "test" omitted
+
+# Unsupported target "fs_link" with type "test" omitted
+
+# Unsupported target "io_async_fd" with type "test" omitted
+
+# Unsupported target "io_async_read" with type "test" omitted
+
+# Unsupported target "io_chain" with type "test" omitted
+
+# Unsupported target "io_copy" with type "test" omitted
+
+# Unsupported target "io_driver" with type "test" omitted
+
+# Unsupported target "io_driver_drop" with type "test" omitted
+
+# Unsupported target "io_lines" with type "test" omitted
+
+# Unsupported target "io_mem_stream" with type "test" omitted
+
+# Unsupported target "io_read" with type "test" omitted
+
+# Unsupported target "io_read_buf" with type "test" omitted
+
+# Unsupported target "io_read_exact" with type "test" omitted
+
+# Unsupported target "io_read_line" with type "test" omitted
+
+# Unsupported target "io_read_to_end" with type "test" omitted
+
+# Unsupported target "io_read_to_string" with type "test" omitted
+
+# Unsupported target "io_read_until" with type "test" omitted
+
+# Unsupported target "io_split" with type "test" omitted
+
+# Unsupported target "io_take" with type "test" omitted
+
+# Unsupported target "io_write" with type "test" omitted
+
+# Unsupported target "io_write_all" with type "test" omitted
+
+# Unsupported target "io_write_buf" with type "test" omitted
+
+# Unsupported target "io_write_int" with type "test" omitted
+
+# Unsupported target "macros_join" with type "test" omitted
+
+# Unsupported target "macros_pin" with type "test" omitted
+
+# Unsupported target "macros_select" with type "test" omitted
+
+# Unsupported target "macros_test" with type "test" omitted
+
+# Unsupported target "macros_try_join" with type "test" omitted
+
+# Unsupported target "net_bind_resource" with type "test" omitted
+
+# Unsupported target "net_lookup_host" with type "test" omitted
+
+# Unsupported target "no_rt" with type "test" omitted
+
+# Unsupported target "process_issue_2174" with type "test" omitted
+
+# Unsupported target "process_issue_42" with type "test" omitted
+
+# Unsupported target "process_kill_on_drop" with type "test" omitted
+
+# Unsupported target "process_smoke" with type "test" omitted
+
+# Unsupported target "rt_basic" with type "test" omitted
+
+# Unsupported target "rt_common" with type "test" omitted
+
+# Unsupported target "rt_threaded" with type "test" omitted
+
+# Unsupported target "signal_ctrl_c" with type "test" omitted
+
+# Unsupported target "signal_drop_recv" with type "test" omitted
+
+# Unsupported target "signal_drop_rt" with type "test" omitted
+
+# Unsupported target "signal_drop_signal" with type "test" omitted
+
+# Unsupported target "signal_multi_rt" with type "test" omitted
+
+# Unsupported target "signal_no_rt" with type "test" omitted
+
+# Unsupported target "signal_notify_both" with type "test" omitted
+
+# Unsupported target "signal_twice" with type "test" omitted
+
+# Unsupported target "signal_usr1" with type "test" omitted
+
+# Unsupported target "sync_barrier" with type "test" omitted
+
+# Unsupported target "sync_broadcast" with type "test" omitted
+
+# Unsupported target "sync_errors" with type "test" omitted
+
+# Unsupported target "sync_mpsc" with type "test" omitted
+
+# Unsupported target "sync_mutex" with type "test" omitted
+
+# Unsupported target "sync_mutex_owned" with type "test" omitted
+
+# Unsupported target "sync_notify" with type "test" omitted
+
+# Unsupported target "sync_oneshot" with type "test" omitted
+
+# Unsupported target "sync_rwlock" with type "test" omitted
+
+# Unsupported target "sync_semaphore" with type "test" omitted
+
+# Unsupported target "sync_semaphore_owned" with type "test" omitted
+
+# Unsupported target "sync_watch" with type "test" omitted
+
+# Unsupported target "task_abort" with type "test" omitted
+
+# Unsupported target "task_blocking" with type "test" omitted
+
+# Unsupported target "task_local" with type "test" omitted
+
+# Unsupported target "task_local_set" with type "test" omitted
+
+# Unsupported target "tcp_accept" with type "test" omitted
+
+# Unsupported target "tcp_connect" with type "test" omitted
+
+# Unsupported target "tcp_echo" with type "test" omitted
+
+# Unsupported target "tcp_into_split" with type "test" omitted
+
+# Unsupported target "tcp_into_std" with type "test" omitted
+
+# Unsupported target "tcp_peek" with type "test" omitted
+
+# Unsupported target "tcp_shutdown" with type "test" omitted
+
+# Unsupported target "tcp_socket" with type "test" omitted
+
+# Unsupported target "tcp_split" with type "test" omitted
+
+# Unsupported target "tcp_stream" with type "test" omitted
+
+# Unsupported target "test_clock" with type "test" omitted
+
+# Unsupported target "time_interval" with type "test" omitted
+
+# Unsupported target "time_pause" with type "test" omitted
+
+# Unsupported target "time_rt" with type "test" omitted
+
+# Unsupported target "time_sleep" with type "test" omitted
+
+# Unsupported target "time_timeout" with type "test" omitted
+
+# Unsupported target "udp" with type "test" omitted
+
+# Unsupported target "uds_cred" with type "test" omitted
+
+# Unsupported target "uds_datagram" with type "test" omitted
+
+# Unsupported target "uds_split" with type "test" omitted
+
+# Unsupported target "uds_stream" with type "test" omitted

--- a/third_party/rust/remote/BUILD.tokio-stream-0.1.2.bazel
+++ b/third_party/rust/remote/BUILD.tokio-stream-0.1.2.bazel
@@ -1,0 +1,81 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "tokio_stream",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "time",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.2",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__futures_core__0_3_8//:futures_core",
+        "@raze__pin_project_lite__0_2_4//:pin_project_lite",
+        "@raze__tokio__1_0_2//:tokio",
+    ],
+)
+
+# Unsupported target "async_send_sync" with type "test" omitted
+
+# Unsupported target "stream_chain" with type "test" omitted
+
+# Unsupported target "stream_collect" with type "test" omitted
+
+# Unsupported target "stream_empty" with type "test" omitted
+
+# Unsupported target "stream_fuse" with type "test" omitted
+
+# Unsupported target "stream_iter" with type "test" omitted
+
+# Unsupported target "stream_merge" with type "test" omitted
+
+# Unsupported target "stream_once" with type "test" omitted
+
+# Unsupported target "stream_pending" with type "test" omitted
+
+# Unsupported target "stream_stream_map" with type "test" omitted
+
+# Unsupported target "stream_timeout" with type "test" omitted
+
+# Unsupported target "time_throttle" with type "test" omitted


### PR DESCRIPTION
Summary:
The [`tokio-stream`] crate makes it easier to work with async streams,
and in particular to iterate over them. This is useful for test code
that needs to iterate over the responses of server-streaming RPCs like
`ReadBlob`.

[`tokio-stream`]: https://crates.io/crates/tokio-stream

Test Plan:
It builds: `bazel build //third_party/rust:tokio_stream`.

wchargin-branch: rust-dep-tokio-stream
