### PR TITLE
line chart: add trapezoid renderer

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
@@ -19,6 +19,7 @@ import {
   CirclePaintOption,
   LinePaintOption,
   ObjectRenderer,
+  TrapezoidPaintOption,
   TrianglePaintOption,
 } from './renderer/renderer_types';
 
@@ -54,6 +55,23 @@ export class PaintBrush {
     const newCacheValue = this.renderer.createOrUpdateCircleObject(
       this.renderCache.getFromPreviousFrame(cacheId),
       loc,
+      paintOpt
+    );
+    if (newCacheValue) {
+      this.renderCache.setToCurrentFrame(cacheId, newCacheValue);
+    }
+  }
+
+  setTrapezoid(
+    cacheId: string,
+    start: Point,
+    end: Point,
+    paintOpt: TrapezoidPaintOption
+  ) {
+    const newCacheValue = this.renderer.createOrUpdateTrapezoidObject(
+      this.renderCache.getFromPreviousFrame(cacheId),
+      start,
+      end,
       paintOpt
     );
     if (newCacheValue) {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -225,6 +225,57 @@ describe('line_chart_v2/lib/renderer test', () => {
         expect(path.style.fill).toBe('rgb(0, 0, 255)');
       });
     });
+
+    describe('trapezoid', () => {
+      it('creates a path with the right shape', () => {
+        renderer.createOrUpdateTrapezoidObject(
+          null,
+          {x: 10, y: 100},
+          {x: 30, y: 100},
+          {visible: true, color: '#f00', width: 6}
+        );
+
+        expect(el.children.length).toBe(1);
+        const path = el.children[0] as SVGPathElement;
+        expect(path.tagName).toBe('path');
+        expect(path.style.display).toBe('');
+        assertSvgPathD(path, [
+          [7, 102],
+          [10, 97],
+          [30, 97],
+          [33, 102],
+        ]);
+        expect(path.style.fill).toBe('rgb(255, 0, 0)');
+      });
+
+      it('updates the path', () => {
+        const obj = renderer.createOrUpdateTrapezoidObject(
+          null,
+          {x: 10, y: 100},
+          {x: 30, y: 100},
+          {visible: true, color: '#f00', width: 6}
+        );
+
+        renderer.createOrUpdateTrapezoidObject(
+          obj,
+          {x: 10, y: 100},
+          {x: 50, y: 100},
+          {visible: true, color: '#00f', width: 6}
+        );
+
+        expect(el.children.length).toBe(1);
+        const path = el.children[0] as SVGPathElement;
+        expect(path.tagName).toBe('path');
+        expect(path.style.display).toBe('');
+        assertSvgPathD(path, [
+          [7, 102],
+          [10, 97],
+          [50, 97],
+          [53, 102],
+        ]);
+        expect(path.style.fill).toBe('rgb(0, 0, 255)');
+      });
+    });
   });
 
   describe('threejs renderer', () => {
@@ -425,6 +476,47 @@ describe('line_chart_v2/lib/renderer test', () => {
         const obj = scene.children[0] as THREE.Mesh;
         expect(obj.position.x).toBe(50);
         expect(obj.position.y).toBe(100);
+        assertMaterial(obj, '#ff0000', true);
+      });
+    });
+
+    describe('trapezoid', () => {
+      it('creates a Mesh object with path', () => {
+        renderer.createOrUpdateTrapezoidObject(
+          null,
+          {x: 100, y: 50},
+          {x: 200, y: 50},
+          {visible: true, color: '#0f0', width: 10}
+        );
+
+        const obj = scene.children[0] as THREE.Mesh;
+        assertPositions(
+          obj.geometry as THREE.BufferGeometry,
+          new Float32Array([95, 47, 0, 100, 56, 0, 200, 56, 0, 205, 47, 0])
+        );
+        assertMaterial(obj, '#00ff00', true);
+      });
+
+      it('updates mesh', () => {
+        const cache = renderer.createOrUpdateTrapezoidObject(
+          null,
+          {x: 100, y: 50},
+          {x: 200, y: 50},
+          {visible: true, color: '#0f0', width: 10}
+        );
+
+        renderer.createOrUpdateTrapezoidObject(
+          cache,
+          {x: 100, y: 50},
+          {x: 300, y: 50},
+          {visible: true, color: '#f00', width: 10}
+        );
+
+        const obj = scene.children[0] as THREE.Mesh;
+        assertPositions(
+          obj.geometry as THREE.BufferGeometry,
+          new Float32Array([95, 47, 0, 100, 56, 0, 300, 56, 0, 305, 47, 0])
+        );
         assertMaterial(obj, '#ff0000', true);
       });
     });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -232,7 +232,7 @@ describe('line_chart_v2/lib/renderer test', () => {
           null,
           {x: 10, y: 100},
           {x: 30, y: 100},
-          {visible: true, color: '#f00', width: 6}
+          {visible: true, color: '#f00', altitude: 6}
         );
 
         expect(el.children.length).toBe(1);
@@ -240,10 +240,10 @@ describe('line_chart_v2/lib/renderer test', () => {
         expect(path.tagName).toBe('path');
         expect(path.style.display).toBe('');
         assertSvgPathD(path, [
-          [7, 102],
+          [7, 103],
           [10, 97],
           [30, 97],
-          [33, 102],
+          [33, 103],
         ]);
         expect(path.style.fill).toBe('rgb(255, 0, 0)');
       });
@@ -253,14 +253,14 @@ describe('line_chart_v2/lib/renderer test', () => {
           null,
           {x: 10, y: 100},
           {x: 30, y: 100},
-          {visible: true, color: '#f00', width: 6}
+          {visible: true, color: '#f00', altitude: 6}
         );
 
         renderer.createOrUpdateTrapezoidObject(
           obj,
           {x: 10, y: 100},
           {x: 50, y: 100},
-          {visible: true, color: '#00f', width: 6}
+          {visible: true, color: '#00f', altitude: 6}
         );
 
         expect(el.children.length).toBe(1);
@@ -268,10 +268,10 @@ describe('line_chart_v2/lib/renderer test', () => {
         expect(path.tagName).toBe('path');
         expect(path.style.display).toBe('');
         assertSvgPathD(path, [
-          [7, 102],
+          [7, 103],
           [10, 97],
           [50, 97],
-          [53, 102],
+          [53, 103],
         ]);
         expect(path.style.fill).toBe('rgb(0, 0, 255)');
       });
@@ -486,13 +486,13 @@ describe('line_chart_v2/lib/renderer test', () => {
           null,
           {x: 100, y: 50},
           {x: 200, y: 50},
-          {visible: true, color: '#0f0', width: 10}
+          {visible: true, color: '#0f0', altitude: 10}
         );
 
         const obj = scene.children[0] as THREE.Mesh;
         assertPositions(
           obj.geometry as THREE.BufferGeometry,
-          new Float32Array([95, 47, 0, 100, 56, 0, 200, 56, 0, 205, 47, 0])
+          new Float32Array([94, 45, 0, 100, 55, 0, 200, 55, 0, 206, 45, 0])
         );
         assertMaterial(obj, '#00ff00', true);
       });
@@ -502,20 +502,20 @@ describe('line_chart_v2/lib/renderer test', () => {
           null,
           {x: 100, y: 50},
           {x: 200, y: 50},
-          {visible: true, color: '#0f0', width: 10}
+          {visible: true, color: '#0f0', altitude: 10}
         );
 
         renderer.createOrUpdateTrapezoidObject(
           cache,
           {x: 100, y: 50},
           {x: 300, y: 50},
-          {visible: true, color: '#f00', width: 10}
+          {visible: true, color: '#f00', altitude: 10}
         );
 
         const obj = scene.children[0] as THREE.Mesh;
         assertPositions(
           obj.geometry as THREE.BufferGeometry,
-          new Float32Array([95, 47, 0, 100, 56, 0, 300, 56, 0, 305, 47, 0])
+          new Float32Array([94, 45, 0, 100, 55, 0, 300, 55, 0, 306, 45, 0])
         );
         assertMaterial(obj, '#ff0000', true);
       });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
