### PR TITLE
line chart: conditionally disable fit to domain

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -66,11 +66,11 @@ limitations under the License.
       </button>
       <button
         mat-menu-item
-        [disabled]="!seriesDataList || !seriesDataList.length || isExtentAtDefault"
+        [disabled]="!seriesDataList || !seriesDataList.length || (newLineChart && !newLineChart.getIsViewBoxOverridden())"
         (click)="resetDomain()"
         [title]="
-            isExtentAtDefault ?
-                'Line chart is already fitted to data. When data updates, line chart '
+            (newLineChart && !newLineChart.getIsViewBoxOverridden) ?
+                'Line chart is already fitted to data. When data updates, the line chart '
                 + 'will auto fit to its domain.' :
                 ''
         "
@@ -101,7 +101,6 @@ limitations under the License.
       [customXFormatter]="xAxisType === XAxisType.RELATIVE ? relativeXFormatter : undefined"
       [ignoreYOutliers]="ignoreOutliers"
       [tooltipTemplate]="tooltip"
-      (isExtentAtDefault)="isExtentAtDefault = $event.atDefault"
     ></line-chart>
 
     <ng-template #legacyChart>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -66,8 +66,14 @@ limitations under the License.
       </button>
       <button
         mat-menu-item
-        [disabled]="!seriesDataList || !seriesDataList.length"
+        [disabled]="!seriesDataList || !seriesDataList.length || isExtentAtDefault"
         (click)="resetDomain()"
+        [title]="
+            isExtentAtDefault ?
+                'Line chart is already fitted to data. When data updates, line chart '
+                + 'will auto fit to its domain.' :
+                ''
+        "
         i18n-aria-label="A button that resets line chart domain to the data"
         aria-label="Fit line chart domains to data"
       >
@@ -95,6 +101,7 @@ limitations under the License.
       [customXFormatter]="xAxisType === XAxisType.RELATIVE ? relativeXFormatter : undefined"
       [ignoreYOutliers]="ignoreOutliers"
       [tooltipTemplate]="tooltip"
+      (isExtentAtDefault)="isExtentAtDefault = $event.atDefault"
     ></line-chart>
 
     <ng-template #legacyChart>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -147,7 +147,6 @@ export class ScalarCardComponent {
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
   @Input() isEverVisible!: boolean;
