### PR TITLE
feature: differentiate overridden flags from default

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -26,11 +26,12 @@ const reducer = createReducer<FeatureFlagState>(
     // Feature flag values have been loaded from a data source. Override current
     // flags with any values specified by the data source and leave values for
     // unspecified properties unchanged.
+
     return {
       ...state,
       isFeatureFlagsLoaded: true,
-      features: {
-        ...state.features,
+      flagOverrides: {
+        ...state.flagOverrides,
         ...features,
       },
     };

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -35,10 +35,10 @@ describe('feature_flag_reducers', () => {
       );
     });
 
-    it('sets the new feature flags onto the state', () => {
+    it('does not overwrite default flags', () => {
       const prevState = buildFeatureFlagState({
         isFeatureFlagsLoaded: false,
-        features: buildFeatureFlag({
+        defaultFlags: buildFeatureFlag({
           enabledExperimentalPlugins: ['foo'],
         }),
       });
@@ -51,17 +51,40 @@ describe('feature_flag_reducers', () => {
         })
       );
 
-      expect(nextState.features).toEqual(
+      expect(nextState.defaultFlags).toEqual(
+        buildFeatureFlag({
+          enabledExperimentalPlugins: ['foo'],
+        })
+      );
+    });
+
+    it('sets the new feature flags onto the state.flagOverrides', () => {
+      const prevState = buildFeatureFlagState({
+        isFeatureFlagsLoaded: false,
+        flagOverrides: buildFeatureFlag({
+          enabledExperimentalPlugins: ['foo'],
+        }),
+      });
+      const nextState = reducers(
+        prevState,
+        actions.partialFeatureFlagsLoaded({
+          features: {
+            enabledExperimentalPlugins: ['foo', 'bar'],
+          },
+        })
+      );
+
+      expect(nextState.flagOverrides).toEqual(
         buildFeatureFlag({
           enabledExperimentalPlugins: ['foo', 'bar'],
         })
       );
     });
 
-    it('ignores unspecified feature flags', () => {
+    it('ignores unspecified feature flag overrides', () => {
       const prevState = buildFeatureFlagState({
         isFeatureFlagsLoaded: false,
-        features: buildFeatureFlag({
+        flagOverrides: buildFeatureFlag({
           enabledExperimentalPlugins: ['foo'],
           inColab: true,
         }),
@@ -75,7 +98,7 @@ describe('feature_flag_reducers', () => {
         })
       );
 
-      expect(nextState.features).toEqual(
+      expect(nextState.flagOverrides).toEqual(
         buildFeatureFlag({
           enabledExperimentalPlugins: ['foo'],
           inColab: false,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -38,14 +38,19 @@ export const getIsFeatureFlagsLoaded = createSelector(
 export const getFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): FeatureFlags => {
-    return {...state.defaultFlags, ...state.flagOverrides};
+    return {
+      ...state.defaultFlags,
+      ...state.flagOverrides,
+      ...state.features,
+    };
   }
 );
 
 export const getOverridenFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): Partial<FeatureFlags> => {
-    return state.flagOverrides;
+    // Temporarily assume state.flagOverrides can be undefined for sync purposes.
+    return state.flagOverrides || {};
   }
 );
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -15,6 +15,7 @@ limitations under the License.
 
 import {createSelector, createFeatureSelector} from '@ngrx/store';
 
+import {FeatureFlags} from '../types';
 import {
   FeatureFlagState,
   FEATURE_FLAG_FEATURE_KEY,
@@ -36,25 +37,32 @@ export const getIsFeatureFlagsLoaded = createSelector(
 
 export const getFeatureFlags = createSelector(
   selectFeatureFlagState,
-  (state) => {
-    return state.features;
+  (state: FeatureFlagState): FeatureFlags => {
+    return {...state.defaultFlags, ...state.flagOverrides};
+  }
+);
+
+export const getOverridenFeatureFlags = createSelector(
+  selectFeatureFlagState,
+  (state: FeatureFlagState): Partial<FeatureFlags> => {
+    return state.flagOverrides;
   }
 );
 
 export const getEnabledExperimentalPlugins = createSelector(
-  selectFeatureFlagState,
-  (state) => {
-    return state.features.enabledExperimentalPlugins;
+  getFeatureFlags,
+  (flags) => {
+    return flags.enabledExperimentalPlugins;
   }
 );
 
-export const getIsInColab = createSelector(selectFeatureFlagState, (state) => {
-  return state.features.inColab;
+export const getIsInColab = createSelector(getFeatureFlags, (flags) => {
+  return flags.inColab;
 });
 
 export const getIsGpuChartEnabled = createSelector(
-  selectFeatureFlagState,
-  (state: FeatureFlagState): boolean => {
-    return state.features.enableGpuChart;
+  getFeatureFlags,
+  (flags): boolean => {
+    return flags.enableGpuChart;
   }
 );

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -39,9 +39,9 @@ export const getFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): FeatureFlags => {
     return {
+      ...state.features,
       ...state.defaultFlags,
       ...state.flagOverrides,
-      ...state.features,
     };
   }
 );

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -35,6 +35,49 @@ describe('feature_flag_selectors', () => {
       );
     });
 
+    it('returns legacy `features` if no overrides or `defaultFlags` are given', () => {
+      const state = buildState(
+        buildFeatureFlagState({
+          features: {
+            enabledExperimentalPlugins: ['foo', 'bar'],
+            enableGpuChart: true,
+            inColab: false,
+            scalarsBatchSize: 10,
+          },
+        })
+      );
+
+      expect(selectors.getFeatureFlags(state)).toEqual({
+        enabledExperimentalPlugins: ['foo', 'bar'],
+        enableGpuChart: true,
+        inColab: false,
+        scalarsBatchSize: 10,
+      });
+    });
+
+    it('combines legacy `features` and overrides', () => {
+      const state = buildState(
+        buildFeatureFlagState({
+          features: {
+            enabledExperimentalPlugins: ['foo', 'bar'],
+            enableGpuChart: false,
+            inColab: false,
+            scalarsBatchSize: 10,
+          },
+          flagOverrides: {
+            enabledExperimentalPlugins: ['baz'],
+          },
+        })
+      );
+
+      expect(selectors.getFeatureFlags(state)).toEqual({
+        enabledExperimentalPlugins: ['baz'],
+        enableGpuChart: false,
+        inColab: false,
+        scalarsBatchSize: 10,
+      });
+    });
+
     it('does not combine array flags', () => {
       const state = buildState(
         buildFeatureFlagState({

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -19,12 +19,13 @@ import {FeatureFlagState} from './feature_flag_types';
 
 export const initialState: FeatureFlagState = {
   isFeatureFlagsLoaded: false,
-  features: {
+  defaultFlags: {
     enabledExperimentalPlugins: [],
     inColab: false,
     enableGpuChart: false,
     scalarsBatchSize: undefined,
   },
+  flagOverrides: {},
 };
 
 /**

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -19,6 +19,12 @@ import {FeatureFlagState} from './feature_flag_types';
 
 export const initialState: FeatureFlagState = {
   isFeatureFlagsLoaded: false,
+  features: {
+    enabledExperimentalPlugins: [],
+    inColab: false,
+    enableGpuChart: false,
+    scalarsBatchSize: undefined,
+  },
   defaultFlags: {
     enabledExperimentalPlugins: [],
     inColab: false,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -19,8 +19,10 @@ export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 
 export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;
-  defaultFlags: FeatureFlags;
-  flagOverrides: Partial<FeatureFlags>;
+  features: FeatureFlags;
+  // Temporarily set undefiend for `defaultFlags` and `flagOverrides` for sync purposes.
+  defaultFlags?: FeatureFlags;
+  flagOverrides?: Partial<FeatureFlags>;
 }
 
 export interface State {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -19,7 +19,8 @@ export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 
 export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;
-  features: FeatureFlags;
+  defaultFlags: FeatureFlags;
+  flagOverrides: Partial<FeatureFlags>;
 }
 
 export interface State {

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -18,12 +18,12 @@ import {FeatureFlagState, FEATURE_FLAG_FEATURE_KEY} from './feature_flag_types';
 
 export function buildFeatureFlagState(
   override: Partial<FeatureFlagState> = {}
-) {
-  const {features: featuresOverride, ...restOverride} = override;
+): FeatureFlagState {
   return {
     isFeatureFlagsLoaded: false,
-    ...restOverride,
-    features: buildFeatureFlag(featuresOverride),
+    ...override,
+    defaultFlags: buildFeatureFlag(override.defaultFlags),
+    flagOverrides: override.flagOverrides ?? {},
   };
 }
 

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -21,8 +21,14 @@ export function buildFeatureFlagState(
 ): FeatureFlagState {
   return {
     isFeatureFlagsLoaded: false,
+    features: {
+      enabledExperimentalPlugins: [],
+      enableGpuChart: false,
+      inColab: false,
+      scalarsBatchSize: 1,
+    },
+    defaultFlags: undefined,
     ...override,
-    defaultFlags: buildFeatureFlag(override.defaultFlags),
     flagOverrides: override.flagOverrides ?? {},
   };
 }

--- a/tensorboard/webapp/routes/core_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider.ts
@@ -78,16 +78,16 @@ export class CoreDeepLinkProvider extends DeepLinkProvider {
   ): Observable<SerializableQueryParams> {
     return combineLatest([
       store.select(selectors.getEnabledExperimentalPlugins),
-      store.select(selectors.getIsGpuChartEnabled),
+      store.select(selectors.getOverridenFeatureFlags),
     ]).pipe(
-      map(([experimentalPlugins, isGpuChartEnabled]) => {
+      map(([experimentalPlugins, overridenFeatureFlags]) => {
         const queryParams = experimentalPlugins.map((pluginId) => {
           return {key: EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY, value: pluginId};
         });
-        if (isGpuChartEnabled) {
+        if (overridenFeatureFlags.enableGpuChart !== undefined) {
           queryParams.push({
             key: GPU_LINE_CHART_QUERY_PARAM_KEY,
-            value: 'true',
+            value: String(overridenFeatureFlags.enableGpuChart),
           });
         }
         return queryParams;

--- a/tensorboard/webapp/routes/core_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider_test.ts
@@ -44,7 +44,7 @@ describe('core deeplink provider', () => {
     store.overrideSelector(selectors.getPinnedCardsWithMetadata, []);
     store.overrideSelector(selectors.getUnresolvedImportedPinnedCards, []);
     store.overrideSelector(selectors.getEnabledExperimentalPlugins, []);
-    store.overrideSelector(selectors.getIsGpuChartEnabled, false);
+    store.overrideSelector(selectors.getOverridenFeatureFlags, {});
 
     queryParamsSerialized = [];
 
@@ -252,12 +252,30 @@ describe('core deeplink provider', () => {
     });
 
     it('serializes enabled fast chart state', () => {
-      store.overrideSelector(selectors.getIsGpuChartEnabled, true);
+      store.overrideSelector(selectors.getOverridenFeatureFlags, {
+        enableGpuChart: false,
+      });
+      store.refreshState();
+
+      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
+        {key: 'fastChart', value: 'false'},
+      ]);
+
+      store.overrideSelector(selectors.getOverridenFeatureFlags, {
+        enableGpuChart: true,
+      });
       store.refreshState();
 
       expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
         {key: 'fastChart', value: 'true'},
       ]);
+    });
+
+    it('omits fast chart state if it is not overriden by user and has default value', () => {
+      store.overrideSelector(selectors.getOverridenFeatureFlags, {});
+      store.refreshState();
+
+      expect(queryParamsSerialized).toEqual([[]]);
     });
   });
 });


### PR DESCRIPTION
This is a roll-forward of #4593 (rolled back by #4599)

Currently, TensorBoard reflects the feature flags as is to the URL. This
means, we cannot differentiate overrides from defaults and makes
changing the defaults harder.

For instance, soon, we want to change fastChart to default true but, in
that case, we don't want the URL to say anything about fastChart. Also,
in that world, we would like to support fastChart=false which should
remain in the URL since it is an explicit override user has requested.

This change, to prevent breakage internally, types `defaultFlags` and
`flagOverrides` as optional while keeping the `features` as required.

The steps to move forward and deprecate the `features` are:
1. [GH] this change
2. [Internal] change every usage of `features` to also provide `defaultFlags` and change their selectors
3. [GH] change `features` to an optional param and make `defaultFlags` to required
4. [Internal] remove all declarations of `features`
5. [GH] remove `features` from the codebase.

Test cl: cl/353795245.