### PR TITLE
rust: upgrade to Rust 1.51.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,11 @@ jobs:
       matrix:
         mode: ['native']
         platform: ['ubuntu-16.04', 'macos-10.15']
-        rust_version: ['1.50.0']
+        rust_version: ['1.51.0']
         include:
           - mode: 'universal'
             platform: 'ubuntu-16.04'
-            rust_version: '1.50.0'
+            rust_version: '1.51.0'
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
@@ -233,7 +233,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        rust_version: ['1.50.0']
+        rust_version: ['1.51.0']
         cargo_raze_version: ['0.9.2']
     steps:
       - uses: actions/checkout@v1

--- a/third_party/rust.bzl
+++ b/third_party/rust.bzl
@@ -21,5 +21,5 @@ load("//third_party/rust:crates.bzl", "raze_fetch_remote_crates")
 
 def tensorboard_rust_workspace():
     """TensorBoard Rust dependencies."""
-    rust_repositories(version = "1.50.0")
+    rust_repositories(version = "1.51.0")
     raze_fetch_remote_crates()


### PR DESCRIPTION
Summary:
Rust 1.51 is out! The [release notes] have the rundown, but the headline
feature is minimal viable const generics, or “non-type template
parameters” by analogy to C++. In particular, items can now be generic
over the length of arrays, which we’ve wanted to do a few times.

Benchmarks show no significant change in runtime performance.

[release notes]: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html

wchargin-branch: rust-v1.51.0
