### PR TITLE
Fix uploader counts of scalars and tensors

### DIFF
--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -788,7 +788,6 @@ class _TensorBatchedRequestSender(object):
         point.value.CopyFrom(value.tensor)
         util.set_timestamp(point.wall_time, event.wall_time)
 
-        self._num_values += 1
         self._tensor_bytes += point.value.ByteSize()
         if point.value.ByteSize() > self._max_tensor_point_size:
             logger.warning(
@@ -811,6 +810,7 @@ class _TensorBatchedRequestSender(object):
 
         try:
             self._byte_budget_manager.add_point(point)
+            self._num_values += 1
         except _OutOfSpaceError:
             tag_proto.points.pop()
             raise

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -529,7 +529,6 @@ class _ScalarBatchedRequestSender(object):
                 raise RuntimeError("add_event failed despite flush")
 
     def _add_event_internal(self, run_name, event, value, metadata):
-        self._num_values += 1
         run_proto = self._runs.get(run_name)
         if run_proto is None:
             run_proto = self._create_run(run_name)
@@ -539,6 +538,7 @@ class _ScalarBatchedRequestSender(object):
             tag_proto = self._create_tag(run_proto, value.tag, metadata)
             self._tags[(run_name, value.tag)] = tag_proto
         self._create_point(tag_proto, event, value)
+        self._num_values += 1
 
     def flush(self):
         """Sends the active request after removing empty runs and tags.

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -703,6 +703,7 @@ class _TensorBatchedRequestSender(object):
             tag_proto = self._create_tag(run_proto, value.tag, metadata)
             self._tags[(run_name, value.tag)] = tag_proto
         self._create_point(tag_proto, event, value, run_name)
+        self._num_values += 1
 
     def flush(self):
         """Sends the active request after removing empty runs and tags.
@@ -810,7 +811,6 @@ class _TensorBatchedRequestSender(object):
 
         try:
             self._byte_budget_manager.add_point(point)
-            self._num_values += 1
         except _OutOfSpaceError:
             tag_proto.points.pop()
             raise

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -201,7 +201,7 @@ def _create_scalar_request_sender(
     experiment_id=None,
     api=_USE_DEFAULT,
     max_request_size=_USE_DEFAULT,
-    tracker=None
+    tracker=None,
 ):
     if api is _USE_DEFAULT:
         api = _create_mock_client()
@@ -221,7 +221,7 @@ def _create_tensor_request_sender(
     api=_USE_DEFAULT,
     max_request_size=_USE_DEFAULT,
     max_tensor_point_size=_USE_DEFAULT,
-    tracker=None
+    tracker=None,
 ):
     if api is _USE_DEFAULT:
         api = _create_mock_client()
@@ -1312,7 +1312,7 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
             mock_client,
             # Set a limit to request size
             max_request_size=1024,
-            tracker=tracker
+            tracker=tracker,
         )
         self._add_events(sender, "train", _apply_compat(events))
         sender.flush()
@@ -1687,7 +1687,7 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             mock_client,
             # Set a limit to request size
             max_request_size=1024,
-            tracker=tracker
+            tracker=tracker,
         )
         self._add_events(sender, "train", _apply_compat(events))
         sender.flush()


### PR DESCRIPTION
### Motivation for features / changes
Fix miscounting error when reporting size of uploads.

### Technical description of changes
The uploader posts values to the upload tracker, which in turn intermittently reports summaries of those values to the user during uploads.  When the upload is complete, upon user termination or after a `--one_shot` upload the total count is reported.  This change fixes a small error where there was over counting.

Specifically, the counts were double incremented in cases where the batch request had met a limit and, instead of acctually inserting a new value, a batch update request was sent.

### Detailed steps to verify changes work correctly (as executed by you)

Adds unit test to cover the case.
Verified uploading a directory of exactly 10k scalars reports exactly 10k scalars

```
$ bazel run tensorboard:tensorboard -- dev upload --logdir ~/tensorboard-logdirs/benchmark_scalars/1e1runs_1e0tags_1e4steps --one_shot
INFO: Analyzed target //tensorboard:tensorboard (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tensorboard:tensorboard up-to-date:
  bazel-bin/tensorboard/tensorboard
INFO: Elapsed time: 0.866s, Critical Path: 0.05s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action

New experiment created. View your TensorBoard at: https://tensorboard.dev/experiment/ntK0hvElQnuDALy9c80X9w/

[2021-02-22T18:05:46] Started scanning logdir.
[2021-02-22T18:07:32] Total uploaded: 100000 scalars, 0 tensors, 0 binary objects
[2021-02-22T18:07:32] Done scanning logdir.
```

googlers, this fixes internal bug b/180747617