### PR TITLE
line chart: render unsafe num in log scale

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/integration_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/integration_test.ts
@@ -27,7 +27,7 @@ function isTriangle(el: Element): boolean {
 }
 
 function isTrepezoid(el: Element): boolean {
-  return el.classList.contains('trepezoid');
+  return el.classList.contains('trapezoid');
 }
 
 describe('line_chart_v2/lib/integration test', () => {
@@ -533,7 +533,7 @@ describe('line_chart_v2/lib/integration test', () => {
       ]);
     });
 
-    it('renders many consecute non-positive value as trepezoid', () => {
+    it('renders many consecute non-positive value as trapezoid', () => {
       chart.resize({width: 100, height: 100});
       chart.setViewBox({x: [0, 100], y: [0, 100]});
       chart.setMetadata({line: buildMetadata({id: 'line', visible: true})});
@@ -552,12 +552,12 @@ describe('line_chart_v2/lib/integration test', () => {
 
       const children = getDomChildren();
       expect(children.length).toBe(2);
-      const [line1, trepezoid] = children;
+      const [line1, trapezoid] = children;
       assertSvgPathD(line1, [
         [0, 1],
         [1, 1],
       ]);
-      expect(isTrepezoid(trepezoid)).toBe(true);
+      expect(isTrepezoid(trapezoid)).toBe(true);
     });
   });
 });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -114,8 +114,8 @@ class Log10Scale implements Scale {
     range: [number, number],
     x: number
   ): number {
-    if (x <= 0) {
-      return range[0];
+    if (!this.isSafeNumber(x)) {
+      return NaN;
     }
 
     const [domainMin, domainMax] = domain;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -143,22 +143,21 @@ describe('line_chart_v2/lib/scale test', () => {
 
     describe('#forward and #reverse', () => {
       it('converts value from domain space to range space', () => {
-        expect(scale.forward([0, 1], [-100, 100], 0)).toBe(-100);
         expect(scale.forward([0, 1], [-100, 0], 0.5)).toBeCloseTo(-0.09, 2);
         expect(scale.forward([0, 1], [-100, 100], 1)).toBe(100);
 
-        expect(scale.forward([0, 1], [-100, 100], -1)).toBe(-100);
         expect(scale.forward([0, 1], [-100, 100], 5)).toBeCloseTo(100, -1);
 
         expect(scale.forward([1, 1000], [0, 1], 100)).toBeCloseTo(0.666, 2);
         expect(scale.forward([0.00001, 1], [0, 5], 0.01)).toBeCloseTo(3);
       });
 
-      // Kind of tentative behavior: it is more correct to return NaN and let
-      // UI elements show the right treatment; we would also need to exclude it
-      // when computed extents but it is out of scope for now.
-      it('handles negative value by treating it min float value', () => {
-        expect(scale.forward([1, 100], [0, 3], -3)).toBe(0);
+      it('handles non-positive value by returning NaN', () => {
+        expect(scale.forward([1, 100], [0, 3], -3)).toBeNaN();
+        expect(scale.forward([1, 100], [0, 3], 0)).toBeNaN();
+        expect(scale.forward([1, 100], [0, 3], -Infinity)).toBeNaN();
+        expect(scale.forward([1, 100], [0, 3], Infinity)).toBeNaN();
+        expect(scale.forward([1, 100], [0, 3], NaN)).toBeNaN();
       });
 
       it('permits negative value in domain by clipping it to min number', () => {
@@ -169,22 +168,17 @@ describe('line_chart_v2/lib/scale test', () => {
       });
 
       it('allows flipping order of the range', () => {
-        expect(scale.forward([0, 1], [100, -100], 0)).toBe(100);
         expect(scale.forward([0, 1], [100, -100], 0.5)).toBeCloseTo(-100, 0);
         expect(scale.forward([0, 1], [100, -100], 1)).toBe(-100);
 
-        // -1 is illegal in especially log domain so it is clipped to min range.
-        expect(scale.forward([0, 1], [100, -100], -1)).toBe(100);
         expect(scale.forward([0, 1], [100, -100], 5)).toBeCloseTo(-100, 0);
       });
 
       it('returns range min value when domain spread is 0', () => {
         expect(scale.forward([1, 1], [0, 100], 1)).toBe(0);
-        expect(scale.forward([1, 1], [0, 100], 0)).toBe(0);
       });
 
       it('does not choke when range spread is 0', () => {
-        expect(scale.forward([0, 1], [100, 100], 0)).toBe(100);
         expect(scale.forward([0, 1], [100, 100], 1)).toBe(100);
       });
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
@@ -157,7 +157,7 @@ export class SeriesLineView extends DataDrawable {
               y: polyline[polyline.length - 1],
             };
             this.paintBrush.setTrapezoid(
-              JSON.stringify(['NaN', series.id, partitionInd, 'trep']),
+              JSON.stringify(['NaN', series.id, partitionInd, 'trapezoid']),
               start,
               end,
               {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -497,7 +497,11 @@ export class LineChartInteractiveViewComponent
   }
 
   shouldRenderTooltipPoint(point: Point | null): boolean {
-    return point !== null && !isNaN(point.x) && !isNaN(point.y);
+    return (
+      point !== null &&
+      this.xScale.isSafeNumber(point.x) &&
+      this.yScale.isSafeNumber(point.y)
+    );
   }
 
   private updateTooltip(event: MouseEvent) {


### PR DESCRIPTION
Previously, due to value clipping at the log scale, we were rendering
unsafe value in log scale (non-positive number) as minimum range value.
This change returns `NaN` for correctness and render those values as
triangles.

Note that we are drawing trapezoid for a long series of NaN as large
amount of THREE.js object causes the line chart to spend ~100ms of
render time per frame.

Example of log scale for a tag that has negative values:
![image](https://user-images.githubusercontent.com/2547313/107296923-2f041e80-6a27-11eb-9ec8-57a57c6b5b69.png)
