### PR TITLE
Add a toggle that turns automatic high-degree node extraction off

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -44,8 +44,6 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
   colorBy: string;
   @property({type: Boolean})
   traceInputs: boolean;
-  @property({type: Boolean})
-  extractNodes: boolean;
 
   // For each render hierarchy, we only fit it to the viewport once (when the scene is attached to
   // the DOM). We do not fit the hierarchy again (unless the user clicks the reset button). For
@@ -664,11 +662,5 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
       this.selectedNode,
       this.traceInputs
     );
-  }
-    
-  // Re-do hierarchy if extraction changes
-  @observe('extractNodes')
-  _updateExtractNodes() {
-    this.renderHierarchy
   }
 }

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -665,4 +665,10 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
       this.traceInputs
     );
   }
+    
+  // Re-do hierarchy if extraction changes
+  @observe('extractNodes')
+  _updateExtractNodes() {
+    this.renderHierarchy
+  }
 }

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -44,6 +44,8 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
   colorBy: string;
   @property({type: Boolean})
   traceInputs: boolean;
+  @property({type: Boolean})
+  extractNodes: boolean;
 
   // For each render hierarchy, we only fit it to the viewport once (when the scene is attached to
   // the DOM). We do not fit the hierarchy again (unless the user clicks the reset button). For

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -77,7 +77,6 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
           health-pill-step-index="{{healthPillStepIndex}}"
           handle-edge-selected="[[handleEdgeSelected]]"
           trace-inputs="[[traceInputs]]"
-          extract-nodes="[[extractNodes]]"
         ></tf-graph-scene>
       </div>
     </div>
@@ -137,7 +136,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
   @property({type: Boolean})
   traceInputs: boolean;
   @property({type: Boolean})
