### PR TITLE
cli: add `--load_fast=auto` option

### DIFF
--- a/tensorboard/data/server/DEVELOPMENT.md
+++ b/tensorboard/data/server/DEVELOPMENT.md
@@ -57,8 +57,8 @@ useful in conjunction with `ibazel` to restart the server when you make changes.
 The server doesn’t have to be running when TensorBoard starts.
 
 To tell TensorBoard to start the server as a subprocess, build with
-`--define=link_data_server=true` and pass `--load_fast` to TensorBoard along
-with a normal `--logdir`. Thus:
+`--define=link_data_server=true` and pass `--load_fast=true` to TensorBoard
+along with a normal `--logdir`. Thus:
 
 ```
 bazel run -c opt --define=link_data_server=true //tensorboard -- \
@@ -75,8 +75,8 @@ for any reason.
 
 As an alternative to `--define=link_data_server=true`, you can set the
 `TENSORBOARD_DATA_SERVER_BINARY` environment variable to the path to a data
-server binary, and pass `--load_fast`. If running with `bazel run`, this should
-be an absolute path.
+server binary, and pass `--load_fast=true`. If running with `bazel run`, this
+should be an absolute path.
 
 As another alternative, you can install the `tensorboard_data_server` package
 into your virtualenv. To do so, run:

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -49,12 +49,6 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
         fake_binary = os.path.join(self.get_temp_dir(), "server")
         with open(fake_binary, "wb"):
             pass
-        self.enter_context(
-            mock.patch.dict(
-                os.environ,
-                {server_ingester._ENV_DATA_SERVER_BINARY: fake_binary},
-            )
-        )
 
         real_popen = subprocess.Popen
         port_file = None  # value of `--port-file` to be stashed here
@@ -86,6 +80,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
         with mock.patch.object(subprocess, "Popen", wraps=fake_popen) as popen:
             with mock.patch.object(grpc, "secure_channel", autospec=True) as sc:
                 ingester = server_ingester.SubprocessServerDataIngester(
+                    server_binary=fake_binary,
                     logdir=tilde_logdir,
                     reload_interval=5,
                     channel_creds_type=grpc_util.ChannelCredsType.LOCAL,

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -388,9 +388,12 @@ port to TensorBoard as a subprocess.(default: %(default)s).\
 
         parser.add_argument(
             "--load_fast",
-            action="store_true",
+            type=str,
+            default="false",
+            choices=["false", "auto", "true"],
             help="""\
-Experimental. Use a data server to accelerate loading.
+Experimental. Use a data server to accelerate loading. Set to "auto" to use a
+data server only if installed.
 """,
         )
 


### PR DESCRIPTION
Summary:
The `--load_fast` argument now takes a tri-state value: one of `false`,
`true`, or `auto`. If set to `auto`, it uses a data server iff one is
available and installed. This is equivalent to “try to use `--load_fast`
but degrade gracefully if that would fail”.

With this change, `--load_fast` *must* take a value. The old behavior of
`--load_fast` is now spelled `--load_fast true`. The default value is
still `false`, so the default behavior is unchanged.

Test Plan:
Try with the following configurations:

  - via Bazel with `--define=link_data_server=true`
  - without Bazel-bundled binary, but with `tensorboard-data-server`
  - with universal wheel of `tensorboard-data-server` installed (should
    fail, because this does not actually include a data server)
  - with nothing installed (should fail)

In each failure case, `--load_fast true` should hard-error, while
`--load_fast auto` should degrade.

wchargin-branch: load-fast-auto
