### PR TITLE
grpc_util: extract channel creds parsing and logic

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -295,6 +295,7 @@ py_library(
     visibility = ["//tensorboard:internal"],
     deps = [
         "//tensorboard:expect_absl_flags_argparse_flags_installed",
+        "//tensorboard/util:grpc_util",
     ],
 )
 
@@ -304,5 +305,6 @@ py_test(
     deps = [
         ":flags_parser",
         "//tensorboard:test",
+        "//tensorboard/util:grpc_util",
     ],
 )

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -17,6 +17,8 @@
 
 import argparse
 
+from tensorboard.util import grpc_util
+
 
 SUBCOMMAND_FLAG = "_uploader__subcommand"
 SUBCOMMAND_KEY_UPLOAD = "UPLOAD"
@@ -61,9 +63,9 @@ def define_flags(parser):
 
     parser.add_argument(
         "--grpc_creds_type",
-        type=str,
-        default="ssl",
-        choices=("local", "ssl", "ssl_dev"),
+        type=grpc_util.ChannelCredsType,
+        default=grpc_util.ChannelCredsType.SSL,
+        choices=grpc_util.ChannelCredsType.choices(),
         help="The type of credentials to use for the gRPC client",
     )
 

--- a/tensorboard/uploader/flags_parser_test.py
+++ b/tensorboard/uploader/flags_parser_test.py
@@ -18,6 +18,7 @@
 from absl.flags import argparse_flags
 
 from tensorboard.uploader import flags_parser
+from tensorboard.util import grpc_util
 from tensorboard import test as tb_test
 
 
@@ -70,6 +71,18 @@ class FlagsParserTest(tb_test.TestCase):
             getattr(flags, flags_parser.SUBCOMMAND_FLAG),
         )
         self.assertEqual(["plugin1", "plugin2"], flags.plugins)
+
+    def test_channel_creds_type_default(self):
+        flags = _define_and_parse_flags(["uploader", "list"])
+        self.assertEqual(grpc_util.ChannelCredsType.SSL, flags.grpc_creds_type)
+
+    def test_channel_creds_type_explicit(self):
+        flags = _define_and_parse_flags(
+            ["uploader", "--grpc_creds_type", "ssl_dev", "list"]
+        )
+        self.assertEqual(
+            grpc_util.ChannelCredsType.SSL_DEV, flags.grpc_creds_type
+        )
 
 
 if __name__ == "__main__":

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -97,19 +97,7 @@ def _run(flags, experiment_url_callback=None):
         sys.stderr.write("\n")  # Extra newline after auth flow messages.
         store.write_credentials(credentials)
 
-    channel_options = None
-    if flags.grpc_creds_type == "local":
-        channel_creds = grpc.local_channel_credentials()
-    elif flags.grpc_creds_type == "ssl":
-        channel_creds = grpc.ssl_channel_credentials()
-    elif flags.grpc_creds_type == "ssl_dev":
-        # Configure the dev cert to use by passing the environment variable
-        # GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=path/to/cert.crt
-        channel_creds = grpc.ssl_channel_credentials()
-        channel_options = [("grpc.ssl_target_name_override", "localhost")]
-    else:
-        msg = "Invalid --grpc_creds_type %s" % flags.grpc_creds_type
-        raise base_plugin.FlagsError(msg)
+    (channel_creds, channel_options) = flags.grpc_creds_type.channel_config()
 
     try:
         server_info = _get_server_info(flags)

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -177,5 +177,13 @@ class VersionMetadataTest(tb_test.TestCase):
         self.assertEqual(result, version.VERSION)
 
 
+class ChannelCredsTypeTest(tb_test.TestCase):
+    def test_all_variants_have_configs(self):
+        for variant in grpc_util.ChannelCredsType.__members__.values():
+            (creds, options) = variant.channel_config()
+            self.assertIsInstance(creds, grpc.ChannelCredentials)
+            self.assertIsInstance(options, list)
+
+
 if __name__ == "__main__":
     tb_test.main()


### PR DESCRIPTION
Summary:
A new `grpc_util.ChannelCredsType` enum represents the user-facing
variants for channel credentials. Flag parsing and consumption now
delegate to that enum rather than hand-enumerating all cases. The goal
is to enable defining a parallel flag to main TensorBoard to configure
the connection to the data server.

We define one method to create both channel creds and options so that
callers are less likely to get credentials but forget to set options,
which would cause `SSL_DEV` to behave incorrectly.

Test Plan:
Unit tests included. As end-to-end tests:

  - `tensorboard dev list` still works
  - `tensorboard dev --grpc_creds_type=ssl list` also still works
  - `tensorboard dev --grpc_creds_type=local list` successfully parses
    and then fails to connect to addresses, which is expected
  - `tensorboard dev --grpc_creds_type=zzz list` fails to parse with
    “invalid ChannelCredsType value: 'zzz'”

wchargin-branch: grpc-channel-creds-util
