### PR TITLE
graph: relax the aggressive numeric node series detection

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/common_test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common_test.ts
@@ -14,9 +14,11 @@ limitations under the License.
 ==============================================================================*/
 import * as tb_debug from '../../../components/tb_debug';
 import * as tf_graph from './graph';
+import * as tf_graph_common from './common';
 import * as tf_graph_hierarchy from './hierarchy';
 import * as tf_graph_loader from './loader';
 import * as tf_graph_parser from './parser';
+import * as tf_graph_proto from './proto';
 
 describe('graph tests', () => {
   let mockTracker: jasmine.SpyObj<any>;
@@ -192,5 +194,197 @@ describe('graph tests', () => {
         ])
       );
     });
+
+    it('groups numeric series of nodes without underscores', async () => {
+      const slimGraph = await graphDefToSlimGraph(
+        await pbtxtToGraphDef(`
+        node {
+          name: "foo1"
+          op: "Add"
+        }
+        node {
+          name: "foo2"
+          op: "Add"
+        }
+        node {
+          name: "foo3"
+          op: "Add"
+        }
+        node {
+          name: "foo4"
+          op: "Add"
+        }
+        node {
+          name: "foo5"
+          op: "Add"
+        }
+      `)
+      );
+      const hierarchy = await tf_graph_hierarchy.build(
+        slimGraph,
+        tf_graph_hierarchy.DefaultHierarchyParams,
+        createProgressTracker()
+      );
+
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual([
+        '__root__',
+        'foo1',
+        'foo2',
+        'foo3',
+        'foo4',
+        'foo5',
+        'foo[1-5]',
+      ]);
+      expect(hierarchy.getSeriesGroupType('foo[1-5]')).toBe(
+        tf_graph.SeriesGroupingType.GROUP
+      );
+    });
+
+    it('groups numeric series of nodes with underscores', async () => {
+      const slimGraph = await graphDefToSlimGraph(
+        await pbtxtToGraphDef(`
+        node {
+          name: "foo_1"
+          op: "Add"
+        }
+        node {
+          name: "foo_2"
+          op: "Add"
+        }
+        node {
+          name: "foo_3"
+          op: "Add"
+        }
+        node {
+          name: "foo_4"
+          op: "Add"
+        }
+        node {
+          name: "foo_5"
+          op: "Add"
+        }
+      `)
+      );
+      const hierarchy = await tf_graph_hierarchy.build(
+        slimGraph,
+        tf_graph_hierarchy.DefaultHierarchyParams,
+        createProgressTracker()
+      );
+
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual([
+        '__root__',
+        'foo_1',
+        'foo_2',
+        'foo_3',
+        'foo_4',
+        'foo_5',
+        'foo_[1-5]',
+      ]);
+      expect(hierarchy.getSeriesGroupType('foo_[1-5]')).toBe(
+        tf_graph.SeriesGroupingType.GROUP
+      );
+    });
+
+    it('groups numeric series of nodes with implicit index 0', async () => {
+      const slimGraph = await graphDefToSlimGraph(
+        await pbtxtToGraphDef(`
+        node {
+          name: "foo"
+          op: "Add"
+        }
+        node {
+          name: "foo1"
+          op: "Add"
+        }
+        node {
+          name: "foo2"
+          op: "Add"
+        }
+        node {
+          name: "foo3"
+          op: "Add"
+        }
+        node {
+          name: "foo4"
+          op: "Add"
+        }
+      `)
+      );
+      const hierarchy = await tf_graph_hierarchy.build(
+        slimGraph,
+        tf_graph_hierarchy.DefaultHierarchyParams,
+        createProgressTracker()
+      );
+
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual([
+        '__root__',
+        'foo',
+        'foo1',
+        'foo2',
+        'foo3',
+        'foo4',
+        'foo[0-4]',
+      ]);
+      expect(hierarchy.getSeriesGroupType('foo[0-4]')).toBe(
+        tf_graph.SeriesGroupingType.GROUP
+      );
+    });
+
+    it('does not group a numeric series of nodes that is too short', async () => {
+      const slimGraph = await graphDefToSlimGraph(
+        await pbtxtToGraphDef(`
+        node {
+          name: "foo1"
+          op: "Add"
+        }
+        node {
+          name: "foo2"
+          op: "Add"
+        }
+        node {
+          name: "foo3"
+          op: "Add"
+        }
+        node {
+          name: "foo4"
+          op: "Add"
+        }
+      `)
+      );
+      const hierarchy = await tf_graph_hierarchy.build(
+        slimGraph,
+        tf_graph_hierarchy.DefaultHierarchyParams,
+        createProgressTracker()
+      );
+
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual(['__root__', 'foo1', 'foo2', 'foo3', 'foo4']);
+    });
   });
 });
