### PR TITLE
graph: fix file upload control when no initial data loaded

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -87,7 +87,10 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
         on-fit-tap="_fit"
         trace-inputs="{{_traceInputs}}"
       ></tf-graph-controls>
-      <div class="center" slot="center">
+      <div
+        class$="center [[_getGraphDisplayClassName(_selectedFile, _datasets)]]"
+        slot="center"
+      >
         <tf-graph-dashboard-loader
           id="loader"
           datasets="[[_datasets]]"
@@ -100,9 +103,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
           hierarchy-params="[[_hierarchyParams]]"
           compatibility-provider="[[_compatibilityProvider]]"
         ></tf-graph-dashboard-loader>
-        <div
-          class$="no-data-message [[_showComponent(_selectedFile, _datasets, 'false')]]"
-        >
+        <div class="no-data-message">
           <h3>No graph definition files were found.</h3>
           <p>
             To store a graph, create a
@@ -137,9 +138,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
             and consider filing an issue on GitHub.
           </p>
         </div>
-        <div
-          class$="graphboard [[_showComponent(_selectedFile, _datasets, 'true')]]"
-        >
+        <div class="graphboard">
           <tf-graph-board
             id="graphboard"
             devices-for-stats="[[_devicesForStats]]"
@@ -192,7 +191,11 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
         height: 100%;
       }
 
