### PR TITLE
time series: change visibility to include uniqueId

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -19,7 +19,13 @@ import {
   TimeSeriesRequest,
   TimeSeriesResponse,
 } from '../data_source';
-import {CardId, HistogramMode, TooltipSort, XAxisType} from '../internal_types';
+import {
+  CardDomUniqueId,
+  CardId,
+  HistogramMode,
+  TooltipSort,
+  XAxisType,
+} from '../internal_types';
 
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
@@ -108,11 +114,11 @@ export const fetchTimeSeriesLoaded = createAction(
 
 /**
  * An event when some cards enter or exit the viewport. The card sets must be
- * mutually exclusive.
+ * mutually exclusive by their `uniqueId`s.
  */
 export const cardVisibilityChanged = createAction(
   '[Metrics] Card Visibility Changed',
-  props<{enteredCards: Set<CardId>; exitedCards: Set<CardId>}>()
+  props<{enteredCards: CardDomUniqueId[]; exitedCards: CardDomUniqueId[]}>()
 );
 
 export const cardStepSliderChanged = createAction(

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -148,14 +148,15 @@ export class MetricsEffects implements OnInitEffects {
   );
 
   private getVisibleCardFetchInfos(): Observable<CardFetchInfo[]> {
-    const visibleCardIds$ = this.store.select(selectors.getVisibleCardIdSet);
+    const visibleCardIds$ = this.store.select(selectors.getVisibleCardIdMap);
     return visibleCardIds$.pipe(
-      switchMap((cardIds) => {
+      switchMap((cardMap) => {
         // Explicitly notify subscribers that there are no visible cards,
         // since `forkJoin` does not emit when passed an empty array.
-        if (!cardIds.size) {
+        if (!cardMap.size) {
           return of([]);
         }
+        const cardIds = new Set(cardMap.values());
         const observables = [...cardIds].map((cardId) => {
           return this.store.select(getCardFetchInfo, cardId).pipe(take(1));
         });

--- a/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
+++ b/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
@@ -245,8 +245,11 @@ describe('metrics effects', () => {
         );
         store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
         store.overrideSelector(
-          selectors.getVisibleCardIdSet,
-          new Set(['card1', 'card2'])
+          selectors.getVisibleCardIdMap,
+          new Map([
+            ['uniq1', 'card1'],
+            ['uniq2', 'card2'],
+          ])
         );
         provideCardFetchInfo([{id: 'card1'}, {id: 'card2'}]);
         store.refreshState();
@@ -293,8 +296,11 @@ describe('metrics effects', () => {
         );
         store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
         store.overrideSelector(
-          selectors.getVisibleCardIdSet,
-          new Set(['card1', 'card2'])
+          selectors.getVisibleCardIdMap,
+          new Map([
+            ['uniq1', 'card1'],
+            ['uniq2', 'card2'],
+          ])
         );
         provideCardFetchInfo([
           {id: 'card1', loadState: DataLoadState.LOADED},
@@ -330,8 +336,11 @@ describe('metrics effects', () => {
       );
       store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
       store.overrideSelector(
-        selectors.getVisibleCardIdSet,
-        new Set(['card1', 'card2'])
+        selectors.getVisibleCardIdMap,
+        new Map([
+          ['uniq1', 'card1'],
+          ['uniq2', 'card2'],
+        ])
       );
       provideCardFetchInfo([
         {id: 'card1', loadState: DataLoadState.LOADING},
@@ -361,7 +370,10 @@ describe('metrics effects', () => {
 
     it('does not re-fetch time series, if no cards are visible', () => {
       store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set([]));
+      store.overrideSelector(
+        selectors.getVisibleCardIdMap,
+        new Map<string, string>()
+      );
       store.refreshState();
       fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
 
@@ -376,7 +388,10 @@ describe('metrics effects', () => {
       store.resetSelectors();
       store.overrideSelector(selectors.getRouteId, 'route1');
       store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
+      store.overrideSelector(
+        selectors.getVisibleCardIdMap,
+        new Map([['uniq1', 'card1']])
+      );
       provideCardFetchInfo([{id: 'card1', loadState: DataLoadState.LOADED}]);
       store.overrideSelector(selectors.getExperimentIdsFromRoute, null);
       store.refreshState();
@@ -429,8 +444,8 @@ describe('metrics effects', () => {
 
       actions$.next(
         actions.cardVisibilityChanged({
-          enteredCards: new Set(),
-          exitedCards: new Set(),
+          enteredCards: [],
+          exitedCards: [],
         })
       );
 
@@ -452,26 +467,29 @@ describe('metrics effects', () => {
       });
 
       store.overrideSelector(
-        selectors.getVisibleCardIdSet,
-        new Set<string>([])
+        selectors.getVisibleCardIdMap,
+        new Map<string, string>()
       );
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
-          enteredCards: new Set(),
-          exitedCards: new Set(['card1']),
+          enteredCards: [],
+          exitedCards: [{uniqueId: 'uniq1', cardId: 'card1'}],
         })
       );
 
       expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
       expect(actualActions).toEqual([]);
 
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
+      store.overrideSelector(
+        selectors.getVisibleCardIdMap,
+        new Map([['uniq1', 'card1']])
+      );
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
-          enteredCards: new Set(['card1']),
-          exitedCards: new Set(),
+          enteredCards: [{uniqueId: 'uniq1', cardId: 'card1'}],
+          exitedCards: [],
         })
       );
 
@@ -503,12 +521,15 @@ describe('metrics effects', () => {
       });
 
       // Initial load.
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
+      store.overrideSelector(
+        selectors.getVisibleCardIdMap,
+        new Map([['uniq1', 'card1']])
+      );
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
-          enteredCards: new Set(['card1']),
-          exitedCards: new Set(),
+          enteredCards: [{uniqueId: 'uniq1', cardId: 'card1'}],
+          exitedCards: [],
         })
       );
 
@@ -516,12 +537,15 @@ describe('metrics effects', () => {
       expect(actualActions).toEqual([]);
 
       // Exit.
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set([]));
+      store.overrideSelector(
+        selectors.getVisibleCardIdMap,
+        new Map<string, string>()
+      );
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
-          enteredCards: new Set(),
-          exitedCards: new Set(['card1']),
+          enteredCards: [],
+          exitedCards: [{uniqueId: 'uniq1', cardId: 'card1'}],
         })
       );
 
@@ -529,12 +553,15 @@ describe('metrics effects', () => {
       expect(actualActions).toEqual([]);
 
       // Re-enter.
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
+      store.overrideSelector(
+        selectors.getVisibleCardIdMap,
+        new Map([['uniq1', 'card1']])
+      );
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
-          enteredCards: new Set(['card1']),
-          exitedCards: new Set(),
+          enteredCards: [{uniqueId: 'uniq1', cardId: 'card1'}],
+          exitedCards: [],
         })
       );
 
@@ -589,14 +616,20 @@ describe('metrics effects', () => {
         .and.returnValue(of([sampleBackendResponses[1]]));
 
       store.overrideSelector(
-        selectors.getVisibleCardIdSet,
-        new Set(['card1', 'card2'])
+        selectors.getVisibleCardIdMap,
+        new Map([
+          ['uniq1', 'card1'],
+          ['uniq2', 'card2'],
+        ])
       );
       store.refreshState();
       actions$.next(
         actions.cardVisibilityChanged({
-          enteredCards: new Set(['card1', 'card2']),
-          exitedCards: new Set(),
+          enteredCards: [
+            {uniqueId: 'uniq1', cardId: 'card1'},
+            {uniqueId: 'uniq2', cardId: 'card2'},
+          ],
+          exitedCards: [],
         })
       );
 
@@ -632,14 +665,14 @@ describe('metrics effects', () => {
         fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries');
 
         store.overrideSelector(
-          selectors.getVisibleCardIdSet,
-          new Set(['card1'])
+          selectors.getVisibleCardIdMap,
+          new Map([['uniq1', 'card1']])
         );
         store.refreshState();
         actions$.next(
           actions.cardVisibilityChanged({
-            enteredCards: new Set(['card1']),
-            exitedCards: new Set(),
+            enteredCards: [{uniqueId: 'uniq1', cardId: 'card1'}],
+            exitedCards: [],
           })
         );
 

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -47,11 +47,20 @@ export type NonPinnedCardId = string;
 export type PinnedCardId = string;
 
 /**
- * A unique identifier to a specific card instance in the UI. This is an opaque
- * ID, meaning that consumers should never peer into/parse it and never assume
- * that it will always be a string.
+ * A unique identifier for a card data that is used to communicate between the store and
+ * the view. There may be multiple card DOMs sharing the cardId. This is an opaque ID,
+ * meaning that consumers should never peer into/parse it and never assume that it will
+ * always be a string.
  */
 export type CardId = NonPinnedCardId | PinnedCardId;
+
+/**
+ * Key uniquely identifying a card DOM for a `cardId`.
+ */
+export interface CardDomUniqueId {
+  uniqueId: string;
+  cardId: string;
+}
 
 export type CardIdWithMetadata = CardMetadata & {
   cardId: CardId;

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -141,17 +141,17 @@ export const getCardMetadata = createSelector(
 );
 
 // A cheap identity selector to skip recomputing selectors when `state` changes.
-const selectVisibleCardIdSet = createSelector(
+const selectVisibleCardDomUniqueIdMap = createSelector(
   selectMetricsState,
-  (state): Set<CardId> => {
+  (state): Map<string, CardId> => {
     return state.visibleCards;
   }
 );
 
-export const getVisibleCardIdSet = createSelector(
-  selectVisibleCardIdSet,
-  (cardIdSet): Set<CardId> => {
-    return cardIdSet;
+export const getVisibleCardIdMap = createSelector(
+  selectVisibleCardDomUniqueIdMap,
+  (cardIdMap): Map<string, CardId> => {
+    return cardIdMap;
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -288,28 +288,36 @@ describe('metrics selectors', () => {
     });
   });
 
-  describe('getVisibleCardIdSet', () => {
+  describe('getVisibleCardIdMap', () => {
     beforeEach(() => {
-      selectors.getVisibleCardIdSet.release();
+      selectors.getVisibleCardIdMap.release();
     });
 
     it('returns an emtpy array', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
-          visibleCards: new Set(),
+          visibleCards: new Map(),
         })
       );
-      expect(selectors.getVisibleCardIdSet(state)).toEqual(new Set<string>([]));
+      expect(selectors.getVisibleCardIdMap(state)).toEqual(
+        new Map<string, string>()
+      );
     });
 
     it('returns a non-empty array', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
-          visibleCards: new Set(['card1', 'card2']),
+          visibleCards: new Map([
+            ['uniq1', 'card1'],
+            ['uniq2', 'card2'],
+          ]),
         })
       );
-      expect(selectors.getVisibleCardIdSet(state)).toEqual(
-        new Set(['card1', 'card2'])
+      expect(selectors.getVisibleCardIdMap(state)).toEqual(
+        new Map([
+          ['uniq1', 'card1'],
+          ['uniq2', 'card2'],
+        ])
       );
     });
   });

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -183,7 +183,7 @@ export interface MetricsRoutelessState {
     imageShowActualSize: boolean;
     histogramMode: HistogramMode;
   };
-  visibleCards: Set<CardId>;
+  visibleCards: Map<string, CardId>;
 }
 
 export type MetricsState = RouteContextedState<

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -87,7 +87,7 @@ function buildBlankState(): MetricsState {
     unresolvedImportedPinnedCards: [],
     cardMetadataMap: {},
     cardStepIndex: {},
-    visibleCards: new Set(),
+    visibleCards: new Map<string, string>(),
     tagFilter: '',
     tagGroupExpanded: new Map(),
   };

--- a/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader.ts
@@ -160,7 +160,15 @@ export class CardLazyLoader implements OnInit, OnDestroy {
     private readonly store: Store<State>
   ) {}
 
-  onCardIntersection(enteredCards: Set<CardId>, exitedCards: Set<CardId>) {
+  onCardIntersection(enteredCardIds: Set<CardId>, exitedCardIds: Set<CardId>) {
+    // WIP: Technically, `cardId` is not unique in the DOM. Will change promptly
+    // to pass actual uniqueId.
+    const enteredCards = [...enteredCardIds].map((cardId) => {
+      return {cardId, uniqueId: cardId};
+    });
+    const exitedCards = [...exitedCardIds].map((cardId) => {
+      return {cardId, uniqueId: cardId};
+    });
     this.store.dispatch(
       actions.cardVisibilityChanged({enteredCards, exitedCards})
     );

--- a/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader_test.ts
@@ -146,8 +146,8 @@ describe('card view test', () => {
     expect(unobserveSpy).not.toHaveBeenCalled();
     expect(dispatchedActions).toEqual([
       actions.cardVisibilityChanged({
-        enteredCards: new Set(['card1']),
-        exitedCards: new Set(),
+        enteredCards: [{uniqueId: 'card1', cardId: 'card1'}],
+        exitedCards: [],
       }),
     ]);
 
@@ -163,12 +163,12 @@ describe('card view test', () => {
     expect(unobserveSpy).toHaveBeenCalled();
     expect(dispatchedActions).toEqual([
       actions.cardVisibilityChanged({
-        enteredCards: new Set(['card1']),
-        exitedCards: new Set(),
+        enteredCards: [{uniqueId: 'card1', cardId: 'card1'}],
+        exitedCards: [],
       }),
       actions.cardVisibilityChanged({
-        enteredCards: new Set(),
-        exitedCards: new Set(['card1']),
+        enteredCards: [],
+        exitedCards: [{uniqueId: 'card1', cardId: 'card1'}],
       }),
     ]);
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -43,7 +43,7 @@ import {
   getIsGpuChartEnabled,
   getRun,
   getRunColorMap,
-  getVisibleCardIdSet,
+  getVisibleCardIdMap,
 } from '../../../selectors';
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
@@ -181,9 +181,11 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
   dataSeries$?: Observable<ScalarCardDataSeries[]>;
   chartMetadataMap$?: Observable<ScalarCardSeriesMetadataMap>;
 
-  readonly isCardVisible$ = this.store.select(getVisibleCardIdSet).pipe(
-    map((visibleSet) => {
-      return visibleSet.has(this.cardId);
+  readonly isCardVisible$ = this.store.select(getVisibleCardIdMap).pipe(
+    map((visibileCardMap) => {
+      // WIP. Temporary while upgrading to introduce globally unique card Id.
+      const cardUniqueId = this.cardId;
+      return visibileCardMap.has(cardUniqueId);
     }),
     distinctUntilChanged()
   );

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -217,7 +217,10 @@ describe('scalar card', () => {
     store.overrideSelector(selectors.getRun, null);
     store.overrideSelector(selectors.getIsGpuChartEnabled, false);
     store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
-    store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
+    store.overrideSelector(
+      selectors.getVisibleCardIdMap,
+      new Map([['card1', 'a']])
+    );
     store.overrideSelector(
       selectors.getMetricsScalarPartitionNonMonotonicX,
       false
@@ -237,7 +240,10 @@ describe('scalar card', () => {
       cardMetadata,
       null /* runToSeries */
     );
-    store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['unknown']));
+    store.overrideSelector(
+      selectors.getVisibleCardIdMap,
+      new Map([['unknown', 'a']])
+    );
 
     const fixture = createComponent('card1');
 
@@ -246,7 +252,10 @@ describe('scalar card', () => {
     );
     expect(lineChart1).toBeNull();
 
-    store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
+    store.overrideSelector(
+      selectors.getVisibleCardIdMap,
+      new Map([['card1', 'a']])
+    );
     store.refreshState();
     fixture.detectChanges();
 
@@ -255,7 +264,10 @@ describe('scalar card', () => {
     );
     expect(lineChart2).not.toBeNull();
 
-    store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['gone']));
+    store.overrideSelector(
+      selectors.getVisibleCardIdMap,
+      new Map([['gone', 'a']])
+    );
     store.refreshState();
     fixture.detectChanges();
 

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -396,8 +396,10 @@ describe('metrics main view', () => {
 
         expect(dispatchedActions).toEqual([
           actions.cardVisibilityChanged({
-            enteredCards: new Set([directives[0].cardId]),
-            exitedCards: new Set(),
+            enteredCards: [
+              {uniqueId: directives[0].cardId, cardId: directives[0].cardId},
+            ],
+            exitedCards: [],
           }),
         ]);
 
@@ -421,12 +423,19 @@ describe('metrics main view', () => {
 
         expect(dispatchedActions).toEqual([
           actions.cardVisibilityChanged({
-            enteredCards: new Set([directives[0].cardId]),
-            exitedCards: new Set(),
+            enteredCards: [
+              {uniqueId: directives[0].cardId, cardId: directives[0].cardId},
+            ],
+            exitedCards: [],
           }),
           actions.cardVisibilityChanged({
-            enteredCards: new Set([directives[1].cardId, directives[2].cardId]),
-            exitedCards: new Set([directives[0].cardId]),
+            enteredCards: [
+              {uniqueId: directives[1].cardId, cardId: directives[1].cardId},
+              {uniqueId: directives[2].cardId, cardId: directives[2].cardId},
+            ],
+            exitedCards: [
+              {uniqueId: directives[0].cardId, cardId: directives[0].cardId},
+            ],
           }),
         ]);
       });
@@ -457,8 +466,10 @@ describe('metrics main view', () => {
         // The more recent entry does not intersect.
         expect(dispatchedActions).toEqual([
           actions.cardVisibilityChanged({
-            enteredCards: new Set(),
-            exitedCards: new Set([directives[0].cardId]),
+            enteredCards: [],
+            exitedCards: [
+              {uniqueId: directives[0].cardId, cardId: directives[0].cardId},
+            ],
           }),
         ]);
 
@@ -477,12 +488,16 @@ describe('metrics main view', () => {
 
         expect(dispatchedActions).toEqual([
           actions.cardVisibilityChanged({
-            enteredCards: new Set(),
-            exitedCards: new Set([directives[0].cardId]),
+            enteredCards: [],
+            exitedCards: [
+              {uniqueId: directives[0].cardId, cardId: directives[0].cardId},
+            ],
           }),
           actions.cardVisibilityChanged({
-            enteredCards: new Set([directives[0].cardId]),
-            exitedCards: new Set(),
+            enteredCards: [
+              {uniqueId: directives[0].cardId, cardId: directives[0].cardId},
+            ],
+            exitedCards: [],
           }),
         ]);
       });


### PR DESCRIPTION
TimeSeries redux store currently holds onto the visibility state of the
cards using cardId as the key. However, the problem is, there can be
multiple cards with the some `cardId` depending on the context and it
leads to suble bugs. Today, in the timeseries dashboard, the filtered
view and the main view are co-existing views that render cards with the
same cardId. However, since the DOM visibility is mutually exclusive,
i.e., while one is visible another is not visible, our store gets very
confused.

We can work around this but, still, we need to properly store these
visibility state corerctly. For instance, our scalar card defers
stamping the heavy line chart component until it is first visible on the
screen. However, if the visibility state is incorrect, there can be
caases when it has to be stamped onto the DOM while it is actually
invisible in the screen because there is another card with the same
cardId visible on the screen.

This change tries to address this by recognizing that the visibility
state is closely tied to the DOM and tries to store the state keyed by a
unique identifier specified by the view (with an ability to relate that
ID to a cardId).