### PR TITLE
line chart: improve major axis render

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ng.html
@@ -26,7 +26,7 @@ limitations under the License.
           [attr.x]="textXPosition(tick.value)"
           [attr.y]="textYPosition(tick.value)"
         >
-          {{tick.tickFormattedString }}
+          {{ tick.tickFormattedString }}
         </text>
         <title>{{ getFormatter().formatReadable(tick.value) }}</title>
       </g>

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ng.html
@@ -18,14 +18,18 @@ limitations under the License.
   <div class="line"></div>
   <div class="minor">
     <svg class="ticks">
-      <ng-container *ngFor="let tick of getTicks()">
-        <g>
-          <text [attr.x]="textXPosition(tick)" [attr.y]="textYPosition(tick)">
-            {{ getFormatter().formatTick(tick) }}
-          </text>
-          <title>{{ getFormatter().formatReadable(tick) }}</title>
-        </g>
-      </ng-container>
+      <g
+        class="minor-tick-label"
+        *ngFor="let tick of minorTicks; trackBy: trackByMinorTick"
+      >
+        <text
+          [attr.x]="textXPosition(tick.value)"
+          [attr.y]="textYPosition(tick.value)"
+        >
+          {{tick.tickFormattedString }}
+        </text>
+        <title>{{ getFormatter().formatReadable(tick.value) }}</title>
+      </g>
     </svg>
     <button
       [class.extent-edit-button]="true"
@@ -43,14 +47,19 @@ limitations under the License.
       <mat-icon svgIcon="edit_24px"></mat-icon>
     </button>
   </div>
-  <svg *ngIf="shouldShowMajorTicks()" class="major ticks">
-    <g *ngFor="let tick of getMajorTicks()">
-      <text [attr.x]="textXPosition(tick)" [attr.y]="textYPosition(tick)">
-        {{ getFormatter().formatShort(tick) }}
-      </text>
-      <title>{{ getFormatter().formatReadable(tick) }}</title>
-    </g>
-  </svg>
+  <div *ngIf="majorTicks.length" class="major ticks">
+    <span
+      *ngFor="let tick of majorTicks; index as i; last as isLast; trackBy: trackByMajorTick"
+      [class.major-label]="true"
+      [class.last]="isLast"
+      [style.left]="getMajorXPosition(tick) + 'px'"
+      [style.width]="getMajorWidthString(tick, isLast, majorTicks[i + 1])"
+      [style.bottom]="getMajorYPosition(tick) + 'px'"
+      [style.height]="getMajorHeightString(tick, isLast, majorTicks[i + 1])"
+      [title]="getFormatter().formatReadable(tick.start)"
+      ><span>{{ tick.tickFormattedString }}</span></span
+    >
+  </div>
 </div>
 <mat-menu
   #manualControl="matMenu"

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
@@ -20,11 +20,7 @@ limitations under the License.
   overflow: hidden;
 }
 
