### PR TITLE
chore: upgrade threejs to 0.125.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "numeric": "^1.2.6",
     "plottable": "^3.9.0",
     "rxjs": "7.0.0-beta.0",
-    "three": "~0.108.0",
+    "three": "~0.125.0",
     "umap-js": "^1.3.2",
     "web-animations-js": "^2.3.2",
     "zone.js": "^0.10.2"

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
@@ -437,10 +437,23 @@ export class MeshViewer extends THREE.EventDispatcher {
     }) as any;
     const geometry = new THREE.BufferGeometry();
     // Flattens the [N, 3] shaped `vertices` into a N*3 length array.
+    // THREE.BufferAttribute expects values to be a shallow list, with the
+    // itemSize specified.
     const flatPoints = new Float32Array(vertices.flat());
     geometry.setAttribute('position', new THREE.BufferAttribute(flatPoints, 3));
 
-    // Flattens the [N, 3] shaped `faces` into a N*3 length array of indices.
+    /**
+     * Flattens the [N, 3] shaped `faces` into a N*3 length array of indices.
+     * This array of integers corresponds to triplets in the 'position'
+     * attribute. For example,
+     *   flatPoints = new Float32Array([7.5, 0, 0, 8.5, 0, 0, 9.5, 0, 0]);
+     *   vertexIndicesPerFace = new Uint16Array([2, 0, 1]);
+     *
+     * corresponds to 1 face with vertices
+     *   vertex1 at (9.5, 0, 0)
+     *   vertex2 at (7.5, 0, 0)
+     *   vertex3 at (8.5, 0, 0)
+     */
     const vertexIndicesPerFace = new Uint16Array(faces.flat());
 
     if (colors && colors.length) {

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
@@ -337,7 +337,7 @@ export class MeshViewer extends THREE.EventDispatcher {
     };
     // Determine what colors will be used.
     if (colors && colors.length == points.length) {
-      defaultConfig.material['vertexColors'] = THREE.VertexColors;
+      defaultConfig.material['vertexColors'] = true;
     } else {
       defaultConfig.material['color'] = this._runColor;
     }
@@ -345,24 +345,18 @@ export class MeshViewer extends THREE.EventDispatcher {
       config,
       defaultConfig
     ) as PointCloudConfig;
-    var geometry = new THREE.Geometry();
-    points.forEach(function (point) {
-      var p = new THREE.Vector3(point[0], point[1], point[2]);
-      const scale = 1;
-      p.x = point[0] * scale;
-      p.y = point[1] * scale;
-      p.z = point[2] * scale;
-      geometry.vertices.push(p);
-    });
+    const geometry = new THREE.BufferGeometry();
+    // Flattens the [N, 3] shaped `points` into a N*3 length array.
+    const flatPoints = new Float32Array(points.flat());
+    geometry.setAttribute('position', new THREE.BufferAttribute(flatPoints, 3));
+
     if (colors && colors.length == points.length) {
-      colors.forEach(function (color) {
-        const c = new THREE.Color(
-          color[0] / 255,
-          color[1] / 255,
-          color[2] / 255
-        );
-        geometry.colors.push(c);
-      });
+      // Flattens the N colors into a N*3 length array.
+      const flatColors = new Float32Array(colors.flat());
+      for (let i = 0; i < flatColors.length; i++) {
+        flatColors[i] = flatColors[i] / 255;
+      }
+      geometry.setAttribute('color', new THREE.BufferAttribute(flatColors, 3));
     }
     var material = new THREE[pc_config.material.cls](pc_config.material);
     var mesh = new THREE.Points(geometry, material);
@@ -441,46 +435,37 @@ export class MeshViewer extends THREE.EventDispatcher {
         metalness: 0,
       },
     }) as any;