+
+async function pbtxtToGraphDef(text: string): Promise<tf_graph_proto.GraphDef> {
+  const encoder = new TextEncoder();
+  return tf_graph_parser.parseGraphPbTxt(encoder.encode(text));
+}
+
+async function graphDefToSlimGraph(
+  graphDef: tf_graph_proto.GraphDef
+): Promise<tf_graph.SlimGraph> {
+  return tf_graph.build(
+    graphDef,
+    tf_graph.DefaultBuildParams,
+    createProgressTracker()
+  );
+}
+
+function createProgressTracker(): tf_graph_common.ProgressTracker {
+  return {
+    setMessage: () => {},
+    updateProgress: () => {},
+    reportError: () => {},
+  };
+}

--- a/tensorboard/plugins/graph/tf_graph_common/common_test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common_test.ts
@@ -529,7 +529,7 @@ async function slimGraphToHierarchy(
   return tf_graph_hierarchy.build(
     slimGraph,
     tf_graph_hierarchy.DefaultHierarchyParams,
-    createProgressTracker()
+    createNoopProgressTracker()
   );
 }
 
@@ -544,11 +544,11 @@ async function graphDefToSlimGraph(
   return tf_graph.build(
     graphDef,
     tf_graph.DefaultBuildParams,
-    createProgressTracker()
+    createNoopProgressTracker()
   );
 }
 
