### PR TITLE
graph: refactor Hierarchy, GraphOptions (2)

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -87,7 +87,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     notify: true,
     observer: '_graphChanged',
   })
-  graphHierarchy: tf_graph.Hierarchy;
+  graphHierarchy: tf_graph_hierarchy.Hierarchy;
   @property({type: Object})
   basicGraph: tf_graph.SlimGraph;
   @property({type: Object})

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
@@ -22,6 +22,7 @@ import * as tf_graph from '../tf_graph_common/graph';
 import * as tf_graph_render from '../tf_graph_common/render';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import {ColorBy} from '../tf_graph_common/view_types';
+import {Hierarchy} from '../tf_graph_common/hierarchy';
 
 /**
  * Element for putting tf-graph and tf-graph-info side by side.
@@ -184,7 +185,7 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
     </div>
   `;
   @property({type: Object})
-  graphHierarchy: tf_graph.Hierarchy;
+  graphHierarchy: Hierarchy;
   @property({type: Object})
   graph: tf_graph.SlimGraph;
   @property({type: Object})

--- a/tensorboard/plugins/graph/tf_graph_common/loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/loader.ts
@@ -22,7 +22,7 @@ import * as tf_graph_util from './util';
 
 export type GraphAndHierarchy = {
   graph: tf_graph.SlimGraph;
-  graphHierarchy: tf_graph.Hierarchy;
+  graphHierarchy: hierarchy.Hierarchy;
 };
 export function fetchAndConstructHierarchicalGraph(
   tracker: tf_graph_util.Tracker,

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -779,13 +779,14 @@ export function removeGradientDefinitions(svgRoot: SVGElement) {
  * for the fill inside the svgRoot when necessary.
  */
 export function getFillForNode(
-  templateIndex: (name: string) => number,
+  templateIndex: (name: string) => number | null,
   colorBy: ColorBy,
   renderInfo: render.RenderNodeInfo,
   isExpanded: boolean,
   svgRoot?: SVGElement
 ): string {
   let colorParams = render.MetanodeColors;
+  templateIndex = templateIndex || (() => 0);
   switch (colorBy) {
     case ColorBy.STRUCTURE:
       if (renderInfo.node.type === NodeType.META) {

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -37,6 +37,7 @@ import {
   OpNode,
   OpNodeImpl,
 } from './graph';
+import {Hierarchy} from './hierarchy';
 import * as tf_graph_util from './util';
 
 export type EdgeData = {
@@ -207,7 +208,7 @@ const nodeDisplayNameRegex = new RegExp(
  * for each node in the graph.
  */
 export class RenderGraphInfo {
-  hierarchy: tf_graph.Hierarchy;
+  hierarchy: Hierarchy;
   private displayingStats: boolean;
   private index: {
     [nodeName: string]: RenderNodeInfo;
@@ -236,7 +237,7 @@ export class RenderGraphInfo {
   // data. If not provided, defaults to encoding tensor size in thickness.
   edgeWidthFunction: EdgeThicknessFunction;
   constructor(
-    hierarchy: tf_graph.Hierarchy,
+    hierarchy: Hierarchy,
     displayingStats: boolean,
     autoExtractNodes: boolean
   ) {
@@ -1853,11 +1854,13 @@ export class RenderGroupNodeInfo extends RenderNodeInfo {
   isolatedOutExtract: RenderNodeInfo[];
   /** Array of nodes to show in the function library scene group. */
   libraryFunctionsExtract: RenderNodeInfo[];
-  constructor(groupNode: GroupNode, graphOptions: any) {
+  constructor(
+    groupNode: GroupNode,
+    graphOptions: tf_graph.LabeledGraphOptions
+  ) {
     super(groupNode);
     let metagraph = groupNode.metagraph;
     let gl = metagraph.graph() as any;
-    graphOptions.compound = true;
     this.coreGraph = createGraph<RenderNodeInfo, RenderMetaedgeInfo>(
       gl.name,
       GraphType.CORE,

--- a/tensorboard/plugins/graph/tf_graph_common/template.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/template.ts
@@ -18,12 +18,12 @@ import * as _ from 'lodash';
 import {
   GroupNode,
   hasSimilarDegreeSequence,
-  Hierarchy,
   Metanode,
   NodeType,
   OpNode,
   SeriesNode,
 } from './graph';
+import {Hierarchy} from './hierarchy';
 
 export function detect(
   h,

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.ts
@@ -24,6 +24,7 @@ import '../tf_graph_op_compat_card/tf-graph-op-compat-card';
 import './tf-node-info';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import {ColorBy} from '../tf_graph_common/view_types';
+import {Hierarchy} from '../tf_graph_common/hierarchy';
 
 @customElement('tf-graph-info')
 class TfGraphInfo extends LegacyElementMixin(PolymerElement) {
@@ -90,7 +91,7 @@ class TfGraphInfo extends LegacyElementMixin(PolymerElement) {
   @property({type: String})
   title: string;
   @property({type: Object})
-  graphHierarchy: tf_graph.Hierarchy;
+  graphHierarchy: Hierarchy;
   @property({type: Object})
   graph: tf_graph.SlimGraph;
   @property({type: Object})

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
@@ -79,7 +79,7 @@ class TfGraphDashboardLoader extends LegacyElementMixin(PolymerElement) {
     readOnly: true, //readonly so outsider can't change this via binding
     notify: true,
   })
-  outGraphHierarchy: tf_graph.Hierarchy;
+  outGraphHierarchy: tf_graph_hierarchy.Hierarchy;
   @property({
     type: Object,
     readOnly: true, //readonly so outsider can't change this via binding

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
@@ -180,7 +180,7 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
     </iron-collapse>
   `;
   @property({type: Object})
-  graphHierarchy: tf_graph.Hierarchy;
+  graphHierarchy: tf_graph_hierarchy.Hierarchy;
   @property({type: Object})
   hierarchyParams: object;
   @property({type: Object})


### PR DESCRIPTION
- Merges Hierarchy with HierarchyImpl, since no subclasses are planned
- Introduces LabeledGraphOptions, an options object that configures
  how graphlib.Graph is created.
- Extracts the Hierarchy's template computation operation into a separate
  method that, in the future, could be called lazily.

Diffbase: https://github.com/tensorflow/tensorboard/pull/4724
Followup: https://github.com/tensorflow/tensorboard/pull/4741