### PR TITLE
line chart: enable GPU line chart by default

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -22,7 +22,7 @@ export const initialState: FeatureFlagState = {
   defaultFlags: {
     enabledExperimentalPlugins: [],
     inColab: false,
-    enableGpuChart: false,
+    enableGpuChart: true,
     scalarsBatchSize: undefined,
   },
   flagOverrides: {},


### PR DESCRIPTION
This change enables the GPU line chart, the new line chart
implementation, on by default in the time series dashboard. We will, in
the future*, remove the old implementation.

To disable the new implementation, you can pass `?fastChart=false` in the query param.

*: Probably after major/minor release of TensorBoard.