### PR TITLE
infra: create dev target

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -357,6 +357,7 @@ tensorboard_zip_file(
     deps = [":dev_assets"],
 )
 
+# Should keep the asset dependencies in sync with :assets.
 tf_web_library(
     name = "dev_assets",
     srcs = [

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -19,6 +19,7 @@ package_group(
 py_binary(
     name = "tensorboard",
     srcs = ["main.py"],
+    data = ["webfiles.zip"],
     main = "main.py",
     srcs_version = "PY3",
     deps = [
@@ -42,6 +43,25 @@ py_library(
     deps = [
         "//tensorboard:expect_absl_logging_installed",
         "//tensorboard/compat:tensorflow",
+    ],
+)
+
+py_binary(
+    name = "dev",
+    srcs = ["main_dev.py"],
+    data = ["dev_webfiles.zip"],
+    main = "main_dev.py",
+    srcs_version = "PY3",
+    deps = [
+        ":default",
+        ":dynamic_plugins",
+        ":lib",
+        ":program",
+        "//tensorboard:expect_absl_flags_installed",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/uploader:uploader_subcommand",
+        "//tensorboard/util:tb_logging",
+        "//tensorboard/util:timing",  # non-strict dep, for patching convenience
     ],
 )
 
@@ -248,7 +268,6 @@ py_library(
 py_library(
     name = "default",
     srcs = ["default.py"],
-    data = ["webfiles.zip"],
     srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_pkg_resources_installed",
@@ -321,6 +340,28 @@ tensorboard_zip_file(
 
 tf_web_library(
     name = "assets",
+    srcs = [
+        "//tensorboard/webapp:index.html",
+        "//tensorboard/webapp:index.js",
+        "//tensorboard/webapp:svg_bundle",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:chart_worker.js",
+    ],
+    path = "/",
+    suppress = ["strictDependencies"],
+    deps = [
+        "//tensorboard/webapp/widgets/source_code/monaco:monaco_editor",
+        "//tensorboard/webapp/widgets/source_code/monaco:monaco_languages",
+        "@com_google_fonts_roboto",
+    ],
+)
+
+tensorboard_zip_file(
+    name = "dev_webfiles",
+    deps = [":dev_assets"],
+)
+
+tf_web_library(
+    name = "dev_assets",
     srcs = [
         "//tensorboard/webapp:index.html",
         "//tensorboard/webapp:index.js",

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -56,10 +56,9 @@ py_binary(
         ":default",
         ":dynamic_plugins",  # loads internal dynamic plugin like projector
         ":lib",
+        ":main_lib",
         ":program",
-        "//tensorboard:expect_absl_flags_installed",
         "//tensorboard/uploader:uploader_subcommand",
-        "//tensorboard/util:tb_logging",
     ],
 )
 

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -24,7 +24,7 @@ py_binary(
     srcs_version = "PY3",
     deps = [
         ":default",
-        ":dynamic_plugins",
+        ":dynamic_plugins",  # loads internal dynamic plugin like projector
         ":lib",
         ":main_lib",
         ":program",
@@ -54,14 +54,12 @@ py_binary(
     srcs_version = "PY3",
     deps = [
         ":default",
-        ":dynamic_plugins",
+        ":dynamic_plugins",  # loads internal dynamic plugin like projector
         ":lib",
         ":program",
         "//tensorboard:expect_absl_flags_installed",
-        "//tensorboard/plugins:base_plugin",
         "//tensorboard/uploader:uploader_subcommand",
         "//tensorboard/util:tb_logging",
-        "//tensorboard/util:timing",  # non-strict dep, for patching convenience
     ],
 )
 

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -48,8 +48,8 @@ def run_main():
         return None
 
     tensorboard = program.TensorBoard(
-        default.get_plugins(),
         lambda: open(path, "rb"),
+        plugins=default.get_plugins(),
         subcommands=[uploader_subcommand.UploaderSubcommand()],
     )
     try:

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -41,8 +41,9 @@ def run_main():
     main_lib.global_init()
 
     path = os.path.join(
-        os.path.dirname(inspect.getfile(sys._getframe(1))), "webfiles.zip"
+        os.path.dirname(inspect.getfile(sys._getframe(0))), "webfiles.zip"
     )
+
     if not os.path.exists(path):
         logger.warning("webfiles.zip static assets not found: %s", path)
         return None

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -31,6 +31,9 @@ from tensorboard import main_lib
 from tensorboard import program
 from tensorboard.plugins import base_plugin
 from tensorboard.uploader import uploader_subcommand
+from tensorboard.util import tb_logging
+
+logger = tb_logging.get_logger()
 
 
 def run_main():

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -21,7 +21,8 @@ wishing to customize the set of plugins or static assets that
 TensorBoard uses can swap out this file with their own.
 """
 
-
+import inspect
+import os
 import sys
 
 from absl import app
@@ -35,9 +36,17 @@ from tensorboard.uploader import uploader_subcommand
 def run_main():
     """Initializes flags and calls main()."""
     main_lib.global_init()
+
+    path = os.path.join(
+        os.path.dirname(inspect.getfile(sys._getframe(1))), "webfiles.zip"
+    )
+    if not os.path.exists(path):
+        logger.warning("webfiles.zip static assets not found: %s", path)
+        return None
+
     tensorboard = program.TensorBoard(
         default.get_plugins(),
-        program.get_default_assets_zip_provider(),
+        lambda: open(path, "rb"),
         subcommands=[uploader_subcommand.UploaderSubcommand()],
     )
     try:

--- a/tensorboard/main_dev.py
+++ b/tensorboard/main_dev.py
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""TensorBoard main module.
-
-This module ties together `tensorboard.program` and
-`tensorboard.default_plugins` to provide standard TensorBoard. It's
-meant to be tiny and act as little other than a config file. Those
-wishing to customize the set of plugins or static assets that
-TensorBoard uses can swap out this file with their own.
-"""
+"""TensorBoard dev main module."""
 
 import inspect
 import os
@@ -52,3 +45,7 @@ def run_main():
     except base_plugin.FlagsError as e:
         print("Error: %s" % e, file=sys.stderr)
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_main()

--- a/tensorboard/main_dev.py
+++ b/tensorboard/main_dev.py
@@ -1,4 +1,4 @@
-# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorboard/main_dev.py
+++ b/tensorboard/main_dev.py
@@ -35,8 +35,8 @@ def run_main():
     )
 
     tensorboard = program.TensorBoard(
-        default.get_plugins(),
         lambda: open(path, "rb"),
+        plugins=default.get_plugins(),
         subcommands=[uploader_subcommand.UploaderSubcommand()],
     )
 

--- a/tensorboard/main_dev.py
+++ b/tensorboard/main_dev.py
@@ -1,0 +1,54 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""TensorBoard main module.
+
+This module ties together `tensorboard.program` and
+`tensorboard.default_plugins` to provide standard TensorBoard. It's
+meant to be tiny and act as little other than a config file. Those
+wishing to customize the set of plugins or static assets that
+TensorBoard uses can swap out this file with their own.
+"""
+
+import inspect
+import os
+import sys
+
+from absl import app
+from tensorboard import default
+from tensorboard import main_lib
+from tensorboard import program
+from tensorboard.plugins import base_plugin
+from tensorboard.uploader import uploader_subcommand
+
+
+def run_main():
+    """Initializes flags and calls main()."""
+    main_lib.global_init()
+
+    path = os.path.join(
+        os.path.dirname(inspect.getfile(sys._getframe(1))), "dev_webfiles.zip"
+    )
+
+    tensorboard = program.TensorBoard(
+        default.get_plugins(),
+        lambda: open(path, "rb"),
+        subcommands=[uploader_subcommand.UploaderSubcommand()],
+    )
+
+    try:
+        app.run(tensorboard.main, flags_parser=tensorboard.configure)
+    except base_plugin.FlagsError as e:
+        print("Error: %s" % e, file=sys.stderr)
+        sys.exit(1)

--- a/tensorboard/main_dev.py
+++ b/tensorboard/main_dev.py
@@ -31,7 +31,7 @@ def run_main():
     main_lib.global_init()
 
     path = os.path.join(
-        os.path.dirname(inspect.getfile(sys._getframe(1))), "dev_webfiles.zip"
+        os.path.dirname(inspect.getfile(sys._getframe(0))), "dev_webfiles.zip"
     )
 
     tensorboard = program.TensorBoard(

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -78,7 +78,7 @@ class TensorBoard(object):
     def __init__(
         self,
         plugins=None,
-        assets_zip_provider=None,
+        assets_zip_provider,
         server_class=None,
         subcommands=None,
     ):
@@ -88,7 +88,8 @@ class TensorBoard(object):
           plugins: A list of TensorBoard plugins to load, as TBPlugin classes or
             TBLoader instances or classes. If not specified, defaults to first-party
             plugins.
-          assets_zip_provider: Delegates to TBContext or uses default if None.
+          assets_zip_provider: A function that provides a zip file containing assets to
+            the application.
           server_class: An optional factory for a `TensorBoardServer` to use
             for serving the TensorBoard WSGI app. If provided, its callable
             signature should match that of `TensorBoardServer.__init__`.
@@ -103,8 +104,6 @@ class TensorBoard(object):
             from tensorboard import default
 
             plugins = default.get_plugins()
-        if assets_zip_provider is None:
-            assets_zip_provider = get_default_assets_zip_provider()
         if server_class is None:
             server_class = create_port_scanning_werkzeug_server
         if subcommands is None:

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -32,7 +32,6 @@ import argparse
 import atexit
 from collections import defaultdict
 import errno
-import inspect
 import logging
 import mimetypes
 import os
@@ -63,24 +62,6 @@ logger = tb_logging.get_logger()
 _SERVE_SUBCOMMAND_NAME = "serve"
 # Internal flag name used to store which subcommand was invoked.
 _SUBCOMMAND_FLAG = "__tensorboard_subcommand"
-
-
-def get_default_assets_zip_provider():
-    """Opens stock TensorBoard web assets collection.
-
-    Returns:
-      Returns function that returns a newly opened file handle to zip file
-      containing static assets for stock TensorBoard, or None if webfiles.zip
-      could not be found. The value the callback returns must be closed. The
-      paths inside the zip file are considered absolute paths on the web server.
-    """
-    path = os.path.join(
-        os.path.dirname(inspect.getfile(sys._getframe(1))), "webfiles.zip"
-    )
-    if not os.path.exists(path):
-        logger.warning("webfiles.zip static assets not found: %s", path)
-        return None
-    return lambda: open(path, "rb")
 
 
 class TensorBoard(object):

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -77,8 +77,8 @@ class TensorBoard(object):
 
     def __init__(
         self,
-        plugins=None,
         assets_zip_provider,
+        plugins=None,
         server_class=None,
         subcommands=None,
     ):

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -85,11 +85,11 @@ class TensorBoard(object):
         """Creates new instance.
 
         Args:
+          assets_zip_provider: A function that provides a zip file containing assets to
+            the application.
           plugins: A list of TensorBoard plugins to load, as TBPlugin classes or
             TBLoader instances or classes. If not specified, defaults to first-party
             plugins.
-          assets_zip_provider: A function that provides a zip file containing assets to
-            the application.
           server_class: An optional factory for a `TensorBoardServer` to use
             for serving the TensorBoard WSGI app. If provided, its callable
             signature should match that of `TensorBoardServer.__init__`.

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -26,37 +26,51 @@ from tensorboard.plugins import base_plugin
 from tensorboard.plugins.core import core_plugin
 
 
+def fake_asset_provider():
+    pass
+
+
 class TensorBoardTest(tb_test.TestCase):
     """Tests the TensorBoard program."""
 
     def testPlugins_pluginClass(self):
-        tb = program.TensorBoard(plugins=[core_plugin.CorePlugin])
+        tb = program.TensorBoard(
+            fake_asset_provider, plugins=[core_plugin.CorePlugin]
+        )
         self.assertIsInstance(tb.plugin_loaders[0], base_plugin.BasicLoader)
         self.assertIs(tb.plugin_loaders[0].plugin_class, core_plugin.CorePlugin)
 
     def testPlugins_pluginLoaderClass(self):
-        tb = program.TensorBoard(plugins=[core_plugin.CorePluginLoader])
+        tb = program.TensorBoard(
+            fake_asset_provider, plugins=[core_plugin.CorePluginLoader]
+        )
         self.assertIsInstance(
             tb.plugin_loaders[0], core_plugin.CorePluginLoader
         )
 
     def testPlugins_pluginLoader(self):
         loader = core_plugin.CorePluginLoader()
-        tb = program.TensorBoard(plugins=[loader])
+        tb = program.TensorBoard(fake_asset_provider, plugins=[loader])
         self.assertIs(tb.plugin_loaders[0], loader)
 
     def testPlugins_invalidType(self):
         plugin_instance = core_plugin.CorePlugin(base_plugin.TBContext())
         with self.assertRaisesRegex(TypeError, "CorePlugin"):
-            tb = program.TensorBoard(plugins=[plugin_instance])
+            tb = program.TensorBoard(
+                fake_asset_provider, plugins=[plugin_instance]
+            )
 
     def testConfigure(self):
-        tb = program.TensorBoard(plugins=[core_plugin.CorePluginLoader])
+        tb = program.TensorBoard(
+            fake_asset_provider, plugins=[core_plugin.CorePluginLoader]
+        )
         tb.configure(logdir="foo")
         self.assertEqual(tb.flags.logdir, "foo")
 
     def testConfigure_unknownFlag(self):
-        tb = program.TensorBoard(plugins=[core_plugin.CorePlugin])
+        tb = program.TensorBoard(
+            fake_asset_provider, plugins=[core_plugin.CorePlugin]
+        )
         with self.assertRaisesRegex(ValueError, "Unknown TensorBoard flag"):
             tb.configure(foo="bar")
 
@@ -150,6 +164,7 @@ class SubcommandTest(tb_test.TestCase):
 
     def testImplicitServe(self):
         tb = program.TensorBoard(
+            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
             subcommands=[_TestSubcommand(lambda parser: None)],
         )
@@ -162,6 +177,7 @@ class SubcommandTest(tb_test.TestCase):
 
     def testExplicitServe(self):
         tb = program.TensorBoard(
+            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
             subcommands=[_TestSubcommand()],
         )
@@ -179,6 +195,7 @@ class SubcommandTest(tb_test.TestCase):
             parser.add_argument("--hello")
 
         tb = program.TensorBoard(
+            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
             subcommands=[_TestSubcommand(define_flags=define_flags)],
         )
@@ -190,6 +207,7 @@ class SubcommandTest(tb_test.TestCase):
 
     def testSubcommand_ExitCode(self):
         tb = program.TensorBoard(
+            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
             subcommands=[_TestSubcommand()],
         )
@@ -199,6 +217,7 @@ class SubcommandTest(tb_test.TestCase):
 
     def testSubcommand_DoesNotInheritBaseArgs(self):
         tb = program.TensorBoard(
+            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
             subcommands=[_TestSubcommand()],
         )
@@ -214,6 +233,7 @@ class SubcommandTest(tb_test.TestCase):
             parser.add_argument("payload")
 
         tb = program.TensorBoard(
+            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
             subcommands=[_TestSubcommand(define_flags=define_flags)],
         )
@@ -226,6 +246,7 @@ class SubcommandTest(tb_test.TestCase):
     def testConflictingNames_AmongSubcommands(self):
         with self.assertRaises(ValueError) as cm:
             tb = program.TensorBoard(
+                fake_asset_provider,
                 plugins=[core_plugin.CorePluginLoader],
                 subcommands=[_TestSubcommand(), _TestSubcommand()],
             )
@@ -235,6 +256,7 @@ class SubcommandTest(tb_test.TestCase):
     def testConflictingNames_WithServe(self):
         with self.assertRaises(ValueError) as cm:
             tb = program.TensorBoard(
+                fake_asset_provider,
                 plugins=[core_plugin.CorePluginLoader],
                 subcommands=[_TestSubcommand(name="serve")],
             )


### PR DESCRIPTION
New `tensorboard:dev` target provides a development instance of the
application which optimizes for development experience. While the
changes are omitted in this commit for brevity, we are looking to stream
line the FE building to optimize for its incremental build time.
