### PR TITLE
data: remove `data_location` method

### DIFF
--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -83,10 +83,6 @@ class MultiplexerDataProvider(provider.DataProvider):
         except ValueError as e:
             return None
 
-    def data_location(self, ctx=None, *, experiment_id):
-        metadata = self.experiment_metadata(ctx, experiment_id=experiment_id)
-        return metadata.data_location
-
     def experiment_metadata(self, ctx=None, *, experiment_id):
         self._validate_context(ctx)
         self._validate_experiment_id(experiment_id)

--- a/tensorboard/backend/event_processing/data_provider_test.py
+++ b/tensorboard/backend/event_processing/data_provider_test.py
@@ -123,11 +123,6 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
         multiplexer = self.create_multiplexer()
         return data_provider.MultiplexerDataProvider(multiplexer, self.logdir)
 
-    def test_data_location(self):
-        provider = self.create_provider()
-        result = provider.data_location(self.ctx, experiment_id="unused")
-        self.assertEqual(result, self.logdir)
-
     def test_experiment_metadata(self):
         provider = self.create_provider()
         result = provider.experiment_metadata(self.ctx, experiment_id="unused")

--- a/tensorboard/data/dispatching_provider.py
+++ b/tensorboard/data/dispatching_provider.py
@@ -102,7 +102,6 @@ class DispatchingDataProvider(provider.DataProvider):
 
         return wrapper
 
-    data_location = _simple_delegate(lambda p: p.data_location)
     experiment_metadata = _simple_delegate(lambda p: p.experiment_metadata)
     list_plugins = _simple_delegate(lambda p: p.list_plugins)
     list_runs = _simple_delegate(lambda p: p.list_runs)

--- a/tensorboard/data/grpc_provider.py
+++ b/tensorboard/data/grpc_provider.py
@@ -49,10 +49,6 @@ class GrpcDataProvider(provider.DataProvider):
     def __str__(self):
         return "GrpcDataProvider(addr=%r)" % self._addr
 
-    def data_location(self, ctx, *, experiment_id):
-        metadata = self.experiment_metadata(ctx, experiment_id=experiment_id)
-        return metadata.data_location
-
     def experiment_metadata(self, ctx, *, experiment_id):
         req = data_provider_pb2.GetExperimentRequest()
         req.experiment_id = experiment_id

--- a/tensorboard/data/grpc_provider_test.py
+++ b/tensorboard/data/grpc_provider_test.py
@@ -48,18 +48,6 @@ class GrpcDataProviderTest(tb_test.TestCase):
         self.provider = grpc_provider.GrpcDataProvider(addr, self.stub)
         self.ctx = context.RequestContext()
 
-    def test_data_location(self):
-        res = data_provider_pb2.GetExperimentResponse()
-        res.data_location = "./logs/mnist"
-        self.stub.GetExperiment.return_value = res
-
-        actual = self.provider.data_location(self.ctx, experiment_id="123")
-        self.assertEqual(actual, "./logs/mnist")
-
-        req = data_provider_pb2.GetExperimentRequest()
-        req.experiment_id = "123"
-        self.stub.GetExperiment.assert_called_once_with(req)
-
     def test_experiment_metadata_when_only_data_location_set(self):
         res = data_provider_pb2.GetExperimentResponse()
         self.stub.GetExperiment.return_value = res

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -104,22 +104,6 @@ class DataProvider(metaclass=abc.ABCMeta):
     If not implemented, optional methods may return `None`.
     """
 
-    def data_location(self, ctx=None, *, experiment_id):
-        """Render a human-readable description of the data source.
-
-        For instance, this might return a path to a directory on disk.
-
-        The default implementation always returns the empty string.
-
-        Args:
-          ctx: A TensorBoard `RequestContext` value.
-          experiment_id: ID of enclosing experiment.
-
-        Returns:
-          A string, which may be empty.
-        """
-        return ""
-
     def experiment_metadata(self, ctx=None, *, experiment_id):
         """Retrieve metadata of a given experiment.
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -175,26 +175,18 @@ class CorePlugin(base_plugin.TBPlugin):
         """Serve a JSON object describing the TensorBoard parameters."""
         ctx = plugin_util.context(request.environ)
         experiment = plugin_util.experiment_id(request.environ)
-        experiment_metadata = self._data_provider.experiment_metadata(
+        md = self._data_provider.experiment_metadata(
             ctx, experiment_id=experiment
         )
-        data_location = (
-            experiment_metadata and experiment_metadata.data_location
-        ) or self._data_provider.data_location(ctx, experiment_id=experiment)
 
         environment = {
             "version": version.VERSION,
-            "data_location": data_location,
+            "data_location": md.data_location,
             "window_title": self._window_title,
+            "experiment_name": md.experiment_name,
+            "experiment_description": md.experiment_description,
+            "creation_time": md.creation_time,
         }
-        if experiment_metadata is not None:
-            environment.update(
-                {
-                    "experiment_name": experiment_metadata.experiment_name,
-                    "experiment_description": experiment_metadata.experiment_description,
-                    "creation_time": experiment_metadata.creation_time,
-                }
-            )
         if self._include_debug_info:
             environment["debug"] = {
                 "data_provider": str(self._data_provider),


### PR DESCRIPTION
Summary:
This has been folded into `experiment_metadata`, per #4777.

Test Plan:
The only remaining match for `data_location(` is the `@property`
definition on `ExperimentMetadata`.

wchargin-branch: rm-data-location
