### PR TITLE
cleanup: remove unused imports in graph code

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {PolymerElement, html} from '@polymer/polymer';
+import {PolymerElement} from '@polymer/polymer';
 import {customElement, observe, property} from '@polymer/decorators';
 import * as _ from 'lodash';
 import * as d3 from 'd3';

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -32,7 +32,6 @@ import {
   Metaedge,
   MetaedgeImpl,
   Metanode,
-  NAMESPACE_DELIM,
   Node,
   NodeType,
   OpNode,

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -19,15 +19,11 @@ import * as PolymerDom from '../../../components/polymer/dom';
 import {
   Class as _Class,
   selectChild as _selectChild,
-  selectOrCreateChild,
   SVG_NAMESPACE,
 } from './common';
-import * as edge from './edge';
 import {NodeType, OpNode} from './graph';
 import * as layout from './layout';
-import * as node from './node';
 import * as render from './render';
-import {TfGraphScene} from './tf-graph-scene';
 
 export const selectChild = _selectChild;
 export const Class = _Class;

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {PolymerElement, html} from '@polymer/polymer';
+import {PolymerElement} from '@polymer/polymer';
 import {customElement, observe, property} from '@polymer/decorators';
 
 import * as tf_graph_common from '../tf_graph_common/common';

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {PolymerElement, html} from '@polymer/polymer';
+import {PolymerElement} from '@polymer/polymer';
 import {customElement, observe, property} from '@polymer/decorators';
 
 import * as tf_graph_hierarchy from '../tf_graph_common/hierarchy';


### PR DESCRIPTION
Small CL to remove unused imports from code in the graph plugin
frontend. These were detected by an IDE using TypeScript language
services.