### PR TITLE
projector: fix the KNN algorithm

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/knn.ts
+++ b/tensorboard/plugins/projector/vz_projector/knn.ts
@@ -74,6 +74,7 @@ export function findKNNGPUCosine<T>(
   const bigMatrixSquared = tf.matMul(bigMatrix, bigMatrixTransposed);
   const cosDist = tf.sub(1, bigMatrixSquared);
   const splits = tf.split(cosDist, numPieces, 1);
+
   function step(resolve: (result: NearestEntry[][]) => void) {
     let progressMsg =
       'Finding nearest neighbors: ' + (progress * 100).toFixed() + '%';
@@ -109,7 +110,7 @@ export function findKNNGPUCosine<T>(
             step(resolve);
           } else {
             logging.setModalMessage(null, KNN_GPU_MSG_ID);
-            // Discard all tenosrs and free up the memory.
+            // Discard all tensors and free up the memory.
             bigMatrix.dispose();
             bigMatrixTransposed.dispose();
             bigMatrixSquared.dispose();

--- a/tensorboard/plugins/projector/vz_projector/knn.ts
+++ b/tensorboard/plugins/projector/vz_projector/knn.ts
@@ -72,8 +72,8 @@ export function findKNNGPUCosine<T>(
   const bigMatrix = tf.tensor(typedArray, [N, dim]);
   const bigMatrixTransposed = bigMatrix.transpose();
   const bigMatrixSquared = tf.matMul(bigMatrix, bigMatrixTransposed);
-  const cosDist = tf.sub(1, bigMatrixSquared);
-  const splits = tf.split(cosDist, numPieces, 1);
+  const cosDistMatrix = tf.sub(1, bigMatrixSquared);
+  const splits = tf.split(cosDistMatrix, numPieces, 1);
 
   function step(resolve: (result: NearestEntry[][]) => void) {
     let progressMsg =
@@ -83,6 +83,7 @@ export function findKNNGPUCosine<T>(
         progressMsg,
         async () => {
           const B = piece < modulo ? M + 1 : M;
+          // `.data()` returns flattened Float32Array of B * N dimension.
           const partial = await splits[piece].data();
           progress += progressDiff;
           for (let i = 0; i < B; i++) {
@@ -114,7 +115,7 @@ export function findKNNGPUCosine<T>(
             bigMatrix.dispose();
             bigMatrixTransposed.dispose();
             bigMatrixSquared.dispose();
-            cosDist.dispose();
+            cosDistMatrix.dispose();
             splits.forEach((split) => split.dispose());
             resolve(nearest);
           }


### PR DESCRIPTION
Previosuly, we were using weblass for GPGPU which had to be replaced for
its lack of security patch. In doing so, we replaced the matmul with
TF.js but we did an incorrect cosine distance computation because we did
not transpose the matrix but instead reshaped it.

With this change, we now calculate the cosine distance better and even
more efficiently using the batch/slice to move less data away from GPU.

Fixes #4687.