### PR TITLE
docs: update `tf.summary.image()`

### DIFF
--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -37,28 +37,32 @@ def image(name, data, step=None, max_outputs=3, description=None):
 
     This example writes 2 random grayscale images:
 
-    >>> w = tf.summary.create_file_writer('test/logs')
-    >>> with w.as_default():
-    ...   image1 = tf.random.uniform(shape=[8, 8, 1])
-    ...   image2 = tf.random.uniform(shape=[8, 8, 1])
-    ...   tf.summary.image("grayscale_noise", [image1, image2], step=0)
+    ```python
+    w = tf.summary.create_file_writer('test/logs')
+    with w.as_default():
+      image1 = tf.random.uniform(shape=[8, 8, 1])
+      image2 = tf.random.uniform(shape=[8, 8, 1])
+      tf.summary.image("grayscale_noise", [image1, image2], step=0)
+    ```
 
     To avoid clipping, data should be converted to one of the following:
 
     - floating point values in the range [0,1], or
     - uint8 values in the range [0,255]
 
-    >>> # Convert the original dtype=int32 `Tensor` into `dtype=float64`.
-    >>> rgb_image_float = tf.constant([
-    ...   [[1000, 0, 0], [0, 500, 1000]],
-    ... ]) / 1000
-    >>> tf.summary.image("picture", [rgb_image_float], step=0)
+    ```python
+    # Convert the original dtype=int32 `Tensor` into `dtype=float64`.
+    rgb_image_float = tf.constant([
+      [[1000, 0, 0], [0, 500, 1000]],
+    ]) / 1000
+    tf.summary.image("picture", [rgb_image_float], step=0)
 
-    >>> # Convert original dtype=uint8 `Tensor` into proper range.
-    >>> rgb_image_uint8 = tf.constant([
-    ...   [[1, 1, 0], [0, 0, 1]],
-    ... ], dtype=tf.uint8) * 255
-    >>> tf.summary.image("picture", [rgb_image_uint8], step=1)
+    # Convert original dtype=uint8 `Tensor` into proper range.
+    rgb_image_uint8 = tf.constant([
+      [[1, 1, 0], [0, 0, 1]],
+    ], dtype=tf.uint8) * 255
+    tf.summary.image("picture", [rgb_image_uint8], step=1)
+    ```
 
     Arguments:
       name: A name for this summary. The summary tag used for TensorBoard will

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -29,37 +29,39 @@ def image(name, data, step=None, max_outputs=3, description=None):
 
     See also `tf.summary.scalar`, `tf.summary.SummaryWriter`.
 
-    Logs a set of images to the current log directory for later analysis
-    in TensorBoard's 'Images' dashboard. Like `tf.summary.scalar` points,
-    each set of images is associated with a `step` and a `name`.  All the
-    image sets with the same `name` constitute a time series of image sets.
+    Writes a collection of images to the current default summary writer. Data
+    appears in TensorBoard's 'Images' dashboard. Like `tf.summary.scalar` points,
+    each collection of images is associated with a `step` and a `name`.  All the
+    image collections with the same `name` constitute a time series of image
+    collections.
 
     This example writes 2 random grayscale images:
 
     ```python
-    test_summary_writer = tf.summary.create_file_writer('test/logs')
-    with test_summary_writer.as_default():
-      image1 = tf.random.normal(shape=[8, 8])
-      image2 = tf.random.normal(shape=[8, 8])
-      tf.summary.image("grayscale noise", [image1, image2], step=0)
+    w = tf.summary.create_file_writer('test/logs')
+    with w.as_default():
+      image1 = tf.random.uniform(shape=[8, 8, 1])
+      image2 = tf.random.uniform(shape=[8, 8, 1])
+      tf.summary.image("grayscale_noise", [image1, image2], step=0)
     ```
 
     To avoid clipping, data should be converted to one of the following:
