### PR TITLE
introduce py_repl() rule for a convenient Bazel-aware python shell

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -1,6 +1,7 @@
 # Description:
 # TensorBoard, a dashboard for investigating TensorFlow
 
+load("//tensorboard/defs:py_repl.bzl", "py_repl")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:zipper.bzl", "tensorboard_zip_file")
 
@@ -60,6 +61,17 @@ py_binary(
         ":program",
         "//tensorboard/uploader:uploader_subcommand",
     ],
+)
+
+# Repl that depends on the full TensorBoard `library`, useful for ad-hoc exploration
+# of the Python API surface. (Mere `python -i` generally doesn't suffice due to deps
+# on generated code and other runfiles-related issues.)
+py_repl(
+    name = "repl",
+    preamble = [
+        # Put statements here like "import tensorboard"
+    ],
+    deps = [":lib"],
 )
 
 # The public TensorBoard python library, bundled with the pip package and

--- a/tensorboard/defs/py_repl.bzl
+++ b/tensorboard/defs/py_repl.bzl
@@ -1,0 +1,80 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defines `py_repl` rule for creating a `bazel run`-able python REPL."""
+
+# Minimal wrapper over ctx.actions.write to write a string to a file.
+# Simpler than the genrule equivalent since we don't need to escape.
+def _write_file_impl(ctx):
+    ctx.actions.write(ctx.outputs.out, ctx.attr.content)
+
+_write_file = rule(
+    implementation = _write_file_impl,
+    attrs = {
+        "out": attr.output(mandatory = True),
+        "content": attr.string(),
+    },
+)
+
+def py_repl(name, preamble = None, deps = None):
+    """Executable target that runs the python interpeter interactively.
+
+    This provides a convenient way to interactively explore Python library
+    code that must be run under Bazel (e.g. it depends on Bazel-generated
+    Python dependencies, so cannot be run using `python -i` alone). It is
+    effectively just a wrapper over defining a `py_binary` with your desired
+    library deps plus a main.py with a few "preamble" lines and then running
+    the resulting built binary using `PYTHONINSPECT=1` to drop you in a REPL.
+
+    Args:
+      name: the name of this target
+      preamble: list of strings definining lines of Python code
+        that should be executed when starting the interpreter
+      deps: py_library targets that should be available as dependencies
+        to import into the interpreter
+    """
+
+    # Print each line of the preamble before executing it.
+    full_preamble = "\n".join(
+        ["print(" + repr(line) + ")\n" + line for line in preamble],
+    )
+
+    _write_file(
+        name = name + "_py_gen",
+        out = name + ".py",
+        content = full_preamble,
+    )
+
+    native.py_binary(
+        name = name + "_py",
+        srcs = [name + ".py"],
+        main = name + ".py",
+        deps = deps,
+    )
+
+    _write_file(
+        name = name + "_sh_gen",
+        out = name + ".sh",
+        content = "PYTHONINSPECT=1 exec $1",
+    )
+
+    # Use `args` to pass the location of the data dep which is shorter
+    # and sweeter than the sh runfiles self-bootstrapping rigamarole.
+    # Thanks, underappreciated https://stackoverflow.com/a/64841428.
+    native.sh_binary(
+        name = name,
+        srcs = [name + ".sh"],
+        args = ["$(location :" + name + "_py)"],
+        data = [":" + name + "_py"],
+    )

--- a/tensorboard/defs/py_repl.bzl
+++ b/tensorboard/defs/py_repl.bzl
@@ -32,11 +32,10 @@ def _dedent(text):
     indents = []
     for line in text.splitlines():
         stripped = line.lstrip(" ")
-        if not stripped:
-            continue
-        indents.append(len(line) - len(stripped))
+        if stripped:
+            indents.append(len(line) - len(stripped))
     if not indents:
-        return
+        return text
     indent = min(indents)
     result = []
     for line in text.splitlines(True):


### PR DESCRIPTION
This adds a `py_repl` build rule that makes it simpler to spin up an interactive Python shell that includes a specified set of Bazel deps, which is useful for ad-hoc exploration of a library interface.

In a conventional Python setup a regular old `python` would work, but with Bazel this is more of a pain to get the correct runfiles, including files potentially generated by Bazel itself (e.g. `_pb2.py` files generated from protos, or genrule-created files).  Using a `py_binary` solves that, but it's a little annoying to clutter the codebase with a nearly empty main.py, and you have to remember the right invocation of `PYTHONINSPECT=1` to have it drop you into the REPL.  This build rule essentially just prepackages all of that for you.