### PR TITLE
graph: minor type fixes for ColorBy, templateIndex (1)

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -31,9 +31,13 @@ import * as tf_graph_render from '../tf_graph_common/render';
 import {template} from './tf-graph-scene.html';
 
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {TfGraphScene} from '../tf_graph_common/tf-graph-scene';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-graph-scene')
-class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
+class TfGraphScene2
+  extends LegacyElementMixin(PolymerElement)
+  implements TfGraphScene {
   static readonly template = template;
 
   @property({type: Object})
@@ -41,7 +45,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
   @property({type: String})
   name: string;
   @property({type: String})
-  colorBy: string;
+  colorBy: ColorBy;
   @property({type: Boolean})
   traceInputs: boolean;
 
@@ -118,7 +122,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
    * This property is a d3.scale.ordinal object.
    */
   @property({type: Object})
-  templateIndex: Function;
+  templateIndex: (name: string) => number;
 
   /**
    * A minimap object to notify for zoom events.
@@ -232,11 +236,8 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
   getGraphSvgRoot(): SVGElement {
     return this.$.svg as SVGElement;
   }
-  /**
-   * @returns {!HTMLElement}
-   */
-  getContextMenu() {
-    return this.$.contextMenu;
+  getContextMenu(): HTMLElement {
+    return this.$.contextMenu as HTMLElement;
   }
   /**
    * Resets the state of the component. Called whenever the whole graph
@@ -254,7 +255,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
     tf_graph_scene_node.removeGradientDefinitions(this.$.svg as SVGElement);
   }
   /** Main method for building the scene */
-  _build(renderHierarchy) {
+  _build(renderHierarchy: tf_graph_render.RenderGraphInfo) {
     this.templateIndex = renderHierarchy.hierarchy.getTemplateIndex();
     tf_graph_util.time(
       'tf-graph-scene (layout):',
@@ -377,7 +378,6 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
   @observe('_isAttached', 'renderHierarchy')
   _animateAndFit() {
     var isAttached = this._isAttached;
-    var renderHierarchy = this.renderHierarchy;
     if (this._hasRenderHierarchyBeenFitOnce || !isAttached) {
       // Do not animate and fit if the scene has already fitted this render hierarchy once. Or if
       // the graph dashboard is not attached (in which case the scene lacks DOM info for fitting).

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -27,6 +27,7 @@ import * as tf_graph_util from '../tf_graph_common/util';
 import * as tf_graph_hierarchy from '../tf_graph_common/hierarchy';
 import * as tf_graph_render from '../tf_graph_common/render';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-graph')
 class TfGraph extends LegacyElementMixin(PolymerElement) {
@@ -120,7 +121,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
   })
   highlightedNode: string;
   @property({type: String})
-  colorBy: string;
+  colorBy: ColorBy;
   @property({
     type: Object,
     notify: true,

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
@@ -21,6 +21,7 @@ import '../tf_graph/tf-graph';
 import * as tf_graph from '../tf_graph_common/graph';
 import * as tf_graph_render from '../tf_graph_common/render';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 /**
  * Element for putting tf-graph and tf-graph-info side by side.
@@ -200,7 +201,7 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
   @property({type: Boolean})
   autoExtractNodes: boolean;
   @property({type: String})
-  colorBy: string;
+  colorBy: ColorBy;
   @property({
     type: Object,
     notify: true,

--- a/tensorboard/plugins/graph/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/BUILD
@@ -27,6 +27,7 @@ tf_ts_library(
         "tf-graph-scene.ts",
         "tf-node-icon.ts",
         "util.ts",
+        "view_types.ts",
     ],
     strict_checks = False,
     visibility = ["//visibility:public"],

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -1359,7 +1359,6 @@ export function buildGroupForAnnotation(
   annotationGroups
     .exit()
     .each(function (a) {
-      let aGroup = d3.select(this);
       // Remove annotation from the index in the scene
       sceneElement.removeAnnotationGroup(a, d);
     })

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -39,6 +39,7 @@ import * as tf_graph_scene from './scene';
 import * as tf_graph_util from './util';
 
 import {TfGraphScene} from './tf-graph-scene';
+import {ColorBy} from './view_types';
 
 /**
  * Select or Create a 'g.nodes' group to a given sceneGroup
@@ -729,15 +730,7 @@ function position(nodeGroup, d: render.RenderNodeInfo) {
     }
   }
 }
-/** Enum specifying the options to color nodes by */
-export enum ColorBy {
-  STRUCTURE,
-  DEVICE,
-  XLA_CLUSTER,
-  COMPUTE_TIME,
-  MEMORY,
-  OP_COMPATIBILITY,
-}
+
 function getGradient(
   id: string,
   colors: Array<{
@@ -786,8 +779,8 @@ export function removeGradientDefinitions(svgRoot: SVGElement) {
  * for the fill inside the svgRoot when necessary.
  */
 export function getFillForNode(
-  templateIndex,
-  colorBy,
+  templateIndex: (name: string) => number,
+  colorBy: ColorBy,
   renderInfo: render.RenderNodeInfo,
   isExpanded: boolean,
   svgRoot?: SVGElement
@@ -880,14 +873,14 @@ export function stylize(
   nodeClass?
 ) {
   nodeClass = nodeClass || Class.Node.SHAPE;
-  let isHighlighted = sceneElement.isNodeHighlighted(renderInfo.node.name);
-  let isSelected = sceneElement.isNodeSelected(renderInfo.node.name);
-  let isExtract =
+  const isHighlighted = sceneElement.isNodeHighlighted(renderInfo.node.name);
+  const isSelected = sceneElement.isNodeSelected(renderInfo.node.name);
+  const isExtract =
     renderInfo.isInExtract ||
     renderInfo.isOutExtract ||
     renderInfo.isLibraryFunction;
-  let isExpanded = renderInfo.expanded && nodeClass !== Class.Annotation.NODE;
-  let isFadedOut = renderInfo.isFadedOut;
+  const isExpanded = renderInfo.expanded && nodeClass !== Class.Annotation.NODE;
+  const isFadedOut = renderInfo.isFadedOut;
   nodeGroup.classed('highlighted', isHighlighted);
   nodeGroup.classed('selected', isSelected);
   nodeGroup.classed('extract', isExtract);
@@ -895,10 +888,12 @@ export function stylize(
   nodeGroup.classed('faded', isFadedOut);
   // Main node always exists here and it will be reached before subscene,
   // so d3 selection is fine here.
-  let node = nodeGroup.select('.' + nodeClass + ' .' + Class.Node.COLOR_TARGET);
-  let fillColor = getFillForNode(
+  const node = nodeGroup.select(
+    '.' + nodeClass + ' .' + Class.Node.COLOR_TARGET
+  );
+  const fillColor = getFillForNode(
     sceneElement.templateIndex,
-    ColorBy[sceneElement.colorBy.toUpperCase()],
+    sceneElement.colorBy,
     renderInfo,
     isExpanded,
     sceneElement.getGraphSvgRoot()
@@ -1366,7 +1361,7 @@ export function buildGroupForAnnotation(
     .each(function (a) {
       let aGroup = d3.select(this);
       // Remove annotation from the index in the scene
-      sceneElement.removeAnnotationGroup(a, d, aGroup);
+      sceneElement.removeAnnotationGroup(a, d);
     })
     .remove();
   return annotationGroups;

--- a/tensorboard/plugins/graph/tf_graph_common/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/tf-graph-scene.ts
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import * as d3 from 'd3';
-import {RenderNodeInfo} from './render';
+import {Annotation, RenderNodeInfo} from './render';
+import {ColorBy} from './view_types';
 
 type Selection = d3.Selection<any, any, any, any>;
 // This technically extends Polymer.Component whose constructor is not
@@ -22,12 +23,15 @@ export abstract class TfGraphScene extends HTMLElement {
   maxMetanodeLabelLength: number;
   maxMetanodeLabelLengthLargeFont: number;
   maxMetanodeLabelLengthFontSize: number;
-  templateIndex: () => {};
-  colorBy: string;
+  templateIndex: (name: string) => number;
+  colorBy: ColorBy;
   abstract fire(eventName: string, daat: any): void;
   abstract addNodeGroup(name: string, selection: Selection): void;
   abstract removeNodeGroup(name: string): void;
-  abstract removeAnnotationGroup(name: string): void;
+  abstract removeAnnotationGroup(
+    annotation: Annotation,
+    renderNode: RenderNodeInfo
+  ): void;
   abstract isNodeExpanded(node: RenderNodeInfo): boolean;
   abstract isNodeHighlighted(nodeName: string): boolean;
   abstract isNodeSelected(nodeName: string): boolean;

--- a/tensorboard/plugins/graph/tf_graph_common/tf-node-icon.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/tf-node-icon.ts
@@ -22,6 +22,7 @@ import * as tf_graph_scene_node from '../tf_graph_common/node';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 
 import './tf-graph-icon';
+import {ColorBy} from './view_types';
 
 @customElement('tf-node-icon')
 class TfNodeIcon extends LegacyElementMixin(PolymerElement) {
@@ -71,7 +72,7 @@ class TfNodeIcon extends LegacyElementMixin(PolymerElement) {
   @property({
     type: Object,
   })
-  colorBy: any = 'structural';
+  colorBy: ColorBy = ColorBy.STRUCTURE;
 
   /**
    * Function used by structural coloring algorithm to determine which
@@ -80,7 +81,7 @@ class TfNodeIcon extends LegacyElementMixin(PolymerElement) {
   @property({
     type: Object,
   })
-  templateIndex: object = null;
+  templateIndex: (name: string) => number | null = null;
 
   /** Type of node to draw (ignored if node is set). */
   @property({
@@ -139,16 +140,14 @@ class TfNodeIcon extends LegacyElementMixin(PolymerElement) {
   _computeFillOverride(
     inputNode,
     inputRenderInfo,
-    inputColorBy,
+    inputColorBy: ColorBy,
     inputTemplateIndex,
     inputFill
   ) {
-    if (inputNode && inputRenderInfo && inputColorBy && inputTemplateIndex) {
-      var ns = tf_graph_scene_node;
-      var colorBy = ns.ColorBy[inputColorBy.toUpperCase()];
-      return ns.getFillForNode(
+    if (inputNode && inputRenderInfo && inputTemplateIndex) {
+      return tf_graph_scene_node.getFillForNode(
         inputTemplateIndex,
-        colorBy,
+        inputColorBy,
         inputRenderInfo,
         false
       );
@@ -202,17 +201,15 @@ class TfNodeIcon extends LegacyElementMixin(PolymerElement) {
   }
   _onFillOverrideChanged(newFill, oldFill) {
     const {node, renderInfo, colorBy, templateIndex} = this;
-    const ns = tf_graph_scene_node;
     if (newFill !== oldFill) {
-      ns.removeGradientDefinitions(
+      tf_graph_scene_node.removeGradientDefinitions(
         (this.$.icon as any).getSvgDefinableElement()
       );
     }
-    if (node && renderInfo && colorBy && templateIndex) {
-      const nsColorBy = ns.ColorBy[colorBy.toUpperCase()];
-      ns.getFillForNode(
+    if (node && renderInfo && templateIndex) {
+      tf_graph_scene_node.getFillForNode(
         templateIndex,
-        nsColorBy,
+        colorBy,
         renderInfo as any,
         false,
         (this.$.icon as any).getSvgDefinableElement()

--- a/tensorboard/plugins/graph/tf_graph_common/view_types.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/view_types.ts
@@ -1,0 +1,29 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * @fileoverview Public view-related types.
+ */
+
+/**
+ * A set of modes, each identifying a particular method for coloring nodes.
+ */
+export enum ColorBy {
+  COMPUTE_TIME = 'compute_time',
+  DEVICE = 'device',
+  MEMORY = 'memory',
+  OP_COMPATIBILITY = 'op_compatibility',
+  STRUCTURE = 'structure',
+  XLA_CLUSTER = 'xla_cluster',
+}

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -28,6 +28,7 @@ import '../../../components/tf_dashboard_common/tensorboard-color';
 import '../tf_graph_common/tf-graph-icon';
 import '../tf_graph_node_search/tf-graph-node-search';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 interface DeviceNameExclude {
   regex: RegExp;
@@ -79,13 +80,6 @@ interface CurrentDevice {
   suffix: string;
   used: boolean;
   ignoredMsg: string | null;
-}
-export enum ColorBy {
-  COMPUTE_TIME = 'compute_time',
-  MEMORY = 'memory',
-  STRUCTURE = 'structure',
-  XLA_CLUSTER = 'xla_cluster',
-  OP_COMPATIBILITY = 'op_compatibility',
 }
 interface ColorParams {
   minValue: number;
@@ -1035,14 +1029,11 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
     notify: true,
   })
   devicesForStats: object = null;
-  /**
-   * @type {!ColorBy}
-   */
   @property({
     type: String,
     notify: true,
   })
-  colorBy: string = ColorBy.STRUCTURE;
+  colorBy: ColorBy = ColorBy.STRUCTURE;
   @property({
     type: Object,
     notify: true,
@@ -1282,7 +1273,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
   get _currentGradientParams(): object {
     var colorByParams = this.colorByParams;
     var colorBy = this.colorBy;
-    if (!this._isGradientColoring(this.stats as any, colorBy as any)) {
+    if (!this._isGradientColoring(this.stats as any, colorBy)) {
       return;
     }
     const params: ColorParams = colorByParams[colorBy];

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.ts
@@ -23,6 +23,7 @@ import '../tf_graph_debugger_data_card/tf-graph-debugger-data-card';
 import '../tf_graph_op_compat_card/tf-graph-op-compat-card';
 import './tf-node-info';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-graph-info')
 class TfGraphInfo extends LegacyElementMixin(PolymerElement) {
@@ -102,7 +103,7 @@ class TfGraphInfo extends LegacyElementMixin(PolymerElement) {
   })
   healthPillStepIndex: number;
   @property({type: String})
-  colorBy: string;
+  colorBy: ColorBy;
   @property({type: String})
   compatNodeTitle: string;
   // Two-ways

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
@@ -27,6 +27,7 @@ import * as tf_graph_scene_node from '../tf_graph_common/node';
 
 import '../../../components/tf_wbr_string/tf-wbr-string';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-node-info')
 class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
@@ -442,7 +443,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   renderHierarchy: any;
   /** What to color the nodes by (compute time, memory, device etc.) */
   @property({type: String})
-  colorBy: string;
+  colorBy: ColorBy;
   @property({
     type: Object,
     computed: '_getNode(graphNodeName, graphHierarchy)',

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-list-item.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-list-item.ts
@@ -19,6 +19,7 @@ import '../../../components/tf_dashboard_common/tensorboard-color';
 import '../tf_graph_common/tf-node-icon';
 
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-node-list-item')
 class TfNodeListItem extends LegacyElementMixin(PolymerElement) {
@@ -116,7 +117,7 @@ class TfNodeListItem extends LegacyElementMixin(PolymerElement) {
   })
   itemType: string;
   @property({type: String})
-  colorBy: string;
+  colorBy: ColorBy;
   @property({type: Object})
   colorByParams: object;
   @property({type: Object})

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-list-item.ts
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-list-item.ts
@@ -19,6 +19,7 @@ import '../../../components/tf_dashboard_common/tensorboard-color';
 import '../tf_graph_common/tf-node-icon';
 
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-graph-op-compat-list-item')
 class TfGraphOpCompatListItem extends LegacyElementMixin(PolymerElement) {
@@ -117,11 +118,11 @@ class TfGraphOpCompatListItem extends LegacyElementMixin(PolymerElement) {
   })
   itemType: string;
   @property({type: String})
-  colorBy: string;
+  colorBy: ColorBy;
   @property({type: Object})
   colorByParams: object;
   @property({type: Object})
-  templateIndex: object;
+  templateIndex: (name: string) => number;
   _itemTypeChanged() {
     if (this.itemType !== 'subnode') {
       this.$['list-item'].classList.add('clickable');


### PR DESCRIPTION
Refactors types for:
- ColorBy: merges 2 duplicate types found in tf_graph and tf_graph_controls
- templateIndex: previously often typed as a generic `Function`

Diffbase: none
Followup: https://github.com/tensorflow/tensorboard/pull/4725