### PR TITLE
sync: fix `@ngrx/store/testing` import

### DIFF
--- a/tensorboard/webapp/notification_center/_views/BUILD
+++ b/tensorboard/webapp/notification_center/_views/BUILD
@@ -51,6 +51,7 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_material_menu",
         "//tensorboard/webapp/angular:expect_angular_material_snackbar",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/notification_center/_redux",
         "//tensorboard/webapp/notification_center/_redux:types",
         "//tensorboard/webapp/testing:mat_icon",


### PR DESCRIPTION
Summary:
Recent changes in #4769 added an import of `@ngrx/store/testing`, which
works fine here but requires an extra build dep internally.

Test Plan:
Test sync now builds: <http://cl/363586736>.

wchargin-branch: sync-20210317-ngrx-store-testing
