### PR TITLE
Expose getParams() in QueryParamsFeatureFlagDataSource

### DIFF
--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -36,7 +36,7 @@ const util = {
 @Injectable()
 export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
   getFeatures() {
-    const params = util.getParams();
+    const params = this.getParams();
     // Set feature flag value for query parameters that are explicitly
     // specified. Feature flags for unspecified query parameters remain unset so
     // their values in the underlying state are not inadvertently changed.
@@ -59,6 +59,10 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
       );
     }
     return featureFlags;
+  }
+
+  protected getParams() {
+    return util.getParams();
   }
 }
 


### PR DESCRIPTION
* Motivation for features / changes

  We want to add application-specific feature flags for varieties of TensorBoard. Part of this work requires implementing application-specific children of QueryParamsFeatureFlagDataSource. There is some logic from the base class that we'd like to share with children, so we can avoid duplicating some testing hooks.

* Technical description of changes

  We expose a new protected method getParams() in QueryParamsFeatureFlagsDataSource. It returns util.getParams(), which can be overriden in tests for the child classes.

  Googlers, see http://cl/353022802 for some more context.
