### PR TITLE
proto: add dep from `:op_def` to `:resource_handle`

### DIFF
--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -131,6 +131,7 @@ tb_proto_library(
     srcs = ["op_def.proto"],
     deps = [
         ":attr_value",
+        ":resource_handle",
         ":types",
     ],
 )


### PR DESCRIPTION
Summary:
As of #4516, `//tensorboard/compat/proto/...` has separate targets for
each proto file, to support generating Go protos. The recent proto
update in #4600 added an `import` statement, which works fine for our
`protos_all` monotarget, and also happens to work for the separate
target since there was already a corresponding transitive dependency.
But this fails inside Google because of an extra strict deps check.

This patch manually adds the offending edge to unbreak the sync. We’ll
look into preventing further such regressions in a follow-up patch.

Test Plan:
Note that #4600 only adds one import statement, and that it corresponds
to this edge. Check that a test sync passes: <http://cl/353789753>.

wchargin-branch: proto-op-def-resource-handle-dep
