### PR TITLE
Plumb --samples_per_plugin to Rust data server

### DIFF
--- a/tensorboard/data/server/bench.rs
+++ b/tensorboard/data/server/bench.rs
@@ -18,6 +18,7 @@ limitations under the License.
 use clap::Clap;
 use log::info;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Instant;
 
 use rustboard_core::cli::dynamic_logdir::DynLogdir;
@@ -46,7 +47,12 @@ fn main() {
 
     let commit = Commit::new();
     let logdir = DynLogdir::new(opts.logdir).expect("DynLogdir::new");
-    let mut loader = LogdirLoader::new(&commit, logdir, opts.reload_threads.unwrap_or(0));
+    let mut loader = LogdirLoader::new(
+        &commit,
+        logdir,
+        opts.reload_threads.unwrap_or(0),
+        Arc::new(None),
+    );
     loader.checksum(opts.checksum); // if neither `--[no-]checksum` given, defaults to false
 
     info!("Starting load cycle");

--- a/tensorboard/data/server/bench.rs
+++ b/tensorboard/data/server/bench.rs
@@ -21,9 +21,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
-use rustboard_core::cli::dynamic_logdir::DynLogdir;
 use rustboard_core::commit::Commit;
 use rustboard_core::logdir::LogdirLoader;
+use rustboard_core::{cli::dynamic_logdir::DynLogdir, types::PluginSamplingHint};
 
 #[derive(Clap)]
 struct Opts {
@@ -51,7 +51,7 @@ fn main() {
         &commit,
         logdir,
         opts.reload_threads.unwrap_or(0),
-        Arc::new(None),
+        Arc::new(PluginSamplingHint::default()),
     );
     loader.checksum(opts.checksum); // if neither `--[no-]checksum` given, defaults to false
 

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -119,14 +119,13 @@ struct Opts {
 
     /// Set explicit series sampling
     ///
-    /// A comma separated list of plugin_name=num_samples pairs to explicitly specify how many
+    /// A comma separated list of `plugin_name=num_samples` pairs to explicitly specify how many
     /// samples to keep per tag for the specified plugin. For unspecified plugins, series are
     /// randomly downsampled to reasonable values to prevent out-of-memory errors in long running
-    /// jobs. Setting a plugin's num_samples to `0` will keep all samples for that plugin. For
-    /// instance, `--samples_per_plugin=scalars=500,images=0` keeps 500 events in each scalar series
-    /// and preserves all images.
-    #[clap(long)]
-    samples_per_plugin: Option<PluginSamplingHint>,
+    /// jobs. For instance, `--samples_per_plugin=scalars=500,images=0` keeps 500 events in each
+    /// scalar series and keeps none of the images.
+    #[clap(long, default_value = "", setting(clap::ArgSettings::AllowEmptyValues))]
+    samples_per_plugin: PluginSamplingHint,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/tensorboard/data/server/logdir.rs
+++ b/tensorboard/data/server/logdir.rs
@@ -77,7 +77,7 @@ pub struct LogdirLoader<'a, L: Logdir> {
     /// Whether new run loaders should unconditionally verify CRCs (see [`RunLoader::checksum`]).
     checksum: bool,
     /// A map defining how many samples per plugin to keep.
-    plugin_sampling_hint: Arc<Option<PluginSamplingHint>>,
+    plugin_sampling_hint: Arc<PluginSamplingHint>,
 }
 
 type Discoveries = HashMap<Run, Vec<EventFileBuf>>;
@@ -101,7 +101,7 @@ where
         commit: &'a Commit,
         logdir: L,
         reload_threads: usize,
-        plugin_sampling_hint: Arc<Option<PluginSamplingHint>>,
+        plugin_sampling_hint: Arc<PluginSamplingHint>,
     ) -> Self {
         let thread_pool = rayon::ThreadPoolBuilder::new()
             .num_threads(reload_threads)
@@ -285,7 +285,8 @@ mod tests {
 
         let commit = Commit::new();
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
-        let mut loader = LogdirLoader::new(&commit, logdir, 1, Arc::new(None));
+        let mut loader =
+            LogdirLoader::new(&commit, logdir, 1, Arc::new(PluginSamplingHint::default()));
 
         // Check that we persist the right run states in the loader.
         loader.reload();
@@ -340,7 +341,8 @@ mod tests {
 
         let commit = Commit::new();
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
-        let mut loader = LogdirLoader::new(&commit, logdir, 1, Arc::new(None));
+        let mut loader =
+            LogdirLoader::new(&commit, logdir, 1, Arc::new(PluginSamplingHint::default()));
 
         let get_run_names = || {
             let runs_store = commit.runs.read().unwrap();
@@ -391,7 +393,8 @@ mod tests {
 
         let commit = Commit::new();
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
-        let mut loader = LogdirLoader::new(&commit, logdir, 1, Arc::new(None));
+        let mut loader =
+            LogdirLoader::new(&commit, logdir, 1, Arc::new(PluginSamplingHint::default()));
         loader.reload();
 
         assert_eq!(
@@ -414,7 +417,8 @@ mod tests {
 
         let commit = Commit::new();
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
-        let mut loader = LogdirLoader::new(&commit, logdir, 1, Arc::new(None));
+        let mut loader =
+            LogdirLoader::new(&commit, logdir, 1, Arc::new(PluginSamplingHint::default()));
         loader.reload(); // should not hang
         Ok(())
     }

--- a/tensorboard/data/server/logdir.rs
+++ b/tensorboard/data/server/logdir.rs
@@ -20,10 +20,11 @@ use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::io::{self, Read};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::commit::Commit;
 use crate::run::RunLoader;
-use crate::types::Run;
+use crate::types::{PluginSamplingHint, Run};
 
 /// A TensorBoard log directory, with event files organized into runs.
 pub trait Logdir {
@@ -75,6 +76,8 @@ pub struct LogdirLoader<'a, L: Logdir> {
     runs: HashMap<Run, RunLoader<<L as Logdir>::File>>,
     /// Whether new run loaders should unconditionally verify CRCs (see [`RunLoader::checksum`]).
     checksum: bool,
+    /// A map defining how many samples per plugin to keep.
+    plugin_sampling_hint: Arc<Option<PluginSamplingHint>>,
 }
 
 type Discoveries = HashMap<Run, Vec<EventFileBuf>>;
@@ -94,7 +97,12 @@ where
     ///
     /// If [`rayon::ThreadPoolBuilder::build`] returns an error; should only happen if there is a
     /// failure to create threads at the OS level.
-    pub fn new(commit: &'a Commit, logdir: L, reload_threads: usize) -> Self {
+    pub fn new(
+        commit: &'a Commit,
+        logdir: L,
+        reload_threads: usize,
+        plugin_sampling_hint: Arc<Option<PluginSamplingHint>>,
+    ) -> Self {
         let thread_pool = rayon::ThreadPoolBuilder::new()
             .num_threads(reload_threads)
             .thread_name(|i| format!("Reloader-{:03}", i))
@@ -106,6 +114,7 @@ where
             logdir,
             runs: HashMap::new(),
             checksum: true,
+            plugin_sampling_hint,
         }
     }
 
@@ -176,8 +185,9 @@ where
         // Add new runs.
         for run_name in discoveries.keys() {
             let checksum = self.checksum;
+            let plugin_sampling_hint = self.plugin_sampling_hint.clone();
             self.runs.entry(run_name.clone()).or_insert_with(|| {
-                let mut loader = RunLoader::new(run_name.clone());
+                let mut loader = RunLoader::new(run_name.clone(), plugin_sampling_hint);
                 loader.checksum(checksum);
                 loader
             });
@@ -275,7 +285,7 @@ mod tests {
 
         let commit = Commit::new();
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
-        let mut loader = LogdirLoader::new(&commit, logdir, 1);
+        let mut loader = LogdirLoader::new(&commit, logdir, 1, Arc::new(None));
 
         // Check that we persist the right run states in the loader.
         loader.reload();
@@ -330,7 +340,7 @@ mod tests {
 
         let commit = Commit::new();
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
-        let mut loader = LogdirLoader::new(&commit, logdir, 1);
+        let mut loader = LogdirLoader::new(&commit, logdir, 1, Arc::new(None));
 
         let get_run_names = || {
             let runs_store = commit.runs.read().unwrap();
@@ -381,7 +391,7 @@ mod tests {
 
         let commit = Commit::new();
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
-        let mut loader = LogdirLoader::new(&commit, logdir, 1);
+        let mut loader = LogdirLoader::new(&commit, logdir, 1, Arc::new(None));
         loader.reload();
 
         assert_eq!(
@@ -404,7 +414,7 @@ mod tests {
 
         let commit = Commit::new();
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
-        let mut loader = LogdirLoader::new(&commit, logdir, 1);
+        let mut loader = LogdirLoader::new(&commit, logdir, 1, Arc::new(None));
         loader.reload(); // should not hang
         Ok(())
     }

--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -68,7 +68,7 @@ enum EventFile<R> {
 }
 
 /// Holds data staged by a `RunLoader` that will be committed to the `Commit`.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct RunLoaderData {
     /// The earliest event `wall_time` seen in any event file in this run.
     ///
@@ -193,10 +193,7 @@ impl<R: Read> RunLoader<R> {
             run,
             files: BTreeMap::new(),
             checksum: true,
-            data: RunLoaderData {
-                plugin_sampling_hint,
-                ..RunLoaderData::default()
-            },
+            data: RunLoaderData::new(plugin_sampling_hint),
         }
     }
 
@@ -315,6 +312,14 @@ impl<R: Read> RunLoader<R> {
 }
 
 impl RunLoaderData {
+    fn new(plugin_sampling_hint: Arc<PluginSamplingHint>) -> Self {
+        Self {
+            start_time: None,
+            time_series: HashMap::new(),
+            plugin_sampling_hint,
+        }
+    }
+
     /// Commits all staged data into the given run of the commit.
     fn commit_all(&mut self, run_data: &RwLock<commit::RunData>) {
         let mut run = run_data.write().expect("acquiring tags lock");

--- a/tensorboard/data/server/types.rs
+++ b/tensorboard/data/server/types.rs
@@ -92,23 +92,33 @@ impl Borrow<str> for Run {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ParsePluginSamplingHintError {
+    #[error("hint components should be of the form `plugin=num_samples`, but found {part:?}")]
+    SyntaxError { part: String },
+    #[error(transparent)]
+    ParseIntError(#[from] std::num::ParseIntError),
+}
+
 /// A map defining how many samples per plugin to keep.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PluginSamplingHint(pub HashMap<String, usize>);
 
 impl FromStr for PluginSamplingHint {
-    type Err = <usize as FromStr>::Err;
+    type Err = ParsePluginSamplingHintError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut result = HashMap::new();
+        if s.is_empty() {
+            return Ok(PluginSamplingHint(result));
+        }
         for pair_str in s.split(',') {
             let pair: Vec<_> = pair_str.split('=').collect();
-            if pair.len() != 2 {
-                error!("While parsing plugin sampling hint: {}", s);
-                std::process::exit(1);
+            if pair.len() != 2 || pair[0].is_empty() {
+                return Err(ParsePluginSamplingHintError::SyntaxError {
+                    part: pair_str.to_string(),
+                });
             }
-            let num_samples = pair[1]
-                .parse::<usize>()
-                .expect("Cannot parse a non-integer sampling hint");
+            let num_samples = pair[1].parse::<usize>()?;
             let plugin_name: String = pair[0].to_string();
             result.insert(plugin_name, num_samples);
         }
@@ -166,15 +176,33 @@ mod tests {
 
     #[test]
     fn test_plugin_sampling_hint() {
-        let samples_per_plugin: &str = "scalars=500,images=0,unknown=10";
-        let mut expected: HashMap<String, usize> = HashMap::new();
-        expected.insert("scalars".to_string(), 500);
-        expected.insert("images".to_string(), 0);
-        expected.insert("unknown".to_string(), 10);
+        // Parse from a valid hint with arbitrary plugin names.
+        let hint1 = "scalars=500,images=0,unknown=10".parse::<PluginSamplingHint>();
+        let mut expected1: HashMap<String, usize> = HashMap::new();
+        expected1.insert("scalars".to_string(), 500);
+        expected1.insert("images".to_string(), 0);
+        expected1.insert("unknown".to_string(), 10);
+        assert_eq!(hint1.unwrap().0, expected1);
 
-        assert_eq!(
-            PluginSamplingHint::from_str(samples_per_plugin).unwrap().0,
-            expected
-        );
+        // Parse from an empty hint.
+        let hint2 = "".parse::<PluginSamplingHint>();
+        let expected2: HashMap<String, usize> = HashMap::new();
+        assert_eq!(hint2.unwrap().0, expected2);
+
+        // Parse from an invalid hint.
+        match "x=1.5".parse::<PluginSamplingHint>().unwrap_err() {
+            ParsePluginSamplingHintError::ParseIntError(_) => (),
+            other => panic!("expected ParseIntError, got {:?}", other),
+        };
+
+        match "=1".parse::<PluginSamplingHint>().unwrap_err() {
+            ParsePluginSamplingHintError::SyntaxError { part: _ } => (),
+            other => panic!("expected SyntaxError, got {:?}", other),
+        };
+
+        match ",=,".parse::<PluginSamplingHint>().unwrap_err() {
+            ParsePluginSamplingHintError::SyntaxError { part: _ } => (),
+            other => panic!("expected SyntaxError, got {:?}", other),
+        };
     }
 }

--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -114,8 +114,14 @@ class SubprocessServerDataIngester(ingester.DataIngester):
             "--port=0",
             "--port-file=%s" % (port_file_path,),
             "--die-after-stdin",
-            "--samples-per-plugin=%s" % samples_per_plugin,
         ]
+        # Passing `--samples-per-plugin` conditionally is non-ideal, since
+        # older data servers (0.3.0) will still die when receiving this unknown
+        # flag explicitly. This flag may be provided unconditionally if servers
+        # support `--undefok` in the future.
+        # See https://github.com/clap-rs/clap/issues/2354.
+        if samples_per_plugin:
+            args.append("--samples-per-plugin=%s" % samples_per_plugin)
         if logger.isEnabledFor(logging.INFO):
             args.append("--verbose")
         if logger.isEnabledFor(logging.DEBUG):

--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -108,9 +108,8 @@ class SubprocessServerDataIngester(ingester.DataIngester):
             "--port=0",
             "--port-file=%s" % (port_file_path,),
             "--die-after-stdin",
+            "--samples-per-plugin=%s" % samples_per_plugin,
         ]
-        if samples_per_plugin:
-            args.append("--samples-per-plugin=%s" % samples_per_plugin)
         if logger.isEnabledFor(logging.INFO):
             args.append("--verbose")
         if logger.isEnabledFor(logging.DEBUG):

--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -60,7 +60,12 @@ class SubprocessServerDataIngester(ingester.DataIngester):
     """Start a new data server as a subprocess."""
 
     def __init__(
-        self, logdir, *, reload_interval, channel_creds_type, samples_per_plugin
+        self,
+        logdir,
+        *,
+        reload_interval,
+        channel_creds_type,
+        samples_per_plugin=None,
     ):
         """Initializes an ingester with the given configuration.
 
@@ -69,13 +74,14 @@ class SubprocessServerDataIngester(ingester.DataIngester):
           reload_interval: Number, as passed to `--reload_interval`.
           channel_creds_type: `grpc_util.ChannelCredsType`, as passed to
             `--grpc_creds_type`.
-          samples_per_plugin: String, as passed to `--samples_per_plugin`.
+          samples_per_plugin: Dict[String, Int], as parsed from
+            `--samples_per_plugin`.
         """
         self._data_provider = None
         self._logdir = logdir
         self._reload_interval = reload_interval
         self._channel_creds_type = channel_creds_type
-        self._samples_per_plugin = samples_per_plugin
+        self._samples_per_plugin = samples_per_plugin or {}
 
     @property
     def data_provider(self):

--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -59,7 +59,9 @@ class ExistingServerDataIngester(ingester.DataIngester):
 class SubprocessServerDataIngester(ingester.DataIngester):
     """Start a new data server as a subprocess."""
 
-    def __init__(self, logdir, *, reload_interval, channel_creds_type, samples_per_plugin):
+    def __init__(
+        self, logdir, *, reload_interval, channel_creds_type, samples_per_plugin
+    ):
         """Initializes an ingester with the given configuration.
 
         Args:
@@ -94,7 +96,9 @@ class SubprocessServerDataIngester(ingester.DataIngester):
         else:
             reload = str(int(self._reload_interval))
 
-        sample_hint_pairs = ["%s=%s" % (k, v) for k, v in self._samples_per_plugin.items()]
+        sample_hint_pairs = [
+            "%s=%s" % (k, v) for k, v in self._samples_per_plugin.items()
+        ]
         samples_per_plugin = ",".join(sample_hint_pairs)
 
         args = [

--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -59,7 +59,7 @@ class ExistingServerDataIngester(ingester.DataIngester):
 class SubprocessServerDataIngester(ingester.DataIngester):
     """Start a new data server as a subprocess."""
 
-    def __init__(self, logdir, *, reload_interval, channel_creds_type):
+    def __init__(self, logdir, *, reload_interval, channel_creds_type, samples_per_plugin):
         """Initializes an ingester with the given configuration.
 
         Args:
@@ -67,11 +67,13 @@ class SubprocessServerDataIngester(ingester.DataIngester):
           reload_interval: Number, as passed to `--reload_interval`.
           channel_creds_type: `grpc_util.ChannelCredsType`, as passed to
             `--grpc_creds_type`.
+          samples_per_plugin: String, as passed to `--samples_per_plugin`.
         """
         self._data_provider = None
         self._logdir = logdir
         self._reload_interval = reload_interval
         self._channel_creds_type = channel_creds_type
+        self._samples_per_plugin = samples_per_plugin
 
     @property
     def data_provider(self):
@@ -92,6 +94,9 @@ class SubprocessServerDataIngester(ingester.DataIngester):
         else:
             reload = str(int(self._reload_interval))
 
+        sample_hint_pairs = ["%s=%s" % (k, v) for k, v in self._samples_per_plugin.items()]
+        samples_per_plugin = ",".join(sample_hint_pairs)
+
         args = [
             server_binary,
             "--logdir=%s" % (self._logdir,),
@@ -100,6 +105,8 @@ class SubprocessServerDataIngester(ingester.DataIngester):
             "--port-file=%s" % (port_file_path,),
             "--die-after-stdin",
         ]
+        if samples_per_plugin:
+            args.append("--samples-per-plugin=%s" % samples_per_plugin)
         if logger.isEnabledFor(logging.INFO):
             args.append("--verbose")
         if logger.isEnabledFor(logging.DEBUG):

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -99,6 +99,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
             "--port=0",
             "--port-file=%s" % port_file,
             "--die-after-stdin",
+            "--samples-per-plugin=",
             "--verbose",  # logging is enabled in tests
         ]
         popen.assert_called_once_with(expected_args, stdin=subprocess.PIPE)

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -99,7 +99,6 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
             "--port=0",
             "--port-file=%s" % port_file,
             "--die-after-stdin",
-            "--samples-per-plugin=",
             "--verbose",  # logging is enabled in tests
         ]
         popen.assert_called_once_with(expected_args, stdin=subprocess.PIPE)

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -389,6 +389,7 @@ class TensorBoard(object):
                 logdir=flags.logdir,
                 reload_interval=flags.reload_interval,
                 channel_creds_type=flags.grpc_creds_type,
+                samples_per_plugin=flags.samples_per_plugin,
             )
         else:
             ingester = local_ingester.LocalDataIngester(flags)


### PR DESCRIPTION
Introduces a `--samples-per-plugin` flag on the Rust data server, which
takes the `--samples_per_plugin` flag from standard TensorBoard's CLI.
At the moment, this change makes the value of `0` interpreted as
"create a reservoir with capacity 0", while traditionally the value would be
interpreted as "create a reservoir with unbounded capacity". This
discrepancy will be fixed in a separate PR.

Test plan:
Added unit tests and ran with `cargo test`.
Ran `bazel run tensorboard:dev --define=link_data_server=true -- --load_fast --logdir <logdir> --bind_all --samples_per_plugin=scalars=5,images=0` and observed that scalar charts that normally show lots of points now only show 5, while images do not appear at all.
![image](https://user-images.githubusercontent.com/2322480/108343194-84ab9a00-7190-11eb-990a-57a257be9bfd.png)


Associated issue: "samples per plugin" item in the Rustboard task list #4422