### PR TITLE
rust: add rustfmt.toml to set `edition = "2018"`

### DIFF
--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -17,6 +17,7 @@
 name = "rustboard"
 version = "0.4.0-alpha.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
+# Keep in sync with `edition` in rustfmt.toml.
 edition = "2018"
 default-run = "rustboard"
 

--- a/tensorboard/data/server/rustfmt.toml
+++ b/tensorboard/data/server/rustfmt.toml
@@ -1,0 +1,19 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Keep in sync with `edition` in Cargo.toml. We replicate it here since
+# `rustfmt` only looks at Cargo.toml when run as `cargo fmt` and some editors
+# run `rustfmt` directly. See: https://github.com/rust-lang/rust-mode/issues/289
+edition = "2018"


### PR DESCRIPTION
This makes my emacs formatting work again now that we use `async`: https://github.com/rust-lang/rustfmt/issues/4454

The ideal solution would probably be if `rust-mode` were to inspect `Cargo.toml` and pass the edition from there into `rustfmt`, but this is a quicker fix than trying to send them that patch.  Also they previously "fixed the glitch" by [just defaulting `rust-mode` to 2018 edition](https://github.com/rust-lang/rust-mode/pull/338) so I'm not sure they would even take the patch; I still ran into this issue since internal to Google `rust-mode` is outdated.  Besides, it seems technically more correct to have the `rustfmt` edition derived from the repo rather than set to a global default that happens to work for our project.

