### PR TITLE
Reland "Disable terser on polymer bundle in dev assets mode (#4651)"

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -45,6 +45,7 @@ tf_js_binary(
     deps = [":polymer3_ts_lib"],
 )
 
+# Keep in sync with //tensorboard/webapp/dev_assets:polymer3_lib_binary_dev
 genrule(
     name = "polymer3_lib_binary",
     srcs = [

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -26,7 +26,14 @@ def tensorboard_webcomponent_library(**kwargs):
     """Rules referencing this will be deleted from the codebase soon."""
     pass
 
-def tf_js_binary(name, compile, deps, visibility = None, **kwargs):
+def tf_js_binary(
+    name,
+    compile,
+    deps,
+    visibility = None,
+    dev_mode_only = False,
+    **kwargs
+):
     """Rules for creating a JavaScript bundle.
 
     Please refer to https://bazelbuild.github.io/rules_nodejs/Built-ins.html#rollup_bundle
@@ -53,7 +60,7 @@ def tf_js_binary(name, compile, deps, visibility = None, **kwargs):
         **kwargs
     )
 
-    if compile:
+    if not dev_mode_only:
         internal_result_name = name + "_terser_internal_min"
         terser_minified(
             name = internal_result_name,

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -35,8 +35,7 @@ def tf_js_binary(name, compile, deps, visibility = None, **kwargs):
 
     # `compile` option is used internally but is not used by rollup_bundle.
     # Discard it.
-    internal_rollup_name = name + "_terser_internal_dbg"
-    internal_min_name = name + "_terser_internal_min"
+    internal_rollup_name = name + "_rollup_internal_dbg"
     rollup_bundle(
         name = internal_rollup_name,
         config_file = "//tensorboard/defs:rollup_config.js",
@@ -54,19 +53,23 @@ def tf_js_binary(name, compile, deps, visibility = None, **kwargs):
         **kwargs
     )
 
-    terser_minified(
-        name = internal_min_name,
-        src = internal_rollup_name,
-        config_file = "//tensorboard/defs:terser_config.json",
-        visibility = ["//visibility:private"],
-        sourcemap = False,
-    )
+    if compile:
+        internal_result_name = name + "_terser_internal_min"
+        terser_minified(
+            name = internal_result_name,
+            src = internal_rollup_name,
+            config_file = "//tensorboard/defs:terser_config.json",
+            visibility = ["//visibility:private"],
+            sourcemap = False,
+        )
+    else:
+        internal_result_name = internal_rollup_name
 
     # For some reason, terser_minified is not visible from other targets. Copy
     # or re-export seems to work okay.
     native.genrule(
         name = name,
-        srcs = [internal_min_name],
+        srcs = [internal_result_name],
         outs = [name + ".js"],
         visibility = visibility,
         cmd = "cat $(SRCS) > $@",

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -60,7 +60,9 @@ def tf_js_binary(
         **kwargs
     )
 
-    if not dev_mode_only:
+    if dev_mode_only:
+        internal_result_name = internal_rollup_name
+    else:
         internal_result_name = name + "_terser_internal_min"
         terser_minified(
             name = internal_result_name,
@@ -69,8 +71,6 @@ def tf_js_binary(
             visibility = ["//visibility:private"],
             sourcemap = False,
         )
-    else:
-        internal_result_name = internal_rollup_name
 
     # For some reason, terser_minified is not visible from other targets. Copy
     # or re-export seems to work okay.

--- a/tensorboard/webapp/dev_assets/BUILD
+++ b/tensorboard/webapp/dev_assets/BUILD
@@ -43,7 +43,8 @@ tf_web_library(
 # By dropping 'compile', this skips the expensive minification step.
 tf_js_binary(
     name = "polymer3_lib_binary_no_shim_dev",
-    compile = False,
+    compile = True,
+    dev_mode_only = True,
     entry_point = "//tensorboard/components:polymer3_lib.ts",
     deps = ["//tensorboard/components:polymer3_ts_lib"],
 )

--- a/tensorboard/webapp/dev_assets/BUILD
+++ b/tensorboard/webapp/dev_assets/BUILD
@@ -6,7 +6,7 @@
 # //tensorboard/webapp:index.html, we had to create the dev_assets version in
 # a different package. Once we can get rid of zip asset provider and a way to
 # alias asset, we would not need the enitrely different Bazel package.
-load("//tensorboard/defs:defs.bzl", "tf_dev_js_binary", "tf_ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_dev_js_binary", "tf_js_binary", "tf_ng_module")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:__pkg__"])
@@ -40,11 +40,33 @@ tf_web_library(
     path = "/tb-webapp",
 )
 
+# By dropping 'compile', this skips the expensive minification step.
+tf_js_binary(
+    name = "polymer3_lib_binary_no_shim_dev",
+    compile = False,
+    entry_point = "//tensorboard/components:polymer3_lib.ts",
+    deps = ["//tensorboard/components:polymer3_ts_lib"],
+)
+
+# Keep in sync with //tensorboard/components:polymer3_lib_binary.
+genrule(
+    name = "polymer3_lib_binary_dev",
+    srcs = [
+        # Do not sort. order is important.
+        "@npm//:node_modules/web-animations-js/web-animations-next-lite.min.js",
+        ":polymer3_lib_binary_no_shim_dev.js",
+    ],
+    outs = ["polymer3_lib_binary_dev.js"],
+    cmd = "for f in $(SRCS); do cat \"$$f\"; echo; done > $@",
+)
+
+# The index.html used for dev mode needs to use the polymer3 lib specifically
+# for dev mode.
 genrule(
     name = "rename_index_html",
     srcs = ["//tensorboard/webapp:index_polymer3.inlined.html"],
     outs = ["index.html"],
-    cmd = "cat $(SRCS) > $@",
+    cmd = "sed 's/polymer3_lib_binary/polymer3_lib_binary_dev/g' $(SRCS) > $@",
 )
 
 # Should keep the asset dependencies in sync with //tensorboard:assets.
@@ -52,7 +74,7 @@ tf_web_library(
     name = "dev_assets",
     srcs = [
         ":index.html",
-        "//tensorboard/components:polymer3_lib_binary.js",
+        ":polymer3_lib_binary_dev.js",
         "//tensorboard/webapp:styles.css",
         "//tensorboard/webapp:svg_bundle",
         "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:chart_worker.js",

--- a/tensorboard/webapp/dev_assets/BUILD
+++ b/tensorboard/webapp/dev_assets/BUILD
@@ -40,7 +40,6 @@ tf_web_library(
     path = "/tb-webapp",
 )
 
-# By dropping 'compile', this skips the expensive minification step.
 tf_js_binary(
     name = "polymer3_lib_binary_no_shim_dev",
     compile = True,
@@ -67,7 +66,7 @@ genrule(
     name = "rename_index_html",
     srcs = ["//tensorboard/webapp:index_polymer3.inlined.html"],
     outs = ["index.html"],
-    cmd = "sed 's/polymer3_lib_binary/polymer3_lib_binary_dev/g' $(SRCS) > $@",
+    cmd = "sed 's/polymer3_lib_binary\\.js/polymer3_lib_binary_dev\\.js/g' $(SRCS) > $@",
 )
 
 # Should keep the asset dependencies in sync with //tensorboard:assets.

--- a/tensorboard/webapp/index_polymer3.uninlined.html
+++ b/tensorboard/webapp/index_polymer3.uninlined.html
@@ -64,6 +64,10 @@ limitations under the License.
     <p>Please enable JavaScript and reload this page.</p>
   </noscript>
   <script jscomp-nocompile src="tf-imports/require.js"></script>
+  <!--
+    Targets like '//tensorboard:dev' may replace the Polymer bundle with a
+    'dev mode' variant.
+  -->
   <script jscomp-nocompile src="polymer3_lib_binary.js"></script>
   <script jscomp-nocompile src="tb-webapp/tb_webapp_binary.js"></script>
   <tb-webapp></tb-webapp>


### PR DESCRIPTION
**Status**: this PR was originally a roll-forward, but that was
abandoned after we reverted (#4655) the offending sync blocker.
This PR is now a re-land of the original #4651 with modifications.

Re-lands the change in #4651 that was reverted in #4655.
The original change used the `compile` option on `tf_js_binary`
as a signal to skip the Terser minification step. However, this
broke internally because `compile=False` has special semantics
in Google.

Now, the reland does the same minification skip when a new
rule attribute `dev_mode_only=True` is present. Internally,
this attribute is ignored.

Googlers, see test sync cl/355919112.

Before this is landed, cl/355772570 must be submitted first,
to fix syncing issues.