### PR TITLE
server_ingester: perform tilde expansion on logdir

### DIFF
--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -109,7 +109,7 @@ class SubprocessServerDataIngester(ingester.DataIngester):
 
         args = [
             server_binary,
-            "--logdir=%s" % (self._logdir,),
+            "--logdir=%s" % os.path.expanduser(self._logdir),
             "--reload=%s" % reload,
             "--port=0",
             "--port-file=%s" % (port_file_path,),

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -79,11 +79,14 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
             threading.Thread(target=target).start()
             return result
 
+        tilde_logdir = "~/tmp/logs"
+        expanded_logdir = os.path.expanduser(tilde_logdir)
+        self.assertNotEqual(tilde_logdir, expanded_logdir)
+
         with mock.patch.object(subprocess, "Popen", wraps=fake_popen) as popen:
             with mock.patch.object(grpc, "secure_channel", autospec=True) as sc:
-                logdir = "/tmp/logs"
                 ingester = server_ingester.SubprocessServerDataIngester(
-                    logdir=logdir,
+                    logdir=tilde_logdir,
                     reload_interval=5,
                     channel_creds_type=grpc_util.ChannelCredsType.LOCAL,
                 )
@@ -94,7 +97,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
 
         expected_args = [
             fake_binary,
-            "--logdir=/tmp/logs",
+            "--logdir=%s" % expanded_logdir,
             "--reload=5",
             "--port=0",
             "--port-file=%s" % port_file,


### PR DESCRIPTION
Summary:
The `rustboard` binary, as a well-behaved CLI application, does not
perform tilde expansion on its arguments, because that is the job of the
shell. However, TensorBoard historically _has_ performed tilde
expansion, and so, when `--logdir '~/foo'` is given, `--load_fast` is a
breaking change.

This patch teaches `server_ingester.py` to also perform tilde expansion.
This way, we recover the same user experience without tarnishing the
integrity of `rustboard` itself, or my precious sensibilities.

Test Plan:
Run `tensorboard --logdir '~/tensorboard_data/mnist'` or something: note
the quotes, preventing tilde expansion in the shell. Note that this
resolves to the same directory as if it had not been quoted, as visible
from the data location in the UI. Note that `--load_fast` now exhibits
the same behavior.

wchargin-branch: server-ingester-tilde-expansion