-      .remove {
+      .no-graph .graphboard {
+        display: none;
+      }
+
+      .center:not(.no-graph) .no-data-message {
         display: none;
       }
     </style>
@@ -339,22 +342,9 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
   _fit() {
     (this.$$('#graphboard') as any).fit();
   }
-  _showComponent(_selectedFile: any, _datasets: any[], _isGraphboard: string) {
+  _getGraphDisplayClassName(_selectedFile: any, _datasets: any[]) {
     const isDataValid = _selectedFile || _datasets.length;
-    const isGraphboard =
-      _isGraphboard === 'true'
-        ? true
-        : _isGraphboard === 'false'
-        ? false
-        : undefined;
-    if (isGraphboard === undefined) {
-      return '';
-    }
-
-    if ((!isDataValid && !isGraphboard) || (isDataValid && isGraphboard)) {
-      return '';
-    }
-    return 'remove';
+    return isDataValid ? '' : 'no-graph';
   }
   _runObserver = tf_storage.getStringObserver(RUN_STORAGE_KEY, {
     defaultValue: '',

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -88,62 +88,58 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
         trace-inputs="{{_traceInputs}}"
       ></tf-graph-controls>
       <div class="center" slot="center">
-        <template
-          is="dom-if"
-          if="[[_datasetsState(_datasetsFetched, _datasets, 'EMPTY')]]"
+        <tf-graph-dashboard-loader
+          id="loader"
+          datasets="[[_datasets]]"
+          selection="[[_selection]]"
+          selected-file="[[_selectedFile]]"
+          out-graph-hierarchy="{{_graphHierarchy}}"
+          out-graph="{{_graph}}"
+          out-stats="{{_stats}}"
+          progress="{{_progress}}"
+          hierarchy-params="[[_hierarchyParams]]"
+          compatibility-provider="[[_compatibilityProvider]]"
+        ></tf-graph-dashboard-loader>
+        <div
+          class$="no-data-message [[_showComponent(_selectedFile, _datasets, 'false')]]"
         >
-          <div style="max-width: 540px; margin: 80px auto 0 auto;">
-            <h3>No graph definition files were found.</h3>
-            <p>
-              To store a graph, create a
-              <code>tf.summary.FileWriter</code>
-              and pass the graph either via the constructor, or by calling its
-              <code>add_graph()</code> method. You may want to check out the
-              <a href="https://www.tensorflow.org/get_started/graph_viz"
-                >graph visualizer tutorial</a
-              >.
-            </p>
+          <h3>No graph definition files were found.</h3>
+          <p>
+            To store a graph, create a
+            <code>tf.summary.FileWriter</code>
+            and pass the graph either via the constructor, or by calling its
+            <code>add_graph()</code> method. You may want to check out the
+            <a href="https://www.tensorflow.org/get_started/graph_viz"
+              >graph visualizer tutorial</a
+            >.
+          </p>
 
-            <p>
-              If you’re new to using TensorBoard, and want to find out how to
-              add data and set up your event files, check out the
-              <a
-                href="https://github.com/tensorflow/tensorboard/blob/master/README.md"
-                >README</a
-              >
-              and perhaps the
-              <a
-                href="https://www.tensorflow.org/get_started/summaries_and_tensorboard"
-                >TensorBoard tutorial</a
-              >.
-            </p>
+          <p>
+            If you’re new to using TensorBoard, and want to find out how to add
+            data and set up your event files, check out the
+            <a
+              href="https://github.com/tensorflow/tensorboard/blob/master/README.md"
+              >README</a
+            >
+            and perhaps the
+            <a
+              href="https://www.tensorflow.org/get_started/summaries_and_tensorboard"
+              >TensorBoard tutorial</a
+            >.
+          </p>
 
-            <p>
-              If you think TensorBoard is configured properly, please see
-              <a
-                href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong"
-                >the section of the README devoted to missing data problems</a
-              >
-              and consider filing an issue on GitHub.
-            </p>
-          </div>
-        </template>
-        <template
-          is="dom-if"
-          if="[[_datasetsState(_datasetsFetched, _datasets, 'PRESENT')]]"
+          <p>
+            If you think TensorBoard is configured properly, please see
+            <a
+              href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong"
+              >the section of the README devoted to missing data problems</a
+            >
+            and consider filing an issue on GitHub.
+          </p>
+        </div>
+        <div
+          class$="graphboard [[_showComponent(_selectedFile, _datasets, 'true')]]"
         >
-          <tf-graph-dashboard-loader
-            id="loader"
-            datasets="[[_datasets]]"
-            selection="[[_selection]]"
-            selected-file="[[_selectedFile]]"
-            out-graph-hierarchy="{{_graphHierarchy}}"
-            out-graph="{{_graph}}"
-            out-stats="{{_stats}}"
-            progress="{{_progress}}"
-            hierarchy-params="[[_hierarchyParams]]"
-            compatibility-provider="[[_compatibilityProvider]]"
-          ></tf-graph-dashboard-loader>
           <tf-graph-board
             id="graphboard"
             devices-for-stats="[[_devicesForStats]]"
@@ -165,7 +161,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
             stats="[[_stats]]"
             trace-inputs="[[_traceInputs]]"
           ></tf-graph-board>
-        </template>
+        </div>
       </div>
     </tf-dashboard-layout>
     <style>
@@ -185,6 +181,19 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
 
       paper-dialog {
         padding: 20px;
+      }
+
+      .no-data-message {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
+      }
+
+      .graphboard {
+        height: 100%;
+      }
+
+      .remove {
+        display: none;
       }
     </style>
   `;
@@ -291,6 +300,8 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
   _compatibilityProvider: object;
   @property({type: Boolean})
   _traceInputs: boolean;
+  @property({type: Object})
+  _selectedFile: any;
   attached() {
     this.set('_isAttached', true);
   }
@@ -327,6 +338,23 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
   }
   _fit() {
     (this.$$('#graphboard') as any).fit();
+  }
+  _showComponent(_selectedFile: any, _datasets: any[], _isGraphboard: string) {
+    const isDataValid = _selectedFile || _datasets.length;
+    const isGraphboard =
+      _isGraphboard === 'true'
+        ? true
+        : _isGraphboard === 'false'
+        ? false
+        : undefined;
+    if (isGraphboard === undefined) {
+      return '';
+    }
+
+    if ((!isDataValid && !isGraphboard) || (isDataValid && isGraphboard)) {
+      return '';
+    }
+    return 'remove';
   }
   _runObserver = tf_storage.getStringObserver(RUN_STORAGE_KEY, {
     defaultValue: '',

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
@@ -96,6 +96,9 @@ class TfGraphDashboardLoader extends LegacyElementMixin(PolymerElement) {
   _template = null;
   @observe('selection', 'compatibilityProvider')
   _selectionChanged(): void {
+    if (!this.selection) {
+      return;
+    }
     // selection can change a lot within a microtask.
     // Don't fetch too much too fast and introduce race condition.
     this.debounce('selectionchange', () => {


### PR DESCRIPTION
* Motivation for features / changes
Fix file upload control function (fixes #4556 #1613)

* Technical description of changes
Previously the board render either the graphboard or no-data messages. Now it renders both and uses css display to control their appearances.
* Screenshots of UI changes
Select file:
![selectFile](https://user-images.githubusercontent.com/1131010/106203288-ff742d00-616f-11eb-9ea5-be3e2cc2d04b.gif)
Normal loading:
![Screen Shot 2021-01-28 at 1 52 56 PM](https://user-images.githubusercontent.com/1131010/106203394-2a5e8100-6170-11eb-90a6-01cf83fc65c7.png)