-  isExtentAtDefault = false;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -147,6 +147,7 @@ export class ScalarCardComponent {
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
   @Input() isEverVisible!: boolean;
+  isExtentAtDefault = false;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -18,9 +18,11 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
+  Output,
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
@@ -123,6 +125,9 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input()
   ignoreYOutliers: boolean = false;
 
+  @Output()
+  readonly isExtentAtDefault = new EventEmitter<{atDefault: boolean}>();
+
   readonly Y_GRID_COUNT = 6;
   readonly X_GRID_COUNT = 10;
 
@@ -176,6 +181,7 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     if (this.scaleUpdated) {
       this.isViewBoxOverridden = false;
+      this.isExtentAtDefault.emit({atDefault: true});
     }
 
     this.isViewBoxChanged =
@@ -375,12 +381,14 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
     this.isViewBoxChanged = true;
     this.viewBox = dataExtent;
     this.updateLineChart();
+    this.isExtentAtDefault.emit({atDefault: false});
   }
 
   viewBoxReset() {
     this.isViewBoxOverridden = false;
     this.isViewBoxChanged = true;
     this.updateLineChart();
+    this.isExtentAtDefault.emit({atDefault: true});
   }
 
   onViewBoxChangedFromAxis(extent: [number, number], axis: 'x' | 'y') {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -18,11 +18,9 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
-  Output,
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
@@ -125,9 +123,6 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input()
   ignoreYOutliers: boolean = false;
 
-  @Output()
-  readonly isExtentAtDefault = new EventEmitter<{atDefault: boolean}>();
-
   readonly Y_GRID_COUNT = 6;
   readonly X_GRID_COUNT = 10;
 
@@ -181,7 +176,6 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     if (this.scaleUpdated) {
       this.isViewBoxOverridden = false;
-      this.isExtentAtDefault.emit({atDefault: true});
     }
 
     this.isViewBoxChanged =
@@ -381,14 +375,16 @@ export class LineChartComponent implements AfterViewInit, OnChanges, OnDestroy {
     this.isViewBoxChanged = true;
     this.viewBox = dataExtent;
     this.updateLineChart();
-    this.isExtentAtDefault.emit({atDefault: false});
   }
 
   viewBoxReset() {
     this.isViewBoxOverridden = false;
     this.isViewBoxChanged = true;
     this.updateLineChart();
-    this.isExtentAtDefault.emit({atDefault: true});
+  }
+
+  getIsViewBoxOverridden(): boolean {
+    return this.isViewBoxOverridden;
   }
 
   onViewBoxChangedFromAxis(extent: [number, number], axis: 'x' | 'y') {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -53,7 +53,6 @@ class FakeGridComponent {
       [seriesMetadataMap]="seriesMetadataMap"
       [yScaleType]="yScaleType"
       [fixedViewBox]="fixedViewBox"
-      (isExtentAtDefault)="isExtentAtDefault($event)"
     ></line-chart>
   `,
   styles: [
@@ -84,9 +83,6 @@ class TestableComponent {
 
   @Input()
   disableUpdate?: boolean;
-
-  @Input()
-  isExtentAtDefault: (event: {atDefault: boolean}) => void = () => {};
 
   // WebGL one is harder to test.
   preferredRendererType = RendererType.SVG;
@@ -577,9 +573,8 @@ describe('line_chart_v2/line_chart test', () => {
     });
   });
 
-  describe('extent at default', () => {
-    it('emits when viewBox is overriden or reset', () => {
-      const isExtentAtDefaultSpy = jasmine.createSpy();
+  describe('#getIsViewBoxOverridden', () => {
+    it('returns its internal state', () => {
       const fixture = createComponent({
         seriesData: [
           buildSeries({
@@ -594,40 +589,20 @@ describe('line_chart_v2/line_chart test', () => {
         seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
         yScaleType: ScaleType.LINEAR,
       });
-      fixture.componentInstance.isExtentAtDefault = isExtentAtDefaultSpy;
       fixture.detectChanges();
 
-      expect(isExtentAtDefaultSpy).toHaveBeenCalledTimes(1);
+      expect(fixture.componentInstance.chart.getIsViewBoxOverridden()).toBe(
+        false
+      );
 
       fixture.componentInstance.triggerViewBoxChange({
         x: [-5, 5],
         y: [0, 10],
       });
-      expect(isExtentAtDefaultSpy).toHaveBeenCalledTimes(2);
 
-      fixture.componentInstance.chart.viewBoxReset();
-      expect(isExtentAtDefaultSpy).toHaveBeenCalledTimes(3);
-      expect(isExtentAtDefaultSpy.calls.allArgs()).toEqual([
-        [{atDefault: true}],
-        [{atDefault: false}],
-        [{atDefault: true}],
-      ]);
-
-      // Changing the data fits the domain to the data but does not emit the extent
-      // change.
-      fixture.componentInstance.seriesData = [
-        buildSeries({
-          id: 'foo',
-          points: [
-            {x: 0, y: 0},
-            {x: 1, y: -1},
-            {x: 2, y: 1},
-            {x: 3, y: 1},
-          ],
-        }),
-      ];
-      fixture.detectChanges();
-      expect(isExtentAtDefaultSpy).toHaveBeenCalledTimes(3);
+      expect(fixture.componentInstance.chart.getIsViewBoxOverridden()).toBe(
+        true
+      );
     });
   });
 });


### PR DESCRIPTION
The new line chart now differentiate the state between viewBox overridden
vs. default. When it is put on the default, any changes in the data will
automatically be reflected in the new domain calculation while when
overridden, the viewBox will be "stuck".

This was one of the older feature requests from the users where they
wanted the line chart to clearly indicate whether it will "auto scroll"
to fit the data or it will be stuck.

With this change, we will improve the feature in a minor way by
disabling the "fit to domain" button when it is already at the default
to indicate that the data updates will trigger a domain update as well.

Do note that the `title` is actually not working inside a mat-menu on a
`disabled` button but we will find a way to make it work in a follow-up.