### PR TITLE
cli: add `--extra_data_server_flags`

### DIFF
--- a/tensorboard/data/server_ingester.py
+++ b/tensorboard/data/server_ingester.py
@@ -68,6 +68,7 @@ class SubprocessServerDataIngester(ingester.DataIngester):
         reload_interval,
         channel_creds_type,
         samples_per_plugin=None,
+        extra_flags=None,
     ):
         """Initializes an ingester with the given configuration.
 
@@ -79,6 +80,8 @@ class SubprocessServerDataIngester(ingester.DataIngester):
             `--grpc_creds_type`.
           samples_per_plugin: Dict[String, Int], as parsed from
             `--samples_per_plugin`.
+          extra_flags: List of extra string flags to be passed to the
+            data server without further interpretation.
         """
         self._server_binary = server_binary
         self._data_provider = None
@@ -86,6 +89,7 @@ class SubprocessServerDataIngester(ingester.DataIngester):
         self._reload_interval = reload_interval
         self._channel_creds_type = channel_creds_type
         self._samples_per_plugin = samples_per_plugin or {}
+        self._extra_flags = list(extra_flags or [])
 
     @property
     def data_provider(self):
@@ -127,6 +131,7 @@ class SubprocessServerDataIngester(ingester.DataIngester):
             args.append("--verbose")
         if logger.isEnabledFor(logging.DEBUG):
             args.append("--verbose")  # Repeat arg to increase verbosity.
+        args.extend(self._extra_flags)
 
         logger.info("Spawning data server: %r", args)
         popen = subprocess.Popen(args, stdin=subprocess.PIPE)

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -93,6 +93,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
                         "scalars": 500,
                         "images": 0,
                     },
+                    extra_flags=["--extra-flags", "--for-fun"],
                 )
                 ingester.start()
         self.assertIsInstance(
@@ -109,6 +110,8 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
             "--die-after-stdin",
             "--error-file=%s" % error_file,
             "--verbose",  # logging is enabled in tests
+            "--extra-flags",
+            "--for-fun",
         ]
         popen.assert_called_once_with(expected_args, stdin=subprocess.PIPE)
         sc.assert_called_once_with(

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -398,6 +398,17 @@ data server only if installed and supported for this invocation.
         )
 
         parser.add_argument(
+            "--extra_data_server_flags",
+            type=str,
+            default="",
+            help="""\
+Experimental. With `--load_fast`, pass these additional command-line flags to
+the data server. Subject to POSIX word splitting per `shlex.split`. Meant for
+debugging; not officially supported.
+""",
+        )
+
+        parser.add_argument(
             "--grpc_creds_type",
             type=grpc_util.ChannelCredsType,
             default=grpc_util.ChannelCredsType.LOCAL,

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -35,6 +35,7 @@ import errno
 import logging
 import mimetypes
 import os
+import shlex
 import signal
 import socket
 import sys
@@ -403,6 +404,7 @@ class TensorBoard(object):
             reload_interval=flags.reload_interval,
             channel_creds_type=flags.grpc_creds_type,
             samples_per_plugin=flags.samples_per_plugin,
+            extra_flags=shlex.split(flags.extra_data_server_flags),
         )
         ingester.start()
         return ingester


### PR DESCRIPTION
Summary:
The main `tensorboard(1)` now proxies any `--extra_data_server_flags` to
the data server binary invoked as a subprocess. This would have been
useful as a less invasive workaround for #4801, and may serve as a
similar escape hatch in the future.

The argument to `--extra_data_server_flags` undergoes POSIX word
splitting, so you can pass multiple arguments by separating them by
spaces, quoting appropriately. Thus:

```
tensorboard --extra_data_server_flags="--host 'localhost or something'"
```

You can’t override flags that `tensorboard(1)` already passes, though,
because the data server will complain about conflicting arguments.
Thus, this interface is marked as unstable and is not intended to ever
be stabilized.

Test Plan:
Unit tests suffice.

wchargin-branch: cli-extra-data-server-flags
