### PR TITLE
accumulator: ignore first `SessionLog.START` event

### DIFF
--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -326,11 +326,14 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         """
         gen = _EventGenerator(self)
         acc = ea.EventAccumulator(gen)
+        slog = event_pb2.SessionLog(status=event_pb2.SessionLog.START)
+
         gen.AddEvent(
             event_pb2.Event(wall_time=0, step=1, file_version="brain.Event:2")
         )
 
         gen.AddScalarTensor("s1", wall_time=1, step=100, value=20)
+        gen.AddEvent(event_pb2.Event(wall_time=1, step=100, session_log=slog))
         gen.AddScalarTensor("s1", wall_time=1, step=200, value=20)
         gen.AddScalarTensor("s1", wall_time=1, step=300, value=20)
         gen.AddScalarTensor("s1", wall_time=1, step=400, value=20)
@@ -338,7 +341,6 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         gen.AddScalarTensor("s2", wall_time=1, step=202, value=20)
         gen.AddScalarTensor("s2", wall_time=1, step=203, value=20)
 
-        slog = event_pb2.SessionLog(status=event_pb2.SessionLog.START)
         gen.AddEvent(event_pb2.Event(wall_time=2, step=201, session_log=slog))
         acc.Reload()
         self.assertEqual([x.step for x in acc.Tensors("s1")], [100, 200])


### PR DESCRIPTION
Summary:
Fixes #4743. A supervisor may use `SessionLog.START` events whenever it
starts, so the first such event does not indicate a *restart* and does
not require preemption. Events like graphs sometimes(?) appear before
the first `SessionLog.START`. This patch changes the accumulator to only
preempt on non-initial `SessionLog.START` events to retain that data.

Test Plan:
The updated unit test fails before this patch and passes after it. Also,
the dataset in #4743 now shows a graph in the graphs dashboard rather
than an internal 404. For posterity, the salient structure of that event
file comprises this sequence of events, all implicitly at step 0:

    { file_version: "brain.Event:2" }
    { graph_def: "..." }
    { meta_graph_def: "..." }
    { session_log { status: START } }

wchargin-branch: prune-session-restarts-only
