### PR TITLE
tensorboard-data-server 0.2.0

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "rustboard"
-version = "0.2.0-alpha.0"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "rustboard"
-version = "0.2.0"
+version = "0.3.0-alpha.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "rustboard"
-version = "0.2.0-alpha.0"
+version = "0.2.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 edition = "2018"
 default-run = "rustboard"

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "rustboard"
-version = "0.2.0"
+version = "0.3.0-alpha.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 edition = "2018"
 default-run = "rustboard"

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -36,7 +36,7 @@ use crate::server::DataProviderHandler;
 use data::tensor_board_data_provider_server::TensorBoardDataProviderServer;
 
 #[derive(Clap, Debug)]
-#[clap(name = "rustboard", version = "0.2.0-alpha.0")]
+#[clap(name = "rustboard", version = "0.2.0")]
 struct Opts {
     /// Log directory to load
     ///

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -36,7 +36,7 @@ use crate::server::DataProviderHandler;
 use data::tensor_board_data_provider_server::TensorBoardDataProviderServer;
 
 #[derive(Clap, Debug)]
-#[clap(name = "rustboard", version = "0.2.0")]
+#[clap(name = "rustboard", version = "0.3.0-alpha.0")]
 struct Opts {
     /// Log directory to load
     ///

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.2.0a0"
+__version__ = "0.2.0"
 
 
 def server_binary():

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.2.0"
+__version__ = "0.3.0a0"
 
 
 def server_binary():


### PR DESCRIPTION
Changes since 0.1.0:

  - performance improvements: checksums off by default; Tokio 1.0
  - `--reload once`, to support TensorBoard `--reload_interval`
  - suppressed “listening on [::1]:PORT” spam

Merge plan: rebase and merge, then release from the unique commit where
the version numbers are 0.2.0.

(Supersedes 0.1.1 from #4586. Let’s use minor releases for now so that
the version numbers advance monotonically with commits.)

