### PR TITLE
rust: add `to_le_bytes!` macro for generating tensor_content fields

### DIFF
--- a/tensorboard/data/server/data_compat.rs
+++ b/tensorboard/data/server/data_compat.rs
@@ -391,7 +391,6 @@ fn tf1x_audio_metadata() -> Box<pb::SummaryMetadata> {
 mod tests {
     use super::*;
     use pb::summary::value::Value;
-    use std::iter::FromIterator;
 
     fn tensor_shape(dims: &[i64]) -> pb::TensorShapeProto {
         pb::TensorShapeProto {
@@ -417,7 +416,7 @@ mod tests {
     //   Bytes::from_iter([].iter().flat_map(|v| array::IntoIter::new(v.to_le_bytes())))
     macro_rules! to_le_bytes {
         ($($x:expr),+ $(,)?) => (
-            Bytes::from_iter([$($x),+].iter()
+            Bytes::from([$($x),+].iter()
                 .map(|v| v.to_le_bytes())
                 .collect::<Vec<_>>()
                 .concat())


### PR DESCRIPTION
This adds a small macro to convert a given array of numeric types that have a `.to_le_bytes()` method into the concatenation of their LE byte representations, as a `bytes::Bytes` instance.  We need a macro (AFAICT) because `.to_le_bytes()` isn't part of a trait, so we can't achieve this using a function with a type parameter.

The actual macro body has a couple of intermediate `Vec` materializations that would be nice to avoid, but after banging my head against it for a while I couldn't figure out a better way until Rust 1.51 when `array::IntoIter` will be available, and it's only test code.

This doesn't save much effort in the existing code, but it's nice to have in the forthcoming histogram tests where we want to test code that emits significantly larger `tensor_content` fields, and this lets us reconstruct the expected values more compactly.