### PR TITLE
pr_curves: warn when metadata version is too new

### DIFF
--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -14,7 +14,6 @@ py_library(
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/util:tb_logging",
     ],
 )
 
@@ -30,6 +29,7 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/data:provider",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/plugins/pr_curve/metadata.py
+++ b/tensorboard/plugins/pr_curve/metadata.py
@@ -17,9 +17,6 @@
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.pr_curve import plugin_data_pb2
-from tensorboard.util import tb_logging
-
-logger = tb_logging.get_logger()
 
 PLUGIN_NAME = "pr_curves"
 
@@ -75,12 +72,5 @@ def parse_plugin_metadata(content):
     result = plugin_data_pb2.PrCurvePluginData.FromString(content)
     if result.version == 0:
         return result
-    else:
-        logger.warning(
-            "Unknown metadata version: %s. The latest version known to "
-            "this build of TensorBoard is %s; perhaps a newer build is "
-            "available?",
-            result.version,
-            PROTO_VERSION,
-        )
-        return result
+    # No other versions known at this time, so no migrations to do.
+    return result


### PR DESCRIPTION
Summary:
Analogue of 5e220deb33ca for PR curves instead of histograms. Might go
ahead and factor this out into a common utility, but for now let’s start
with this in case changes for TF 2.x compatibility want changes to the
serialized form.

Test Plan:
Same as in 5e220deb33ca.

wchargin-branch: pr-curves-version-warning
