### PR TITLE
npmi: tweak typing for sync

### DIFF
--- a/tensorboard/webapp/plugins/npmi/util/umap_test.ts
+++ b/tensorboard/webapp/plugins/npmi/util/umap_test.ts
@@ -68,7 +68,7 @@ describe('umap utils', () => {
       [0, 1, 2, 3, 4],
       () => {}
     );
-    expect(embeddingDataSet.projections.umap).toBeTrue();
+    expect(embeddingDataSet.projections['umap']).toBeTrue();
     expect(embeddingDataSet.hasUmapRun).toBeTrue();
     for (const key of embeddingDataSet.pointKeys) {
       expect(embeddingDataSet.points[key].projections['umap-0']).toBeTruthy();


### PR DESCRIPTION
`projections` are typed as just a key-value or string to boolean yet it
is accessed via `.` accessor. This breaks the type checker inside.
