### PR TITLE
types: make `features` omittable by typing

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -39,7 +39,7 @@ export const getFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): FeatureFlags => {
     return {
-      ...state.features,
+      ...('features' in state ? state.features : undefined),
       ...state.defaultFlags,
       ...state.flagOverrides,
     };

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -17,13 +17,22 @@ import {FeatureFlags} from '../types';
 
 export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 
-export interface FeatureFlagState {
+export interface FeatureFlagStateBeforeMigration {
   isFeatureFlagsLoaded: boolean;
-  // Temporarily define `features` while we are migrating and syncing.
   features?: FeatureFlags;
   defaultFlags: FeatureFlags;
   flagOverrides?: Partial<FeatureFlags>;
 }
+
+export interface FeatureFlagStateAfterMigration {
+  isFeatureFlagsLoaded: boolean;
+  defaultFlags: FeatureFlags;
+  flagOverrides?: Partial<FeatureFlags>;
+}
+
+export type FeatureFlagState =
+  | FeatureFlagStateAfterMigration
+  | FeatureFlagStateBeforeMigration;
 
 export interface State {
   [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagState;

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -21,7 +21,6 @@ export function buildFeatureFlagState(
 ): FeatureFlagState {
   return {
     isFeatureFlagsLoaded: false,
-    features: undefined,
     defaultFlags: {
       enabledExperimentalPlugins: [],
       enableGpuChart: false,


### PR DESCRIPTION
In the selector where we still need to support `features`, we check for
existence of a property to refine the type for backwards compatibility.
