### PR TITLE
default: switch to `EntryPoint.resolve`

### DIFF
--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -138,7 +138,7 @@ def get_dynamic_plugins():
     [1]: https://packaging.python.org/specifications/entry-points/
     """
     return [
-        entry_point.load()
+        entry_point.resolve()
         for entry_point in pkg_resources.iter_entry_points(
             "tensorboard_plugins"
         )

--- a/tensorboard/default_test.py
+++ b/tensorboard/default_test.py
@@ -42,7 +42,7 @@ class FakeEntryPoint(pkg_resources.EntryPoint):
         """
         return cls("foo", "bar")
 
-    def load(self):
+    def resolve(self):
         """Returns FakePlugin instead of resolving module.
 
         Returns:


### PR DESCRIPTION
Summary:
We use Python [entry points] to discover dynamic plugins and load their
entry points using the `load` method. It turns out that this does more
than expected: it updates the global working set, analyzes requirements,
and throws an error in some cases where it shouldn’t (see #4761). This
patch switches `.load()` to `.resolve()`, which [actually just resolves
the symbol][resolve].

Fixes #4761.

[entry points]: https://packaging.python.org/specifications/entry-points/
[resolve]: https://github.com/pypa/setuptools/blob/b2f7b8f92725c63b164d5776f85e67cc560def4e/pkg_resources/__init__.py#L2452-L2460

Test Plan:
Run `//tensorboard/data/server/pip_package:install` to install RustBoard
version 0.4.0a0 into a virtualenv with a `tb-nightly` that requires it
at version `<0.4.0`. Launch TensorBoard, and note that it no longer
fails at startup time with a `VersionConflict` error.

wchargin-branch: entrypoint-resolve
