### PR TITLE
docs: require scheme for TBdev gRPC API endpoint

### DIFF
--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -74,7 +74,8 @@ message Compatibility {
 
 message ApiServer {
   // gRPC server URI: <https://github.com/grpc/grpc/blob/master/doc/naming.md>.
-  // For example: "api.tensorboard.dev:443".
+  // A scheme should always be specified, even if that is `dns`.
+  // For example: "dns:///api.tensorboard.dev:443".
   string endpoint = 1;
 }
 


### PR DESCRIPTION
Summary:
The [gRPC docs] indicate that the default scheme for a channel address
is `dns:///`, but inside Google this is not always the case (Googlers,
see <http://b/179805849>.) Thus, we now require that the API endpoint to
the TensorBoard.dev gRPC server include an explicit scheme. The current
prod servers don’t follow this, but they will soon following internal
changes.

[gRPC docs]: https://github.com/grpc/grpc/blob/master/doc/naming.md

wchargin-branch: docs-grpc-scheme
