### PR TITLE
tensorboard-data-server 0.4.0

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "rustboard"
-version = "0.4.0"
+version = "0.5.0-alpha.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "rustboard"
-version = "0.4.0-alpha.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "rustboard"
-version = "0.4.0-alpha.0"
+version = "0.4.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 # Keep in sync with `edition` in rustfmt.toml.
 edition = "2018"

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "rustboard"
-version = "0.4.0"
+version = "0.5.0-alpha.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 # Keep in sync with `edition` in rustfmt.toml.
 edition = "2018"

--- a/tensorboard/data/server/lib.rs
+++ b/tensorboard/data/server/lib.rs
@@ -19,7 +19,7 @@ limitations under the License.
 
 /// Package version. Keep in sync with `Cargo.toml`. We don't use `env!("CARGO_PKG_VERSION")`
 /// because of <https://github.com/bazelbuild/rules_rust/issues/573>.
-pub(crate) const VERSION: &str = "0.4.0";
+pub(crate) const VERSION: &str = "0.5.0-alpha.0";
 
 pub mod blob_key;
 pub mod cli;

--- a/tensorboard/data/server/lib.rs
+++ b/tensorboard/data/server/lib.rs
@@ -19,7 +19,7 @@ limitations under the License.
 
 /// Package version. Keep in sync with `Cargo.toml`. We don't use `env!("CARGO_PKG_VERSION")`
 /// because of <https://github.com/bazelbuild/rules_rust/issues/573>.
-pub(crate) const VERSION: &str = "0.4.0-alpha.0";
+pub(crate) const VERSION: &str = "0.4.0";
 
 pub mod blob_key;
 pub mod cli;

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.4.0"
+__version__ = "0.5.0a0"
 
 
 def server_binary():

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.4.0a0"
+__version__ = "0.4.0"
 
 
 def server_binary():


### PR DESCRIPTION
Changes since 0.3.0:

  - tensor support: histograms, text, PR curves, hparams
  - `--samples_per_plugin` support
  - data location support
  - bug fix for relative paths (#4684)

Merge plan: rebase and merge, then release from the unique commit where
the version numbers are 0.4.0.
