### PR TITLE
refactor: move hparams state out of runs

### DIFF
--- a/tensorboard/webapp/hparams/BUILD
+++ b/tensorboard/webapp/hparams/BUILD
@@ -1,0 +1,20 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_web_test_suite", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])
+
+tf_ts_library(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+    deps = ["//tensorboard/webapp/runs/data_source"],
+)
+
+tf_ng_web_test_suite(
+    name = "karma_test",
+    deps = [
+        "//tensorboard/webapp/hparams/_redux:_redux_test_lib",
+    ],
+)

--- a/tensorboard/webapp/hparams/_redux/BUILD
+++ b/tensorboard/webapp/hparams/_redux/BUILD
@@ -1,0 +1,79 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])
+
+tf_ts_library(
+    name = "hparams_types",
+    srcs = [
+        "hparams_types.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/hparams:types",
+    ],
+)
+
+tf_ts_library(
+    name = "hparams_actions",
+    srcs = [
+        "hparams_actions.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/hparams:types",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "hparams_reducers",
+    srcs = [
+        "hparams_reducers.ts",
+    ],
+    deps = [
+        ":hparams_actions",
+        ":hparams_types",
+        "//tensorboard/webapp/hparams:types",
+        "//tensorboard/webapp/runs/actions",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "hparams_selectors",
+    srcs = [
+        "hparams_selectors.ts",
+    ],
+    deps = [
+        ":hparams_actions",
+        ":hparams_types",
+        "//tensorboard/webapp/hparams:types",
+        "//tensorboard/webapp/runs/actions",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "testing",
+    testonly = True,
+    srcs = [
+        "testing.ts",
+    ],
+    deps = [
+        ":hparams_types",
+        "//tensorboard/webapp/hparams:types",
+    ],
+)
+
+tf_ts_library(
+    name = "_redux_test_lib",
+    testonly = True,
+    srcs = [
+        "hparams_selectors_test.ts",
+    ],
+    deps = [
+        ":hparams_selectors",
+        ":testing",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/hparams/_redux/hparams_actions.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_actions.ts
@@ -1,0 +1,55 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * @fileoverview Hparams Ngrx actions.
+ */
+
+import {createAction, props} from '@ngrx/store';
+
+import {DiscreteHparamValues} from '../types';
+
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
+
+export const hparamsDiscreteHparamFilterChanged = createAction(
+  '[Runs] Run Discrete Hparam Filter Changed',
+  props<{
+    experimentId: string;
+    hparamName: string;
+    filterValues: DiscreteHparamValues;
+    includeUndefined: boolean;
+  }>()
+);
+
+export const hparamsIntervalHparamFilterChanged = createAction(
+  '[Runs] Run Interval Hparam Filter Changed',
+  props<{
+    experimentId: string;
+    hparamName: string;
+    filterLowerValue: number;
+    filterUpperValue: number;
+    includeUndefined: boolean;
+  }>()
+);
+
+export const hparamsMetricFilterChanged = createAction(
+  '[Runs] Run Metric Filter Changed',
+  props<{
+    experimentId: string;
+    metricTag: string;
+    filterLowerValue: number;
+    filterUpperValue: number;
+    includeUndefined: boolean;
+  }>()
+);

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
@@ -1,0 +1,300 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Action, ActionReducer, createReducer, on} from '@ngrx/store';
+
+import {fetchRunsSucceeded} from '../../runs/actions';
+import * as actions from './hparams_actions';
+import {
+  DiscreteFilter,
+  DiscreteHparamValue,
+  DomainType,
+  IntervalFilter,
+} from '../types';
+import {ExperimentToHparams, HparamsState} from './hparams_types';
+
+const initialState: HparamsState = {data: {}};
+
+const reducer: ActionReducer<HparamsState, Action> = createReducer(
+  initialState,
+  on(actions.hparamsDiscreteHparamFilterChanged, (state, action) => {
+    const {experimentId, hparamName, filterValues, includeUndefined} = action;
+    const data = state.data[experimentId];
+
+    // Unknown experimentId. Ignore.
+    if (!data) return state;
+
+    const defaultFilter = data.hparam.defaultFilters.get(hparamName);
+    if (!defaultFilter) {
+      throw new Error(`Unknown hparams: ${hparamName}`);
+    }
+
+    if (defaultFilter.type === DomainType.INTERVAL) {
+      throw new Error(
+        `Invariant error: Hparams filter is INTERVAL but got a DISCRETE change`
+      );
+    }
+    const existingFilter = {
+      ...defaultFilter,
+      ...data.hparam.filters.get(hparamName),
+    } as DiscreteFilter;
+
+    const newHparamFilters = new Map(data.hparam.filters);
+    newHparamFilters.set(hparamName, {
+      ...existingFilter,
+      includeUndefined,
+      filterValues,
+    });
+
+    return {
+      ...state,
+      data: {
+        ...state.data,
+        [experimentId]: {
+          ...data,
+          hparam: {
+            ...data.hparam,
+            filters: newHparamFilters,
+          },
+        },
+      },
+    };
+  }),
+  on(actions.hparamsIntervalHparamFilterChanged, (state, action) => {
+    const {
+      experimentId,
+      hparamName,
+      filterLowerValue,
+      filterUpperValue,
+      includeUndefined,
+    } = action;
+
+    const data = state.data[experimentId];
+
+    // Unknown experimentId. Ignore.
+    if (!data) return state;
+
+    const defaultFilter = data.hparam.defaultFilters.get(hparamName);
+
+    if (!defaultFilter) {
+      throw new Error(`Unknown hparams: ${hparamName}`);
+    }
+
+    if (defaultFilter.type === DomainType.DISCRETE) {
+      throw new Error(
+        `Invariant error: Hparams filter is DISCRETE but got an INTERVAL change`
+      );
+    }
+    const existingFilter = {
+      ...defaultFilter,
+      ...data.hparam.filters.get(hparamName),
+    } as IntervalFilter;
+
+    const newHparamFilters = new Map(data.hparam.filters);
+    newHparamFilters.set(hparamName, {
+      ...existingFilter,
+      includeUndefined,
+      filterLowerValue,
+      filterUpperValue,
+    });
+
+    return {
+      ...state,
+      data: {
+        ...state.data,
+        [experimentId]: {
+          ...data,
+          hparam: {
+            ...data.hparam,
+            filters: newHparamFilters,
+          },
+        },
+      },
+    };
+  }),
+  on(actions.hparamsMetricFilterChanged, (state, action) => {
+    const {
+      experimentId,
+      metricTag,
+      filterLowerValue,
+      filterUpperValue,
+      includeUndefined,
+    } = action;
+
+    const data = state.data[experimentId];
+
+    // Unknown experimentId. Ignore.
+    if (!data) return state;
+
+    const defaultFilter = data.metric.defaultFilters.get(metricTag);
+    if (!defaultFilter) {
+      throw new Error(`Unknown metric: ${metricTag}`);
+    }
+    const existingFilter = {
+      ...defaultFilter,
+      ...data.metric.filters.get(metricTag),
+    } as IntervalFilter;
+
+    const newMetricFilters = new Map(data.metric.filters);
+    newMetricFilters.set(metricTag, {
+      ...existingFilter,
+      includeUndefined,
+      filterLowerValue,
+      filterUpperValue,
+    });
+
+    return {
+      ...state,
+      data: {
+        ...state.data,
+        [experimentId]: {
+          ...data,
+          metric: {
+            ...data.metric,
+            filters: newMetricFilters,
+          },
+        },
+      },
+    };
+  }),
+  /**
+   * Sets default filter values.
+   *
+   * Implementation note: hparam values are defined as part of the spec but
+   * metrics are defined with the `runToHparamsAndMetrics`. We need to collect
+   * all the values for metrics, then compute the bound to create the default
+   * filter value. When the metric values are missing, we set the bound to (0,
+   * 1).
+   */
+  on(fetchRunsSucceeded, (state, action) => {
+    if (Object.keys(action.newRunsAndMetadata).length === 0) {
+      return state;
+    }
+
+    const eidToHparams: ExperimentToHparams = {...state.data};
+
+    // Arbitrary ordered collection of metric values collected across
+    // experiments and runs to compute extents of metrics.
+    const metricValueMinAndMax = new Map<string, {min: number; max: number}>();
+    const metricTags = new Set<string>();
+    for (const eid of Object.keys(action.newRunsAndMetadata)) {
+      const newHparamFilters = new Map<
+        string,
+        DiscreteFilter | IntervalFilter
+      >();
+      const newMetricFilters = new Map<string, IntervalFilter>();
+      const discreteHparams = new Map<string, Set<DiscreteHparamValue>>();
+      const intervalHparams = new Map<
+        string,
+        {minValue: number; maxValue: number}
+      >();
+
+      const {runs, metadata} = action.newRunsAndMetadata[eid];
+      // Tabulate all the metric values from runs.
+      for (const run of runs) {
+        const hparamAndMetrics = metadata.runToHparamsAndMetrics[run.id];
+        if (!hparamAndMetrics) {
+          continue;
+        }
+        for (const metric of hparamAndMetrics.metrics) {
+          const minAndMax = metricValueMinAndMax.get(metric.tag);
+          metricValueMinAndMax.set(metric.tag, {
+            min: minAndMax
+              ? Math.min(minAndMax.min, metric.value)
+              : metric.value,
+            max: minAndMax
+              ? Math.max(minAndMax.max, metric.value)
+              : metric.value,
+          });
+        }
+      }
+      // Record and combine all hparam specs (multiple experiments can
+      // have hparams of same name but disjoint set of domain).
+      for (const {name, domain} of metadata.hparamSpecs) {
+        if (domain.type === DomainType.DISCRETE) {
+          const values = discreteHparams.get(name) || new Set();
+          for (const value of domain.values) {
+            values.add(value);
+          }
+          discreteHparams.set(name, values);
+        } else {
+          const existing = intervalHparams.get(name);
+          intervalHparams.set(name, {
+            minValue: existing
+              ? Math.min(domain.minValue, existing.minValue)
+              : domain.minValue,
+            maxValue: existing
+              ? Math.max(domain.maxValue, existing.maxValue)
+              : domain.maxValue,
+          });
+        }
+      }
+      for (const metricSpec of metadata.metricSpecs) {
+        metricTags.add(metricSpec.tag);
+      }
+
+      for (const [name, values] of discreteHparams) {
+        newHparamFilters.set(name, {
+          type: DomainType.DISCRETE,
+          includeUndefined: true,
+          possibleValues: [...values],
+          filterValues: [...values],
+        } as DiscreteFilter);
+      }
+      for (const [name, {minValue, maxValue}] of intervalHparams) {
+        newHparamFilters.set(name, {
+          type: DomainType.INTERVAL,
+          includeUndefined: true,
+          minValue,
+          maxValue,
+          filterLowerValue: minValue,
+          filterUpperValue: maxValue,
+        } as IntervalFilter);
+      }
+      for (const metricTag of metricTags) {
+        const minAndMax = metricValueMinAndMax.get(metricTag);
+        newMetricFilters.set(metricTag, {
+          type: DomainType.INTERVAL,
+          includeUndefined: true,
+          minValue: minAndMax?.min ?? 0,
+          maxValue: minAndMax?.max ?? 0,
+          filterLowerValue: minAndMax?.min ?? 0,
+          filterUpperValue: minAndMax?.max ?? 0,
+        });
+      }
+
+      eidToHparams[eid] = {
+        hparam: {
+          ...eidToHparams[eid]?.hparam,
+          specs: metadata.hparamSpecs,
+          defaultFilters: newHparamFilters,
+        },
+        metric: {
+          ...eidToHparams[eid]?.metric,
+          specs: metadata.metricSpecs,
+          defaultFilters: newMetricFilters,
+        },
+      };
+    }
+
+    return {
+      ...state,
+      data: eidToHparams,
+    };
+  })
+);
+
+export function reducers(state: HparamsState | undefined, action: Action) {
+  return reducer(state, action);
+}

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
@@ -1,0 +1,101 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {createFeatureSelector, createSelector} from '@ngrx/store';
+
+import {DiscreteFilter, IntervalFilter} from '../types';
+import {
+  HparamsMetricsAndFilters,
+  HparamsState,
+  HPARAMS_FEATURE_KEY,
+  State,
+} from './hparams_types';
+
+/** @typehack */ import * as _typeHackNgrxStoreStore from '@ngrx/store/store';
+
+const getHparamsState = createFeatureSelector<State, HparamsState>(
+  HPARAMS_FEATURE_KEY
+);
+
+const getHparamsForExperiment = createSelector(
+  getHparamsState,
+  (
+    state: HparamsState,
+    experimentId: string
+  ): HparamsMetricsAndFilters | undefined => {
+    return state.data[experimentId];
+  }
+);
+
+// Cheap identity selectors to skip recomputing selectors.
+const getHparamDefaultFilter = createSelector(
+  getHparamsForExperiment,
+  (
+    data: HparamsMetricsAndFilters | undefined
+  ): Map<string, IntervalFilter | DiscreteFilter> => {
+    if (!data) return new Map();
+    return data.hparam.defaultFilters;
+  }
+);
+
+const getHparamFilter = createSelector(
+  getHparamsForExperiment,
+  (
+    data: HparamsMetricsAndFilters | undefined
+  ): Map<string, IntervalFilter | DiscreteFilter> => {
+    if (!data) return new Map();
+    return data.hparam.filters;
+  }
+);
+
+const getMetricDefaultFilter = createSelector(
+  getHparamsForExperiment,
+  (data: HparamsMetricsAndFilters | undefined): Map<string, IntervalFilter> => {
+    if (!data) return new Map();
+    return data.metric.defaultFilters;
+  }
+);
+
+const getMetricFilter = createSelector(
+  getHparamsForExperiment,
+  (data: HparamsMetricsAndFilters | undefined): Map<string, IntervalFilter> => {
+    if (!data) return new Map();
+    return data.metric.filters;
+  }
+);
+
+/**
+ * Returns Observable that emits map of hparam name to filter values.
+ */
+export const getRunHparamFilterMap = createSelector(
+  getHparamDefaultFilter,
+  getHparamFilter,
+  (
+    defaultFilterMap,
+    filterMap
+  ): Map<string, IntervalFilter | DiscreteFilter> => {
+    return new Map([...defaultFilterMap, ...filterMap]);
+  }
+);
+
+/**
+ * Returns Observable that emits map of metric tag to filter values.
+ */
+export const getRunMetricFilterMap = createSelector(
+  getMetricDefaultFilter,
+  getMetricFilter,
+  (defaultFilterMap, filterMap): Map<string, IntervalFilter> => {
+    return new Map([...defaultFilterMap, ...filterMap]);
+  }
+);

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
@@ -1,0 +1,235 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import * as selectors from './hparams_selectors';
+import {
+  buildIntervalFilter,
+  buildHparam,
+  buildHparamSpec,
+  buildHparamsState,
+  buildMetric,
+  buildMetricSpec,
+  buildStateFromHparamsState,
+  buildDiscreteFilter,
+} from './testing';
+
+describe('hparams/_redux/hparams_selectors_test', () => {
+  describe('#getRunHparamFilterMap', () => {
+    beforeEach(() => {
+      // Clear the memoization.
+      selectors.getRunHparamFilterMap.release();
+    });
+
+    it('returns default hparam filter map', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          foo: {
+            hparam: buildHparam({
+              specs: [buildHparamSpec({name: 'optimizer'})],
+              defaultFilters: new Map([
+                [
+                  'optimizer',
+                  buildDiscreteFilter({
+                    filterValues: ['a', 'b', 'c'],
+                  }),
+                ],
+              ]),
+            }),
+            metric: buildMetric(),
+          },
+        })
+      );
+
+      expect(selectors.getRunHparamFilterMap(state, 'foo')).toEqual(
+        new Map([
+          ['optimizer', buildDiscreteFilter({filterValues: ['a', 'b', 'c']})],
+        ])
+      );
+    });
+
+    it('returns custom hparam filter map', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          foo: {
+            hparam: buildHparam({
+              specs: [buildHparamSpec({name: 'optimizer'})],
+              defaultFilters: new Map([
+                [
+                  'optimizer',
+                  buildDiscreteFilter({
+                    filterValues: ['a', 'b', 'c'],
+                  }),
+                ],
+              ]),
+              filters: new Map([
+                [
+                  'optimizer',
+                  buildDiscreteFilter({
+                    filterValues: ['d', 'e', 'f'],
+                  }),
+                ],
+              ]),
+            }),
+            metric: buildMetric(),
+          },
+        })
+      );
+
+      expect(selectors.getRunHparamFilterMap(state, 'foo')).toEqual(
+        new Map([
+          [
+            'optimizer',
+            buildDiscreteFilter({
+              filterValues: ['d', 'e', 'f'],
+            }),
+          ],
+        ])
+      );
+    });
+
+    it('returns empty map for an unknown exp', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          foo: {
+            hparam: buildHparam({
+              specs: [buildHparamSpec({name: 'optimizer'})],
+              defaultFilters: new Map([
+                ['optimizer', buildDiscreteFilter({filterValues: ['a']})],
+              ]),
+            }),
+            metric: buildMetric(),
+          },
+        })
+      );
+
+      expect(selectors.getRunHparamFilterMap(state, 'bar')).toEqual(new Map());
+    });
+  });
+
+  describe('#getRunMetricFilterMap', () => {
+    beforeEach(() => {
+      // Clear the memoization.
+      selectors.getRunMetricFilterMap.release();
+    });
+
+    it('returns default metric filter map', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          foo: {
+            hparam: buildHparam(),
+            metric: buildMetric({
+              specs: [buildMetricSpec({tag: 'acc'})],
+              defaultFilters: new Map([
+                [
+                  'acc',
+                  buildIntervalFilter({
+                    filterLowerValue: 0,
+                    filterUpperValue: 1,
+                  }),
+                ],
+              ]),
+            }),
+          },
+        })
+      );
+
+      expect(selectors.getRunMetricFilterMap(state, 'foo')).toEqual(
+        new Map([
+          [
+            'acc',
+            buildIntervalFilter({
+              filterLowerValue: 0,
+              filterUpperValue: 1,
+            }),
+          ],
+        ])
+      );
+    });
+
+    it('returns custom metric filter map', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          foo: {
+            hparam: buildHparam(),
+            metric: buildMetric({
+              specs: [buildMetricSpec({tag: 'acc'})],
+              defaultFilters: new Map([
+                [
+                  'acc',
+                  buildIntervalFilter({
+                    filterLowerValue: 0,
+                    filterUpperValue: 1,
+                  }),
+                ],
+              ]),
+              filters: new Map([
+                [
+                  'acc',
+                  buildIntervalFilter({
+                    filterLowerValue: 0,
+                    filterUpperValue: 0.1,
+                  }),
+                ],
+              ]),
+            }),
+          },
+        })
+      );
+      expect(selectors.getRunMetricFilterMap(state, 'foo')).toEqual(
+        new Map([
+          [
+            'acc',
+            buildIntervalFilter({
+              filterLowerValue: 0,
+              filterUpperValue: 0.1,
+            }),
+          ],
+        ])
+      );
+    });
+
+    it('returns empty map for an unknown exp', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          foo: {
+            hparam: buildHparam(),
+            metric: buildMetric({
+              specs: [buildMetricSpec({tag: 'acc'})],
+              defaultFilters: new Map([
+                [
+                  'acc',
+                  buildIntervalFilter({
+                    filterLowerValue: 0,
+                    filterUpperValue: 1,
+                  }),
+                ],
+              ]),
+              filters: new Map([
+                [
+                  'acc',
+                  buildIntervalFilter({
+                    filterLowerValue: 0,
+                    filterUpperValue: 0.1,
+                  }),
+                ],
+              ]),
+            }),
+          },
+        })
+      );
+      expect(selectors.getRunMetricFilterMap(state, 'bar')).toEqual(new Map());
+    });
+  });
+});

