### PR TITLE
line chart: improve small number on linear scale 

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -34,7 +34,7 @@ export function createScale(type: ScaleType): Scale {
 
 const PADDING_RATIO = 0.05;
 
-class LinearScale implements Scale {
+export class LinearScale implements Scale {
   private transform(
     inputSpace: [number, number],
     outputSpace: [number, number],

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -16,6 +16,7 @@ tf_ng_module(
     name = "sub_view",
     srcs = [
         "chart_view_utils.ts",
+        "line_chart_axis_utils.ts",
         "line_chart_axis_view.ts",
         "line_chart_grid_view.ts",
         "line_chart_interactive_utils.ts",
@@ -54,6 +55,7 @@ tf_ts_library(
     name = "sub_view_tests",
     testonly = True,
     srcs = [
+        "line_chart_axis_utils_test.ts",
         "line_chart_axis_view_test.ts",
         "line_chart_grid_view_test.ts",
         "line_chart_interactive_utils_test.ts",

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
@@ -39,7 +39,7 @@ function getNumLeadingZerosInFractional(value: number): number {
   return 0;
 }
 
-export function getTicks(
+export function getStandardTicks(
   scale: Scale,
   formatter: Formatter,
   maxMinorTickCount: number,
@@ -66,9 +66,11 @@ export function getTicksForTemporalScale(
   const [low, high] = lowAndHigh;
   let majorTicks = scale.ticks(lowAndHigh, 2);
   if (high - low >= DAY_IN_MS || majorTicks.length > 2) {
-    majorTicks = [];
+    // Return standard ticks.
+    return getStandardTicks(scale, formatter, maxMinorTickCount, lowAndHigh);
   }
 
+  // Do something special for this special case.
   const minorTickVals = scale.ticks(lowAndHigh, maxMinorTickCount);
   return {
     major: majorTicks.map((tickVal) => {
@@ -95,9 +97,11 @@ export function getTicksForLinearScale(
   const [low, high] = lowAndHigh;
   const diff = Math.abs(high - low);
   if (diff > 1e-3) {
-    return getTicks(scale, formatter, maxMinorTickCount, lowAndHigh);
+    // Return standard ticks.
+    return getStandardTicks(scale, formatter, maxMinorTickCount, lowAndHigh);
   }
 
+  // Do something special for this special case.
   const minorTickVals = scale.ticks([low, high], maxMinorTickCount);
   const numFractionalToKeep = getNumLeadingZerosInFractional(diff);
   const majorTickVals = scale.ticks([low, high], 2);

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
@@ -41,9 +41,9 @@ export function getTicksForLinearScale(
   scale: LinearScale,
   formatter: Formatter,
   maxMinorTickCount: number,
-  low: number,
-  high: number
+  lowAndHigh: [number, number]
 ): {minor: MinorTick[]; major: MajorTick[]} {
+  const [low, high] = lowAndHigh;
   const minorTickVals = scale.ticks([low, high], maxMinorTickCount);
 
   const diff = Math.abs(high - low);
@@ -59,7 +59,7 @@ export function getTicksForLinearScale(
     };
   }
 
-  const numFranctionalToKeep = getNumLeadingZerosInFractional(diff);
+  const numFractionalToKeep = getNumLeadingZerosInFractional(diff);
   const majorTickVals = scale.ticks([low, high], 2);
   const minor: MinorTick[] = [];
 
@@ -68,7 +68,7 @@ export function getTicksForLinearScale(
     const [whole, fractional = ''] = String(val).split('.', 2);
     // Rounded to the n
     const flooredNumber = Number(
-      whole + '.' + fractional.slice(0, numFranctionalToKeep)
+      whole + '.' + fractional.slice(0, numFractionalToKeep)
     );
     majorTickValMap.set(flooredNumber, {
       // Put it in the middle. If the flooredNumber is 231.041, then put the axis label
@@ -78,7 +78,7 @@ export function getTicksForLinearScale(
     });
   }
 
-  const maximumDiff = 10 * Math.pow(10, -numFranctionalToKeep);
+  const maximumDiff = 10 * Math.pow(10, -numFractionalToKeep);
 
   for (const val of minorTickVals) {
     for (const flooredMajorVal of majorTickValMap.keys()) {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
@@ -1,0 +1,99 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Formatter} from '../lib/public_types';
+import {LinearScale} from '../lib/scale';
+
+export interface MinorTick {
+  value: number;
+  tickFormattedString: string;
+}
+
+// Major tick, unlike the minor tick, spans a range.
+export interface MajorTick {
+  // Start of the major tick range. An end is implicitly defined by next major tick while
+  // it can certainly change to explicitly define the end.
+  start: number;
+  tickFormattedString: string;
+}
+
+function getNumLeadingZerosInFractional(value: number): number {
+  const maybeExponential = value.toExponential().split('e-', 2);
+  if (maybeExponential.length === 2) {
+    return Number(maybeExponential[1]) - 1;
+  }
+  return 0;
+}
+
+export function getTicksForLinearScale(
+  scale: LinearScale,
+  formatter: Formatter,
+  maxMinorTickCount: number,
+  low: number,
+  high: number
+): {minor: MinorTick[]; major: MajorTick[]} {
+  const minorTickVals = scale.ticks([low, high], maxMinorTickCount);
+
+  const diff = Math.abs(high - low);
+  if (diff > 1e-3) {
+    return {
+      major: [],
+      minor: minorTickVals.map((tickVal) => {
+        return {
+          value: tickVal,
+          tickFormattedString: formatter.formatTick(tickVal),
+        };
+      }),
+    };
+  }
+
+  const numFranctionalToKeep = getNumLeadingZerosInFractional(diff);
+  const majorTickVals = scale.ticks([low, high], 2);
+  const minor: MinorTick[] = [];
+
+  const majorTickValMap = new Map<number, MajorTick>();
+  for (const val of majorTickVals) {
+    const [whole, fractional = ''] = String(val).split('.', 2);
+    // Rounded to the n
+    const flooredNumber = Number(
+      whole + '.' + fractional.slice(0, numFranctionalToKeep)
+    );
+    majorTickValMap.set(flooredNumber, {
+      // Put it in the middle. If the flooredNumber is 231.041, then put the axis label
+      // at 231.0415 which is not the most ideal but certainly better than 231.041.
+      start: flooredNumber,
+      tickFormattedString: formatter.formatShort(flooredNumber),
+    });
+  }
+
+  const maximumDiff = 10 * Math.pow(10, -numFranctionalToKeep);
+
+  for (const val of minorTickVals) {
+    for (const flooredMajorVal of majorTickValMap.keys()) {
+      const diff = Math.abs(val - flooredMajorVal);
+      if (diff >= 0 && diff < maximumDiff) {
+        // `diff` can have very minute number because of IEEE 754.
+        const remainder = String(val).slice(String(flooredMajorVal).length);
+        minor.push({
+          value: val,
+          tickFormattedString: `…${remainder || '0'}`,
+        });
+        break;
+      }
+    }
+  }
+
+  return {major: Array.from(majorTickValMap.values()), minor};
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
@@ -70,7 +70,6 @@ export function getTicksForTemporalScale(
     return getStandardTicks(scale, formatter, maxMinorTickCount, lowAndHigh);
   }
 
-  // Do something special for this special case.
   const minorTickVals = scale.ticks(lowAndHigh, maxMinorTickCount);
   return {
     major: majorTicks.map((tickVal) => {
@@ -101,7 +100,6 @@ export function getTicksForLinearScale(
     return getStandardTicks(scale, formatter, maxMinorTickCount, lowAndHigh);
   }
 
-  // Do something special for this special case.
   const minorTickVals = scale.ticks([low, high], maxMinorTickCount);
   const numFractionalToKeep = getNumLeadingZerosInFractional(diff);
   const majorTickVals = scale.ticks([low, high], 2);

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
@@ -13,10 +13,165 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {LinearScale} from '../lib/scale';
-import {getTicksForLinearScale} from './line_chart_axis_utils';
+import {createScale, LinearScale, ScaleType, TemporalScale} from '../lib/scale';
+import {
+  getStandardTicks,
+  getTicksForLinearScale,
+  getTicksForTemporalScale,
+} from './line_chart_axis_utils';
 
 describe('line_chart_v2/sub_view/axis_utils test', () => {
+  describe('#getStandardTicks', () => {
+    const scale = createScale(ScaleType.LOG10);
+
+    it('returns no major ticks', () => {
+      const {major, minor} = getStandardTicks(
+        scale,
+        scale.defaultFormatter,
+        5,
+        [1, 10]
+      );
+
+      expect(major).toEqual([]);
+      expect(minor).toEqual([
+        {value: 1, tickFormattedString: '1'},
+        {value: 2, tickFormattedString: '2'},
+        {value: 3, tickFormattedString: '3'},
+        {value: 4, tickFormattedString: '4'},
+        {value: 5, tickFormattedString: '5'},
+        {value: 6, tickFormattedString: '6'},
+        {value: 7, tickFormattedString: '7'},
+        {value: 8, tickFormattedString: '8'},
+        {value: 9, tickFormattedString: '9'},
+        {value: 10, tickFormattedString: '10'},
+      ]);
+    });
+  });
+
+  describe('#getTicksForTemporalScale', () => {
+    const scale = new TemporalScale();
+
+    it('returns temporal ticks', () => {
+      const {major, minor} = getTicksForTemporalScale(
+        scale,
+        scale.defaultFormatter,
+        5,
+        [
+          new Date('2000/01/01 5:00').getTime(),
+          new Date('2000/01/01 10:00').getTime(),
+        ]
+      );
+
+      expect(major).toEqual([
+        {
+          start: new Date('2000/01/01 6:00').getTime(),
+          tickFormattedString: 'Jan 1, 2000, 6:00:00 AM',
+        },
+        {
+          start: new Date('2000/01/01 9:00').getTime(),
+          tickFormattedString: 'Jan 1, 2000, 9:00:00 AM',
+        },
+      ]);
+      expect(minor).toEqual([
+        {
+          value: new Date('2000/01/01 5:00').getTime(),
+          tickFormattedString: '05 AM',
+        },
+        {
+          value: new Date('2000/01/01 6:00').getTime(),
+          tickFormattedString: '06 AM',
+        },
+        {
+          value: new Date('2000/01/01 7:00').getTime(),
+          tickFormattedString: '07 AM',
+        },
+        {
+          value: new Date('2000/01/01 8:00').getTime(),
+          tickFormattedString: '08 AM',
+        },
+        {
+          value: new Date('2000/01/01 9:00').getTime(),
+          tickFormattedString: '09 AM',
+        },
+        {
+          value: new Date('2000/01/01 10:00').getTime(),
+          tickFormattedString: '10 AM',
+        },
+      ]);
+    });
+
+    it('returns only minor when d3 ticks return less than 2 major axes', () => {
+      const {major, minor} = getTicksForTemporalScale(
+        scale,
+        scale.defaultFormatter,
+        5,
+        [
+          new Date('2000/01/01 1:00').getTime(),
+          new Date('2000/01/01 2:00').getTime(),
+        ]
+      );
+      expect(major).toEqual([]);
+      expect(minor).toEqual([
+        {
+          value: new Date('2000/01/01 1:00').getTime(),
+          tickFormattedString: '01 AM',
+        },
+        {
+          value: new Date('2000/01/01 1:15').getTime(),
+          tickFormattedString: '01:15',
+        },
+        {
+          value: new Date('2000/01/01 1:30').getTime(),
+          tickFormattedString: '01:30',
+        },
+        {
+          value: new Date('2000/01/01 1:45').getTime(),
+          tickFormattedString: '01:45',
+        },
+        {
+          value: new Date('2000/01/01 2:00').getTime(),
+          tickFormattedString: '02 AM',
+        },
+      ]);
+    });
+
+    it('does not return major when diff in time is greater than or equal to 1d', () => {
+      const {major, minor} = getTicksForTemporalScale(
+        scale,
+        scale.defaultFormatter,
+        5,
+        [
+          new Date('2000/01/01 00:00').getTime(),
+          new Date('2000/01/05 00:00').getTime(),
+        ]
+      );
+
+      expect(major).toEqual([]);
+      expect(minor).toEqual([
+        {
+          value: new Date('2000/01/01 0:00').getTime(),
+          tickFormattedString: '2000',
+        },
+        {
+          value: new Date('2000/01/02 0:00').getTime(),
+          tickFormattedString: 'Jan 02',
+        },
+        {
+          value: new Date('2000/01/03 0:00').getTime(),
+          tickFormattedString: 'Mon 03',
+        },
+        {
+          value: new Date('2000/01/04 0:00').getTime(),
+          tickFormattedString: 'Tue 04',
+        },
+        {
+          value: new Date('2000/01/05 0:00').getTime(),
+          tickFormattedString: 'Wed 05',
+        },
+      ]);
+    });
+  });
+
   describe('#getTicksForLinearScale', () => {
     const scale = new LinearScale();
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
@@ -25,8 +25,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
         scale,
         scale.defaultFormatter,
         5,
-        1,
-        10
+        [1, 10]
       );
 
       expect(major).toEqual([]);
@@ -44,8 +43,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
         scale,
         scale.defaultFormatter,
         2,
-        1.015,
-        1.115
+        [1.015, 1.115]
       );
 
       expect(major).toEqual([]);
@@ -61,8 +59,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
           scale,
           scale.defaultFormatter,
           2,
-          1.94515,
-          1.9452
+          [1.94515, 1.9452]
         );
 
         expect(major).toEqual([
@@ -83,8 +80,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
           scale,
           scale.defaultFormatter,
           2,
-          1.123456789012345,
-          1.123456789012392
+          [1.123456789012345, 1.123456789012392]
         );
 
         expect(major).toEqual([
@@ -102,8 +98,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
           scale,
           scale.defaultFormatter,
           2,
-          1235000.123451,
-          1235000.123455
+          [1235000.123451, 1235000.123455]
         );
 
         expect(major).toEqual([
@@ -124,8 +119,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
           scale,
           scale.defaultFormatter,
           2,
-          1.9452,
-          1.94515
+          [1.9452, 1.94515]
         );
 
         expect(major).toEqual([

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
@@ -1,0 +1,144 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {LinearScale} from '../lib/scale';
+import {getTicksForLinearScale} from './line_chart_axis_utils';
+
+describe('line_chart_v2/sub_view/axis_utils test', () => {
+  describe('#getTicksForLinearScale', () => {
+    const scale = new LinearScale();
+
+    it('returns no major ticks for extents in integers', () => {
+      const {major, minor} = getTicksForLinearScale(
+        scale,
+        scale.defaultFormatter,
+        5,
+        1,
+        10
+      );
+
+      expect(major).toEqual([]);
+      expect(minor).toEqual([
+        {value: 2, tickFormattedString: '2'},
+        {value: 4, tickFormattedString: '4'},
+        {value: 6, tickFormattedString: '6'},
+        {value: 8, tickFormattedString: '8'},
+        {value: 10, tickFormattedString: '10'},
+      ]);
+    });
+
+    it('returns no major ticks for numbers with less than three decimal digits', () => {
+      const {major, minor} = getTicksForLinearScale(
+        scale,
+        scale.defaultFormatter,
+        2,
+        1.015,
+        1.115
+      );
+
+      expect(major).toEqual([]);
+      expect(minor).toEqual([
+        {value: 1.05, tickFormattedString: '1.05'},
+        {value: 1.1, tickFormattedString: '1.1'},
+      ]);
+    });
+
+    describe('very small differences', () => {
+      it('creates a major tick since very long minor tick labels are not legible', () => {
+        const {major, minor} = getTicksForLinearScale(
+          scale,
+          scale.defaultFormatter,
+          2,
+          1.94515,
+          1.9452
+        );
+
+        expect(major).toEqual([
+          {start: 1.9451, tickFormattedString: '1.9451'},
+          {start: 1.9452, tickFormattedString: '1.9452'},
+        ]);
+        expect(minor).toEqual([
+          // Truncated by major tick, 1.9451.
+          {value: 1.94516, tickFormattedString: '…6'},
+          {value: 1.94518, tickFormattedString: '…8'},
+          // Truncated by major tick, 1.9452.
+          {value: 1.9452, tickFormattedString: '…0'},
+        ]);
+      });
+
+      it('handles very minute differences in extent', () => {
+        const {major, minor} = getTicksForLinearScale(
+          scale,
+          scale.defaultFormatter,
+          2,
+          1.123456789012345,
+          1.123456789012392
+        );
+
+        expect(major).toEqual([
+          // Why is the formatted with trailing "23" stripped out? Fix it later.
+          {start: 1.1234567890123, tickFormattedString: '1.12345678901'},
+        ]);
+        expect(minor).toEqual([
+          {value: 1.12345678901236, tickFormattedString: '…6'},
+          {value: 1.12345678901238, tickFormattedString: '…8'},
+        ]);
+      });
+
+      it('breaks out to major axis when difference is small, not number', () => {
+        const {major, minor} = getTicksForLinearScale(
+          scale,
+          scale.defaultFormatter,
+          2,
+          1235000.123451,
+          1235000.123455
+        );
+
+        expect(major).toEqual([
+          // Why is the formatted with trailing "23" stripped out? Fix it later.
+          {
+            start: 1235000.12345,
+            tickFormattedString: '1.24e+6',
+          },
+        ]);
+        expect(minor).toEqual([
+          {value: 1235000.123452, tickFormattedString: '…2'},
+          {value: 1235000.123454, tickFormattedString: '…4'},
+        ]);
+      });
+
+      it('handles flipped axis', () => {
+        const {major, minor} = getTicksForLinearScale(
+          scale,
+          scale.defaultFormatter,
+          2,
+          1.9452,
+          1.94515
+        );
+
+        expect(major).toEqual([
+          // Why is the formatted with trailing "23" stripped out? Fix it later.
+          {start: 1.9452, tickFormattedString: '1.9452'},
+          {start: 1.9451, tickFormattedString: '1.9451'},
+        ]);
+        expect(minor).toEqual([
+          {value: 1.9452, tickFormattedString: '…0'},
+          {value: 1.94518, tickFormattedString: '…8'},
+          {value: 1.94516, tickFormattedString: '…6'},
+        ]);
+      });
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -26,7 +26,7 @@ import {
   getScaleRangeFromDomDim,
 } from './chart_view_utils';
 import {
-  getTicks,
+  getStandardTicks,
   getTicksForLinearScale,
   getTicksForTemporalScale,
   MajorTick,
@@ -86,7 +86,7 @@ export class LineChartAxisComponent {
         this.axisExtent
       );
     } else {
-      ticks = getTicks(
+      ticks = getStandardTicks(
         this.scale,
         this.getFormatter(),
         maxTickSize,

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -19,28 +19,19 @@ import {
   Input,
   Output,
 } from '@angular/core';
-
 import {Dimension, Formatter, Scale} from '../lib/public_types';
-import {TemporalScale} from '../lib/scale';
+import {LinearScale, TemporalScale} from '../lib/scale';
 import {
   getDomSizeInformedTickCount,
   getScaleRangeFromDomDim,
 } from './chart_view_utils';
+import {
+  getTicksForLinearScale,
+  MajorTick,
+  MinorTick,
+} from './line_chart_axis_utils';
 
 const DAY_IN_MS = 24 * 1000 * 60 * 60;
-
-interface MinorTick {
-  value: number;
-  tickFormattedString: string;
-}
-
-// Major tick, unlike the minor tick, spans a range.
-interface MajorTick {
-  // Start of the major tick range. An end is implicitly defined by next major tick while
-  // it can certainly change to explicitly define the end.
-  start: number;
-  tickFormattedString: string;
-}
 
 @Component({
   selector: 'line-chart-axis',
@@ -76,9 +67,24 @@ export class LineChartAxisComponent {
   minorTicks: MinorTick[] = [];
 
   ngOnChanges() {
-    const {major, minor} = this.getMajorMinorTicks();
-    this.majorTicks = major;
-    this.minorTicks = minor;
+    if (this.scale instanceof LinearScale) {
+      const domSize =
+        this.axis === 'x' ? this.domDim.width : this.domDim.height;
+      const maxTickSize = getDomSizeInformedTickCount(domSize, this.gridCount);
+      const {major, minor} = getTicksForLinearScale(
+        this.scale,
+        this.getFormatter(),
+        maxTickSize,
+        this.axisExtent[0],
+        this.axisExtent[1]
+      );
+      this.majorTicks = major;
+      this.minorTicks = minor;
+    } else {
+      const {major, minor} = this.getMajorMinorTicks();
+      this.majorTicks = major;
+      this.minorTicks = minor;
+    }
   }
 
   getFormatter(): Formatter {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -75,8 +75,7 @@ export class LineChartAxisComponent {
         this.scale,
         this.getFormatter(),
         maxTickSize,
-        this.axisExtent[0],
-        this.axisExtent[1]
+        this.axisExtent
       );
       this.majorTicks = major;
       this.minorTicks = minor;


### PR DESCRIPTION
When you zoom in a lot on a line chart, current line chart tries to
cramp labels with many digits into the small space causing them to
overlap and cause major visual jank.

With recent improvements to the major ticks to work on y-axis too, when
we detect small differences in the extent, we now show a major ticks for
the linear scale, too, and remove a lot of redundant long prefixes from
the minor ticks.

![image](https://user-images.githubusercontent.com/2547313/110008914-2541a400-7cd1-11eb-8a9e-bc33c04319de.png)

This PR contains #4727 