-    - floating point values in the range [0,1]
-    or
+
+    - floating point values in the range [0,1], or
     - uint8 values in the range [0,255]
 
     ```python
-    # Using division to convert the origional dtype=Int32 value into
-    # dtype=float64.
-    rgb_image_scaled = tf.constant([
-      [[255, 127, 0], [0, 127, 255]],
-    ]) / 255
+    # Convert the original dtype=int32 `Tensor` into `dtype=float64`.
+    rgb_image_float = tf.constant([
+      [[100, 0, 0], [0, 50, 100]],
+    ]) / 100
+    tf.summary.image("picture", [rgb_image_float], step=0)
 
+    # Convert original dtype=uint8 `Tensor` into proper range.
     rgb_image_uint8 = tf.constant([
-      [[255, 255, 0], [0, 127, 255]],
-    ], dtype=tf.uint8)
-    tf.summary.image("rgb picture", [rgb_image_scaled, rgb_image_uint8], step=0)
+      [[1, 1, 0], [0, 0, 1]],
+    ], dtype=tf.uint8) * 255
+    tf.summary.image("picture", [rgb_image_uint8], step=1)
     ```
 
     Arguments:
@@ -71,7 +73,8 @@ def image(name, data, step=None, max_outputs=3, description=None):
         should be 1, 2, 3, or 4 (grayscale, grayscale with alpha, RGB, RGBA).
         Any of the dimensions may be statically unknown (i.e., `None`).
         Floating point data will be clipped to the range [0,1]. Other data types
-        may be clipped into an allowed range for safe casting to uint8.
+        will be clipped into an allowed range for safe casting to uint8, using
+        `tf.image.convert_image_dtype`.
       step: Explicit `int64`-castable monotonic step value for this summary. If
         omitted, this defaults to `tf.summary.experimental.get_step()`, which must
         not be None.

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -53,8 +53,8 @@ def image(name, data, step=None, max_outputs=3, description=None):
     ```python
     # Convert the original dtype=int32 `Tensor` into `dtype=float64`.
     rgb_image_float = tf.constant([
-      [[100, 0, 0], [0, 50, 100]],
-    ]) / 100
+      [[1000, 0, 0], [0, 500, 1000]],
+    ]) / 1000
     tf.summary.image("picture", [rgb_image_float], step=0)
 
     # Convert original dtype=uint8 `Tensor` into proper range.

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -27,6 +27,36 @@ from tensorboard.util import lazy_tensor_creator
 def image(name, data, step=None, max_outputs=3, description=None):
     """Write an image summary.
 
+    This method writes a set of images to the current log directory.
+    The written data appears in TensorBoard's 'Images' dashboard.
+
+    This example writes 2 random grayscale images:
+
+    ```
+    writer = tf.summary.create_file_writer('logs')
+    with writer.as_default():
+      image1 = tf.random.normal(shape=[8, 8])
+      image2 = tf.random.normal(shape=[8, 8])
+      tf.summary.image("grayscale noise", [image1, image2], step=0)
+    ```
+
+    To avoid clipping, data should be converted to one of the following:
+    - floating point values in the range [0,1]
+    - uint8 values in the range [0,255]
+
+    ```
+    # Using division to convert the origional dtype=Int32 value into
+    # dtype=float64.
+    rgb_image_scaled = tf.constant([
+      [[255, 127, 0], [0, 127, 255]],
+    ]) / 255
+
+    rgb_image_uint8 = tf.constant([
+      [[255, 255, 0], [0, 127, 255]],
+    ], dtype=tf.uint8)
+    tf.summary.image("rgb picture", [rgb_image_scaled, rgb_image_uint8], step=0)
+    ```
+
     Arguments:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.
@@ -35,7 +65,8 @@ def image(name, data, step=None, max_outputs=3, description=None):
         width of the images, and `c` is the number of channels, which
         should be 1, 2, 3, or 4 (grayscale, grayscale with alpha, RGB, RGBA).
         Any of the dimensions may be statically unknown (i.e., `None`).
-        Floating point data will be clipped to the range [0,1).
+        Floating point data will be clipped to the range [0,1]. Other data types
+        may be clipped into an allowed range for safe casting to uint8.
       step: Explicit `int64`-castable monotonic step value for this summary. If
         omitted, this defaults to `tf.summary.experimental.get_step()`, which must
         not be None.

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -27,12 +27,14 @@ from tensorboard.util import lazy_tensor_creator
 def image(name, data, step=None, max_outputs=3, description=None):
     """Write an image summary.
 
-    This method writes a set of images to the current log directory.
-    The written data appears in TensorBoard's 'Images' dashboard.
+    Logs a set of images to the current log directory for later analysis
+    in TensorBoard's 'Images' dashboard. Like `tf.summary.scalar` points,
+    each set of images is associated with a `step` and a `name`.  All the
+    image sets with the same `name` constitute a time series of image sets.
 
     This example writes 2 random grayscale images:
 
-    ```
+    ```python
     writer = tf.summary.create_file_writer('logs')
     with writer.as_default():
       image1 = tf.random.normal(shape=[8, 8])
@@ -42,9 +44,10 @@ def image(name, data, step=None, max_outputs=3, description=None):
 
     To avoid clipping, data should be converted to one of the following:
     - floating point values in the range [0,1]
+    or
     - uint8 values in the range [0,255]
 
-    ```
+    ```python
     # Using division to convert the origional dtype=Int32 value into
     # dtype=float64.
     rgb_image_scaled = tf.constant([

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -37,32 +37,28 @@ def image(name, data, step=None, max_outputs=3, description=None):
 
     This example writes 2 random grayscale images:
 
-    ```python
-    w = tf.summary.create_file_writer('test/logs')
-    with w.as_default():
-      image1 = tf.random.uniform(shape=[8, 8, 1])
-      image2 = tf.random.uniform(shape=[8, 8, 1])
-      tf.summary.image("grayscale_noise", [image1, image2], step=0)
-    ```
+    >>> w = tf.summary.create_file_writer('test/logs')
+    >>> with w.as_default():
+    ...   image1 = tf.random.uniform(shape=[8, 8, 1])
+    ...   image2 = tf.random.uniform(shape=[8, 8, 1])
+    ...   tf.summary.image("grayscale_noise", [image1, image2], step=0)
 
     To avoid clipping, data should be converted to one of the following:
 
     - floating point values in the range [0,1], or
     - uint8 values in the range [0,255]
 
-    ```python
-    # Convert the original dtype=int32 `Tensor` into `dtype=float64`.
-    rgb_image_float = tf.constant([
-      [[1000, 0, 0], [0, 500, 1000]],
-    ]) / 1000
-    tf.summary.image("picture", [rgb_image_float], step=0)
+    >>> # Convert the original dtype=int32 `Tensor` into `dtype=float64`.
+    >>> rgb_image_float = tf.constant([
+    ...   [[1000, 0, 0], [0, 500, 1000]],
+    ... ]) / 1000
+    >>> tf.summary.image("picture", [rgb_image_float], step=0)
 
