### PR TITLE
data: pass `--samples-per-plugin` unconditionally

### DIFF
--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -114,17 +114,11 @@ class SubprocessServerDataIngester(ingester.DataIngester):
             self._server_binary,
             "--logdir=%s" % os.path.expanduser(self._logdir),
             "--reload=%s" % reload,
+            "--samples-per-plugin=%s" % samples_per_plugin,
             "--port=0",
             "--port-file=%s" % (port_file_path,),
             "--die-after-stdin",
         ]
-        # Passing `--samples-per-plugin` conditionally is non-ideal, since
-        # older data servers (0.3.0) will still die when receiving this unknown
-        # flag explicitly. This flag may be provided unconditionally if servers
-        # support `--undefok` in the future.
-        # See https://github.com/clap-rs/clap/issues/2354.
-        if samples_per_plugin:
-            args.append("--samples-per-plugin=%s" % samples_per_plugin)
         if logger.isEnabledFor(logging.INFO):
             args.append("--verbose")
         if logger.isEnabledFor(logging.DEBUG):

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -98,10 +98,10 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
             fake_binary,
             "--logdir=%s" % expanded_logdir,
             "--reload=5",
+            "--samples-per-plugin=scalars=500,images=all",
             "--port=0",
             "--port-file=%s" % port_file,
             "--die-after-stdin",
-            "--samples-per-plugin=scalars=500,images=all",
             "--verbose",  # logging is enabled in tests
         ]
         popen.assert_called_once_with(expected_args, stdin=subprocess.PIPE)


### PR DESCRIPTION
Summary:
In #4689, we decided to only pass `--samples-per-plugin` to the data
server conditionally, because at the time the latest public release of
the data server did not support that flag. Since then, v0.4.0 has been
published, so we can pass the flag unconditionally.

Test Plan:
Verified that with latest `tb-nightly`’s dependencies, the server
behaves as expected both with and without `--samples_per_plugin`.

wchargin-branch: data-always-pass-samples
