### PR TITLE
line chart: fill the origin with a rectangle

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -67,4 +67,5 @@ limitations under the License.
     [gridCount]="X_GRID_COUNT"
     [scale]="xScale"
   ></line-chart-axis>
+  <div class="dot"><span class="rect"></span></div>
 </div>

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -25,7 +25,7 @@ limitations under the License.
   width: 100%;
   grid-template-areas:
     'yaxis series'
-    '. xaxis';
+    'dot xaxis';
   grid-template-columns: 50px 1fr;
   grid-auto-rows: 1fr 30px;
 }
@@ -53,4 +53,17 @@ limitations under the License.
 
 .y-axis {
   grid-area: yaxis;
+}
+
+.dot {
+  align-items: flex-start;
+  display: flex;
+  grid-area: dot;
+  justify-content: flex-end;
+
+  .rect {
+    height: 1px;
+    width: 1px;
+    background-color: #aaa;
+  }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -32,14 +32,7 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
   selector: 'line-chart-axis',
   template: `
     <div [class]="axis + '-axis'">
-      <svg class="line">
-        <ng-container *ngIf="axis === 'x'; else yAxisLine">
-          <line x1="0" y1="0" [attr.x2]="domDim.width" y2="0"></line>
-        </ng-container>
-        <ng-template #yAxisLine>
-          <line x1="0" y1="0" x2="0" [attr.y2]="domDim.height"></line>
-        </ng-template>
-      </svg>
+      <div class="line"></div>
       <svg class="minor ticks">
         <ng-container *ngFor="let tick of getTicks()">
           <g>
@@ -90,6 +83,7 @@ const DAY_IN_MS = 24 * 1000 * 60 * 60;
       }
 
       .line {
+        background-color: #aaa;
         flex: 0 0 1px;
         justify-content: stretch;
       }


### PR DESCRIPTION
We are using CSS `grid` to render the new line chart and this resulted
in an awkward missing pixel at the "origin". To illustrate this with
simple diagram:
```
          |
          |
          |
missing ->x------
```

With this change, we are now rendering the missing origin rectangle with
a span.

About seemingly unrelated change: when using SVG path to render the axis
lines, it was not as crisp as a border and resulted in noticeable visual
jank with the rectangle.
