### PR TITLE
line chart: adjust tooltip positions

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -163,9 +163,9 @@ export class LineChartInteractiveViewComponent
       originY: 'bottom',
       overlayY: 'top',
     },
-    // Then top
+    // Then top left
     {
-      offsetY: 5,
+      offsetY: -15,
       originX: 'start',
       overlayX: 'start',
       originY: 'top',
@@ -173,7 +173,7 @@ export class LineChartInteractiveViewComponent
     },
     // then top, right aligned
     {
-      offsetX: 5,
+      offsetY: -15,
       originX: 'end',
       overlayX: 'end',
       originY: 'top',
@@ -189,7 +189,7 @@ export class LineChartInteractiveViewComponent
     },
     // then left
     {
-      offsetX: 5,
+      offsetX: -5,
       originX: 'start',
       overlayX: 'end',
       originY: 'top',


### PR DESCRIPTION
For line chart, we are using Angular overlay to create, adjust, and
position the tooltip. The overlay supports a position preference
configuration which tries to fit the overlay in the available viewport
space in the order provided in the preference.

Problem: our configuration was a bit faulty and offset[X,Y] were using
wrong signs causing tooltip to overlap with the chart (by 5px) when the
tooltip was placed above the chart. Instead of pushing the tooltip down
by 5px, we meant to place 5px above.

Fix: reviewed the configuration again for their signage and adjusted the
amount for better UX.
