### PR TITLE
Update protos for TF 2021-01-25 head

### DIFF
--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -593,6 +593,11 @@ message ConfigProto {
       MLIR_BRIDGE_ROLLOUT_ENABLED = 1;
       // Disabling the MLIR bridge disables it for all graphs in this session.
       MLIR_BRIDGE_ROLLOUT_DISABLED = 2;
+      // Enable the MLIR bridge on a per graph basis based on an analysis of
+      // the features used in the graph. If the features used by the graph are
+      // supported by the MLIR bridge, the MLIR bridge will be used to run the
+      // graph.
+      MLIR_BRIDGE_ROLLOUT_SAFE_MODE_ENABLED = 3;
     }
     // This field is underdevelopment, for now use enable_mlir_bridge
     // (b/166038521).
@@ -620,6 +625,11 @@ message ConfigProto {
     // The XLA fusion autotuner can improve performance by executing a heuristic
     // search on the compiler parameters.
     int64 xla_fusion_autotuner_thresh = 15;
+
+    // Whether runtime execution uses TFRT.
+    bool use_tfrt = 18;
+
+    // Next: 19
   }
 
   Experimental experimental = 16;

--- a/tensorboard/compat/proto/graph.proto
+++ b/tensorboard/compat/proto/graph.proto
@@ -26,8 +26,6 @@ message GraphDef {
   // compatible, this field is entirely ignored.
   int32 version = 3 [deprecated = true];
 
-  // EXPERIMENTAL. DO NOT USE OR DEPEND ON THIS YET.
-  //
   // "library" provides user-defined functions.
   //
   // Naming:

--- a/tensorboard/compat/proto/op_def.proto
+++ b/tensorboard/compat/proto/op_def.proto
@@ -8,6 +8,7 @@ option java_package = "org.tensorflow.framework";
 option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/op_def_go_proto";
 import "tensorboard/compat/proto/attr_value.proto";
 import "tensorboard/compat/proto/types.proto";
+import "tensorboard/compat/proto/resource_handle.proto";
 
 // Defines an operation. A NodeDef in a GraphDef specifies an Op by
 // using the "op" field which should match the name of a OpDef.
@@ -41,6 +42,9 @@ message OpDef {
     // If specified, attr must have type "list(type)", and none of
     // type, type_attr, and number_attr may be specified.
     string type_list_attr = 6;
+
+    // The handle data for resource inputs.
+    repeated ResourceHandleProto.DtypeAndShape handle_data = 7;
 
     // For inputs: if true, the inputs are required to be refs.
     //   By default, inputs can be either refs or non-refs.

--- a/tensorboard/compat/proto/rewriter_config.proto
+++ b/tensorboard/compat/proto/rewriter_config.proto
@@ -121,6 +121,14 @@ message RewriterConfig {
   // is experimental and may be removed in the future.
   bool experimental_disable_compressed_tensor_optimization = 26;
 
+  // Disable folding quantization emulation ops such as FakeQuantWithMinMax* and
+  // QuantizeAndDequantize*. Some compilers (e.g. the TF-to-tflite converter)
+  // have to extract quantization configs (e.g. min/max range, number of bits,
+  // and per-channel) from the quantization emulation ops. Note that this flag
+  // is experimental and may be removed in the future. See b/174138564 for more
+  // details.
+  bool experimental_disable_folding_quantization_emulation = 27;
+
   enum MemOptType {
     // The default setting (SCHEDULING and SWAPPING HEURISTICS only)
     DEFAULT_MEM_OPT = 0;

--- a/tensorboard/compat/proto/saved_object_graph.proto
+++ b/tensorboard/compat/proto/saved_object_graph.proto
@@ -179,12 +179,12 @@ message FunctionSpec {
   // field, so we instead map to an enum.
   //
   // See `tf.function` for details.
-  enum ExperimentalCompile {
+  enum JitCompile {
     DEFAULT = 0;
     ON = 1;
     OFF = 2;
   }
-  ExperimentalCompile experimental_compile = 6;
+  JitCompile jit_compile = 6;
 
   reserved 3, 4;
 }

--- a/tensorboard/compat/proto/summary.proto
+++ b/tensorboard/compat/proto/summary.proto
@@ -68,8 +68,7 @@ enum DataClass {
   // processed by data ingestion pipelines.
   DATA_CLASS_UNKNOWN = 0;
   // Scalar time series. Each `Value` for the corresponding tag must have
-  // `tensor` set to a rank-0 tensor of floating-point dtype, which will be
-  // converted to float64.
+  // `tensor` set to a rank-0 tensor of type `DT_FLOAT` (float32).
   DATA_CLASS_SCALAR = 1;
   // Tensor time series. Each `Value` for the corresponding tag must have
   // `tensor` set. The tensor value is arbitrary, but should be small to

--- a/tensorboard/compat/proto/types.proto
+++ b/tensorboard/compat/proto/types.proto
@@ -84,4 +84,6 @@ enum SpecializedType {
   ST_INVALID = 0;
   // "tensorflow::TensorList" in the variant type registry.
   ST_TENSOR_LIST = 1;
+  // "tensorflow::data::Optional" in the variant type registry.
+  ST_OPTIONAL = 2;
 }

--- a/tensorboard/data/server/tensorboard.pb.rs
+++ b/tensorboard/data/server/tensorboard.pb.rs
@@ -133,6 +133,8 @@ pub enum SpecializedType {
     StInvalid = 0,
     /// "tensorflow::TensorList" in the variant type registry.
     StTensorList = 1,
+    /// "tensorflow::data::Optional" in the variant type registry.
+    StOptional = 2,
 }
 /// Protocol buffer representing a handle to a tensorflow resource. Handles are
 /// not valid across executions, but can be serialized back and forth from within
@@ -424,8 +426,7 @@ pub enum DataClass {
     /// processed by data ingestion pipelines.
     Unknown = 0,
     /// Scalar time series. Each `Value` for the corresponding tag must have
-    /// `tensor` set to a rank-0 tensor of floating-point dtype, which will be
-    /// converted to float64.
+    /// `tensor` set to a rank-0 tensor of type `DT_FLOAT` (float32).
     Scalar = 1,
     /// Tensor time series. Each `Value` for the corresponding tag must have
     /// `tensor` set. The tensor value is arbitrary, but should be small to


### PR DESCRIPTION
Summary:
Pulls in [TensorFlow commit b565087c5cd7][c], which updates the docs for
the `DataClass` enum. Miscellaneous updates included as well.

[c]: https://github.com/tensorflow/tensorflow/commit/b565087c5cd72fc222a0610011335a381d7f7ac7

Generated with:

```
$ tensorboard/compat/proto/update.sh ~/git/tensorflow
$ bazel run //tensorboard/data/server:update_protos
```

Test Plan:
Changes are all either backward-compatible or to experimental messages
that we don’t use, so unit tests should suffice.

wchargin-branch: protos-sync-b565087c5cd7