-    # Convert original dtype=uint8 `Tensor` into proper range.
-    rgb_image_uint8 = tf.constant([
-      [[1, 1, 0], [0, 0, 1]],
-    ], dtype=tf.uint8) * 255
-    tf.summary.image("picture", [rgb_image_uint8], step=1)
-    ```
+    >>> # Convert original dtype=uint8 `Tensor` into proper range.
+    >>> rgb_image_uint8 = tf.constant([
+    ...   [[1, 1, 0], [0, 0, 1]],
+    ... ], dtype=tf.uint8) * 255
+    >>> tf.summary.image("picture", [rgb_image_uint8], step=1)
 
     Arguments:
       name: A name for this summary. The summary tag used for TensorBoard will

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -27,6 +27,8 @@ from tensorboard.util import lazy_tensor_creator
 def image(name, data, step=None, max_outputs=3, description=None):
     """Write an image summary.
 
+    See also `tf.summary.scalar`, `tf.summary.SummaryWriter`.
+
     Logs a set of images to the current log directory for later analysis
     in TensorBoard's 'Images' dashboard. Like `tf.summary.scalar` points,
     each set of images is associated with a `step` and a `name`.  All the
@@ -35,8 +37,8 @@ def image(name, data, step=None, max_outputs=3, description=None):
     This example writes 2 random grayscale images:
 
     ```python
-    writer = tf.summary.create_file_writer('logs')
-    with writer.as_default():
+    test_summary_writer = tf.summary.create_file_writer('test/logs')
+    with test_summary_writer.as_default():
       image1 = tf.random.normal(shape=[8, 8])
       image2 = tf.random.normal(shape=[8, 8])
       tf.summary.image("grayscale noise", [image1, image2], step=0)


### PR DESCRIPTION
Update documentation for `tf.summary.image`.

#API_FIXIT_3_18_21

From what I understand, OSS is the source of truth, but the
TF Devsite is not updated immediately without manually doing
an internal process to update the devsite.