### PR TITLE
rust: add `rayon` dependency

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -798,6 +798,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +873,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
+ "rayon",
  "serde",
  "serde_json",
  "tempfile",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -36,6 +36,7 @@ log = "0.4.11"
 prost = "0.7.0"
 rand = "0.7.3"
 rand_chacha = "0.2.2"
+rayon = "1.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.59"
 thiserror = "1.0.21"

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -139,6 +139,15 @@ alias(
 )
 
 alias(
+    name = "rayon",
+    actual = "@raze__rayon__1_5_0//:rayon",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "serde",
     actual = "@raze__serde__1_0_118//:serde",
     tags = [

--- a/third_party/rust/crates.bzl
+++ b/third_party/rust/crates.bzl
@@ -873,6 +873,26 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__rayon__1_5_0",
+        url = "https://crates.io/api/v1/crates/rayon/1.5.0/download",
+        type = "tar.gz",
+        sha256 = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674",
+        strip_prefix = "rayon-1.5.0",
+        build_file = Label("//third_party/rust/remote:BUILD.rayon-1.5.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rayon_core__1_9_0",
+        url = "https://crates.io/api/v1/crates/rayon-core/1.9.0/download",
+        type = "tar.gz",
+        sha256 = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a",
+        strip_prefix = "rayon-core-1.9.0",
+        build_file = Label("//third_party/rust/remote:BUILD.rayon-core-1.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__redox_syscall__0_1_57",
         url = "https://crates.io/api/v1/crates/redox_syscall/0.1.57/download",
         type = "tar.gz",

--- a/third_party/rust/remote/BUILD.crossbeam-channel-0.5.0.bazel
+++ b/third_party/rust/remote/BUILD.crossbeam-channel-0.5.0.bazel
@@ -43,6 +43,7 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     crate_features = [
         "crossbeam-utils",
+        "default",
         "std",
     ],
     crate_root = "src/lib.rs",

--- a/third_party/rust/remote/BUILD.crossbeam-deque-0.8.0.bazel
+++ b/third_party/rust/remote/BUILD.crossbeam-deque-0.8.0.bazel
@@ -36,6 +36,7 @@ rust_library(
     crate_features = [
         "crossbeam-epoch",
         "crossbeam-utils",
+        "default",
         "std",
     ],
     crate_root = "src/lib.rs",

--- a/third_party/rust/remote/BUILD.crossbeam-utils-0.8.1.bazel
+++ b/third_party/rust/remote/BUILD.crossbeam-utils-0.8.1.bazel
@@ -38,6 +38,7 @@ rust_library(
     name = "crossbeam_utils",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "default",
         "lazy_static",
         "std",
     ],

--- a/third_party/rust/remote/BUILD.rayon-1.5.0.bazel
+++ b/third_party/rust/remote/BUILD.rayon-1.5.0.bazel
@@ -1,0 +1,87 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+# Unsupported target "cpu_monitor" with type "example" omitted
+
+rust_library(
+    name = "rayon",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.5.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__crossbeam_deque__0_8_0//:crossbeam_deque",
+        "@raze__either__1_6_1//:either",
+        "@raze__rayon_core__1_9_0//:rayon_core",
+    ],
+)
+
+# Unsupported target "chars" with type "test" omitted
+
+# Unsupported target "clones" with type "test" omitted
+
+# Unsupported target "collect" with type "test" omitted
+
+# Unsupported target "cross-pool" with type "test" omitted
+
+# Unsupported target "debug" with type "test" omitted
+
+# Unsupported target "intersperse" with type "test" omitted
+
+# Unsupported target "issue671" with type "test" omitted
+
+# Unsupported target "issue671-unzip" with type "test" omitted
+
+# Unsupported target "iter_panic" with type "test" omitted
+
+# Unsupported target "named-threads" with type "test" omitted
+
+# Unsupported target "octillion" with type "test" omitted
+
+# Unsupported target "producer_split_at" with type "test" omitted
+
+# Unsupported target "sort-panic-safe" with type "test" omitted
+
+# Unsupported target "str" with type "test" omitted

--- a/third_party/rust/remote/BUILD.rayon-core-1.9.0.bazel
+++ b/third_party/rust/remote/BUILD.rayon-core-1.9.0.bazel
@@ -1,0 +1,81 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/rust", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "rayon_core",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.9.0",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__crossbeam_channel__0_5_0//:crossbeam_channel",
+        "@raze__crossbeam_deque__0_8_0//:crossbeam_deque",
+        "@raze__crossbeam_utils__0_8_1//:crossbeam_utils",
+        "@raze__lazy_static__1_4_0//:lazy_static",
+        "@raze__num_cpus__1_13_0//:num_cpus",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "double_init_fail" with type "test" omitted
+
+# Unsupported target "init_zero_threads" with type "test" omitted
+
+# Unsupported target "scope_join" with type "test" omitted
+
+# Unsupported target "scoped_threadpool" with type "test" omitted
+
+# Unsupported target "simple_panic" with type "test" omitted
+
+# Unsupported target "stack_overflow_crash" with type "test" omitted


### PR DESCRIPTION
Summary:
The [`rayon`] crate provides easy data parallelism: change `iter()` to
`par_iter()` and you’re off to the races—but not the data races, which
are prevented at compile time. We can use it to load runs concurrently.

[`rayon`]: https://crates.io/crates/rayon

Test Plan:
It builds: `bazel build //third_party/rust:rayon`.

wchargin-branch: rust-dep-rayon
