### PR TITLE
timeseries: refactor scalar container data fetch

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -62,7 +62,7 @@ type StepDatum = ScalarStepDatum;
 
 export type SeriesPoint = Point<StepDatum>;
 
-export type SeriesDataList = Array<SeriesData<Metadata, StepDatum>>;
+export type LegacySeriesDataList = Array<SeriesData<Metadata, StepDatum>>;
 
 export type ScalarChartEvalPoint = EvaluationPoint<Metadata, StepDatum>;
 
@@ -138,7 +138,7 @@ export class ScalarCardComponent {
   @Input() runColorScale!: RunColorScale;
   @Input() ignoreOutliers!: boolean;
   @Input() scalarSmoothing!: number;
-  @Input() seriesDataList!: SeriesDataList;
+  @Input() seriesDataList!: LegacySeriesDataList;
 
   // gpu chart related props.
   @Input() isCardVisible!: boolean;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -63,7 +63,7 @@ import {
 import {CardId, CardMetadata, XAxisType} from '../../types';
 import {CardRenderer} from '../metrics_view_types';
 import {getTagDisplayName} from '../utils';
-import {SeriesDataList, SeriesPoint} from './scalar_card_component';
+import {LegacySeriesDataList} from './scalar_card_component';
 import {
   ScalarCardDataSeries,
   ScalarCardPoint,
@@ -77,8 +77,8 @@ type ScalarCardMetadata = CardMetadata & {
 };
 
 function areSeriesDataListEqual(
-  listA: SeriesDataList,
-  listB: SeriesDataList
+  listA: LegacySeriesDataList,
+  listB: LegacySeriesDataList
 ): boolean {
   if (listA.length !== listB.length) {
     return false;
@@ -100,14 +100,14 @@ function areSeriesDataListEqual(
   });
 }
 
-interface RunIdAndPoints {
-  runId: string;
+interface PartialSeries {
+  seriesId: string;
   points: ScalarCardPoint[];
 }
 
 function areSeriesEqual(
-  listA: RunIdAndPoints[],
-  listB: RunIdAndPoints[]
+  listA: PartialSeries[],
+  listB: PartialSeries[]
 ): boolean {
   if (listA.length !== listB.length) {
     return false;
@@ -117,7 +117,7 @@ function areSeriesEqual(
     const listAPoints = listAVal.points;
     const listBPoints = listBVal.points;
     return (
-      listAVal.runId === listBVal.runId &&
+      listAVal.seriesId === listBVal.seriesId &&
       listAPoints.length === listBPoints.length &&
       listAPoints.every((listAPoint, index) => {
         const listBPoint = listBPoints[index];
@@ -135,7 +135,7 @@ function areSeriesEqual(
       [runColorScale]="runColorScale"
       [title]="title$ | async"
       [tag]="tag$ | async"
-      [seriesDataList]="seriesDataList$ | async"
+      [seriesDataList]="legacySeriesDataList$ | async"
       [tooltipSort]="tooltipSort$ | async"
       [ignoreOutliers]="ignoreOutliers$ | async"
       [xAxisType]="xAxisType$ | async"
@@ -178,7 +178,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
   loadState$?: Observable<DataLoadState>;
   title$?: Observable<string>;
   tag$?: Observable<string>;
-  seriesDataList$?: Observable<SeriesDataList> = of([]);
+  legacySeriesDataList$?: Observable<LegacySeriesDataList> = of([]);
   isPinned$?: Observable<boolean>;
   dataSeries$?: Observable<ScalarCardDataSeries[]>;
   chartMetadataMap$?: Observable<ScalarCardSeriesMetadataMap>;
@@ -246,45 +246,53 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
       })
     );
 
-    const settingsAndTimeSeries$ = combineLatest([
-      this.store.select(getMetricsXAxisType),
-      this.store.select(getCardTimeSeries, this.cardId),
-    ]);
-    const runIdAndPoints$ = settingsAndTimeSeries$.pipe(
-      filter(([_, runToSeries]) => !!runToSeries),
-      map(
-        ([xAxisType, runToSeries]) =>
-          ({xAxisType, runToSeries} as {
-            xAxisType: XAxisType;
-            runToSeries: RunToSeries<PluginType.SCALARS>;
-          })
-      ),
-      map(({xAxisType, runToSeries}) => {
+    const nonNullRunsToScalarSeries$ = this.store
+      .select(getCardTimeSeries, this.cardId)
+      .pipe(
+        filter((runToSeries) => Boolean(runToSeries)),
+        map((runToSeries) => runToSeries as RunToSeries<PluginType.SCALARS>),
+        shareReplay(1)
+      );
+
+    const partialSeries$ = nonNullRunsToScalarSeries$.pipe(
+      combineLatestWith(this.store.select(getMetricsXAxisType)),
+      map(([runToSeries, xAxisType]) => {
         const runIds = Object.keys(runToSeries);
-        const results = runIds.map((runId) => {
+        const results = runIds.map((seriesId) => {
           return {
-            runId,
-            points: this.stepSeriesToLineSeries(runToSeries[runId], xAxisType),
+            seriesId,
+            points: this.stepSeriesToLineSeries(
+              runToSeries[seriesId],
+              xAxisType
+            ),
           };
         });
         return results;
       }),
-      distinctUntilChanged(areSeriesEqual),
-      shareReplay(1)
+      distinctUntilChanged(areSeriesEqual)
     );
 
-    this.seriesDataList$ = runIdAndPoints$.pipe(
-      switchMap((runIdAndPoints) => {
-        if (!runIdAndPoints.length) {
-          return of([]);
-        }
+    this.legacySeriesDataList$ = partialSeries$.pipe(
+      switchMap<PartialSeries[], Observable<LegacySeriesDataList>>(
+        (runIdAndPoints) => {
+          if (!runIdAndPoints.length) {
+            return of([] as LegacySeriesDataList);
+          }
 
-        return combineLatest(
-          runIdAndPoints.map((runIdAndPoint) => {
-            return this.getRunDisplayNameAndPoints(runIdAndPoint);
-          })
-        );
-      }),
+          const dataList$ = runIdAndPoints.map((runIdAndPoint) => {
+            return this.getRunDisplayName(runIdAndPoint.seriesId).pipe(
+              map<string, LegacySeriesDataList[number]>((displayName) => {
+                return {
+                  ...runIdAndPoint,
+                  metadata: {displayName},
+                  visible: false,
+                };
+              })
+            );
+          });
+          return combineLatest(dataList$);
+        }
+      ),
       combineLatestWith(this.store.select(getCurrentRouteRunSelection)),
       // When the `fetchRunsSucceeded` action fires, the run selection
       // map and the metadata change. To prevent quick fire of changes,
@@ -292,82 +300,98 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
       // store change.
       debounceTime(0),
       map(([result, runSelectionMap]) => {
-        return result.map(({runId, displayName, points}) => {
+        return result.map((seriesData) => {
           return {
-            seriesId: runId,
-            metadata: {displayName},
-            points,
-            visible: Boolean(runSelectionMap && runSelectionMap.get(runId)),
+            ...seriesData,
+            visible: Boolean(
+              runSelectionMap && runSelectionMap.get(seriesData.seriesId)
+            ),
           };
         });
       }),
-      startWith([]),
+      startWith([] as LegacySeriesDataList),
       distinctUntilChanged(areSeriesDataListEqual)
-    );
+    ) as Observable<LegacySeriesDataList>;
 
     function getSmoothedSeriesId(seriesId: string): string {
       return JSON.stringify(['smoothed', seriesId]);
     }
 
-    this.dataSeries$ = runIdAndPoints$.pipe(
-      combineLatestWith(
-        this.store.select(getMetricsScalarSmoothing),
-        this.store.select(getMetricsXAxisType)
-      ),
-      switchMap(([runsData, smoothing, xAxisType]) => {
-        const dataSeriesList = runsData.map(({runId, points}) => {
-          points = points.map((point) => {
-            // Convert wallTime in seconds to milliseconds.
-            // TODO(stephanwlee): when the legacy line chart is removed, do the conversion at
-            // the effects.
+    this.dataSeries$ = partialSeries$.pipe(
+      combineLatestWith(this.store.select(getMetricsXAxisType)),
+      // Normalize time and, optionally, compute relative time.
+      map(([partialSeries, xAxisType]) => {
+        return partialSeries.map((partial) => {
+          // Normalize data and convert wallTime in seconds to milliseconds.
+          // TODO(stephanwlee): when the legacy line chart is removed, do the conversion
+          // at the effects.
+          let normalizedPoints = partial.points.map((point) => {
             const wallTime = point.wallTime * 1000;
             const x = xAxisType === XAxisType.STEP ? point.x : wallTime;
+
             return {...point, x, wallTime};
           });
 
-          if (xAxisType === XAxisType.RELATIVE && points.length) {
-            const firstPoint = points[0];
-            points = points.map((point) => ({
+          if (xAxisType === XAxisType.RELATIVE && normalizedPoints.length) {
+            const firstPoint = normalizedPoints[0];
+            normalizedPoints = normalizedPoints.map((point) => ({
               ...point,
               x: point.x - firstPoint.x,
             }));
           }
-          return {id: runId, points};
+
+          return {seriesId: partial.seriesId, points: normalizedPoints};
         });
-
-        if (smoothing === 0) {
-          return of(dataSeriesList);
-        }
-
-        return from(classicSmoothing(dataSeriesList, smoothing)).pipe(
-          map((smoothedDataSeriesList) => {
-            const smoothedList = dataSeriesList.map((dataSeries, index) => {
-              return {
-                id: getSmoothedSeriesId(dataSeries.id),
-                points: smoothedDataSeriesList[index].points.map(
-                  ({y}, pointIndex) => {
-                    return {...dataSeries.points[pointIndex], y};
-                  }
-                ),
-              };
-            });
-            return [...dataSeriesList, ...smoothedList];
-          })
-        );
       }),
-      startWith([]),
-      shareReplay(1)
+      // Smooth
+      combineLatestWith(this.store.select(getMetricsScalarSmoothing)),
+      switchMap<[PartialSeries[], number], Observable<ScalarCardDataSeries[]>>(
+        ([runsData, smoothing]) => {
+          const cleanedRunsData = runsData.map(({seriesId, points}) => ({
+            id: seriesId,
+            points,
+          }));
+          if (smoothing <= 0) {
+            return of(cleanedRunsData);
+          }
+
+          return from(classicSmoothing(cleanedRunsData, smoothing)).pipe(
+            map((smoothedDataSeriesList) => {
+              const smoothedList = cleanedRunsData.map((dataSeries, index) => {
+                return {
+                  id: getSmoothedSeriesId(dataSeries.id),
+                  points: smoothedDataSeriesList[index].points.map(
+                    ({y}, pointIndex) => {
+                      return {...dataSeries.points[pointIndex], y};
+                    }
+                  ),
+                };
+              });
+              return [...cleanedRunsData, ...smoothedList];
+            })
+          );
+        }
+      ),
+      startWith([] as ScalarCardDataSeries[])
     );
 
-    this.chartMetadataMap$ = runIdAndPoints$.pipe(
-      switchMap((runIdAndPoints) => {
-        if (!runIdAndPoints.length) {
+    this.chartMetadataMap$ = nonNullRunsToScalarSeries$.pipe(
+      switchMap<
+        RunToSeries<PluginType.SCALARS>,
+        Observable<Array<{seriesId: string; displayName: string}>>
+      >((runToSeries) => {
+        const runIds = Object.keys(runToSeries);
+        if (!runIds.length) {
           return of([]);
         }
 
         return combineLatest(
-          runIdAndPoints.map((runIdAndPoint) => {
-            return this.getRunDisplayNameAndPoints(runIdAndPoint);
+          runIds.map((seriesId) => {
+            return this.getRunDisplayName(seriesId).pipe(
+              map((displayName) => {
+                return {seriesId, displayName};
+              })
+            );
           })
         );
       }),
@@ -381,17 +405,17 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
       // debounce by a microtask to emit only single change for the runs
       // store change.
       debounceTime(0),
-      map(([displayNameAndPoints, runSelectionMap, colorMap, smoothing]) => {
+      map(([seriesAndDisplayNames, runSelectionMap, colorMap, smoothing]) => {
         const metadataMap: ScalarCardSeriesMetadataMap = {};
         const shouldSmooth = smoothing > 0;
 
-        for (const {displayName, runId} of displayNameAndPoints) {
-          metadataMap[runId] = {
+        for (const {seriesId, displayName} of seriesAndDisplayNames) {
+          metadataMap[seriesId] = {
             type: SeriesType.ORIGINAL,
-            id: runId,
+            id: seriesId,
             displayName,
-            visible: Boolean(runSelectionMap && runSelectionMap.get(runId)),
-            color: colorMap[runId] ?? '#fff',
+            visible: Boolean(runSelectionMap && runSelectionMap.get(seriesId)),
+            color: colorMap[seriesId] ?? '#fff',
             aux: false,
             opacity: 1,
           };
@@ -409,7 +433,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
             type: SeriesType.DERIVED,
             aux: false,
             originalSeriesId: id,
-            opacity: 1,
           };
 
           metadata.aux = true;
@@ -417,7 +440,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
         }
         return metadataMap;
       }),
-      startWith({})
+      startWith({} as ScalarCardSeriesMetadataMap)
     );
 
     this.loadState$ = this.store.select(getCardLoadState, this.cardId);
@@ -437,23 +460,18 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
     this.isPinned$ = this.store.select(getCardPinnedState, this.cardId);
   }
 
-  private getRunDisplayNameAndPoints(runIdAndPoint: {
-    runId: string;
-    points: SeriesPoint[];
-  }): Observable<{runId: string; displayName: string; points: SeriesPoint[]}> {
-    const {runId, points} = runIdAndPoint;
+  private getRunDisplayName(runId: string): Observable<string> {
     return combineLatest([
       this.store.select(getExperimentIdForRunId, {runId}),
       this.store.select(getExperimentIdToAliasMap),
       this.store.select(getRun, {runId}),
     ]).pipe(
       map(([experimentId, idToAlias, run]) => {
-        const displayName = getDisplayNameForRun(
+        return getDisplayNameForRun(
           runId,
           run,
           experimentId ? idToAlias[experimentId] : null
         );
-        return {runId, displayName, points};
       })
     );
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -61,7 +61,7 @@ import {TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardComponent,
   ScalarChartEvalPoint,
-  SeriesDataList,
+  LegacySeriesDataList,
   TooltipColumns,
 } from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
@@ -78,7 +78,7 @@ import {
 class TestableLineChart {
   @Input() colorScale!: RunColorScale;
   @Input() tooltipColumns!: TooltipColumns;
-  @Input() seriesDataList!: SeriesDataList;
+  @Input() seriesDataList!: LegacySeriesDataList;
   @Input() smoothingEnabled!: boolean;
   @Input() ignoreYOutliers!: boolean;
   @Input() smoothingWeight!: number;


### PR DESCRIPTION
Previously, types flow through Observable in the scalars card container
was quite confusing with its typing and naming. This change refactors a
bit so it is easier by reorganizing and added certain types to be more
explicit.
