### PR TITLE
graph: color large graphs by 'none' instead of 'structure' by default (4)

### DIFF
--- a/tensorboard/components/tb_debug/types.ts
+++ b/tensorboard/components/tb_debug/types.ts
@@ -44,7 +44,10 @@ export enum GraphDebugTimingEventId {
   RENDER_BUILD_HIERARCHY = 'RENDER_BUILD_HIERARCHY',
   RENDER_SCENE_LAYOUT = 'RENDER_SCENE_LAYOUT',
   RENDER_SCENE_BUILD_SCENE = 'RENDER_SCENE_BUILD_SCENE',
-  // Total graph loading (superset of other phases).
+  // Total graph loading (superset of other phases). Note that after [1],
+  // this timing no longer includes `HIERARCHY_FIND_SIMILAR_SUBGRAPHS`,
+  // which is computed lazily.
+  // [1] https://github.com/tensorflow/tensorboard/pull/4742
   GRAPH_LOAD_SUCCEEDED = 'GRAPH_LOAD_SUCCEEDED',
   GRAPH_LOAD_FAILED = 'GRAPH_LOAD_FAILED',
 }

--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.ts
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.ts
@@ -113,7 +113,7 @@ class TfGraphApp extends LegacyElementMixin(PolymerElement) {
             graph-hierarchy="[[graphHierarchy]]"
             graph="[[graph]]"
             progress="[[_progress]]"
-            color-by="[[colorBy]]"
+            color-by="{{colorBy}}"
             color-by-params="{{colorByParams}}"
             render-hierarchy="{{_renderHierarchy}}"
             selected-node="{{selectedNode}}"

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
@@ -16,6 +16,7 @@ import {PolymerElement, html} from '@polymer/polymer';
 import {customElement, observe, property} from '@polymer/decorators';
 
 import '../../../components/polymer/irons_and_papers';
+
 import '../tf_graph_info/tf-graph-info';
 import '../tf_graph/tf-graph';
 import * as tf_graph from '../tf_graph_common/graph';
@@ -308,5 +309,30 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
     this._selectedNodeInclude = node
       ? node.include
       : tf_graph.InclusionType.UNSPECIFIED;
+  }
+  @observe('graph')
+  _slimGraphChanged() {
+    // By default, avoid coloring by 'structure' for large graphs, since it may be very expensive.
+    // Color by 'structure' is still available to users via explicit gesture.
+    if (!this.graph) {
+      return;
+    }
+    const isGraphTooLarge =
+      Object.keys(this.graph.nodes).length > 10000 &&
+      this.graph.edges.length > 10000;
+    if (isGraphTooLarge && this.colorBy === ColorBy.STRUCTURE) {
+      this.colorBy = ColorBy.NONE;
+      this.fire('color-by-changed', this.colorBy);
+    }
+  }
+  @observe('colorBy', 'graphHierarchy')
+  _ensureTemplates() {
+    if (!this.graphHierarchy || this.colorBy !== ColorBy.STRUCTURE) {
+      return;
+    }
+    if (this.graphHierarchy.getTemplateIndex()) {
+      return;
+    }
+    this.graphHierarchy.updateTemplates();
   }
 }

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.ts
@@ -31,9 +31,9 @@ import {Hierarchy} from '../tf_graph_common/hierarchy';
  * a 'large' graph. Graphs that exceed all these constraints should not
  * have templates computed by default.
  */
