### PR TITLE
Add ipynb tutorial for text summaries

### DIFF
--- a/docs/text_summaries.ipynb
+++ b/docs/text_summaries.ipynb
@@ -178,34 +178,7 @@
       "metadata": {
         "id": "T_X-wIy-lD9f"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "      <iframe id=\"tensorboard-frame-9381929c3767b97b\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-              "      </iframe>\n",
-              "      <script>\n",
-              "        (function() {\n",
-              "          const frame = document.getElementById(\"tensorboard-frame-9381929c3767b97b\");\n",
-              "          const url = new URL(\"/\", window.location);\n",
-              "          const port = 6007;\n",
-              "          if (port) {\n",
-              "            url.port = port;\n",
-              "          }\n",
-              "          frame.src = url;\n",
-              "        })();\n",
-              "      </script>\n",
-              "    "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "%tensorboard --logdir logs"
       ]
@@ -262,34 +235,7 @@
       "metadata": {
         "id": "515199f4b547"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "      <iframe id=\"tensorboard-frame-4a8120aa135ba5f2\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-              "      </iframe>\n",
-              "      <script>\n",
-              "        (function() {\n",
-              "          const frame = document.getElementById(\"tensorboard-frame-4a8120aa135ba5f2\");\n",
-              "          const url = new URL(\"/\", window.location);\n",
-              "          const port = 6010;\n",
-              "          if (port) {\n",
-              "            url.port = port;\n",
-              "          }\n",
-              "          frame.src = url;\n",
-              "        })();\n",
-              "      </script>\n",
-              "    "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "%tensorboard --logdir logs/multiple_texts --samples_per_plugin 'text=5'"
       ]
@@ -366,43 +312,7 @@
       "metadata": {
         "id": "57082d8d6839"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "Reusing TensorBoard on port 6008 (pid 44187), started 1 day, 16:31:45 ago. (Use '!kill 44187' to kill it.)"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "      <iframe id=\"tensorboard-frame-d949964a890a033\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-              "      </iframe>\n",
-              "      <script>\n",
-              "        (function() {\n",
-              "          const frame = document.getElementById(\"tensorboard-frame-d949964a890a033\");\n",
-              "          const url = new URL(\"/\", window.location);\n",
-              "          const port = 6008;\n",
-              "          if (port) {\n",
-              "            url.port = port;\n",
-              "          }\n",
-              "          frame.src = url;\n",
-              "        })();\n",
-              "      </script>\n",
-              "    "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "%tensorboard --logdir logs/markdown"
       ]

