### PR TITLE
rust: make RunLoader commit periodically while loading a large run

### DIFF
--- a/tensorboard/data/server/logdir.rs
+++ b/tensorboard/data/server/logdir.rs
@@ -214,7 +214,7 @@ impl<'a> LogdirLoader<'a> {
                     // first relpath.
                     relpath: event_files[0].run_relpath.clone(),
                     loader: {
-                        let mut loader = RunLoader::new();
+                        let mut loader = RunLoader::new(run_name.clone());
                         loader.checksum(checksum);
                         loader
                     },

--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -189,7 +189,7 @@ impl RunLoader {
         debug!("Starting load for run {:?}", run_name);
         let start = Instant::now();
         self.update_file_set(filenames);
-        self.reload_files();
+        self.reload_files(read_event);
         commit_all(&mut self.data, run_data);
         debug!(
             "Finished load for run {:?} ({:?})",
@@ -235,8 +235,8 @@ impl RunLoader {
         }
     }
 
-    /// Reads data from all active event files.
-    fn reload_files(&mut self) {
+    /// Reads data from all active event files, and calls a handler for each event.
+    fn reload_files<F: FnMut(&mut RunLoaderData, pb::Event)>(&mut self, mut handle_event: F) {
         for (filename, ef) in self.files.iter_mut() {
             let reader = match ef {
                 EventFile::Dead => continue,
@@ -256,7 +256,7 @@ impl RunLoader {
                         break;
                     }
                 };
-                read_event(&mut self.data, event);
+                handle_event(&mut self.data, event);
             }
         }
     }

--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -37,7 +37,7 @@ use crate::types::{Run, Step, Tag, WallTime};
 #[derive(Debug)]
 pub struct RunLoader {
     /// The run name associated with this loader. Used primarily for logging; the run name is
-    /// canonically defined by the map key under which this `RunLoader` is stored in LogdirLoader.
+    /// canonically defined by the map key under which this `RunLoader` is stored in `LogdirLoader`.
     run: Run,
     /// The event files in this run.
     ///
@@ -164,7 +164,7 @@ const COMMIT_INTERVAL: Duration = Duration::from_secs(5);
 impl RunLoader {
     pub fn new(run: Run) -> Self {
         Self {
-            run: run,
+            run,
             files: BTreeMap::new(),
             checksum: true,
             data: RunLoaderData::default(),

--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -37,7 +37,7 @@ use crate::types::{Run, Step, Tag, WallTime};
 #[derive(Debug)]
 pub struct RunLoader {
     /// The run name associated with this loader. Used primarily for logging; the run name is
-    /// canonically defined by the map key under which this RunLoader is stored in LogdirLoader.
+    /// canonically defined by the map key under which this `RunLoader` is stored in LogdirLoader.
     run: Run,
     /// The event files in this run.
     ///
@@ -50,7 +50,7 @@ pub struct RunLoader {
     /// Whether to compute CRCs for records before parsing as protos.
     checksum: bool,
 
-    /// The data staged by this RunLoader.
+    /// The data staged by this `RunLoader`.
     data: RunLoaderData,
 }
 
@@ -66,8 +66,8 @@ enum EventFile<R> {
     Dead,
 }
 
-/// Holds data staged by a RunLoader that will be commited to the Commit.
-#[derive(Debug)]
+/// Holds data staged by a `RunLoader` that will be committed to the `Commit`.
+#[derive(Debug, Default)]
 struct RunLoaderData {
     /// The earliest event `wall_time` seen in any event file in this run.
     ///
@@ -165,10 +165,7 @@ impl RunLoader {
             run: run,
             files: BTreeMap::new(),
             checksum: true,
-            data: RunLoaderData {
-                start_time: None,
-                time_series: HashMap::new(),
-            },
+            data: RunLoaderData::default(),
         }
     }
 
@@ -310,12 +307,8 @@ fn read_event(data: &mut RunLoaderData, e: pb::Event) {
         }
         Some(wt) => wt,
     };
-    if data
-        .start_time
-        .map(|start| wall_time < start)
-        .unwrap_or(true)
-    {
-        (*data).start_time = Some(wall_time);
+    if data.start_time.map_or(true, |start| wall_time < start) {
+        data.start_time = Some(wall_time);
     }
     match e.what {
         Some(pb::event::What::GraphDef(graph_bytes)) => {

--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -86,6 +86,8 @@ class SubprocessServerDataIngester(ingester.DataIngester):
         ]
         if logger.isEnabledFor(logging.INFO):
             args.append("--verbose")
+        if logger.isEnabledFor(logging.DEBUG):
+            args.append("--verbose")  # Repeat arg to increase verbosity.
 
         logger.info("Spawning data server: %r", args)
         popen = subprocess.Popen(args, stdin=subprocess.PIPE)


### PR DESCRIPTION
Addresses the online commits task from #4422.

RunLoader's `reload()` method now ensures that we commit all time series data staged from the run at a regular interval (which I've hardcoded to 5 seconds), rather than waiting until all event files in the run have been read to exhaustion before committing any data.  I did a little refactoring to facilitate making this change which I've broken out into separate commits.

Based on a minimal amount of benchmarking against the ~20GiB event file from `gs://tensorboard-bench-logs/nndiv_100m/events.out.tfevents.1549560561.hostname`, it looks like this adds about 1% overhead in reading the file to completion (first is unmodified code; second is with this PR):

```
$ hyperfine -m 5 'bazel-bin/tensorboard/data/server/bench --logdir ~/scratch/tensorboard-bench-logs/'
Benchmark #1: bazel-bin/tensorboard/data/server/bench --logdir ~/scratch/tensorboard-bench-logs/
  Time (mean ± σ):     168.505 s ±  2.442 s    [User: 164.278 s, System: 4.212 s]
  Range (min … max):   166.091 s … 171.609 s    5 runs

$ hyperfine -m 5 'bazel-bin/tensorboard/data/server/bench --logdir ~/scratch/tensorboard-bench-logs/'
Benchmark #1: bazel-bin/tensorboard/data/server/bench --logdir ~/scratch/tensorboard-bench-logs/
  Time (mean ± σ):     171.296 s ±  2.586 s    [User: 167.006 s, System: 4.275 s]
  Range (min … max):   167.432 s … 174.439 s    5 runs
```

Test plan: ran against the aforementioned logdir and verified that we now see new data steadily appearing at 5 second intervals.

I haven't modified the unit tests to cover this behavior because I was a bit unsure about how to go about it.  My main thought was parameterizing `reload()` (or `RunLoader` at construction) in order to inject some kind of fake clock object, but I wasn't sure if there was a standard technique used for this.  Open to suggestions.