### PR TITLE
cleanup: reduce amount of boilerplate needed in main.py

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -25,12 +25,23 @@ py_binary(
         ":default",
         ":dynamic_plugins",
         ":lib",
+        ":main_lib",
         ":program",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/uploader:uploader_subcommand",
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:timing",  # non-strict dep, for patching convenience
+    ],
+)
+
+py_library(
+    name = "main_lib",
+    srcs = ["main_lib.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorboard:expect_absl_logging_installed",
+        "//tensorboard/compat:tensorflow",
     ],
 )
 
@@ -198,11 +209,11 @@ py_library(
         ":manager",
         ":version",
         "//tensorboard:expect_absl_flags_installed",
-        "//tensorboard:expect_absl_logging_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:data_ingester",
         "//tensorboard/backend/event_processing:event_file_inspector",
         "//tensorboard/data:server_ingester",
+        "//tensorboard/plugins/core:core_plugin",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -36,6 +36,7 @@ os.environ["GCS_READ_CACHE_DISABLED"] = "1"
 
 import sys
 
+from absl import app
 from tensorboard import default
 from tensorboard import program
 from tensorboard.compat import tf
@@ -63,21 +64,10 @@ def run_main():
         subcommands=[uploader_subcommand.UploaderSubcommand()],
     )
     try:
-        from absl import app
-
-        # Import this to check that app.run() will accept the flags_parser argument.
-        from absl.flags import argparse_flags  # noqa: F401
-
         app.run(tensorboard.main, flags_parser=tensorboard.configure)
-        raise AssertionError("absl.app.run() shouldn't return")
-    except ImportError:
-        pass
     except base_plugin.FlagsError as e:
         print("Error: %s" % e, file=sys.stderr)
         sys.exit(1)
-
-    tensorboard.configure(sys.argv)
-    sys.exit(tensorboard.main())
 
 
 if __name__ == "__main__":

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -22,42 +22,19 @@ TensorBoard uses can swap out this file with their own.
 """
 
 
-import os
-
-# TF versions prior to 1.15.0 included default GCS filesystem caching logic
-# that interacted pathologically with the pattern of reads used by TensorBoard
-# for logdirs. See: https://github.com/tensorflow/tensorboard/issues/1225
-# The problematic behavior was fixed in 1.15.0 by
-# https://github.com/tensorflow/tensorflow/commit/e43b94649d3e1ac5d538e4eca9166b899511d681
-# but for older versions of TF, we avoid a regression by setting this env var to
-# disable the cache, which must be done before the first import of tensorflow.
-os.environ["GCS_READ_CACHE_DISABLED"] = "1"
-
-
 import sys
 
 from absl import app
 from tensorboard import default
+from tensorboard import main_lib
 from tensorboard import program
-from tensorboard.compat import tf
 from tensorboard.plugins import base_plugin
 from tensorboard.uploader import uploader_subcommand
-from tensorboard.util import tb_logging
-
-
-logger = tb_logging.get_logger()
 
 
 def run_main():
     """Initializes flags and calls main()."""
-    program.setup_environment()
-
-    if getattr(tf, "__version__", "stub") == "stub":
-        print(
-            "TensorFlow installation not found - running with reduced feature set.",
-            file=sys.stderr,
-        )
-
+    main_lib.global_init()
     tensorboard = program.TensorBoard(
         default.get_plugins(),
         program.get_default_assets_zip_provider(),

--- a/tensorboard/main_lib.py
+++ b/tensorboard/main_lib.py
@@ -1,0 +1,47 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Helpers for TensorBoard main module."""
+
+import os
+import sys
+
+import absl.logging
+
+from tensorboard.compat import tf
+
+
+def global_init():
+    """Modifies the global environment for running TensorBoard as main.
+
+    This functions changes global state in the Python process, so it should
+    not be called from library routines.
+    """
+    # TF versions prior to 1.15.0 included default GCS filesystem caching logic
+    # that interacted pathologically with the pattern of reads used by TensorBoard
+    # for logdirs. See: https://github.com/tensorflow/tensorboard/issues/1225
+    # The problematic behavior was fixed in 1.15.0 by
+    # https://github.com/tensorflow/tensorflow/commit/e43b94649d3e1ac5d538e4eca9166b899511d681
+    # but for older versions of TF, we avoid a regression by setting this env var to
+    # disable the cache, which must be done before the first import of tensorflow.
+    os.environ["GCS_READ_CACHE_DISABLED"] = "1"
+
+    if getattr(tf, "__version__", "stub") == "stub":
+        print(
+            "TensorFlow installation not found - running with reduced feature set.",
+            file=sys.stderr,
+        )
+
+    # Only emit log messages at WARNING and above by default to reduce spam.
+    absl.logging.set_verbosity(absl.logging.WARNING)

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -45,7 +45,6 @@ import urllib.parse
 
 from absl import flags as absl_flags
 from absl.flags import argparse_flags
-import absl.logging
 from werkzeug import serving
 
 from tensorboard import manager
@@ -64,16 +63,6 @@ logger = tb_logging.get_logger()
 _SERVE_SUBCOMMAND_NAME = "serve"
 # Internal flag name used to store which subcommand was invoked.
 _SUBCOMMAND_FLAG = "__tensorboard_subcommand"
-
-
-def setup_environment():
-    """Makes recommended modifications to the environment.
-
-    This functions changes global state in the Python process. Calling
-    this function is a good idea, but it can't appropriately be called
-    from library routines.
-    """
-    absl.logging.set_verbosity(absl.logging.WARNING)
 
 
 def get_default_assets_zip_provider():


### PR DESCRIPTION
This cleans up our main.py to reduce boilerplate needed for the minimal functionality:

1) We migrate a few lines of global initialization (which are themselves short, but have longer comments) into a new `global_init()` helper in a `main_lib.py` library; this supersedes `program.setup_environment()`.  (We don't want to just move everything into `program` since we don't want it to pick up a dependency on TensorFlow.)

2) We remove some fallback logic in `main.py` that handled the case where we don't have `absl` available.  It's been a required dep for years (since #1654).

This is intended to simplify the process of forking `main.py` as is being done in #4588.