### PR TITLE
Remove unnecessary "language in" setting

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -447,7 +447,6 @@ public final class Vulcanize {
     // Nice options.
     options.setColorizeErrorOutput(true);
     options.setContinueAfterErrors(true);
-    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2018);
     options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT_2015);
     options.setGenerateExports(true);
     options.setStrictModeInput(false);


### PR DESCRIPTION
Now that the default stable language_in value for Closure Compiler is ES2020,
there's no value to explicitly specifying an older language version.

In the future, we plan to get rid of settings older than the current default.

* Motivation for features / changes

* Technical description of changes

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
