### PR TITLE
pip: require tensorboard-data-server 0.5.0

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,7 +26,7 @@ numpy >= 1.12.0
 protobuf >= 3.6.0
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
-tensorboard-data-server >= 0.4.0, < 0.5.0
+tensorboard-data-server >= 0.5.0, < 0.6.0
 tensorboard-plugin-wit >= 1.6.0
 werkzeug >= 0.11.15
 # python3 specifically requires wheel 0.26


### PR DESCRIPTION
Summary:
We’ve released tensorboard-data-server==0.5.0. This patch updates the
dependency from TensorBoard to the data server.

Test Plan:
Run `//tensorboard/pip_package:extract_pip_package` and install the
wheel into a new virtualenv. Note that the new data server is installed
and that --load_fast with Custom Scalars, Mesh dashboards works as
desired.