### PR TITLE
Add `async_call_with_retries` method to grpc_util.

### DIFF
--- a/tensorboard/util/grpc_util.py
+++ b/tensorboard/util/grpc_util.py
@@ -92,6 +92,8 @@ def async_call_with_retries(
         like the standard `time` module; if not passed, uses the normal module.
 
     """
+    if clock is None:
+        clock = time
     if num_remaining_tries < 0:
         # This should not happen in the course of normal operations and
         # indicates a bug in the implementation.

--- a/tensorboard/util/grpc_util.py
+++ b/tensorboard/util/grpc_util.py
@@ -51,9 +51,7 @@ _GRPC_RETRYABLE_STATUS_CODES = frozenset(
 _VERSION_METADATA_KEY = "tensorboard-version"
 
 
-def async_call_with_retries(
-    api_method, request, done_callback, clock=None
-):
+def async_call_with_retries(api_method, request, done_callback, clock=None):
     """Initiate an asynchronous call to a gRPC stub, with retry logic.
 
     This is similar to the `async_call` API, except that the call is handled

--- a/tensorboard/util/grpc_util.py
+++ b/tensorboard/util/grpc_util.py
@@ -131,6 +131,12 @@ def async_call_with_retries(
                 return
             # If able to retry, wait then do so.
             backoff_secs = _compute_backoff_seconds(num_tries_so_far + 1)
+            logger.info(
+                "RPC call %s attempted %d times, retrying in %.1f seconds",
+                rpc_name,
+                num_tries_so_far,
+                backoff_secs,
+            )
             clock.sleep(backoff_secs)
             async_call_with_retries(
                 api_method=api_method,

--- a/tensorboard/util/grpc_util.py
+++ b/tensorboard/util/grpc_util.py
@@ -50,14 +50,15 @@ _GRPC_RETRYABLE_STATUS_CODES = frozenset(
 # gRPC metadata key whose value contains the client version.
 _VERSION_METADATA_KEY = "tensorboard-version"
 
+
 def async_call_with_retries(
     api_method,
     request,
     completion_handler,
     num_remaining_tries=_GRPC_RETRY_MAX_ATTEMPTS - 1,
     num_tries_so_far=0,
-    clock=None
-    ):
+    clock=None,
+):
     """Initiate an asynchronous call to a gRPC stub, with retry logic.
 
     This is similar to the `async_call` API, except that the call is handled
@@ -95,7 +96,8 @@ def async_call_with_retries(
         # This should not happen in the course of normal operations and
         # indicates a bug in the implementation.
         raise ValueError(
-            "num_remaining_tries=%d. expected >= 0." % num_remaining_tries)
+            "num_remaining_tries=%d. expected >= 0." % num_remaining_tries
+        )
     # We can't actually use api_method.__name__ because it's not a real method,
     # it's a special gRPC callable instance that doesn't expose the method name.
     rpc_name = request.__class__.__name__.replace("Request", "")
@@ -134,10 +136,10 @@ def async_call_with_retries(
                 completion_handler=completion_handler,
                 num_remaining_tries=num_remaining_tries - 1,
                 num_tries_so_far=num_tries_so_far + 1,
-                clock=clock)
+                clock=clock,
+            )
 
     future.add_done_callback(retry_handler)
-
 
 
 def _compute_backoff_seconds(num_attempts):
@@ -149,6 +151,7 @@ def _compute_backoff_seconds(num_attempts):
         _GRPC_RETRY_EXPONENTIAL_BASE ** num_attempts
     ) * jitter_factor
     return backoff_secs
+
 
 def call_with_retries(api_method, request, clock=None):
     """Call a gRPC stub API method, with automatic retry logic.

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -18,7 +18,6 @@
 import contextlib
 import hashlib
 import threading
-from unittest import mock
 
 from concurrent import futures
 import grpc

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -18,6 +18,7 @@
 import contextlib
 import hashlib
 import threading
+from unittest import mock
 
 from concurrent import futures
 import grpc
@@ -159,6 +160,161 @@ class CallWithRetriesTest(tb_test.TestCase):
             grpc_util.extract_version(grpc_util.version_metadata())
         )
         self.assertEqual(make_response(expected_nonce), response)
+
+
+class AsyncCallWithRetriesTest(tb_test.TestCase):
+
+    def test_aync_call_with_retries_invokes_callback(self):
+        # Setup: Basic server, echos input.
+        def handler(request, _):
+            return make_response(request.nonce)
+        # Set up a callback which:
+        # 1) Records that it has been executed (mock_callback)
+        # 2) Triggers the keep_alive_event, notifying when it is ok
+        #    to kill the server.
+        keep_alive_event = threading.Event()
+        mock_callback = mock.Mock()
+        def wrapped_mock_callback(future):
+            mock_callback(future)
+            keep_alive_event.set()
+
+        server = TestGrpcServer(handler)
+        with server.run() as client:
+            # Execute `async_call_with_retries` with the callback.
+            grpc_util.async_call_with_retries(
+                client.TestRpc,
+                make_request(42),
+                completion_handler=wrapped_mock_callback
+            )
+            # Keep the test alive until the event is triggered.
+            keep_alive_event.wait()
+
+        # Expect: callback is invoked.
+        mock_callback.assert_called_once()
+
+    def test_aync_call_with_retries_succeeds(self):
+        # Setup: Basic server, echos input.
+        def handler(request, _):
+            return make_response(request.nonce)
+        # Set up a callback which:
+        # 1) Verifies the correct value has been returned in the future.
+        # 2) Triggers the keep_alive_event, notifying when it is ok
+        #    to kill the server.
+        keep_alive_event = threading.Event()
+        def check_value(future):
+            self.assertEqual(make_response(42), future.result())
+            keep_alive_event.set()
+
+        server = TestGrpcServer(handler)
+        with server.run() as client:
+            # Execute `async_call_with_retries` with the callback.
+            grpc_util.async_call_with_retries(
+                client.TestRpc,
+                make_request(42),
+                completion_handler=check_value
+            )
+            # Keep the test alive until the event is triggered.
+            keep_alive_event.wait()
+
+    def test_async_call_with_retries_fails_immediately_on_permanent_error(self):
+        # Setup: Server which fails with an ISE.
+        def handler(_, context):
+            context.abort(grpc.StatusCode.INTERNAL, "foo")
+
+        # Set up a callback which:
+        # 1) Verifies the Exception against expectations.
+        # 2) Triggers the keep_alive_event, notifying when it is ok
+        #    to kill the server.
+        keep_alive_event = threading.Event()
+        def check_exception(future):
+            raised = future.exception()
+            self.assertIsInstance(raised,grpc.RpcError)
+            self.assertEqual(grpc.StatusCode.INTERNAL, raised.code())
+            self.assertEqual("foo", raised.details())
+            keep_alive_event.set()
+
+        server = TestGrpcServer(handler)
+        with server.run() as client:
+            # Execute `async_call_with_retries` with the callback.
+            grpc_util.async_call_with_retries(
+                client.TestRpc,
+                make_request(42),
+                completion_handler=check_exception
+            )
+            # Keep the test alive until the event is triggered.
+            keep_alive_event.wait()
+
+
+    def test_async_with_retries_fails_after_backoff_on_nonpermanent_error(self):
+        attempt_times = []
+        fake_time = test_util.FakeTime()
+
+        # Setup: Server which always fails with an UNAVAILABLE error.
+        def handler(_, context):
+            attempt_times.append(fake_time.time())
+            context.abort(grpc.StatusCode.UNAVAILABLE, "foo")
+
+        # Set up a callback which:
+        # 1) Verifies the Exception against expectations.
+        # 2) Verifies the number of attempts and delays between them
+        # 3) Triggers the keep_alive_event, notifying when it is ok
+        #    to kill the server.
+        keep_alive_event = threading.Event()
+        def check_exception(future):
+            raised = future.exception()
+            self.assertEqual(grpc.StatusCode.UNAVAILABLE, raised.code())
+            self.assertEqual("foo", raised.details())
+            self.assertLen(attempt_times, 5)
+            self.assertBetween(attempt_times[1] - attempt_times[0], 2, 4)
+            self.assertBetween(attempt_times[2] - attempt_times[1], 4, 8)
+            self.assertBetween(attempt_times[3] - attempt_times[2], 8, 16)
+            self.assertBetween(attempt_times[4] - attempt_times[3], 16, 32)
+            keep_alive_event.set()
+
+
+        server = TestGrpcServer(handler)
+        with server.run() as client:
+            # Execute `async_call_with_retries` with the callback.
+            grpc_util.async_call_with_retries(
+                client.TestRpc, make_request(42), clock=fake_time, completion_handler=check_exception
+            )
+            # Keep the test alive until the event is triggered.
+            keep_alive_event.wait()
+
+    def test_async_with_retries_succeeds_after_backoff_on_transient_error(self):
+        attempt_times = []
+        fake_time = test_util.FakeTime()
+
+        # Setup: Server which passes on the third attempt.
+        def handler(request, context):
+            attempt_times.append(fake_time.time())
+            if len(attempt_times) < 3:
+                context.abort(grpc.StatusCode.UNAVAILABLE, "foo")
+            return make_response(request.nonce)
+
+        # Set up a callback which:
+        # 1) Verifies the response contains the expected value
+        # 2) Verifies the number of attempts and delays between them
+        # 3) Triggers the keep_alive_event, notifying when it is ok
+        #    to kill the server.
+        keep_alive_event = threading.Event()
+        def check_value(future):
+            self.assertEqual(make_response(42), future.result())
+            self.assertLen(attempt_times, 3)
+            self.assertBetween(attempt_times[1] - attempt_times[0], 2, 4)
+            self.assertBetween(attempt_times[2] - attempt_times[1], 4, 8)
+            keep_alive_event.set()
+
+        server = TestGrpcServer(handler)
+        with server.run() as client:
+            grpc_util.async_call_with_retries(
+                client.TestRpc,
+                make_request(42),
+                clock=fake_time,
+                completion_handler=check_value
+            )
+            # Keep the test alive until the event is triggered.
+            keep_alive_event.wait()
 
 
 class VersionMetadataTest(tb_test.TestCase):

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -185,7 +185,7 @@ class AsyncCallWithRetriesTest(tb_test.TestCase):
             grpc_util.async_call_with_retries(
                 client.TestRpc,
                 make_request(42),
-                completion_handler=wrapped_mock_callback,
+                done_callback=wrapped_mock_callback,
             )
             # Keep the test alive until the event is triggered.
             keep_alive_event.wait()
@@ -212,7 +212,7 @@ class AsyncCallWithRetriesTest(tb_test.TestCase):
         with server.run() as client:
             # Execute `async_call_with_retries` with the callback.
             grpc_util.async_call_with_retries(
-                client.TestRpc, make_request(42), completion_handler=check_value
+                client.TestRpc, make_request(42), done_callback=check_value
             )
             # Keep the test alive until the event is triggered.
             keep_alive_event.wait()
@@ -242,7 +242,7 @@ class AsyncCallWithRetriesTest(tb_test.TestCase):
             grpc_util.async_call_with_retries(
                 client.TestRpc,
                 make_request(42),
-                completion_handler=check_exception,
+                done_callback=check_exception,
             )
             # Keep the test alive until the event is triggered.
             keep_alive_event.wait()
@@ -283,7 +283,7 @@ class AsyncCallWithRetriesTest(tb_test.TestCase):
                 client.TestRpc,
                 make_request(42),
                 clock=fake_time,
-                completion_handler=check_exception,
+                done_callback=check_exception,
             )
             # Keep the test alive until the event is triggered.
             keep_alive_event.wait()
@@ -319,7 +319,7 @@ class AsyncCallWithRetriesTest(tb_test.TestCase):
                 client.TestRpc,
                 make_request(42),
                 clock=fake_time,
-                completion_handler=check_value,
+                done_callback=check_value,
             )
             # Keep the test alive until the event is triggered.
             keep_alive_event.wait()

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -163,89 +163,53 @@ class CallWithRetriesTest(tb_test.TestCase):
 
 
 class AsyncCallWithRetriesTest(tb_test.TestCase):
