### PR TITLE
types: set `defaultFlags` as required property

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -35,7 +35,7 @@ describe('feature_flag_selectors', () => {
       );
     });
 
-    it('returns legacy `features` if no overrides or `defaultFlags` are given', () => {
+    it('prefers required `defaultFlags` over features', () => {
       const state = buildState(
         buildFeatureFlagState({
           features: {
@@ -44,34 +44,17 @@ describe('feature_flag_selectors', () => {
             inColab: false,
             scalarsBatchSize: 10,
           },
-        })
-      );
-
-      expect(selectors.getFeatureFlags(state)).toEqual({
-        enabledExperimentalPlugins: ['foo', 'bar'],
-        enableGpuChart: true,
-        inColab: false,
-        scalarsBatchSize: 10,
-      });
-    });
-
-    it('combines legacy `features` and overrides', () => {
-      const state = buildState(
-        buildFeatureFlagState({
-          features: {
-            enabledExperimentalPlugins: ['foo', 'bar'],
+          defaultFlags: {
+            enabledExperimentalPlugins: ['foo'],
             enableGpuChart: false,
             inColab: false,
             scalarsBatchSize: 10,
           },
-          flagOverrides: {
-            enabledExperimentalPlugins: ['baz'],
-          },
         })
       );
 
       expect(selectors.getFeatureFlags(state)).toEqual({
-        enabledExperimentalPlugins: ['baz'],
+        enabledExperimentalPlugins: ['foo'],
         enableGpuChart: false,
         inColab: false,
         scalarsBatchSize: 10,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -19,9 +19,9 @@ export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 
 export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;
-  features: FeatureFlags;
-  // Temporarily set undefiend for `defaultFlags` and `flagOverrides` for sync purposes.
-  defaultFlags?: FeatureFlags;
+  // Temporarily define `features` while we are migrating and syncing.
+  features?: FeatureFlags;
+  defaultFlags: FeatureFlags;
   flagOverrides?: Partial<FeatureFlags>;
 }
 

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -21,13 +21,13 @@ export function buildFeatureFlagState(
 ): FeatureFlagState {
   return {
     isFeatureFlagsLoaded: false,
-    features: {
+    features: undefined,
+    defaultFlags: {
       enabledExperimentalPlugins: [],
       enableGpuChart: false,
       inColab: false,
       scalarsBatchSize: 1,
     },
-    defaultFlags: undefined,
     ...override,
     flagOverrides: override.flagOverrides ?? {},
   };


### PR DESCRIPTION
We are in process of upgrading our FeatureFlag store to divide default
flag vs. overrides. Previously, everything was mixed into `features`
making certain UX impossible.

Because there is a corresponding code internally, we cannot just switch
immediately so this change is the 3rd of 5th step to safely migrate all
use caess.