-    let geometry = new THREE.Geometry();
-    vertices.forEach(function (point) {
-      let p = new THREE.Vector3(point[0], point[1], point[2]);
-      const scale = 1;
-      p.x = point[0] * scale;
-      p.y = point[1] * scale;
-      p.z = point[2] * scale;
-      geometry.vertices.push(p);
-    });
-    faces.forEach(function (face_indices) {
-      let face = new THREE.Face3(
-        face_indices[0],
-        face_indices[1],
-        face_indices[2]
-      );
-      if (colors && colors.length) {
-        const face_colors = [
-          colors[face_indices[0]],
-          colors[face_indices[1]],
-          colors[face_indices[2]],
-        ];
-        for (let i = 0; i < face_colors.length; i++) {
-          const vertex_color = face_colors[i];
-          let color = new THREE.Color(
-            vertex_color[0] / 255,
-            vertex_color[1] / 255,
-            vertex_color[2] / 255
-          );
-          face.vertexColors.push(color);
-        }
-      }
-      geometry.faces.push(face);
-    });
+    const geometry = new THREE.BufferGeometry();
+    // Flattens the [N, 3] shaped `vertices` into a N*3 length array.
+    const flatPoints = new Float32Array(vertices.flat());
+    geometry.setAttribute('position', new THREE.BufferAttribute(flatPoints, 3));
+
+    // Flattens the [N, 3] shaped `faces` into a N*3 length array of indices.
+    const vertexIndicesPerFace = new Uint16Array(faces.flat());
+
     if (colors && colors.length) {
+      // Flat colors is a N*3*3 length array of colors, where there are N faces,
+      // each face has 3 colors, and each color has 3 components (RGB).
+      const flatColors = colors.flat();
+      for (let i = 0; i < flatColors.length; i++) {
+        flatColors[i] = flatColors[i] / 255;
+      }
+      geometry.setAttribute(
+        'color',
+        new THREE.BufferAttribute(new Float32Array(flatColors), 3)
+      );
+
       mesh_config.material = mesh_config.material || {};
-      mesh_config.material.vertexColors = THREE.VertexColors;
+      mesh_config.material.vertexColors = true;
     }
+
     geometry.center();
     geometry.computeBoundingSphere();
+    // We intentionally set the index before `computeVertexNormals()`, which may
+    // check for indexed values.
+    geometry.setIndex(new THREE.BufferAttribute(vertexIndicesPerFace, 1));
     geometry.computeVertexNormals();
