### PR TITLE
Support http server port reuse

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -342,6 +342,21 @@ unavailable. (default: "default").\
         )
 
         parser.add_argument(
+            "--reuse_port",
+            metavar="BOOL",
+            # Custom str-to-bool converter since regular bool() doesn't work.
+            type=lambda v: {"true": True, "false": False}.get(v.lower(), v),
+            choices=[True, False],
+            default=False,
+            help="""\
+Enables the SO_REUSEPORT option on the socket opened by TensorBoard's HTTP
+server, for platforms that support it. This is useful in cases when a parent
+process has obtained the port already and wants to delegate access to the
+port to TensorBoard as a subprocess.(default: %(default)s).\
+""",
+        )
+
+        parser.add_argument(
             "--load_fast",
             action="store_true",
             help="""\

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -57,6 +57,7 @@ class FakeFlags(object):
         path_prefix="",
         generic_data="true",
         grpc_data_provider="",
+        reuse_port=False
     ):
         self.bind_all = bind_all
         self.host = host
@@ -69,7 +70,7 @@ class FakeFlags(object):
         self.path_prefix = path_prefix
         self.generic_data = generic_data
         self.grpc_data_provider = grpc_data_provider
-
+        self.reuse_port = reuse_port
 
 class CorePluginFlagsTest(tf.test.TestCase):
     def testFlag(self):

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -72,6 +72,7 @@ class FakeFlags(object):
         self.grpc_data_provider = grpc_data_provider
         self.reuse_port = reuse_port
 
+
 class CorePluginFlagsTest(tf.test.TestCase):
     def testFlag(self):
         loader = core_plugin.CorePluginLoader()

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -57,7 +57,7 @@ class FakeFlags(object):
         path_prefix="",
         generic_data="true",
         grpc_data_provider="",
-        reuse_port=False
+        reuse_port=False,
     ):
         self.bind_all = bind_all
         self.host = host

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -89,6 +89,7 @@ class WerkzeugServerTest(tb_test.TestCase):
         flags = argparse.Namespace()
         kwargs.setdefault("host", None)
         kwargs.setdefault("bind_all", kwargs["host"] is None)
+        kwargs.setdefault("reuse_port", False)
         for k, v in kwargs.items():
             setattr(flags, k, v)
         return flags


### PR DESCRIPTION
* Motivation for features / changes

ReusePort scenario: 
parent process occupies the port, then share the port through service such as ZooKeeper and [TonY](https://github.com/linkedin/TonY) (TensorFlow on Yarn), and then child process (TensorBoard process) reuse the port.

* Technical description of changes

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
