### PR TITLE
rust: implement tensor RPCs and client

### DIFF
--- a/tensorboard/data/BUILD
+++ b/tensorboard/data/BUILD
@@ -124,6 +124,7 @@ py_library(
         "//tensorboard:expect_grpc_installed",
         "//tensorboard/data/proto:protos_all_py_pb2",
         "//tensorboard/data/proto:protos_all_py_pb2_grpc",
+        "//tensorboard/util:tensor_util",
         "//tensorboard/util:timing",
     ],
 )
@@ -141,8 +142,10 @@ py_test(
         "//tensorboard:errors",
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_grpc_testing_installed",
+        "//tensorboard:expect_numpy_installed",
         "//tensorboard:test",
         "//tensorboard/data/proto:protos_all_py_pb2",
         "//tensorboard/data/proto:protos_all_py_pb2_grpc",
+        "//tensorboard/util:tensor_util",
     ],
 )

--- a/tensorboard/data/grpc_provider.py
+++ b/tensorboard/data/grpc_provider.py
@@ -18,6 +18,7 @@ import contextlib
 
 import grpc
 
+from tensorboard.util import tensor_util
 from tensorboard.util import timing
 from tensorboard import errors
 from tensorboard.data import provider
@@ -130,6 +131,71 @@ class GrpcDataProvider(provider.DataProvider):
                             step=step,
                             wall_time=wt,
                             value=value,
+                        )
+                        series.append(point)
+            return result
+
+    @timing.log_latency
+    def list_tensors(
+        self, ctx, *, experiment_id, plugin_name, run_tag_filter=None
+    ):
+        with timing.log_latency("build request"):
+            req = data_provider_pb2.ListTensorsRequest()
+            req.experiment_id = experiment_id
+            req.plugin_filter.plugin_name = plugin_name
+            _populate_rtf(run_tag_filter, req.run_tag_filter)
+        with timing.log_latency("_stub.ListTensors"):
+            with _translate_grpc_error():
+                res = self._stub.ListTensors(req)
+        with timing.log_latency("build result"):
+            result = {}
+            for run_entry in res.runs:
+                tags = {}
+                result[run_entry.run_name] = tags
+                for tag_entry in run_entry.tags:
+                    time_series = tag_entry.metadata
+                    tags[tag_entry.tag_name] = provider.TensorTimeSeries(
+                        max_step=time_series.max_step,
+                        max_wall_time=time_series.max_wall_time,
+                        plugin_content=time_series.summary_metadata.plugin_data.content,
+                        description=time_series.summary_metadata.summary_description,
+                        display_name=time_series.summary_metadata.display_name,
+                    )
+            return result
+
+    @timing.log_latency
+    def read_tensors(
+        self,
+        ctx,
+        *,
+        experiment_id,
+        plugin_name,
+        downsample=None,
+        run_tag_filter=None,
+    ):
+        with timing.log_latency("build request"):
+            req = data_provider_pb2.ReadTensorsRequest()
+            req.experiment_id = experiment_id
+            req.plugin_filter.plugin_name = plugin_name
+            _populate_rtf(run_tag_filter, req.run_tag_filter)
+            req.downsample.num_points = downsample
+        with timing.log_latency("_stub.ReadTensors"):
+            with _translate_grpc_error():
+                res = self._stub.ReadTensors(req)
+        with timing.log_latency("build result"):
+            result = {}
+            for run_entry in res.runs:
+                tags = {}
+                result[run_entry.run_name] = tags
+                for tag_entry in run_entry.tags:
+                    series = []
+                    tags[tag_entry.tag_name] = series
+                    d = tag_entry.data
+                    for (step, wt, value) in zip(d.step, d.wall_time, d.value):
+                        point = provider.TensorDatum(
+                            step=step,
+                            wall_time=wt,
+                            numpy=tensor_util.make_ndarray(value),
                         )
                         series.append(point)
             return result

