### PR TITLE
xsrf: implement basic custom header checker 

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -12,6 +12,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":json_util",
+        "//tensorboard:errors",
         "@org_pocoo_werkzeug",
     ],
 )
@@ -24,6 +25,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":http_util",
+        "//tensorboard:errors",
         "//tensorboard:test",
         "@org_pocoo_werkzeug",
     ],

--- a/tensorboard/webapp/webapp_data_source/tb_http_client.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {filter, mergeMap, take, withLatestFrom} from 'rxjs/operators';
@@ -80,6 +80,8 @@ export class TBHttpClient implements TBHttpClientInterface {
       withLatestFrom(this.store.select(getIsInColab)),
       mergeMap(([, isInColab]) => {
         const resolvedPath = this.resolveAppRoot(path);
+        options.headers = options.headers ?? new HttpHeaders();
+        options.headers = options.headers.set('X-TensorBoard-Post', '1');
 
         // Google-internal Colab does not support HTTP POST requests, so we fall
         // back to HTTP GET (even though public Colab supports POST)

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
@@ -103,6 +103,17 @@ describe('TBHttpClient', () => {
     });
   });
 
+  it('sets custom header for all POST requests', () => {
+    const body = new FormData();
+    body.append('formKey', 'value');
+    store.overrideSelector(getIsFeatureFlagsLoaded, true);
+    store.overrideSelector(getIsInColab, false);
+    tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
+    httpMock.expectOne((req) => {
+      return req.headers.has('X-TensorBoard-Post');
+    });
+  });
+
   it('prefixes absolute paths with the app-root', () => {
     appRootProvider.setAppRoot('/my-path-prefix/');
 


### PR DESCRIPTION
This change adds a basic XSRF custom header checker. For a Werkzeug
application that should be protected, you must put a decorator and it
will, by default, check the header for the custom header,
`X-TensorBoard-Post`.

temporary: this PR contains content of #4596.