### PR TITLE
ci: run on pushes to tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
       - master
       - '[0-9]+.*'
       - 'ci-*'
+    tags:
+      - '*'
   pull_request: {}
   schedule:
     # 13:00 UTC is 05:00 in Pacific standard time (UTC-8), which is well


### PR DESCRIPTION
Summary:
Running CI on tags seems sensible on its own merits, and also enables us
to trigger CI on data server releases by tagging them rather than using
a temporary branch.

Test Plan:
The workflow run for this PR should show that the definition is still
valid. After merging, push a new tag for a commit that includes this
patch, and check that it starts a CI run.

wchargin-branch: ci-trigger-on-tags
