### PR TITLE
runs table: support hparam and metrics sorting

### DIFF
--- a/tensorboard/webapp/runs/actions/runs_actions.ts
+++ b/tensorboard/webapp/runs/actions/runs_actions.ts
@@ -20,7 +20,11 @@ import {createAction, props} from '@ngrx/store';
 
 import {SortDirection} from '../../types/ui';
 import {Run} from '../data_source/runs_data_source_types';
-import {DiscreteHparamValues, ExperimentIdToRunsAndMetadata} from '../types';
+import {
+  DiscreteHparamValues,
+  ExperimentIdToRunsAndMetadata,
+  SortKey,
+} from '../types';
 
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
@@ -74,7 +78,7 @@ export const runSelectorPaginationOptionChanged = createAction(
 
 export const runSelectorSortChanged = createAction(
   '[Runs] Run Selector Sort Changed',
-  props<{column: string; direction: SortDirection}>()
+  props<{key: SortKey; direction: SortDirection}>()
 );
 
 export const runSelectorRegexFilterChanged = createAction(

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -19,9 +19,9 @@ import {
   createReducer,
   on,
 } from '@ngrx/store';
-import {DataLoadState} from '../../types/data';
 
 import {createRouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
+import {DataLoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
 import * as colorUtils from '../../util/colors';
 import {composeReducers} from '../../util/ngrx';
@@ -32,7 +32,6 @@ import {
   DomainType,
   IntervalFilter,
 } from '../types';
-
 import {
   MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT,
   RunsDataState,
@@ -205,7 +204,7 @@ const {
     },
     regexFilter: '',
     sort: {
-      column: null,
+      key: null,
       direction: SortDirection.UNSET,
     },
     hparamFilters: new Map(),
@@ -248,7 +247,7 @@ const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(
     return {
       ...state,
       sort: {
-        column: action.column,
+        key: action.key,
         direction: action.direction,
       },
     };

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -12,15 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {DataLoadState} from '../../types/data';
-
 import {deepFreeze} from '../../testing/lang';
+import {DataLoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
 import * as colorUtils from '../../util/colors';
 import * as actions from '../actions';
 import {buildHparamsAndMetadata} from '../data_source/testing';
-import {DiscreteFilter, IntervalFilter} from '../types';
-
+import {DiscreteFilter, IntervalFilter, SortType} from '../types';
 import * as runsReducers from './runs_reducers';
 import {DomainType, MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT} from './runs_types';
 import {
@@ -881,7 +879,7 @@ describe('runs_reducers', () => {
     it('updates the sort changed', () => {
       const state = buildRunsState(undefined, {
         sort: {
-          column: null,
+          key: null,
           direction: SortDirection.UNSET,
         },
       });
@@ -889,13 +887,13 @@ describe('runs_reducers', () => {
       const nextState = runsReducers.reducers(
         state,
         actions.runSelectorSortChanged({
-          column: 'experiment_name',
+          key: {type: SortType.EXPERIMENT_NAME},
           direction: SortDirection.ASC,
         })
       );
 
       expect(nextState.ui.sort).toEqual({
-        column: 'experiment_name',
+        key: {type: SortType.EXPERIMENT_NAME},
         direction: SortDirection.ASC,
       });
     });

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -13,20 +13,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {createFeatureSelector, createSelector} from '@ngrx/store';
+
 import {DataLoadState, LoadState} from '../../types/data';
-
 import {SortDirection} from '../../types/ui';
-import {DiscreteFilter, IntervalFilter} from '../types';
-
+import {DiscreteFilter, IntervalFilter, SortKey} from '../types';
 import {combineHparamAndMetricSpecs} from './runs_selectors_utils';
 import {
   ExperimentToHparamAndMetricSpec,
   HparamAndMetricSpec,
   Run,
-  RUNS_FEATURE_KEY,
   RunsDataState,
   RunsState,
   RunsUiState,
+  RUNS_FEATURE_KEY,
   State,
 } from './runs_types';
 import {serializeExperimentIds} from './utils';
@@ -175,7 +174,7 @@ export const getRunSelectorRegexFilter = createSelector(
  */
 export const getRunSelectorSort = createSelector(
   getUiState,
-  (state: RunsUiState): {column: string | null; direction: SortDirection} => {
+  (state: RunsUiState): {key: SortKey | null; direction: SortDirection} => {
     return state.sort;
   }
 );

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -13,9 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {DataLoadState} from '../../types/data';
-
 import {SortDirection} from '../../types/ui';
-
+import {SortType} from '../types';
 import * as selectors from './runs_selectors';
 import {
   buildDiscreteFilter,
@@ -349,12 +348,15 @@ describe('runs_selectors', () => {
     it('returns sort options', () => {
       const state = buildStateFromRunsState(
         buildRunsState(undefined, {
-          sort: {column: 'hey', direction: SortDirection.UNSET},
+          sort: {
+            key: {type: SortType.RUN_NAME},
+            direction: SortDirection.UNSET,
+          },
         })
       );
 
       expect(selectors.getRunSelectorSort(state)).toEqual({
-        column: 'hey',
+        key: {type: SortType.RUN_NAME},
         direction: SortDirection.UNSET,
       });
     });

--- a/tensorboard/webapp/runs/store/runs_types.ts
+++ b/tensorboard/webapp/runs/store/runs_types.ts
@@ -16,13 +16,15 @@ limitations under the License.
  * @fileoverview Types of experiments that come from the backend.
  */
 
-import {LoadState} from '../../types/data';
-
 import {RouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
+import {LoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
-import {HparamValue} from '../data_source/runs_data_source_types';
-import {HparamSpec, MetricSpec} from '../data_source/runs_data_source_types';
-import {DiscreteFilter, IntervalFilter} from '../types';
+import {
+  HparamSpec,
+  HparamValue,
+  MetricSpec,
+} from '../data_source/runs_data_source_types';
+import {DiscreteFilter, IntervalFilter, SortKey} from '../types';
 
 export {Domain, DomainType} from '../data_source/runs_data_source_types';
 
@@ -76,7 +78,7 @@ export interface RunsDataState {
 export interface RunsUiRoutefulState {
   paginationOption: {pageIndex: number; pageSize: number};
   regexFilter: string;
-  sort: {column: string | null; direction: SortDirection};
+  sort: {key: SortKey | null; direction: SortDirection};
 
   // Each route may keep track of its own hparam/metric filter values that
   // overrides the default filters.

--- a/tensorboard/webapp/runs/store/testing.ts
+++ b/tensorboard/webapp/runs/store/testing.ts
@@ -69,7 +69,7 @@ export function buildRunsState(
     ui: {
       paginationOption: {pageIndex: 0, pageSize: 0},
       regexFilter: '',
-      sort: {column: null, direction: SortDirection.UNSET},
+      sort: {key: null, direction: SortDirection.UNSET},
       defaultRunColor: new Map(),
       runColorOverride: new Map(),
       hparamFilters: new Map(),

--- a/tensorboard/webapp/runs/types.ts
+++ b/tensorboard/webapp/runs/types.ts
@@ -50,3 +50,25 @@ export type ExperimentIdToRunsAndMetadata = Record<
     metadata: HparamsAndMetadata;
   }
 >;
+
+export enum SortType {
+  EXPERIMENT_NAME,
+  HPARAM,
+  METRIC,
+  RUN_NAME,
+}
+
+export interface HparamsSortKey {
+  type: SortType.HPARAM;
+  name: string;
+}
+
+export interface MetricsSortKey {
+  type: SortType.METRIC;
+  tag: string;
+}
+
+export type SortKey =
+  | HparamsSortKey
+  | MetricsSortKey
+  | {type: SortType.RUN_NAME | SortType.EXPERIMENT_NAME};

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -101,13 +101,13 @@ limitations under the License.
 
           <span
             *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
-            [mat-sort-header]="RunsTableColumn.EXPERIMENT_NAME"
+            [mat-sort-header]="{type: SortType.EXPERIMENT_NAME}"
             >Experiment</span
           >
 
           <span
             *ngSwitchCase="RunsTableColumn.RUN_NAME"
-            [mat-sort-header]="RunsTableColumn.RUN_NAME"
+            [mat-sort-header]="{type: SortType.RUN_NAME}"
             >Run</span
           >
 
@@ -119,6 +119,7 @@ limitations under the License.
         *ngFor="let column of hparamColumns; trackBy: trackByHparamColumn"
         role="columnheader"
         class="column"
+        [mat-sort-header]="{type: SortType.HPARAM, name: column.name}"
       >
         <span class="name">{{ column.displayName || column.name }}</span>
         <ng-container *ngIf="column.filter">
@@ -183,6 +184,7 @@ limitations under the License.
         *ngFor="let column of metricColumns; trackBy: trackByMetricColumn"
         role="columnheader"
         class="column"
+        [mat-sort-header]="{type: SortType.METRIC, tag: column.tag}"
       >
         <span class="name">{{ column.displayName || column.tag }}</span>
         <ng-container *ngIf="column.filter">

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
@@ -34,7 +34,7 @@ import {
   DiscreteHparamValues,
   IntervalFilter,
 } from '../../types';
-import {DiscreteHparamValue, DomainType} from '../../types';
+import {DiscreteHparamValue, DomainType, SortKey, SortType} from '../../types';
 
 import {HparamSpec, MetricSpec, RunsTableColumn, RunTableItem} from './types';
 
@@ -80,6 +80,7 @@ export class RunsTableComponent implements OnChanges {
   readonly dataSource = new MatTableDataSource<RunTableItem>();
   readonly DomainType = DomainType;
   readonly RunsTableColumn = RunsTableColumn;
+  readonly SortType = SortType;
 
   @Input() showExperimentName!: boolean;
   @Input() columns!: RunsTableColumn[];
@@ -112,7 +113,7 @@ export class RunsTableComponent implements OnChanges {
   }>();
   @Output()
   onSortChange = new EventEmitter<{
-    column: RunsTableColumn;
+    key: SortKey;
     direction: SortDirection;
   }>();
   @Output()
@@ -187,10 +188,10 @@ export class RunsTableComponent implements OnChanges {
       default:
         direction = SortDirection.UNSET;
     }
-    this.onSortChange.emit({
-      column: sort.active as RunsTableColumn,
-      direction,
-    });
+    // HACK: Technically, sort.key is a string but in reality, MatSort supports an object
+    // as the sort.id and, thus, sort.active can be an object.
+    const key = (sort.active as unknown) as SortKey;
+    this.onSortChange.emit({key, direction});
   }
 
   onFilterKeyUp(event: KeyboardEvent) {


### PR DESCRIPTION
This change completes the implementation of the runs table sorting.
Previously, we only supported sorting by experiment name and runs name.
However, with this change, we want to sort by an arbitrary hparam or
metric key user provided.
