### PR TITLE
rust: improve GCS credential error handling

### DIFF
--- a/tensorboard/data/server/gcs/gsutil.rs
+++ b/tensorboard/data/server/gcs/gsutil.rs
@@ -60,7 +60,7 @@ fn main() {
     let opts: Opts = Opts::parse();
     init_logging(&opts);
 
-    let client = gcs::Client::new(gcs::Credentials::from_disk()).unwrap();
+    let client = gcs::Client::new(gcs::Credentials::from_disk().unwrap()).unwrap();
     match opts.subcmd {
         Subcommand::Ls(opts) => {
             log::info!("ENTER gcs::Client::list");


### PR DESCRIPTION
Summary:
Failure cases when obtaining GCS credentials are now handled in a more
structured manner. Instead of just logging ad hoc warnings, we return
error details to the caller. In particular, this lets the caller
distinguish the case where the user has credentials of a format that we
don’t support, such as service account private keys.

The log messages are nicer, too: in case of a service account key, we
recognize and explain the problem instead of just emitting a JSON error.

Test Plan:
To test each error case, set `GOOGLE_APPLICATION_CREDENTIALS` to:

  - `/enoent` or `/etc/shadow` to test `Unreadable(...)`;
  - `/dev/null` to test `Unparseable(...)`;
  - a service account credentials file to test `Unsupported(...)`.
    (Or, just a valid JSON file without the needed fields.)

Then note that both anonymous access and properly authenticated access
still work.

wchargin-branch: rust-gcs-error-handling
