### PR TITLE
rust: support unbounded reservoirs

### DIFF
--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -121,9 +121,10 @@ struct Opts {
     ///
     /// A comma separated list of `plugin_name=num_samples` pairs to explicitly specify how many
     /// samples to keep per tag for the specified plugin. For unspecified plugins, series are
-    /// randomly downsampled to reasonable values to prevent out-of-memory errors in long running
-    /// jobs. For instance, `--samples_per_plugin=scalars=500,images=0` keeps 500 events in each
-    /// scalar series and keeps none of the images.
+    /// randomly downsampled to reasonable values to prevent out-of-memory errors in long-running
+    /// jobs. Each `num_samples` may be the special token `all` to retain all data without
+    /// downsampling. For instance, `--samples_per_plugin=scalars=500,images=all,audio=0` keeps 500
+    /// events in each scalar series, all of the images, and none of the audio.
     #[clap(long, default_value = "", setting(clap::ArgSettings::AllowEmptyValues))]
     samples_per_plugin: PluginSamplingHint,
 }

--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -103,7 +103,8 @@ class SubprocessServerDataIngester(ingester.DataIngester):
             reload = str(int(self._reload_interval))
 
         sample_hint_pairs = [
-            "%s=%s" % (k, v) for k, v in self._samples_per_plugin.items()
+            "%s=%s" % (k, "all" if v == 0 else v)
+            for k, v in self._samples_per_plugin.items()
         ]
         samples_per_plugin = ",".join(sample_hint_pairs)
 

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -86,6 +86,10 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
                     logdir=logdir,
                     reload_interval=5,
                     channel_creds_type=grpc_util.ChannelCredsType.LOCAL,
+                    samples_per_plugin={
+                        "scalars": 500,
+                        "images": 0,
+                    },
                 )
                 ingester.start()
         self.assertIsInstance(
@@ -99,6 +103,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
             "--port=0",
             "--port-file=%s" % port_file,
             "--die-after-stdin",
+            "--samples-per-plugin=scalars=500,images=all",
             "--verbose",  # logging is enabled in tests
         ]
         popen.assert_called_once_with(expected_args, stdin=subprocess.PIPE)


### PR DESCRIPTION
Summary:
The `--samples-per-plugin` argument now understands inputs like
`scalars=100,images=all`. This indicates that some reservoirs should
have unbounded capacity.

Reservoir constructors take `impl Into<Capacity>` so that passing a bare
`usize` is still valid, enjoying all the concision of dynamic typing
alongside the safety of sound static analysis.

Test Plan:
Due to #4752, passing `--samples_per_plugin=scalars=0` to TensorBoard
does not actually work, with or without `--load_fast`. But unit tests
have decent coverage, and manual end-to-end tests against a live data
server show that it really does return lots of data.

wchargin-branch: rust-unbounded-reservoir
