### PR TITLE
sync: fix graph symbols exported improperly

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -35,7 +35,7 @@ import {TfGraphScene} from '../tf_graph_common/tf-graph-scene';
 import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-graph-scene')
-export class TfGraphScene2
+class TfGraphScene2
   extends LegacyElementMixin(PolymerElement)
   implements TfGraphScene {
   static readonly template = template;

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -21,7 +21,6 @@ import * as _ from 'lodash';
 import '../../../components/polymer/irons_and_papers';
 import * as tb_debug from '../../../components/tb_debug';
 import './tf-graph-scene';
-import {TfGraphScene2} from './tf-graph-scene';
 import * as tf_graph from '../tf_graph_common/graph';
 import * as tf_graph_scene from '../tf_graph_common/scene';
 import * as tf_graph_util from '../tf_graph_common/util';
@@ -341,7 +340,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     this.graphHierarchy.addListener(
       tf_graph_hierarchy.HierarchyEvent.TEMPLATES_UPDATED,
       () => {
-        (this.$.scene as TfGraphScene2).nodeColorsChanged();
+        (this.$.scene as any).nodeColorsChanged();
       }
     );
 

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -109,7 +109,7 @@ const GRADIENT_COMPATIBLE_COLOR_BY: Set<ColorBy> = new Set([
   ColorBy.MEMORY,
 ]);
 @customElement('tf-graph-controls')
-export class TfGraphControls extends LegacyElementMixin(PolymerElement) {
+class TfGraphControls extends LegacyElementMixin(PolymerElement) {
   static readonly template = html`
     <style>
       :host {


### PR DESCRIPTION
Some Polymer element classes in the Graph dashboard are exported
for use as types in other files. This breaks the sync inside Google, so
this change removes the `export`s. Note, there is no functional change.

A working hypothesis is that TSC is run with `--declaration` internally,
and we might want to consider adding that in OSS as well.

Googlers, see test sync cl/361900919