### PR TITLE
line chart: fix axis layout

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -70,6 +70,7 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
   styles: [
     `
       :host {
+        contain: strict;
         display: flex;
         overflow: hidden;
       }
@@ -87,6 +88,12 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
       text {
         font-size: 11px;
         user-select: none;
+      }
+
+      .x-axis,
+      .y-axis {
+        height: 100%;
+        width: 100%;
       }
 
       .x-axis {


### PR DESCRIPTION
bug: x-axis did not extend to the full width of the line chart.
fix: use width: 100% and height: 100% on the inner element.

Before
![image](https://user-images.githubusercontent.com/2547313/105119285-daebc700-5a84-11eb-80bd-8f2e64163d21.png)


After
![image](https://user-images.githubusercontent.com/2547313/105119245-cb6c7e00-5a84-11eb-86c9-c6406eb10448.png)