-function createProgressTracker(): tf_graph_common.ProgressTracker {
+function createNoopProgressTracker(): tf_graph_common.ProgressTracker {
   return {
     setMessage: () => {},
     updateProgress: () => {},

--- a/tensorboard/plugins/graph/tf_graph_common/common_test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common_test.ts
@@ -196,8 +196,7 @@ describe('graph tests', () => {
     });
 
     it('groups numeric series of nodes without underscores', async () => {
-      const slimGraph = await graphDefToSlimGraph(
-        await pbtxtToGraphDef(`
+      const pbtxt = `
         node {
           name: "foo1"
           op: "Add"
@@ -218,14 +217,9 @@ describe('graph tests', () => {
           name: "foo5"
           op: "Add"
         }
-      `)
-      );
-      const hierarchy = await tf_graph_hierarchy.build(
-        slimGraph,
-        tf_graph_hierarchy.DefaultHierarchyParams,
-        createProgressTracker()
-      );
-
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
       const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
       expect(nodeNames).toEqual([
         '__root__',
@@ -242,8 +236,7 @@ describe('graph tests', () => {
     });
 
     it('groups numeric series of nodes with underscores', async () => {
-      const slimGraph = await graphDefToSlimGraph(
-        await pbtxtToGraphDef(`
+      const pbtxt = `
         node {
           name: "foo_1"
           op: "Add"
@@ -264,14 +257,9 @@ describe('graph tests', () => {
           name: "foo_5"
           op: "Add"
         }
-      `)
-      );
-      const hierarchy = await tf_graph_hierarchy.build(
-        slimGraph,
-        tf_graph_hierarchy.DefaultHierarchyParams,
-        createProgressTracker()
-      );
-
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
       const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
       expect(nodeNames).toEqual([
         '__root__',
@@ -288,8 +276,7 @@ describe('graph tests', () => {
     });
 
     it('groups numeric series of nodes with implicit index 0', async () => {
-      const slimGraph = await graphDefToSlimGraph(
-        await pbtxtToGraphDef(`
+      const pbtxt = `
         node {
           name: "foo"
           op: "Add"
@@ -310,14 +297,9 @@ describe('graph tests', () => {
           name: "foo4"
           op: "Add"
         }
-      `)
-      );
-      const hierarchy = await tf_graph_hierarchy.build(
-        slimGraph,
-        tf_graph_hierarchy.DefaultHierarchyParams,
-        createProgressTracker()
-      );
-
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
       const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
       expect(nodeNames).toEqual([
         '__root__',
@@ -334,8 +316,7 @@ describe('graph tests', () => {
     });
 
     it('does not group a numeric series of nodes that is too short', async () => {
-      const slimGraph = await graphDefToSlimGraph(
-        await pbtxtToGraphDef(`
+      const pbtxt = `
         node {
           name: "foo1"
           op: "Add"
@@ -352,19 +333,205 @@ describe('graph tests', () => {
           name: "foo4"
           op: "Add"
         }
-      `)
-      );
-      const hierarchy = await tf_graph_hierarchy.build(
-        slimGraph,
-        tf_graph_hierarchy.DefaultHierarchyParams,
-        createProgressTracker()
-      );
-
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
       const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
       expect(nodeNames).toEqual(['__root__', 'foo1', 'foo2', 'foo3', 'foo4']);
     });
+
+    it('groups a numeric series ignoring NodeDef order in pbtxt', async () => {
+      const pbtxt = `
+        node {
+          name: "foo2"
+          op: "Add"
+        }
+        node {
+          name: "foo3"
+          op: "Add"
+        }
+        node {
+          name: "foo1"
+          op: "Add"
+        }
+        node {
+          name: "foo5"
+          op: "Add"
+        }
+        node {
+          name: "foo4"
+          op: "Add"
+        }
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual([
+        '__root__',
+        'foo1',
+        'foo2',
+        'foo3',
+        'foo4',
+        'foo5',
+        'foo[1-5]',
+      ]);
+    });
+
+    it('does not group a non-sequential numeric series', async () => {
+      const pbtxt = `
+        node {
+          name: "foo1"
+          op: "Add"
+        }
+        node {
+          name: "foo3"
+          op: "Add"
+        }
+        node {
+          name: "foo5"
+          op: "Add"
+        }
+        node {
+          name: "foo7"
+          op: "Add"
+        }
+        node {
+          name: "foo9"
+          op: "Add"
+        }
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual([
+        '__root__',
+        'foo1',
+        'foo3',
+        'foo5',
+        'foo7',
+        'foo9',
+      ]);
+    });
+
+    it('does not treat a mixed format of underscores as a numeric series', async () => {
+      const pbtxt = `
+        node {
+          name: "foo_1"
+          op: "Add"
+        }
+        node {
+          name: "foo2"
+          op: "Add"
+        }
+        node {
+          name: "foo_3"
+          op: "Add"
+        }
+        node {
+          name: "foo4"
+          op: "Add"
+        }
+        node {
+          name: "foo_5"
+          op: "Add"
+        }
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual([
+        '__root__',
+        'foo2',
+        'foo4',
+        'foo_1',
+        'foo_3',
+        'foo_5',
+      ]);
+    });
+
+    it('does not group a numeric series whose numbers are not the suffix', async () => {
+      const pbtxt = `
+        node {
+          name: "foo1a"
+          op: "Add"
+        }
+        node {
+          name: "foo2a"
+          op: "Add"
+        }
+        node {
+          name: "foo3a"
+          op: "Add"
+        }
+        node {
+          name: "foo4a"
+          op: "Add"
+        }
+        node {
+          name: "foo5a"
+          op: "Add"
+        }
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual([
+        '__root__',
+        'foo1a',
+        'foo2a',
+        'foo3a',
+        'foo4a',
+        'foo5a',
+      ]);
+    });
+
+    it('does not group a numeric series whose prefixes do not match', async () => {
+      const pbtxt = `
+        node {
+          name: "foo1"
+          op: "Add"
+        }
+        node {
+          name: "bar2"
+          op: "Add"
+        }
+        node {
+          name: "foo3"
+          op: "Add"
+        }
+        node {
+          name: "bar4"
+          op: "Add"
+        }
+        node {
+          name: "foo5"
+          op: "Add"
+        }
+      `;
+      const slimGraph = await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+      const hierarchy = await slimGraphToHierarchy(slimGraph);
+      const nodeNames = Object.keys(hierarchy.getNodeMap()).sort();
+      expect(nodeNames).toEqual([
+        '__root__',
+        'bar2',
+        'bar4',
+        'foo1',
+        'foo3',
+        'foo5',
+      ]);
+    });
   });
 });
+
+async function slimGraphToHierarchy(
+  slimGraph: tf_graph.SlimGraph
+): Promise<tf_graph_hierarchy.Hierarchy> {
+  return tf_graph_hierarchy.build(
+    slimGraph,
+    tf_graph_hierarchy.DefaultHierarchyParams,
+    createProgressTracker()
+  );
+}
 
 async function pbtxtToGraphDef(text: string): Promise<tf_graph_proto.GraphDef> {
   const encoder = new TextEncoder();

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -1039,11 +1039,11 @@ function detectSeriesUsingNumericSuffixes(
     // number at the end of the name after an underscore, which is allowed to
     // vary.
     _.each(members, function (name: string) {
-      let isGroup = name.charAt(name.length - 1) === '*';
-      let namepath = name.split('/');
-      let leaf = namepath[namepath.length - 1];
-      let parent = namepath.slice(0, namepath.length - 1).join('/');
-      let matches = leaf.match(/^(\D*)_(\d+)$/);
+      const isGroup = name.charAt(name.length - 1) === '*';
+      const namepath = name.split('/');
+      const leaf = namepath[namepath.length - 1];
+      const parent = namepath.slice(0, namepath.length - 1).join('/');
+      const matches = leaf.match(/^(\D*)(\d+)$/);
       let prefix;
       let id;
       let suffix = '';
@@ -1057,9 +1057,9 @@ function detectSeriesUsingNumericSuffixes(
         id = 0;
         suffix = isGroup ? '*' : '';
       }
-      let seriesName = getSeriesNodeName(prefix, suffix, parent);
+      const seriesName = getSeriesNodeName(prefix, suffix, parent);
       candidatesDict[seriesName] = candidatesDict[seriesName] || [];
-      let seriesNode = createSeriesNode(
+      const seriesNode = createSeriesNode(
         prefix,
         suffix,
         parent,

--- a/tensorboard/plugins/graph/tf_graph_common/loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/loader.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import * as tb_debug from '../../../components/tb_debug';
 
+import * as tf_graph_common from './common';
 import * as tf_graph from './graph';
 import * as hierarchy from './hierarchy';
 import * as op from './op';
@@ -25,7 +26,7 @@ export type GraphAndHierarchy = {
   graphHierarchy: hierarchy.Hierarchy;
 };
 export function fetchAndConstructHierarchicalGraph(
-  tracker: tf_graph_util.Tracker,
+  tracker: tf_graph_common.ProgressTracker,
   remotePath: string | null,
   pbTxtFile: Blob | null,
   compatibilityProvider: op.CompatibilityProvider = new op.TpuCompatibilityProvider(),

--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -86,7 +86,7 @@ export function fetchAndParseGraphData(
   path: string,
   pbTxtFile: Blob,
   tracker: ProgressTracker
-) {
+): Promise<tf_graph_proto.GraphDef> {
   return tf_graph_util
     .runAsyncPromiseTask(
       'Reading graph pbtxt',
@@ -315,10 +315,10 @@ function parsePbtxtFile(
   }
   // Run through the file a line at a time.
   return streamParse(input, function (line: string) {
+    line = line.trim();
     if (!line) {
       return;
     }
-    line = line.trim();
     switch (line[line.length - 1]) {
       case '{': // create new object
         let name = line.substring(0, line.length - 2).trim();

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -82,11 +82,6 @@ export function time<T>(
   }
   return result;
 }
-export type Tracker = {
-  setMessage: (msg: string) => void;
-  updateProgress: (value: number) => void;
-  reportError: (msg: string, error: Error) => void;
-};
 /**
  * Creates a tracker that sets the progress property of the
  * provided polymer component. The provided component must have
@@ -94,7 +89,7 @@ export type Tracker = {
  * property is an object with a numerical 'value' property and a
  * string 'msg' property.
  */
-export function getTracker(polymerComponent: any): Tracker {
+export function getTracker(polymerComponent: any): ProgressTracker {
   return {
     setMessage: function (msg) {
       polymerComponent.set('progress', {


### PR DESCRIPTION
Before, these nodes [add_0, add_1, add_2, ...] could be collapsed into
a single "series group node", while [add1, add2, add3, ...] could not.
This change relaxes the strict regex check to allow names without
underscores.

Note that the "minimum 5 node series length" constraint still applies,
as the main heuristic that guards against overly aggressive series
grouping.