--- a/tensorboard/data/server/server.rs
+++ b/tensorboard/data/server/server.rs
@@ -234,16 +234,114 @@ impl TensorBoardDataProvider for DataProviderHandler {
 
     async fn list_tensors(
         &self,
-        _request: Request<data::ListTensorsRequest>,
+        req: Request<data::ListTensorsRequest>,
     ) -> Result<Response<data::ListTensorsResponse>, Status> {
-        Err(Status::unimplemented("not yet implemented"))
+        let req = req.into_inner();
+        let want_plugin = parse_plugin_filter(req.plugin_filter)?;
+        let (run_filter, tag_filter) = parse_rtf(req.run_tag_filter);
+        let runs = self.read_runs()?;
+
+        let mut res: data::ListTensorsResponse = Default::default();
+        for (run, data) in runs.iter() {
+            if !run_filter.want(run) {
+                continue;
+            }
+            let data = data
+                .read()
+                .map_err(|_| Status::internal(format!("failed to read run data for {:?}", run)))?;
+            let mut run_res: data::list_tensors_response::RunEntry = Default::default();
+            for (tag, ts) in &data.tensors {
+                if !tag_filter.want(tag) {
+                    continue;
+                }
+                if plugin_name(&ts.metadata) != Some(&want_plugin) {
+                    continue;
+                }
+                let max_step = match ts.valid_values().last() {
+                    None => continue,
+                    Some((step, _, _)) => step,
+                };
+                // TODO(@wchargin): Consider tracking this on the time series itself?
+                let max_wall_time = ts
+                    .valid_values()
+                    .map(|(_, wt, _)| wt)
+                    .max()
+                    .expect("have valid values for step but not wall time");
+                run_res.tags.push(data::list_tensors_response::TagEntry {
+                    tag_name: tag.0.clone(),
+                    metadata: Some(data::TensorMetadata {
+                        max_step: max_step.into(),
+                        max_wall_time: max_wall_time.into(),
+                        summary_metadata: Some(*ts.metadata.clone()),
+                        ..Default::default()
+                    }),
+                });
+            }
+            if !run_res.tags.is_empty() {
+                run_res.run_name = run.0.clone();
+                res.runs.push(run_res);
+            }
+        }
+
+        Ok(Response::new(res))
     }
 
     async fn read_tensors(
         &self,
-        _request: Request<data::ReadTensorsRequest>,
+        req: Request<data::ReadTensorsRequest>,
     ) -> Result<Response<data::ReadTensorsResponse>, Status> {
-        Err(Status::unimplemented("not yet implemented"))
+        let req = req.into_inner();
+        let want_plugin = parse_plugin_filter(req.plugin_filter)?;
+        let (run_filter, tag_filter) = parse_rtf(req.run_tag_filter);
+        let num_points = parse_downsample(req.downsample)?;
+        let runs = self.read_runs()?;
+
+        let mut res: data::ReadTensorsResponse = Default::default();
+        for (run, data) in runs.iter() {
+            if !run_filter.want(run) {
+                continue;
+            }
+            let data = data
+                .read()
+                .map_err(|_| Status::internal(format!("failed to read run data for {:?}", run)))?;
+            let mut run_res: data::read_tensors_response::RunEntry = Default::default();
+            for (tag, ts) in &data.tensors {
+                if !tag_filter.want(tag) {
+                    continue;
+                }
+                if plugin_name(&ts.metadata) != Some(&want_plugin) {
+                    continue;
+                }
+
+                let mut points = ts.valid_values().collect::<Vec<_>>();
+                downsample::downsample(&mut points, num_points);
+                let n = points.len();
+                let mut steps = Vec::with_capacity(n);
+                let mut wall_times = Vec::with_capacity(n);
+                let mut values = Vec::with_capacity(n);
+                for (step, wall_time, value) in points {
+                    steps.push(step.into());
+                    wall_times.push(wall_time.into());
+                    // Clone the TensorProto to get a copy to send in the response.
+                    values.push(value.clone());
+                }
+
+                run_res.tags.push(data::read_tensors_response::TagEntry {
+                    tag_name: tag.0.clone(),
+                    data: Some(data::TensorData {
+                        step: steps,
+                        wall_time: wall_times,
+                        value: values,
+                    }),
+                });
+            }
+            if !run_res.tags.is_empty() {
+                run_res.run_name = run.0.clone();
+                res.runs.push(run_res);
+            }
+        }
+
+        Ok(Response::new(res))
     }
 
     async fn list_blob_sequences(
@@ -818,6 +916,107 @@ mod tests {
         let train_run = &map[&Run("train".to_string())];
         let xent_data = &train_run[&Tag("xent".to_string())].data.as_ref().unwrap();
         assert_eq!(xent_data.value, Vec::<f32>::new());
+    }
+
+    #[tokio::test]
+    async fn test_list_tensors() {
+        let commit = CommitBuilder::new()
+            .run("run_with_no_data", None)
+            .scalars("train", "accuracy", |b| b.build())
+            .tensors("train", "weights", |b| b.build())
+            .tensors("test", "weights", |mut b| {
+                b.wall_time_start(1235.0).step_start(0).len(3).build()
+            })
+            .build();
+        let handler = sample_handler(commit);
+        let req = Request::new(data::ListTensorsRequest {
+            experiment_id: "123".to_string(),
+            plugin_filter: Some(data::PluginFilter {
+                plugin_name: "tensors".to_string(),
+            }),
+            ..Default::default()
+        });
+        let res = handler.list_tensors(req).await.unwrap().into_inner();
+
+        assert_eq!(res.runs.len(), 2);
+        let map = run_tag_map!(res.runs);
+
+        let test_run = &map[&Run("test".to_string())];
+        assert_eq!(test_run.len(), 1);
+        let weights_metadata = &test_run[&Tag("weights".to_string())]
+            .metadata
+            .as_ref()
+            .unwrap();
+        assert_eq!(weights_metadata.max_step, 2);
+        assert_eq!(weights_metadata.max_wall_time, 1237.0);
+        assert_eq!(
+            weights_metadata
+                .summary_metadata
+                .as_ref()
+                .unwrap()
+                .plugin_data
+                .as_ref()
+                .unwrap()
+                .plugin_name,
+            "tensors".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_tensors() {
+        fn make_string_tensor_proto<T: Into<Bytes>>(value: T) -> pb::TensorProto {
+            pb::TensorProto {
+                dtype: pb::DataType::DtString.into(),
+                tensor_shape: None, // Scalar shape
+                string_val: vec![value.into()],
+                ..Default::default()
+            }
+        };
+        let commit = CommitBuilder::new()
+            .tensors("train", "status", |mut b| {
+                b.plugin_name("text")
+                    .len(3)
+                    .wall_time_start(1235.0)
+                    .step_start(0)
+                    .eval(|Step(i)| make_string_tensor_proto(format!("Step {}", i)))
+                    .build()
+            })
+            .tensors("test", "weights", |b| b.build())
+            .build();
+        let handler = sample_handler(commit);
+        let req = Request::new(data::ReadTensorsRequest {
+            experiment_id: "123".to_string(),
+            plugin_filter: Some(data::PluginFilter {
+                plugin_name: "text".to_string(),
+            }),
+            run_tag_filter: Some(data::RunTagFilter {
+                runs: Some(data::RunFilter {
+                    names: vec!["train".to_string(), "nonexistent".to_string()],
+                }),
+                tags: None,
+            }),
+            downsample: Some(data::Downsample { num_points: 1000 }),
+            ..Default::default()
+        });
+
+        let res = handler.read_tensors(req).await.unwrap().into_inner();
+
+        assert_eq!(res.runs.len(), 1);
+        let map = run_tag_map!(res.runs);
+
+        let train_run = &map[&Run("train".to_string())];
+        assert_eq!(train_run.len(), 1);
+        let status_data = &train_run[&Tag("status".to_string())].data.as_ref().unwrap();
+        assert_eq!(status_data.step, vec![0, 1, 2]);
+        assert_eq!(status_data.wall_time, vec![1235.0, 1236.0, 1237.0]);
+        assert_eq!(
+            status_data.value,
+            vec![
+                make_string_tensor_proto("Step 0"),
+                make_string_tensor_proto("Step 1"),
+                make_string_tensor_proto("Step 2"),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/tensorboard/data/server/server.rs
+++ b/tensorboard/data/server/server.rs
@@ -968,7 +968,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_tensors() {
-        fn make_string_tensor_proto<T: Into<Bytes>>(value: T) -> pb::TensorProto {
+        fn make_string_tensor_proto(value: impl Into<Bytes>) -> pb::TensorProto {
             pb::TensorProto {
                 dtype: pb::DataType::DtString.into(),
                 tensor_shape: None, // Scalar shape


### PR DESCRIPTION
Implements RPC-level support for the tensor data class in Rustboard (part of #4422).  In particular we include tensor time series when generating the `ListPlugins` response, and we wire up `ListTensors` and `ReadTensors` on both the server and client.  The latter RPCs are almost identical to the scalars ones; the only nontrivial differences involve handling the actual `TensorProto` values, where we have to explicitly clone them out of the `Commit` on the server side, and convert them into numpy arrays on the client side.

This doesn't yet render any data on its own, since nothing populates the `tensors` fields in the commit (which were introduced by #4710), but with coming PRs that implement the population side, I've tested end-to-end that this correctly renders the expected dashboards.  (There are also unit tests for server and client modeled on those for scalars.)

