### PR TITLE
timeseries: implement runs x-axis splitter

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -230,6 +230,7 @@ tf_ts_library(
         ":image_card",
         ":run_name",
         ":scalar_card",
+        ":scalar_card_types",
         ":utils",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -141,11 +141,22 @@ tf_ng_module(
 )
 
 tf_ts_library(
+    name = "scalar_card_types",
+    srcs = [
+        "scalar_card_types.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/widgets/line_chart_v2",
+    ],
+)
+
+tf_ts_library(
     name = "utils",
     srcs = [
         "utils.ts",
     ],
     deps = [
+        ":scalar_card_types",
         "//tensorboard/webapp/runs/store:types",
     ],
 )
@@ -164,13 +175,13 @@ tf_ng_module(
         "scalar_card_component.ts",
         "scalar_card_container.ts",
         "scalar_card_module.ts",
-        "scalar_card_types.ts",
     ],
     assets = [
         ":scalar_card_styles",
         "scalar_card_component.ng.html",
     ],
     deps = [
+        ":scalar_card_types",
         ":utils",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -425,11 +425,22 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
         const metadataMap: ScalarCardSeriesMetadataMap = {};
         const shouldSmooth = smoothing > 0;
 
-        for (const {seriesId, runId, displayName} of namedPartitionedSeries) {
+        for (const partitioned of namedPartitionedSeries) {
+          const {
+            seriesId,
+            runId,
+            displayName,
+            partitionIndex,
+            partitionSize,
+          } = partitioned;
+
           metadataMap[seriesId] = {
             type: SeriesType.ORIGINAL,
-            id: runId,
-            displayName,
+            id: seriesId,
+            displayName:
+              partitionSize > 1
+                ? `${displayName}: ${partitionIndex}`
+                : displayName,
             visible: Boolean(runSelectionMap && runSelectionMap.get(runId)),
             color: colorMap[runId] ?? '#fff',
             aux: false,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -1769,7 +1769,7 @@ describe('scalar card', () => {
             ],
           },
           {
-            id: 'run2',
+            id: '["run2",0]',
             points: [{wallTime: 2000, value: 1, step: 1, x: 1, y: 1}],
           },
         ]);
@@ -1780,7 +1780,7 @@ describe('scalar card', () => {
             type: SeriesType.ORIGINAL,
             visible: false,
             color: '#f00',
-            opacity: 0.6,
+            opacity: 1,
             aux: false,
           },
           '["run1",1]': {
@@ -1792,8 +1792,8 @@ describe('scalar card', () => {
             opacity: 1,
             aux: false,
           },
-          run2: {
-            id: 'run2',
+          '["run2",0]': {
+            id: '["run2",0]',
             displayName: 'run2',
             type: SeriesType.ORIGINAL,
             visible: false,
@@ -1861,7 +1861,7 @@ describe('scalar card', () => {
             type: SeriesType.ORIGINAL,
             visible: false,
             color: '#f00',
-            opacity: 0.6,
+            opacity: 1,
             aux: false,
           },
           '["run1",1]': {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -52,3 +52,18 @@ export interface ScalarCardPoint extends Point {
 }
 
 export type ScalarCardDataSeries = DataSeries<ScalarCardPoint>;
+
+export interface PartialSeries {
+  runId: string;
+  points: ScalarCardPoint[];
+}
+
+export interface PartitionedSeries {
+  // id that uniquely identifies a partitioned series. This may be derived from runId
+  // but is not interchangeable.
+  seriesId: string;
+  partitionIndex: number;
+  partitionSize: number;
+  runId: string;
+  points: ScalarCardPoint[];
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -46,6 +46,11 @@ export function partitionSeries(series: PartialSeries[]): PartitionedSeries[] {
     let currentPoints: PartitionedSeries['points'] = [];
 
     for (const point of datum.points) {
+      if (!Number.isFinite(point.x)) {
+        currentPoints.push(point);
+        continue;
+      }
+
       if (point.x < lastXValue) {
         currentPartition.push({
           seriesId: JSON.stringify([datum.runId, currentPartition.length]),

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -42,7 +42,9 @@ export function partitionSeries(series: PartialSeries[]): PartitionedSeries[] {
       PartitionedSeries,
       'partitionSize' | 'partitionIndex'
     >> = [];
-    let lastXValue = datum.points[0]?.x ?? 0;
+    let lastXValue = Number.isFinite(datum.points[0]?.x)
+      ? datum.points[0]!.x
+      : -Infinity;
     let currentPoints: PartitionedSeries['points'] = [];
 
     for (const point of datum.points) {

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Run} from '../../../runs/store/runs_types';
+import {PartialSeries, PartitionedSeries} from './scalar_card_types';
 
 export function getDisplayNameForRun(
   runId: string,
@@ -28,4 +29,48 @@ export function getDisplayNameForRun(
     .join('/');
 
   return displayName;
+}
+
+/**
+ * Partitions runs into pseudo runs when its points have non-monotonically increasing
+ * steps.
+ */
+export function partitionSeries(series: PartialSeries[]): PartitionedSeries[] {
+  const partitionedSeries: PartitionedSeries[] = [];
+  for (const datum of series) {
+    const currentPartition: Array<Omit<
+      PartitionedSeries,
+      'partitionSize' | 'partitionIndex'
+    >> = [];
+    let lastXValue = datum.points[0]?.x ?? 0;
+    let currentPoints: PartitionedSeries['points'] = [];
+
+    for (const point of datum.points) {
+      if (point.x < lastXValue) {
+        currentPartition.push({
+          seriesId: JSON.stringify([datum.runId, currentPartition.length]),
+          runId: datum.runId,
+          points: currentPoints,
+        });
+        currentPoints = [];
+      }
+      currentPoints.push(point);
+      lastXValue = point.x;
+    }
+
+    currentPartition.push({
+      seriesId: JSON.stringify([datum.runId, currentPartition.length]),
+      runId: datum.runId,
+      points: currentPoints,
+    });
+
+    for (let index = 0; index < currentPartition.length; index++) {
+      partitionedSeries.push({
+        ...currentPartition[index],
+        partitionIndex: index,
+        partitionSize: currentPartition.length,
+      });
+    }
+  }
+  return partitionedSeries;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -84,6 +84,50 @@ describe('metrics card_renderer utils test', () => {
       ]);
     });
 
+    it('behaves correctly with non-positive steps', () => {
+      const actual = partitionSeries([
+        {
+          runId: 'a',
+          points: buildPoints([0, -30, -15, -50]),
+        },
+        {
+          runId: 'b',
+          points: buildPoints([-2, -1, 0]),
+        },
+      ]);
+
+      expect(actual).toEqual([
+        {
+          seriesId: '["a",0]',
+          runId: 'a',
+          points: buildPoints([0]),
+          partitionIndex: 0,
+          partitionSize: 3,
+        },
+        {
+          seriesId: '["a",1]',
+          runId: 'a',
+          points: buildPoints([-30, -15]),
+          partitionIndex: 1,
+          partitionSize: 3,
+        },
+        {
+          seriesId: '["a",2]',
+          runId: 'a',
+          points: buildPoints([-50]),
+          partitionIndex: 2,
+          partitionSize: 3,
+        },
+        {
+          seriesId: '["b",0]',
+          runId: 'b',
+          points: buildPoints([-2, -1, 0]),
+          partitionIndex: 0,
+          partitionSize: 1,
+        },
+      ]);
+    });
+
     it('handles zero length points', () => {
       const actual = partitionSeries([
         {
@@ -162,6 +206,25 @@ describe('metrics card_renderer utils test', () => {
             seriesId: '["a",0]',
             runId: 'a',
             points: buildPoints([-1, Infinity, NaN]),
+            partitionIndex: 0,
+            partitionSize: 1,
+          },
+        ]);
+      });
+
+      it('does not put starting infinite in a separate partition', () => {
+        const actual = partitionSeries([
+          {
+            runId: 'a',
+            points: buildPoints([Infinity, 0, 1]),
+          },
+        ]);
+
+        expect(actual).toEqual([
+          {
+            seriesId: '["a",0]',
+            runId: 'a',
+            points: buildPoints([Infinity, 0, 1]),
             partitionIndex: 0,
             partitionSize: 1,
           },


### PR DESCRIPTION
Please refer to #4696 for definition of the monotonic step and what
problem we are trying to solve.

This change adds integration of the user setting to detect non-monotonic
step changes and split runs into sub runs. While this change is only
applied to the new GPU line chart, it can easily transfer to the legacy
one.

![image](https://user-images.githubusercontent.com/2547313/108788296-7fea3b80-752c-11eb-92da-dec9d7af27ae.png)