-const MAX_GRAPH_SIZE_TO_COMPUTE_TEMPLATES = {
-  maxNodeCount: 10000,
-  maxEdgeCount: 10000,
+const maxGraphSizeToComputeTemplates = {
+  MAX_NODE_COUNT: 10000,
+  MAX_EDGE_COUNT: 10000,
 };
 
 /**
@@ -331,10 +331,10 @@ class TfGraphBoard extends LegacyElementMixin(PolymerElement) {
     if (!this.graph) {
       return;
     }
-    const {maxNodeCount, maxEdgeCount} = MAX_GRAPH_SIZE_TO_COMPUTE_TEMPLATES;
+    const {MAX_NODE_COUNT, MAX_EDGE_COUNT} = maxGraphSizeToComputeTemplates;
     const isGraphTooLarge =
-      Object.keys(this.graph.nodes).length > maxNodeCount &&
-      this.graph.edges.length > maxEdgeCount;
+      Object.keys(this.graph.nodes).length > MAX_NODE_COUNT &&
+      this.graph.edges.length > MAX_EDGE_COUNT;
     if (isGraphTooLarge && this.colorBy === ColorBy.STRUCTURE) {
       this.colorBy = ColorBy.NONE;
     }

--- a/tensorboard/plugins/graph/tf_graph_common/common_test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common_test.ts
@@ -39,7 +39,9 @@ describe('graph tests', () => {
     );
 
     const debugListenerSpy = spyOn(tb_debug, 'notifyActionEventFromPolymer');
-    await tf_graph_loader.fetchAndConstructHierarchicalGraph(
+    const {
+      graphHierarchy,
+    } = await tf_graph_loader.fetchAndConstructHierarchicalGraph(
       mockTracker,
       null /* remotePath */,
       null /* pbTxtFile */
@@ -76,16 +78,21 @@ describe('graph tests', () => {
       },
       {
         eventCategory: tb_debug.GRAPH_DEBUG_TIMING_EVENT_CATEGORY,
-        eventAction:
-          tb_debug.GraphDebugEventId.HIERARCHY_FIND_SIMILAR_SUBGRAPHS,
-        eventValue: jasmine.any(Number),
-      },
-      {
-        eventCategory: tb_debug.GRAPH_DEBUG_TIMING_EVENT_CATEGORY,
         eventAction: tb_debug.GraphDebugEventId.GRAPH_LOAD_SUCCEEDED,
         eventValue: jasmine.any(Number),
       },
     ]);
