### PR TITLE
graph: fix pixelated SVG for Chromium

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -278,6 +278,15 @@ export const template = html`
 
     /* --- Node label --- */
 
+    .node {
+      /* Provide a hint to browsers to avoid using their static rasterization
+      at initial scale, which looks very pixelated on Chromium. Note that we
+      intentionally do *not* use 'will-change: transform' and 'translateZ(0)
+      here, which introduce blurry on Firefox.
+      See https://github.com/tensorflow/tensorboard/issues/4744 */
+      transform: translateZ(1px);
+    }
+
     .node > text.nodelabel {
       cursor: pointer;
       fill: #444;

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -280,9 +280,9 @@ export const template = html`
 
     .node {
       /* Provide a hint to browsers to avoid using their static rasterization
-      at initial scale, which looks very pixelated on Chromium. Note that we
-      intentionally do *not* use 'will-change: transform' and 'translateZ(0)
-      here, which introduce blurry on Firefox.
+      at initial scale, which looks very pixelated on Chromium when zoomed in.
+      Note that we intentionally do *not* use 'will-change: transform' and
+      'translateZ(0) here, which introduce blurriness on Firefox.
       See https://github.com/tensorflow/tensorboard/issues/4744 */
       transform: translateZ(1px);
     }

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -278,11 +278,6 @@ export const template = html`
 
     /* --- Node label --- */
 
-    #root,
-    .node {
-      will-change: transform;
-    }
-
     .node > text.nodelabel {
       cursor: pointer;
       fill: #444;


### PR DESCRIPTION
Starting in Chromium 89, zooming in on nodes in the Graph dashboard
yields very pixelated rendering artifacts. See details in [1]. This
regression is a result of changes to Chromium's SVG renderer [2].

To workaround the symptom, this change replaces the
`will-change: transform` CSS with `transform: translateZ(1px)`. Newer
Chromium versions take the former `will-change` as a hint to use the
rasterized result at initial scale, which renders faster at the cost of
image quality.

Note that we intentionally do not do `transform: translateZ(0)`. The
`1px` is important to avoid introducing a blurry text regression in
Firefox [4], for unknown reasons. The "#root" node does not have
`transform: translateZ(1px)` because this would interfere with
panning the graph.

The `will-change` rule was added in TB PR [3], but removing it has no
noticeable effect on load performance or panning the viewport.

[1] https://github.com/tensorflow/tensorboard/issues/4744
[2] https://bugs.chromium.org/p/chromium/issues/detail?id=1185435
[3] https://github.com/tensorflow/tensorboard/pull/4495
[4] https://imgur.com/a/irk0jB7
![image](https://user-images.githubusercontent.com/2322480/110383819-b1293800-8011-11eb-925f-2f0ae21348ad.png)

EDIT: original approach just removed will-change, but is now updated
to avoid regressing Firefox.