### PR TITLE
line chart: put fades around start&end of text

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -32,18 +32,15 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
   selector: 'line-chart-axis',
   template: `
     <div [class]="axis + '-axis'">
-      <svg class="minor">
+      <svg class="line">
         <ng-container *ngIf="axis === 'x'; else yAxisLine">
           <line x1="0" y1="0" [attr.x2]="domDim.width" y2="0"></line>
         </ng-container>
         <ng-template #yAxisLine>
-          <line
-            [attr.x1]="domDim.width"
-            y1="0"
-            [attr.x2]="domDim.width"
-            [attr.y2]="domDim.height"
-          ></line>
+          <line x1="0" y1="0" x2="0" [attr.y2]="domDim.height"></line>
         </ng-template>
+      </svg>
+      <svg class="minor ticks">
         <ng-container *ngFor="let tick of getTicks()">
           <g>
             <text [attr.x]="textXPosition(tick)" [attr.y]="textYPosition(tick)">
@@ -55,7 +52,7 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
           </g>
         </ng-container>
       </svg>
-      <svg *ngIf="shouldShowMajorTicks()" class="major">
+      <svg *ngIf="shouldShowMajorTicks()" class="major ticks">
         <g *ngFor="let tick of getMajorTicks()">
           <text [attr.x]="textXPosition(tick)" [attr.y]="textYPosition(tick)">
             {{ getFormatter().formatShort(tick) }}
@@ -75,11 +72,6 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
         overflow: hidden;
       }
 
-      svg {
-        height: 100%;
-        width: 100%;
-      }
-
       line {
         stroke: #333;
         stroke-width: 1px;
@@ -92,8 +84,14 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
 
       .x-axis,
       .y-axis {
+        display: flex;
         height: 100%;
         width: 100%;
+      }
+
+      .line {
+        flex: 0 0 1px;
+        justify-content: stretch;
       }
 
       .x-axis {
@@ -105,13 +103,47 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
         text-anchor: middle;
       }
 
+      .x-axis .ticks {
+        -webkit-mask-image: linear-gradient(
+          to right,
+          #0000 0%,
+          #000 10%,
+          #000 90%,
+          #0000 100%
+        );
+        mask-image: linear-gradient(
+          to right,
+          #0000 0%,
+          #000 10%,
+          #000 90%,
+          #0000 100%
+        );
+      }
+
       .y-axis {
-        flex-direction: row;
+        flex-direction: row-reverse;
       }
 
       .y-axis text {
         dominant-baseline: central;
         text-anchor: end;
+      }
+
+      .y-axis .ticks {
+        -webkit-mask-image: linear-gradient(
+          to bottom,
+          #0000 0%,
+          #000 10%,
+          #000 90%,
+          #0000 100%
+        );
+        mask-image: linear-gradient(
+          to bottom,
+          #0000 0%,
+          #000 10%,
+          #000 90%,
+          #0000 100%
+        );
       }
     `,
   ],

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
@@ -54,7 +54,7 @@ class TestableComponent {
   };
 }
 
-fdescribe('line_chart_v2/sub_view/grid test', () => {
+describe('line_chart_v2/sub_view/grid test', () => {
   const ByCss = {
     GRID_LINE: By.css('line'),
   };

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
@@ -54,7 +54,7 @@ class TestableComponent {
   };
 }
 
-describe('line_chart_v2/sub_view/grid test', () => {
+fdescribe('line_chart_v2/sub_view/grid test', () => {
   const ByCss = {
     GRID_LINE: By.css('line'),
   };


### PR DESCRIPTION
The GPU line chart does not account for space when creating tick string.
This can of course lead to clipping which is kind of fine except it can
sometimes lead to a confusing chart when the substring can make a lot of
sense. While this is mitigated by `<title>` and tooltips, we lose the
glance-ability.

To give user a hint that the tick string might be clipped, we now use
faded mask on the tick strings.

![image](https://user-images.githubusercontent.com/2547313/105911930-93fb5580-5fdf-11eb-9f6d-c99a817df873.png)