--- a/tensorboard/webapp/hparams/_redux/hparams_types.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_types.ts
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * @fileoverview Hparams types for usage in reducers and effects.
+ */
+
+import {DiscreteFilter, HparamSpec, IntervalFilter, MetricSpec} from '../types';
+
+/**
+ * Key used to namespace the hparams reducer.
+ */
+export const HPARAMS_FEATURE_KEY = 'hparams';
+
+export type ExperimentId = string;
+
+export interface HparamsMetricsAndFilters {
+  hparam: {
+    specs: HparamSpec[];
+    filters: Map<string, DiscreteFilter | IntervalFilter>;
+    defaultFilters: Map<string, DiscreteFilter | IntervalFilter>;
+  };
+  metric: {
+    specs: MetricSpec[];
+    filters: Map<string, IntervalFilter>;
+    defaultFilters: Map<string, IntervalFilter>;
+  };
+}
+
+export type ExperimentToHparams = Record<
+  ExperimentId,
+  HparamsMetricsAndFilters
+>;
+
+export interface HparamsState {
+  data: ExperimentToHparams;
+}
+
+export interface State {
+  [HPARAMS_FEATURE_KEY]?: HparamsState;
+}

--- a/tensorboard/webapp/hparams/_redux/testing.ts
+++ b/tensorboard/webapp/hparams/_redux/testing.ts
@@ -1,0 +1,116 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {
+  HparamsValueType,
+  DomainType,
+  HparamSpec,
+  MetricSpec,
+  DiscreteFilter,
+  DatasetType,
+  IntervalFilter,
+} from '../types';
+import {
+  HparamsMetricsAndFilters,
+  HparamsState,
+  HPARAMS_FEATURE_KEY,
+  State,
+} from './hparams_types';
+
+export function buildHparam(
+  override: Partial<HparamsMetricsAndFilters['hparam']> = {}
+): HparamsMetricsAndFilters['hparam'] {
+  return {
+    specs: [],
+    filters: new Map(),
+    defaultFilters: new Map(),
+    ...override,
+  };
+}
+
+export function buildMetric(
+  override: Partial<HparamsMetricsAndFilters['metric']> = {}
+): HparamsMetricsAndFilters['metric'] {
+  return {
+    specs: [],
+    filters: new Map(),
+    defaultFilters: new Map(),
+    ...override,
+  };
+}
+export function buildHparamsState(
+  dataOverride?: Partial<HparamsState['data']>
+): HparamsState {
+  return {
+    data: {
+      ...dataOverride,
+    } as Record<string, HparamsMetricsAndFilters>,
+  };
+}
+
+export function buildStateFromHparamsState(hparamsState: HparamsState): State {
+  return {[HPARAMS_FEATURE_KEY]: hparamsState};
+}
+
+export function buildHparamSpec(
+  override: Partial<HparamSpec> = {}
+): HparamSpec {
+  return {
+    description: '',
+    displayName: 'Sample Param',
+    domain: {type: DomainType.INTERVAL, minValue: 0, maxValue: 1},
+    name: 'sample_param',
+    type: HparamsValueType.DATA_TYPE_FLOAT64,
+    ...override,
+  };
+}
+
+export function buildMetricSpec(
+  override: Partial<MetricSpec> = {}
+): MetricSpec {
+  return {
+    tag: 'tag',
+    displayName: 'Tag',
+    description: 'This is a tags',
+    datasetType: DatasetType.DATASET_TRAINING,
+    ...override,
+  };
+}
+
+export function buildDiscreteFilter(
+  override: Partial<DiscreteFilter> = {}
+): DiscreteFilter {
+  return {
+    type: DomainType.DISCRETE,
+    includeUndefined: true,
+    possibleValues: [1, 10, 100],
+    filterValues: [1, 100],
+    ...override,
+  };
+}
+
+export function buildIntervalFilter(
+  override: Partial<IntervalFilter> = {}
+): IntervalFilter {
+  return {
+    type: DomainType.INTERVAL,
+    includeUndefined: true,
+    minValue: 0,
+    maxValue: 100,
+    filterLowerValue: 5,
+    filterUpperValue: 10,
+    ...override,
+  };
+}

--- a/tensorboard/webapp/hparams/types.ts
+++ b/tensorboard/webapp/hparams/types.ts
@@ -1,0 +1,46 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  DiscreteHparamValues,
+  DomainType,
+} from '../runs/data_source/runs_data_source_types';
+
+export {
+  DatasetType,
+  DiscreteHparamValue,
+  DiscreteHparamValues,
+  DomainType,
+  HparamSpec,
+  HparamsValueType,
+  MetricSpec,
+} from '../runs/data_source/runs_data_source_types';
+
+export interface DiscreteFilter {
+  type: DomainType.DISCRETE;
+  includeUndefined: boolean;
+  possibleValues: DiscreteHparamValues;
+  // Subset of `possibleValues`
+  filterValues: DiscreteHparamValues;
+}
+
+export interface IntervalFilter {
+  type: DomainType.INTERVAL;
+  includeUndefined: boolean;
+  minValue: number;
+  maxValue: number;
+  // Filter values have to be in between min and max values (inclusive).
+  filterLowerValue: number;
+  filterUpperValue: number;
+}


### PR DESCRIPTION
This change largely takes hparams and its filter data from runs_reducer
and reimplements `eid` indexed data.

New reducer is not yet integrated into the app and will be done in a follow up.