### PR TITLE
docs: update `tf.summary.histogram()`

### DIFF
--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -49,8 +49,8 @@ def histogram(name, data, step=None, buckets=None, description=None):
     each histogram is associated with a `step` and a `name`. All the histograms
     with the same `name` constitute a time series of histograms.
 
-    When higher order `Tensor`s are flattened to produce a histogram of all
-    entries within.
+    The histogram is calculated over all the elements of the given `Tensor`
+    without regard to its shape or rank.
 
     This example writes 2 histograms:
 
@@ -83,7 +83,8 @@ def histogram(name, data, step=None, buckets=None, description=None):
     Arguments:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.
-      data: A `Tensor` of any shape. Must be castable to `float64`.
+      data: A `Tensor` of any shape. The histogram is computed over its elements,
+        which must be castable to `float64`.
       step: Explicit `int64`-castable monotonic step value for this summary. If
         omitted, this defaults to `tf.summary.experimental.get_step()`, which must
         not be None.

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -41,6 +41,8 @@ DEFAULT_BUCKET_COUNT = 30
 def histogram(name, data, step=None, buckets=None, description=None):
     """Write a histogram summary.
 
+    See also `tf.summary.scalar`, `tf.summary.SummaryWriter`.
+
     Logs a histogram to the current log directory for later analysis in
     TensorBoard's 'Histograms' and 'Distributions' dashboards (one histogram
     will appear in both). Like `tf.summary.scalar` points, each histogram is
@@ -50,8 +52,8 @@ def histogram(name, data, step=None, buckets=None, description=None):
     This example writes 2 histograms:
 
     ```python
-    writer = tf.summary.create_file_writer('logs')
-    with writer.as_default():
+    test_summary_writer = tf.summary.create_file_writer('test/logs')
+    with test_summary_writer.as_default():
       tf.summary.histogram("activations", [-10, 0, 10], step=0)
       tf.summary.histogram("initial weights", tf.random.normal([5]), step=0)
     ```
@@ -60,8 +62,8 @@ def histogram(name, data, step=None, buckets=None, description=None):
     thereof) at specific layers in a neural network, over time.
 
     ```python
-    writer = tf.summary.create_file_writer('logs')
-    with writer.as_default():
+    test_summary_writer = tf.summary.create_file_writer('test/logs')
+    with test_summary_writer.as_default():
       for step in steps:
         # After computing activations...
         tf.summary.histogram("layer1/activate", layer1_activate, step=step)

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -54,26 +54,31 @@ def histogram(name, data, step=None, buckets=None, description=None):
 
     This example writes 2 histograms:
 
-    >>> w = tf.summary.create_file_writer('test/logs')
-    >>> with w.as_default():
-    ...     tf.summary.histogram("activations", tf.random.uniform([100, 50]), step=0)
-    ...     tf.summary.histogram("initial_weights", tf.random.normal([1000]), step=0)
+    ```python
+    w = tf.summary.create_file_writer('test/logs')
+    with w.as_default():
+        tf.summary.histogram("activations", tf.random.uniform([100, 50]), step=0)
+        tf.summary.histogram("initial_weights", tf.random.normal([1000]), step=0)
+    ```
 
     A common use case is to examine the changing activation patterns (or lack
     thereof) at specific layers in a neural network, over time.
 
-    >>> w = tf.summary.create_file_writer('test/logs')
-    >>> with w.as_default():
-    >>> for step in range(100):
-    ...     # Generate fake "activations".
-    ...     activations = [
-    ...         tf.random.normal([1000], mean=step, stddev=1),
-    ...         tf.random.normal([1000], mean=step, stddev=10),
-    ...         tf.random.normal([1000], mean=step, stddev=100),
-    ...     ]
-    ...     tf.summary.histogram("layer1/activate", activations[0], step=step)
-    ...     tf.summary.histogram("layer2/activate", activations[1], step=step)
-    ...     tf.summary.histogram("layer3/activate", activations[2], step=step)
+    ```python
+    w = tf.summary.create_file_writer('test/logs')
+    with w.as_default():
+    for step in range(100):
+        # Generate fake "activations".
+        activations = [
+            tf.random.normal([1000], mean=step, stddev=1),
+            tf.random.normal([1000], mean=step, stddev=10),
+            tf.random.normal([1000], mean=step, stddev=100),
+        ]
+
+        tf.summary.histogram("layer1/activate", activations[0], step=step)
+        tf.summary.histogram("layer2/activate", activations[1], step=step)
+        tf.summary.histogram("layer3/activate", activations[2], step=step)
+    ```
 
     Arguments:
       name: A name for this summary. The summary tag used for TensorBoard will

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -43,32 +43,41 @@ def histogram(name, data, step=None, buckets=None, description=None):
 
     See also `tf.summary.scalar`, `tf.summary.SummaryWriter`.
 
-    Logs a histogram to the current log directory for later analysis in
-    TensorBoard's 'Histograms' and 'Distributions' dashboards (one histogram
-    will appear in both). Like `tf.summary.scalar` points, each histogram is
-    associated with a `step` and a `name`. All the histograms with the same
-    `name` constitute a time series of histograms.
+    Writes a histogram to the current default summary writer, for later analysis
+    in TensorBoard's 'Histograms' and 'Distributions' dashboards (data written
+    using this API will appear in both places). Like `tf.summary.scalar` points,
+    each histogram is associated with a `step` and a `name`. All the histograms
+    with the same `name` constitute a time series of histograms.
+
+    When higher order `Tensor`s are flattened to produce a histogram of all
+    entries within.
 
     This example writes 2 histograms:
 
     ```python
-    test_summary_writer = tf.summary.create_file_writer('test/logs')
-    with test_summary_writer.as_default():
-      tf.summary.histogram("activations", [-10, 0, 10], step=0)
-      tf.summary.histogram("initial weights", tf.random.normal([5]), step=0)
+    w = tf.summary.create_file_writer('test/logs')
+    with w.as_default():
+        tf.summary.histogram("activations", tf.random.uniform([100, 50]), step=0)
+        tf.summary.histogram("initial_weights", tf.random.normal([1000]), step=0)
     ```
 
     A common use case is to examine the changing activation patterns (or lack
     thereof) at specific layers in a neural network, over time.
 
     ```python
-    test_summary_writer = tf.summary.create_file_writer('test/logs')
-    with test_summary_writer.as_default():
-      for step in steps:
-        # After computing activations...
-        tf.summary.histogram("layer1/activate", layer1_activate, step=step)
-        tf.summary.histogram("layer2/activate", layer2_activate, step=step)
-        tf.summary.histogram("layer3/activate", layer3_activate, step=step)
+    w = tf.summary.create_file_writer('test/logs')
+    with w.as_default():
+    for step in range(100):
+        # Generate fake "activations".
+        activations = [
+            tf.random.normal([1000], mean=step, stddev=1),
+            tf.random.normal([1000], mean=step, stddev=10),
+            tf.random.normal([1000], mean=step, stddev=100),
+        ]
+
+        tf.summary.histogram("layer1/activate", activations[0], step=step)
+        tf.summary.histogram("layer2/activate", activations[1], step=step)
+        tf.summary.histogram("layer3/activate", activations[2], step=step)
     ```
 
     Arguments:

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -54,31 +54,26 @@ def histogram(name, data, step=None, buckets=None, description=None):
 
     This example writes 2 histograms:
 
-    ```python
-    w = tf.summary.create_file_writer('test/logs')
-    with w.as_default():
-        tf.summary.histogram("activations", tf.random.uniform([100, 50]), step=0)
-        tf.summary.histogram("initial_weights", tf.random.normal([1000]), step=0)
-    ```
+    >>> w = tf.summary.create_file_writer('test/logs')
+    >>> with w.as_default():
+    ...     tf.summary.histogram("activations", tf.random.uniform([100, 50]), step=0)
+    ...     tf.summary.histogram("initial_weights", tf.random.normal([1000]), step=0)
 
     A common use case is to examine the changing activation patterns (or lack
     thereof) at specific layers in a neural network, over time.
 
-    ```python
-    w = tf.summary.create_file_writer('test/logs')
-    with w.as_default():
-    for step in range(100):
-        # Generate fake "activations".
-        activations = [
-            tf.random.normal([1000], mean=step, stddev=1),
-            tf.random.normal([1000], mean=step, stddev=10),
-            tf.random.normal([1000], mean=step, stddev=100),
-        ]
-
-        tf.summary.histogram("layer1/activate", activations[0], step=step)
-        tf.summary.histogram("layer2/activate", activations[1], step=step)
-        tf.summary.histogram("layer3/activate", activations[2], step=step)
-    ```
+    >>> w = tf.summary.create_file_writer('test/logs')
+    >>> with w.as_default():
+    >>> for step in range(100):
+    ...     # Generate fake "activations".
+    ...     activations = [
+    ...         tf.random.normal([1000], mean=step, stddev=1),
+    ...         tf.random.normal([1000], mean=step, stddev=10),
+    ...         tf.random.normal([1000], mean=step, stddev=100),
+    ...     ]
+    ...     tf.summary.histogram("layer1/activate", activations[0], step=step)
+    ...     tf.summary.histogram("layer2/activate", activations[1], step=step)
+    ...     tf.summary.histogram("layer3/activate", activations[2], step=step)
 
     Arguments:
       name: A name for this summary. The summary tag used for TensorBoard will

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -41,6 +41,34 @@ DEFAULT_BUCKET_COUNT = 30
 def histogram(name, data, step=None, buckets=None, description=None):
     """Write a histogram summary.
 
