### PR TITLE
time series: download link

### DIFF
--- a/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
@@ -266,7 +266,34 @@ export class TBMetricsDataSource implements MetricsDataSource {
       );
   }
 
-  imageUrl(imageId: ImageId) {
+  imageUrl(imageId: ImageId): string {
     return `${HTTP_PATH_PREFIX}/imageData?imageId=${imageId}`;
+  }
+
+  downloadUrl(
+    pluginId: PluginType,
+    tag: string,
+    runId: string,
+    downloadType: 'json' | 'csv'
+  ): string {
+    const {run, experimentId} = parseRunId(runId);
+    let pluginAndRoute: string;
+    switch (pluginId) {
+      case PluginType.SCALARS:
+        pluginAndRoute = 'scalars/scalars';
+        break;
+      default:
+        throw new Error(
+          `Not implemented: downloadUrl for ${pluginId} is not implemented yet`
+        );
+    }
+
+    if (!experimentId) {
+      throw new Error(
+        'experimentId is empty; it is required to form downloadUrl.'
+      );
+    }
+    const params = new URLSearchParams({tag, run, format: downloadType});
+    return `/experiment/${experimentId}/data/plugin/${pluginAndRoute}?${params}`;
   }
 }

--- a/tensorboard/webapp/metrics/data_source/metrics_data_source_test.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source_test.ts
@@ -299,4 +299,41 @@ describe('TBMetricsDataSource test', () => {
       ]);
     });
   });
