### PR TITLE
rust: make CRC checking optional

### DIFF
--- a/tensorboard/data/server/bench.rs
+++ b/tensorboard/data/server/bench.rs
@@ -31,6 +31,7 @@ struct Opts {
     log_level: String,
     // Pair of `--no-checksum` and `--checksum` flags, defaulting to "no checksum".
     #[clap(long, multiple_occurrences = true, overrides_with = "checksum")]
+    #[allow(unused)]
     no_checksum: bool,
     #[clap(long, multiple_occurrences = true, overrides_with = "no_checksum")]
     checksum: bool,

--- a/tensorboard/data/server/bench.rs
+++ b/tensorboard/data/server/bench.rs
@@ -29,6 +29,11 @@ struct Opts {
     logdir: PathBuf,
     #[clap(long, default_value = "info")]
     log_level: String,
+    // Pair of `--no-checksum` and `--checksum` flags, defaulting to "no checksum".
+    #[clap(long, multiple_occurrences = true, overrides_with = "checksum")]
+    no_checksum: bool,
+    #[clap(long, multiple_occurrences = true, overrides_with = "no_checksum")]
+    checksum: bool,
 }
 
 fn main() {
@@ -37,6 +42,7 @@ fn main() {
 
     let commit = Commit::new();
     let mut loader = LogdirLoader::new(&commit, opts.logdir);
+    loader.checksum(opts.checksum); // if neither `--[no-]checksum` given, defaults to false
 
     info!("Starting load cycle");
     let start = Instant::now();

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -105,6 +105,7 @@ struct Opts {
         overrides_with = "checksum",
         hidden = true
     )]
+    #[allow(unused)]
     no_checksum: bool,
 }
 

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -86,6 +86,26 @@ struct Opts {
     /// port file is specified but cannot be written, the server will die.
     #[clap(long)]
     port_file: Option<PathBuf>,
+
+    /// Checksum all records (negate with `--no-checksum`)
+    ///
+    /// With `--checksum`, every record will be checksummed before being parsed. With
+    /// `--no-checksum` (the default), records are only checksummed if parsing fails. Skipping
+    /// checksums for records that successfully parse can be significantly faster, but also means
+    /// that some bit flips may not be detected.
+    #[clap(long, multiple_occurrences = true, overrides_with = "no_checksum")]
+    checksum: bool,
+
+    /// Only checksum records that fail to parse
+    ///
+    /// Negates `--checksum`. This is the default.
+    #[clap(
+        long,
+        multiple_occurrences = true,
+        overrides_with = "checksum",
+        hidden = true
+    )]
+    no_checksum: bool,
 }
 
 /// A duration in seconds.
@@ -148,16 +168,16 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .spawn({
             let logdir = opts.logdir;
             let reload_interval = opts.reload_interval;
-            move || {
-                let mut loader = LogdirLoader::new(commit, logdir);
-                loop {
-                    info!("Starting load cycle");
-                    let start = Instant::now();
-                    loader.reload();
-                    let end = Instant::now();
-                    info!("Finished load cycle ({:?})", end - start);
-                    thread::sleep(reload_interval.duration());
-                }
+            let mut loader = LogdirLoader::new(commit, logdir);
+            // Checksum only if `--checksum` given (i.e., off by default).
+            loader.checksum(opts.checksum);
+            move || loop {
+                info!("Starting load cycle");
+                let start = Instant::now();
+                loader.reload();
+                let end = Instant::now();
+                info!("Finished load cycle ({:?})", end - start);
+                thread::sleep(reload_interval.duration());
             }
         })
         .expect("failed to spawn reloader thread");


### PR DESCRIPTION
Summary:
Instead of computing checksums for every record, we can now compute
checksums only for records that fail proto parsing. This means that bit
flips in payloads like string fields may not be caught. But it comes
with a significant performance improvement:

  - 2.42× (±0.24×) faster for `mnist` (125 ms → 50 ms)
  - 1.20× (±0.03×) faster for `edge_cgan` (10.4 s → 8.7 s)
  - 1.23× (±0.01×) faster for `nndiv` (182 s → 148 s)

Both the main RustBoard binary and the `bench` binary now take
`--checksum`/`--no-checksum` flags, defaulting to `--no-checksum`.

Test Plan:
Unit tests extended. Benchmarked with:

```
hyperfine -w3 \
    './target/release/bench --logdir ~/testdata/edge_cgan/ {cksum}' \
    -L cksum --checksum,--no-checksum
```

wchargin-branch: rust-optional-crc