@@ -69,6 +69,16 @@ export interface ObjectRenderer<CacheValue = {}> {
     paintOpt: CirclePaintOption
   ): CacheValue | null;
 
+  /**
+   * Draws or enqueues trapezoid drawing operations depending on a renderer.
+   */
+  createOrUpdateTrapezoidObject(
+    cached: CacheValue | null,
+    start: Point,
+    end: Point,
+    paintOpt: TrapezoidPaintOption
+  ): CacheValue | null;
+
   flush(): void;
 
   destroyObject(cachedValue: CacheValue): void;
@@ -86,6 +96,10 @@ export interface LinePaintOption extends PaintOption {
 
 export interface TrianglePaintOption extends PaintOption {
   size: number;
+}
+
+export interface TrapezoidPaintOption extends PaintOption {
+  width: number;
 }
 
 export interface CirclePaintOption extends PaintOption {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
@@ -99,7 +99,7 @@ export interface TrianglePaintOption extends PaintOption {
 }
 
 export interface TrapezoidPaintOption extends PaintOption {
-  width: number;
+  altitude: number;
 }
 
 export interface CirclePaintOption extends PaintOption {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -229,13 +229,13 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
     const width = (2 / Math.sqrt(3)) * altitude;
     const vertices = new Float32Array([
       start.x - width / 2,
-      start.y + altitude / 3,
+      start.y + altitude / 2,
       start.x,
-      start.y - (altitude * 2) / 3,
+      start.y - altitude / 2,
       end.x,
-      end.y - (altitude * 2) / 3,
+      end.y - altitude / 2,
       end.x + width / 2,
-      end.y + altitude / 3,
+      end.y + altitude / 2,
     ]);
 
     const svgPath = createOrUpdateObject(

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -19,6 +19,7 @@ import {
   CirclePaintOption,
   LinePaintOption,
   ObjectRenderer,
+  TrapezoidPaintOption,
   TrianglePaintOption,
 } from './renderer_types';
 
@@ -212,5 +213,61 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
           dom: svgCircle,
           data: loc,
         };
+  }
+
+  createOrUpdateTrapezoidObject(
+    cached: PathCacheValue | null,
+    start: Point,
+    end: Point,
+    paintOpt: TrapezoidPaintOption
+  ): PathCacheValue | null {
+    if (start.y !== end.y) {
+      throw new RangeError('Input error: start.y != end.y.');
+    }
+
+    const {width, color} = paintOpt;
+    const altitude = (width * Math.sqrt(3)) / 2;
+    const vertices = new Float32Array([
+      start.x - width / 2,
+      start.y + altitude / 3,
+      start.x,
+      start.y - (altitude * 2) / 3,
+      end.x,
+      end.y - (altitude * 2) / 3,
+      end.x + width / 2,
+      end.y + altitude / 3,
+    ]);
+
+    const svgPath = createOrUpdateObject(
+      cached?.dom,
+      () => {
+        const dom = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'path'
+        );
+
+        dom.classList.add('trapezoid');
+        dom.style.fill = 'none';
+        const data = this.createPathDString(vertices);
+        dom.setAttribute('d', data + 'Z');
+        this.svg.appendChild(dom);
+        return dom;
+      },
+      (dom) => {
+        // Modifying/overwriting three vertices is cheap enough. Update always.
+        const data = this.createPathDString(vertices);
+        dom.setAttribute('d', data + 'Z');
+        return dom;
+      },
+      paintOpt
+    );
+
+    if (svgPath === null) return null;
+
+    svgPath.style.fill = color;
+    return {
+      dom: svgPath,
+      data: vertices,
+    };
   }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -225,8 +225,8 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
       throw new RangeError('Input error: start.y != end.y.');
     }
 
