### PR TITLE
time series: fix the data download module

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_module.ts
@@ -36,5 +36,6 @@ import {DataDownloadDialogContainer} from './data_download_dialog_container';
     MatSelectModule,
     MetricsDataSourceModule,
   ],
+  entryComponents: [DataDownloadDialogContainer],
 })
 export class DataDownloadModule {}


### PR DESCRIPTION
Internally, we still need the entryComponents property to make work.
Without it, the MatDialog cannot mount the component.
