### PR TITLE
Move the tfo-only images into comments.

### DIFF
--- a/docs/get_started.ipynb
+++ b/docs/get_started.ipynb
@@ -238,7 +238,7 @@
         "id": "MCsoUNb6YhGc"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/quickstart_model_fit.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/quickstart_model_fit.png?raw=1\"/> -->"
       ]
     },
     {
@@ -481,7 +481,7 @@
         "id": "NVpnilhEgQXk"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/quickstart_gradient_tape.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/quickstart_gradient_tape.png?raw=1\"/> -->"
       ]
     },
     {

--- a/docs/graphs.ipynb
+++ b/docs/graphs.ipynb
@@ -313,7 +313,7 @@
         "id": "F-2yw5qd7OpK"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_computation.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_computation.png?raw=1\"/> -->"
       ]
     },
     {
@@ -322,7 +322,7 @@
         "id": "jDRynpVw53SJ"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_computation_detail.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_computation_detail.png?raw=1\"/> -->"
       ]
     },
     {
@@ -344,8 +344,8 @@
         "id": "Qw9rbEcE6eZB"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_tag_selection.png?raw=1\"/> <br/>\n",
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_conceptual.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_tag_selection.png?raw=1\"/> --> <br/>\n",
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_conceptual.png?raw=1\"/> -->"
       ]
     },
     {
@@ -429,7 +429,7 @@
         "id": "WDl1PBFQ64xi"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_autograph.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/graphs_autograph.png?raw=1\"/> -->"
       ]
     },
     {

--- a/docs/hyperparameter_tuning_with_hparams.ipynb
+++ b/docs/hyperparameter_tuning_with_hparams.ipynb
@@ -398,7 +398,7 @@
         "id": "UTWg9nXnxWWI"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"images/hparams_table.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"images/hparams_table.png?raw=1\"/> -->"
       ]
     },
     {
@@ -479,7 +479,7 @@
         "id": "Po7rTfQswAMT"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"images/hparams_parallel_coordinates.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"images/hparams_parallel_coordinates.png?raw=1\"/> -->"
       ]
     },
     {

--- a/docs/image_summaries.ipynb
+++ b/docs/image_summaries.ipynb
@@ -295,7 +295,7 @@
         "id": "c8n8YqGlT3-c"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/> -->"
       ]
     },
     {
@@ -346,7 +346,7 @@
         "id": "Fr6LFQG9UD6z"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_multiple.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_multiple.png?raw=1\"/> -->"
       ]
     },
     {
@@ -423,7 +423,7 @@
         "id": "o_tIghRsXY7S"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_arbitrary.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_arbitrary.png?raw=1\"/> -->"
       ]
     },
     {
@@ -601,9 +601,9 @@
         "id": "o7PnxGf8Ur6F"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_accuracy.png?raw=1\"/>\n",
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_accuracy.png?raw=1\"/> -->\n",
         "\n",
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_cm.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_cm.png?raw=1\"/> -->"
       ]
     },
     {

--- a/docs/scalars_and_keras.ipynb
+++ b/docs/scalars_and_keras.ipynb
@@ -251,7 +251,7 @@
         "id": "QmQHlG10Kpu2"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/scalars_loss.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/scalars_loss.png?raw=1\"/> -->"
       ]
     },
     {
@@ -413,7 +413,7 @@
         "id": "GkIahGZKK9I7"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/scalars_custom_lr.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/scalars_custom_lr.png?raw=1\"/> -->"
       ]
     },
     {

--- a/docs/tensorboard_in_notebooks.ipynb
+++ b/docs/tensorboard_in_notebooks.ipynb
@@ -291,7 +291,7 @@
         "id": "Po7rTfQswAMT"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/notebook_tensorboard.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/notebook_tensorboard.png?raw=1\"/> -->"
       ]
     },
     {
@@ -331,7 +331,7 @@
         "id": "ALxC8BbWWV91"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/notebook_tensorboard_two_runs.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/notebook_tensorboard_two_runs.png?raw=1\"/> -->"
       ]
     },
     {
@@ -423,7 +423,7 @@
         "id": "za2GqzKiWY-R"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/notebook_tensorboard_tall.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/notebook_tensorboard_tall.png?raw=1\"/> -->"
       ]
     }
   ],

--- a/docs/tensorboard_projector_plugin.ipynb
+++ b/docs/tensorboard_projector_plugin.ipynb
@@ -273,7 +273,7 @@
         "id": "YtzW8mr_wmbD"
       },
       "source": [
-        "<img class=\"tfo-display-only-on-site\" src=\"images/embedding_projector.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"images/embedding_projector.png?raw=1\"/> -->"
       ]
     },
     {
@@ -285,11 +285,11 @@
         "## Analysis\n",
         "The TensorBoard Projector is a great tool for analyzing your data and seeing embedding values relative to each other. The dashboard allows searching for specific terms, and highlights words that are nearby in the embedding space. From this example we can see that Wes **Anderson** and Alfred **Hitchcock** are both rather neutral terms, but that they are referenced in different contexts.\n",
         "\n",
-        "<img class=\"tfo-display-only-on-site\" src=\"images/embedding_projector_hitchcock.png?raw=1\"/>\n",
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"images/embedding_projector_hitchcock.png?raw=1\"/> -->\n",
         "\n",
         "Hitchcock is closer associated to words like `nightmare`, which likely relates to his work in horror movies. While Anderson is closer to the word `heart`, reflecting his heartwarming style.\n",
         "\n",
-        "<img class=\"tfo-display-only-on-site\" src=\"images/embedding_projector_anderson.png?raw=1\"/>"
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"images/embedding_projector_anderson.png?raw=1\"/> -->"
       ]
     }
   ],


### PR DESCRIPTION
These will be uncommented in the site-import pipeline.

The goal here is to make the output less confusing when run in colab.

The code to make these replacements was:

```
import pathlib
import re

for path in pathlib.Path('.').rglob('*.ipynb'):
  content = path.read_text()
  new_content = re.sub('(<.*?tfo-display-only-on-site.*?/>)', r'<!-- \1 -->', content)
  if content != new_content:
    print(path)

  path.write_text(new_content)
```

see cl/356365619 , b/124898762 for context. 