+    const callCountAfterLoader = debugListenerSpy.calls.count();
+
+    // Computing templates is done lazily.
+    graphHierarchy.updateTemplates();
+
+    expect(debugListenerSpy.calls.count()).toBe(callCountAfterLoader + 1);
+    expect(debugListenerSpy.calls.mostRecent().args[0]).toEqual({
+      eventCategory: tb_debug.GRAPH_DEBUG_TIMING_EVENT_CATEGORY,
+      eventAction: tb_debug.GraphDebugEventId.HIERARCHY_FIND_SIMILAR_SUBGRAPHS,
+      eventValue: jasmine.any(Number),
+    });
   });
 
   it('notifies listeners of events when graph fails to load', async () => {

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -402,8 +402,14 @@ export class Hierarchy extends tf_graph_util.Dispatcher<HierarchyEvent> {
    * graphs.
    */
   updateTemplates() {
-    this.templates = template.detect(this, this.verifyTemplate);
-    this.dispatchEvent(HierarchyEvent.TEMPLATES_UPDATED);
+    tf_graph_util.time(
+      'Finding similar subgraphs',
+      () => {
+        this.templates = template.detect(this, this.verifyTemplate);
+        this.dispatchEvent(HierarchyEvent.TEMPLATES_UPDATED);
+      },
+      tb_debug.GraphDebugEventId.HIERARCHY_FIND_SIMILAR_SUBGRAPHS
+    );
   }
 }
 /**
@@ -470,7 +476,7 @@ export function build(
   return tf_graph_util
     .runAsyncTask(
       'Adding nodes',
-      20,
+      30,
       () => {
         // Get all the possible device and XLA cluster names.
         let deviceNames = {};
@@ -493,7 +499,7 @@ export function build(
     .then(() => {
       return tf_graph_util.runAsyncTask(
         'Detect series',
-        20,
+        30,
         () => {
           if (params.seriesNodeMinSize > 0) {
             groupSeries(
@@ -513,23 +519,12 @@ export function build(
     .then(() => {
       return tf_graph_util.runAsyncTask(
         'Adding edges',
-        30,
+        40,
         () => {
           addEdges(h, graph, seriesNames);
         },
         tracker,
         tb_debug.GraphDebugEventId.HIERARCHY_ADD_EDGES
-      );
-    })
-    .then(() => {
-      return tf_graph_util.runAsyncTask(
-        'Finding similar subgraphs',
-        30,
-        () => {
-          h.updateTemplates();
-        },
-        tracker,
-        tb_debug.GraphDebugEventId.HIERARCHY_FIND_SIMILAR_SUBGRAPHS
       );
     })
     .then(() => {

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -788,12 +788,15 @@ export function getFillForNode(
   let colorParams = render.MetanodeColors;
   templateIndex = templateIndex || (() => 0);
   switch (colorBy) {
+    // The 'none' mode still colors nodes, just ignores the template structural
+    // colors.
+    case ColorBy.NONE:
     case ColorBy.STRUCTURE:
       if (renderInfo.node.type === NodeType.META) {
         let tid = (<Metanode>renderInfo.node).templateId;
-        return tid === null
-          ? colorParams.UNKNOWN
-          : colorParams.STRUCTURE_PALETTE(templateIndex(tid), isExpanded);
+        return colorBy === ColorBy.STRUCTURE && tid !== null
+          ? colorParams.STRUCTURE_PALETTE(templateIndex(tid), isExpanded)
+          : colorParams.UNKNOWN;
       } else if (renderInfo.node.type === NodeType.SERIES) {
         // If expanded, we're showing the background rect, which we want to
         // appear gray. Otherwise we're showing a stack of ellipses which we

--- a/tensorboard/plugins/graph/tf_graph_common/view_types.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/view_types.ts
@@ -20,6 +20,7 @@ limitations under the License.
  * A set of modes, each identifying a particular method for coloring nodes.
  */
 export enum ColorBy {
+  NONE = 'none',
   COMPUTE_TIME = 'compute_time',
   DEVICE = 'device',
   MEMORY = 'memory',

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -109,7 +109,7 @@ const GRADIENT_COMPATIBLE_COLOR_BY: Set<ColorBy> = new Set([
   ColorBy.MEMORY,
 ]);
 @customElement('tf-graph-controls')
-class TfGraphControls extends LegacyElementMixin(PolymerElement) {
+export class TfGraphControls extends LegacyElementMixin(PolymerElement) {
   static readonly template = html`
     <style>
       :host {
@@ -506,13 +506,19 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
           selected="{{colorBy}}"
           on-paper-radio-group-changed="_onColorByChangedByUserGesture"
         >
-          <paper-radio-button name="structure">Structure</paper-radio-button>
+          <paper-radio-button name="[[ColorBy.NONE]]">None</paper-radio-button>
 
-          <paper-radio-button name="device">Device</paper-radio-button>
+          <paper-radio-button name="[[ColorBy.STRUCTURE]]"
+            >Structure</paper-radio-button
+          >
+
+          <paper-radio-button name="[[ColorBy.DEVICE]]"
+            >Device</paper-radio-button
+          >
 
           <paper-radio-button
             id="xla-cluster-radio-button"
-            name="xla_cluster"
+            name="[[ColorBy.XLA_CLUSTER]]"
             disabled="[[!_xlaClustersProvided(renderHierarchy)]]"
           >
             XLA Cluster
@@ -529,7 +535,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
 
           <paper-radio-button
             id="compute-time-radio-button"
-            name="compute_time"
+            name="[[ColorBy.COMPUTE_TIME]]"
             disabled="[[!stats]]"
           >
             Compute time
@@ -546,7 +552,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
 
           <paper-radio-button
             id="memory-radio-button"
-            name="memory"
+            name="[[ColorBy.MEMORY]]"
             disabled="[[!stats]]"
           >
             Memory
@@ -563,7 +569,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
 
           <paper-radio-button
             id="tpu-compatibility-radio-button"
-            name="op_compatibility"
+            name="[[ColorBy.OP_COMPATIBILITY]]"
           >
             TPU Compatibility
           </paper-radio-button>
@@ -1012,6 +1018,9 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
       </iron-collapse>
     </div>
   `;
+  // Expose values for use in template.
+  ColorBy = ColorBy;
+
   // Public API.
   /**
    * @type {?tf_graph_proto.StepStats}

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -27,9 +27,11 @@ import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mix
 
 import '../tf_graph_board/tf-graph-board';
 import '../tf_graph_controls/tf-graph-controls';
+import {TfGraphControls} from '../tf_graph_controls/tf-graph-controls';
 import '../tf_graph_loader/tf-graph-dashboard-loader';
 import * as tf_graph_op from '../tf_graph_common/op';
 import * as tf_graph_render from '../tf_graph_common/render';
+import {ColorBy} from '../tf_graph_common/view_types';
 
 /**
  * The (string) name for the run of the selected dataset in the graph dashboard.
@@ -162,6 +164,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
             stats="[[_stats]]"
             trace-inputs="[[_traceInputs]]"
             auto-extract-nodes="[[_autoExtractNodes]]"
+            on-color-by-changed="_onBoardColorByChanged"
           ></tf-graph-board>
         </div>
       </div>
@@ -592,5 +595,9 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
       return;
     }
     this._requestHealthPills();
+  }
+  _onBoardColorByChanged(event: CustomEvent) {
+    ((this.$
+      .controls as unknown) as TfGraphControls).colorBy = event.detail as ColorBy;
   }
 }

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -27,11 +27,9 @@ import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mix
 
 import '../tf_graph_board/tf-graph-board';
 import '../tf_graph_controls/tf-graph-controls';
-import {TfGraphControls} from '../tf_graph_controls/tf-graph-controls';
 import '../tf_graph_loader/tf-graph-dashboard-loader';
 import * as tf_graph_op from '../tf_graph_common/op';
 import * as tf_graph_render from '../tf_graph_common/render';
-import {ColorBy} from '../tf_graph_common/view_types';
 
 /**
  * The (string) name for the run of the selected dataset in the graph dashboard.
@@ -146,7 +144,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
           <tf-graph-board
             id="graphboard"
             devices-for-stats="[[_devicesForStats]]"
-            color-by="[[_colorBy]]"
+            color-by="{{_colorBy}}"
             color-by-params="{{_colorByParams}}"
             graph-hierarchy="[[_graphHierarchy]]"
             graph="[[_graph]]"
@@ -164,7 +162,6 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
             stats="[[_stats]]"
             trace-inputs="[[_traceInputs]]"
             auto-extract-nodes="[[_autoExtractNodes]]"
-            on-color-by-changed="_onBoardColorByChanged"
           ></tf-graph-board>
         </div>
       </div>
@@ -595,9 +592,5 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
       return;
     }
     this._requestHealthPills();
-  }
-  _onBoardColorByChanged(event: CustomEvent) {
-    ((this.$
-      .controls as unknown) as TfGraphControls).colorBy = event.detail as ColorBy;
   }
 }


### PR DESCRIPTION
The "Color by structure" mode can be very expensive to compute,
often consistently freezing TensorBoard for minutes with some large
graphs. This introduces a new "Color by none", which does not color
groups by structure.

Opening TensorBoard's Graphs with a small graph will still default to
"structure" coloring, but when loading a large graph, it will
automatically switch to "none", requiring the user to opt-in by clicking
on the radio button.

The condition for a large graph is "10K+ nodes && 10K+ edges", but
this can be tuned. These were determined by examining several
graphs manually:

| (# nodes, # edges)  | Time computing templates (sec) | Time to load (after) | Notes
| ------------- | ------------- | -------- | ----- |
| (12, 19)  | 0.004  | <3s |
| (125, 144)  | 0.007  | <3s |
| (233, 410)  | 0.013  | <3s |
| (361, 394)  | 0.011s  | <3s | Resnet8 |
| (601, 956)  | 0.013s  | <3s | Mnist |
| (603, 955)  | 0.016s  | <3s | Recommender |
| (6K, 9K)  | 0.4s  | <3s | Cifar |
| (35K, 1,968K)  | 3.6s  | 24s |
| (160K, 660K)  | unknown (2m+)  | 1m45s |
| (224K, 229K)  | 102s  | 23s |

Screenshot
![image](https://user-images.githubusercontent.com/2322480/110190811-1561b700-7dda-11eb-9078-09eccbdd3389.png)

Diffbase: https://github.com/tensorflow/tensorboard/pull/4741
Followup: none