### PR TITLE
timeseries: customizable settings w/ DI

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -280,6 +280,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/feature_flag/effects:effects_test_lib",
         "//tensorboard/webapp/feature_flag/store:store_test_lib",
         "//tensorboard/webapp/header:test_lib",
+        "//tensorboard/webapp/metrics:integration_test",
         "//tensorboard/webapp/metrics:test_lib",
         "//tensorboard/webapp/metrics/data_source:metrics_data_source_test",
         "//tensorboard/webapp/metrics/effects:effects_test",

--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -139,6 +139,15 @@ tf_ts_library(
     ],
 )
 
+# This is a dummy rule used as a @angular/material/icon/testing dependency.
+tf_ts_library(
+    name = "expect_angular_material_icon_testing",
+    srcs = [],
+    deps = [
+        "@npm//@angular/material",
+    ],
+)
+
 # This is a dummy rule used as a @angular/material/input dependency.
 tf_ts_library(
     name = "expect_angular_material_input",

--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -15,6 +15,7 @@ tf_ng_module(
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/effects",
         "//tensorboard/webapp/metrics/store",
+        "//tensorboard/webapp/metrics/store:metrics_initial_state_provider",
         "//tensorboard/webapp/metrics/views",
         "//tensorboard/webapp/plugins:plugin_registry",
         "//tensorboard/webapp/runs/views/runs_selector",
@@ -66,5 +67,25 @@ tf_ts_library(
         "@npm//@angular/core",
         "@npm//@types/jasmine",
         "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "integration_test",
+    testonly = True,
+    srcs = [
+        "metrics_integration_test.ts",
+    ],
+    deps = [
+        ":metrics",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_dynamic_testing",
+        "//tensorboard/webapp/metrics/store:metrics_initial_state_provider",
+        "//tensorboard/webapp/metrics/store:types",
+        "//tensorboard/webapp/metrics/views",
+        "//tensorboard/webapp/testing:integration_test_module",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
     ],
 )

--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -85,6 +85,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/store:types",
         "//tensorboard/webapp/metrics/views",
         "//tensorboard/webapp/testing:integration_test_module",
+        "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",
     ],

--- a/tensorboard/webapp/metrics/metrics_integration_test.ts
+++ b/tensorboard/webapp/metrics/metrics_integration_test.ts
@@ -1,0 +1,66 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+
+import {IntegrationTestSetupModule} from '../testing/integration_test_module';
+import {MetricsModule} from './metrics_module';
+import {METRICS_INITIAL_SETTINGS} from './store/metrics_initial_state_provider';
+import {METRICS_SETTINGS_DEFAULT} from './store/metrics_types';
+import {MetricsDashboardContainer} from './views/metrics_container';
+
+describe('metrics integration test', () => {
+  const ByCss = {
+    SCALARS_SMOOTHING_INPUT: By.css('.scalars-smoothing input'),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        IntegrationTestSetupModule,
+        NoopAnimationsModule,
+        MetricsModule,
+      ],
+    });
+  });
+
+  describe('dependency injection', () => {
+    it('populates correct default settings', async () => {
+      await TestBed.compileComponents();
+      const fixture = TestBed.createComponent(MetricsDashboardContainer);
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(ByCss.SCALARS_SMOOTHING_INPUT);
+      expect(input.nativeElement.value).toBe('0.6');
+    });
+
+    it('permits overriding default settings with DI', async () => {
+      TestBed.overrideProvider(METRICS_INITIAL_SETTINGS, {
+        useValue: {
+          ...METRICS_SETTINGS_DEFAULT,
+          scalarSmoothing: 0.3,
+        },
+      });
+      await TestBed.compileComponents();
+      const fixture = TestBed.createComponent(MetricsDashboardContainer);
+
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(ByCss.SCALARS_SMOOTHING_INPUT);
+      expect(input.nativeElement.value).toBe('0.3');
+    });
+  });
+});

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -22,7 +22,12 @@ import {RunsSelectorModule} from '../runs/views/runs_selector/runs_selector_modu
 
 import {METRICS_PLUGIN_ID, MetricsDataSourceModule} from './data_source';
 import {MetricsEffects} from './effects';
