### PR TITLE
types: remove `features` from FeatureFlag

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -39,7 +39,6 @@ export const getFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): FeatureFlags => {
     return {
-      ...('features' in state ? state.features : undefined),
       ...state.defaultFlags,
       ...state.flagOverrides,
     };

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -35,32 +35,6 @@ describe('feature_flag_selectors', () => {
       );
     });
 
-    it('prefers required `defaultFlags` over features', () => {
-      const state = buildState(
-        buildFeatureFlagState({
-          features: {
-            enabledExperimentalPlugins: ['foo', 'bar'],
-            enableGpuChart: true,
-            inColab: false,
-            scalarsBatchSize: 10,
-          },
-          defaultFlags: {
-            enabledExperimentalPlugins: ['foo'],
-            enableGpuChart: false,
-            inColab: false,
-            scalarsBatchSize: 10,
-          },
-        })
-      );
-
-      expect(selectors.getFeatureFlags(state)).toEqual({
-        enabledExperimentalPlugins: ['foo'],
-        enableGpuChart: false,
-        inColab: false,
-        scalarsBatchSize: 10,
-      });
-    });
-
     it('does not combine array flags', () => {
       const state = buildState(
         buildFeatureFlagState({

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -19,12 +19,6 @@ import {FeatureFlagState} from './feature_flag_types';
 
 export const initialState: FeatureFlagState = {
   isFeatureFlagsLoaded: false,
-  features: {
-    enabledExperimentalPlugins: [],
-    inColab: false,
-    enableGpuChart: false,
-    scalarsBatchSize: undefined,
-  },
   defaultFlags: {
     enabledExperimentalPlugins: [],
     inColab: false,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -19,20 +19,9 @@ export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 
 export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;
-  // Temporarily define `features` while we are migrating and syncing.
-  features?: FeatureFlags;
   defaultFlags: FeatureFlags;
   flagOverrides?: Partial<FeatureFlags>;
 }
-
-export interface FeatureFlagStateAfterMigration {
-  isFeatureFlagsLoaded: boolean;
-  defaultFlags: FeatureFlags;
-  flagOverrides?: Partial<FeatureFlags>;
-}
-
-type FeatureFlagMigration = FeatureFlagStateAfterMigration | FeatureFlagState;
-
 export interface State {
-  [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagMigration;
+  [FEATURE_FLAG_FEATURE_KEY]?: FeatureFlagState;
 }


### PR DESCRIPTION
This is last of the type upgrades we are making. This change removes
last remains of `features` in favor of `defaultFlags` and
`flagOverrides` in the FeatureFlag reducers.
