### PR TITLE
tensorboard-data-server 0.1.0

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "rustboard"
-version = "0.1.0"
+version = "0.2.0-alpha.0"
 dependencies = [
  "async-stream 0.3.0",
  "async-trait",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "rustboard"
-version = "0.1.0"
+version = "0.2.0-alpha.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 edition = "2018"
 default-run = "rustboard"

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -35,7 +35,7 @@ use crate::server::DataProviderHandler;
 use data::tensor_board_data_provider_server::TensorBoardDataProviderServer;
 
 #[derive(Clap, Debug)]
-#[clap(name = "rustboard", version = "0.1.0")]
+#[clap(name = "rustboard", version = "0.2.0-alpha.0")]
 struct Opts {
     /// Log directory to load
     ///

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.1.0a0"
+__version__ = "0.1.0"
 
 
 def server_binary():

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.1.0"
+__version__ = "0.2.0a0"
 
 
 def server_binary():


### PR DESCRIPTION
This PR bumps the data server version number from 0.1.0a0 to 0.1.0, and
then to 0.2.0a0. Plan: merge with rebase, then release from the data
server binaries at the first commit as built by GitHub CI.

Notes:

  - Rust versions use <https://semver.org>, so prerelease specifiers are
    like `0.2.0-alpha.0` rather than Python `0.2.0a0`.
  - We could use `version = clap::crate_version!()` in the Rust code to
    avoid having to duplicate across `Cargo.toml` and `cli.rs`. This
    works fine when building with Cargo. But `CARGO_PKG_VERSION` is not
    set when building with Bazel, so for now I’m doing the simple thing
    and duplicating the string manually.

Test Plan:
Note that `cargo run -- -h` and `bazel run . -- -h` both print the
correct version.