+
+  describe('#downloadUrl', () => {
+    it('forms correct Url', () => {
+      expect(
+        dataSource.downloadUrl(PluginType.SCALARS, 'tag1', 'exp1/run1', 'json')
+      ).toBe(
+        '/experiment/exp1/data/plugin/scalars/scalars?tag=tag1&run=run1&format=json'
+      );
+      expect(
+        dataSource.downloadUrl(PluginType.SCALARS, 'tag1', 'exp1/run1', 'csv')
+      ).toBe(
+        '/experiment/exp1/data/plugin/scalars/scalars?tag=tag1&run=run1&format=csv'
+      );
+      expect(
+        dataSource.downloadUrl(PluginType.SCALARS, 'tag1', 'e2/run1', 'json')
+      ).toBe(
+        '/experiment/e2/data/plugin/scalars/scalars?tag=tag1&run=run1&format=json'
+      );
+      expect(
+        dataSource.downloadUrl(PluginType.SCALARS, 'tag1', 'e2/run1', 'csv')
+      ).toBe(
+        '/experiment/e2/data/plugin/scalars/scalars?tag=tag1&run=run1&format=csv'
+      );
+    });
+
+    it('throws for histogram data type', () => {
+      expect(() =>
+        dataSource.downloadUrl(PluginType.HISTOGRAMS, 'tag1', 'e/r', 'json')
+      ).toThrowError(/Not implemented/);
+    });
+
+    it('throws when experiment id is missing', () => {
+      expect(() =>
+        dataSource.downloadUrl(PluginType.SCALARS, 'tag1', 'run1', 'json')
+      ).toThrowError(/experimentId is empty/);
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/data_source/types.ts
+++ b/tensorboard/webapp/metrics/data_source/types.ts
@@ -173,6 +173,12 @@ export abstract class MetricsDataSource {
     requests: TimeSeriesRequest[]
   ): Observable<TimeSeriesResponse[]>;
   abstract imageUrl(imageId: ImageId): string;
+  abstract downloadUrl(
+    pluginId: PluginType,
+    tag: string,
+    runId: string,
+    downloadType: 'json' | 'csv'
+  ): string;
 }
 
 export function isFailedTimeSeriesResponse(

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -295,6 +295,15 @@ export class TestingMetricsDataSource implements MetricsDataSource {
   imageUrl(imageId: ImageId) {
     return '';
   }
+
+  downloadUrl(
+    pluginId: PluginType,
+    tag: string,
+    runId: string,
+    downloadType: 'json' | 'csv'
+  ) {
+    return '';
+  }
 }
 
 export function provideTestingMetricsDataSource() {

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -221,6 +221,7 @@ tf_ng_module(
         ":utils",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_dialog",
         "//tensorboard/webapp/angular:expect_angular_material_icon",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -37,6 +37,41 @@ tf_ng_module(
 )
 
 tf_sass_binary(
+    name = "data_download_dialog_styles",
+    src = "data_download_dialog_component.scss",
+)
+
+tf_ng_module(
+    name = "data_download_dialog",
+    srcs = [
+        "data_download_dialog_component.ts",
+        "data_download_dialog_container.ts",
+        "data_download_module.ts",
+    ],
+    assets = [
+        ":data_download_dialog_styles",
+        "data_download_dialog_component.ng.html",
+    ],
+    deps = [
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/angular:expect_angular_material_button",
+        "//tensorboard/webapp/angular:expect_angular_material_dialog",
+        "//tensorboard/webapp/angular:expect_angular_material_input",
+        "//tensorboard/webapp/angular:expect_angular_material_select",
+        "//tensorboard/webapp/metrics:types",
+        "//tensorboard/webapp/metrics/data_source",
+        "//tensorboard/webapp/metrics/data_source:types",
+        "//tensorboard/webapp/runs:types",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/forms",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+tf_sass_binary(
     name = "histogram_card_styles",
     src = "histogram_card_component.scss",
     deps = [
@@ -181,11 +216,13 @@ tf_ng_module(
         "scalar_card_component.ng.html",
     ],
     deps = [
+        ":data_download_dialog",
         ":scalar_card_types",
         ":utils",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_material_button",
+        "//tensorboard/webapp/angular:expect_angular_material_dialog",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_material_menu",
         "//tensorboard/webapp/angular:expect_angular_material_progress_spinner",
@@ -218,6 +255,7 @@ tf_ts_library(
     srcs = [
         "card_lazy_loader_test.ts",
         "card_view_test.ts",
+        "data_download_dialog_test.ts",
         "histogram_card_test.ts",
         "image_card_test.ts",
         "run_name_test.ts",
@@ -226,6 +264,7 @@ tf_ts_library(
     ],
     deps = [
         ":card_renderer",
+        ":data_download_dialog",
         ":histogram_card",
         ":image_card",
         ":run_name",
@@ -237,8 +276,11 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_material_button",
+        "//tensorboard/webapp/angular:expect_angular_material_dialog",
+        "//tensorboard/webapp/angular:expect_angular_material_input",
         "//tensorboard/webapp/angular:expect_angular_material_menu",
         "//tensorboard/webapp/angular:expect_angular_material_progress_spinner",
+        "//tensorboard/webapp/angular:expect_angular_material_select",
         "//tensorboard/webapp/angular:expect_angular_material_slider",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
@@ -259,6 +301,7 @@ tf_ts_library(
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/core",
+        "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.ng.html
@@ -34,7 +34,7 @@ limitations under the License.
 
   <mat-dialog-content>
     <mat-form-field class="run-selector" appearance="fill">
-      <mat-label>Select a run to download a data</mat-label>
+      <mat-label>Select a run to download a data for a series</mat-label>
       <select
         matNativeControl
         name="run"
@@ -49,9 +49,8 @@ limitations under the License.
       </select>
     </mat-form-field>
 
-    <div class="donwload-controls">
-      <span>Download as…</span
-      ><a
+    <div class="download-controls">
+      <span>Download as…</span>&nbsp;<a
         mat-stroked-button
         [disabled]="!downloadUrlJson"
         [download]="getDownloadName('json')"

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.ng.html
@@ -43,7 +43,7 @@ limitations under the License.
         [value]="selectedRunId || ''"
         (change)="runSelected.emit($event.target.value)"
       >
-        <option selected>-</option>
+        <option selected [value]="''">-</option>
         <!-- There is no guarantee that the run.name is unique but run.id is.-->
         <option *ngFor="let run of runs" [value]="run.id">{{run.name}}</option>
       </select>
@@ -55,14 +55,14 @@ limitations under the License.
         mat-stroked-button
         [disabled]="!downloadUrlJson"
         [download]="getDownloadName('json')"
-        [href]="downloadUrlJson"
+        [attr.href]="downloadUrlJson"
         >JSON</a
       >
       <a
         mat-stroked-button
         [disabled]="!downloadUrlCsv"
         [download]="getDownloadName('csv')"
-        [href]="downloadUrlCsv"
+        [attr.href]="downloadUrlCsv"
         >CSV</a
       >
     </div>

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.ng.html
@@ -1,0 +1,76 @@
+<!--
+@license
+Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<ng-container *ngIf="cardMetadata; else noCardMetadata">
+  <h2>
+    <ng-template #dataName>
+      <ng-container [ngSwitch]="cardMetadata.plugin">
+        <span *ngSwitchCase="PluginType.SCALARS">scalar</span>
+        <span *ngSwitchCase="PluginType.HISTOGRAMS">histogram</span>
+        <span *NgSwitchDefault>unknown</span>
+      </ng-container>
+    </ng-template>
+
+    <span>Download&nbsp;</span
+    ><ng-container *ngTemplateOutlet="dataName"></ng-container
+    ><span>&nbsp;data for&nbsp;</span
+    ><code class="tag-name" [title]="cardMetadata.tag"
+      >{{cardMetadata.tag}}</code
+    >
+  </h2>
+
+  <mat-dialog-content>
+    <mat-form-field class="run-selector" appearance="fill">
+      <mat-label>Select a run to download a data</mat-label>
+      <select
+        matNativeControl
+        name="run"
+        cdkFocusInitial
+        required
+        [value]="selectedRunId || ''"
+        (change)="runSelected.emit($event.target.value)"
+      >
+        <option selected>-</option>
+        <!-- There is no guarantee that the run.name is unique but run.id is.-->
+        <option *ngFor="let run of runs" [value]="run.id">{{run.name}}</option>
+      </select>
+    </mat-form-field>
+
+    <div class="donwload-controls">
+      <span>Download as…</span
+      ><a
+        mat-stroked-button
+        [disabled]="!downloadUrlJson"
+        [download]="getDownloadName('json')"
+        [href]="downloadUrlJson"
+        >JSON</a
+      >
+      <a
+        mat-stroked-button
+        [disabled]="!downloadUrlCsv"
+        [download]="getDownloadName('csv')"
+        [href]="downloadUrlCsv"
+        >CSV</a
+      >
+    </div>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-button mat-dialog-close>Close</button>
+  </mat-dialog-actions>
+</ng-container>
+
+<ng-template #noCardMetadata>Loading...</ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.scss
@@ -14,22 +14,9 @@ limitations under the License.
 ==============================================================================*/
 @import 'tensorboard/webapp/theme/tb_theme';
 
-:host {
-  width: 400px;
-}
-
 h2 {
-  align-items: baseline;
-  display: flex;
   font-size: 1.25em;
-
-  .tag-name {
-    display: inline-block;
-    font-size: monospace;
-    max-width: 20ch;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+  overflow-wrap: break-word;
 }
 
 .run-selector {
@@ -37,10 +24,10 @@ h2 {
   width: 100%;
 }
 
-.donwload-controls {
+.download-controls {
   font-size: 0.9em;
 
   a {
-    margin-left: 10px;
+    margin: 3px 10px 3px 0;
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.scss
@@ -1,0 +1,46 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
+:host {
+  width: 400px;
+}
+
+h2 {
+  align-items: baseline;
+  display: flex;
+  font-size: 1.25em;
+
+  .tag-name {
+    display: inline-block;
+    font-size: monospace;
+    max-width: 20ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.run-selector {
+  font-size: 0.9em;
+  width: 100%;
+}
+
+.donwload-controls {
+  font-size: 0.9em;
+
+  a {
+    margin-left: 10px;
+  }
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_component.ts
@@ -1,0 +1,58 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+
+import {Run} from '../../../runs/types';
+import {CardMetadata} from '../../types';
+import {PluginType} from '../../data_source/types';
+
+@Component({
+  selector: 'data_download_dialog_component',
+  templateUrl: 'data_download_dialog_component.ng.html',
+  styleUrls: ['data_download_dialog_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DataDownloadDialogComponent {
+  @Input()
+  cardMetadata!: CardMetadata;
+
+  @Input()
+  runs!: Run[];
+
+  @Input()
+  selectedRunId!: string | null;
+
+  @Input()
+  downloadUrlCsv!: string | null;
+
+  @Input()
+  downloadUrlJson!: string | null;
+
+  @Output()
+  readonly runSelected = new EventEmitter<string>();
+
+  readonly PluginType = PluginType;
+
+  getDownloadName(type: 'json' | 'csv'): string {
+    const run = this.runs.find((run) => run.id === this.selectedRunId);
+    return run ? `${run.name}.${type}` : '';
+  }
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_container.ts
@@ -1,0 +1,111 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {Store} from '@ngrx/store';
+import {Observable, BehaviorSubject, combineLatest} from 'rxjs';
+import {filter, startWith, map} from 'rxjs/operators';
+
+import {State} from '../../../app_state';
+import {Run} from '../../../runs/types';
+import {
+  getCardMetadata,
+  getCardTimeSeries,
+  getRunMap,
+} from '../../../selectors';
+import {MetricsDataSource} from '../../data_source/types';
+import {CardMetadata} from '../../types';
+
+export interface DataDownloadDialogData {
+  cardId: string;
+}
+
+@Component({
+  selector: 'data_download_dialog',
+  template: `<data_download_dialog_component
+    [cardMetadata]="cardMetadata$ | async"
+    [runs]="runs$ | async"
+    [selectedRunId]="selectedRunId$ | async"
+    [downloadUrlCsv]="downloadUrlCsv$ | async"
+    [downloadUrlJson]="downloadUrlJson$ | async"
+    (runSelected)="selectedRunId$.next($event)"
+  ></data_download_dialog_component>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DataDownloadDialogContainer {
+  readonly runs$: Observable<Run[]>;
+  readonly cardMetadata$: Observable<CardMetadata>;
+
+  readonly selectedRunId$ = new BehaviorSubject<string | null>(null);
+  readonly downloadUrlCsv$: Observable<string | null>;
+  readonly downloadUrlJson$: Observable<string | null>;
+
+  constructor(
+    store: Store<State>,
+    dataSource: MetricsDataSource,
+    @Inject(MAT_DIALOG_DATA) data: DataDownloadDialogData
+  ) {
+    this.cardMetadata$ = store
+      .select(getCardMetadata, data.cardId)
+      .pipe(filter((metadata) => Boolean(metadata))) as Observable<
+      CardMetadata
+    >;
+
+    this.downloadUrlCsv$ = combineLatest([
+      store.select(getCardMetadata, data.cardId),
+      this.selectedRunId$,
+    ]).pipe(
+      map(([metadata, selectedRunId]) => {
+        if (!metadata || !selectedRunId) return null;
+        return dataSource.downloadUrl(
+          metadata.plugin,
+          metadata.tag,
+          selectedRunId!,
+          'csv'
+        );
+      }),
+      startWith(null)
+    );
+    this.downloadUrlJson$ = combineLatest([
+      store.select(getCardMetadata, data.cardId),
+      this.selectedRunId$,
+    ]).pipe(
+      map(([metadata, selectedRunId]) => {
+        if (!metadata || !selectedRunId) return null;
+        return dataSource.downloadUrl(
+          metadata.plugin,
+          metadata.tag,
+          selectedRunId!,
+          'json'
+        );
+      }),
+      startWith(null)
+    );
+
+    this.runs$ = combineLatest([
+      store.select(getRunMap),
+      store.select(getCardTimeSeries, data.cardId),
+    ]).pipe(
+      map(([runMap, runToSeries]) => {
+        if (!runToSeries) return [];
+        return Object.keys(runToSeries)
+          .map((runId) => {
+            return runMap.get(runId);
+          })
+          .filter(Boolean) as Run[];
+      })
+    );
+  }
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_test.ts
@@ -43,7 +43,7 @@ describe('metrics/views/data_download_dialog', () => {
 
   const ByCss = {
     SELECT: By.css('select'),
-    SELECT_OPTION: By.css('select option[value]'),
+    SELECT_OPTION: By.css('select option:not([value=""])'),
     DOWNLOAD: By.css('a'),
   };
 

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_test.ts
@@ -1,0 +1,258 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+import {MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+
+import {State} from '../../../app_state';
+import {Run} from '../../../runs/store/runs_types';
+import {buildRun} from '../../../runs/store/testing';
+import {
+  getCardMetadata,
+  getCardTimeSeries,
+  getRunMap,
+} from '../../../selectors';
+import {MetricsDataSource, PluginType} from '../../data_source';
+import {createScalarStepData, TestingMetricsDataSource} from '../../testing';
+import {DataDownloadDialogComponent} from './data_download_dialog_component';
+import {
+  DataDownloadDialogContainer,
+  DataDownloadDialogData,
+} from './data_download_dialog_container';
+
+describe('metrics/views/data_download_dialog', () => {
+  let store: MockStore<State>;
+  let dataSource: TestingMetricsDataSource;
+
+  const ByCss = {
+    SELECT: By.css('select'),
+    SELECT_OPTION: By.css('select option[value]'),
+    DOWNLOAD: By.css('a'),
+  };
+
+  async function createComponent(
+    cardId: string
+  ): Promise<ComponentFixture<DataDownloadDialogContainer>> {
+    const dialogData: DataDownloadDialogData = {cardId};
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, FormsModule],
+      declarations: [DataDownloadDialogContainer, DataDownloadDialogComponent],
+      providers: [
+        provideMockStore({}),
+        {provide: MAT_DIALOG_DATA, useValue: dialogData},
+        {provide: MetricsDataSource, useClass: TestingMetricsDataSource},
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    dataSource = TestBed.inject(MetricsDataSource) as TestingMetricsDataSource;
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    store.overrideSelector(getRunMap, new Map<string, Run>());
+    store.overrideSelector(getCardMetadata, null);
+    store.overrideSelector(getCardTimeSeries, {});
+
+    const fixture = TestBed.createComponent(DataDownloadDialogContainer);
+    return fixture;
+  }
+
+  it('renders', async () => {
+    const fixture = await createComponent('card1');
+    store.overrideSelector(getCardMetadata, {
+      plugin: PluginType.SCALARS,
+      tag: 'tag1',
+      runId: null,
+    });
+    store.overrideSelector(getCardTimeSeries, {
+      'exp1/run1': createScalarStepData(),
+      'exp1/run2': createScalarStepData(),
+    });
+    store.overrideSelector(
+      getRunMap,
+      new Map([
+        [
+          'exp1/run1',
+          buildRun({
+            id: 'exp1/run1',
+            name: 'Run 1',
+          }),
+        ],
+        [
+          'exp1/run2',
+          buildRun({
+            id: 'exp1/run2',
+            name: 'Run dos',
+          }),
+        ],
+      ])
+    );
+    fixture.detectChanges();
+
+    const options = fixture.debugElement.queryAll(ByCss.SELECT_OPTION);
+    expect(options.length).toBe(2);
+    expect(options.map((option) => option.nativeElement.textContent)).toEqual([
+      'Run 1',
+      'Run dos',
+    ]);
+
+    const downloadLinks = fixture.debugElement.queryAll(ByCss.DOWNLOAD);
+    for (const link of downloadLinks) {
+      expect(link.properties['disabled']).toBe(true);
+    }
+  });
+
+  it('omits runIds without run metadata', async () => {
+    const fixture = await createComponent('card1');
+    store.overrideSelector(getCardMetadata, {
+      plugin: PluginType.SCALARS,
+      tag: 'tag1',
+      runId: null,
+    });
+    store.overrideSelector(getCardTimeSeries, {
+      'exp1/run1': createScalarStepData(),
+      'exp1/run2': createScalarStepData(),
+    });
+    store.overrideSelector(
+      getRunMap,
+      new Map([
+        [
+          'exp1/run1',
+          buildRun({
+            id: 'exp1/run1',
+            name: 'Run 1',
+          }),
+        ],
+      ])
+    );
+    fixture.detectChanges();
+
+    const options = fixture.debugElement.queryAll(ByCss.SELECT_OPTION);
+    expect(options.length).toBe(1);
+    expect(options.map((option) => option.nativeElement.textContent)).toEqual([
+      'Run 1',
+    ]);
+  });
+
+  it('enables the download links when run is selected', async () => {
+    const fixture = await createComponent('card1');
+    const downloadUrlSpy = spyOn(dataSource, 'downloadUrl');
+    downloadUrlSpy
+      .withArgs(PluginType.SCALARS, 'tag1', 'exp1/run2', 'json')
+      .and.returnValue('/url1');
+    downloadUrlSpy
+      .withArgs(PluginType.SCALARS, 'tag1', 'exp1/run2', 'csv')
+      .and.returnValue('/url2');
+    store.overrideSelector(getCardMetadata, {
+      plugin: PluginType.SCALARS,
+      tag: 'tag1',
+      runId: null,
+    });
+    store.overrideSelector(getCardTimeSeries, {
+      'exp1/run1': createScalarStepData(),
+      'exp1/run2': createScalarStepData(),
+    });
+    store.overrideSelector(
+      getRunMap,
+      new Map([
+        [
+          'exp1/run1',
+          buildRun({
+            id: 'exp1/run1',
+            name: 'Run 1',
+          }),
+        ],
+        [
+          'exp1/run2',
+          buildRun({
+            id: 'exp1/run2',
+            name: 'Run dos',
+          }),
+        ],
+      ])
+    );
+    fixture.detectChanges();
+
+    const selectEl = fixture.debugElement.query(ByCss.SELECT).nativeElement;
+    selectEl.value = 'exp1/run2';
+    // Let Angular and FormsControl know.
+    selectEl.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const downloadLinks = fixture.debugElement.queryAll(ByCss.DOWNLOAD);
+    for (const link of downloadLinks) {
+      expect(link.properties['disabled']).toBe(false);
+    }
+    const pathAndQueries = downloadLinks.map((link) => {
+      return link.nativeElement.href.slice(link.nativeElement.origin.length);
+    });
+    expect(pathAndQueries).toEqual(['/url1', '/url2']);
+  });
+
+  it('forms correct url even if run names are all the same', async () => {
+    const fixture = await createComponent('card1');
+    const downloadUrlSpy = spyOn(dataSource, 'downloadUrl');
+    downloadUrlSpy
+      .withArgs(PluginType.SCALARS, 'tag1', 'exp2/run1', 'json')
+      .and.returnValue('/url1');
+    downloadUrlSpy
+      .withArgs(PluginType.SCALARS, 'tag1', 'exp2/run1', 'csv')
+      .and.returnValue('/url2');
+    store.overrideSelector(getCardMetadata, {
+      plugin: PluginType.SCALARS,
+      tag: 'tag1',
+      runId: null,
+    });
+    store.overrideSelector(getCardTimeSeries, {
+      'exp1/run1': createScalarStepData(),
+      'exp2/run1': createScalarStepData(),
+    });
+    store.overrideSelector(
+      getRunMap,
+      new Map([
+        [
+          'exp1/run1',
+          buildRun({
+            id: 'exp1/run1',
+            name: 'RunName',
+          }),
+        ],
+        [
+          'exp2/run1',
+          buildRun({
+            id: 'exp2/run1',
+            name: 'RunName',
+          }),
+        ],
+      ])
+    );
+    fixture.detectChanges();
+
+    const selectEl = fixture.debugElement.query(ByCss.SELECT).nativeElement;
+    selectEl.value = 'exp2/run1';
+    // Let Angular and FormsControl know.
+    selectEl.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const downloadLinks = fixture.debugElement.queryAll(ByCss.DOWNLOAD);
+    const pathAndQueries = downloadLinks.map((link) => {
+      return link.nativeElement.href.slice(link.nativeElement.origin.length);
+    });
+    expect(pathAndQueries).toEqual(['/url1', '/url2']);
+  });
+});

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_module.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_module.ts
@@ -1,0 +1,40 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatDialogModule} from '@angular/material/dialog';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+
+import {MetricsDataSourceModule} from '../../data_source';
+import {DataDownloadDialogComponent} from './data_download_dialog_component';
+import {DataDownloadDialogContainer} from './data_download_dialog_container';
+
+@NgModule({
+  declarations: [DataDownloadDialogContainer, DataDownloadDialogComponent],
+  exports: [DataDownloadDialogContainer],
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatInputModule,
+    MatSelectModule,
+    MetricsDataSourceModule,
+  ],
+})
+export class DataDownloadModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -80,6 +80,10 @@ limitations under the License.
         <mat-icon svgIcon="settings_overscan_24px"></mat-icon>
         <span>Fit domain to data</span>
       </button>
+      <button mat-menu-item (click)="openDataDownloadDialog()">
+        <mat-icon svgIcon="get_app_24px"></mat-icon>
+        <span>Download data</span>
+      </button>
     </mat-menu>
   </span>
 </div>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -83,7 +83,7 @@ limitations under the License.
       <button
         mat-menu-item
         (click)="openDataDownloadDialog()"
-        aria-label="Open data download dialog"
+        aria-label="Open dialog to download data"
       >
         <mat-icon svgIcon="get_app_24px"></mat-icon>
         <span>Download data</span>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -80,7 +80,11 @@ limitations under the License.
         <mat-icon svgIcon="settings_overscan_24px"></mat-icon>
         <span>Fit domain to data</span>
       </button>
-      <button mat-menu-item (click)="openDataDownloadDialog()">
+      <button
+        mat-menu-item
+        (click)="openDataDownloadDialog()"
+        aria-label="Open data download dialog"
+      >
         <mat-icon svgIcon="get_app_24px"></mat-icon>
         <span>Download data</span>
       </button>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {ComponentType} from '@angular/cdk/overlay';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -47,7 +48,6 @@ import {
 } from '../../../widgets/line_chart_v2/types';
 import {ScalarStepDatum} from '../../data_source';
 import {TooltipSort, XAxisType} from '../../types';
-import {DataDownloadDialogContainer} from './data_download_dialog_container';
 import {
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
@@ -121,7 +121,7 @@ const DEFAULT_TOOLTIP_COLUMNS: TooltipColumns = [
   styleUrls: ['scalar_card_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ScalarCardComponent {
+export class ScalarCardComponent<Downloader> {
   readonly RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS = RESIZE_REDRAW_DEBOUNCE_TIME_IN_MS;
   readonly DataLoadState = DataLoadState;
   readonly RendererType = RendererType;
@@ -129,13 +129,13 @@ export class ScalarCardComponent {
   @Input() cardId!: string;
   @Input() loadState!: DataLoadState;
   @Input() title!: string;
-  @Input() runIds!: string[];
   @Input() tag!: string;
   @Input() tooltipSort!: TooltipSort;
   @Input() xAxisType!: XAxisType;
   @Input() showFullSize!: boolean;
   @Input() isPinned!: boolean;
 
+  @Input() DataDownloadComponent!: ComponentType<Downloader>;
   @Input() newXScaleType!: ScaleType;
 
   // Legacy chart related; to be removed.
@@ -264,7 +264,7 @@ export class ScalarCardComponent {
   }
 
   openDataDownloadDialog(): void {
-    this.dialog.open(DataDownloadDialogContainer, {
+    this.dialog.open(this.DataDownloadComponent, {
       data: {cardId: this.cardId},
     });
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -21,6 +21,7 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
+import {MatDialog} from '@angular/material/dialog';
 
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
@@ -46,6 +47,7 @@ import {
 } from '../../../widgets/line_chart_v2/types';
 import {ScalarStepDatum} from '../../data_source';
 import {TooltipSort, XAxisType} from '../../types';
+import {DataDownloadDialogContainer} from './data_download_dialog_container';
 import {
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
@@ -124,8 +126,10 @@ export class ScalarCardComponent {
   readonly DataLoadState = DataLoadState;
   readonly RendererType = RendererType;
 
+  @Input() cardId!: string;
   @Input() loadState!: DataLoadState;
   @Input() title!: string;
+  @Input() runIds!: string[];
   @Input() tag!: string;
   @Input() tooltipSort!: TooltipSort;
   @Input() xAxisType!: XAxisType;
@@ -159,7 +163,7 @@ export class ScalarCardComponent {
   @ViewChild(NewLineChartComponent)
   newLineChart?: NewLineChartComponent;
 
-  constructor(private readonly ref: ElementRef) {}
+  constructor(private readonly ref: ElementRef, private dialog: MatDialog) {}
 
   yAxisType = YAxisType.LINEAR;
   newYScaleType = ScaleType.LINEAR;
@@ -257,5 +261,11 @@ export class ScalarCardComponent {
           return a.metadata.distSqToCursor - b.metadata.distSqToCursor;
         });
     }
+  }
+
+  openDataDownloadDialog(): void {
+    this.dialog.open(DataDownloadDialogContainer, {
+      data: {cardId: this.cardId},
+    });
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -129,10 +129,12 @@ function areSeriesEqual(
   selector: 'scalar-card',
   template: `
     <scalar-card-component
+      [cardId]="cardId"
       [loadState]="loadState$ | async"
       [runColorScale]="runColorScale"
       [title]="title$ | async"
       [tag]="tag$ | async"
+      [runIds]="runIds$ | async"
       [seriesDataList]="legacySeriesDataList$ | async"
       [tooltipSort]="tooltipSort$ | async"
       [ignoreOutliers]="ignoreOutliers$ | async"
@@ -176,6 +178,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
   loadState$?: Observable<DataLoadState>;
   title$?: Observable<string>;
   tag$?: Observable<string>;
+  runIds$?: Observable<string[]>;
   legacySeriesDataList$?: Observable<LegacySeriesDataList> = of([]);
   isPinned$?: Observable<boolean>;
   dataSeries$?: Observable<ScalarCardDataSeries[]>;
@@ -251,6 +254,12 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
         map((runToSeries) => runToSeries as RunToSeries<PluginType.SCALARS>),
         shareReplay(1)
       );
+
+    this.runIds$ = nonNullRunsToScalarSeries$.pipe(
+      map((runToSeries) => {
+        return Object.keys(runToSeries);
+      })
+    );
 
     const partialSeries$ = nonNullRunsToScalarSeries$.pipe(
       combineLatestWith(this.store.select(getMetricsXAxisType)),

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -23,6 +23,7 @@ import {LineChartModule} from '../../../widgets/line_chart/line_chart_module';
 import {LineChartModule as LineChartV2Module} from '../../../widgets/line_chart_v2/line_chart_module';
 import {ResizeDetectorModule} from '../../../widgets/resize_detector_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
+import {DataDownloadModule} from './data_download_module';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
 
@@ -31,6 +32,7 @@ import {ScalarCardContainer} from './scalar_card_container';
   exports: [ScalarCardContainer],
   imports: [
     CommonModule,
+    DataDownloadModule,
     LineChartModule,
     LineChartV2Module,
     MatButtonModule,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -21,6 +21,7 @@ import {
   TestBed,
   tick,
 } from '@angular/core/testing';
+import {MatDialogModule} from '@angular/material/dialog';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {By} from '@angular/platform-browser';
@@ -184,6 +185,7 @@ describe('scalar card', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
+        MatDialogModule,
         MatIconTestingModule,
         MatMenuModule,
         MatProgressSpinnerModule,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -1907,7 +1907,7 @@ describe('scalar card', () => {
       fixture.detectChanges();
 
       openOverflowMenu(fixture);
-      getMenuButton('Open data download dialog').click();
+      getMenuButton('Open dialog to download data').click();
       fixture.detectChanges();
       flush();
 

--- a/tensorboard/webapp/runs/types.ts
+++ b/tensorboard/webapp/runs/types.ts
@@ -23,6 +23,7 @@ export {
   DiscreteHparamValue,
   DiscreteHparamValues,
   DomainType,
+  Run,
 } from './data_source/runs_data_source_types';
 
 export interface DiscreteFilter {


### PR DESCRIPTION
With this change, when user clicks on overflow menu, one will find a
menu item for downloading the data. When user clicks on it, time series
will bring up a dialog which user can interact with to select a run to
download for the tag selected.

Do note that this is not yet implemented for the histograms and image
data types.

![image](https://user-images.githubusercontent.com/2547313/111853217-4ca28e80-88d7-11eb-9992-bfa21b61f463.png)

Sync is not tested yet and will be tested after a code review.