### PR TITLE
cli: enable fast Rust data loading by default

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -394,9 +394,9 @@ port to TensorBoard as a subprocess.(default: %(default)s).\
             help="""\
 Use alternate mechanism to load data. Typically 100x faster or more, but only
 available on some platforms and invocations. Defaults to "auto" to use this new
-mode only if only if available, otherwise falling back to the legacy loading
-path. Set to "true" to suppress the advisory note and hard-fail if the fast
-codepath is not available. Set to "false" to always fall back. Feedback/issues:
+mode only if available, otherwise falling back to the legacy loading path. Set
+to "true" to suppress the advisory note and hard-fail if the fast codepath is
+not available. Set to "false" to always fall back. Feedback/issues:
 https://github.com/tensorflow/tensorboard/issues/4784
 (default: %(default)s)
 """,

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -392,11 +392,13 @@ port to TensorBoard as a subprocess.(default: %(default)s).\
             default="auto",
             choices=["false", "auto", "true"],
             help="""\
-Use alternate mechanism to load data. Typically 100x faster or more. Set to
-"auto" to use this new mode only if only if installed and supported for this
-invocation. Set to "true" to suppress the advisory note and hard-fail if the
-fast codepath is not available. Set to "false" to always fall back to legacy
-loading. (default: %(default)s)
+Use alternate mechanism to load data. Typically 100x faster or more, but only
+available on some platforms and invocations. Defaults to "auto" to use this new
+mode only if only if available, otherwise falling back to the legacy loading
+path. Set to "true" to suppress the advisory note and hard-fail if the fast
+codepath is not available. Set to "false" to always fall back. Feedback/issues:
+https://github.com/tensorflow/tensorboard/issues/4784
+(default: %(default)s)
 """,
         )
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -389,11 +389,14 @@ port to TensorBoard as a subprocess.(default: %(default)s).\
         parser.add_argument(
             "--load_fast",
             type=str,
-            default="false",
+            default="auto",
             choices=["false", "auto", "true"],
             help="""\
-Experimental. Use a data server to accelerate loading. Set to "auto" to use a
-data server only if installed and supported for this invocation.
+Use alternate mechanism to load data. Typically 100x faster or more. Set to
+"auto" to use this new mode only if only if installed and supported for this
+invocation. Set to "true" to suppress the advisory note and hard-fail if the
+fast codepath is not available. Set to "false" to always fall back to legacy
+loading. (default: %(default)s)
 """,
         )
 


### PR DESCRIPTION
Summary:
Running `tensorboard` now defaults to the fast data loading codepath
when available. This *does not* affect systems where RustBoard is not
installed, including on platforms where it’s unavailable. It also does
not affect invocations in which RustBoard detects that it is not
suitable for the job, such as an unsupported remote filesystem or
credential set. In such cases, TensorBoard will automatically fall back
to the legacy multiplexer paths. This selection is silent unless
`--verbosity 0` is given.

Because of this automatic fallback detection, this change is expected to
be “safe”. There may of course be undiscovered bugs in RustBoard, in
which case users have `--load_fast=false` as an escape hatch.

Users can also set `--load_fast=true` to bypass the selection logic,
suppress the advisory note that new loading logic is being used, and
hard-fail if RustBoard is not available.

Test Plan:
`bazel run //tensorboard` loads fast.

wchargin-branch: load-fast-auto
