### PR TITLE
data_compat: mark converted image and audio data

### DIFF
--- a/tensorboard/data/server/BUILD
+++ b/tensorboard/data/server/BUILD
@@ -120,6 +120,8 @@ genrule(
     srcs = [
         "//tensorboard/compat/proto:proto_srcs",
         "//tensorboard/data/proto:proto_srcs",
+        "//tensorboard/plugins/audio:proto_srcs",
+        "//tensorboard/plugins/image:proto_srcs",
     ],
     outs = _genproto_files,
     cmd = "$(execpath :gen_protos_tool) $(RULEDIR)",

--- a/tensorboard/data/server/gen_protos_tool.rs
+++ b/tensorboard/data/server/gen_protos_tool.rs
@@ -33,6 +33,8 @@ fn main() -> std::io::Result<()> {
             &[
                 "tensorboard/compat/proto/event.proto",
                 "tensorboard/data/proto/data_provider.proto",
+                "tensorboard/plugins/audio/plugin_data.proto",
+                "tensorboard/plugins/image/plugin_data.proto",
             ],
             &["."],
         )

--- a/tensorboard/data/server/tensorboard.pb.rs
+++ b/tensorboard/data/server/tensorboard.pb.rs
@@ -591,3 +591,52 @@ pub enum WorkerShutdownMode {
     WaitForCoordinator = 2,
     ShutdownAfterTimeout = 3,
 }
+/// Audio summaries created by the `tensorboard.plugins.audio.summary`
+/// module will include `SummaryMetadata` whose `plugin_data` field has
+/// as `content` a binary string that is the encoding of an
+/// `AudioPluginData` proto.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AudioPluginData {
+    /// Version `0` is the only supported version. It has the following
+    /// semantics:
+    ///
+    ///   - If the tensor shape is rank-2, then `t[:, 0]` represent encoded
+    ///     audio data, and `t[:, 1]` represent corresponding UTF-8 encoded
+    ///     Markdown labels.
+    ///   - If the tensor shape is rank-1, then `t[:]` represent encoded
+    ///     audio data. There are no labels.
+    #[prost(int32, tag="1")]
+    pub version: i32,
+    #[prost(enumeration="audio_plugin_data::Encoding", tag="2")]
+    pub encoding: i32,
+    /// Indicates whether this time series data was originally represented
+    /// as `Summary.Value.Audio` values and has been automatically
+    /// converted to bytestring tensors.
+    #[prost(bool, tag="3")]
+    pub converted_to_tensor: bool,
+}
+/// Nested message and enum types in `AudioPluginData`.
+pub mod audio_plugin_data {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Encoding {
+        /// Do not use `UNKNOWN`; it is only present because it must be.
+        Unknown = 0,
+        Wav = 11,
+    }
+}
+/// Image summaries created by the `tensorboard.plugins.image.summary`
+/// module will include `SummaryMetadata` whose `plugin_data` field has
+/// as `content` a binary string that is the encoding of an
+/// `ImagePluginData` proto.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ImagePluginData {
+    /// Version `0` is the only supported version.
+    #[prost(int32, tag="1")]
+    pub version: i32,
+    /// Indicates whether this time series data was originally represented
+    /// as `Summary.Value.Image` values and has been automatically
+    /// converted to bytestring tensors.
+    #[prost(bool, tag="2")]
+    pub converted_to_tensor: bool,
+}

--- a/tensorboard/data_compat.py
+++ b/tensorboard/data_compat.py
@@ -108,6 +108,7 @@ def _migrate_image_value(value):
     summary_metadata = image_metadata.create_summary_metadata(
         display_name=value.metadata.display_name or value.tag,
         description=value.metadata.summary_description,
+        converted_to_tensor=True,
     )
     return make_summary(value.tag, summary_metadata, data)
 
@@ -119,6 +120,7 @@ def _migrate_audio_value(value):
         display_name=value.metadata.display_name or value.tag,
         description=value.metadata.summary_description,
         encoding=audio_metadata.Encoding.Value("WAV"),
+        converted_to_tensor=True,
     )
     return make_summary(value.tag, summary_metadata, data)
 

--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -88,8 +88,24 @@ class MigrateValueTest(tf.test.TestCase):
             display_name="k488/audio/0",
             description="",
             encoding=audio_metadata.Encoding.Value("WAV"),
+            converted_to_tensor=True,
+        )
+
+        # Check serialized submessages...
+        plugin_content = audio_metadata.parse_plugin_metadata(
+            new_value.metadata.plugin_data.content
+        )
+        expected_content = audio_metadata.parse_plugin_metadata(
+            expected_metadata.plugin_data.content
+        )
+        self.assertEqual(plugin_content, expected_content)
+        # ...then check full metadata except plugin content, since
+        # serialized forms need not be identical.
+        new_value.metadata.plugin_data.content = (
+            expected_metadata.plugin_data.content
         )
         self.assertEqual(expected_metadata, new_value.metadata)
+
         self.assertTrue(new_value.HasField("tensor"))
         data = tensor_util.make_ndarray(new_value.tensor)
         self.assertEqual((1, 2), data.shape)
