### PR TITLE
chore: fix typo of "overriden" to "overridden"

### DIFF
--- a/tensorboard/components/tf_markdown_view/sanitize.ts
+++ b/tensorboard/components/tf_markdown_view/sanitize.ts
@@ -16,7 +16,7 @@ limitations under the License.
 /**
  * Does not actually sanitize html.
  *
- * This exported function is overriden in the internal Google repository for
+ * This exported function is overridden in the internal Google repository for
  * compatibility with security libraries used internally at Google.
  */
 export function sanitize(html: string) {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -46,7 +46,7 @@ export const getFeatureFlags = createSelector(
   }
 );
 
-export const getOverridenFeatureFlags = createSelector(
+export const getOverriddenFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): Partial<FeatureFlags> => {
     // Temporarily assume state.flagOverrides can be undefined for sync purposes.

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -98,15 +98,15 @@ describe('feature_flag_selectors', () => {
     });
   });
 
-  describe('#getOverridenFeatureFlags', () => {
+  describe('#getOverriddenFeatureFlags', () => {
     it('returns empty object if it is not overridden', () => {
       const state = buildState(buildFeatureFlagState());
-      const actual = selectors.getOverridenFeatureFlags(state);
+      const actual = selectors.getOverriddenFeatureFlags(state);
 
       expect(actual).toEqual({});
     });
 
-    it('returns only overriden parts', () => {
+    it('returns only overridden parts', () => {
       const state = buildState(
         buildFeatureFlagState({
           defaultFlags: buildFeatureFlag({
@@ -117,7 +117,7 @@ describe('feature_flag_selectors', () => {
           },
         })
       );
-      const actual = selectors.getOverridenFeatureFlags(state);
+      const actual = selectors.getOverriddenFeatureFlags(state);
 
       expect(actual).toEqual({enableGpuChart: false});
     });

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -99,7 +99,7 @@ limitations under the License.
   -- subsequent attempt to reload environment data.
   --
   -- In other flavors of TensorBoard the root cause may be different so we allow
-  -- this template to be overriden by the parent component. -->
+  -- this template to be overridden by the parent component. -->
 <ng-template #environmentFailureDefaultTemplate>
   <h3 class="environment-not-loaded">Data could not be loaded.</h3>
   <p>The TensorBoard server may be down or inaccessible.</p>

--- a/tensorboard/webapp/routes/core_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider.ts
@@ -78,16 +78,16 @@ export class CoreDeepLinkProvider extends DeepLinkProvider {
   ): Observable<SerializableQueryParams> {
     return combineLatest([
       store.select(selectors.getEnabledExperimentalPlugins),
-      store.select(selectors.getOverridenFeatureFlags),
+      store.select(selectors.getOverriddenFeatureFlags),
     ]).pipe(
-      map(([experimentalPlugins, overridenFeatureFlags]) => {
+      map(([experimentalPlugins, overriddenFeatureFlags]) => {
         const queryParams = experimentalPlugins.map((pluginId) => {
           return {key: EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY, value: pluginId};
         });
-        if (overridenFeatureFlags.enableGpuChart !== undefined) {
+        if (overriddenFeatureFlags.enableGpuChart !== undefined) {
           queryParams.push({
             key: GPU_LINE_CHART_QUERY_PARAM_KEY,
-            value: String(overridenFeatureFlags.enableGpuChart),
+            value: String(overriddenFeatureFlags.enableGpuChart),
           });
         }
         return queryParams;

--- a/tensorboard/webapp/routes/core_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider_test.ts
@@ -44,7 +44,7 @@ describe('core deeplink provider', () => {
     store.overrideSelector(selectors.getPinnedCardsWithMetadata, []);
     store.overrideSelector(selectors.getUnresolvedImportedPinnedCards, []);
     store.overrideSelector(selectors.getEnabledExperimentalPlugins, []);
-    store.overrideSelector(selectors.getOverridenFeatureFlags, {});
+    store.overrideSelector(selectors.getOverriddenFeatureFlags, {});
 
     queryParamsSerialized = [];
 
@@ -252,7 +252,7 @@ describe('core deeplink provider', () => {
     });
 
     it('serializes enabled fast chart state', () => {
-      store.overrideSelector(selectors.getOverridenFeatureFlags, {
+      store.overrideSelector(selectors.getOverriddenFeatureFlags, {
         enableGpuChart: false,
       });
       store.refreshState();
@@ -261,7 +261,7 @@ describe('core deeplink provider', () => {
         {key: 'fastChart', value: 'false'},
       ]);
 
-      store.overrideSelector(selectors.getOverridenFeatureFlags, {
+      store.overrideSelector(selectors.getOverriddenFeatureFlags, {
         enableGpuChart: true,
       });
       store.refreshState();
@@ -271,8 +271,8 @@ describe('core deeplink provider', () => {
       ]);
     });
 
-    it('omits fast chart state if it is not overriden by user and has default value', () => {
-      store.overrideSelector(selectors.getOverridenFeatureFlags, {});
+    it('omits fast chart state if it is not overridden by user and has default value', () => {
+      store.overrideSelector(selectors.getOverriddenFeatureFlags, {});
       store.refreshState();
 
       expect(queryParamsSerialized).toEqual([[]]);

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -140,7 +140,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
   private isDataUpdated = false;
   private isMetadataUpdated = false;
   private isFixedViewBoxUpdated = false;
-  private isViewBoxOverriden = false;
+  private isViewBoxOverridden = false;
   // Must set the default view box since it is an optional input and won't trigger
   // onChanges.
   private isViewBoxChanged = true;
@@ -176,7 +176,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     this.isViewBoxChanged =
       this.isViewBoxChanged ||
-      (!this.isViewBoxOverriden && this.shouldUpdateDefaultViewBox(changes));
+      (!this.isViewBoxOverridden && this.shouldUpdateDefaultViewBox(changes));
 
     this.updateLineChart();
   }
@@ -336,7 +336,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     if (this.isFixedViewBoxUpdated && this.fixedViewBox) {
       this.viewBox = this.fixedViewBox;
-    } else if (!this.isViewBoxOverriden && this.isViewBoxChanged) {
+    } else if (!this.isViewBoxOverridden && this.isViewBoxChanged) {
       const dataExtent = computeDataSeriesExtent(
         this.seriesData,
         this.seriesMetadataMap,
@@ -362,14 +362,14 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
   }
 
   onViewBoxChanged({dataExtent}: {dataExtent: Extent}) {
-    this.isViewBoxOverriden = true;
+    this.isViewBoxOverridden = true;
     this.isViewBoxChanged = true;
     this.viewBox = dataExtent;
     this.updateLineChart();
   }
 
   onViewBoxReset() {
-    this.isViewBoxOverriden = false;
+    this.isViewBoxOverridden = false;
     this.isViewBoxChanged = true;
     this.updateLineChart();
   }


### PR DESCRIPTION
The common typo was caught by the internal lint tool.