### PR TITLE
cli: note when data server is used implicitly

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -63,6 +63,15 @@ _SERVE_SUBCOMMAND_NAME = "serve"
 # Internal flag name used to store which subcommand was invoked.
 _SUBCOMMAND_FLAG = "__tensorboard_subcommand"
 
+# Message printed when we actually use the data server, so that users are not
+# caught terribly by surprise.
+_DATA_SERVER_MESSAGE = """
+NOTE: Using experimental fast data loading logic. To disable, pass
+    "--load_fast=false" and report issues on GitHub. More details:
+    https://github.com/tensorflow/tensorboard/issues/4784
+
+"""
+
 
 class TensorBoard(object):
     """Class for running TensorBoard.
@@ -393,6 +402,9 @@ class TensorBoard(object):
                     sys.exit(1)
                 logger.info("No data server: %s", e)
             else:
+                if flags.load_fast == "auto":
+                    sys.stderr.write(_DATA_SERVER_MESSAGE)
+                    sys.stderr.flush()
                 return server_ingester.SubprocessServerDataIngester(
                     server_binary=server_binary,
                     logdir=flags.logdir,


### PR DESCRIPTION
Summary:
We’d like to set `--load_fast=auto` as the default for TensorBoard 2.5.
To make that less surprising, we now print an informational message when
`--load_fast` is set to `auto` and the data server is actually used. We
don’t show it with `--load_fast=true`; if you pass that, we assume that
you know what you’re doing. The message looks like:

```
$ tensorboard --logdir /tmp/logs --bind_all --load_fast=auto
2021-03-17 11:41:51.151546: W tensorflow/stream_executor/platform/default/dso_loader.cc:60] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
2021-03-17 11:41:51.151567: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.

NOTE: Using experimental fast data loading logic. To disable, pass
    "--load_fast=false" and report issues on GitHub. More details:
    https://github.com/tensorflow/tensorboard/issues/4784

TensorBoard 2.5.0a0 at http://localhost:6007/ (Press CTRL+C to quit)
```

Test Plan:
Run with `--load_fast` set to `false`, `auto`, and `true`, and note that
the message only appears when set to `auto`. Then uninstall the data
server and run with `auto`, and note that the message does not appear.

wchargin-branch: cli-data-server-message
