### PR TITLE
core: drop support for negative `--reload_interval`

### DIFF
--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -89,8 +89,6 @@ class LocalDataIngester(ingester.DataIngester):
 
     def start(self):
         """Starts ingesting data based on the ingester flag configuration."""
-        if self._reload_interval < 0:
-            return
 
         def _reload():
             while True:

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -15,6 +15,7 @@
 """TensorBoard core plugin package."""
 
 
+import argparse
 import functools
 import gzip
 import io
@@ -478,12 +479,11 @@ relevant for db read-only mode. Each thread reloads one run at a time.
         parser.add_argument(
             "--reload_interval",
             metavar="SECONDS",
-            type=float,
+            type=_nonnegative_float,
             default=5.0,
             help="""\
 How often the backend should load more data, in seconds. Set to 0 to
-load just once at startup and a negative number to never reload at all.
-Not relevant for DB read-only mode. (default: %(default)s)\
+load just once at startup. Must be non-negative. (default: %(default)s)\
 """,
         )
 
@@ -632,3 +632,12 @@ def _parse_samples_per_plugin(value):
             k, v = token.strip().split("=")
             result[k] = int(v)
     return result
+
+
+def _nonnegative_float(v):
+    try:
+        v = float(v)
+    except ValueError:
+        raise argparse.ArgumentTypeError("invalid float: %r" % v)
+    if not (v >= 0):  # no NaNs, please
+        raise argparse.ArgumentTypeError("must be non-negative: %r" % v)


### PR DESCRIPTION
Summary:
In #1001, we changed the interpretation of `--reload_interval` such that
negative values caused event files not to be read at all. This was to
accommodate DB mode: when loading from a database, reading event files
was superfluous. But DB mode is gone, and the corresponding distinction
for a Rust-based data provider is handled by the ingester system
instead. That is, `event_processing/data_ingester.py` now always loads
event files, and `data/server_ingester.py` never loads event files.

This is technically a backward-incompatible change, but DB mode was
always experimental, so the only stable use of this was to launch a
TensorBoard instance that never loaded any data at all. I’m okay with
breaking such use cases.

Test Plan:
Running with `--reload_interval` set to `0` or `1` or `inf` still works;
setting it to `-1` or `nan` or `zzz` gives an appropriate error message.

wchargin-branch: no-negative-reload-interval