+
     let material = new THREE[mesh_config.material.cls](mesh_config.material);
     let mesh = new THREE.Mesh(geometry, material);
     mesh.castShadow = true;

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizer3DLabels.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizer3DLabels.ts
@@ -71,7 +71,7 @@ const VERTEX_SHADER = `
       gl_Position = projectionMatrix * mvPosition;
     }`;
 const FRAGMENT_SHADER = `
-    uniform sampler2D texture;
+    uniform sampler2D shaderTexture;
     uniform bool picking;
     varying vec2 vUv;
     varying vec3 vColor;
@@ -80,7 +80,7 @@ const FRAGMENT_SHADER = `
       if (picking) {
         gl_FragColor = vec4(vColor, 1.0);
       } else {
-        vec4 fromTexture = texture2D(texture, vUv);
+        vec4 fromTexture = texture2D(shaderTexture, vUv);
         gl_FragColor = vec4(vColor, 1.0) * fromTexture;
       }
     }`;
@@ -179,7 +179,7 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     }
     this.glyphTexture = this.createGlyphTexture();
     this.uniforms = {
-      texture: {type: 't'},
+      shaderTexture: {type: 't'},
       picking: {type: 'bool'},
     };
     this.material = new THREE.ShaderMaterial({
@@ -210,10 +210,10 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     let uv = new THREE.BufferAttribute(uvArray, UV_ELEMENTS_PER_ENTRY);
     let colors = new THREE.BufferAttribute(colorsArray, RGB_ELEMENTS_PER_ENTRY);
     this.geometry = new THREE.BufferGeometry();
-    this.geometry.addAttribute('posObj', positionObject);
-    this.geometry.addAttribute('position', this.positions);
-    this.geometry.addAttribute('uv', uv);
-    this.geometry.addAttribute('color', colors);
+    this.geometry.setAttribute('posObj', positionObject);
+    this.geometry.setAttribute('position', this.positions);
+    this.geometry.setAttribute('uv', uv);
+    this.geometry.setAttribute('color', colors);
     let lettersSoFar = 0;
     for (let i = 0; i < pointCount; i++) {
       const label = this.labelStrings[i];
@@ -275,8 +275,8 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     ) {
       return;
     }
-    const colors = this.geometry.getAttribute('color') as THREE.BufferAttribute;
-    (colors as any).setArray(this.renderColors);
+    const colors = new THREE.BufferAttribute(this.renderColors, 3);
+    this.geometry.setAttribute('color', colors);
     const n = pointColors.length / XYZ_ELEMENTS_PER_ENTRY;
     let src = 0;
     for (let i = 0; i < n; ++i) {
@@ -319,10 +319,10 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     if (this.geometry == null) {
       return;
     }
-    this.material.uniforms.texture.value = this.glyphTexture.texture;
+    this.material.uniforms.shaderTexture.value = this.glyphTexture.texture;
     this.material.uniforms.picking.value = true;
-    const colors = this.geometry.getAttribute('color') as THREE.BufferAttribute;
-    (colors as any).setArray(this.pickingColors);
+    const colors = new THREE.BufferAttribute(this.pickingColors, 3);
+    this.geometry.setAttribute('color', colors);
     colors.needsUpdate = true;
   }
   onRender(rc: RenderContext) {
@@ -333,10 +333,10 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
       return;
     }
     this.colorLabels(rc.pointColors);
-    this.material.uniforms.texture.value = this.glyphTexture.texture;
+    this.material.uniforms.shaderTexture.value = this.glyphTexture.texture;
     this.material.uniforms.picking.value = false;
-    const colors = this.geometry.getAttribute('color') as THREE.BufferAttribute;
-    (colors as any).setArray(this.renderColors);
+    const colors = new THREE.BufferAttribute(this.renderColors, 3);
+    this.geometry.setAttribute('color', colors);
     colors.needsUpdate = true;
   }
   onPointPositionsChanged(newPositions: Float32Array) {

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerPolylines.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerPolylines.ts
@@ -51,13 +51,13 @@ export class ScatterPlotVisualizerPolylines implements ScatterPlotVisualizer {
     this.polylines = [];
     for (let i = 0; i < this.dataSet.sequences.length; i++) {
       const geometry = new THREE.BufferGeometry();
-      geometry.addAttribute('position', this.polylinePositionBuffer[i]);
-      geometry.addAttribute('color', this.polylineColorBuffer[i]);
+      geometry.setAttribute('position', this.polylinePositionBuffer[i]);
+      geometry.setAttribute('color', this.polylineColorBuffer[i]);
       const material = new THREE.LineBasicMaterial({
         linewidth: 1, // unused default, overwritten by width array.
         opacity: 1.0, // unused default, overwritten by opacity array.
         transparent: true,
-        vertexColors: THREE.VertexColors as any,
+        vertexColors: true,
       });
       const polyline = new THREE.LineSegments(geometry, material);
       polyline.frustumCulled = false;
@@ -131,10 +131,14 @@ export class ScatterPlotVisualizerPolylines implements ScatterPlotVisualizer {
       const mat = this.polylines[i].material as THREE.LineBasicMaterial;
       mat.opacity = renderContext.polylineOpacities[i];
       mat.linewidth = renderContext.polylineWidths[i];
-      (this.polylineColorBuffer[i] as any).setArray(
-        renderContext.polylineColors[i]
+
+      const newColor = new THREE.BufferAttribute(
+        renderContext.polylineColors[i],
+        3
       );
-      this.polylineColorBuffer[i].needsUpdate = true;
+      this.polylineColorBuffer[i] = newColor;
+      newColor.needsUpdate = true;
+      this.polylines[i].geometry.setAttribute('color', newColor);
     }
   }
   onPickingRender(renderContext: RenderContext) {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4994,10 +4994,10 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-three@~0.108.0:
-  version "0.108.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.108.0.tgz#53d26597c7932f214bb43f4655e566d2058143b5"
-  integrity sha512-d1ysIXwi8qTlbmMwrTxi5pYiiYIflEr0e48krP0LAY8ndS8c6fkLHn6NvRT+o76/Fs9PBLxFViuI62iGVWwwlg==
+three@~0.125.0:
+  version "0.125.2"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.125.2.tgz#dcba12749a2eb41522e15212b919cd3fbf729b12"
+  integrity sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
Upgrading to the newer Three.js 0.125.0 to silence dependabot warnings.
Notable changes:
- `Material`'s `vertexColors` is now a boolean
- `BufferAttribute.setArray` was removed in favor of
   `BufferedGeometry.setAttribute`
- Words like `texture` became reserved keywords when used in Three.js'
   shaders

Manually checked that the mesh demo, projector demo, and some custom
projector example with sprite images look as expected. I did not test the
"polylines that connect multiple points in a dataset" feature in the Projector
since I do not know how it works. Line charts in the Time Series look normal
as well.

See the Three.js changelog: https://github.com/mrdoob/three.js/wiki/Migration-Guide
Will be rendered obsolete: https://github.com/tensorflow/tensorboard/pull/4715
Googlers, see b/150083780, test sync cl/364427588, and copybara
cl/365095009.

![image](https://user-images.githubusercontent.com/2322480/112070522-13625c80-8b2b-11eb-8fd7-c8f89f13c961.png)
