### PR TITLE
data: make metadata required, providing defaults

### DIFF
--- a/tensorboard/data/dispatching_provider_test.py
+++ b/tensorboard/data/dispatching_provider_test.py
@@ -39,7 +39,7 @@ class PlaceholderDataProvider(provider.DataProvider):
         return "%s://%s" % (self._name, experiment_id)
 
     def experiment_metadata(self, ctx, *, experiment_id):
-        return None
+        return provider.ExperimentMetadata()
 
     def list_plugins(self, ctx, *, experiment_id):
         self._validate_eid(experiment_id)

--- a/tensorboard/data/grpc_provider.py
+++ b/tensorboard/data/grpc_provider.py
@@ -61,8 +61,6 @@ class GrpcDataProvider(provider.DataProvider):
         req.experiment_id = experiment_id
         with _translate_grpc_error():
             res = self._stub.GetExperiment(req)
-        if not (res.name or res.description or res.HasField("creation_time")):
-            return None
         res = provider.ExperimentMetadata(
             experiment_name=res.name,
             experiment_description=res.description,

--- a/tensorboard/data/grpc_provider_test.py
+++ b/tensorboard/data/grpc_provider_test.py
@@ -67,7 +67,7 @@ class GrpcDataProviderTest(tb_test.TestCase):
         actual = self.provider.experiment_metadata(
             self.ctx, experiment_id="123"
         )
-        self.assertIsNone(actual)
+        self.assertEqual(actual, provider.ExperimentMetadata())
 
         req = data_provider_pb2.GetExperimentRequest()
         req.experiment_id = "123"

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -131,11 +131,10 @@ class DataProvider(metaclass=abc.ABCMeta):
           experiment_id:  ID of the experiment in question.
 
         Returns:
-          If the metadata does not exist, `None`.
-          Otherwise, an `ExperimentMetadata` object containing metadata about
-            the experiment.
+          An `ExperimentMetadata` object containing metadata about the
+          experiment.
         """
-        return None
+        return ExperimentMetadata()
 
     def list_plugins(self, ctx=None, *, experiment_id):
         """List all plugins that own data in a given experiment.
@@ -379,6 +378,9 @@ class DataProvider(metaclass=abc.ABCMeta):
 class ExperimentMetadata(object):
     """Metadata about an experiment.
 
+    All fields have default values: i.e., they will always be present on
+    the object, but may be omitted in a constructor call.
+
     Attributes:
       experiment_name: A user-facing name for the experiment (as a `str`).
       experiment_description: A user-facing description for the experiment
@@ -387,7 +389,13 @@ class ExperimentMetadata(object):
         seconds since the epoch.
     """
 
-    def __init__(self, experiment_name, experiment_description, creation_time):
+    def __init__(
+        self,
+        *,
+        experiment_name="",
+        experiment_description="",
+        creation_time=0,
+    ):
         self._experiment_name = experiment_name
         self._experiment_description = experiment_description
         self._creation_time = creation_time
@@ -404,25 +412,21 @@ class ExperimentMetadata(object):
     def creation_time(self):
         return self._creation_time
 
+    def _as_tuple(self):
+        """Helper for `__eq__` and `__hash__`."""
+        return (
+            self._experiment_name,
+            self._experiment_description,
+            self._creation_time,
+        )
+
     def __eq__(self, other):
         if not isinstance(other, ExperimentMetadata):
             return False
-        if self._experiment_name != other._experiment_name:
-            return False
-        if self._experiment_description != other._experiment_description:
-            return False
-        if self._creation_time != other._creation_time:
-            return False
-        return True
+        return self._as_tuple() == other._as_tuple()
 
     def __hash__(self):
-        return hash(
-            (
-                self._experiment_name,
-                self._experiment_description,
-                self._creation_time,
-            )
-        )
+        return hash(self._as_tuple())
 
     def __repr__(self):
         return "ExperimentMetadata(%s)" % ", ".join(

--- a/tensorboard/data/provider_test.py
+++ b/tensorboard/data/provider_test.py
@@ -28,6 +28,9 @@ class DataProviderTest(tb_test.TestCase):
 
 
 class ExperimentMetadataTest(tb_test.TestCase):
+    def test_defaults(self):
+        provider.ExperimentMetadata()
+
     def test_attributes(self):
         e1 = provider.ExperimentMetadata(
             experiment_name="FooExperiment",


### PR DESCRIPTION
Summary:
The `experiment_metadata` call is now required to return a non-`None`
value, but the fields now all have default values. This way, we can more
easily add new fields in a backward-compatible way. See #4777.

A few Google-internal data providers still have cases where they can
return `None`, so `core_plugin` (the unique call site) still tolerates
that deviation.

Test Plan:
Note that TensorBoard still looks the same: the `/data/environment`
response has some extra fields, but we don’t render a header bar or
anything.

wchargin-branch: metadata-required
