### PR TITLE
rust: prefer Bazel-built server to Python dep

### DIFF
--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -150,6 +150,11 @@ def _get_server_binary():
             )
         return env_result
 
+    bundle_result = os.path.join(os.path.dirname(__file__), "server", "server")
+    if os.path.exists(bundle_result):
+        logging.info("Server binary (from bundle): %s", bundle_result)
+        return bundle_result
+
     try:
         import tensorboard_data_server
     except ImportError:
@@ -163,12 +168,8 @@ def _get_server_binary():
             )
         return pkg_result
 
-    bundle_result = os.path.join(os.path.dirname(__file__), "server", "server")
-    logging.info("Server binary (from bundle): %s", bundle_result)
-    if not os.path.exists(bundle_result):
-        raise RuntimeError(
-            "TensorBoard data server not found. This mode is experimental "
-            "and not supported in release builds. If building from source, "
-            "pass --define=link_data_server=true."
-        )
-    return bundle_result
+    raise RuntimeError(
+        "TensorBoard data server not found. This mode is experimental "
+        "and not supported in release builds. If building from source, "
+        "pass --define=link_data_server=true."
+    )


### PR DESCRIPTION
Summary:
Since `tensorboard` will eventually depend on `tensorboard-data-server`,
the data server will be installed in our normal dev virtualenvs. When
developing the Rust server with `--define=link_data_server=true`, we
want local changes to take precedence. This patch updates the server
ingester to check for a bundled server binary before checking for a
dynamically imported Python package.

An explicit `TENSORBOARD_DATA_SERVER_BINARY` environment variable still
overrides both of the other mechanisms.

Test Plan:
Run with `--load_fast --verbosity 0` and watch the “Server binary” log
line to see how the bundle is being resolved, in these configurations:

  - no `--define`, no Python package: should fail
  - `--define`, no Python package: should use Bazel binary
  - `--define`, with Python package: should use Bazel binary
  - no `--define`, with Python package: should use Python package

wchargin-branch: rust-bazel-precedence
