### PR TITLE
Disable terser on polymer bundle in dev assets mode

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_dev_js_binary", "tf_js_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -38,11 +38,31 @@ tf_ts_library(
     ],
 )
 
+# A target for development only. By dropping 'compile', this skips the expensive
+# minification step.
+tf_js_binary(
+    name = "polymer3_lib_binary_no_shim_dev",
+    compile = False,
+    entry_point = ":polymer3_lib.ts",
+    deps = [":polymer3_ts_lib"],
+)
+
 tf_js_binary(
     name = "polymer3_lib_binary_no_shim",
     compile = True,
     entry_point = ":polymer3_lib.ts",
     deps = [":polymer3_ts_lib"],
+)
+
+genrule(
+    name = "polymer3_lib_binary_dev",
+    srcs = [
+        # Do not sort. order is important.
+        "@npm//:node_modules/web-animations-js/web-animations-next-lite.min.js",
+        ":polymer3_lib_binary_no_shim_dev.js",
+    ],
+    outs = ["polymer3_lib_binary_dev.js"],
+    cmd = "for f in $(SRCS); do cat \"$$f\"; echo; done > $@",
 )
 
 genrule(

--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_dev_js_binary", "tf_js_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -38,15 +38,6 @@ tf_ts_library(
     ],
 )
 
-# A target for development only. By dropping 'compile', this skips the expensive
-# minification step.
-tf_js_binary(
-    name = "polymer3_lib_binary_no_shim_dev",
-    compile = False,
-    entry_point = ":polymer3_lib.ts",
-    deps = [":polymer3_ts_lib"],
-)
-
 tf_js_binary(
     name = "polymer3_lib_binary_no_shim",
     compile = True,
@@ -54,17 +45,7 @@ tf_js_binary(
     deps = [":polymer3_ts_lib"],
 )
 
-genrule(
-    name = "polymer3_lib_binary_dev",
-    srcs = [
-        # Do not sort. order is important.
-        "@npm//:node_modules/web-animations-js/web-animations-next-lite.min.js",
-        ":polymer3_lib_binary_no_shim_dev.js",
-    ],
-    outs = ["polymer3_lib_binary_dev.js"],
-    cmd = "for f in $(SRCS); do cat \"$$f\"; echo; done > $@",
-)
-
+# Keep in sync with //tensorboard/webapp/dev_assets:polymer3_lib_binary_dev
 genrule(
     name = "polymer3_lib_binary",
     srcs = [

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -35,8 +35,7 @@ def tf_js_binary(name, compile, deps, visibility = None, **kwargs):
 
     # `compile` option is used internally but is not used by rollup_bundle.
     # Discard it.
-    internal_rollup_name = name + "_terser_internal_dbg"
-    internal_min_name = name + "_terser_internal_min"
+    internal_rollup_name = name + "_rollup_internal_dbg"
     rollup_bundle(
         name = internal_rollup_name,
         config_file = "//tensorboard/defs:rollup_config.js",
@@ -54,19 +53,23 @@ def tf_js_binary(name, compile, deps, visibility = None, **kwargs):
         **kwargs
     )
 
-    terser_minified(
-        name = internal_min_name,
-        src = internal_rollup_name,
-        config_file = "//tensorboard/defs:terser_config.json",
-        visibility = ["//visibility:private"],
-        sourcemap = False,
-    )
+    if compile:
+        internal_result_name = name + "_terser_internal_min"
+        terser_minified(
+            name = internal_result_name,
+            src = internal_rollup_name,
+            config_file = "//tensorboard/defs:terser_config.json",
+            visibility = ["//visibility:private"],
+            sourcemap = False,
+        )
+    else:
+        internal_result_name = internal_rollup_name
 
     # For some reason, terser_minified is not visible from other targets. Copy
     # or re-export seems to work okay.
     native.genrule(
         name = name,
-        srcs = [internal_min_name],
+        srcs = [internal_result_name],
         outs = [name + ".js"],
         visibility = visibility,
         cmd = "cat $(SRCS) > $@",

--- a/tensorboard/webapp/dev_assets/BUILD
+++ b/tensorboard/webapp/dev_assets/BUILD
@@ -6,7 +6,7 @@
 # //tensorboard/webapp:index.html, we had to create the dev_assets version in
 # a different package. Once we can get rid of zip asset provider and a way to
 # alias asset, we would not need the enitrely different Bazel package.
-load("//tensorboard/defs:defs.bzl", "tf_dev_js_binary", "tf_ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_dev_js_binary", "tf_js_binary", "tf_ng_module")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:__pkg__"])
@@ -40,6 +40,26 @@ tf_web_library(
     path = "/tb-webapp",
 )
 
+# By dropping 'compile', this skips the expensive minification step.
+tf_js_binary(
+    name = "polymer3_lib_binary_no_shim_dev",
+    compile = False,
+    entry_point = "//tensorboard/components:polymer3_lib.ts",
+    deps = ["//tensorboard/components:polymer3_ts_lib"],
+)
+
+# Keep in sync with //tensorboard/components:polymer3_lib_binary.
+genrule(
+    name = "polymer3_lib_binary_dev",
+    srcs = [
+        # Do not sort. order is important.
+        "@npm//:node_modules/web-animations-js/web-animations-next-lite.min.js",
+        ":polymer3_lib_binary_no_shim_dev.js",
+    ],
+    outs = ["polymer3_lib_binary_dev.js"],
+    cmd = "for f in $(SRCS); do cat \"$$f\"; echo; done > $@",
+)
+
 # The index.html used for dev mode needs to use the polymer3 lib specifically
 # for dev mode.
 genrule(
@@ -54,7 +74,7 @@ tf_web_library(
     name = "dev_assets",
     srcs = [
         ":index.html",
-        "//tensorboard/components:polymer3_lib_binary_dev.js",
+        ":polymer3_lib_binary_dev.js",
         "//tensorboard/webapp:styles.css",
         "//tensorboard/webapp:svg_bundle",
         "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:chart_worker.js",

--- a/tensorboard/webapp/dev_assets/BUILD
+++ b/tensorboard/webapp/dev_assets/BUILD
@@ -40,11 +40,13 @@ tf_web_library(
     path = "/tb-webapp",
 )
 
+# The index.html used for dev mode needs to use the polymer3 lib specifically
+# for dev mode.
 genrule(
     name = "rename_index_html",
     srcs = ["//tensorboard/webapp:index_polymer3.inlined.html"],
     outs = ["index.html"],
-    cmd = "cat $(SRCS) > $@",
+    cmd = "sed 's/polymer3_lib_binary/polymer3_lib_binary_dev/g' $(SRCS) > $@",
 )
 
 # Should keep the asset dependencies in sync with //tensorboard:assets.
@@ -52,7 +54,7 @@ tf_web_library(
     name = "dev_assets",
     srcs = [
         ":index.html",
-        "//tensorboard/components:polymer3_lib_binary.js",
+        "//tensorboard/components:polymer3_lib_binary_dev.js",
         "//tensorboard/webapp:styles.css",
         "//tensorboard/webapp:svg_bundle",
         "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:chart_worker.js",


### PR DESCRIPTION
While the Angular bundle incremental build time was improved
with the `tensorboard:dev` mode, the Polymer 3 bundle still
relies on Rollup. After Terser was introduced in the build, the
Polymer incremental build time can take 30+ sec on top of the
TypeScript compilation time.

This change removes the Terser step from the Polymer bundling
phase, only for the dev assets mode.