### PR TITLE
histograms: warn when metadata version is too new

### DIFF
--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -19,6 +19,7 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/data:provider",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/plugins/histogram/metadata.py
+++ b/tensorboard/plugins/histogram/metadata.py
@@ -63,12 +63,5 @@ def parse_plugin_metadata(content):
         result = plugin_data_pb2.HistogramPluginData.FromString(content)
         if result.version == 0:
             return result
-        else:
-            logger.warning(
-                "Unknown metadata version: %s. The latest version known to "
-                "this build of TensorBoard is %s; perhaps a newer build is "
-                "available?",
-                result.version,
-                PROTO_VERSION,
-            )
-            return result
+        # No other versions known at this time, so no migrations to do.
+        return result


### PR DESCRIPTION
Summary:
We’re considering making changes to the histogram data format, most
immediately to resolve dynamic shape issues, but maybe also to generally
improve the sampling and binning behavior. This patch teaches the
histograms plugin to check the summary metadata’s `version` field and
complain if it’s not not `0` (the default, and the implicit value).
This way, if users try to use an old TensorBoard version to read data in
the new format, they’ll see a nice message instead of potential crashes
or misrepresented data.

It’d be reasonable to adopt something similar for all our plugins, but
let’s start here for now.

Test Plan:
Changing the check to `md.version != 777` properly causes a message to
be printed once (only) and no data to appear in the UI.

wchargin-branch: histograms-version-warning