-line {
-  stroke: #333;
-  stroke-width: 1px;
-}
-
+.major-label,
 text {
   font-size: 11px;
   user-select: none;
@@ -38,6 +34,7 @@ text {
 
 .major,
 .minor {
+  flex: 1 0;
   overflow: hidden;
 }
 
@@ -53,8 +50,14 @@ text {
   width: 100%;
 }
 
+$_axis-margin: 5px;
+
 .x-axis {
   flex-direction: column;
+
+  .line {
+    margin-bottom: $_axis-margin;
+  }
 
   text {
     dominant-baseline: hanging;
@@ -81,6 +84,10 @@ text {
 
 .y-axis {
   flex-direction: row-reverse;
+
+  .line {
+    margin-left: $_axis-margin;
+  }
 
   text {
     dominant-baseline: central;
@@ -152,4 +159,51 @@ text {
 .axis:hover .extent-edit-button,
 .extent-edit-menu-opened {
   display: initial;
+}
+
+.major {
+  position: relative;
+  overflow: hidden;
+  contain: strict;
+
+  .major-label {
+    align-items: center;
+    box-sizing: border-box;
+    display: inline-flex;
+    justify-content: center;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+  }
+
+  .major-label span {
+    max-width: 100%;
+  }
+}
+
+$_border-style: 1px solid mat-color($mat-gray, 500);
+
+.x-axis .major-label {
+  border-left: $_border-style;
+  padding: 0 5px;
+
+  &.last {
+    border-right: $_border-style;
+  }
+}
+
+.y-axis .major-label {
+  border-bottom: $_border-style;
+  height: 100%;
+  padding: 5px 0;
+  width: 100%;
+
+  &.last {
+    border-top: $_border-style;
+  }
+
+  > span {
+    transform: rotate(-90deg);
+    transform-origin: center;
+  }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
@@ -50,17 +50,15 @@ text {
   width: 100%;
 }
 
-$_axis-margin: 5px;
-
 .x-axis {
   flex-direction: column;
 
   .line {
-    margin-bottom: $_axis-margin;
+    margin-bottom: 3px;
   }
 
   text {
-    dominant-baseline: hanging;
+    dominant-baseline: text-before-edge;
     text-anchor: middle;
   }
 
@@ -86,7 +84,7 @@ $_axis-margin: 5px;
   flex-direction: row-reverse;
 
   .line {
-    margin-left: $_axis-margin;
+    margin-left: 5px;
   }
 
   text {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -34,7 +34,10 @@ interface MinorTick {
   tickFormattedString: string;
 }
 
+// Major tick, unlike the minor tick, spans a range.
 interface MajorTick {
+  // Start of the major tick range. An end is implicitly defined by next major tick while
+  // it can certainly change to explicitly define the end.
   start: number;
   tickFormattedString: string;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
@@ -77,7 +77,7 @@ describe('line_chart_v2/sub_view/axis test', () => {
   const ByCss = {
     X_AXIS: By.css('line-chart-axis .x-axis'),
     X_AXIS_LABEL: By.css('line-chart-axis .x-axis .minor text'),
-    X_AXIS_MAJOR_TICK_LABEL: By.css('line-chart-axis .x-axis .major text'),
+    X_AXIS_MAJOR_TICK_LABEL: By.css('line-chart-axis .x-axis .major-label'),
     Y_AXIS_LABEL: By.css('line-chart-axis .y-axis text'),
     X_AXIS_EDIT_BUTTON: By.css('line-chart-axis .x-axis .extent-edit-button'),
   };
@@ -104,22 +104,6 @@ describe('line_chart_v2/sub_view/axis test', () => {
       el.nativeElement.textContent.trim()
     );
     expect(actualLabels).toEqual(axisLabels);
-  }
-
-  function assertLabelLoc(
-    debugElements: DebugElement[],
-    expectedLocs: Array<{x: number; y: number}>
-  ) {
-    const expected = expectedLocs.map((loc) => ({
-      x: String(loc.x),
-      y: String(loc.y),
-    }));
-    const actuals = debugElements.map((el) => ({
-      x: String(el.attributes['x']),
-      y: String(el.attributes['y']),
-    }));
-
-    expect(expected).toEqual(actuals);
   }
 
   it('renders tick in human readable format', () => {
@@ -160,32 +144,6 @@ describe('line_chart_v2/sub_view/axis test', () => {
       '0.6',
       '0.8',
       '1',
-    ]);
-  });
-
-  it('aligns y axis to the right edge of its dom', () => {
-    const fixture = TestBed.createComponent(TestableComponent);
-    fixture.detectChanges();
-
-    assertLabelLoc(fixture.debugElement.queryAll(ByCss.Y_AXIS_LABEL), [
-      // -1 is at the bottom of the DOM
-      {x: 95, y: 200},
-      {x: 95, y: 150},
-      {x: 95, y: 100},
-      {x: 95, y: 50},
-      // 1 is at the top.
-      {x: 95, y: 0},
-    ]);
-  });
-
-  it('aligns x axis to the top edge of its dom', () => {
-    const fixture = TestBed.createComponent(TestableComponent);
-    fixture.detectChanges();
-
-    assertLabelLoc(fixture.debugElement.queryAll(ByCss.X_AXIS_LABEL), [
-      {x: 0, y: 5},
-      {x: 50, y: 5},
-      {x: 100, y: 5},
     ]);
   });
 


### PR DESCRIPTION
In very limited use cases of the wall time or temporal scale, the new
line chart shows a major axis to avoid overcrowding of the minor ticks
with long labels.

Previously, the major tick labels were placed only on the "beginning"
which often can be outside of the viewport. For example, for minor ticks
from "4:23" to "4:59", if the major tick goes from "<Date> 4:00" and
"<Date> 5:00", you may not be able to see the label for "4:00" at all.

This change fixes that by putting a border around, using previous
example, 4:00 to 5:00, and centering the label in the available space.

Other things you might notice are:
- refactor how ticks are generated and its data structure
- instead of using `x` and `y` property on SVG, we use padding and
  margin to position axes now (with little to no visual change).

Before:
![image](https://user-images.githubusercontent.com/2547313/110008273-638a9380-7cd0-11eb-95d2-70ba272bf16c.png)

After:
![image](https://user-images.githubusercontent.com/2547313/110008224-52da1d80-7cd0-11eb-843b-e1faf5e220c3.png)
