### PR TITLE
debugger_v2: start multiplexer lazily

### DIFF
--- a/docs/debugger_v2.md
+++ b/docs/debugger_v2.md
@@ -118,8 +118,9 @@ tensorboard --logdir /tmp/tfdbg2_logdir
 ```
 
 In the web browser, navigate to TensorBoard’s page at http://localhost:6006. The
-“Debugger V2” plugin should be activated by default, displaying a page that
-looks like the following:
+“Debugger V2” plugin will be inactive by default, so select it from the
+“Inactive plugins” menu at top right. Once selected, it should look like the
+following:
 
 ![Debugger V2 full view screenshot](./images/debugger_v2_1_full_view.png)
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -150,7 +150,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
 
     def testPluginIsActiveWithDataExists(self):
         _generate_tfdbg_v2_data(self.logdir)
-        self.assertTrue(self.plugin.is_active())
+        self.assertFalse(self.plugin.is_active())  # never explicitly active
 
     def testConcurrentCallsToPluginIsActiveWhenNotActive(self):
         results = collections.deque()
@@ -164,20 +164,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         for thread in threads:
             thread.join()
         self.assertEqual(list(results), [False] * 4)
-
-    def testConcurrentCallsToPluginIsActiveWhenActive(self):
-        _generate_tfdbg_v2_data(self.logdir)
-        results = collections.deque()
-
-        def query_is_active():
-            results.append(self.plugin.is_active())
-
-        threads = [threading.Thread(target=query_is_active) for _ in range(4)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-        self.assertEqual(list(results), [True] * 4)
 
     def testServeRunsWithoutExistingRuns(self):
         response = self.server.get(_ROUTE_PREFIX + "/runs")


### PR DESCRIPTION
Summary:
The DebuggerV2 plugin reads data outside of the usual summary-based
workflows, and has its own loading infrastructure for doing so. Until
this patch, the plugin would start recursively scanning the user’s log
directory at plugin initialization time—even before the server launches.
This can take a lot of resources and introduce a lot of contention,
especially on remote file systems.

This patch defers all such logic until users of the frontend explicitly
activate the plugin. Startup time improves greatly (see below).

Test Plan:
When pointing at `gs://tensorboard-bench-logs`, the time between process
start and the “server ready” line drops from 9.5 seconds to 1.7 seconds,
as measured by:

```
bazel-bin/tensorboard/tensorboard --logdir gs://tensorboard-bench-logs 2>&1 \
    | ts -s '[%.s]'
```

After generating test data as described in the tutorial, the plugin is
indeed inactive by default, and does indeed still appear to work if
manually activated.

wchargin-branch: dbgv2-lazy-load
