### PR TITLE
line chart: allow application to configure

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -87,7 +87,6 @@ limitations under the License.
     <line-chart
       *ngIf="gpuLineChartEnabled; else legacyChart"
       [disableUpdate]="!isCardVisible"
-      [preferredRendererType]="RendererType.WEBGL"
       [seriesData]="dataSeries"
       [seriesMetadataMap]="chartMetadataMap"
       [xScaleType]="newXScaleType"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -39,11 +39,7 @@ import {
 } from '../../../widgets/line_chart/line_chart_types';
 import {relativeTimeFormatter} from '../../../widgets/line_chart_v2/lib/formatter';
 import {LineChartComponent as NewLineChartComponent} from '../../../widgets/line_chart_v2/line_chart_component';
-import {
-  RendererType,
-  ScaleType,
-  TooltipDatum,
-} from '../../../widgets/line_chart_v2/types';
+import {ScaleType, TooltipDatum} from '../../../widgets/line_chart_v2/types';
 import {ScalarStepDatum} from '../../data_source';
 import {TooltipSort, XAxisType} from '../../types';
 import {
@@ -122,7 +118,6 @@ const DEFAULT_TOOLTIP_COLUMNS: TooltipColumns = [
 export class ScalarCardComponent {
   readonly RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS = RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS;
   readonly DataLoadState = DataLoadState;
-  readonly RendererType = RendererType;
 
   @Input() loadState!: DataLoadState;
   @Input() title!: string;

--- a/tensorboard/webapp/widgets/line_chart_v2/types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/types.ts
@@ -13,6 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {InjectionToken} from '@angular/core';
+import {RendererType} from './lib/public_types';
+
 // Only selectively export types that would be used by the user of the line chart.
 export {
   DataSeries,
@@ -23,3 +26,20 @@ export {
   ScaleType,
 } from './lib/public_types';
 export {TooltipDatum} from './sub_view/line_chart_interactive_view';
+
+/**
+ * Line chart by default prefers WEBGL implementation but this flag lets application
+ * tweak the default renderer.
+ */
+export const PREFERRED_RENDERER = new InjectionToken<RendererType>(
+  '[Line Chart] Default Preferred Renderer'
+);
+
+/**
+ * Line chart, when using WEBGL renderer, uses a worker thread when OffscreenCanvas is
+ * supported by the browser. This injection token lets application globally disable the
+ * worker renderering when the value is true.
+ */
+export const FORCE_DISABLE_WORKER = new InjectionToken<boolean>(
+  '[Line Chart] Disable Worker'
+);


### PR DESCRIPTION
With this change, we can selectively disable worker and use SVG
renderer when the application provides the value.
