### PR TITLE
Revert "types: make `features` omittable by typing"

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -39,7 +39,7 @@ export const getFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): FeatureFlags => {
     return {
-      ...('features' in state ? state.features : undefined),
+      ...state.features,
       ...state.defaultFlags,
       ...state.flagOverrides,
     };

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -17,22 +17,13 @@ import {FeatureFlags} from '../types';
 
 export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 
-export interface FeatureFlagStateBeforeMigration {
+export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;
+  // Temporarily define `features` while we are migrating and syncing.
   features?: FeatureFlags;
   defaultFlags: FeatureFlags;
   flagOverrides?: Partial<FeatureFlags>;
 }
-
-export interface FeatureFlagStateAfterMigration {
-  isFeatureFlagsLoaded: boolean;
-  defaultFlags: FeatureFlags;
-  flagOverrides?: Partial<FeatureFlags>;
-}
-
-export type FeatureFlagState =
-  | FeatureFlagStateAfterMigration
-  | FeatureFlagStateBeforeMigration;
 
 export interface State {
   [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagState;

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -21,6 +21,7 @@ export function buildFeatureFlagState(
 ): FeatureFlagState {
   return {
     isFeatureFlagsLoaded: false,
+    features: undefined,
     defaultFlags: {
       enabledExperimentalPlugins: [],
       enableGpuChart: false,


### PR DESCRIPTION
Reverts tensorflow/tensorboard#4648

This change breaks the sync as it can violate certain types defined internally. Until internal codes can take this change, this PR is reverted.