### PR TITLE
Introduce a selector providing a RunId to Run map

### DIFF
--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -76,6 +76,17 @@ export const getRuns = createSelector(
 );
 
 /**
+ * Returns an Observable that emits a map from RunIds to Runs. Note: the keys
+ * do NOT necessarily correspond to the current route's runs.
+ */
+export const getRunMap = createSelector(
+  getDataState,
+  (state: RunsDataState): Map<string, Run> => {
+    return new Map(Object.entries(state.runMetadata));
+  }
+);
+
+/**
  * Returns Observable that emits load state of the runs list.
  */
 export const getRunsLoadState = createSelector(

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -162,6 +162,41 @@ describe('runs_selectors', () => {
     });
   });
 
+  describe('#getRunMap', () => {
+    beforeEach(() => {
+      // Clear the memoization.
+      selectors.getRunMap.release();
+    });
+
+    it('returns a map from RunId to Run', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          runMetadata: {
+            run1: buildRun({id: 'run1'}),
+            run2: buildRun({id: 'run2'}),
+          },
+        })
+      );
+
+      expect(selectors.getRunMap(state)).toEqual(
+        new Map([
+          ['run1', buildRun({id: 'run1'})],
+          ['run2', buildRun({id: 'run2'})],
+        ])
+      );
+    });
+
+    it('returns an empty map if there are no runs', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          runMetadata: {},
+        })
+      );
+
+      expect(selectors.getRunMap(state)).toEqual(new Map());
+    });
+  });
+
   describe('#getRunsLoadState', () => {
     beforeEach(() => {
       // Clear the memoization.


### PR DESCRIPTION
Existing ngrx selectors in the Run feature store offer ways to get a `Run`
from its associated `runId`, and a list of `Run`s for a specific
`experimentId`. However, it would be convenient for consumers who
wish to convert a batch of `runId`s into a batch of `Run`s without having
to do a combination of multiple `getRun()` calls.

This introduces a convenience selector that returns a map that
consumers can use for easy lookup.  For example,

```ts
// Container
<component [handyMap] = "store.select(getRunMap) | async">
```
```ts
// Component
@Input handyMap;
// ...
const run = this.handyMap.get(runId);
```

This change is intended to offer support for
https://github.com/tensorflow/tensorboard/pull/4592