### PR TITLE
line chart: scale aware scroll to zoom

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -421,7 +421,7 @@ export class LineChartInteractiveViewComponent
             this.domDim,
             SCROLL_ZOOM_SPEED_FACTOR,
             this.xScale,
-            this.yScale,
+            this.yScale
           ),
         });
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -419,7 +419,9 @@ export class LineChartInteractiveViewComponent
             event,
             this.viewExtent,
             this.domDim,
-            SCROLL_ZOOM_SPEED_FACTOR
+            SCROLL_ZOOM_SPEED_FACTOR,
+            this.xScale,
+            this.yScale,
           ),
         });
 


### PR DESCRIPTION
Previously, in the interactive_view, we used simple arithmetic to
propose new viewExtent based on scroll magnitude and velocity, but it
did not account for the scale. As such, we are now using scale to
compute the next extent based on the position and speed of the cursor
and scroll.