--- a/docs/text_summaries.ipynb
+++ b/docs/text_summaries.ipynb
@@ -1,327 +1,437 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "djUvWu41mtXa"
-      },
-      "source": [
-        "##### Copyright 2021 The TensorFlow Authors."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "su2RaORHpReL"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NztQK2uFpXT-"
-      },
-      "source": [
-        "# Displaying text data in TensorBoard\n",
-        "\n",
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/text_summaries\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eDXRFe_qp5C3"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "Using the **TensorFlow Text Summary API,** you can easily log arbitrary text and view it in TensorBoard. This can be extremely helpful to sample and examine your input data, or to [record execution metadata]() or [generated text]().  You can also log diagnostic data as text that can be helpful in the course of your model development.\n",
-        "\n",
-        "In this tutorial, you will try out some basic use cases of the Summary API."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dG-nnZK9qW9z"
-      },
-      "source": [
-        "## Setup"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3U5gdCw_nSG3"
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "  # %tensorflow_version only exists in Colab.\n",
-        "  %tensorflow_version 2.x\n",
-        "except Exception:\n",
-        "  pass\n",
-        "\n",
-        "# Load the TensorBoard notebook extension.\n",
-        "%load_ext tensorboard"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "1qIKtOBrqc9Y"
-      },
-      "outputs": [],
-      "source": [
-        "import tensorflow as tf\n",
-        "from tensorboard.plugins.text.summary_v2 import text\n",
-        "\n",
-        "from datetime import datetime\n",
-        "import json\n",
-        "from packaging import version\n",
-        "import tempfile\n",
-        "\n",
-        "print(\"TensorFlow version: \", tf.__version__)\n",
-        "assert version.parse(tf.__version__).release[0] >= 2, \\\n",
-        "    \"This notebook requires TensorFlow 2.0 or above.\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qNsjMY0364j4"
-      },
-      "source": [
-        "## Logging a single piece of text\n",
-        "\n",
-        "To understand how the Image Summary API works, you're going to simply log a bit of text and see how it is presented in tensorboard.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "FxMPcdmvBn9t"
-      },
-      "outputs": [],
-      "source": [
-        "my_text = \"Hello world! 😃\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "IJNpyVyxbVtT"
-      },
-      "outputs": [],
-      "source": [
-        "# Clear out any prior log data.\n",
-        "!rm -rf logs\n",
-        "\n",
-        "# Sets up a timestamped log directory.\n",
-        "logdir = \"logs/text_basics/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-        "# Creates a file writer for the log directory.\n",
-        "file_writer = tf.summary.create_file_writer(logdir)\n",
-        "\n",
-        "# Using the file writer, log the text.\n",
-        "with file_writer.as_default():\n",
-        "  tf.summary.text(\"My first text\", my_text, step=0)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rngALbRogXe6"
-      },
-      "source": [
-        "Now, use TensorBoard to examine the image. Wait a few seconds for the UI to spin up."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "T_X-wIy-lD9f"
-      },
-      "outputs": [],
-      "source": [
-        "%tensorboard --logdir logs"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "c8n8YqGlT3-c"
-      },
-      "source": [
-        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/> -->"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "34enxJjjgWi7"
-      },
-      "source": [
-        "## Organizing multiple text streams\n",
-        "\n",
-        "If you have multiple streams of text, you can keep them in separate namespaces to help organize them, just like scalars or other data.\n",
-        "\n",
-        "Note that if you log text at many steps, TensorBoard will subsample the steps to display.  Again, this behavior is the same as for scalars, where the data is subsampled to make the presentation manageable."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "dda6960f0119"
-      },
-      "outputs": [],
-      "source": [
-        "# Sets up a second directory to not overwrite the first one.\n",
-        "logdir = \"logs/multiple_texts/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-        "# Creates a file writer for the log directory.\n",
-        "file_writer = tf.summary.create_file_writer(logdir)\n",
-        "\n",
-        "# Using the file writer, log the text.\n",
-        "with file_writer.as_default():\n",
-        "  with tf.name_scope(\"Name scope 1\"):\n",
-        "    for step in range(20):\n",
-        "      tf.summary.text(\"a stream of text\", f\"Hello from step {step}\", step=step)\n",
-        "      tf.summary.text(\"another stream of text\", f\"This can be kept separate {step}\", step=step)\n",
-        "  with tf.name_scope(\"Name scope 2\"):\n",
-        "    tf.summary.text(\"just from step 0\", f\"This is an important announcement from step 0\", step=0)\n",
-        "    "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "515199f4b547"
-      },
-      "outputs": [],
-      "source": [
-        "%tensorboard --logdir logs"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bjACE1lAsqUd"
-      },
-      "source": [
-        "## Using markdown\n",
-        "\n",
-        "Tensorboard supports logging text in markdown to make it easier to read and understand."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "iHUjCXbetIpb"
-      },
-      "outputs": [],
-      "source": [
-        "# Sets up a third timestamped log directory under \"logs\"\n",
-        "logdir = \"logs/markdown/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-        "# Creates a file writer for the log directory.\n",
-        "file_writer = tf.summary.create_file_writer(logdir)\n",
-        "\n",
-        "some_obj_worth_noting = {\n",
-        "  \"tfds_training_data\": {\n",
-        "      \"name\": \"mnist\",\n",
-        "      \"split\": \"train\",\n",
-        "      \"shuffle_files\": \"True\",\n",
-        "  },\n",
-        "  \"keras_optimizer\": {\n",
-        "      \"name\": \"Adagrad\",\n",
-        "      \"learning_rate\": \"0.001\",\n",
-        "      \"epsilon\": 1e-07,\n",
-        "  },\n",
-        "  \"hardware\": \"Cloud TPU\",\n",
-        "}\n",
-        "\n",
-        "\n",
-        "def pretty_json(hp):\n",
-        "  json_hp = json.dumps(hp, indent=2)\n",
-        "  s = \"\"\n",
-        "  for line in json_hp.splitlines():\n",
-        "    s += \"\\t\" + line + \"\\n\"\n",
-        "  return s\n",
-        "\n",
-        "markdown_text = \"\"\"\n",
-        "### Markdown Text\n",
-        "\n",
-        "TensorBorad supports a number of markdown idioms, such as\n",
-        "\n",
-        "    preformatted code\n",
-        "   \n",
-        "**bold text**\n",
-        "\n",
-        "| and | tables |\n",
-        "| ---- | ---------- |\n",
-        "| among | others |\n",
-        "\"\"\"\n",
-        "\n",
-        "with file_writer.as_default():\n",
-        "  tf.summary.text(\"Run Params\", pretty_json(some_obj_worth_noting), step=0)\n",
-        "  tf.summary.text(\"Markdown jubiliee\", markdown_text, step=0)\n",
-        "    "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "57082d8d6839"
-      },
-      "outputs": [],
-      "source": [
-        "%tensorboard --logdir logs/markdown"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "text_summaries.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "djUvWu41mtXa"
+   },
+   "source": [
+    "##### Copyright 2021 The TensorFlow Authors."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "cellView": "form",
+    "id": "su2RaORHpReL"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NztQK2uFpXT-"
+   },
+   "source": [
+    "# Displaying text data in TensorBoard\n",
+    "\n",
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/text_summaries\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eDXRFe_qp5C3"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "Using the **TensorFlow Text Summary API,** you can easily log arbitrary text and view it in TensorBoard. This can be extremely helpful to sample and examine your input data, or to record execution metadata or generated text.  You can also log diagnostic data as text that can be helpful in the course of your model development.\n",
+    "\n",
+    "In this tutorial, you will try out some basic use cases of the Text Summary API."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dG-nnZK9qW9z"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "3U5gdCw_nSG3"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "  # %tensorflow_version only exists in Colab.\n",
+    "  %tensorflow_version 2.x\n",
+    "except Exception:\n",
+    "  pass\n",
+    "\n",
+    "# Load the TensorBoard notebook extension.\n",
+    "%load_ext tensorboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "1qIKtOBrqc9Y"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TensorFlow version:  2.5.0-dev20210219\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "from datetime import datetime\n",
+    "import json\n",
+    "from packaging import version\n",
+    "import tempfile\n",
+    "\n",
+    "print(\"TensorFlow version: \", tf.__version__)\n",
+    "assert version.parse(tf.__version__).release[0] >= 2, \\\n",
+    "    \"This notebook requires TensorFlow 2.0 or above.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qNsjMY0364j4"
+   },
+   "source": [
+    "## Logging a single piece of text\n",
+    "\n",
+    "To understand how the Text Summary API works, you're going to simply log a bit of text and see how it is presented in TensorBoard.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "FxMPcdmvBn9t"
+   },
+   "outputs": [],
+   "source": [
+    "my_text = \"Hello world! 😃\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "IJNpyVyxbVtT"
+   },
+   "outputs": [],
+   "source": [
+    "# Clear out any prior log data.\n",
+    "!rm -rf logs\n",
+    "\n",
+    "# Sets up a timestamped log directory.\n",
+    "logdir = \"logs/text_basics/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "# Creates a file writer for the log directory.\n",
+    "file_writer = tf.summary.create_file_writer(logdir)\n",
+    "\n",
+    "# Using the file writer, log the text.\n",
+    "with file_writer.as_default():\n",
+    "  tf.summary.text(\"first_text\", my_text, step=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rngALbRogXe6"
+   },
+   "source": [
+    "Now, use TensorBoard to examine the text. Wait a few seconds for the UI to spin up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "T_X-wIy-lD9f"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "      <iframe id=\"tensorboard-frame-9381929c3767b97b\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+       "      </iframe>\n",
+       "      <script>\n",
+       "        (function() {\n",
+       "          const frame = document.getElementById(\"tensorboard-frame-9381929c3767b97b\");\n",
+       "          const url = new URL(\"/\", window.location);\n",
+       "          const port = 6007;\n",
+       "          if (port) {\n",
+       "            url.port = port;\n",
+       "          }\n",
+       "          frame.src = url;\n",
+       "        })();\n",
+       "      </script>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%tensorboard --logdir logs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "c8n8YqGlT3-c"
+   },
+   "source": [
+    "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/> -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "34enxJjjgWi7"
+   },
+   "source": [
+    "## Organizing multiple text streams\n",
+    "\n",
+    "If you have multiple streams of text, you can keep them in separate namespaces to help organize them, just like scalars or other data.\n",
+    "\n",
+    "Note that if you log text at many steps, TensorBoard will subsample the steps to display so as to make the presentation manageable.  You can control the sampling rate using the `--samples_per_plugin` flag."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "dda6960f0119"
+   },
+   "outputs": [],
+   "source": [
+    "# Sets up a second directory to not overwrite the first one.\n",
+    "logdir = \"logs/multiple_texts/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "# Creates a file writer for the log directory.\n",
+    "file_writer = tf.summary.create_file_writer(logdir)\n",
+    "\n",
+    "# Using the file writer, log the text.\n",
+    "with file_writer.as_default():\n",
+    "  with tf.name_scope(\"name_scope_1\"):\n",
+    "    for step in range(20):\n",
+    "      tf.summary.text(\"a_stream_of_text\", f\"Hello from step {step}\", step=step)\n",
+    "      tf.summary.text(\"another_stream_of_text\", f\"This can be kept separate {step}\", step=step)\n",
+    "  with tf.name_scope(\"name_scope_2\"):\n",
+    "    tf.summary.text(\"just_from_step_0\", \"This is an important announcement from step 0\", step=0)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "id": "515199f4b547"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "      <iframe id=\"tensorboard-frame-4a8120aa135ba5f2\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+       "      </iframe>\n",
+       "      <script>\n",
+       "        (function() {\n",
+       "          const frame = document.getElementById(\"tensorboard-frame-4a8120aa135ba5f2\");\n",
+       "          const url = new URL(\"/\", window.location);\n",
+       "          const port = 6010;\n",
+       "          if (port) {\n",
+       "            url.port = port;\n",
+       "          }\n",
+       "          frame.src = url;\n",
+       "        })();\n",
+       "      </script>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%tensorboard --logdir logs/multiple_texts --samples_per_plugin 'text=5'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bjACE1lAsqUd"
+   },
+   "source": [
+    "## Markdown interpretation\n",
+    "\n",
+    "TensorBoard interprets text summaries as Markdown, since rich formatting can make the data you log easier to read and understand, as shown below. (If you don't want Markdown interpretation, see [this issue](https://github.com/tensorflow/tensorboard/issues/830) for workarounds to suppress interpretation.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "iHUjCXbetIpb"
+   },
+   "outputs": [],
+   "source": [
+    "# Sets up a third timestamped log directory under \"logs\"\n",
+    "logdir = \"logs/markdown/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "# Creates a file writer for the log directory.\n",
+    "file_writer = tf.summary.create_file_writer(logdir)\n",
+    "\n",
+    "some_obj_worth_noting = {\n",
+    "  \"tfds_training_data\": {\n",
+    "      \"name\": \"mnist\",\n",
+    "      \"split\": \"train\",\n",
+    "      \"shuffle_files\": \"True\",\n",
+    "  },\n",
+    "  \"keras_optimizer\": {\n",
+    "      \"name\": \"Adagrad\",\n",
+    "      \"learning_rate\": \"0.001\",\n",
+    "      \"epsilon\": 1e-07,\n",
+    "  },\n",
+    "  \"hardware\": \"Cloud TPU\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "# TODO: Update this example when TensorBoard is released with\n",
+    "# https://github.com/tensorflow/tensorboard/pull/4585\n",
+    "# which supports fenced codeblocks in Markdown.\n",
+    "def pretty_json(hp):\n",
+    "  json_hp = json.dumps(hp, indent=2)\n",
+    "  return \"\".join(\"\\t\" + line for line in json_hp.splitlines(True))\n",
+    "\n",
+    "markdown_text = \"\"\"\n",
+    "### Markdown Text\n",
+    "\n",
+    "TensorBoard supports basic markdown syntax, including:\n",
+    "\n",
+    "    preformatted code\n",
+    "\n",
+    "**bold text**\n",
+    "\n",
+    "| and | tables |\n",
+    "| ---- | ---------- |\n",
+    "| among | others |\n",
+    "\"\"\"\n",
+    "\n",
+    "with file_writer.as_default():\n",
+    "  tf.summary.text(\"run_params\", pretty_json(some_obj_worth_noting), step=0)\n",
+    "  tf.summary.text(\"markdown_jubiliee\", markdown_text, step=0)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "57082d8d6839"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Reusing TensorBoard on port 6008 (pid 44187), started 1 day, 16:31:45 ago. (Use '!kill 44187' to kill it.)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "      <iframe id=\"tensorboard-frame-d949964a890a033\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+       "      </iframe>\n",
+       "      <script>\n",
+       "        (function() {\n",
+       "          const frame = document.getElementById(\"tensorboard-frame-d949964a890a033\");\n",
+       "          const url = new URL(\"/\", window.location);\n",
+       "          const port = 6008;\n",
+       "          if (port) {\n",
+       "            url.port = port;\n",
+       "          }\n",
+       "          frame.src = url;\n",
+       "        })();\n",
+       "      </script>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%tensorboard --logdir logs/markdown"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "text_summaries.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/text_summaries.ipynb
+++ b/docs/text_summaries.ipynb
@@ -1,0 +1,451 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "djUvWu41mtXa"
+   },
+   "source": [
+    "##### Copyright 2021 The TensorFlow Authors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "cellView": "form",
+    "id": "su2RaORHpReL"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NztQK2uFpXT-"
+   },
+   "source": [
+    "# Displaying text data in TensorBoard\n",
+    "\n",
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/text_summaries\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eDXRFe_qp5C3"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "Using the **TensorFlow Text Summary API,** you can easily log arbitrary text and view it in TensorBoard. This can be extremely helpful to sample and examine your input data, or to [record execution metadata]() or [generated text]().  You can also log diagnostic data as text that can be helpful in the course of your model development.\n",
+    "\n",
+    "In this tutorial, you will try out some basic use cases of the Summary API."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dG-nnZK9qW9z"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "3U5gdCw_nSG3"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "  # %tensorflow_version only exists in Colab.\n",
+    "  %tensorflow_version 2.x\n",
+    "except Exception:\n",
+    "  pass\n",
+    "\n",
+    "# Load the TensorBoard notebook extension.\n",
+    "%load_ext tensorboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "1qIKtOBrqc9Y"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TensorFlow version:  2.5.0-dev20210219\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "from tensorboard.plugins.text.summary_v2 import text\n",
+    "\n",
+    "from datetime import datetime\n",
+    "import json\n",
+    "from packaging import version\n",
+    "import tempfile\n",
+    "\n",
+    "print(\"TensorFlow version: \", tf.__version__)\n",
+    "assert version.parse(tf.__version__).release[0] >= 2, \\\n",
+    "    \"This notebook requires TensorFlow 2.0 or above.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qNsjMY0364j4"
+   },
+   "source": [
+    "## Logging a single piece of text\n",
+    "\n",
+    "To understand how the Image Summary API works, you're going to simply log a bit of text and see how it is presented in tensorboard.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "FxMPcdmvBn9t"
+   },
+   "outputs": [],
+   "source": [
+    "my_text = \"Hello world! 😃\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "IJNpyVyxbVtT"
+   },
+   "outputs": [],
+   "source": [
+    "# Clear out any prior log data.\n",
+    "!rm -rf logs\n",
+    "\n",
+    "# Sets up a timestamped log directory.\n",
+    "logdir = \"logs/text_basics/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "# Creates a file writer for the log directory.\n",
+    "file_writer = tf.summary.create_file_writer(logdir)\n",
+    "\n",
+    "# Using the file writer, log the text.\n",
+    "with file_writer.as_default():\n",
+    "  tf.summary.text(\"My first text\", my_text, step=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rngALbRogXe6"
+   },
+   "source": [
+    "Now, use TensorBoard to examine the image. Wait a few seconds for the UI to spin up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "T_X-wIy-lD9f",
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Reusing TensorBoard on port 6007 (pid 41780), started 0:26:32 ago. (Use '!kill 41780' to kill it.)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "      <iframe id=\"tensorboard-frame-7b1be06bbcde4e3f\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+       "      </iframe>\n",
+       "      <script>\n",
+       "        (function() {\n",
+       "          const frame = document.getElementById(\"tensorboard-frame-7b1be06bbcde4e3f\");\n",
+       "          const url = new URL(\"/\", window.location);\n",
+       "          const port = 6007;\n",
+       "          if (port) {\n",
+       "            url.port = port;\n",
+       "          }\n",
+       "          frame.src = url;\n",
+       "        })();\n",
+       "      </script>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%tensorboard --logdir logs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "c8n8YqGlT3-c"
+   },
+   "source": [
+    "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/> -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "34enxJjjgWi7"
+   },
+   "source": [
+    "## Organizing multiple text streams\n",
+    "\n",
+    "If you have multiple streams of text, you can keep them in separate namespaces to help organize them, just like scalars or other data.\n",
+    "\n",
+    "Note that if you log text at many steps, TensorBoard will subsample the steps to display.  Again, this behavior is the same as for scalars, where the data is subsampled to make the presentation manageable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sets up a second directory to not overwrite the first one.\n",
+    "logdir = \"logs/multiple_texts/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "# Creates a file writer for the log directory.\n",
+    "file_writer = tf.summary.create_file_writer(logdir)\n",
+    "\n",
+    "# Using the file writer, log the text.\n",
+    "with file_writer.as_default():\n",
+    "  with tf.name_scope(\"Name scope 1\"):\n",
+    "    for step in range(20):\n",
+    "      tf.summary.text(\"a stream of text\", f\"Hello from step {step}\", step=step)\n",
+    "      tf.summary.text(\"another stream of text\", f\"This can be kept separate {step}\", step=step)\n",
+    "  with tf.name_scope(\"Name scope 2\"):\n",
+    "    tf.summary.text(\"just from step 0\", f\"This is an important announcement from step 0\", step=0)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Reusing TensorBoard on port 6007 (pid 41780), started 0:26:39 ago. (Use '!kill 41780' to kill it.)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "      <iframe id=\"tensorboard-frame-1729b2c89cc5cdce\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+       "      </iframe>\n",
+       "      <script>\n",
+       "        (function() {\n",
+       "          const frame = document.getElementById(\"tensorboard-frame-1729b2c89cc5cdce\");\n",
+       "          const url = new URL(\"/\", window.location);\n",
+       "          const port = 6007;\n",
+       "          if (port) {\n",
+       "            url.port = port;\n",
+       "          }\n",
+       "          frame.src = url;\n",
+       "        })();\n",
+       "      </script>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%tensorboard --logdir logs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bjACE1lAsqUd"
+   },
+   "source": [
+    "## Using markdown\n",
+    "\n",
+    "Tensorboard supports logging text in markdown to make it easier to read and understand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "id": "iHUjCXbetIpb"
+   },
+   "outputs": [],
+   "source": [
+    "# Sets up a third timestamped log directory under \"logs\"\n",
+    "logdir = \"logs/markdown/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "# Creates a file writer for the log directory.\n",
+    "file_writer = tf.summary.create_file_writer(logdir)\n",
+    "\n",
+    "some_obj_worth_noting = {\n",
+    "  \"tfds_training_data\": {\n",
+    "      \"name\": \"mnist\",\n",
+    "      \"split\": \"train\",\n",
+    "      \"shuffle_files\": \"True\",\n",
+    "  },\n",
+    "  \"keras_optimizer\": {\n",
+    "      \"name\": \"Adagrad\",\n",
+    "      \"learning_rate\": \"0.001\",\n",
+    "      \"epsilon\": 1e-07,\n",
+    "  },\n",
+    "  \"hardware\": \"Cloud TPU\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def pretty_json(hp):\n",
+    "  json_hp = json.dumps(hp, indent=2)\n",
+    "  s = \"\"\n",
+    "  for line in json_hp.splitlines():\n",
+    "    s += \"\\t\" + line + \"\\n\"\n",
+    "  return s\n",
+    "\n",
+    "markdown_text = \"\"\"\n",
+    "### Markdown Text\n",
+    "\n",
+    "TensorBorad supports a number of markdown idioms, such as\n",
+    "\n",
+    "    preformatted code\n",
+    "   \n",
+    "**bold text**\n",
+    "\n",
+    "| and | tables |\n",
+    "| ---- | ---------- |\n",
+    "| among | others |\n",
+    "\"\"\"\n",
+    "\n",
+    "with file_writer.as_default():\n",
+    "  tf.summary.text(\"Run Params\", pretty_json(some_obj_worth_noting), step=0)\n",
+    "  tf.summary.text(\"Markdown jubiliee\", markdown_text, step=0)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "      <iframe id=\"tensorboard-frame-c5e2ab8254bd9647\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+       "      </iframe>\n",
+       "      <script>\n",
+       "        (function() {\n",
+       "          const frame = document.getElementById(\"tensorboard-frame-c5e2ab8254bd9647\");\n",
+       "          const url = new URL(\"/\", window.location);\n",
+       "          const port = 6008;\n",
+       "          if (port) {\n",
+       "            url.port = port;\n",
+       "          }\n",
+       "          frame.src = url;\n",
+       "        })();\n",
+       "      </script>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%tensorboard --logdir logs/markdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "image_summaries.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/docs/text_summaries.ipynb
+++ b/docs/text_summaries.ipynb
@@ -1,451 +1,327 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "djUvWu41mtXa"
-   },
-   "source": [
-    "##### Copyright 2021 The TensorFlow Authors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "cellView": "form",
-    "id": "su2RaORHpReL"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "NztQK2uFpXT-"
-   },
-   "source": [
-    "# Displaying text data in TensorBoard\n",
-    "\n",
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/text_summaries\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "eDXRFe_qp5C3"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "Using the **TensorFlow Text Summary API,** you can easily log arbitrary text and view it in TensorBoard. This can be extremely helpful to sample and examine your input data, or to [record execution metadata]() or [generated text]().  You can also log diagnostic data as text that can be helpful in the course of your model development.\n",
-    "\n",
-    "In this tutorial, you will try out some basic use cases of the Summary API."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dG-nnZK9qW9z"
-   },
-   "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "id": "3U5gdCw_nSG3"
-   },
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "  # %tensorflow_version only exists in Colab.\n",
-    "  %tensorflow_version 2.x\n",
-    "except Exception:\n",
-    "  pass\n",
-    "\n",
-    "# Load the TensorBoard notebook extension.\n",
-    "%load_ext tensorboard"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "1qIKtOBrqc9Y"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TensorFlow version:  2.5.0-dev20210219\n"
-     ]
-    }
-   ],
-   "source": [
-    "import tensorflow as tf\n",
-    "from tensorboard.plugins.text.summary_v2 import text\n",
-    "\n",
-    "from datetime import datetime\n",
-    "import json\n",
-    "from packaging import version\n",
-    "import tempfile\n",
-    "\n",
-    "print(\"TensorFlow version: \", tf.__version__)\n",
-    "assert version.parse(tf.__version__).release[0] >= 2, \\\n",
-    "    \"This notebook requires TensorFlow 2.0 or above.\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "qNsjMY0364j4"
-   },
-   "source": [
-    "## Logging a single piece of text\n",
-    "\n",
-    "To understand how the Image Summary API works, you're going to simply log a bit of text and see how it is presented in tensorboard.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "id": "FxMPcdmvBn9t"
-   },
-   "outputs": [],
-   "source": [
-    "my_text = \"Hello world! 😃\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "IJNpyVyxbVtT"
-   },
-   "outputs": [],
-   "source": [
-    "# Clear out any prior log data.\n",
-    "!rm -rf logs\n",
-    "\n",
-    "# Sets up a timestamped log directory.\n",
-    "logdir = \"logs/text_basics/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-    "# Creates a file writer for the log directory.\n",
-    "file_writer = tf.summary.create_file_writer(logdir)\n",
-    "\n",
-    "# Using the file writer, log the text.\n",
-    "with file_writer.as_default():\n",
-    "  tf.summary.text(\"My first text\", my_text, step=0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "rngALbRogXe6"
-   },
-   "source": [
-    "Now, use TensorBoard to examine the image. Wait a few seconds for the UI to spin up."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "id": "T_X-wIy-lD9f",
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Reusing TensorBoard on port 6007 (pid 41780), started 0:26:32 ago. (Use '!kill 41780' to kill it.)"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "djUvWu41mtXa"
+      },
+      "source": [
+        "##### Copyright 2021 The TensorFlow Authors."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "text/html": [
-       "\n",
-       "      <iframe id=\"tensorboard-frame-7b1be06bbcde4e3f\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-       "      </iframe>\n",
-       "      <script>\n",
-       "        (function() {\n",
-       "          const frame = document.getElementById(\"tensorboard-frame-7b1be06bbcde4e3f\");\n",
-       "          const url = new URL(\"/\", window.location);\n",
-       "          const port = 6007;\n",
-       "          if (port) {\n",
-       "            url.port = port;\n",
-       "          }\n",
-       "          frame.src = url;\n",
-       "        })();\n",
-       "      </script>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "su2RaORHpReL"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%tensorboard --logdir logs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "c8n8YqGlT3-c"
-   },
-   "source": [
-    "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/> -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "34enxJjjgWi7"
-   },
-   "source": [
-    "## Organizing multiple text streams\n",
-    "\n",
-    "If you have multiple streams of text, you can keep them in separate namespaces to help organize them, just like scalars or other data.\n",
-    "\n",
-    "Note that if you log text at many steps, TensorBoard will subsample the steps to display.  Again, this behavior is the same as for scalars, where the data is subsampled to make the presentation manageable."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Sets up a second directory to not overwrite the first one.\n",
-    "logdir = \"logs/multiple_texts/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-    "# Creates a file writer for the log directory.\n",
-    "file_writer = tf.summary.create_file_writer(logdir)\n",
-    "\n",
-    "# Using the file writer, log the text.\n",
-    "with file_writer.as_default():\n",
-    "  with tf.name_scope(\"Name scope 1\"):\n",
-    "    for step in range(20):\n",
-    "      tf.summary.text(\"a stream of text\", f\"Hello from step {step}\", step=step)\n",
-    "      tf.summary.text(\"another stream of text\", f\"This can be kept separate {step}\", step=step)\n",
-    "  with tf.name_scope(\"Name scope 2\"):\n",
-    "    tf.summary.text(\"just from step 0\", f\"This is an important announcement from step 0\", step=0)\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Reusing TensorBoard on port 6007 (pid 41780), started 0:26:39 ago. (Use '!kill 41780' to kill it.)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "text/html": [
-       "\n",
-       "      <iframe id=\"tensorboard-frame-1729b2c89cc5cdce\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-       "      </iframe>\n",
-       "      <script>\n",
-       "        (function() {\n",
-       "          const frame = document.getElementById(\"tensorboard-frame-1729b2c89cc5cdce\");\n",
-       "          const url = new URL(\"/\", window.location);\n",
-       "          const port = 6007;\n",
-       "          if (port) {\n",
-       "            url.port = port;\n",
-       "          }\n",
-       "          frame.src = url;\n",
-       "        })();\n",
-       "      </script>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NztQK2uFpXT-"
+      },
+      "source": [
+        "# Displaying text data in TensorBoard\n",
+        "\n",
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/text_summaries\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%tensorboard --logdir logs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bjACE1lAsqUd"
-   },
-   "source": [
-    "## Using markdown\n",
-    "\n",
-    "Tensorboard supports logging text in markdown to make it easier to read and understand."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "id": "iHUjCXbetIpb"
-   },
-   "outputs": [],
-   "source": [
-    "# Sets up a third timestamped log directory under \"logs\"\n",
-    "logdir = \"logs/markdown/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-    "# Creates a file writer for the log directory.\n",
-    "file_writer = tf.summary.create_file_writer(logdir)\n",
-    "\n",
-    "some_obj_worth_noting = {\n",
-    "  \"tfds_training_data\": {\n",
-    "      \"name\": \"mnist\",\n",
-    "      \"split\": \"train\",\n",
-    "      \"shuffle_files\": \"True\",\n",
-    "  },\n",
-    "  \"keras_optimizer\": {\n",
-    "      \"name\": \"Adagrad\",\n",
-    "      \"learning_rate\": \"0.001\",\n",
-    "      \"epsilon\": 1e-07,\n",
-    "  },\n",
-    "  \"hardware\": \"Cloud TPU\",\n",
-    "}\n",
-    "\n",
-    "\n",
-    "def pretty_json(hp):\n",
-    "  json_hp = json.dumps(hp, indent=2)\n",
-    "  s = \"\"\n",
-    "  for line in json_hp.splitlines():\n",
-    "    s += \"\\t\" + line + \"\\n\"\n",
-    "  return s\n",
-    "\n",
-    "markdown_text = \"\"\"\n",
-    "### Markdown Text\n",
-    "\n",
-    "TensorBorad supports a number of markdown idioms, such as\n",
-    "\n",
-    "    preformatted code\n",
-    "   \n",
-    "**bold text**\n",
-    "\n",
-    "| and | tables |\n",
-    "| ---- | ---------- |\n",
-    "| among | others |\n",
-    "\"\"\"\n",
-    "\n",
-    "with file_writer.as_default():\n",
-    "  tf.summary.text(\"Run Params\", pretty_json(some_obj_worth_noting), step=0)\n",
-    "  tf.summary.text(\"Markdown jubiliee\", markdown_text, step=0)\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "text/html": [
-       "\n",
-       "      <iframe id=\"tensorboard-frame-c5e2ab8254bd9647\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-       "      </iframe>\n",
-       "      <script>\n",
-       "        (function() {\n",
-       "          const frame = document.getElementById(\"tensorboard-frame-c5e2ab8254bd9647\");\n",
-       "          const url = new URL(\"/\", window.location);\n",
-       "          const port = 6008;\n",
-       "          if (port) {\n",
-       "            url.port = port;\n",
-       "          }\n",
-       "          frame.src = url;\n",
-       "        })();\n",
-       "      </script>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eDXRFe_qp5C3"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "Using the **TensorFlow Text Summary API,** you can easily log arbitrary text and view it in TensorBoard. This can be extremely helpful to sample and examine your input data, or to [record execution metadata]() or [generated text]().  You can also log diagnostic data as text that can be helpful in the course of your model development.\n",
+        "\n",
+        "In this tutorial, you will try out some basic use cases of the Summary API."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dG-nnZK9qW9z"
+      },
+      "source": [
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3U5gdCw_nSG3"
+      },
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "  # %tensorflow_version only exists in Colab.\n",
+        "  %tensorflow_version 2.x\n",
+        "except Exception:\n",
+        "  pass\n",
+        "\n",
+        "# Load the TensorBoard notebook extension.\n",
+        "%load_ext tensorboard"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "1qIKtOBrqc9Y"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow as tf\n",
+        "from tensorboard.plugins.text.summary_v2 import text\n",
+        "\n",
+        "from datetime import datetime\n",
+        "import json\n",
+        "from packaging import version\n",
+        "import tempfile\n",
+        "\n",
+        "print(\"TensorFlow version: \", tf.__version__)\n",
+        "assert version.parse(tf.__version__).release[0] >= 2, \\\n",
+        "    \"This notebook requires TensorFlow 2.0 or above.\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qNsjMY0364j4"
+      },
+      "source": [
+        "## Logging a single piece of text\n",
+        "\n",
+        "To understand how the Image Summary API works, you're going to simply log a bit of text and see how it is presented in tensorboard.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "FxMPcdmvBn9t"
+      },
+      "outputs": [],
+      "source": [
+        "my_text = \"Hello world! 😃\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "IJNpyVyxbVtT"
+      },
+      "outputs": [],
+      "source": [
+        "# Clear out any prior log data.\n",
+        "!rm -rf logs\n",
+        "\n",
+        "# Sets up a timestamped log directory.\n",
+        "logdir = \"logs/text_basics/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+        "# Creates a file writer for the log directory.\n",
+        "file_writer = tf.summary.create_file_writer(logdir)\n",
+        "\n",
+        "# Using the file writer, log the text.\n",
+        "with file_writer.as_default():\n",
+        "  tf.summary.text(\"My first text\", my_text, step=0)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rngALbRogXe6"
+      },
+      "source": [
+        "Now, use TensorBoard to examine the image. Wait a few seconds for the UI to spin up."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "T_X-wIy-lD9f"
+      },
+      "outputs": [],
+      "source": [
+        "%tensorboard --logdir logs"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "c8n8YqGlT3-c"
+      },
+      "source": [
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/> -->"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "34enxJjjgWi7"
+      },
+      "source": [
+        "## Organizing multiple text streams\n",
+        "\n",
+        "If you have multiple streams of text, you can keep them in separate namespaces to help organize them, just like scalars or other data.\n",
+        "\n",
+        "Note that if you log text at many steps, TensorBoard will subsample the steps to display.  Again, this behavior is the same as for scalars, where the data is subsampled to make the presentation manageable."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "dda6960f0119"
+      },
+      "outputs": [],
+      "source": [
+        "# Sets up a second directory to not overwrite the first one.\n",
+        "logdir = \"logs/multiple_texts/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+        "# Creates a file writer for the log directory.\n",
+        "file_writer = tf.summary.create_file_writer(logdir)\n",
+        "\n",
+        "# Using the file writer, log the text.\n",
+        "with file_writer.as_default():\n",
+        "  with tf.name_scope(\"Name scope 1\"):\n",
+        "    for step in range(20):\n",
+        "      tf.summary.text(\"a stream of text\", f\"Hello from step {step}\", step=step)\n",
+        "      tf.summary.text(\"another stream of text\", f\"This can be kept separate {step}\", step=step)\n",
+        "  with tf.name_scope(\"Name scope 2\"):\n",
+        "    tf.summary.text(\"just from step 0\", f\"This is an important announcement from step 0\", step=0)\n",
+        "    "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "515199f4b547"
+      },
+      "outputs": [],
+      "source": [
+        "%tensorboard --logdir logs"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bjACE1lAsqUd"
+      },
+      "source": [
+        "## Using markdown\n",
+        "\n",
+        "Tensorboard supports logging text in markdown to make it easier to read and understand."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iHUjCXbetIpb"
+      },
+      "outputs": [],
+      "source": [
+        "# Sets up a third timestamped log directory under \"logs\"\n",
+        "logdir = \"logs/markdown/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+        "# Creates a file writer for the log directory.\n",
+        "file_writer = tf.summary.create_file_writer(logdir)\n",
+        "\n",
+        "some_obj_worth_noting = {\n",
+        "  \"tfds_training_data\": {\n",
+        "      \"name\": \"mnist\",\n",
+        "      \"split\": \"train\",\n",
+        "      \"shuffle_files\": \"True\",\n",
+        "  },\n",
+        "  \"keras_optimizer\": {\n",
+        "      \"name\": \"Adagrad\",\n",
+        "      \"learning_rate\": \"0.001\",\n",
+        "      \"epsilon\": 1e-07,\n",
+        "  },\n",
+        "  \"hardware\": \"Cloud TPU\",\n",
+        "}\n",
+        "\n",
+        "\n",
+        "def pretty_json(hp):\n",
+        "  json_hp = json.dumps(hp, indent=2)\n",
+        "  s = \"\"\n",
+        "  for line in json_hp.splitlines():\n",
+        "    s += \"\\t\" + line + \"\\n\"\n",
+        "  return s\n",
+        "\n",
+        "markdown_text = \"\"\"\n",
+        "### Markdown Text\n",
+        "\n",
+        "TensorBorad supports a number of markdown idioms, such as\n",
+        "\n",
+        "    preformatted code\n",
+        "   \n",
+        "**bold text**\n",
+        "\n",
+        "| and | tables |\n",
+        "| ---- | ---------- |\n",
+        "| among | others |\n",
+        "\"\"\"\n",
+        "\n",
+        "with file_writer.as_default():\n",
+        "  tf.summary.text(\"Run Params\", pretty_json(some_obj_worth_noting), step=0)\n",
+        "  tf.summary.text(\"Markdown jubiliee\", markdown_text, step=0)\n",
+        "    "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "57082d8d6839"
+      },
+      "outputs": [],
+      "source": [
+        "%tensorboard --logdir logs/markdown"
+      ]
     }
