### PR TITLE
change RequestContext WSGI environ key to comply with spec

### DIFF
--- a/tensorboard/context.py
+++ b/tensorboard/context.py
@@ -17,13 +17,8 @@
 from tensorboard import auth as auth_lib
 
 
-class _TensorBoardRequestContextKey:
-    pass
-
-
-# A `RequestContext` value is stored on WSGI environments under this key
-# (an arbitrary sentinel object).
-_WSGI_KEY = _TensorBoardRequestContextKey()
+# A `RequestContext` value is stored on WSGI environments under this key.
+_WSGI_KEY = "tensorboard.request_context"
 
 
 class RequestContext(object):


### PR DESCRIPTION
This changes the WSGI `environ` key used for `RequestContext` from being a sentinel object to being the ordinary string `tensorboard.request_context`.

Although a sentinel object is elegantly collision-proof and would be fine in a normal dict, a close read of the WSGI spec reveals that `environ` is meant to contain only string keys:

> Finally, the `environ` dictionary may also contain server-defined variables. These variables should be named using only lower-case letters, numbers, dots, and underscores, and should be prefixed with a name that is unique to the defining server or gateway. For example, `mod_python` might define variables with names like `mod_python.some_variable`.
> -- from the bottom of https://www.python.org/dev/peps/pep-0333/#environ-variables

This updates our key to follow that suggestion.

This change was motivated by the following logic in Werkzeug, which raises an exception from its header-parsing routing upon encountering our lovely sentinel object in the `environ` dict and attempting to `.startswith()` it:

https://github.com/pallets/werkzeug/blob/1.0.1/src/werkzeug/datastructures.py#L1472