@@ -141,9 +157,26 @@ class MigrateValueTest(tf.test.TestCase):
 
         self.assertEqual("mona_lisa/image/0", new_value.tag)
         expected_metadata = image_metadata.create_summary_metadata(
-            display_name="mona_lisa/image/0", description=""
+            display_name="mona_lisa/image/0",
+            description="",
+            converted_to_tensor=True,
+        )
+
+        # Check serialized submessages...
+        plugin_content = image_metadata.parse_plugin_metadata(
+            new_value.metadata.plugin_data.content
+        )
+        expected_content = image_metadata.parse_plugin_metadata(
+            expected_metadata.plugin_data.content
+        )
+        self.assertEqual(plugin_content, expected_content)
+        # ...then check full metadata except plugin content, since
+        # serialized forms need not be identical.
+        new_value.metadata.plugin_data.content = (
+            expected_metadata.plugin_data.content
         )
         self.assertEqual(expected_metadata, new_value.metadata)
+
         self.assertTrue(new_value.HasField("tensor"))
         (width, height, data) = tensor_util.make_ndarray(new_value.tensor)
         self.assertEqual(b"200", width)

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -7,6 +7,11 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
+filegroup(
+    name = "proto_srcs",
+    srcs = glob(["*.proto"]),
+)
+
 py_library(
     name = "audio_plugin",
     srcs = ["audio_plugin.py"],

--- a/tensorboard/plugins/audio/metadata.py
+++ b/tensorboard/plugins/audio/metadata.py
@@ -31,14 +31,18 @@ PROTO_VERSION = 0
 Encoding = plugin_data_pb2.AudioPluginData.Encoding
 
 
-def create_summary_metadata(display_name, description, encoding):
+def create_summary_metadata(
+    display_name, description, encoding, *, converted_to_tensor=None
+):
     """Create a `SummaryMetadata` proto for audio plugin data.
 
     Returns:
       A `SummaryMetadata` protobuf object.
     """
     content = plugin_data_pb2.AudioPluginData(
-        version=PROTO_VERSION, encoding=encoding
+        version=PROTO_VERSION,
+        encoding=encoding,
+        converted_to_tensor=converted_to_tensor,
     )
     metadata = summary_pb2.SummaryMetadata(
         display_name=display_name,

--- a/tensorboard/plugins/audio/plugin_data.proto
+++ b/tensorboard/plugins/audio/plugin_data.proto
@@ -39,4 +39,9 @@ message AudioPluginData {
   int32 version = 1;
 
   Encoding encoding = 2;
+
+  // Indicates whether this time series data was originally represented
+  // as `Summary.Value.Audio` values and has been automatically
+  // converted to bytestring tensors.
+  bool converted_to_tensor = 3;
 }

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -7,6 +7,11 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
+filegroup(
+    name = "proto_srcs",
+    srcs = glob(["*.proto"]),
+)
+
 py_library(
     name = "images_plugin",
     srcs = ["images_plugin.py"],

--- a/tensorboard/plugins/image/metadata.py
+++ b/tensorboard/plugins/image/metadata.py
@@ -28,13 +28,18 @@ PLUGIN_NAME = "images"
 PROTO_VERSION = 0
 
 
-def create_summary_metadata(display_name, description):
+def create_summary_metadata(
+    display_name, description, *, converted_to_tensor=None
+):
     """Create a `summary_pb2.SummaryMetadata` proto for image plugin data.
 
     Returns:
       A `summary_pb2.SummaryMetadata` protobuf object.
     """
-    content = plugin_data_pb2.ImagePluginData(version=PROTO_VERSION)
+    content = plugin_data_pb2.ImagePluginData(
+        version=PROTO_VERSION,
+        converted_to_tensor=converted_to_tensor,
+    )
     metadata = summary_pb2.SummaryMetadata(
         display_name=display_name,
         summary_description=description,

--- a/tensorboard/plugins/image/plugin_data.proto
+++ b/tensorboard/plugins/image/plugin_data.proto
@@ -24,4 +24,9 @@ package tensorboard;
 message ImagePluginData {
   // Version `0` is the only supported version.
   int32 version = 1;
+
+  // Indicates whether this time series data was originally represented
+  // as `Summary.Value.Image` values and has been automatically
+  // converted to bytestring tensors.
+  bool converted_to_tensor = 2;
 }


### PR DESCRIPTION
Summary:
In TensorFlow 1.x, image and audio data are represented with a separate
time series for each batch item (`input_image/image/0`, etc.). In
TensorFlow 2.x, a time series may include multiple batch items. This
patch adds a field to image and audio metadata protos to indicate that
they have been automatically converted (by `data_compat`) from TF 1.x to
TF 2.x. This way, downstream code can tell that a TF 1.x time series may
be part of a larger batch even though it only contains a single sample.

Since this new annotation is a proto field that is `true` only for
legacy data, summary metadata for TF 2.x summaries is unchanged.

Test Plan:
As end-to-end tests, verified that the images and audio dashboards both
still work with TF 1.x data, and checked with `grpc_cli` that the data
server returns summary metadata with non-empty `plugin_data.content`:

```
grpc_cli --channel_creds_type=local \
    --protofiles tensorboard/data/proto/data_provider.proto \
    call localhost:41905 TensorBoardDataProvider.ListBlobSequences \
    'plugin_filter { plugin_name: "audio" }'
```

wchargin-branch: mark-tf1x-image-audio
