### PR TITLE
rust: implement data_compat.rs basic tensor support

### DIFF
--- a/tensorboard/data/server/data_compat.rs
+++ b/tensorboard/data/server/data_compat.rs
@@ -651,49 +651,42 @@ mod tests {
 
         #[test]
         fn test_metadata_tensor_with_dataclass() {
-            let md = pb::SummaryMetadata {
-                plugin_data: Some(PluginData {
-                    plugin_name: "rando".to_string(),
-                    content: Bytes::from_static(b"preserved!"),
-                    ..Default::default()
-                }),
-                data_class: pb::DataClass::Tensor.into(),
-                ..Default::default()
-            };
+            let md = blank_with_plugin_content(
+                "rando",
+                pb::DataClass::Tensor,
+                Bytes::from_static(b"preserved!"),
+            );
             let v = SummaryValue(Box::new(Value::Tensor(pb::TensorProto {
                 dtype: pb::DataType::DtString.into(),
                 string_val: vec![Bytes::from_static(b"foo")],
                 ..Default::default()
             })));
-            let result = v.initial_metadata(Some(md.clone()));
-            assert_eq!(*result, md);
+            let result = v.initial_metadata(Some(md.as_ref().clone()));
+            assert_eq!(*result, *md);
         }
 
         #[test]
         fn test_metadata_tensor_without_dataclass() {
-            for plugin_name in vec![
+            for plugin_name in &[
                 plugin_names::HISTOGRAMS,
                 plugin_names::TEXT,
                 plugin_names::PR_CURVES,
                 plugin_names::HPARAMS,
             ] {
-                let md = pb::SummaryMetadata {
-                    plugin_data: Some(PluginData {
-                        plugin_name: plugin_name.to_string(),
-                        content: Bytes::from_static(b"preserved!"),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                };
+                let md = blank_with_plugin_content(
+                    plugin_name,
+                    pb::DataClass::Unknown,
+                    Bytes::from_static(b"preserved!"),
+                );
                 let v = SummaryValue(Box::new(Value::Tensor(pb::TensorProto {
                     dtype: pb::DataType::DtString.into(),
                     string_val: vec![Bytes::from_static(b"foo")],
                     ..Default::default()
                 })));
-                let result = v.initial_metadata(Some(md.clone()));
+                let result = v.initial_metadata(Some(md.as_ref().clone()));
                 let expected = pb::SummaryMetadata {
                     data_class: pb::DataClass::Tensor.into(),
-                    ..md
+                    ..*md
                 };
                 assert_eq!(*result, expected);
             }

--- a/tensorboard/data/server/data_compat.rs
+++ b/tensorboard/data/server/data_compat.rs
@@ -42,8 +42,6 @@ pub(crate) mod plugin_names {
     pub const TEXT: &str = "text";
     pub const PR_CURVES: &str = "pr_curves";
     pub const HPARAMS: &str = "hparams";
-    pub const MESH: &str = "mesh";
-    pub const NPMI: &str = "npmi";
 }
 
 /// The inner contents of a single value from an event.
@@ -298,9 +296,7 @@ impl SummaryValue {
                     Some(plugin_names::HISTOGRAMS)
                     | Some(plugin_names::TEXT)
                     | Some(plugin_names::HPARAMS)
-                    | Some(plugin_names::PR_CURVES)
-                    | Some(plugin_names::MESH)
-                    | Some(plugin_names::NPMI) => {
+                    | Some(plugin_names::PR_CURVES) => {
                         md.data_class = pb::DataClass::Tensor.into();
                     }
                     Some(plugin_names::IMAGES)
@@ -680,8 +676,6 @@ mod tests {
                 plugin_names::TEXT,
                 plugin_names::PR_CURVES,
                 plugin_names::HPARAMS,
-                plugin_names::MESH,
-                plugin_names::NPMI,
             ] {
                 let md = pb::SummaryMetadata {
                     plugin_data: Some(PluginData {


### PR DESCRIPTION
This wires up `data_compat.rs` handling for tensors, as part of the tensor support subtask of #4422, which includes:

- adding `initial_metadata()` special-cases for tensor-dataclass plugins
- adding `into_tensor()` for enriching tensor values
- calling `into_tensor()` from within RunLoader
- tests for the above

I also adjusted some naming of other tests within `data_compat.rs` to be (IMO) slightly more precise and clear now that we have the new tensor test methods.

Note that we don't yet handle A) events with no summary value that should nonetheless be treated as having implicit Tensor values (the use case being hparams metadata persistence), and B) legacy histogram data stored in `HistogramProto`.  I've left those for later PRs.

Test plan: I confirmed that with this change and the preceding RPC PR, we can now render the "normal" tensor dashboards.   In particular, what now works is: text, histograms/distributions for data written with the tensor-based histogram summary APIs, PR curves, and NPMI (the visualization seems somewhat broken, at least with the demo data, but it's equivalently broken with and without `--load_fast` now). Hparams doesn't work yet per the note above. The mesh plugin hasn't been DataProviderized; I included it for completeness anyway but it's untested.