### PR TITLE
program: restore default assets zip provider

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -19,10 +19,10 @@ package_group(
 py_binary(
     name = "tensorboard",
     srcs = ["main.py"],
-    data = ["webfiles.zip"],
     main = "main.py",
     srcs_version = "PY3",
     deps = [
+        ":assets_lib",  # link dep for webfiles assets
         ":default",
         ":dynamic_plugins",  # loads internal dynamic plugin like projector
         ":lib",
@@ -104,6 +104,27 @@ py_test(
     tags = ["support_notf"],
     visibility = ["//tensorboard:internal"],
     deps = [":lib"],
+)
+
+py_library(
+    name = "assets_lib",
+    srcs = ["assets.py"],
+    data = ["webfiles.zip"],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorboard/util:tb_logging",
+    ],
+)
+
+py_test(
+    name = "assets_lib_test",
+    srcs = ["assets_test.py"],
+    main = "assets_test.py",
+    srcs_version = "PY3",
+    deps = [
+        ":assets_lib",
+        "//tensorboard:test",
+    ],
 )
 
 py_library(

--- a/tensorboard/assets.py
+++ b/tensorboard/assets.py
@@ -1,0 +1,36 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Bindings for TensorBoard frontend assets."""
+
+import os
+
+from tensorboard.util import tb_logging
+
+logger = tb_logging.get_logger()
+
+
+def get_default_assets_zip_provider():
+    """Try to get a function to provide frontend assets.
+
+    Returns:
+      Either (a) a callable that takes no arguments and returns an open
+      file handle to a Zip archive of frontend assets, or (b) `None`, if
+      the frontend assets cannot be found.
+    """
+    path = os.path.join(os.path.dirname(__file__), "webfiles.zip")
+    if not os.path.exists(path):
+        logger.warning("webfiles.zip static assets not found: %s", path)
+        return None
+    return lambda: open(path, "rb")

--- a/tensorboard/assets_test.py
+++ b/tensorboard/assets_test.py
@@ -1,0 +1,35 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `tensorboard.assets`."""
+
+import zipfile
+
+from tensorboard import assets
+from tensorboard import test as tb_test
+
+
+class AssetsTest(tb_test.TestCase):
+    def test(self):
+        provider = assets.get_default_assets_zip_provider()
+        self.assertIsNotNone(provider)
+
+        assets_zip = provider()
+        with zipfile.ZipFile(assets_zip) as zf:
+            with zf.open("index.html") as index_file:
+                self.assertIsInstance(index_file.read(), bytes)
+
+
+if __name__ == "__main__":
+    tb_test.main()

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -40,16 +40,7 @@ def run_main():
     """Initializes flags and calls main()."""
     main_lib.global_init()
 
-    path = os.path.join(
-        os.path.dirname(inspect.getfile(sys._getframe(0))), "webfiles.zip"
-    )
-
-    if not os.path.exists(path):
-        logger.warning("webfiles.zip static assets not found: %s", path)
-        return None
-
     tensorboard = program.TensorBoard(
-        lambda: open(path, "rb"),
         plugins=default.get_plugins(),
         subcommands=[uploader_subcommand.UploaderSubcommand()],
     )

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -21,8 +21,6 @@ wishing to customize the set of plugins or static assets that
 TensorBoard uses can swap out this file with their own.
 """
 
-import inspect
-import os
 import sys
 
 from absl import app

--- a/tensorboard/main_dev.py
+++ b/tensorboard/main_dev.py
@@ -30,13 +30,10 @@ def run_main():
     """Initializes flags and calls main()."""
     main_lib.global_init()
 
-    path = os.path.join(
-        os.path.dirname(inspect.getfile(sys._getframe(0))), "dev_webfiles.zip"
-    )
-
+    path = os.path.join(os.path.dirname(__file__), "dev_webfiles.zip")
     tensorboard = program.TensorBoard(
-        lambda: open(path, "rb"),
         plugins=default.get_plugins(),
+        assets_zip_provider=lambda: open(path, "rb"),
         subcommands=[uploader_subcommand.UploaderSubcommand()],
     )
 

--- a/tensorboard/main_dev.py
+++ b/tensorboard/main_dev.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """TensorBoard dev main module."""
 
-import inspect
 import os
 import sys
 

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -88,8 +88,10 @@ class TensorBoard(object):
           plugins: A list of TensorBoard plugins to load, as TBPlugin classes or
             TBLoader instances or classes. If not specified, defaults to first-party
             plugins.
-          assets_zip_provider: A function that provides a zip file containing assets to
-            the application.
+          assets_zip_provider: A function that provides a zip file containing
+            assets to the application. If `None`, the default TensorBoard web
+            assets will be used. (If building from source, your binary must
+            explicitly depend on `//tensorboard:assets_lib` if you pass `None`.)
           server_class: An optional factory for a `TensorBoardServer` to use
             for serving the TensorBoard WSGI app. If provided, its callable
             signature should match that of `TensorBoardServer.__init__`.

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -77,19 +77,19 @@ class TensorBoard(object):
 
     def __init__(
         self,
-        assets_zip_provider,
         plugins=None,
+        assets_zip_provider=None,
         server_class=None,
         subcommands=None,
     ):
         """Creates new instance.
 
         Args:
-          assets_zip_provider: A function that provides a zip file containing assets to
-            the application.
           plugins: A list of TensorBoard plugins to load, as TBPlugin classes or
             TBLoader instances or classes. If not specified, defaults to first-party
             plugins.
+          assets_zip_provider: A function that provides a zip file containing assets to
+            the application.
           server_class: An optional factory for a `TensorBoardServer` to use
             for serving the TensorBoard WSGI app. If provided, its callable
             signature should match that of `TensorBoardServer.__init__`.
@@ -104,6 +104,18 @@ class TensorBoard(object):
             from tensorboard import default
 
             plugins = default.get_plugins()
+        if assets_zip_provider is None:
+            try:
+                from tensorboard import assets
+            except ImportError as e:
+                # `tensorboard.assets` is not a strict Bazel dep; clients are
+                # required to either depend on `//tensorboard:assets_lib` or
+                # pass a valid assets provider.
+                raise ImportError(
+                    "No `assets_zip_provider` given, but `tensorboard.assets` "
+                    "could not be imported to resolve defaults"
+                ) from e
+            assets_zip_provider = assets.get_default_assets_zip_provider()
         if server_class is None:
             server_class = create_port_scanning_werkzeug_server
         if subcommands is None:

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -35,14 +35,16 @@ class TensorBoardTest(tb_test.TestCase):
 
     def testPlugins_pluginClass(self):
         tb = program.TensorBoard(
-            fake_asset_provider, plugins=[core_plugin.CorePlugin]
+            plugins=[core_plugin.CorePlugin],
+            assets_zip_provider=fake_asset_provider,
         )
         self.assertIsInstance(tb.plugin_loaders[0], base_plugin.BasicLoader)
         self.assertIs(tb.plugin_loaders[0].plugin_class, core_plugin.CorePlugin)
 
     def testPlugins_pluginLoaderClass(self):
         tb = program.TensorBoard(
-            fake_asset_provider, plugins=[core_plugin.CorePluginLoader]
+            plugins=[core_plugin.CorePluginLoader],
+            assets_zip_provider=fake_asset_provider,
         )
         self.assertIsInstance(
             tb.plugin_loaders[0], core_plugin.CorePluginLoader
@@ -50,26 +52,32 @@ class TensorBoardTest(tb_test.TestCase):
 
     def testPlugins_pluginLoader(self):
         loader = core_plugin.CorePluginLoader()
-        tb = program.TensorBoard(fake_asset_provider, plugins=[loader])
+        tb = program.TensorBoard(
+            plugins=[loader],
+            assets_zip_provider=fake_asset_provider,
+        )
         self.assertIs(tb.plugin_loaders[0], loader)
 
     def testPlugins_invalidType(self):
         plugin_instance = core_plugin.CorePlugin(base_plugin.TBContext())
         with self.assertRaisesRegex(TypeError, "CorePlugin"):
             tb = program.TensorBoard(
-                fake_asset_provider, plugins=[plugin_instance]
+                plugins=[plugin_instance],
+                assets_zip_provider=fake_asset_provider,
             )
 
     def testConfigure(self):
         tb = program.TensorBoard(
-            fake_asset_provider, plugins=[core_plugin.CorePluginLoader]
+            plugins=[core_plugin.CorePluginLoader],
+            assets_zip_provider=fake_asset_provider,
         )
         tb.configure(logdir="foo")
         self.assertEqual(tb.flags.logdir, "foo")
 
     def testConfigure_unknownFlag(self):
         tb = program.TensorBoard(
-            fake_asset_provider, plugins=[core_plugin.CorePlugin]
+            plugins=[core_plugin.CorePlugin],
+            assets_zip_provider=fake_asset_provider,
         )
         with self.assertRaisesRegex(ValueError, "Unknown TensorBoard flag"):
             tb.configure(foo="bar")
@@ -164,8 +172,8 @@ class SubcommandTest(tb_test.TestCase):
 
     def testImplicitServe(self):
         tb = program.TensorBoard(
-            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
+            assets_zip_provider=fake_asset_provider,
             subcommands=[_TestSubcommand(lambda parser: None)],
         )
         tb.configure(("tb", "--logdir", "logs", "--path_prefix", "/x///"))
@@ -177,8 +185,8 @@ class SubcommandTest(tb_test.TestCase):
 
     def testExplicitServe(self):
         tb = program.TensorBoard(
-            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
+            assets_zip_provider=fake_asset_provider,
             subcommands=[_TestSubcommand()],
         )
         tb.configure(
@@ -195,8 +203,8 @@ class SubcommandTest(tb_test.TestCase):
             parser.add_argument("--hello")
 
         tb = program.TensorBoard(
-            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
+            assets_zip_provider=fake_asset_provider,
             subcommands=[_TestSubcommand(define_flags=define_flags)],
         )
         tb.configure(("tb", "test", "--hello", "world"))
@@ -207,8 +215,8 @@ class SubcommandTest(tb_test.TestCase):
 
     def testSubcommand_ExitCode(self):
         tb = program.TensorBoard(
-            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
+            assets_zip_provider=fake_asset_provider,
             subcommands=[_TestSubcommand()],
         )
         _TestSubcommand.run.return_value = 77
@@ -217,8 +225,8 @@ class SubcommandTest(tb_test.TestCase):
 
     def testSubcommand_DoesNotInheritBaseArgs(self):
         tb = program.TensorBoard(
-            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
+            assets_zip_provider=fake_asset_provider,
             subcommands=[_TestSubcommand()],
         )
         with self.assertRaises(SystemExit):
@@ -233,8 +241,8 @@ class SubcommandTest(tb_test.TestCase):
             parser.add_argument("payload")
 
         tb = program.TensorBoard(
-            fake_asset_provider,
             plugins=[core_plugin.CorePluginLoader],
+            assets_zip_provider=fake_asset_provider,
             subcommands=[_TestSubcommand(define_flags=define_flags)],
         )
         with self.assertRaises(SystemExit):
@@ -246,8 +254,8 @@ class SubcommandTest(tb_test.TestCase):
     def testConflictingNames_AmongSubcommands(self):
         with self.assertRaises(ValueError) as cm:
             tb = program.TensorBoard(
-                fake_asset_provider,
                 plugins=[core_plugin.CorePluginLoader],
+                assets_zip_provider=fake_asset_provider,
                 subcommands=[_TestSubcommand(), _TestSubcommand()],
             )
         self.assertIn("Duplicate subcommand name:", str(cm.exception))
@@ -256,8 +264,8 @@ class SubcommandTest(tb_test.TestCase):
     def testConflictingNames_WithServe(self):
         with self.assertRaises(ValueError) as cm:
             tb = program.TensorBoard(
-                fake_asset_provider,
                 plugins=[core_plugin.CorePluginLoader],
+                assets_zip_provider=fake_asset_provider,
                 subcommands=[_TestSubcommand(name="serve")],
             )
         self.assertIn("Duplicate subcommand name:", str(cm.exception))


### PR DESCRIPTION
Summary:
This patch reverts the backward-incompatible changes to `program` made
in #4588, while retaining the new functionality in that change.
Specifically, we restore the calling convention of `TensorBoard`
(reordering the parameters was a breaking change, as was removing the
default value). For clarity, the data dependency to `webfiles.zip` lives
in a new Python module, `//tensorboard:assets_lib`. The `program` module
late-imports this only if no assets zip provider is given, in which case
the caller is expected to have a build dep on `:assets_lib`. The main
`//tensorboard` binary does so; `//tensorboard:dev` does not.

Test Plan:
Tested `//tensorboard`, `//tensorboard:dev`, and the Pip package in a
new virtualenv. There is no build path from `:dev` to the prod assets:

```
$ bazel query 'somepath(//tensorboard:dev, //tensorboard:webfiles.zip)'
INFO: Empty results
```

wchargin-branch: program-default-assets
