### PR TITLE
rust: implement data location

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -404,6 +404,35 @@ class ExperimentMetadata(object):
     def creation_time(self):
         return self._creation_time
 
+    def __eq__(self, other):
+        if not isinstance(other, ExperimentMetadata):
+            return False
+        if self._experiment_name != other._experiment_name:
+            return False
+        if self._experiment_description != other._experiment_description:
+            return False
+        if self._creation_time != other._creation_time:
+            return False
+        return True
+
+    def __hash__(self):
+        return hash(
+            (
+                self._experiment_name,
+                self._experiment_description,
+                self._creation_time,
+            )
+        )
+
+    def __repr__(self):
+        return "ExperimentMetadata(%s)" % ", ".join(
+            (
+                "experiment_name=%r" % (self._experiment_name,),
+                "experiment_description=%r" % (self._experiment_description,),
+                "creation_time=%r" % (self._creation_time,),
+            )
+        )
+
 
 class Run(object):
     """Metadata about a run.

--- a/tensorboard/data/provider_test.py
+++ b/tensorboard/data/provider_test.py
@@ -38,6 +38,31 @@ class ExperimentMetadataTest(tb_test.TestCase):
         self.assertEqual(e1.experiment_description, "Experiment on Foo")
         self.assertEqual(e1.creation_time, 1.25)
 
+    def test_eq(self):
+        def md(**kwargs):
+            kwargs.setdefault("experiment_name", "FooExperiment")
+            kwargs.setdefault("experiment_description", "Experiment on Foo")
+            kwargs.setdefault("creation_time", 1.25)
+            return provider.ExperimentMetadata(**kwargs)
+
+        a1 = md()
+        a2 = md()
+        b = md(experiment_name="BarExperiment")
+        self.assertEqual(a1, a2)
+        self.assertNotEqual(a1, b)
+        self.assertNotEqual(b, object())
+
+    def test_repr(self):
+        x = provider.ExperimentMetadata(
+            experiment_name="FooExperiment",
+            experiment_description="Experiment on Foo",
+            creation_time=1.25,
+        )
+        repr_ = repr(x)
+        self.assertIn(repr(x.experiment_name), repr_)
+        self.assertIn(repr(x.experiment_description), repr_)
+        self.assertIn(repr(x.creation_time), repr_)
+
 
 class RunTest(tb_test.TestCase):
     def test_eq(self):

--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -183,6 +183,8 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("listening on {:?}", bound);
     }
 
+    let data_location = opts.logdir.display().to_string();
+
     // Leak the commit object, since the Tonic server must have only 'static references. This only
     // leaks the outer commit structure (of constant size), not the pointers to the actual data.
     let commit: &'static Commit = Box::leak(Box::new(Commit::new()));
@@ -215,7 +217,10 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .expect("failed to spawn reloader thread");
 
-    let handler = DataProviderHandler { commit };
+    let handler = DataProviderHandler {
+        data_location,
+        commit,
+    };
     Server::builder()
         .add_service(TensorBoardDataProviderServer::new(handler))
         .serve_with_incoming(TcpListenerStream::new(listener))


### PR DESCRIPTION
Summary:
This patch implements `GetExperiment` for the Rust data server and the
Python data provider. The server only populates the data location field,
because we don’t actually have any other experiment metadata.

Test Plan:
Tested with `--load_fast` using a local logdir and a GCS logdir.

wchargin-branch: rust-data-location