-   ],
-   "source": [
-    "%tensorboard --logdir logs/markdown"
-   ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "text_summaries.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "image_summaries.ipynb",
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/text_summaries.ipynb
+++ b/docs/text_summaries.ipynb
@@ -1,437 +1,424 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "djUvWu41mtXa"
-   },
-   "source": [
-    "##### Copyright 2021 The TensorFlow Authors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "cellView": "form",
-    "id": "su2RaORHpReL"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "NztQK2uFpXT-"
-   },
-   "source": [
-    "# Displaying text data in TensorBoard\n",
-    "\n",
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/text_summaries\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "eDXRFe_qp5C3"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "Using the **TensorFlow Text Summary API,** you can easily log arbitrary text and view it in TensorBoard. This can be extremely helpful to sample and examine your input data, or to record execution metadata or generated text.  You can also log diagnostic data as text that can be helpful in the course of your model development.\n",
-    "\n",
-    "In this tutorial, you will try out some basic use cases of the Text Summary API."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dG-nnZK9qW9z"
-   },
-   "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "id": "3U5gdCw_nSG3"
-   },
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "  # %tensorflow_version only exists in Colab.\n",
-    "  %tensorflow_version 2.x\n",
-    "except Exception:\n",
-    "  pass\n",
-    "\n",
-    "# Load the TensorBoard notebook extension.\n",
-    "%load_ext tensorboard"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "1qIKtOBrqc9Y"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TensorFlow version:  2.5.0-dev20210219\n"
-     ]
-    }
-   ],
-   "source": [
-    "import tensorflow as tf\n",
-    "\n",
-    "from datetime import datetime\n",
-    "import json\n",
-    "from packaging import version\n",
-    "import tempfile\n",
-    "\n",
-    "print(\"TensorFlow version: \", tf.__version__)\n",
-    "assert version.parse(tf.__version__).release[0] >= 2, \\\n",
-    "    \"This notebook requires TensorFlow 2.0 or above.\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "qNsjMY0364j4"
-   },
-   "source": [
-    "## Logging a single piece of text\n",
-    "\n",
-    "To understand how the Text Summary API works, you're going to simply log a bit of text and see how it is presented in TensorBoard.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "id": "FxMPcdmvBn9t"
-   },
-   "outputs": [],
-   "source": [
-    "my_text = \"Hello world! 😃\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "id": "IJNpyVyxbVtT"
-   },
-   "outputs": [],
-   "source": [
-    "# Clear out any prior log data.\n",
-    "!rm -rf logs\n",
-    "\n",
-    "# Sets up a timestamped log directory.\n",
-    "logdir = \"logs/text_basics/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-    "# Creates a file writer for the log directory.\n",
-    "file_writer = tf.summary.create_file_writer(logdir)\n",
-    "\n",
-    "# Using the file writer, log the text.\n",
-    "with file_writer.as_default():\n",
-    "  tf.summary.text(\"first_text\", my_text, step=0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "rngALbRogXe6"
-   },
-   "source": [
-    "Now, use TensorBoard to examine the text. Wait a few seconds for the UI to spin up."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "id": "T_X-wIy-lD9f"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "      <iframe id=\"tensorboard-frame-9381929c3767b97b\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-       "      </iframe>\n",
-       "      <script>\n",
-       "        (function() {\n",
-       "          const frame = document.getElementById(\"tensorboard-frame-9381929c3767b97b\");\n",
-       "          const url = new URL(\"/\", window.location);\n",
-       "          const port = 6007;\n",
-       "          if (port) {\n",
-       "            url.port = port;\n",
-       "          }\n",
-       "          frame.src = url;\n",
-       "        })();\n",
-       "      </script>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "djUvWu41mtXa"
+      },
+      "source": [
+        "##### Copyright 2021 The TensorFlow Authors."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%tensorboard --logdir logs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "c8n8YqGlT3-c"
-   },
-   "source": [
-    "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/> -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "34enxJjjgWi7"
-   },
-   "source": [
-    "## Organizing multiple text streams\n",
-    "\n",
-    "If you have multiple streams of text, you can keep them in separate namespaces to help organize them, just like scalars or other data.\n",
-    "\n",
-    "Note that if you log text at many steps, TensorBoard will subsample the steps to display so as to make the presentation manageable.  You can control the sampling rate using the `--samples_per_plugin` flag."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "dda6960f0119"
-   },
-   "outputs": [],
-   "source": [
-    "# Sets up a second directory to not overwrite the first one.\n",
-    "logdir = \"logs/multiple_texts/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-    "# Creates a file writer for the log directory.\n",
-    "file_writer = tf.summary.create_file_writer(logdir)\n",
-    "\n",
-    "# Using the file writer, log the text.\n",
-    "with file_writer.as_default():\n",
-    "  with tf.name_scope(\"name_scope_1\"):\n",
-    "    for step in range(20):\n",
-    "      tf.summary.text(\"a_stream_of_text\", f\"Hello from step {step}\", step=step)\n",
-    "      tf.summary.text(\"another_stream_of_text\", f\"This can be kept separate {step}\", step=step)\n",
-    "  with tf.name_scope(\"name_scope_2\"):\n",
-    "    tf.summary.text(\"just_from_step_0\", \"This is an important announcement from step 0\", step=0)\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "id": "515199f4b547"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "      <iframe id=\"tensorboard-frame-4a8120aa135ba5f2\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-       "      </iframe>\n",
-       "      <script>\n",
-       "        (function() {\n",
-       "          const frame = document.getElementById(\"tensorboard-frame-4a8120aa135ba5f2\");\n",
-       "          const url = new URL(\"/\", window.location);\n",
-       "          const port = 6010;\n",
-       "          if (port) {\n",
-       "            url.port = port;\n",
-       "          }\n",
-       "          frame.src = url;\n",
-       "        })();\n",
-       "      </script>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%tensorboard --logdir logs/multiple_texts --samples_per_plugin 'text=5'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bjACE1lAsqUd"
-   },
-   "source": [
-    "## Markdown interpretation\n",
-    "\n",
-    "TensorBoard interprets text summaries as Markdown, since rich formatting can make the data you log easier to read and understand, as shown below. (If you don't want Markdown interpretation, see [this issue](https://github.com/tensorflow/tensorboard/issues/830) for workarounds to suppress interpretation.)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "iHUjCXbetIpb"
-   },
-   "outputs": [],
-   "source": [
-    "# Sets up a third timestamped log directory under \"logs\"\n",
-    "logdir = \"logs/markdown/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
-    "# Creates a file writer for the log directory.\n",
-    "file_writer = tf.summary.create_file_writer(logdir)\n",
-    "\n",
-    "some_obj_worth_noting = {\n",
-    "  \"tfds_training_data\": {\n",
-    "      \"name\": \"mnist\",\n",
-    "      \"split\": \"train\",\n",
-    "      \"shuffle_files\": \"True\",\n",
-    "  },\n",
-    "  \"keras_optimizer\": {\n",
-    "      \"name\": \"Adagrad\",\n",
-    "      \"learning_rate\": \"0.001\",\n",
-    "      \"epsilon\": 1e-07,\n",
-    "  },\n",
-    "  \"hardware\": \"Cloud TPU\",\n",
-    "}\n",
-    "\n",
-    "\n",
-    "# TODO: Update this example when TensorBoard is released with\n",
-    "# https://github.com/tensorflow/tensorboard/pull/4585\n",
-    "# which supports fenced codeblocks in Markdown.\n",
-    "def pretty_json(hp):\n",
-    "  json_hp = json.dumps(hp, indent=2)\n",
-    "  return \"\".join(\"\\t\" + line for line in json_hp.splitlines(True))\n",
-    "\n",
-    "markdown_text = \"\"\"\n",
-    "### Markdown Text\n",
-    "\n",
-    "TensorBoard supports basic markdown syntax, including:\n",
-    "\n",
-    "    preformatted code\n",
-    "\n",
-    "**bold text**\n",
-    "\n",
-    "| and | tables |\n",
-    "| ---- | ---------- |\n",
-    "| among | others |\n",
-    "\"\"\"\n",
-    "\n",
-    "with file_writer.as_default():\n",
-    "  tf.summary.text(\"run_params\", pretty_json(some_obj_worth_noting), step=0)\n",
-    "  tf.summary.text(\"markdown_jubiliee\", markdown_text, step=0)\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "57082d8d6839"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Reusing TensorBoard on port 6008 (pid 44187), started 1 day, 16:31:45 ago. (Use '!kill 44187' to kill it.)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "text/html": [
-       "\n",
-       "      <iframe id=\"tensorboard-frame-d949964a890a033\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
-       "      </iframe>\n",
-       "      <script>\n",
-       "        (function() {\n",
-       "          const frame = document.getElementById(\"tensorboard-frame-d949964a890a033\");\n",
-       "          const url = new URL(\"/\", window.location);\n",
-       "          const port = 6008;\n",
-       "          if (port) {\n",
-       "            url.port = port;\n",
-       "          }\n",
-       "          frame.src = url;\n",
-       "        })();\n",
-       "      </script>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "cellView": "form",
+        "id": "su2RaORHpReL"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NztQK2uFpXT-"
+      },
+      "source": [
+        "# Displaying text data in TensorBoard\n",
+        "\n",
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/text_summaries\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/text_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eDXRFe_qp5C3"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "Using the **TensorFlow Text Summary API,** you can easily log arbitrary text and view it in TensorBoard. This can be extremely helpful to sample and examine your input data, or to record execution metadata or generated text.  You can also log diagnostic data as text that can be helpful in the course of your model development.\n",
+        "\n",
+        "In this tutorial, you will try out some basic use cases of the Text Summary API."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dG-nnZK9qW9z"
+      },
+      "source": [
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "3U5gdCw_nSG3"
+      },
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "  # %tensorflow_version only exists in Colab.\n",
+        "  %tensorflow_version 2.x\n",
+        "except Exception:\n",
+        "  pass\n",
+        "\n",
+        "# Load the TensorBoard notebook extension.\n",
+        "%load_ext tensorboard"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "1qIKtOBrqc9Y"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "TensorFlow version:  2.5.0-dev20210219\n"
+          ]
+        }
+      ],
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "from datetime import datetime\n",
+        "import json\n",
+        "from packaging import version\n",
+        "import tempfile\n",
+        "\n",
+        "print(\"TensorFlow version: \", tf.__version__)\n",
+        "assert version.parse(tf.__version__).release[0] >= 2, \\\n",
+        "    \"This notebook requires TensorFlow 2.0 or above.\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qNsjMY0364j4"
+      },
+      "source": [
+        "## Logging a single piece of text\n",
+        "\n",
+        "To understand how the Text Summary API works, you're going to simply log a bit of text and see how it is presented in TensorBoard.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "FxMPcdmvBn9t"
+      },
+      "outputs": [],
+      "source": [
+        "my_text = \"Hello world! 😃\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "IJNpyVyxbVtT"
+      },
+      "outputs": [],
+      "source": [
+        "# Clear out any prior log data.\n",
+        "!rm -rf logs\n",
+        "\n",
+        "# Sets up a timestamped log directory.\n",
+        "logdir = \"logs/text_basics/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+        "# Creates a file writer for the log directory.\n",
+        "file_writer = tf.summary.create_file_writer(logdir)\n",
+        "\n",
+        "# Using the file writer, log the text.\n",
+        "with file_writer.as_default():\n",
+        "  tf.summary.text(\"first_text\", my_text, step=0)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rngALbRogXe6"
+      },
+      "source": [
+        "Now, use TensorBoard to examine the text. Wait a few seconds for the UI to spin up."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "T_X-wIy-lD9f"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "      <iframe id=\"tensorboard-frame-9381929c3767b97b\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+              "      </iframe>\n",
+              "      <script>\n",
+              "        (function() {\n",
+              "          const frame = document.getElementById(\"tensorboard-frame-9381929c3767b97b\");\n",
+              "          const url = new URL(\"/\", window.location);\n",
+              "          const port = 6007;\n",
+              "          if (port) {\n",
+              "            url.port = port;\n",
+              "          }\n",
+              "          frame.src = url;\n",
+              "        })();\n",
+              "      </script>\n",
+              "    "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "%tensorboard --logdir logs"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "c8n8YqGlT3-c"
+      },
+      "source": [
+        "<!-- <img class=\"tfo-display-only-on-site\" src=\"https://github.com/tensorflow/tensorboard/blob/master/docs/images/images_single.png?raw=1\"/> -->"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "34enxJjjgWi7"
+      },
+      "source": [
+        "## Organizing multiple text streams\n",
+        "\n",
+        "If you have multiple streams of text, you can keep them in separate namespaces to help organize them, just like scalars or other data.\n",
+        "\n",
+        "Note that if you log text at many steps, TensorBoard will subsample the steps to display so as to make the presentation manageable.  You can control the sampling rate using the `--samples_per_plugin` flag."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "dda6960f0119"
+      },
+      "outputs": [],
+      "source": [
+        "# Sets up a second directory to not overwrite the first one.\n",
+        "logdir = \"logs/multiple_texts/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+        "# Creates a file writer for the log directory.\n",
+        "file_writer = tf.summary.create_file_writer(logdir)\n",
+        "\n",
+        "# Using the file writer, log the text.\n",
+        "with file_writer.as_default():\n",
+        "  with tf.name_scope(\"name_scope_1\"):\n",
+        "    for step in range(20):\n",
+        "      tf.summary.text(\"a_stream_of_text\", f\"Hello from step {step}\", step=step)\n",
+        "      tf.summary.text(\"another_stream_of_text\", f\"This can be kept separate {step}\", step=step)\n",
+        "  with tf.name_scope(\"name_scope_2\"):\n",
+        "    tf.summary.text(\"just_from_step_0\", \"This is an important announcement from step 0\", step=0)\n",
+        "    "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "id": "515199f4b547"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "      <iframe id=\"tensorboard-frame-4a8120aa135ba5f2\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+              "      </iframe>\n",
+              "      <script>\n",
+              "        (function() {\n",
+              "          const frame = document.getElementById(\"tensorboard-frame-4a8120aa135ba5f2\");\n",
+              "          const url = new URL(\"/\", window.location);\n",
+              "          const port = 6010;\n",
+              "          if (port) {\n",
+              "            url.port = port;\n",
+              "          }\n",
+              "          frame.src = url;\n",
+              "        })();\n",
+              "      </script>\n",
+              "    "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "%tensorboard --logdir logs/multiple_texts --samples_per_plugin 'text=5'"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bjACE1lAsqUd"
+      },
+      "source": [
+        "## Markdown interpretation\n",
+        "\n",
+        "TensorBoard interprets text summaries as Markdown, since rich formatting can make the data you log easier to read and understand, as shown below. (If you don't want Markdown interpretation, see [this issue](https://github.com/tensorflow/tensorboard/issues/830) for workarounds to suppress interpretation.)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "iHUjCXbetIpb"
+      },
+      "outputs": [],
+      "source": [
+        "# Sets up a third timestamped log directory under \"logs\"\n",
+        "logdir = \"logs/markdown/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+        "# Creates a file writer for the log directory.\n",
+        "file_writer = tf.summary.create_file_writer(logdir)\n",
+        "\n",
+        "some_obj_worth_noting = {\n",
+        "  \"tfds_training_data\": {\n",
+        "      \"name\": \"mnist\",\n",
+        "      \"split\": \"train\",\n",
+        "      \"shuffle_files\": \"True\",\n",
+        "  },\n",
+        "  \"keras_optimizer\": {\n",
+        "      \"name\": \"Adagrad\",\n",
+        "      \"learning_rate\": \"0.001\",\n",
+        "      \"epsilon\": 1e-07,\n",
+        "  },\n",
+        "  \"hardware\": \"Cloud TPU\",\n",
+        "}\n",
+        "\n",
+        "\n",
+        "# TODO: Update this example when TensorBoard is released with\n",
+        "# https://github.com/tensorflow/tensorboard/pull/4585\n",
+        "# which supports fenced codeblocks in Markdown.\n",
+        "def pretty_json(hp):\n",
+        "  json_hp = json.dumps(hp, indent=2)\n",
+        "  return \"\".join(\"\\t\" + line for line in json_hp.splitlines(True))\n",
+        "\n",
+        "markdown_text = \"\"\"\n",
+        "### Markdown Text\n",
+        "\n",
+        "TensorBoard supports basic markdown syntax, including:\n",
+        "\n",
+        "    preformatted code\n",
+        "\n",
+        "**bold text**\n",
+        "\n",
+        "| and | tables |\n",
+        "| ---- | ---------- |\n",
+        "| among | others |\n",
+        "\"\"\"\n",
+        "\n",
+        "with file_writer.as_default():\n",
+        "  tf.summary.text(\"run_params\", pretty_json(some_obj_worth_noting), step=0)\n",
+        "  tf.summary.text(\"markdown_jubiliee\", markdown_text, step=0)\n",
+        "    "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "57082d8d6839"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "Reusing TensorBoard on port 6008 (pid 44187), started 1 day, 16:31:45 ago. (Use '!kill 44187' to kill it.)"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "      <iframe id=\"tensorboard-frame-d949964a890a033\" width=\"100%\" height=\"800\" frameborder=\"0\">\n",
+              "      </iframe>\n",
+              "      <script>\n",
+              "        (function() {\n",
+              "          const frame = document.getElementById(\"tensorboard-frame-d949964a890a033\");\n",
+              "          const url = new URL(\"/\", window.location);\n",
+              "          const port = 6008;\n",
+              "          if (port) {\n",
+              "            url.port = port;\n",
+              "          }\n",
+              "          frame.src = url;\n",
+              "        })();\n",
+              "      </script>\n",
+              "    "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "%tensorboard --logdir logs/markdown"
+      ]
     }
-   ],
-   "source": [
-    "%tensorboard --logdir logs/markdown"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "text_summaries.ipynb",
-   "toc_visible": true
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "text_summaries.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
* Motivation for features / changes
Adds a tutorial for how to use text summaries.  The tutorial is very basic and only covers adding text under different tags, as well as how to use markdown.  An example is included for how to use markdown to nicely format a json object. 

* Technical description of changes

Added a ipynb file by generating it on my local machine and testing in jupyter.