### PR TITLE
line chart: fix line chart not updating bug

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -187,16 +187,13 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
   }
 
   ngAfterViewInit() {
-    const dimPropChanged = this.readAndUpdateDomDimensions();
     this.initializeChart();
-    const viewboxPropChanged = this.updateLineChart();
+    this.updateLineChart();
 
     // After view is initialized, if we ever change the Angular prop that should propagate
     // to children, we need to retrigger the Angular change. Since we lazily update the
     // property, these may return false.
-    if (dimPropChanged || viewboxPropChanged) {
-      this.changeDetector.detectChanges();
-    }
+    this.changeDetector.detectChanges();
   }
 
   onViewResize() {
@@ -266,6 +263,8 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
     const callbacks: ChartCallbacks = {onDrawEnd: () => {}};
     let params: ChartOptions | null = null;
 
+    this.readAndUpdateDomDimensions();
+
     switch (rendererType) {
       case RendererType.SVG: {
         params = {
@@ -306,8 +305,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
     return getRendererType(this.preferredRendererType);
   }
 
-  private readAndUpdateDomDimensions(): boolean {
-    const prevDomDimension = this.domDimensions;
+  private readAndUpdateDomDimensions(): void {
     this.domDimensions = {
       main: {
         width: this.seriesView.nativeElement.clientWidth,
@@ -322,23 +320,13 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
         height: this.yAxis.nativeElement.clientHeight,
       },
     };
-
-    return (
-      prevDomDimension.main.width !== this.domDimensions.main.width ||
-      prevDomDimension.main.height !== this.domDimensions.main.height ||
-      prevDomDimension.xAxis.width !== this.domDimensions.xAxis.width ||
-      prevDomDimension.xAxis.height !== this.domDimensions.xAxis.height ||
-      prevDomDimension.yAxis.width !== this.domDimensions.yAxis.width ||
-      prevDomDimension.yAxis.height !== this.domDimensions.yAxis.height
-    );
   }
 
   /**
    * Minimally and imperatively updates the chart library depending on prop changed.
    */
-  private updateLineChart(): boolean {
-    if (!this.lineChart || this.disableUpdate) return false;
-    let ngStateUpdated = false;
+  private updateLineChart() {
+    if (!this.lineChart || this.disableUpdate) return;
 
     if (this.scaleUpdated) {
       this.scaleUpdated = false;
@@ -370,7 +358,6 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
         x: this.xScale.niceDomain(dataExtent.x ?? DEFAULT_EXTENT.x),
         y: this.yScale.niceDomain(dataExtent.y ?? DEFAULT_EXTENT.y),
       };
-      ngStateUpdated = true;
     }
 
     // There are below conditions in which the viewBox changes.
@@ -382,8 +369,6 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
       this.isViewBoxChanged = false;
       this.lineChart.setViewBox(this.viewBox);
     }
-
-    return ngStateUpdated;
   }
 
   onViewBoxChanged({dataExtent}: {dataExtent: Extent}) {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -191,8 +191,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
     this.updateLineChart();
 
     // After view is initialized, if we ever change the Angular prop that should propagate
-    // to children, we need to retrigger the Angular change. Since we lazily update the
-    // property, these may return false.
+    // to children, we need to retrigger the Angular change.
     this.changeDetector.detectChanges();
   }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -17,6 +17,7 @@ import {OverlayModule} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 
 import {ChartImpl} from './lib/chart';
 import {
@@ -28,6 +29,18 @@ import {
 } from './lib/public_types';
 import {buildMetadata, buildSeries} from './lib/testing';
 import {LineChartComponent} from './line_chart_component';
+
+@Component({
+  selector: 'line-chart-grid-view',
+  template: ``,
+})
+class FakeGridComponent {
+  @Input()
+  viewExtent!: Extent;
+
+  @Input()
+  domDim!: {width: number; height: number};
+}
 
 @Component({
   selector: 'testable-comp',
@@ -90,7 +103,7 @@ describe('line_chart_v2/line_chart test', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TestableComponent, LineChartComponent],
+      declarations: [TestableComponent, LineChartComponent, FakeGridComponent],
       imports: [CommonModule, OverlayModule],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -253,6 +266,7 @@ describe('line_chart_v2/line_chart test', () => {
       yScaleType: ScaleType.LINEAR,
     });
     fixture.detectChanges();
+
     expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
     expect(updateViewBoxSpy.calls.argsFor(0)).toEqual([
       {x: [-0.2, 2.2], y: [-1.2, 1.2]},
@@ -290,6 +304,34 @@ describe('line_chart_v2/line_chart test', () => {
     expect(updateViewBoxSpy.calls.argsFor(3)).toEqual([
       {x: [-0.5, 4.5], y: [-2, 2]},
     ]);
+  });
+
+  it('sets correct domDim and viewBox on initial render', () => {
+    const fixture = createComponent({
+      seriesData: [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+          ],
+        }),
+      ],
+      seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+      yScaleType: ScaleType.LINEAR,
+    });
+    fixture.detectChanges();
+
+    const grid = fixture.debugElement.query(By.directive(FakeGridComponent));
+    expect(grid.componentInstance.domDim).toEqual({
+      width: 150,
+      height: 70,
+    });
+    expect(grid.componentInstance.viewExtent).toEqual({
+      x: [-0.2, 2.2],
+      y: [-1.2, 1.2],
+    });
   });
 
   describe('data change', () => {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -266,7 +266,6 @@ describe('line_chart_v2/line_chart test', () => {
       yScaleType: ScaleType.LINEAR,
     });
     fixture.detectChanges();
-
     expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
     expect(updateViewBoxSpy.calls.argsFor(0)).toEqual([
       {x: [-0.2, 2.2], y: [-1.2, 1.2]},
@@ -324,6 +323,8 @@ describe('line_chart_v2/line_chart test', () => {
     fixture.detectChanges();
 
     const grid = fixture.debugElement.query(By.directive(FakeGridComponent));
+    // In testable-comp, we hard coded dimension of 200x150. Since we use about
+    // 50px and 30px for y-axis and x-axis, respectively, we have 150x70 here.
     expect(grid.componentInstance.domDim).toEqual({
       width: 150,
       height: 70,


### PR DESCRIPTION
When the line chart is initialized but never resized, currently our
`domDimension` and `viewBox` which is updated lazily after content is
initialized is not reflected to the template and their children. This is
because we use OnPush change detector and we never explicitly ask
Angular to detect changes.

This bug manifests especially when you spam on the tag filter and get
the timing right.
