### PR TITLE
chore: stricter types for JSON.parse

### DIFF
--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -153,7 +153,9 @@ export class SlicingControl {
    */
   render(slicingSpec?: TensorViewSlicingSpec) {
     if (slicingSpec != null) {
-      this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+      this.slicingSpec = JSON.parse(
+        JSON.stringify(slicingSpec)
+      ) as TensorViewSlicingSpec;
     }
     if (this.slicingSpec === null) {
       throw new Error(
@@ -386,7 +388,9 @@ export class SlicingControl {
    *   by SlicingControl.
    */
   setSlicingSpec(slicingSpec: TensorViewSlicingSpec) {
-    this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+    this.slicingSpec = JSON.parse(
+      JSON.stringify(slicingSpec)
+    ) as TensorViewSlicingSpec;
     if (this.slicingSpec === null) {
       throw new Error('Cannot set slicing spec to null.');
     }

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -508,13 +508,17 @@ export class TensorWidgetImpl implements TensorWidget {
         this.tensorView.spec.shape,
         async (slicingSpec: TensorViewSlicingSpec) => {
           if (!areSlicingSpecsCompatible(this.slicingSpec, slicingSpec)) {
-            this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+            this.slicingSpec = JSON.parse(
+              JSON.stringify(slicingSpec)
+            ) as TensorViewSlicingSpec;
             // The dimension arrangement has changed in the slicing spec.
             // The rulers and value divs must be re-created. This is why
             // `render()` is called instead of `renderRulersAndValueDivs()`.
             await this.render();
           } else {
-            this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+            this.slicingSpec = JSON.parse(
+              JSON.stringify(slicingSpec)
+            ) as TensorViewSlicingSpec;
             await this.renderRulersAndValueDivs();
           }
         }

--- a/tensorboard/defs/strict_type_check.d.ts
+++ b/tensorboard/defs/strict_type_check.d.ts
@@ -13,8 +13,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// Type override of lib.es2015.collection.d.ts.
-// Make sure key/value types are not inferred as any.
+// Type override of lib.es2015.collection.d.ts. Make sure key/value types are
+// not inferred as any.
 interface MapConstructor {
   new <K, V>(): Map<K, V>;
+}
+
+// Type override of TypeScript's 'src/lib/es5.d.ts'.
+interface JSON {
+  /**
+   * In default TypeScript, `JSON.parse` is typed as:
+   * ```
+   *   parse(
+   *     text: string,
+   *     reviver?: (this: any, key: string, value: any) => any
+   *   ): any
+   * ```
+   * We upgrade some of the `any`s to stricter `unknown`s, and drop the `this`.
+   */
+  parse(
+    text: string,
+    reviver?: (key: string, value: unknown) => unknown
+  ): unknown;
 }

--- a/tensorboard/plugins/projector/vz_projector/data-provider-server.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider-server.ts
@@ -62,7 +62,7 @@ export class ServerDataProvider implements DataProvider {
       logging.setErrorMessage(xhr.responseText, 'fetching runs');
     };
     xhr.onload = () => {
-      const runs = JSON.parse(xhr.responseText);
+      const runs = JSON.parse(xhr.responseText) as string[];
       logging.setModalMessage(null, msgId);
       callback(runs);
     };
@@ -147,7 +147,7 @@ export class ServerDataProvider implements DataProvider {
     };
     xhr.onload = () => {
       logging.setModalMessage(null, msgId);
-      const bookmarks = JSON.parse(xhr.responseText);
+      const bookmarks = JSON.parse(xhr.responseText) as State[];
       callback(bookmarks);
     };
     xhr.send();

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-bookmark-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-bookmark-panel.ts
@@ -137,7 +137,7 @@ class BookmarkPanel extends LegacyElementMixin(PolymerElement) {
       const fileReader = new FileReader();
       fileReader.onload = (evt) => {
         const str: string = fileReader.result as string;
-        const savedStates = JSON.parse(str);
+        const savedStates = JSON.parse(str) as State[];
         // Verify the bookmarks match.
         if (this.savedStatesValid(savedStates)) {
           this.addStates(savedStates);
@@ -238,7 +238,7 @@ class BookmarkPanel extends LegacyElementMixin(PolymerElement) {
    * viewable states.
    */
   loadSavedStates(serializedStates: string) {
-    this.savedStates = JSON.parse(serializedStates);
+    this.savedStates = JSON.parse(serializedStates) as State[];
     this.updateHasStates();
   }
   /**

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.ts
@@ -97,7 +97,7 @@ class VzProjectorDashboard extends PolymerElement {
     xhr.onload = () => {
       // Set this to true so we only initialize once.
       this._initialized = true;
-      let runs = JSON.parse(xhr.responseText);
+      let runs = JSON.parse(xhr.responseText) as string[];
       this.set('dataNotFound', runs.length === 0);
     };
     xhr.onerror = () => {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
@@ -453,7 +453,7 @@ export class TfScalarCard extends PolymerElement {
     // defined in tf_color_scale.
     return {
       scale: (name) => {
-        const [, run] = JSON.parse(name);
+        const [, run] = JSON.parse(name) as [string, string];
         return runsColorScale(run);
       },
     };


### PR DESCRIPTION
Increases strictness of `JSON.parse`s typing to match internal
policies.

Tested by running `bazel run tensorboard:dev` and seeing that
it builds successfully.

Googlers, see b/179426717 and test sync cl/355885039.