-  extractNodes: boolean;
+  autoExtractNodes: boolean;
   @property({type: Array})
   nodeContextMenuItems: unknown[];
   @property({
@@ -176,7 +175,17 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     (this.$$('tf-graph-scene') as any).panToNode(nodeName);
   }
   @observe(
-    'extractNodes',
+    'autoExtractNodes',
+  )
+  _autoExtractNodesChanged() {
+    var graphHierarchy = this.graphHierarchy;
+    if (!graphHierarchy) return;
+    for (const node of Object.values(graphHierarchy.getNodeMap())) {
+        node.include = tf_graph.InclusionType.UNSPECIFIED;
+    }
+    this._buildRenderHierarchy(graphHierarchy);
+  }
+  @observe(
     'graphHierarchy',
     'edgeWidthFunction',
     'handleNodeSelected',
@@ -271,7 +280,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
         const renderGraph = new tf_graph_render.RenderGraphInfo(
           graphHierarchy,
           !!this.stats, /** displayingStats */
-          !!this.extractNodes
+          this.autoExtractNodes
         );
         renderGraph.edgeLabelFunction = this.edgeLabelFunction;
         renderGraph.edgeWidthFunction = this.edgeWidthFunction;

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -179,7 +179,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     var graphHierarchy = this.graphHierarchy;
     if (!graphHierarchy) return;
     for (const node of Object.values(graphHierarchy.getNodeMap())) {
-        node.include = tf_graph.InclusionType.UNSPECIFIED;
+      node.include = tf_graph.InclusionType.UNSPECIFIED;
     }
     this._buildRenderHierarchy(graphHierarchy);
   }
@@ -277,7 +277,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
       () => {
         const renderGraph = new tf_graph_render.RenderGraphInfo(
           graphHierarchy,
-          !!this.stats, /** displayingStats */
+          !!this.stats /** displayingStats */,
           this.autoExtractNodes
         );
         renderGraph.edgeLabelFunction = this.edgeLabelFunction;

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -174,9 +174,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
   panToNode(nodeName) {
     (this.$$('tf-graph-scene') as any).panToNode(nodeName);
   }
-  @observe(
-    'autoExtractNodes',
-  )
+  @observe('autoExtractNodes')
   _autoExtractNodesChanged() {
     var graphHierarchy = this.graphHierarchy;
     if (!graphHierarchy) return;

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -77,6 +77,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
           health-pill-step-index="{{healthPillStepIndex}}"
           handle-edge-selected="[[handleEdgeSelected]]"
           trace-inputs="[[traceInputs]]"
+          extract-nodes="[[extractNodes]]"
         ></tf-graph-scene>
       </div>
     </div>
@@ -135,6 +136,8 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
   renderHierarchy: tf_graph_render.RenderGraphInfo;
   @property({type: Boolean})
   traceInputs: boolean;
+  @property({type: Boolean})
+  extractNodes: boolean;
   @property({type: Array})
   nodeContextMenuItems: unknown[];
   @property({
@@ -173,6 +176,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     (this.$$('tf-graph-scene') as any).panToNode(nodeName);
   }
   @observe(
+    'extractNodes',
     'graphHierarchy',
     'edgeWidthFunction',
     'handleNodeSelected',
@@ -264,9 +268,10 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     const renderGraph = tf_graph_util.time(
       'new tf_graph_render.Hierarchy',
       () => {
-        var renderGraph = new tf_graph_render.RenderGraphInfo(
+        const renderGraph = new tf_graph_render.RenderGraphInfo(
           graphHierarchy,
-          !!this.stats /** displayingStats */
+          !!this.stats, /** displayingStats */
+          !!this.extractNodes
         );
         renderGraph.edgeLabelFunction = this.edgeLabelFunction;
         renderGraph.edgeWidthFunction = this.edgeWidthFunction;

--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.ts
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.ts
@@ -97,7 +97,7 @@ class TfGraphApp extends LegacyElementMixin(PolymerElement) {
             selected-file="{{selectedFile}}"
             on-fit-tap="_fit"
             trace-inputs="{{_traceInputs}}"
-            extract-nodes="{{_extractNodes}}"
+            auto-extract-nodes="{{_autoExtractNodes}}"
           ></tf-graph-controls>
           <tf-graph-loader
             id="loader"
@@ -118,7 +118,7 @@ class TfGraphApp extends LegacyElementMixin(PolymerElement) {
             render-hierarchy="{{_renderHierarchy}}"
             selected-node="{{selectedNode}}"
             trace-inputs="[[_traceInputs]]"
-            extractNodes="[[_extractNodes]]"
+            autoExtractNodes="[[_autoExtractNodes]]"
           ></tf-graph-board>
         </div>
       </div>
@@ -167,7 +167,7 @@ class TfGraphApp extends LegacyElementMixin(PolymerElement) {
   @property({type: Boolean})
   _traceInputs: boolean;
   @property({type: Boolean})
-  _extractNodes: boolean;
+  _autoExtractNodes: boolean;
   _updateToolbar() {
     (this.$$('.container') as HTMLElement).classList.toggle(
       'no-toolbar',

--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.ts
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.ts
@@ -97,6 +97,7 @@ class TfGraphApp extends LegacyElementMixin(PolymerElement) {
             selected-file="{{selectedFile}}"
             on-fit-tap="_fit"
             trace-inputs="{{_traceInputs}}"
+            extract-nodes="{{_extractNodes}}"
           ></tf-graph-controls>
           <tf-graph-loader
             id="loader"
@@ -117,6 +118,7 @@ class TfGraphApp extends LegacyElementMixin(PolymerElement) {
             render-hierarchy="{{_renderHierarchy}}"
             selected-node="{{selectedNode}}"
             trace-inputs="[[_traceInputs]]"
+            extractNodes="[[_extractNodes]]"
           ></tf-graph-board>
         </div>
       </div>
@@ -164,6 +166,8 @@ class TfGraphApp extends LegacyElementMixin(PolymerElement) {
   _progress: object;
   @property({type: Boolean})
   _traceInputs: boolean;
+  @property({type: Boolean})
+  _extractNodes: boolean;
   _updateToolbar() {
     (this.$$('.container') as HTMLElement).classList.toggle(
       'no-toolbar',

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
@@ -152,6 +152,7 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
           handle-node-selected="[[handleNodeSelected]]"
           handle-edge-selected="[[handleEdgeSelected]]"
           trace-inputs="[[traceInputs]]"
+          extract-nodes="[[extractNodes]]"
         ></tf-graph>
       </div>
       <div id="info">
@@ -196,6 +197,8 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
   progress: object;
   @property({type: Boolean})
   traceInputs: boolean;
+  @property({type: Boolean})
+  extractNodes: boolean;
   @property({type: String})
   colorBy: string;
   @property({

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
@@ -1,3 +1,6 @@
+    for (const node of Object.values(this.graphHierarchy.getNodeMap())) {
+        node.include = tf_graph.InclusionType.UNSPECIFIED;
+    }
 /* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -152,7 +155,7 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
           handle-node-selected="[[handleNodeSelected]]"
           handle-edge-selected="[[handleEdgeSelected]]"
           trace-inputs="[[traceInputs]]"
-          extract-nodes="[[extractNodes]]"
+          auto-extract-nodes="[[autoExtractNodes]]"
         ></tf-graph>
       </div>
       <div id="info">
@@ -198,7 +201,7 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
   @property({type: Boolean})
   traceInputs: boolean;
   @property({type: Boolean})
-  extractNodes: boolean;
+  autoExtractNodes: boolean;
   @property({type: String})
   colorBy: string;
   @property({

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
@@ -1,6 +1,3 @@
-    for (const node of Object.values(this.graphHierarchy.getNodeMap())) {
-        node.include = tf_graph.InclusionType.UNSPECIFIED;
-    }
 /* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -230,17 +230,17 @@ export class RenderGraphInfo {
   };
   root: RenderGroupNodeInfo;
   traceInputs: boolean;
-  extractNodes: boolean;
+  private autoExtractNodes: boolean;
   edgeLabelFunction: EdgeLabelFunction;
   // An optional function that computes the thickness of an edge given edge
   // data. If not provided, defaults to encoding tensor size in thickness.
   edgeWidthFunction: EdgeThicknessFunction;
   constructor(hierarchy: tf_graph.Hierarchy,
               displayingStats: boolean,
-              extractNodes: boolean) {
+              autoExtractNodes: boolean) {
     this.hierarchy = hierarchy;
     this.displayingStats = displayingStats;
-    this.extractNodes = extractNodes;
+    this.autoExtractNodes = autoExtractNodes;
     this.index = {};
     this.renderedOpNames = [];
     this.computeScales();
@@ -943,7 +943,7 @@ export class RenderGraphInfo {
       coreGraph.setEdge(edgeObj.v, edgeObj.w, renderMetaedgeInfo);
     });
     if (renderGroupNodeInfo.node.type === NodeType.META) {
-      extractHighDegrees(renderGroupNodeInfo, this.extractNodes);
+      extractHighDegrees(renderGroupNodeInfo, this.autoExtractNodes);
     }
     // If there are functions, it is possible for metanodes to be dynamically
     // added later. Construct the hierarchies for nodes that are predecessors to
@@ -2179,11 +2179,11 @@ export function mapIndexToHue(id: number): number {
  * screw up the graph layout.
  *
  * @param {Render.Node} renderNode Node to manipulate.
- * @param {boolean} extractNodes Whether to automatically exclude high-degree
+ * @param {boolean} autoExtractNodes Whether to automatically exclude high-degree
  *   nodes from the main graph. If false, only exclude predefined nodes.
  */
 function extractHighDegrees(renderNode: RenderGroupNodeInfo,
-                            extractNodes: boolean) {
+                            autoExtractNodes: boolean) {
   extractSpecifiedNodes(renderNode);
 
   if (PARAMS.outExtractTypes.length) {
@@ -2196,7 +2196,7 @@ function extractHighDegrees(renderNode: RenderGroupNodeInfo,
     extractPredefinedSource(renderNode);
   }
 
-  if (extractNodes) {
+  if (autoExtractNodes) {
     extractHighInOrOutDegree(renderNode);
   }
 

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -235,9 +235,11 @@ export class RenderGraphInfo {
   // An optional function that computes the thickness of an edge given edge
   // data. If not provided, defaults to encoding tensor size in thickness.
   edgeWidthFunction: EdgeThicknessFunction;
-  constructor(hierarchy: tf_graph.Hierarchy,
-              displayingStats: boolean,
-              autoExtractNodes: boolean) {
+  constructor(
+    hierarchy: tf_graph.Hierarchy,
+    displayingStats: boolean,
+    autoExtractNodes: boolean
+  ) {
     this.hierarchy = hierarchy;
     this.displayingStats = displayingStats;
     this.autoExtractNodes = autoExtractNodes;
@@ -2182,8 +2184,10 @@ export function mapIndexToHue(id: number): number {
  * @param {boolean} autoExtractNodes Whether to automatically exclude high-degree
  *   nodes from the main graph. If false, only exclude predefined nodes.
  */
-function extractHighDegrees(renderNode: RenderGroupNodeInfo,
-                            autoExtractNodes: boolean) {
+function extractHighDegrees(
+  renderNode: RenderGroupNodeInfo,
+  autoExtractNodes: boolean
+) {
   extractSpecifiedNodes(renderNode);
 
   if (PARAMS.outExtractTypes.length) {

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -1093,7 +1093,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
   autoExtractNodes: boolean = false;
   @property({
     type: Number,
-    observer: '_selectedTagIndexChanged',
+    notify: true,
   })
   _selectedTagIndex: number = 0;
   /**
@@ -1369,7 +1369,6 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     this._selectedTagIndex = 0;
     this._selectedGraphType = this._getDefaultSelectionType();
     this.traceInputs = false; // Set trace input to off-state.
-    this.autoExtractNodes = true;
     this._setDownloadFilename(
       this.datasets[runIndex] ? this.datasets[runIndex].name : ''
     );

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -492,6 +492,13 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
           </paper-toggle-button>
         </div>
       </div>
+      <div class="control-holder">
+        <div>
+          <paper-toggle-button checked="{{extractNodes}}" class="title">
+            Auto-extract high-degree nodes
+          </paper-toggle-button>
+        </div>
+      </div>
       <template is="dom-if" if="[[healthPillsFeatureEnabled]]">
         <div class="control-holder">
           <paper-toggle-button checked="{{healthPillsToggledOn}}" class="title"
@@ -1080,6 +1087,11 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
   })
   traceInputs: boolean = false;
   @property({
+    type: Boolean,
+    notify: true,
+  })
+  extractNodes: boolean = false;
+  @property({
     type: Number,
     observer: '_selectedTagIndexChanged',
   })
@@ -1357,6 +1369,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     this._selectedTagIndex = 0;
     this._selectedGraphType = this._getDefaultSelectionType();
     this.traceInputs = false; // Set trace input to off-state.
+    this.extractNodes = true;
     this._setDownloadFilename(
       this.datasets[runIndex] ? this.datasets[runIndex].name : ''
     );

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -1090,10 +1090,10 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     type: Boolean,
     notify: true,
   })
-  autoExtractNodes: boolean = false;
+  autoExtractNodes: boolean = true;
   @property({
     type: Number,
-    notify: true,
+    observer: '_selectedTagIndexChanged',
   })
   _selectedTagIndex: number = 0;
   /**

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -494,7 +494,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
       </div>
       <div class="control-holder">
         <div>
-          <paper-toggle-button checked="{{extractNodes}}" class="title">
+          <paper-toggle-button checked="{{autoExtractNodes}}" class="title">
             Auto-extract high-degree nodes
           </paper-toggle-button>
         </div>
@@ -1090,7 +1090,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     type: Boolean,
     notify: true,
   })
-  extractNodes: boolean = false;
+  autoExtractNodes: boolean = false;
   @property({
     type: Number,
     observer: '_selectedTagIndexChanged',
@@ -1369,7 +1369,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     this._selectedTagIndex = 0;
     this._selectedGraphType = this._getDefaultSelectionType();
     this.traceInputs = false; // Set trace input to off-state.
-    this.extractNodes = true;
+    this.autoExtractNodes = true;
     this._setDownloadFilename(
       this.datasets[runIndex] ? this.datasets[runIndex].name : ''
     );

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -87,7 +87,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
         health-pills-toggled-on="{{healthPillsToggledOn}}"
         on-fit-tap="_fit"
         trace-inputs="{{_traceInputs}}"
-        extract-nodes="{{_extractNodes}}"
+        auto-extract-nodes="{{_autoExtractNodes}}"
       ></tf-graph-controls>
       <div
         class$="center [[_getGraphDisplayClassName(_selectedFile, _datasets)]]"
@@ -161,7 +161,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
             selected-node="{{_selectedNode}}"
             stats="[[_stats]]"
             trace-inputs="[[_traceInputs]]"
-            extract-nodes="[[_extractNodes]]"
+            auto-extract-nodes="[[_autoExtractNodes]]"
           ></tf-graph-board>
         </div>
       </div>
@@ -307,7 +307,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
   @property({type: Boolean})
   _traceInputs: boolean;
   @property({type: Boolean})
-  _extractNodes: boolean;
+  _autoExtractNodes: boolean;
   @property({type: Object})
   _selectedFile: any;
   attached() {

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -87,6 +87,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
         health-pills-toggled-on="{{healthPillsToggledOn}}"
         on-fit-tap="_fit"
         trace-inputs="{{_traceInputs}}"
+        extract-nodes="{{_extractNodes}}"
       ></tf-graph-controls>
       <div
         class$="center [[_getGraphDisplayClassName(_selectedFile, _datasets)]]"
@@ -160,6 +161,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
             selected-node="{{_selectedNode}}"
             stats="[[_stats]]"
             trace-inputs="[[_traceInputs]]"
+            extract-nodes="[[_extractNodes]]"
           ></tf-graph-board>
         </div>
       </div>
@@ -304,6 +306,8 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
   _compatibilityProvider: object;
   @property({type: Boolean})
   _traceInputs: boolean;
+  @property({type: Boolean})
+  _extractNodes: boolean;
   @property({type: Object})
   _selectedFile: any;
   attached() {


### PR DESCRIPTION
This adds a toggle (next to "trace inputs") which turns automatic high-degree node extraction off.

* Motivation for features / changes
Automatic aux node creation can break the graph up in unwanted ways. For some graphs, the high-degree heuristic is not useful (graphs that have high-degree internal nodes, e.g., if you concatenate lots of towers or some such)

* Technical description of changes
This adds an argument to the hierarchy constructor which if passed, avoids calling the high-degree node extraction code. It also removes the hard-coded PARAM entry for node extraction (which turned off all node extraction, but wasn't user settable).

* Detailed steps to verify changes work correctly (as executed by you)

  - build
  - upload graph known to be broken apart verify it's broken apart
  - toggle "auto-extract high-degree nodes" 
  - verify graph changes, and high-degree nodes are not extracted

* Alternate designs / implementations considered

  - Make the in/out degree triggering extraction configurable (probably not worth it)
  - Turn off high-degree extraction altogether instead of providing the option (would work for me, but I'm hesitant to break others in this manner)
  - Rely more heavily on op list extraction (this might work, but I lack the expertise to come up with a good op list)