-    def test_aync_call_with_retries_invokes_callback(self):
+    def test_aync_call_with_retries_completes(self):
         # Setup: Basic server, echos input.
         def handler(request, _):
             return make_response(request.nonce)
 
-        # Set up a callback which:
-        # 1) Records that it has been executed (mock_callback).
-        # 2) Triggers the keep_alive_event, notifying when it is ok
-        #    to kill the server.
-        keep_alive_event = threading.Event()
-        mock_callback = mock.Mock()
-
-        def wrapped_mock_callback(future):
-            mock_callback(future)
-            keep_alive_event.set()
-
         server = TestGrpcServer(handler)
         with server.run() as client:
-            # Execute `async_call_with_retries` with the callback.
-            grpc_util.async_call_with_retries(
+            # Execute `async_call_with_retries`
+            future = grpc_util.async_call_with_retries(
                 client.TestRpc,
                 make_request(42),
-                done_callback=wrapped_mock_callback,
             )
-            # Keep the test alive until the event is triggered.
-            keep_alive_event.wait()
-
-        # Expect: callback is invoked.
-        mock_callback.assert_called_once()
+            # Wait for completion & collect result
+            future.result(2)
 
     def test_aync_call_with_retries_succeeds(self):
         # Setup: Basic server, echos input.
         def handler(request, _):
             return make_response(request.nonce)
 
-        # Set up a callback which:
-        # 1) Verifies the correct value has been returned in the future.
-        # 2) Triggers the keep_alive_event, notifying when it is ok
-        #    to kill the server.
-        keep_alive_event = threading.Event()
-
-        def check_value(future):
-            self.assertEqual(make_response(42), future.result())
-            keep_alive_event.set()
-
         server = TestGrpcServer(handler)
         with server.run() as client:
             # Execute `async_call_with_retries` with the callback.
-            grpc_util.async_call_with_retries(
-                client.TestRpc, make_request(42), done_callback=check_value
+            future = grpc_util.async_call_with_retries(
+                client.TestRpc, make_request(42)
             )
-            # Keep the test alive until the event is triggered.
-            keep_alive_event.wait()
+            # Verify the correct value has been returned in the future.
+            self.assertEqual(make_response(42), future.result(2))
 
     def test_async_call_with_retries_fails_immediately_on_permanent_error(self):
         # Setup: Server which fails with an ISE.
         def handler(_, context):
             context.abort(grpc.StatusCode.INTERNAL, "death_ray")
 
-        # Set up a callback which:
-        # 1) Verifies the future raises an Exception which is the right type and
-        #    carries the right message.
-        # 2) Triggers the keep_alive_event, notifying when it is ok
-        #    to kill the server.
-        keep_alive_event = threading.Event()
-
-        def check_exception(future):
-            raised = future.exception()
-            self.assertIsInstance(raised, grpc.RpcError)
-            self.assertEqual(grpc.StatusCode.INTERNAL, raised.code())
-            self.assertEqual("death_ray", raised.details())
-            keep_alive_event.set()
-
         server = TestGrpcServer(handler)
         with server.run() as client:
-            # Execute `async_call_with_retries` with the callback.
-            grpc_util.async_call_with_retries(
+            # Execute `async_call_with_retries`
+            future = grpc_util.async_call_with_retries(
                 client.TestRpc,
                 make_request(42),
-                done_callback=check_exception,
             )
-            # Keep the test alive until the event is triggered.
-            keep_alive_event.wait()
+            # Expect that the future raises an Exception which is the
+            # right type and carries the right message.
+            with self.assertRaises(grpc.RpcError) as raised:
+                future.result(2)
+            self.assertEqual(grpc.StatusCode.INTERNAL, raised.exception.code())
+            self.assertEqual("death_ray", raised.exception.details())
 
     def test_async_with_retries_fails_after_backoff_on_nonpermanent_error(self):
         attempt_times = []
@@ -258,35 +222,28 @@ class AsyncCallWithRetriesTest(tb_test.TestCase):
                 grpc.StatusCode.UNAVAILABLE, f"just a sec {len(attempt_times)}."
             )
 
-        # Set up a callback which:
-        # 1) Verifies the final raised Exception against expectations.
-        # 2) Verifies the number of attempts and delays between them.
-        # 3) Triggers the keep_alive_event, notifying when it is ok
-        #    to kill the server.
-        keep_alive_event = threading.Event()
-
-        def check_exception(future):
-            raised = future.exception()
-            self.assertEqual(grpc.StatusCode.UNAVAILABLE, raised.code())
-            self.assertEqual("just a sec 5.", raised.details())
+        server = TestGrpcServer(handler)
+        with server.run() as client:
+            # Execute `async_call_with_retries` against the scripted server.
+            future = grpc_util.async_call_with_retries(
+                client.TestRpc,
+                make_request(42),
+                clock=fake_time,
+            )
+            # Expect that the future raises an Exception which is the right
+            # type and carries the right message.
+            with self.assertRaises(grpc.RpcError) as raised:
+                future.result(2)
+            self.assertEqual(
+                grpc.StatusCode.UNAVAILABLE, raised.exception.code()
+            )
+            self.assertEqual("just a sec 5.", raised.exception.details())
+            # Verify the number of attempts and delays between them.
             self.assertLen(attempt_times, 5)
             self.assertBetween(attempt_times[1] - attempt_times[0], 2, 4)
             self.assertBetween(attempt_times[2] - attempt_times[1], 4, 8)
             self.assertBetween(attempt_times[3] - attempt_times[2], 8, 16)
             self.assertBetween(attempt_times[4] - attempt_times[3], 16, 32)
-            keep_alive_event.set()
-
-        server = TestGrpcServer(handler)
-        with server.run() as client:
-            # Execute `async_call_with_retries` with the callback.
-            grpc_util.async_call_with_retries(
-                client.TestRpc,
-                make_request(42),
-                clock=fake_time,
-                done_callback=check_exception,
-            )
-            # Keep the test alive until the event is triggered.
-            keep_alive_event.wait()
 
     def test_async_with_retries_succeeds_after_backoff_on_transient_error(self):
         attempt_times = []
@@ -299,30 +256,21 @@ class AsyncCallWithRetriesTest(tb_test.TestCase):
                 context.abort(grpc.StatusCode.UNAVAILABLE, "foo")
             return make_response(request.nonce)
 
-        # Set up a callback which:
-        # 1) Verifies the response contains the expected value.
-        # 2) Verifies the number of attempts and delays between them.
-        # 3) Triggers the keep_alive_event, notifying when it is ok
-        #    to kill the server.
-        keep_alive_event = threading.Event()
-
-        def check_value(future):
-            self.assertEqual(make_response(42), future.result())
-            self.assertLen(attempt_times, 3)
-            self.assertBetween(attempt_times[1] - attempt_times[0], 2, 4)
-            self.assertBetween(attempt_times[2] - attempt_times[1], 4, 8)
-            keep_alive_event.set()
-
         server = TestGrpcServer(handler)
         with server.run() as client:
-            grpc_util.async_call_with_retries(
+            # Execute `async_call_with_retries` against the scripted server.
+            future = grpc_util.async_call_with_retries(
                 client.TestRpc,
                 make_request(42),
                 clock=fake_time,
-                done_callback=check_value,
             )
-            # Keep the test alive until the event is triggered.
-            keep_alive_event.wait()
+            # Expect:
+            # 1) The response contains the expected value.
+            # 2) The number of attempts and delays between them.
+            self.assertEqual(make_response(42), future.result(2))
+            self.assertLen(attempt_times, 3)
+            self.assertBetween(attempt_times[1] - attempt_times[0], 2, 4)
+            self.assertBetween(attempt_times[2] - attempt_times[1], 4, 8)
 
 
 class VersionMetadataTest(tb_test.TestCase):

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -268,23 +268,20 @@ class AsyncCallWithRetriesTest(tb_test.TestCase):
         def check_exception(future):
             raised = future.exception()
             self.assertEqual(grpc.StatusCode.UNAVAILABLE, raised.code())
-            self.assertEqual("just a sec 6.", raised.details())
-            self.assertLen(attempt_times, 6)
+            self.assertEqual("just a sec 5.", raised.details())
+            self.assertLen(attempt_times, 5)
             self.assertBetween(attempt_times[1] - attempt_times[0], 2, 4)
             self.assertBetween(attempt_times[2] - attempt_times[1], 4, 8)
             self.assertBetween(attempt_times[3] - attempt_times[2], 8, 16)
             self.assertBetween(attempt_times[4] - attempt_times[3], 16, 32)
-            self.assertBetween(attempt_times[5] - attempt_times[4], 32, 64)
             keep_alive_event.set()
 
         server = TestGrpcServer(handler)
         with server.run() as client:
-            # Execute `async_call_with_retries` with the callback.  Call
-            # with explicit num retries (5) instead of default.
+            # Execute `async_call_with_retries` with the callback.
             grpc_util.async_call_with_retries(
                 client.TestRpc,
                 make_request(42),
-                num_remaining_tries=5,
                 clock=fake_time,
                 completion_handler=check_exception,
             )


### PR DESCRIPTION
* Motivation for features / changes
Towards making uploader asynchronous (for upload speed to TensorBoard.dev).  Actually making the uploader use this new utility will follow in a separate PR.  This portion is submitted separately in the spirit of smaller, easier to understand PRs.

* Technical description of changes
Creates a new util API `async_call_with_retries` which mirrors the existing `call_with_retries` but (unsurprisingly) returns right away and completes the gRPC call asynchronously, using the gRPC `future` API.   The retry functionality is implemented as a recursive call where the continuation calls the same API with a decremented number of remaining tries.

* Test Plan:
Adds unit tests covering cases very similar to the `call_with_retries` functionality.   I've also tested that this API meets the needs to make the uploader asynchronous.