### PR TITLE
rust: read from `CARGO_PKG_VERSION`

### DIFF
--- a/tensorboard/data/server/BUILD
+++ b/tensorboard/data/server/BUILD
@@ -43,6 +43,7 @@ rust_library(
         "writer.rs",
     ] + _checked_in_proto_files,
     edition = "2018",
+    version = "0.3.0-alpha.0",
     deps = [
         "//third_party/rust:async_stream",
         "//third_party/rust:base64",

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -36,7 +36,7 @@ use crate::server::DataProviderHandler;
 use data::tensor_board_data_provider_server::TensorBoardDataProviderServer;
 
 #[derive(Clap, Debug)]
-#[clap(name = "rustboard", version = "0.3.0-alpha.0")]
+#[clap(name = "rustboard", version = clap::crate_version!())]
 struct Opts {
     /// Log directory to load
     ///


### PR DESCRIPTION
Summary:
Rust programs expect the `CARGO_PKG_VERSION` environment variable to be
defined at compile time; Cargo sets this to the package version from
`Cargo.toml`, and Bazel sets it to the `version` attribute of the
library. This patch moves our version number from being hard-coded in
`cli.rs` to being hard-coded in the BUILD file (and also in `Cargo.toml`
in either case). This way, we can use the version in more places, like
user agent strings without needing to keep more things in sync.

Test Plan:
Both `cargo run -- -h` and `bazel run . -- -h` show the correct version
number in the help information.

wchargin-branch: rust-env-version
