### PR TITLE
graph: instrument debug events for user actions

### DIFF
--- a/tensorboard/components/tb_debug/types.ts
+++ b/tensorboard/components/tb_debug/types.ts
@@ -19,12 +19,14 @@ export interface ActionEvent {
   eventValue?: number;
 }
 
+export const GRAPH_DEBUG_ACTION_EVENT_CATEGORY = 'Graph dashboard actions';
 export const GRAPH_DEBUG_TIMING_EVENT_CATEGORY = 'Graph dashboard timings';
 
-export enum GraphDebugEventId {
-  /**
-   * Pre-rendering.
-   */
+/**
+ * Timing-based events, part of `GRAPH_DEBUG_TIMING_EVENT_CATEGORY`.
+ */
+export enum GraphDebugTimingEventId {
+  // Pre-rendering.
   FETCH_PBTXT_BYTES = 'FETCH_PBTXT_BYTES',
   PARSE_PBTXT_INTO_OBJECT = 'PARSE_PBTXT_INTO_OBJECT',
   FETCH_METADATA_PBTXT_BYTES = 'FETCH_METADATA_PBTXT_BYTES',
@@ -35,15 +37,44 @@ export enum GraphDebugEventId {
   HIERARCHY_DETECT_SERIES = 'HIERARCHY_DETECT_SERIES',
   HIERARCHY_ADD_EDGES = 'HIERARCHY_ADD_EDGES',
   HIERARCHY_FIND_SIMILAR_SUBGRAPHS = 'HIERARCHY_FIND_SIMILAR_SUBGRAPHS',
-  /**
-   * Rendering.
-   */
+  // Rendering.
   RENDER_BUILD_HIERARCHY = 'RENDER_BUILD_HIERARCHY',
   RENDER_SCENE_LAYOUT = 'RENDER_SCENE_LAYOUT',
   RENDER_SCENE_BUILD_SCENE = 'RENDER_SCENE_BUILD_SCENE',
-  /**
-   * Total graph loading (superset of other phases).
-   */
+  // Total graph loading (superset of other phases).
   GRAPH_LOAD_SUCCEEDED = 'GRAPH_LOAD_SUCCEEDED',
   GRAPH_LOAD_FAILED = 'GRAPH_LOAD_FAILED',
 }
+
+/**
+ * Non-timing based actions due to user interaction, part of
+ * `GRAPH_DEBUG_ACTION_EVENT_CATEGORY`.
+ */
+export enum GraphDebugActionEventId {
+  // Labeled by state: expanded or collapsed.
+  NODE_EXPANSION_TOGGLED = 'NODE_EXPANSION_TOGGLED',
+  NODE_SEARCH_RESULT_FOCUSED = 'NODE_SEARCH_RESULT_FOCUSED',
+  // Labeled by direction between auxiliary graph and the main graph.
+  NODE_AUXILIARY_EXTRACTION_CHANGED = 'NODE_AUXILIARY_EXTRACTION_CHANGED',
+  // Labeled by graph type: Op, Conceptual, Profile.
+  GRAPH_TYPE_CHANGED = 'GRAPH_TYPE_CHANGED',
+  TRACE_INPUT_MODE_TOGGLED = 'TRACE_INPUT_MODE_TOGGLED',
+  // Labeled by mode: Structure, Device, TPU Compat, etc.
+  NODE_COLOR_MODE_CHANGED = 'NODE_COLOR_MODE_CHANGED',
+  UPLOADED_GRAPH_FROM_FILESYSTEM = 'UPLOADED_GRAPH_FROM_FILESYSTEM',
+}
+
+const graphDebugTimingEventIds = Object.values(
+  GraphDebugTimingEventId
+) as string[];
+
+export function isDebugTimingEventId(eventId: string) {
+  return graphDebugTimingEventIds.includes(eventId);
+}
+
+// Merge the string enums.
+export const GraphDebugEventId = {
+  ...GraphDebugTimingEventId,
+  ...GraphDebugActionEventId,
+};
+export type GraphDebugEventId = typeof GraphDebugEventId;

--- a/tensorboard/components/tb_debug/types.ts
+++ b/tensorboard/components/tb_debug/types.ts
@@ -64,14 +64,6 @@ export enum GraphDebugActionEventId {
   UPLOADED_GRAPH_FROM_FILESYSTEM = 'UPLOADED_GRAPH_FROM_FILESYSTEM',
 }
 
-const graphDebugTimingEventIds = Object.values(
-  GraphDebugTimingEventId
-) as string[];
-
-export function isDebugTimingEventId(eventId: string) {
-  return graphDebugTimingEventIds.includes(eventId);
-}
-
 // Merge the string enums.
 export const GraphDebugEventId = {
   ...GraphDebugTimingEventId,

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -417,7 +417,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
       this.$.scene.setNodeExpanded(renderNode);
     }, 75);
     tf_graph_util.notifyDebugEvent({
-      eventId: tb_debug.GraphDebugEventId.NODE_EXPANSION_TOGGLED,
+      actionId: tb_debug.GraphDebugEventId.NODE_EXPANSION_TOGGLED,
       eventLabel: renderNode.expanded ? 'expanded' : 'collapsed',
     });
   }
