### PR TITLE
npmi: fix the undefined in the selector

### DIFF
--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_component.ng.html
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_component.ng.html
@@ -40,7 +40,7 @@ limitations under the License.
       [maxCount]="maxCount"
       [annotation]="annotation"
       [runHeight]="runHeight"
-      [hasEmbedding]="embeddingData[annotation] !== undefined"
+      [hasEmbedding]="embeddingData && embeddingData[annotation] !== undefined"
       (click)="rowClicked($event, annotation)"
     >
     </npmi-annotation>

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_component.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_component.ts
@@ -34,7 +34,7 @@ import {
 })
 export class AnnotationsListComponent {
   @Input() annotations!: AnnotationDataListing;
-  @Input() embeddingData!: EmbeddingListing;
+  @Input() embeddingData?: EmbeddingListing;
   @Input() annotationsExpanded!: boolean;
   @Input() numAnnotations!: number;
   @Input() annotationSort!: AnnotationSort;


### PR DESCRIPTION
`getEmbeddingDataSet` is typed as something that can return an undefined
but component is typed as non-nullable which is incorrect. Angular does
not correctly type check across the component tree and resulted in
incorrect typing.

This change fixes the case when we try to access property in an
undefined in a template.