+    Logs a histogram to the current log directory for later analysis in
+    TensorBoard's 'Histograms' and 'Distributions' dashboards (one histogram
+    will appear in both). Like `tf.summary.scalar` points, each histogram is
+    associated with a `step` and a `name`. All the histograms with the same
+    `name` constitute a time series of histograms.
+
+    This example writes 2 histograms:
+
+    ```python
+    writer = tf.summary.create_file_writer('logs')
+    with writer.as_default():
+      tf.summary.histogram("activations", [-10, 0, 10], step=0)
+      tf.summary.histogram("initial weights", tf.random.normal([5]), step=0)
+    ```
+
+    A common use case is to examine the changing activation patterns (or lack
+    thereof) at specific layers in a neural network, over time.
+
+    ```python
+    writer = tf.summary.create_file_writer('logs')
+    with writer.as_default():
+      for step in steps:
+        # After computing activations...
+        tf.summary.histogram("layer1/activate", layer1_activate, step=step)
+        tf.summary.histogram("layer2/activate", layer2_activate, step=step)
+        tf.summary.histogram("layer3/activate", layer3_activate, step=step)
+    ```
+
     Arguments:
       name: A name for this summary. The summary tag used for TensorBoard will
         be this name prefixed by any active name scopes.


### PR DESCRIPTION
Update documentation for `tf.summary.histogram`.

#API_FIXIT_3_18_21

From what I understand, OSS is the source of truth, but the
TF Devsite is not updated immediately without manually doing
an internal process to update the devsite.