-import {METRICS_FEATURE_KEY, reducers} from './store';
+import {METRICS_FEATURE_KEY, METRICS_SETTINGS_DEFAULT, reducers} from './store';
+import {
+  getConfig,
+  METRICS_INITIAL_SETTINGS,
+  METRICS_STORE_CONFIG_TOKEN,
+} from './store/metrics_initial_state_provider';
 import {MetricsDashboardContainer} from './views/metrics_container';
 import {MetricsViewsModule} from './views/metrics_views_module';
 import {AlertActionModule} from '../alert/alert_action_module';
@@ -65,9 +70,24 @@ export function alertActionProvider() {
     ),
     MetricsDataSourceModule,
     MetricsViewsModule,
-    StoreModule.forFeature(METRICS_FEATURE_KEY, reducers),
+    StoreModule.forFeature(
+      METRICS_FEATURE_KEY,
+      reducers,
+      METRICS_STORE_CONFIG_TOKEN
+    ),
     EffectsModule.forFeature([MetricsEffects]),
     AlertActionModule.registerAlertActions(alertActionProvider),
+  ],
+  providers: [
+    {
+      provide: METRICS_STORE_CONFIG_TOKEN,
+      useFactory: getConfig,
+      deps: [METRICS_INITIAL_SETTINGS],
+    },
+    {
+      provide: METRICS_INITIAL_SETTINGS,
+      useValue: METRICS_SETTINGS_DEFAULT,
+    },
   ],
   entryComponents: [MetricsDashboardContainer],
 })

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -24,6 +24,19 @@ tf_ts_library(
         "//tensorboard/webapp/util:lang",
         "//tensorboard/webapp/util:ngrx",
         "//tensorboard/webapp/util:types",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ng_module(
+    name = "metrics_initial_state_provider",
+    srcs = [
+        "metrics_initial_state_provider.ts",
+    ],
+    deps = [
+        ":store",
+        ":types",
+        "@npm//@angular/core",
         "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/metrics/store/metrics_initial_state_provider.ts
+++ b/tensorboard/webapp/metrics/store/metrics_initial_state_provider.ts
@@ -1,0 +1,49 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {InjectionToken} from '@angular/core';
+import {StoreConfig} from '@ngrx/store';
+
+import {INITIAL_STATE} from './metrics_reducers';
+import {MetricsState} from './metrics_types';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+export const METRICS_STORE_CONFIG_TOKEN = new InjectionToken<
+  StoreConfig<MetricsState>
+>('Metrics Store Config');
+
+export const METRICS_INITIAL_SETTINGS = new InjectionToken<
+  StoreConfig<MetricsState['settings'] | null>
+>('Metrics Initial Settings Config');
+
+export function getConfig(
+  settings: MetricsState['settings']
+): StoreConfig<MetricsState> {
+  if (!settings) {
+    return {
+      initialState: INITIAL_STATE,
+    };
+  }
+
+  return {
+    initialState: {
+      // For other states, please make sure you only provide the routeless state. Routeful
+      // initial state cannot be dependency injected as of right now.
+      ...INITIAL_STATE,
+      settings,
+    },
+  };
+}

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -260,6 +260,8 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState(
   }
 );
 
+export const INITIAL_STATE = initialState;
+
 const reducer = createReducer(
   initialState,
   on(stateRehydratedFromUrl, (state, {routeKind, partialState}) => {
@@ -758,7 +760,7 @@ const reducer = createReducer(
   })
 );
 
-export function reducers(state: MetricsState, action: Action) {
+export function reducers(state: MetricsState | undefined, action: Action) {
   return composeReducers(reducer, routeContextReducer)(state, action);
 }
 

--- a/tensorboard/webapp/runs/views/runs_selector/runs_selector_container.ts
+++ b/tensorboard/webapp/runs/views/runs_selector/runs_selector_container.ts
@@ -36,7 +36,9 @@ import {RunsTableColumn} from '../runs_table/types';
 export class RunsSelectorContainer {
   @Input() showHparamsAndMetrics?: boolean;
 
-  readonly experimentIds$ = this.store.select(getExperimentIdsFromRoute);
+  readonly experimentIds$ = this.store
+    .select(getExperimentIdsFromRoute)
+    .pipe(map((experimentIdsOrNull) => experimentIdsOrNull ?? []));
   readonly columns$ = this.store.select(getExperimentIdsFromRoute).pipe(
     map((ids) => {
       return [

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -16,7 +16,7 @@ import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
 import {createSelector, Store} from '@ngrx/store';
 import {DataLoadState, LoadState} from '../../../types/data';
 import {combineLatest, Observable, of} from 'rxjs';
-import {combineLatestWith, map, shareReplay} from 'rxjs/operators';
+import {combineLatestWith, map, shareReplay, startWith} from 'rxjs/operators';
 
 import {State} from '../../../app_state';
 import {
@@ -435,7 +435,8 @@ export class RunsTableContainer implements OnInit {
         }
         const {pageSize, pageIndex} = paginationOption;
         return items.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize);
-      })
+      }),
+      startWith([])
     );
 
     return slicedItems;

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -25,6 +25,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/angular:expect_angular_material_icon",
+        "//tensorboard/webapp/angular:expect_angular_material_icon_testing",
         "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -24,6 +24,7 @@ tf_ng_module(
         "mat_icon_module.ts",
     ],
     deps = [
+        "//tensorboard/webapp/angular:expect_angular_material_icon",
         "@npm//@angular/core",
     ],
 )
@@ -54,6 +55,31 @@ tf_ng_module(
     deps = [
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "@npm//@angular/core",
+    ],
+)
+
+tf_ng_module(
+    name = "integration_test_module",
+    srcs = [
+        "integration_test_module.ts",
+    ],
+    deps = [
+        ":mat_icon",
+        "//tensorboard/webapp:reducer_config",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_dynamic_testing",
+        "//tensorboard/webapp/app_routing",
+        "//tensorboard/webapp/app_routing:route_config",
+        "//tensorboard/webapp/app_routing:route_registry",
+        "//tensorboard/webapp/app_routing:types",
+        "//tensorboard/webapp/core",
+        "//tensorboard/webapp/deeplink",
+        "//tensorboard/webapp/feature_flag",
+        "//tensorboard/webapp/runs",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
     ],
 )
 

--- a/tensorboard/webapp/testing/integration_test_module.ts
+++ b/tensorboard/webapp/testing/integration_test_module.ts
@@ -58,7 +58,7 @@ export class TestableComponent {}
 
 // Fake route definition to prevent route redirection due to the `defaultRoute` on the
 // real one.
-function provideRoute(): RouteDef[] {
+export function provideRoute(): RouteDef[] {
   return [
     {
       routeKind: RouteKind.EXPERIMENT,
@@ -80,5 +80,7 @@ function provideRoute(): RouteDef[] {
     NgrxEffectsModule.forRoot([]),
   ],
   providers: [{provide: HashDeepLinker, useClass: TestableNoopHashDeepLinker}],
+  declarations: [TestableComponent],
+  exports: [TestableComponent],
 })
 export class IntegrationTestSetupModule {}

--- a/tensorboard/webapp/testing/integration_test_module.ts
+++ b/tensorboard/webapp/testing/integration_test_module.ts
@@ -1,0 +1,84 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * Module for helping with integrational style testing.
+ *
+ * This module does not facilitate any screenshot testing.
+ */
+import {Component, Injectable, NgModule} from '@angular/core';
+import {EffectsModule as NgrxEffectsModule} from '@ngrx/effects';
+import {StoreModule as NgrxStoreModule} from '@ngrx/store';
+
+import {AppRoutingModule} from '../app_routing/app_routing_module';
+import {RouteDef} from '../app_routing/route_config_types';
+import {RouteRegistryModule} from '../app_routing/route_registry_module';
+import {RouteKind} from '../app_routing/types';
+import {CoreModule} from '../core/core_module';
+import {DeepLinkerInterface, HashDeepLinker} from '../deeplink';
+import {FeatureFlagModule} from '../feature_flag/feature_flag_module';
+import {RunsModule} from '../runs/runs_module';
+import {MatIconTestingModule} from './mat_icon_module';
+
+/**
+ * Prevent reading or modification of real hashes.
+ */
+@Injectable()
+export class TestableNoopHashDeepLinker implements DeepLinkerInterface {
+  getString(key: string): string {
+    return '';
+  }
+  setString(key: string, value: string): void {
+    // noop
+  }
+  getPluginId(): string {
+    return '';
+  }
+  setPluginId(pluginId: string): void {
+    // noop
+  }
+}
+
+@Component({
+  selector: 'test',
+  template: 'hello',
+})
+export class TestableComponent {}
+
+// Fake route definition to prevent route redirection due to the `defaultRoute` on the
+// real one.
+function provideRoute(): RouteDef[] {
+  return [
+    {
+      routeKind: RouteKind.EXPERIMENT,
+      path: '/',
+      ngComponent: TestableComponent,
+    },
+  ];
+}
+
+@NgModule({
+  imports: [
+    MatIconTestingModule,
+    FeatureFlagModule,
+    CoreModule,
+    AppRoutingModule,
+    RunsModule,
+    RouteRegistryModule.registerRoutes(provideRoute),
+    NgrxStoreModule.forRoot([]),
+    NgrxEffectsModule.forRoot([]),
+  ],
+  providers: [{provide: HashDeepLinker, useClass: TestableNoopHashDeepLinker}],
+})
+export class IntegrationTestSetupModule {}

--- a/tensorboard/webapp/testing/mat_icon_module.ts
+++ b/tensorboard/webapp/testing/mat_icon_module.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Component, Input, NgModule} from '@angular/core';
+import {MatIconTestingModule as RealMatIconTestingModule} from '@angular/material/icon/testing';
 
 // Keep in sync with the 'svg_bundle' target in tensorboard/webapp/BUILD.
 const KNOWN_SVG_ICON = new Set([
@@ -107,5 +108,6 @@ export class MatIcon {
 @NgModule({
   exports: [MatIcon],
   declarations: [MatIcon],
+  imports: [RealMatIconTestingModule],
 })
 export class MatIconTestingModule {}

--- a/tensorboard/webapp/testing/mat_icon_module.ts
+++ b/tensorboard/webapp/testing/mat_icon_module.ts
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Component, Input, NgModule} from '@angular/core';
-import {MatIconTestingModule as RealMatIconTestingModule} from '@angular/material/icon/testing';
+import {MatIconRegistry} from '@angular/material/icon';
+import {FakeMatIconRegistry} from '@angular/material/icon/testing';
 
 // Keep in sync with the 'svg_bundle' target in tensorboard/webapp/BUILD.
 const KNOWN_SVG_ICON = new Set([
@@ -108,6 +109,6 @@ export class MatIcon {
 @NgModule({
   exports: [MatIcon],
   declarations: [MatIcon],
-  imports: [RealMatIconTestingModule],
+  providers: [{provide: MatIconRegistry, useClass: FakeMatIconRegistry}],
 })
 export class MatIconTestingModule {}


### PR DESCRIPTION
This change introduces DI for the time series' redux state to allow
different application to provide the default settings. Do note that this
pattern CANNOT be used for a route aware states.

Also do note that this change introduces some infrastructure for
integrational style testing using Jasmine to better test the behavior
provided by the metrics_module which otherwise is not really tested.

Extraneous looking changes are due to the integration test which,
for instance, does not provide certain values from the store (due to a
lacking experimentId from the route) and break certain assumptions.