### PR TITLE
graph: fix `NotFoundError` typo

### DIFF
--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -62,6 +62,7 @@ py_test(
     deps = [
         ":graphs_plugin",
         ":graphs_plugin_test_lib",
+        "//tensorboard:errors",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -196,7 +196,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
             return self._data_provider.read_blob(
                 ctx, blob_key=blob_ref.blob_key
             )
-        raise errors.NotFound()
+        raise errors.NotFoundError()
 
     def graph_impl(
         self,


### PR DESCRIPTION
Summary:
When requesting a blob that doesn’t exist, we intend to 404, but instead
500 because the error type is called `NotFoundError`, not `NotFound`.

Test Plan:
Regression test included.

wchargin-branch: graph-notfound
