### PR TITLE
graph: notify consumers when Hierarchy's templates update (3)

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -33,10 +33,9 @@ import {template} from './tf-graph-scene.html';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import {TfGraphScene} from '../tf_graph_common/tf-graph-scene';
 import {ColorBy} from '../tf_graph_common/view_types';
-import {HierarchyEvent} from '../tf_graph_common/hierarchy';
 
 @customElement('tf-graph-scene')
-class TfGraphScene2
+export class TfGraphScene2
   extends LegacyElementMixin(PolymerElement)
   implements TfGraphScene {
   static readonly template = template;
@@ -258,13 +257,6 @@ class TfGraphScene2
   /** Main method for building the scene */
   _build(renderHierarchy: tf_graph_render.RenderGraphInfo) {
     this.templateIndex = renderHierarchy.hierarchy.getTemplateIndex();
-    renderHierarchy.hierarchy.addListener(
-      HierarchyEvent.TemplatesUpdated,
-      () => {
-        this.templateIndex = renderHierarchy.hierarchy.getTemplateIndex();
-        this._nodeColorsChanged();
-      }
-    );
     tf_graph_util.time(
       'tf-graph-scene (layout):',
       function () {
@@ -480,8 +472,12 @@ class TfGraphScene2
    * UI controls.
    */
   @observe('colorBy')
-  _nodeColorsChanged() {
+  nodeColorsChanged() {
     if (this.renderHierarchy != null) {
+      // Formatters will read `sceneElement.templateIndex` directly.
+      // Ensure that it is up to date.
+      this.templateIndex = this.renderHierarchy.hierarchy.getTemplateIndex();
+
       // We iterate through each svg node and update its state.
       _.each(this._nodeGroupIndex, (nodeGroup, nodeName) => {
         this._updateNodeState(nodeName);

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -33,6 +33,7 @@ import {template} from './tf-graph-scene.html';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import {TfGraphScene} from '../tf_graph_common/tf-graph-scene';
 import {ColorBy} from '../tf_graph_common/view_types';
+import {HierarchyEvent} from '../tf_graph_common/hierarchy';
 
 @customElement('tf-graph-scene')
 class TfGraphScene2
@@ -257,6 +258,13 @@ class TfGraphScene2
   /** Main method for building the scene */
   _build(renderHierarchy: tf_graph_render.RenderGraphInfo) {
     this.templateIndex = renderHierarchy.hierarchy.getTemplateIndex();
+    renderHierarchy.hierarchy.addListener(
+      HierarchyEvent.TemplatesUpdated,
+      () => {
+        this.templateIndex = renderHierarchy.hierarchy.getTemplateIndex();
+        this._nodeColorsChanged();
+      }
+    );
     tf_graph_util.time(
       'tf-graph-scene (layout):',
       function () {
@@ -467,12 +475,12 @@ class TfGraphScene2
       functionLibraryTitleStyle.display = 'none';
     }
   }
-  @observe('colorBy')
   /**
    * Called whenever the user changed the 'color by' option in the
    * UI controls.
    */
-  _colorByChanged() {
+  @observe('colorBy')
+  _nodeColorsChanged() {
     if (this.renderHierarchy != null) {
       // We iterate through each svg node and update its state.
       _.each(this._nodeGroupIndex, (nodeGroup, nodeName) => {

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -21,6 +21,7 @@ import * as _ from 'lodash';
 import '../../../components/polymer/irons_and_papers';
 import * as tb_debug from '../../../components/tb_debug';
 import './tf-graph-scene';
+import {TfGraphScene2} from './tf-graph-scene';
 import * as tf_graph from '../tf_graph_common/graph';
 import * as tf_graph_scene from '../tf_graph_common/scene';
 import * as tf_graph_util from '../tf_graph_common/util';
@@ -333,6 +334,17 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     (this.$.scene as any).fit();
   }
   _graphChanged() {
+    if (!this.graphHierarchy) {
+      return;
+    }
+
+    this.graphHierarchy.addListener(
+      tf_graph_hierarchy.HierarchyEvent.TEMPLATES_UPDATED,
+      () => {
+        (this.$.scene as TfGraphScene2).nodeColorsChanged();
+      }
+    );
+
     // When a new graph is loaded, fire this event so that there is no
     // info-card being displayed for the previously-loaded graph.
     this.fire('graph-select');

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -48,10 +48,17 @@ import * as tf_graph from './graph';
 import * as tf_graph_proto from './proto';
 import * as tf_graph_util from './util';
 
+export enum HierarchyEvent {
+  /**
+   * Fired when the templates may have been updated. No event payload attached.
+   */
+  TemplatesUpdated = 'TemplatesUpdated',
+}
+
 /**
  * Class for the Graph Hierarchy for TensorFlow graph.
  */
-export class Hierarchy {
+export class Hierarchy extends tf_graph_util.Dispatcher {
   root: Metanode;
   libraryFunctions: {
     [key: string]: LibraryFunctionData;
@@ -86,6 +93,7 @@ export class Hierarchy {
   };
 
   constructor(params: HierarchyParams) {
+    super();
     this.graphOptions.compound = true;
     this.graphOptions.rankdir = params.rankDirection;
     this.root = createMetanode(ROOT_NAME, this.graphOptions);
@@ -369,6 +377,9 @@ export class Hierarchy {
   /**
    * Returns a d3 Ordinal function that can be used to look up the index of
    * a node based on its template id.
+   *
+   * When templates update, the Hierarchy will dispatch an event
+   * `HierarchyEvent.TemplateUpdated` to consumers.
    */
   getTemplateIndex(): (string) => number | null {
     if (!this.templates) {
@@ -392,6 +403,7 @@ export class Hierarchy {
    */
   updateTemplates() {
     this.templates = template.detect(this, this.verifyTemplate);
+    this.dispatchEvent(HierarchyEvent.TemplatesUpdated);
   }
 }
 /**

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -52,13 +52,13 @@ export enum HierarchyEvent {
   /**
    * Fired when the templates may have been updated. No event payload attached.
    */
-  TemplatesUpdated = 'TemplatesUpdated',
+  TEMPLATES_UPDATED,
 }
 
 /**
  * Class for the Graph Hierarchy for TensorFlow graph.
  */
-export class Hierarchy extends tf_graph_util.Dispatcher {
+export class Hierarchy extends tf_graph_util.Dispatcher<HierarchyEvent> {
   root: Metanode;
   libraryFunctions: {
     [key: string]: LibraryFunctionData;
@@ -379,7 +379,7 @@ export class Hierarchy extends tf_graph_util.Dispatcher {
    * a node based on its template id.
    *
    * When templates update, the Hierarchy will dispatch an event
-   * `HierarchyEvent.TemplateUpdated` to consumers.
+   * `HierarchyEvent.TEMPLATES_UPDATED` to consumers.
    */
   getTemplateIndex(): (string) => number | null {
     if (!this.templates) {
@@ -403,7 +403,7 @@ export class Hierarchy extends tf_graph_util.Dispatcher {
    */
   updateTemplates() {
     this.templates = template.detect(this, this.verifyTemplate);
-    this.dispatchEvent(HierarchyEvent.TemplatesUpdated);
+    this.dispatchEvent(HierarchyEvent.TEMPLATES_UPDATED);
   }
 }
 /**

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -417,3 +417,33 @@ export function maybeTruncateString(
 
   return start === 0 ? text[0] : text.slice(0, start) + '…';
 }
+
+export type EventType = string;
+
+export class Dispatcher {
+  private eventTypeToListeners = new Map<EventType, Function[]>();
+
+  private getListeners(eventType) {
+    if (!this.eventTypeToListeners.has(eventType)) {
+      this.eventTypeToListeners.set(eventType, []);
+    }
+    return this.eventTypeToListeners.get(eventType);
+  }
+
+  addListener(eventType: EventType, listener: Function) {
+    this.getListeners(eventType).push(listener);
+  }
+
+  removeListener(eventType: EventType, listener: Function) {
+    const newListeners = this.getListeners(eventType).filter((x) => {
+      return x !== listener;
+    });
+    this.eventTypeToListeners.set(eventType, newListeners);
+  }
+
+  dispatchEvent(eventType: EventType, payload?: any) {
+    for (const listener of this.getListeners(eventType)) {
+      listener(payload);
+    }
+  }
+}

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -418,9 +418,32 @@ export function maybeTruncateString(
   return start === 0 ? text[0] : text.slice(0, start) + '…';
 }
 
-export type EventType = string;
-
-export class Dispatcher {
+/**
+ * Extend this subclass to receive event dispatching traits.
+ * Useful for when various locations need to observe changes on
+ * a common instance, who has a limited lifetime.
+ *
+ * This is not intended for use with framework-supported elements.
+ * For example, prefer using `@Output myEmitter` on Angular
+ * Components, or Polymer's `on-myprop-changed` for Polymer
+ * elements, instead.
+ *
+ * Example usage:
+ *
+ * ```
+ * export enum ReactorEvent {EXPLODED}
+ * export class Reactor extends Dispatcher<ReactorEvent> {
+ *   _update() {
+ *     this.dispatchEvent(ReactorEvent.EXPLODED);
+ *   }
+ * }
+ *
+ * // Elsewhere
+ * const r = new Reactor();
+ * r.addEventListener(ReactorEvent.EXPLODED, this._cleanup);
+ * ```
+ */
+export class Dispatcher<EventType = any> {
   private eventTypeToListeners = new Map<EventType, Function[]>();
 
   private getListeners(eventType) {

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
@@ -739,7 +739,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   _graphHierarchyChanged() {
     this._templateIndex = this.graphHierarchy.getTemplateIndex();
     this.graphHierarchy.addListener(
-      tf_graph_hierarchy.HierarchyEvent.TemplatesUpdated,
+      tf_graph_hierarchy.HierarchyEvent.TEMPLATES_UPDATED,
       () => {
         this._templateIndex = this.graphHierarchy.getTemplateIndex();
       }

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
@@ -14,13 +14,14 @@ limitations under the License.
 ==============================================================================*/
 
 import {PolymerElement, html} from '@polymer/polymer';
-import {computed, customElement, property} from '@polymer/decorators';
+import {computed, customElement, observe, property} from '@polymer/decorators';
 import * as _ from 'lodash';
 
 import '../../../components/polymer/irons_and_papers';
 import '../tf_graph_common/tf-node-icon';
 import './tf-node-list-item';
 import * as tf_graph from '../tf_graph_common/graph';
+import * as tf_graph_hierarchy from '../tf_graph_common/hierarchy';
 import * as tf_graph_util from '../tf_graph_common/util';
 import * as tf_graph_scene_edge from '../tf_graph_common/edge';
 import * as tf_graph_scene_node from '../tf_graph_common/node';
@@ -438,7 +439,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   @property({type: String})
   graphNodeName: string;
   @property({type: Object})
-  graphHierarchy: any;
+  graphHierarchy: tf_graph_hierarchy.Hierarchy;
   @property({type: Object})
   renderHierarchy: any;
   /** What to color the nodes by (compute time, memory, device etc.) */
@@ -478,13 +479,10 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   _auxButtonText: string;
   @property({type: String})
   _groupButtonText: string;
+  @property({type: Object})
+  _templateIndex: (name: string) => number | null = null;
   expandNode() {
     this.fire('_node.expand', (this as any).node);
-  }
-  @computed('graphHierarchy')
-  get _templateIndex(): object {
-    var graphHierarchy = this.graphHierarchy;
-    return graphHierarchy.getTemplateIndex();
   }
   _getNode(graphNodeName, graphHierarchy) {
     return graphHierarchy.node(graphNodeName);
@@ -736,5 +734,15 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   }
   _isInSeries(node) {
     return tf_graph_scene_node.canBeInSeries(node);
+  }
+  @observe('graphHierarchy')
+  _graphHierarchyChanged() {
+    this._templateIndex = this.graphHierarchy.getTemplateIndex();
+    this.graphHierarchy.addListener(
+      tf_graph_hierarchy.HierarchyEvent.TemplatesUpdated,
+      () => {
+        this._templateIndex = this.graphHierarchy.getTemplateIndex();
+      }
+    );
   }
 }

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
@@ -262,7 +262,7 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
   _graphHierarchyChanged() {
     this._templateIndex = this.graphHierarchy.getTemplateIndex();
     this.graphHierarchy.addListener(
-      tf_graph_hierarchy.HierarchyEvent.TemplatesUpdated,
+      tf_graph_hierarchy.HierarchyEvent.TEMPLATES_UPDATED,
       () => {
         this._templateIndex = this.graphHierarchy.getTemplateIndex();
       }

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {PolymerElement, html} from '@polymer/polymer';
-import {computed, customElement, property} from '@polymer/decorators';
+import {computed, customElement, observe, property} from '@polymer/decorators';
 import * as d3 from 'd3';
 
 import '../../../components/polymer/irons_and_papers';
@@ -199,11 +199,8 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
     type: String,
   })
   _opIncompatColor: string = tf_graph_render.OpNodeColors.INCOMPATIBLE;
-  @computed('graphHierarchy')
-  get _templateIndex(): object {
-    var graphHierarchy = this.graphHierarchy;
-    return graphHierarchy.getTemplateIndex();
-  }
+  @property({type: Object})
+  _templateIndex: (name: string) => number | null = null;
   _getNode(nodeName, graphHierarchy) {
     return graphHierarchy.node(nodeName);
   }
@@ -260,5 +257,15 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
       return graphHierarchy.root.compatibilityHistogram.incompatible;
     }
     return 0;
+  }
+  @observe('graphHierarchy')
+  _graphHierarchyChanged() {
+    this._templateIndex = this.graphHierarchy.getTemplateIndex();
+    this.graphHierarchy.addListener(
+      tf_graph_hierarchy.HierarchyEvent.TemplatesUpdated,
+      () => {
+        this._templateIndex = this.graphHierarchy.getTemplateIndex();
+      }
+    );
   }
 }


### PR DESCRIPTION
The motivation behind these changes is to allow the `.templates` field,
currently stored in the Hierarchy, to be computed lazily, e.g. only if/when
the user selects the "Color by structure" mode.

This introduces a "Dispatcher" class, used to give the `Hierarchy` the
traits to allow it to dispatch events and let Hierarchy clients register to
listen to those events. Doing so allows components inside `<tf-node-info>`
and `<tf-graph-scene>`, who currently read the templates, to listen for
changes.

For reference, the hierarchy of Polymer components looks like:
```html
- <tf-graph-dashboard>
  - <tf-graph-dashboard-loader {{graphHierarchy}}>; creates GraphDef, SlimGraph, Hierarchy, also used externally
  - <tf-graph-controls>; also used externally
  - <tf-graph-board [[graphHierarchy]]>; also used externally
    - <tf-graph {{graphHierarchy}}>; creates Hierarchy, RenderHierarchy
      - <tf-graph-scene>
        - <tf-graph-minimap>
    - <tf-graph-info [[graphHierarchy]]> (floating info panels on the right)
      - <tf-node-info>
        - <tf-node-icon [[_templateIndex]]>
        - <tf-node-list-item [[_templateIndex]]>
```

Our use case requires
- some way to inform all components who depend on the templates,
  that they have changed.
- one component to be responsible for the business logic
  (only hierarchy.updateTemplates() if colorBy === structure)

Currently, the templateIndex, when computed, is not passed via
Polymer data bindings. Instead, consumers receive the Hierarchy and call its
`.getTemplateIndex()` method.

This Dispatcher trait approach achieves the goals without having to do a
major refactoring, without modifying `<tf-graph-board>`'s public fields,
and without making Hierarchy aware of the `ColorBy` concept.

Alternatives considered
- Move Hierarchy to `<tf-graph-board>`, make it responsible for propagating 
  all Hierarchy event notifications to descendants. Notably, changing
  `<tf-graph-board>` would affect internal consumers who use it publicly
  (unfortunately).
- Make the `<tf-graph-controls>` responsible for updating the hierarchy's
  templates, and use data binding to notify everyone of the `[[templateIndex]]`.
  Polymer's order of events made this complex.
- Don't pass the Hierarchy from the `<tf-graph>` to the `<tf-graph-info>`.

Diffbase: https://github.com/tensorflow/tensorboard/pull/4725
Followup: https://github.com/tensorflow/tensorboard/pull/4742