### PR TITLE
Fix typo in the projector notebook

### DIFF
--- a/docs/tensorboard_projector_plugin.ipynb
+++ b/docs/tensorboard_projector_plugin.ipynb
@@ -156,7 +156,7 @@
       "source": [
         "# Keras Embedding Layer\n",
         "\n",
-        "A [Keras Embedding Layer](https://keras.io/layers/embeddings/) can be used to train an embedding for each word in your volcabulary. Each word (or sub-word in this case) will be associated with a 16-dimensional vector (or embedding) that will be trained by the model.\n",
+        "A [Keras Embedding Layer](https://keras.io/layers/embeddings/) can be used to train an embedding for each word in your vocabulary. Each word (or sub-word in this case) will be associated with a 16-dimensional vector (or embedding) that will be trained by the model.\n",
         "\n",
         "See [this tutorial](https://www.tensorflow.org/tutorials/text/word_embeddings?hl=en) to learn more about word embeddings."
       ]


### PR DESCRIPTION
`volcabulary` → `vocabulary`