### PR TITLE
graph: fix TS types for SlimGraph, Hierarchy, RenderGraphInfo usage

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -86,9 +86,9 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     notify: true,
     observer: '_graphChanged',
   })
-  graphHierarchy: object;
+  graphHierarchy: tf_graph.Hierarchy;
   @property({type: Object})
-  basicGraph: object;
+  basicGraph: tf_graph.SlimGraph;
   @property({type: Object})
   stats: object;
   @property({type: Object})
@@ -132,7 +132,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     readOnly: true,
     notify: true,
   })
-  renderHierarchy: any;
+  renderHierarchy: tf_graph_render.RenderGraphInfo;
   @property({type: Boolean})
   traceInputs: boolean;
   @property({type: Array})
@@ -191,12 +191,12 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     if (this.graphHierarchy) {
       if (stats && devicesForStats) {
         tf_graph.joinStatsInfoWithGraph(
-          this.basicGraph as any,
+          this.basicGraph,
           stats as any,
           devicesForStats as any
         );
         tf_graph_hierarchy.joinAndAggregateStats(
-          this.graphHierarchy as any,
+          this.graphHierarchy,
           stats as any
         );
       }
@@ -283,10 +283,8 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
           };
         }
         anyThis._setColorByParams({
-          compute_time: getColorParamsFromScale(
-            renderGraph.computeTimeScale as any
-          ),
-          memory: getColorParamsFromScale(renderGraph.memoryUsageScale as any),
+          compute_time: getColorParamsFromScale(renderGraph.computeTimeScale),
+          memory: getColorParamsFromScale(renderGraph.memoryUsageScale),
           device: _.map(renderGraph.deviceColorMap.domain(), function (
             deviceName
           ) {
@@ -426,8 +424,8 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     var nodeName = event.detail.name;
     this.nodeToggleExtract(nodeName);
   }
-  nodeToggleExtract(nodeName) {
-    var renderNode = this.renderHierarchy.getRenderNodeByName(nodeName);
+  nodeToggleExtract(nodeName: string) {
+    const renderNode = this.renderHierarchy.getRenderNodeByName(nodeName);
     if (renderNode.node.include == tf_graph.InclusionType.INCLUDE) {
       renderNode.node.include = tf_graph.InclusionType.EXCLUDE;
     } else if (renderNode.node.include == tf_graph.InclusionType.EXCLUDE) {
@@ -468,7 +466,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
       'Namespace hierarchy'
     );
     tf_graph_hierarchy
-      .build(this.basicGraph as any, this.hierarchyParams, hierarchyTracker)
+      .build(this.basicGraph, this.hierarchyParams, hierarchyTracker)
       .then(
         function (graphHierarchy) {
           this.set('graphHierarchy', graphHierarchy);

--- a/tensorboard/plugins/graph/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/BUILD
@@ -15,6 +15,7 @@ tf_ts_library(
     deps = [
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/plugins/graph/tf_graph_board",
+        "//tensorboard/plugins/graph/tf_graph_common",
         "//tensorboard/plugins/graph/tf_graph_controls",
         "//tensorboard/plugins/graph/tf_graph_loader",
         "@npm//@polymer/decorators",

--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.ts
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.ts
@@ -18,6 +18,7 @@ import {customElement, property} from '@polymer/decorators';
 import '../tf_graph_board/tf-graph-board';
 import '../tf_graph_controls/tf-graph-controls';
 import '../tf_graph_loader/tf-graph-loader';
+import * as tf_graph_render from '../tf_graph_common/render';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 
 /**
@@ -158,7 +159,7 @@ class TfGraphApp extends LegacyElementMixin(PolymerElement) {
   })
   selectedNode: string;
   @property({type: Object})
-  _renderHierarchy: object;
+  _renderHierarchy: tf_graph_render.RenderGraphInfo;
   @property({type: Object})
   _progress: object;
   @property({type: Boolean})

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
@@ -19,6 +19,7 @@ import '../../../components/polymer/irons_and_papers';
 import '../tf_graph_info/tf-graph-info';
 import '../tf_graph/tf-graph';
 import * as tf_graph from '../tf_graph_common/graph';
+import * as tf_graph_render from '../tf_graph_common/render';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 
 /**
@@ -181,9 +182,9 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
     </div>
   `;
   @property({type: Object})
-  graphHierarchy: object;
+  graphHierarchy: tf_graph.Hierarchy;
   @property({type: Object})
-  graph: object;
+  graph: tf_graph.SlimGraph;
   @property({type: Object})
   stats: object;
   /**
@@ -206,7 +207,7 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
     type: Object,
     notify: true,
   })
-  renderHierarchy: any;
+  renderHierarchy: tf_graph_render.RenderGraphInfo;
   // Whether debugger data is enabled for this instance of Tensorboard.
   @property({type: Boolean})
   debuggerDataEnabled: boolean;

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -413,7 +413,7 @@ export interface HierarchyParams {
   // into series nodes.
   useGeneralizedSeriesPatterns: boolean;
 }
-export const DefaultHierarchyParams = {
+export const DefaultHierarchyParams: HierarchyParams = {
   verifyTemplate: true,
   seriesNodeMinSize: 5,
   seriesMap: {},

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -2185,12 +2185,12 @@ export function mapIndexToHue(id: number): number {
  */
 function extractHighDegrees(renderNode: RenderGroupNodeInfo) {
   extractSpecifiedNodes(renderNode);
-  if (PARAMS.outExtractTypes) {
+  if (PARAMS.outExtractTypes.length) {
     extractPredefinedSink(renderNode);
   }
   // This has to come before extract high in-degree to protect the core part
   // that takes many variables.
-  if (PARAMS.inExtractTypes) {
+  if (PARAMS.inExtractTypes.length) {
     extractPredefinedSource(renderNode);
   }
   extractHighInOrOutDegree(renderNode);

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -1052,7 +1052,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
   @property({
     type: Object,
   })
-  renderHierarchy: object;
+  renderHierarchy: tf_graph_render.RenderGraphInfo;
   /**
    * @type {!Selection}
    */

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -29,6 +29,7 @@ import '../tf_graph_board/tf-graph-board';
 import '../tf_graph_controls/tf-graph-controls';
 import '../tf_graph_loader/tf-graph-dashboard-loader';
 import * as tf_graph_op from '../tf_graph_common/op';
+import * as tf_graph_render from '../tf_graph_common/render';
 
 /**
  * The (string) name for the run of the selected dataset in the graph dashboard.
@@ -216,7 +217,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
   })
   _selectedDataset: number = 0;
   @property({type: Object, observer: '_renderHierarchyChanged'})
-  _renderHierarchy: any;
+  _renderHierarchy: tf_graph_render.RenderGraphInfo;
   @property({
     type: Object,
   })

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/tf-graph-debugger-data-card.ts
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/tf-graph-debugger-data-card.ts
@@ -284,7 +284,7 @@ class TfGraphDebuggerDataCard extends LegacyElementMixin(PolymerElement) {
     </paper-material>
   `;
   @property({type: Object})
-  renderHierarchy: any;
+  renderHierarchy: tf_graph_render.RenderGraphInfo;
   @property({
     type: Array,
     notify: true,

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.ts
@@ -17,6 +17,8 @@ import {PolymerElement, html} from '@polymer/polymer';
 import {customElement, property} from '@polymer/decorators';
 
 import '../../../components/polymer/irons_and_papers';
+import * as tf_graph from '../tf_graph_common/graph';
+import * as tf_graph_render from '../tf_graph_common/render';
 import '../tf_graph_debugger_data_card/tf-graph-debugger-data-card';
 import '../tf_graph_op_compat_card/tf-graph-op-compat-card';
 import './tf-node-info';
@@ -87,11 +89,11 @@ class TfGraphInfo extends LegacyElementMixin(PolymerElement) {
   @property({type: String})
   title: string;
   @property({type: Object})
-  graphHierarchy: object;
+  graphHierarchy: tf_graph.Hierarchy;
   @property({type: Object})
-  graph: object;
+  graph: tf_graph.SlimGraph;
   @property({type: Object})
-  renderHierarchy: object;
+  renderHierarchy: tf_graph_render.RenderGraphInfo;
   @property({type: Object})
   nodeNamesToHealthPills: object;
   @property({

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
@@ -17,12 +17,13 @@ import {PolymerElement} from '@polymer/polymer';
 import {customElement, observe, property} from '@polymer/decorators';
 
 import * as tf_graph_common from '../tf_graph_common/common';
-import * as tf_graph_controls from '../tf_graph_controls/tf-graph-controls';
+import * as tf_graph from '../tf_graph_common/graph';
 import * as tf_graph_hierarchy from '../tf_graph_common/hierarchy';
 import * as tf_graph_loader from '../tf_graph_common/loader';
 import * as tf_graph_op from '../tf_graph_common/op';
 import * as tf_graph_parser from '../tf_graph_common/parser';
 import * as tf_graph_util from '../tf_graph_common/util';
+import * as tf_graph_controls from '../tf_graph_controls/tf-graph-controls';
 
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import {getRouter} from '../../../components/tf_backend/router';
@@ -78,13 +79,13 @@ class TfGraphDashboardLoader extends LegacyElementMixin(PolymerElement) {
     readOnly: true, //readonly so outsider can't change this via binding
     notify: true,
   })
-  outGraphHierarchy: object;
+  outGraphHierarchy: tf_graph.Hierarchy;
   @property({
     type: Object,
     readOnly: true, //readonly so outsider can't change this via binding
     notify: true,
   })
-  outGraph: object;
+  outGraph: tf_graph.SlimGraph;
   @property({
     type: Object,
     readOnly: true, // This property produces data.
@@ -192,8 +193,8 @@ class TfGraphDashboardLoader extends LegacyElementMixin(PolymerElement) {
         tracker,
         path,
         pbTxtFile,
-        this.compatibilityProvider as any,
-        this.hierarchyParams as any
+        this.compatibilityProvider,
+        this.hierarchyParams
       )
       .then(
         function ({graph, graphHierarchy}) {

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
@@ -19,6 +19,7 @@ import * as d3 from 'd3';
 
 import '../../../components/polymer/irons_and_papers';
 import './tf-graph-op-compat-list-item';
+import * as tf_graph from '../tf_graph_common/graph';
 import * as tf_graph_hierarchy from '../tf_graph_common/hierarchy';
 import * as tf_graph_render from '../tf_graph_common/render';
 
@@ -179,11 +180,11 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
     </iron-collapse>
   `;
   @property({type: Object})
-  graphHierarchy: any;
+  graphHierarchy: tf_graph.Hierarchy;
   @property({type: Object})
   hierarchyParams: object;
   @property({type: Object})
-  renderHierarchy: any;
+  renderHierarchy: tf_graph_render.RenderGraphInfo;
   @property({type: String})
   nodeTitle: string;
   @property({


### PR DESCRIPTION
Minor, non-exhaustive set of TypeScript annotation changes related
to Graph code.

Googlers, see test sync cl/360315680.