### PR TITLE
infra: implement dev assets

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -354,25 +354,7 @@ tf_web_library(
 
 tensorboard_zip_file(
     name = "dev_webfiles",
-    deps = [":dev_assets"],
-)
-
-# Should keep the asset dependencies in sync with :assets.
-tf_web_library(
-    name = "dev_assets",
-    srcs = [
-        "//tensorboard/webapp:index.html",
-        "//tensorboard/webapp:index.js",
-        "//tensorboard/webapp:svg_bundle",
-        "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:chart_worker.js",
-    ],
-    path = "/",
-    suppress = ["strictDependencies"],
-    deps = [
-        "//tensorboard/webapp/widgets/source_code/monaco:monaco_editor",
-        "//tensorboard/webapp/widgets/source_code/monaco:monaco_languages",
-        "@com_google_fonts_roboto",
-    ],
+    deps = ["//tensorboard/webapp/dev_assets"],
 )
 
 # This is a dummy rule used as a numpy dependency in open-source.

--- a/tensorboard/webapp/dev_assets/BUILD
+++ b/tensorboard/webapp/dev_assets/BUILD
@@ -1,0 +1,71 @@
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_module")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:__pkg__"])
+
+licenses(["notice"])
+
+tf_ng_module(
+    name = "ng_main",
+    srcs = [
+        "main_dev.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp:ng_main",
+        "@npm//@angular/localize",
+    ],
+)
+
+tf_js_binary(
+    name = "tb_webapp_binary",
+    compile = 1,
+    entry_point = "main_dev.ts",
+    deps = [
+        ":ng_main",
+        "//tensorboard/webapp/angular:expect_angular_material_tabs",
+        "//tensorboard/webapp/angular:expect_angular_material_toolbar",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/material",
+        "@npm//@angular/platform-browser",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+        "@npm//zone.js",
+    ],
+)
+
+tf_web_library(
+    name = "tb_webapp",
+    srcs = [
+        ":tb_webapp_binary.js",
+    ],
+    path = "/tb-webapp",
+)
+
+genrule(
+    name = "rename_index_html",
+    srcs = ["//tensorboard/webapp:index_polymer3.inlined.html"],
+    outs = ["index.html"],
+    cmd = "cat $(SRCS) > $@",
+)
+
+# Should keep the asset dependencies in sync with //tensorboard:assets.
+tf_web_library(
+    name = "dev_assets",
+    srcs = [
+        ":index.html",
+        "//tensorboard/components:polymer3_lib_binary.js",
+        "//tensorboard/webapp:styles.css",
+        "//tensorboard/webapp:svg_bundle",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:chart_worker.js",
+    ],
+    path = "/",
+    deps = [
+        ":tb_webapp",
+        "//tensorboard/components/tf_imports:roboto",
+        "//tensorboard/webapp/widgets/source_code/monaco:monaco_editor",
+        "//tensorboard/webapp/widgets/source_code/monaco:monaco_languages",
+        "//tensorboard/webapp/widgets/source_code/monaco:requirejs",
+        "@com_google_fonts_roboto",
+    ],
+)

--- a/tensorboard/webapp/dev_assets/BUILD
+++ b/tensorboard/webapp/dev_assets/BUILD
@@ -1,3 +1,11 @@
+# Build targets for building development webapp assets.
+#
+# This largely duplicates asset related targets in //tensorboard/webapp.
+# Because we had to create `index.html` to be zippped by the
+# tensorboard_zip_file which ends up having the same target name as
+# //tensorboard/webapp:index.html, we had to create the dev_assets version in
+# a different package. Once we can get rid of zip asset provider and a way to
+# alias asset, we would not need the enitrely different Bazel package.
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_module")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 

--- a/tensorboard/webapp/dev_assets/BUILD
+++ b/tensorboard/webapp/dev_assets/BUILD
@@ -26,7 +26,6 @@ tf_js_binary(
         "//tensorboard/webapp/angular:expect_angular_material_toolbar",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@angular/material",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//rxjs",

--- a/tensorboard/webapp/dev_assets/main_dev.ts
+++ b/tensorboard/webapp/dev_assets/main_dev.ts
@@ -12,4 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import './bootstrap';
+import '@angular/localize/init';
+
+import '../bootstrap';


### PR DESCRIPTION
With this change, dev assets are significantly different than prod one.

To enumerate the differences:
- Angular application now loads in dev mode allowing ngrx to print
diagnostic information on console
- No longer vulcanize. Previously, we vulcanized to inline CSS, HTML,
and resources and combined JavaScript into a single source. With this
change, we no longer inline/concat sources and load them separately.
  - this breaks roboto.html loading as it internally uses rel="import"
  but we intend to get rid of it to remove dependency on
  tensorboard_html_binary which pulls in Java dependency.

~temporary: this change contains PR #4588~