-    const {width, color} = paintOpt;
-    const altitude = (width * Math.sqrt(3)) / 2;
+    const {altitude, color} = paintOpt;
+    const width = (2 / Math.sqrt(3)) * altitude;
     const vertices = new Float32Array([
       start.x - width / 2,
       start.y + altitude / 3,

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -431,10 +431,10 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
     const {altitude} = paintOpt;
     const width = (2 / Math.sqrt(3)) * altitude;
     const shape = new THREE.Shape([
-      new THREE.Vector2(start.x - width / 2, start.y - altitude / 3),
-      new THREE.Vector2(start.x, start.y + (altitude * 2) / 3),
-      new THREE.Vector2(end.x, end.y + (altitude * 2) / 3),
-      new THREE.Vector2(end.x + width / 2, end.y - altitude / 3),
+      new THREE.Vector2(start.x - width / 2, start.y - altitude / 2),
+      new THREE.Vector2(start.x, start.y + altitude / 2),
+      new THREE.Vector2(end.x, end.y + altitude / 2),
+      new THREE.Vector2(end.x + width / 2, end.y - altitude / 2),
     ]);
     shape.autoClose = true;
     const geom = new THREE.ShapeBufferGeometry(shape);

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -428,9 +428,8 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
       throw new RangeError('Input error: start.y != end.y.');
     }
 
-    const {width} = paintOpt;
-    const altitude = (width * Math.sqrt(3)) / 2;
-
+    const {altitude} = paintOpt;
+    const width = (2 / Math.sqrt(3)) * altitude;
     const shape = new THREE.Shape([
       new THREE.Vector2(start.x - width / 2, start.y - altitude / 3),
       new THREE.Vector2(start.x, start.y + (altitude * 2) / 3),
@@ -441,7 +440,7 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
     const geom = new THREE.ShapeBufferGeometry(shape);
 
     if (!cached) {
-      const mesh = this.createMesh(geom as any, paintOpt);
+      const mesh = this.createMesh(geom, paintOpt);
       if (mesh === null) return null;
       this.scene.add(mesh);
       return {type: CacheType.TRAPEZOID, data: [start, end], obj3d: mesh};


### PR DESCRIPTION
## Motivation 
When there is a NaN value in the line chart, we render a triangle in place of the NaN based on some business logic. However, when number of NaN becomes high (e.g., entire dataset has millions of NaNs), the new line chart mostly chokes because it simply creates way too many three.js objects. While we have not delved too deeply into it, it spends considerable amount of time in our updater as well as three.js renderer when having too many objects at least compared to one object with many vertices.

To supply the assessment with an imprecise data, when rendering 20 runs, we achieve about 15 FPS with lines (it draws many triangles for the thickness) while it achieves about 2 FPS (~600ms per frame) when drawing all points as triangles. 

## Solution
For consecutive NaNs, instead of drawing many number of triangles, we collapse them into a trapezoid (many dense triangles already looked like one).