### PR TITLE
rust: fix a few Clippy warnings

### DIFF
--- a/tensorboard/data/server/data_compat.rs
+++ b/tensorboard/data/server/data_compat.rs
@@ -113,10 +113,10 @@ impl EventValue {
                     let w = format!("{}", im.width).into_bytes();
                     let h = format!("{}", im.height).into_bytes();
                     let buf = im.encoded_image_string;
-                    Ok(BlobSequenceValue(vec![w.into(), h.into(), buf.into()]))
+                    Ok(BlobSequenceValue(vec![w.into(), h.into(), buf]))
                 }
                 pb::summary::value::Value::Audio(au) => {
-                    Ok(BlobSequenceValue(vec![au.encoded_audio_string.into()]))
+                    Ok(BlobSequenceValue(vec![au.encoded_audio_string]))
                 }
                 pb::summary::value::Value::Tensor(mut tp)
                     if tp.dtype == i32::from(pb::DataType::DtString) =>

--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -117,7 +117,7 @@ impl StageTimeSeries {
     }
 
     fn capacity(
-        metadata: &Box<pb::SummaryMetadata>,
+        metadata: &pb::SummaryMetadata,
         plugin_sampling_hint: Arc<PluginSamplingHint>,
     ) -> usize {
         let data_class =


### PR DESCRIPTION
Summary:
Nothing critical: some unnecessary `.into()`s from #4677 and some
unnecessary `&Box<T>` double-indirection from #4689.

wchargin-branch: rust-clippy-fixes-20210225
