### PR TITLE
type: allow complete omission of `features`

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -39,7 +39,7 @@ export const getFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): FeatureFlags => {
     return {
-      ...state.features,
+      ...('features' in state ? state.features : undefined),
       ...state.defaultFlags,
       ...state.flagOverrides,
     };

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -25,6 +25,14 @@ export interface FeatureFlagState {
   flagOverrides?: Partial<FeatureFlags>;
 }
 
+export interface FeatureFlagStateAfterMigration {
+  isFeatureFlagsLoaded: boolean;
+  defaultFlags: FeatureFlags;
+  flagOverrides?: Partial<FeatureFlags>;
+}
+
+type FeatureFlagMigration = FeatureFlagStateAfterMigration | FeatureFlagState;
+
 export interface State {
-  [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagState;
+  [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagMigration;
 }

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {buildFeatureFlag} from '../testing';
 import {FeatureFlagState, FEATURE_FLAG_FEATURE_KEY} from './feature_flag_types';
 
 export function buildFeatureFlagState(
@@ -21,7 +20,6 @@ export function buildFeatureFlagState(
 ): FeatureFlagState {
   return {
     isFeatureFlagsLoaded: false,
-    features: undefined,
     defaultFlags: {
       enabledExperimentalPlugins: [],
       enableGpuChart: false,


### PR DESCRIPTION
This change retypes the feature flag store to allow for complete removal
of the `features`. Do note that we internally still define `features`
and as such, we need to keep the `features` around with a union type.
