### PR TITLE
ci: install TensorBoard deps after TensorFlow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
             "common --google_credentials=${creds_file}" \
             "common --remote_upload_local_results=true" \
             ;
+      - name: 'Install TensorFlow'
+        run: pip install "${{ matrix.tf_version_id }}"
+        if: matrix.tf_version_id != 'notf'
       - name: 'Install Python dependencies'
         run: |
           python -m pip install -U pip
@@ -81,9 +84,6 @@ jobs:
             -r ./tensorboard/pip_package/requirements.txt \
             -r ./tensorboard/pip_package/requirements_dev.txt \
             ;
-      - name: 'Install TensorFlow'
-        run: pip install "${{ matrix.tf_version_id }}"
-        if: matrix.tf_version_id != 'notf'
       - name: 'Check Pip state'
         run: pip freeze --all
       - name: 'Bazel: fetch'

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,7 +26,7 @@ numpy >= 1.12.0
 protobuf >= 3.6.0
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
-tensorboard-data-server >= 0.5.0, < 0.6.0
+tensorboard-data-server >= 0.4.0, < 0.5.0
 tensorboard-plugin-wit >= 1.6.0
 werkzeug >= 0.11.15
 # python3 specifically requires wheel 0.26

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,7 +26,7 @@ numpy >= 1.12.0
 protobuf >= 3.6.0
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
-tensorboard-data-server >= 0.4.0, < 0.5.0
+tensorboard-data-server >= 0.5.0, < 0.6.0
 tensorboard-plugin-wit >= 1.6.0
 werkzeug >= 0.11.15
 # python3 specifically requires wheel 0.26


### PR DESCRIPTION
Summary:
Installing `tf-nightly` pulls in `tb-nightly` and its dependencies. This
installs over our `requirements.txt`, which matters when there are
version differences. In particular, a PR that upgrades a dependency in
`requirements.txt` should be tested on the new version, not the old one.

Test Plan:
A prior version of this PR also upgraded a package version. The “Check
Pip state” action showed that we now test on the upgraded version.

wchargin-branch: ci-fix-deps-install-order
