### PR TITLE
line chart: fix tick text clipping at axis edges

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -45,7 +45,7 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
           ></line>
         </ng-template>
         <ng-container *ngFor="let tick of getTicks()">
-          <g>
+          <g *ngIf="shouldShowMinorTick(tick, axis)">
             <text [attr.x]="textXPosition(tick)" [attr.y]="textYPosition(tick)">
               {{ getFormatter().formatTick(tick) }}
             </text>
@@ -160,6 +160,17 @@ export class LineChartAxisComponent {
 
   getMajorTicks(): number[] {
     return this.scale.ticks(this.axisExtent, 2);
+  }
+
+  shouldShowMinorTick(tick: number, axis: 'x' | 'y'): boolean {
+    // Hide the tick text when it is too close to the left/right edge.
+    const fractionOfFullExtent =
+      (tick - this.axisExtent[0]) / (this.axisExtent[1] - this.axisExtent[0]);
+    const margin = axis === 'x' ? 0.075 : 0.03;
+    if (fractionOfFullExtent < margin || fractionOfFullExtent > 1 - margin) {
+      return false;
+    }
+    return true;
   }
 
   getTicks(): number[] {


### PR DESCRIPTION
In the new `?fastChart=true` line charts, tick labels on the x/y axes
show number values as strings. When the text is too close to the
left/right/top/bottom edge of the chart, the text can be visually
"cut off" in the middle.

This change automatically hides tick text if the tick is too close to
the edge of the chart.

Before
![image](https://user-images.githubusercontent.com/2322480/105786401-e0885780-5f31-11eb-8d5a-307e1a777eb7.png)

After
![image](https://user-images.githubusercontent.com/2322480/105786409-e5e5a200-5f31-11eb-9f33-082ee3f23e8b.png)
