### PR TITLE
rustboard: propagate --verbosity=debug to tensorboard-data-server

### DIFF
--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -86,6 +86,8 @@ class SubprocessServerDataIngester(ingester.DataIngester):
         ]
         if logger.isEnabledFor(logging.INFO):
             args.append("--verbose")
+        if logger.isEnabledFor(logging.DEBUG):
+            args.append("--verbose")  # Repeat arg to increase verbosity.
 
         logger.info("Spawning data server: %r", args)
         popen = subprocess.Popen(args, stdin=subprocess.PIPE)


### PR DESCRIPTION
This extends the current propagation of `INFO`-level logging to also apply to `DEBUG` - we just pass `--verbose` a second time if the Python code is logging at `DEBUG`.