### PR TITLE
rust: remove copy in GCS reading

### DIFF
--- a/tensorboard/data/server/BUILD
+++ b/tensorboard/data/server/BUILD
@@ -53,6 +53,7 @@ rust_library(
         "//tensorboard/data/server/cargo:async_stream",
         "//tensorboard/data/server/cargo:base64",
         "//tensorboard/data/server/cargo:byteorder",
+        "//tensorboard/data/server/cargo:bytes",
         "//tensorboard/data/server/cargo:clap",
         "//tensorboard/data/server/cargo:crc",
         "//tensorboard/data/server/cargo:env_logger",


### PR DESCRIPTION
Summary:
We now let `gcs::Client::read` return `Bytes` rather than `Vec<u8>` so
that it can pass the response body directly from the HTTP client to the
caller, without additional copying.

For end-to-end speed, benchmarks suggest that this is inconclusive:

dataset     | before (s)   | after (s)   | improvement factor
------------|--------------|-------------|--------------------
`mnist`     | 1.12 ± 0.14  | 1.05 ± 0.06 | 1.05 ± 0.14
`edge_cgan` | 21.0 ± 2.0   | 20.1 ± 0.6  | 1.05 ± 0.11

The confidence intervals clearly overlap. But this change eliminates a
large copy and simplifies the code a bit, so it’s nice to have anyway.

Test Plan:
Type checking suffices; smoke testing `gs://tensorboard-bench-logs/mnist`
with `--load_fast` also checks out.

wchargin-branch: rust-gcs-read-no-copy