@@ -441,7 +441,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     this._buildRenderHierarchy(this.graphHierarchy);
 
     tf_graph_util.notifyDebugEvent({
-      eventId: tb_debug.GraphDebugEventId.NODE_AUXILIARY_EXTRACTION_CHANGED,
+      actionId: tb_debug.GraphDebugEventId.NODE_AUXILIARY_EXTRACTION_CHANGED,
       eventLabel:
         renderNode.node.include === tf_graph.InclusionType.INCLUDE
           ? 'Auxiliary to Main'

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -416,6 +416,10 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     this.async(function () {
       this.$.scene.setNodeExpanded(renderNode);
     }, 75);
+    tf_graph_util.notifyDebugEvent({
+      eventId: tb_debug.GraphDebugEventId.NODE_EXPANSION_TOGGLED,
+      eventLabel: renderNode.expanded ? 'expanded' : 'collapsed',
+    });
   }
   _nodeToggleExtract(event) {
     // Toggle the include setting of the specified node appropriately.
@@ -435,6 +439,14 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     }
     // Rebuild the render hierarchy.
     this._buildRenderHierarchy(this.graphHierarchy);
+
+    tf_graph_util.notifyDebugEvent({
+      eventId: tb_debug.GraphDebugEventId.NODE_AUXILIARY_EXTRACTION_CHANGED,
+      eventLabel:
+        renderNode.node.include === tf_graph.InclusionType.INCLUDE
+          ? 'Auxiliary to Main'
+          : 'Main to Auxiliary',
+    });
   }
   _nodeToggleSeriesGroup(event) {
     // Toggle the group setting of the specified node appropriately.

--- a/tensorboard/plugins/graph/tf_graph_common/loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/loader.ts
@@ -71,7 +71,7 @@ export function fetchAndConstructHierarchicalGraph(
         hierarchyTracker
       );
       tf_graph_util.notifyDebugEvent({
-        eventId: tb_debug.GraphDebugEventId.GRAPH_LOAD_SUCCEEDED,
+        timingId: tb_debug.GraphDebugEventId.GRAPH_LOAD_SUCCEEDED,
         eventValue: Date.now() - start,
       });
       return {graph, graphHierarchy};
@@ -82,7 +82,7 @@ export function fetchAndConstructHierarchicalGraph(
       const msg = `Graph visualization failed.\n\n${e}`;
       tracker.reportError(msg, e);
       tf_graph_util.notifyDebugEvent({
-        eventId: tb_debug.GraphDebugEventId.GRAPH_LOAD_FAILED,
+        timingId: tb_debug.GraphDebugEventId.GRAPH_LOAD_FAILED,
         eventValue: Date.now() - start,
       });
       // Don't swallow the error.

--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -13,6 +13,7 @@ tf_ts_library(
     deps = [
         "//tensorboard/components/polymer:irons_and_papers",
         "//tensorboard/components/polymer:legacy_element_mixin",
+        "//tensorboard/components/tb_debug",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/plugins/graph/tf_graph_common",
         "//tensorboard/plugins/graph/tf_graph_node_search",

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -1121,21 +1121,21 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
 
   _onGraphTypeChangedByUserGesture() {
     tf_graph_util.notifyDebugEvent({
-      eventId: tb_debug.GraphDebugEventId.GRAPH_TYPE_CHANGED,
+      actionId: tb_debug.GraphDebugEventId.GRAPH_TYPE_CHANGED,
       eventLabel: this._selectedGraphType,
     });
   }
 
   _onColorByChangedByUserGesture() {
     tf_graph_util.notifyDebugEvent({
-      eventId: tb_debug.GraphDebugEventId.NODE_COLOR_MODE_CHANGED,
+      actionId: tb_debug.GraphDebugEventId.NODE_COLOR_MODE_CHANGED,
       eventLabel: this.colorBy,
     });
   }
 
   _onTraceInputsChangedByUserGesture() {
     tf_graph_util.notifyDebugEvent({
-      eventId: tb_debug.GraphDebugEventId.TRACE_INPUT_MODE_TOGGLED,
+      actionId: tb_debug.GraphDebugEventId.TRACE_INPUT_MODE_TOGGLED,
     });
   }
 
@@ -1323,7 +1323,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     this.set('selectedFile', e);
 
     tf_graph_util.notifyDebugEvent({
-      eventId: tb_debug.GraphDebugEventId.UPLOADED_GRAPH_FROM_FILESYSTEM,
+      actionId: tb_debug.GraphDebugEventId.UPLOADED_GRAPH_FROM_FILESYSTEM,
     });
   }
   _datasetsChanged(newDatasets: Dataset, oldDatasets: Dataset) {

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -18,6 +18,7 @@ import {computed, customElement, property} from '@polymer/decorators';
 import * as _ from 'lodash';
 
 import '../../../components/polymer/irons_and_papers';
+import * as tb_debug from '../../../components/tb_debug';
 import * as tf_graph_common from '../tf_graph_common/common';
 import * as tf_graph_render from '../tf_graph_common/render';
 import * as tf_graph_proto from '../tf_graph_common/proto';
@@ -458,7 +459,10 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
         </div>
       </template>
       <div class="control-holder">
-        <paper-radio-group selected="{{_selectedGraphType}}">
+        <paper-radio-group
+          selected="{{_selectedGraphType}}"
+          on-paper-radio-group-changed="_onGraphTypeChangedByUserGesture"
+        >
           <!-- Note that the name has to match that of tf_graph_common.SelectionType. -->
           <paper-radio-button
             name="op_graph"
@@ -479,7 +483,11 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
       </div>
       <div class="control-holder">
         <div>
-          <paper-toggle-button checked="{{traceInputs}}" class="title">
+          <paper-toggle-button
+            checked="{{traceInputs}}"
+            class="title"
+            on-change="_onTraceInputsChangedByUserGesture"
+          >
             Trace inputs
           </paper-toggle-button>
         </div>
@@ -493,7 +501,10 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
       </template>
       <div class="control-holder">
         <div class="title">Color</div>
-        <paper-radio-group selected="{{colorBy}}">
+        <paper-radio-group
+          selected="{{colorBy}}"
+          on-paper-radio-group-changed="_onColorByChangedByUserGesture"
+        >
           <paper-radio-button name="structure">Structure</paper-radio-button>
 
           <paper-radio-button name="device">Device</paper-radio-button>
@@ -1107,6 +1118,27 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     type: Boolean,
   })
   _legendOpened: boolean = true;
+
+  _onGraphTypeChangedByUserGesture() {
+    tf_graph_util.notifyDebugEvent({
+      eventId: tb_debug.GraphDebugEventId.GRAPH_TYPE_CHANGED,
+      eventLabel: this._selectedGraphType,
+    });
+  }
+
+  _onColorByChangedByUserGesture() {
+    tf_graph_util.notifyDebugEvent({
+      eventId: tb_debug.GraphDebugEventId.NODE_COLOR_MODE_CHANGED,
+      eventLabel: this.colorBy,
+    });
+  }
+
+  _onTraceInputsChangedByUserGesture() {
+    tf_graph_util.notifyDebugEvent({
+      eventId: tb_debug.GraphDebugEventId.TRACE_INPUT_MODE_TOGGLED,
+    });
+  }
+
   _xlaClustersProvided(
     renderHierarchy: tf_graph_render.RenderGraphInfo | null
   ) {
@@ -1289,6 +1321,10 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     }
     this._setDownloadFilename(filePath);
     this.set('selectedFile', e);
+
+    tf_graph_util.notifyDebugEvent({
+      eventId: tb_debug.GraphDebugEventId.UPLOADED_GRAPH_FROM_FILESYSTEM,
+    });
   }
   _datasetsChanged(newDatasets: Dataset, oldDatasets: Dataset) {
     if (oldDatasets != null) {

--- a/tensorboard/plugins/graph/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_node_search/BUILD
@@ -12,6 +12,7 @@ tf_ts_library(
     deps = [
         "//tensorboard/components/polymer:irons_and_papers",
         "//tensorboard/components/polymer:legacy_element_mixin",
+        "//tensorboard/components/tb_debug",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/plugins/graph/tf_graph_common",
         "@npm//@polymer/decorators",

--- a/tensorboard/plugins/graph/tf_graph_node_search/tf-graph-node-search.ts
+++ b/tensorboard/plugins/graph/tf_graph_node_search/tf-graph-node-search.ts
@@ -173,7 +173,7 @@ class TfGraphNodeSearch extends LegacyElementMixin(PolymerElement) {
     const node = e.model.item;
     this.set('selectedNode', node);
     tf_graph_util.notifyDebugEvent({
-      eventId: tb_debug.GraphDebugEventId.NODE_SEARCH_RESULT_FOCUSED,
+      actionId: tb_debug.GraphDebugEventId.NODE_SEARCH_RESULT_FOCUSED,
     });
   }
 }

--- a/tensorboard/plugins/graph/tf_graph_node_search/tf-graph-node-search.ts
+++ b/tensorboard/plugins/graph/tf_graph_node_search/tf-graph-node-search.ts
@@ -18,8 +18,11 @@ import {computed, customElement, observe, property} from '@polymer/decorators';
 import * as _ from 'lodash';
 
 import '../../../components/polymer/irons_and_papers';
+import * as tb_debug from '../../../components/tb_debug';
 import '../../../components/tf_dashboard_common/tensorboard-color';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+
+import * as tf_graph_util from '../tf_graph_common/util';
 
 @customElement('tf-graph-node-search')
 class TfGraphNodeSearch extends LegacyElementMixin(PolymerElement) {
@@ -169,5 +172,8 @@ class TfGraphNodeSearch extends LegacyElementMixin(PolymerElement) {
   _matchClicked(e) {
     const node = e.model.item;
     this.set('selectedNode', node);
+    tf_graph_util.notifyDebugEvent({
+      eventId: tb_debug.GraphDebugEventId.NODE_SEARCH_RESULT_FOCUSED,
+    });
   }
 }


### PR DESCRIPTION
The Graph code includes instrumentation to notify when timing events
occur for debugging. This change adds new instrumentation points
for non-timing related user-initiated actions, such as expanding a node,
performing a search, and toggling the "Trace Inputs" control.

Notably, these non-timing debug events have their own category,
and use the `eventLabel` optionally, instead of the `eventValue` field
required for timing-related events.

Test plan:
Manually checked that events are notified by adding a `console.log`
from inside `notifyActionEventFromPolymer()`, and observed the
output

![image](https://user-images.githubusercontent.com/2322480/107102227-b2770300-67ce-11eb-914f-201fd3ca96f6.png)

Googlers, see test sync cl/355952339