### PR TITLE
rust: plumb reload interval to data server

### DIFF
--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -57,12 +57,12 @@ struct Opts {
     #[clap(long, default_value = "6806")]
     port: u16,
 
-    /// Delay between reload cycles (seconds)
+    /// Seconds to sleep between reloads, or "once"
     ///
     /// Number of seconds to wait between finishing one load cycle and starting the next one. This
-    /// does not include the time for the reload itself.
-    #[clap(long, default_value = "5")]
-    reload_interval: Seconds,
+    /// does not include the time for the reload itself. If "once", data will be loaded only once.
+    #[clap(long, default_value = "5", value_name = "secs")]
+    reload: ReloadStrategy,
 
     /// Use verbose output (-vv for very verbose output)
     #[clap(long = "verbose", short, parse(from_occurrences))]
@@ -88,18 +88,21 @@ struct Opts {
     port_file: Option<PathBuf>,
 }
 
-/// A duration in seconds.
-#[derive(Debug, Copy, Clone)]
-struct Seconds(u64);
-impl FromStr for Seconds {
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ReloadStrategy {
+    Loop { delay: Duration },
+    Once,
+}
+impl FromStr for ReloadStrategy {
     type Err = <u64 as FromStr>::Err;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse().map(Seconds)
-    }
-}
-impl Seconds {
-    fn duration(self) -> Duration {
-        Duration::from_secs(self.0)
+        if s == "once" {
+            Ok(ReloadStrategy::Once)
+        } else {
+            Ok(ReloadStrategy::Loop {
+                delay: Duration::from_secs(s.parse()?),
+            })
+        }
     }
 }
 
@@ -147,7 +150,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .name("Reloader".to_string())
         .spawn({
             let logdir = opts.logdir;
-            let reload_interval = opts.reload_interval;
+            let reload = opts.reload;
             move || {
                 let mut loader = LogdirLoader::new(commit, logdir);
                 loop {
@@ -156,7 +159,10 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     loader.reload();
                     let end = Instant::now();
                     info!("Finished load cycle ({:?})", end - start);
-                    thread::sleep(reload_interval.duration());
+                    match reload {
+                        ReloadStrategy::Loop { delay } => thread::sleep(delay),
+                        ReloadStrategy::Once => break,
+                    };
                 }
             }
         })
@@ -193,4 +199,22 @@ fn write_port_file(path: &Path, port: u16) -> std::io::Result<()> {
     writeln!(f, "{}", port)?;
     f.sync_all()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_reload() {
+        assert_eq!("once".parse::<ReloadStrategy>(), Ok(ReloadStrategy::Once));
+        assert_eq!(
+            "5".parse::<ReloadStrategy>(),
+            Ok(ReloadStrategy::Loop {
+                delay: Duration::from_secs(5)
+            })
+        );
+        "5s".parse::<ReloadStrategy>()
+            .expect_err("explicit \"s\" trailer should be forbidden");
+    }
 }

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -171,35 +171,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .name("Reloader".to_string())
         .spawn({
             let logdir = opts.logdir;
-<<<<<<< HEAD
-            let reload = opts.reload;
-            move || {
-                let mut loader = LogdirLoader::new(commit, logdir);
-                loop {
-                    info!("Starting load cycle");
-                    let start = Instant::now();
-                    loader.reload();
-                    let end = Instant::now();
-                    info!("Finished load cycle ({:?})", end - start);
-                    match reload {
-                        ReloadStrategy::Loop { delay } => thread::sleep(delay),
-                        ReloadStrategy::Once => break,
-                    };
-                }
-||||||| 6b085ffd3
-            let reload_interval = opts.reload_interval;
-            move || {
-                let mut loader = LogdirLoader::new(commit, logdir);
-                loop {
-                    info!("Starting load cycle");
-                    let start = Instant::now();
-                    loader.reload();
-                    let end = Instant::now();
-                    info!("Finished load cycle ({:?})", end - start);
-                    thread::sleep(reload_interval.duration());
-                }
-=======
-            let reload_interval = opts.reload_interval;
+            let reload_strategy = opts.reload;
             let mut loader = LogdirLoader::new(commit, logdir);
             // Checksum only if `--checksum` given (i.e., off by default).
             loader.checksum(opts.checksum);
@@ -209,8 +181,10 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 loader.reload();
                 let end = Instant::now();
                 info!("Finished load cycle ({:?})", end - start);
-                thread::sleep(reload_interval.duration());
->>>>>>> ec1ec35c5f1f090146dfda702c6adc8965c99998
+                match reload_strategy {
+                    ReloadStrategy::Loop { delay } => thread::sleep(delay),
+                    ReloadStrategy::Once => break,
+                };
             }
         })
         .expect("failed to spawn reloader thread");

--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -52,9 +52,10 @@ class ExistingServerDataIngester(ingester.DataIngester):
 class SubprocessServerDataIngester(ingester.DataIngester):
     """Start a new data server as a subprocess."""
 
-    def __init__(self, logdir):
+    def __init__(self, logdir, reload_interval):
         self._data_provider = None
         self._logdir = logdir
+        self._reload_interval = reload_interval
 
     @property
     def data_provider(self):
@@ -70,9 +71,15 @@ class SubprocessServerDataIngester(ingester.DataIngester):
         tmpdir = tempfile.TemporaryDirectory(prefix="tensorboard_data_server_")
         port_file_path = os.path.join(tmpdir.name, "port")
 
+        if self._reload_interval <= 0:
+            reload = "once"
+        else:
+            reload = str(int(self._reload_interval))
+
         args = [
             server_binary,
             "--logdir=%s" % (self._logdir,),
+            "--reload=%s" % reload,
             "--port=0",
             "--port-file=%s" % (port_file_path,),
             "--die-after-stdin",

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -78,7 +78,10 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
         with mock.patch.object(subprocess, "Popen", wraps=fake_popen) as popen:
             with mock.patch.object(grpc, "secure_channel", autospec=True) as sc:
                 logdir = "/tmp/logs"
-                ingester = server_ingester.SubprocessServerDataIngester(logdir)
+                ingester = server_ingester.SubprocessServerDataIngester(
+                    logdir=logdir,
+                    reload_interval=5,
+                )
                 ingester.start()
         self.assertIsInstance(
             ingester.data_provider, grpc_provider.GrpcDataProvider
@@ -87,6 +90,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
         expected_args = [
             fake_binary,
             "--logdir=/tmp/logs",
+            "--reload=5",
             "--port=0",
             "--port-file=%s" % port_file,
             "--die-after-stdin",

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -408,7 +408,8 @@ class TensorBoard(object):
             )
         elif flags.load_fast:
             ingester = server_ingester.SubprocessServerDataIngester(
-                flags.logdir
+                logdir=flags.logdir,
+                reload_interval=flags.reload_interval,
             )
         else:
             ingester = local_ingester.LocalDataIngester(flags)


### PR DESCRIPTION
Summary:
The TensorBoard `--reload_interval` flag now affects the flags passed to
the data server. To faithfully interpret the flag, we also teach the
data server to accept `--reload once`, corresponding to what TensorBoard
calls `--reload_interval 0`. We introduce this separate syntax to keep
the interpretation of `--reload N` continuous in `N`.

Test Plan:
Run with `--load_fast --verbosity 0 --reload_interval N` for various
values of `N`. Note that with `--reload_interval 0`, the data server
prints info logs for only one loading cycle, whereas with positive
intervals it delays for the correct amount of time. Note that fractional
intervals don’t cause a crash (they truncate).

wchargin-branch: rust-plumb-reload-interval
