### PR TITLE
pip: depend on `tensorboard-data-server`

### DIFF
--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -192,7 +192,6 @@ def _get_server_binary():
         return pkg_result
 
     raise RuntimeError(
-        "TensorBoard data server not found. This mode is experimental "
-        "and not supported in release builds. If building from source, "
-        "pass --define=link_data_server=true."
+        "TensorBoard data server not found. This mode is experimental. "
+        "If building from source, pass --define=link_data_server=true."
     )

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,6 +26,7 @@ numpy >= 1.12.0
 protobuf >= 3.6.0
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
+tensorboard-data-server >= 0.3.0, < 0.4.0
 tensorboard-plugin-wit >= 1.6.0
 werkzeug >= 0.11.15
 # python3 specifically requires wheel 0.26


### PR DESCRIPTION
Summary:
The `tensorboard` Pip package now depends on `tensorboard-data-server`.
Thus, users of standard TensorBoard may now pass `--load_fast` on
supported platforms. Users can still install TensorBoard even on a
platform that does not support the data server, because the data server
package includes a universal binary (`*-py3-none-any.whl`). This package
can always be installed, but does not implement any functionality, and
so attempting to use it with `--load_fast` will fail at runtime.

For now, we pin to exactly the v0.3.x minor series so that we can more
comfortably make breaking changes to the data server.

Test Plan:
Run `//tensorboard/pip_package:extract_pip_package` and install the
resulting wheel into a fresh virtualenv. Note that both TensorBoard and
the data server are installed, and that launching TensorBoard with
`--load_fast --verbosity 0` (a) logs that the data server is being
launched “from Python package” and (b) loads fast.

wchargin-branch: pip-data-server-dep
