### PR TITLE
rust: improve startup error handling

### DIFF
--- a/tensorboard/data/server/cli/dynamic_logdir.rs
+++ b/tensorboard/data/server/cli/dynamic_logdir.rs
@@ -106,7 +106,7 @@ impl DynLogdir {
 ///
 /// [rfc]: https://tools.ietf.org/html/rfc3986#section-3.1
 fn is_protocol(s: &str) -> bool {
-    if !s.chars().nth(0).map_or(false, |c| c.is_ascii_alphabetic()) {
+    if !s.chars().next().map_or(false, |c| c.is_ascii_alphabetic()) {
         return false;
     }
     s.chars()

--- a/tensorboard/data/server/cli/dynamic_logdir.rs
+++ b/tensorboard/data/server/cli/dynamic_logdir.rs
@@ -15,7 +15,7 @@ limitations under the License.
 
 //! Log directory as specified by user arguments.
 
-use log::{error, warn};
+use log::error;
 use std::collections::HashMap;
 use std::io::{self, Read};
 use std::path::PathBuf;
@@ -93,7 +93,6 @@ impl DynLogdir {
         let mut parts = gcs_path.splitn(2, '/');
         let bucket = parts.next().unwrap().to_string(); // splitn always yields at least one element
         let prefix = parts.next().unwrap_or("").to_string();
-<<<<<<< HEAD
         let client = gcs::Client::new(gcs::Credentials::from_disk()?)?;
         Ok(DynLogdir::Gcs(gcs::Logdir::new(client, bucket, prefix)))
     }
@@ -102,29 +101,6 @@ impl DynLogdir {
 fn is_protocol(s: &str) -> bool {
     if s.is_empty() || !s.is_ascii() {
         return false;
-||||||| abc8b03bb
-        let client = match gcs::Client::new(gcs::Credentials::from_disk()) {
-            Err(e) => {
-                error!("Could not open GCS connection: {}", e);
-                return None;
-            }
-            Ok(c) => c,
-        };
-        Some(DynLogdir::Gcs(gcs::Logdir::new(client, bucket, prefix)))
-=======
-        let creds = gcs::Credentials::from_disk().unwrap_or_else(|e| {
-            warn!("Using anonymous GCS credentials: {}", e);
-            Default::default()
-        });
-        let client = match gcs::Client::new(creds) {
-            Err(e) => {
-                error!("Could not open GCS connection: {}", e);
-                return None;
-            }
-            Ok(c) => c,
-        };
-        Some(DynLogdir::Gcs(gcs::Logdir::new(client, bucket, prefix)))
->>>>>>> 186d901ad94f3995f33d09388bde6368422f2470
     }
     s.chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')

--- a/tensorboard/data/server/cli/dynamic_logdir.rs
+++ b/tensorboard/data/server/cli/dynamic_logdir.rs
@@ -98,8 +98,15 @@ impl DynLogdir {
     }
 }
 
+/// [RFC 3986, section 3.1][rfc] specifies:
+///
+/// ```text
+/// scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+/// ```
+///
+/// [rfc]: https://tools.ietf.org/html/rfc3986#section-3.1
 fn is_protocol(s: &str) -> bool {
-    if s.is_empty() || !s.is_ascii() {
+    if !s.chars().nth(0).map_or(false, |c| c.is_ascii_alphabetic()) {
         return false;
     }
     s.chars()

--- a/tensorboard/data/server/gcs.rs
+++ b/tensorboard/data/server/gcs.rs
@@ -19,6 +19,6 @@ mod auth;
 mod client;
 mod logdir;
 
-pub use auth::Credentials;
-pub use client::Client;
+pub use auth::{Credentials, CredentialsError};
+pub use client::{Client, ClientError};
 pub use logdir::Logdir;

--- a/tensorboard/data/server/gcs/auth.rs
+++ b/tensorboard/data/server/gcs/auth.rs
@@ -242,7 +242,6 @@ impl Credentials {
     }
 }
 
-<<<<<<< HEAD
 /// Partial structure of the `GOOGLE_APPLICATION_CREDENTIALS` file.
 #[derive(Deserialize)]
 struct ApplicationCreds {
@@ -279,45 +278,6 @@ impl ApplicationCreds {
     }
 }
 
-||||||| abc8b03bb
-=======
-/// Partial structure of the `GOOGLE_APPLICATION_CREDENTIALS` file.
-#[derive(Deserialize)]
-struct ApplicationCreds {
-    r#type: Option<String>,
-    client_id: Option<String>,
-    client_secret: Option<String>,
-    refresh_token: Option<String>,
-}
-
-/// User's credentials may be valid, but are not supported.
-///
-/// Currently, we only support OAuth refresh tokens, not service account private keys.
-#[derive(Debug, thiserror::Error)]
-#[error("unsupported credentials of type {:?}; only OAuth refresh tokens supported", .creds_type)]
-pub struct UnsupportedCredentialsError {
-    /// The `"type"` field found in the credentials JSON file, for informational purposes.
-    creds_type: String,
-}
-
-impl ApplicationCreds {
-    fn into_credentials(self) -> Result<Credentials, UnsupportedCredentialsError> {
-        match (self.client_id, self.client_secret, self.refresh_token) {
-            (Some(client_id), Some(client_secret), Some(refresh_token)) => {
-                Ok(Credentials::RefreshToken(RefreshToken(RefreshTokenCreds {
-                    client_id,
-                    client_secret,
-                    refresh_token,
-                })))
-            }
-            _ => Err(UnsupportedCredentialsError {
-                creds_type: self.r#type.unwrap_or_default(),
-            }),
-        }
-    }
-}
-
->>>>>>> 186d901ad94f3995f33d09388bde6368422f2470
 /// Persistent credentials in the form of an OAuth refresh token. Can be posted to an OAuth token
 /// endpoint to obtain a short-lived access token.
 #[derive(Deserialize)]

--- a/tensorboard/data/server/gcs/auth.rs
+++ b/tensorboard/data/server/gcs/auth.rs
@@ -255,7 +255,7 @@ struct ApplicationCreds {
 ///
 /// Currently, we only support OAuth refresh tokens, not service account private keys.
 #[derive(Debug, thiserror::Error)]
-#[error("unsupported credentials of type {:?}; only OAuth refresh tokens supported", .creds_type)]
+#[error("unsupported GCS credentials of type {creds_type:?}; only OAuth refresh tokens supported")]
 pub struct UnsupportedCredentialsError {
     /// The `"type"` field found in the credentials JSON file, for informational purposes.
     creds_type: String,

--- a/tensorboard/data/server/gcs/client.rs
+++ b/tensorboard/data/server/gcs/client.rs
@@ -45,14 +45,19 @@ pub struct Client {
     http: HttpClient,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("failed to initialize GCS client: {0}")]
+pub struct ClientError(#[source] reqwest::Error);
+
 impl Client {
     /// Creates a new GCS client with the given credentials.
     ///
     /// May fail if constructing the underlying HTTP client fails.
-    pub fn new(creds: Credentials) -> reqwest::Result<Self> {
+    pub fn new(creds: Credentials) -> Result<Self, ClientError> {
         let http = HttpClient::builder()
             .user_agent(format!("tensorboard-data-server/{}", crate::VERSION))
-            .build()?;
+            .build()
+            .map_err(ClientError)?;
         let token_store = Arc::new(TokenStore::new(creds));
         Ok(Self { http, token_store })
     }

--- a/tensorboard/data/server/gcs/gsutil.rs
+++ b/tensorboard/data/server/gcs/gsutil.rs
@@ -60,7 +60,7 @@ fn main() {
     let opts: Opts = Opts::parse();
     init_logging(&opts);
 
-    let client = gcs::Client::new(gcs::Credentials::from_disk()).unwrap();
+    let client = gcs::Client::new(gcs::Credentials::from_disk().unwrap()).unwrap();
     match opts.subcmd {
         Subcommand::Ls(opts) => {
             log::info!("ENTER gcs::Client::list");


### PR DESCRIPTION
Summary:
RustBoard currently writes normal logs to stderr, and also writes any
fatal startup errors to stderr. This makes it impossible to detect and
capture startup errors without also suppressing the log output. As of
this patch, you can pass `--error-file FILE` to ask RustBoard to write
fatal errors to `FILE` instead, so you can leave stderr unencumbered.

In this patch, we also improve error handling for unknown protocols
(like `--logdir wat://mnist`), which complements `--error-file` by
making the startup errors themselves more helpful.

This will be used in `tensorboard(1)` to gracefully fall back to the
legacy multiplexer in case of unsupported invocations: i.e., option (3)
as discussed in #4786.

Test Plan:
Run the data server with `--logdir wat://`, or point to a GCS logdir
while `GOOGLE_APPLICATION_CREDENTIALS` is set to something unreadable.
Note that without `--error-file`, these both continue to write an error
to stderr, and with `--error-file`, they both write to the given file.

wchargin-branch: rust-improve-startup-errors
