### PR TITLE
alerts: plumb followupAction into store

### DIFF
--- a/tensorboard/webapp/alert/store/BUILD
+++ b/tensorboard/webapp/alert/store/BUILD
@@ -48,6 +48,7 @@ tf_ts_library(
         ":testing",
         ":types",
         "//tensorboard/webapp/alert/actions",
+        "@npm//@ngrx/store",
         "@npm//@types/jasmine",
     ],
 )

--- a/tensorboard/webapp/alert/store/alert_reducers.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers.ts
@@ -26,10 +26,14 @@ const reducer = createReducer(
   initialState,
   on(
     actions.alertReported,
-    (state: AlertState, {localizedMessage}): AlertState => {
+    (state: AlertState, {localizedMessage, followupAction}): AlertState => {
       return {
         ...state,
-        latestAlert: {localizedMessage, created: Date.now()},
+        latestAlert: {
+          localizedMessage,
+          followupAction,
+          created: Date.now(),
+        },
       };
     }
   )

--- a/tensorboard/webapp/alert/store/alert_reducers_test.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers_test.ts
@@ -12,9 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {createAction} from '@ngrx/store';
+
 import * as alertActions from '../actions';
 import * as alertReducers from './alert_reducers';
 import {buildAlertState} from './testing';
+
+const retryForTestAction = createAction('[Test] Action Retried');
 
 describe('alert_reducers', () => {
   it('saves alerts with a timestamp', () => {
@@ -22,20 +26,33 @@ describe('alert_reducers', () => {
     const action1 = alertActions.alertReported({
       localizedMessage: 'Foo1 failed',
     });
+
+    const followupActionGetter = async () => {
+      return retryForTestAction();
+    };
     const action2 = alertActions.alertReported({
       localizedMessage: 'Foo2 failed',
+      followupAction: {
+        localizedLabel: 'Retry Foo2?',
+        getFollowupAction: followupActionGetter,
+      },
     });
     const state1 = buildAlertState({latestAlert: null});
 
     const state2 = alertReducers.reducers(state1, action1);
     expect(state2.latestAlert!).toEqual({
       localizedMessage: 'Foo1 failed',
+      followupAction: undefined,
       created: 123,
     });
 
     const state3 = alertReducers.reducers(state2, action2);
     expect(state3.latestAlert!).toEqual({
       localizedMessage: 'Foo2 failed',
+      followupAction: {
+        localizedLabel: 'Retry Foo2?',
+        getFollowupAction: followupActionGetter,
+      },
       created: 234,
     });
   });


### PR DESCRIPTION
The `Alerts` feature's views are responsible for handling and surfacing
alerts from actions in a "toast" UI. Modules may register a `followup`
action to explicitly show a "retry" style button that triggers a followup
action.

The retry button did not appear as expected, since the reducer was
only storing the `localizedMessage` field. This change includes the
optional `followupAction` as well.

Tested by manually modifying `metrics_module.ts`'s `alertFromAction`
registration to return a followup action:
```ts
return {
  localizedMessage: 'whoah message',
  followupAction: {
    localizedLabel: 'whoah label',
    getFollowupAction: async () => {
      console.log('yay')
      return actions.cardStepSliderChanged({cardId: 'blah', stepIndex: 0});
    },
  }
};
```
then after clicking the 'Pin' icon on a card to trigger the action, observed
that the followup action produces the desired retry button.
![image](https://user-images.githubusercontent.com/2322480/109215576-325a1280-7768-11eb-83ca-40398a0d14ce.png)
