### PR TITLE
line chart: restore thicker line width

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -231,24 +231,18 @@ describe('line_chart_v2/lib/renderer test', () => {
     let renderer: ThreeRenderer;
     let scene: THREE.Scene;
 
-    function assertLine(line: THREE.Line, polyline: Polyline) {
+    function assertLine(line: THREE.Mesh, polyline: Polyline) {
       const geometry = line.geometry as THREE.BufferGeometry;
       const positions = geometry.getAttribute(
         'position'
       ) as THREE.BufferAttribute;
-      let positionIndex = 0;
-      for (
-        let polylineIndex = 0;
-        polylineIndex < polyline.length;
-        polylineIndex += 2
-      ) {
-        const expectedX = polyline[polylineIndex];
-        const expectedY = polyline[polylineIndex + 1];
-        const actualX = positions.array[positionIndex++];
-        const actualY = positions.array[positionIndex++];
-        const actualZ = positions.array[positionIndex++];
-        expect(actualX).toBe(expectedX);
-        expect(actualY).toBe(expectedY);
+      // Each segment has 2 triangles, each with 3 vertices, each with 3
+      // coordinates.
+      const expectedNumSegments = Math.max(polyline.length / 2 - 1, 0);
+      const expectedNumCoordinates = expectedNumSegments * 2 * 3 * 3;
+      expect(positions.array.length).toBe(expectedNumCoordinates);
+      for (let i = 2; i < positions.array.length; i += 3) {
+        const actualZ = positions.array[i];
         expect(actualZ).toBe(0);
       }
     }
@@ -271,7 +265,7 @@ describe('line_chart_v2/lib/renderer test', () => {
       longHexString: string,
       visibility: boolean
     ) {
-      const material = obj.material as THREE.LineBasicMaterial;
+      const material = obj.material as THREE.MeshBasicMaterial;
       expect(material.visible).toBe(visibility);
       expect(material.color.getHexString()).toBe(longHexString.slice(1));
     }
@@ -293,8 +287,8 @@ describe('line_chart_v2/lib/renderer test', () => {
       );
 
       expect(scene.children.length).toBe(1);
-      const lineObject = scene.children[0] as THREE.Line;
-      expect(lineObject).toBeInstanceOf(THREE.Line);
+      const lineObject = scene.children[0] as THREE.Mesh;
+      expect(lineObject).toBeInstanceOf(THREE.Mesh);
       assertLine(lineObject, new Float32Array([0, 10, 10, 100]));
       assertMaterial(lineObject, '#ff0000', true);
     });
@@ -312,7 +306,7 @@ describe('line_chart_v2/lib/renderer test', () => {
         {visible: true, color: '#0f0', width: 3}
       );
 
-      const lineObject = scene.children[0] as THREE.Line;
+      const lineObject = scene.children[0] as THREE.Mesh;
       assertLine(lineObject, new Float32Array([0, 5, 5, 50, 10, 100]));
       assertMaterial(lineObject, '#00ff00', true);
     });
@@ -330,7 +324,7 @@ describe('line_chart_v2/lib/renderer test', () => {
         width: 3,
       });
 
-      const lineObject = scene.children[0] as THREE.Line;
+      const lineObject = scene.children[0] as THREE.Mesh;
       assertLine(lineObject, new Float32Array(0));
       assertMaterial(lineObject, '#00ff00', true);
     });
@@ -348,7 +342,7 @@ describe('line_chart_v2/lib/renderer test', () => {
         {visible: false, color: '#0f0', width: 3}
       );
 
-      const lineObject = scene.children[0] as THREE.Line;
+      const lineObject = scene.children[0] as THREE.Mesh;
       assertLine(lineObject, new Float32Array([0, 10, 10, 100]));
       assertMaterial(lineObject, '#ff0000', false);
     });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -42,8 +42,9 @@ enum CacheType {
 
 interface LineCacheValue {
   type: CacheType.LINE;
-  obj3d: THREE.Line;
+  obj3d: THREE.Mesh;
   data: Polyline;
+  width: number;
 }
 
 interface TriangleCacheValue {
@@ -61,9 +62,10 @@ interface CircleCacheValue {
 type CacheValue = LineCacheValue | TriangleCacheValue | CircleCacheValue;
 
 /**
- * Updates BufferGeometry with Float32Array that denotes flattened array of Vec2 (<x, y>).
+ * Updates BufferGeometry with Float32Array that denotes flattened array of Vec2
+ * (<x, y>) representing points that form a connected set of line segments.
  */
-function updateGeometryWithVec2Array(
+function updatePolylineGeometry(
   geometry: THREE.BufferGeometry,
   flatVec2: Float32Array
 ) {
@@ -93,13 +95,111 @@ function updateGeometryWithVec2Array(
 }
 
 /**
+ * Updates BufferGeometry with Float32Array that denotes flattened array of Vec2
+ * (<x, y>) representing points that form a connected set of line segments.
+ * Unlike the simpler `updatePolylineGeometry`, this variant constructs more
+ * vertices to support line thickness.
+ *
+ * This custom logic handles line thickness, since the 'linewidth' property of
+ * THREE.LineBasicMaterial is ignored [1]. Each line segment is a rectangle
+ * that is split into 2 triangles [A->B->C] and [C->B->D]. Each triangle has
+ * 3 components (x, y, z).
+ *
+ * Assuming a line segment is as follows:
+ *              A             C
+ *              |             |
+ * (startPoint) |-------------| (endPoint)
+ *              |             |
+ *              B             D
+ *
+ * [1] https://github.com/mrdoob/three.js/issues/14627
+ */
+function updateThickPolylineGeometry(
+  geometry: THREE.BufferGeometry,
+  flatVec2: Float32Array,
+  thickness: number
+) {
+  const numSegments = flatVec2.length / 2 - 1;
+  const numVertices = numSegments * 2 * 3;
+  const numComponents = numVertices * 3;
+  let positionAttributes = geometry.attributes[
+    'position'
+  ] as THREE.BufferAttribute;
+  if (!positionAttributes || positionAttributes.count !== numVertices) {
+    positionAttributes = new THREE.BufferAttribute(
+      new Float32Array(numComponents),
+      3
+    );
+    geometry.addAttribute('position', positionAttributes);
+  }
+
+  const values = positionAttributes.array as Float32Array;
+  const zeroVec = new THREE.Vector2(0, 0);
+  for (let i = 0; i < numSegments; i++) {
+    const [x1, y1, x2, y2] = [
+      flatVec2[2 * i],
+      flatVec2[2 * i + 1],
+      flatVec2[2 * i + 2],
+      flatVec2[2 * i + 3],
+    ];
+    const startPointVec = new THREE.Vector2(x1, y1);
+    const endPointVec = new THREE.Vector2(x2, y2);
+    const unitNormalVec = new THREE.Vector2(x2 - x1, y2 - y1)
+      .rotateAround(zeroVec, Math.PI / 2)
+      .setLength(1);
+    const A = startPointVec
+      .clone()
+      .addScaledVector(unitNormalVec, thickness / 2);
+    const B = startPointVec
+      .clone()
+      .addScaledVector(unitNormalVec, -thickness / 2);
+    const C = endPointVec.clone().addScaledVector(unitNormalVec, thickness / 2);
+    const D = endPointVec
+      .clone()
+      .addScaledVector(unitNormalVec, -thickness / 2);
+
+    // Keep each face's vertices in counterclockwise order, to ensure normals
+    // point outwards from the screen.
+    const components = [
+      // A->B->C triangle.
+      A.x,
+      A.y,
+      0,
+      B.x,
+      B.y,
+      0,
+      C.x,
+      C.y,
+      0,
+      // C->B->D triangle.
+      C.x,
+      C.y,
+      0,
+      B.x,
+      B.y,
+      0,
+      D.x,
+      D.y,
+      0,
+    ];
+    values.set(components, i * components.length);
+  }
+
+  positionAttributes.needsUpdate = true;
+  geometry.setDrawRange(0, numComponents);
+  // Need to update the bounding sphere so renderer does not skip rendering
+  // this object because it is outside of the camera viewpoint (frustum).
+  geometry.computeBoundingSphere();
+}
+
+/**
  * Updates an THREE.Object3D like object with geometry and material. Returns true if
  * geometry is updated (i.e., updateGeometry callback is invoked) and returns false
  * otherwise. It is possible that we minimally update the material without updating the
  * geometry.
  */
 function updateObject(
-  object: THREE.Mesh | THREE.Line,
+  object: THREE.Mesh,
   updateGeometry: (geometry: THREE.BufferGeometry) => THREE.BufferGeometry,
   materialOption: {visible: boolean; color: string; opacity?: number}
 ): boolean {
@@ -165,7 +265,7 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
     const obj3d = cacheValue.obj3d;
     this.scene.remove(obj3d);
 
-    if (obj3d instanceof THREE.Mesh || obj3d instanceof THREE.Line) {
+    if (obj3d instanceof THREE.Mesh) {
       obj3d.geometry.dispose();
       const materials = Array.isArray(obj3d.material)
         ? obj3d.material
@@ -192,23 +292,24 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
         paintOpt.opacity ?? 1
       );
       const geometry = new THREE.BufferGeometry();
-      const material = new THREE.LineBasicMaterial({
-        color: newColor,
-        linewidth: width,
-      });
-      const line = new THREE.Line(geometry, material);
+      const material = new THREE.LineBasicMaterial({color: newColor});
+      const line = new THREE.Mesh(geometry, material);
       material.visible = visible;
-      updateGeometryWithVec2Array(geometry, polyline);
+      updateThickPolylineGeometry(geometry, polyline, width);
       this.scene.add(line);
-      return {type: CacheType.LINE, data: polyline, obj3d: line};
+      return {type: CacheType.LINE, data: polyline, obj3d: line, width};
     }
 
-    const {data: prevPolyline, obj3d: line} = cachedLine;
+    const {data: prevPolyline, obj3d: line, width: prevWidth} = cachedLine;
     const geomUpdated = updateObject(
       line,
       (geometry) => {
-        if (!prevPolyline || !arePolylinesEqual(prevPolyline, polyline)) {
-          updateGeometryWithVec2Array(geometry, polyline);
+        if (
+          width !== prevWidth ||
+          !prevPolyline ||
+          !arePolylinesEqual(prevPolyline, polyline)
+        ) {
+          updateThickPolylineGeometry(geometry, polyline, width);
         }
         return geometry;
       },
@@ -216,16 +317,11 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
     );
     if (!geomUpdated) return cachedLine;
 
-    const material = line.material as THREE.LineBasicMaterial;
-    if (material.linewidth !== width) {
-      material.linewidth = width;
-      material.needsUpdate = true;
-    }
-
     return {
       type: CacheType.LINE,
       data: polyline,
       obj3d: line,
+      width,
     };
   }
 
@@ -259,7 +355,7 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
 
     if (!cached) {
       const geom = new THREE.BufferGeometry();
-      updateGeometryWithVec2Array(geom, vertices);
+      updatePolylineGeometry(geom, vertices);
       const mesh = this.createMesh(geom, paintOpt);
       if (mesh === null) return null;
       this.scene.add(mesh);
@@ -270,7 +366,7 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
       cached.obj3d,
       (geom) => {
         // Updating a geometry with three vertices is cheap enough. Update always.
-        updateGeometryWithVec2Array(geom, vertices);
+        updatePolylineGeometry(geom, vertices);
         return geom;
       },
       paintOpt

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
@@ -131,7 +131,7 @@ export class SeriesLineView extends DataDrawable {
                 color: metadata.color,
                 visible: metadata.visible,
                 opacity: metadata.opacity ?? 1,
-                width: 1,
+                width: 2,
               }
             );
           }


### PR DESCRIPTION
WebGL enabled line charts have been using a thinner line thickness
by default, due to a limitation in WebGL [1]. A common workaround
is to render line thickness manually, turning each line segment into
a rectangle composed of 2 triangles. This change uses the approach
to restore the 2 pixel line width found in stable TensorBoard.

Notably, line segments used to be representable by 2 vertices are
now represented with 6 vertices (2 triangles), so performance is
expected to degrade.

This change does not take into account the "end caps" of each line,
so minor artifacts are noticeable when examining the joint between
two consecutive line segments carefully. Addressing the end caps
may require adding more triangles, which adds a decent amount
of complexity without significant noticeable benefit.

Manually checked by:
Adding `?fastChart=true#timeseries` to the URL to view WebGL enabled
line charts in Time Series.

[1] https://github.com/mrdoob/three.js/issues/14627

Before (with ?fastChart=true)
![image](https://user-images.githubusercontent.com/2322480/105344253-8a18c300-5b97-11eb-9e30-7be236f76a3a.png)

After (with ?fastChart=true)
![image](https://user-images.githubusercontent.com/2322480/105344273-93099480-5b97-11eb-9c3c-b64b5f2a9bea.png)
