### PR TITLE
plugin_util: factor out summary metadata version checker

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -592,6 +592,7 @@ py_library(
     deps = [
         ":context",
         "//tensorboard/backend:experiment_id",
+        "//tensorboard/util:tb_logging",
         "@org_mozilla_bleach",
         "@org_pythonhosted_markdown",
     ],

--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -25,7 +25,10 @@ import markdown
 
 from tensorboard import context as _context
 from tensorboard.backend import experiment_id as _experiment_id
+from tensorboard.util import tb_logging
 
+
+logger = tb_logging.get_logger()
 
 _ALLOWED_ATTRIBUTES = {
     "a": ["href", "title"],
@@ -174,3 +177,50 @@ def experiment_id(environ):
       A experiment ID, as a possibly-empty `str`.
     """
     return environ.get(_experiment_id.WSGI_ENVIRON_KEY, "")
+
+
+class _MetadataVersionChecker:
+    """TensorBoard-internal utility for warning when data is too new.
+
+    Specify a maximum known `version` number as stored in summary
+    metadata, and automatically reject and warn on data from newer
+    versions. This keeps a (single) bit of internal state to handle
+    logging a warning to the user at most once.
+
+    This should only be used by plugins bundled with TensorBoard, since
+    it may instruct users to upgrade their copy of TensorBoard.
+    """
+
+    def __init__(self, data_kind, latest_known_version):
+        """Initialize a `_MetadataVersionChecker`.
+
+        Args:
+          data_kind: A human-readable description of the kind of data
+            being read, like "scalar" or "histogram" or "PR curve".
+          latest_known_version: Highest tolerated value of `version`,
+            like `0`.
+        """
+        self._data_kind = data_kind
+        self._latest_known_version = latest_known_version
+        self._warned = False
+
+    def ok(self, version, run, tag):
+        """Test whether `version` is permitted, else complain."""
+        if 0 <= version <= self._latest_known_version:
+            return True
+        self._maybe_warn(version, run, tag)
+        return False
+
+    def _maybe_warn(self, version, run, tag):
+        if self._warned:
+            return
+        self._warned = True
+        logger.warning(
+            "Some %s data is too new to be read by this version of TensorBoard. "
+            "Upgrading TensorBoard may fix this. "
+            "(sample: run %r, tag %r, data version %r)",
+            self._data_kind,
+            run,
+            tag,
+            version,
+        )

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -129,7 +129,6 @@ py_library(
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/util:tb_logging",
     ],
 )
 

--- a/tensorboard/plugins/audio/audio_plugin.py
+++ b/tensorboard/plugins/audio/audio_plugin.py
@@ -52,6 +52,10 @@ class AudioPlugin(base_plugin.TBPlugin):
         self._downsample_to = (context.sampling_hints or {}).get(
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
+        self._version_checker = plugin_util._MetadataVersionChecker(
+            data_kind="audio",
+            latest_known_version=0,
+        )
 
     def get_plugin_apps(self):
         return {
@@ -99,6 +103,9 @@ class AudioPlugin(base_plugin.TBPlugin):
         result = {run: {} for run in mapping}
         for (run, tag_to_time_series) in mapping.items():
             for (tag, time_series) in tag_to_time_series.items():
+                md = metadata.parse_plugin_metadata(time_series.plugin_content)
+                if not self._version_checker.ok(md.version, run, tag):
+                    continue
                 description = plugin_util.markdown_to_safe_html(
                     time_series.description
                 )

--- a/tensorboard/plugins/audio/metadata.py
+++ b/tensorboard/plugins/audio/metadata.py
@@ -17,9 +17,6 @@
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.audio import plugin_data_pb2
-from tensorboard.util import tb_logging
-
-logger = tb_logging.get_logger()
 
 PLUGIN_NAME = "audio"
 
@@ -69,12 +66,5 @@ def parse_plugin_metadata(content):
     result = plugin_data_pb2.AudioPluginData.FromString(content)
     if result.version == 0:
         return result
-    else:
-        logger.warning(
-            "Unknown metadata version: %s. The latest version known to "
-            "this build of TensorBoard is %s; perhaps a newer build is "
-            "available?",
-            result.version,
-            PROTO_VERSION,
-        )
-        return result
+    # No other versions known at this time, so no migrations to do.
+    return result

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -19,7 +19,6 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/data:provider",
         "//tensorboard/plugins:base_plugin",
-        "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
     ],
 )
@@ -80,7 +79,6 @@ py_library(
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/util:tb_logging",
     ],
 )
 

--- a/tensorboard/plugins/histogram/metadata.py
+++ b/tensorboard/plugins/histogram/metadata.py
@@ -17,9 +17,6 @@
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.histogram import plugin_data_pb2
-from tensorboard.util import tb_logging
-
-logger = tb_logging.get_logger()
 
 PLUGIN_NAME = "histograms"
 

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -131,7 +131,6 @@ py_library(
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/util:tb_logging",
     ],
 )
 

--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -66,6 +66,10 @@ class ImagesPlugin(base_plugin.TBPlugin):
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
         self._data_provider = context.data_provider
+        self._version_checker = plugin_util._MetadataVersionChecker(
+            data_kind="image",
+            latest_known_version=0,
+        )
 
     def get_plugin_apps(self):
         return {
@@ -89,6 +93,9 @@ class ImagesPlugin(base_plugin.TBPlugin):
         result = {run: {} for run in mapping}
         for (run, tag_to_content) in mapping.items():
             for (tag, metadatum) in tag_to_content.items():
+                md = metadata.parse_plugin_metadata(metadatum.plugin_content)
+                if not self._version_checker.ok(md.version, run, tag):
+                    continue
                 description = plugin_util.markdown_to_safe_html(
                     metadatum.description
                 )

--- a/tensorboard/plugins/image/metadata.py
+++ b/tensorboard/plugins/image/metadata.py
@@ -17,9 +17,6 @@
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.image import plugin_data_pb2
-from tensorboard.util import tb_logging
-
-logger = tb_logging.get_logger()
 
 PLUGIN_NAME = "images"
 
@@ -65,12 +62,5 @@ def parse_plugin_metadata(content):
     result = plugin_data_pb2.ImagePluginData.FromString(content)
     if result.version == 0:
         return result
-    else:
-        logger.warning(
-            "Unknown metadata version: %s. The latest version known to "
-            "this build of TensorBoard is %s; perhaps a newer build is "
-            "available?",
-            result.version,
-            PROTO_VERSION,
-        )
-        return result
+    # No other versions known at this time, so no migrations to do.
+    return result

--- a/tensorboard/plugins/mesh/metadata.py
+++ b/tensorboard/plugins/mesh/metadata.py
@@ -123,12 +123,6 @@ def parse_plugin_metadata(content):
     if not isinstance(content, bytes):
         raise TypeError("Content type must be bytes.")
     result = plugin_data_pb2.MeshPluginData.FromString(content)
-    if not 0 <= result.version <= get_current_version():
-        raise ValueError(
-            "Unknown metadata version: %s. The latest version known to "
-            "this build of TensorBoard is %s; perhaps a newer build is "
-            "available?" % (result.version, get_current_version())
-        )
     # Add components field to older version of the proto.
     if result.components == 0:
         result.components = get_components_bitmask(

--- a/tensorboard/plugins/mesh/metadata_test.py
+++ b/tensorboard/plugins/mesh/metadata_test.py
@@ -15,8 +15,6 @@
 """Tests for util functions to create/parse mesh plugin metadata."""
 
 
-from unittest import mock
-
 import tensorflow as tf
 from tensorboard.plugins.mesh import metadata
 from tensorboard.plugins.mesh import plugin_data_pb2

--- a/tensorboard/plugins/mesh/metadata_test.py
+++ b/tensorboard/plugins/mesh/metadata_test.py
@@ -73,20 +73,6 @@ class MetadataTest(tf.test.TestCase):
         self.assertEqual(self.json_config, parsed_metadata.json_config)
         self.assertEqual(self.components, parsed_metadata.components)
 
-    def test_metadata_version(self):
-        """Tests that only the latest version of metadata is supported."""
-        with mock.patch.object(
-            metadata, "get_current_version", return_value=100
-        ):
-            self._create_metadata()
-        # Change the version.
-        with mock.patch.object(metadata, "get_current_version", return_value=1):
-            # Try to parse metadata from a prior version.
-            with self.assertRaises(ValueError):
-                metadata.parse_plugin_metadata(
-                    self.summary_metadata.plugin_data.content
-                )
-
     def test_tensor_shape(self):
         """Tests that target tensor should be of particular shape."""
         with self.assertRaisesRegex(

--- a/tensorboard/plugins/metrics/metrics_plugin.py
+++ b/tensorboard/plugins/metrics/metrics_plugin.py
@@ -171,7 +171,6 @@ def _get_run_tag_info(mapping, parse_metadata, version_checker):
                 continue
             result[run].append(tag)
     return result
-    #return {run: sorted(mapping[run]) for run in mapping}
 
 
 def _format_basic_mapping(mapping, parse_metadata, version_checker):

--- a/tensorboard/plugins/npmi/BUILD
+++ b/tensorboard/plugins/npmi/BUILD
@@ -97,7 +97,6 @@ py_library(
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/util:tb_logging",
     ],
 )
 

--- a/tensorboard/plugins/npmi/metadata.py
+++ b/tensorboard/plugins/npmi/metadata.py
@@ -17,9 +17,6 @@
 from tensorboard.compat.proto import summary_pb2
 
 from tensorboard.plugins.npmi import plugin_data_pb2
-from tensorboard.util import tb_logging
-
-logger = tb_logging.get_logger()
 
 PLUGIN_NAME = "npmi"
 
@@ -58,12 +55,5 @@ def parse_plugin_metadata(content):
     result = plugin_data_pb2.NpmiPluginData.FromString(content)
     if result.version == 0:
         return result
-    else:
-        logger.warning(
-            "Unknown metadata version: %s. The latest version known to "
-            "this build of TensorBoard is %s; perhaps a newer build is "
-            "available?",
-            result.version,
-            PROTO_VERSION,
-        )
-        return result
+    # No other versions known at this time, so no migrations to do.
+    return result

--- a/tensorboard/plugins/npmi/npmi_plugin.py
+++ b/tensorboard/plugins/npmi/npmi_plugin.py
@@ -70,6 +70,10 @@ class NpmiPlugin(base_plugin.TBPlugin):
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
         self._data_provider = context.data_provider
+        self._version_checker = plugin_util._MetadataVersionChecker(
+            data_kind="nPMI",
+            latest_known_version=0,
+        )
 
     def get_plugin_apps(self):
         return {
@@ -103,6 +107,9 @@ class NpmiPlugin(base_plugin.TBPlugin):
         for (run, tag_to_content) in mapping.items():
             result[run] = []
             for (tag, metadatum) in tag_to_content.items():
+                md = metadata.parse_plugin_metadata(metadatum.plugin_content)
+                if not self._version_checker.ok(md.version, run, tag):
+                    continue
                 content = metadata.parse_plugin_metadata(
                     metadatum.plugin_content
                 )

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -29,7 +29,6 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/data:provider",
         "//tensorboard/plugins:base_plugin",
-        "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -21,9 +21,7 @@ from tensorboard.data import provider
 from tensorboard.backend import http_util
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.pr_curve import metadata
-from tensorboard.util import tb_logging
 
-logger = tb_logging.get_logger()
 
 _DEFAULT_DOWNSAMPLING = 100  # PR curves per time series
 
@@ -44,7 +42,10 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
         self._downsample_to = (context.sampling_hints or {}).get(
             metadata.PLUGIN_NAME, _DEFAULT_DOWNSAMPLING
         )
-        self._warned_about_new_metadata = False
+        self._version_checker = plugin_util._MetadataVersionChecker(
+            data_kind="PR curve",
+            latest_known_version=0,
+        )
 
     @wrappers.Request.application
     def pr_curves_route(self, request):
@@ -150,8 +151,7 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
         for (run, tag_to_time_series) in mapping.items():
             for (tag, time_series) in tag_to_time_series.items():
                 md = metadata.parse_plugin_metadata(time_series.plugin_content)
-                if md.version != 0:
-                    self._maybe_warn_about_new_metadata(run, tag, md.version)
+                if not self._version_checker.ok(md.version, run, tag):
                     continue
                 result[run][tag] = {
                     "displayName": time_series.display_name,
@@ -160,19 +160,6 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
                     ),
                 }
         return result
-
-    def _maybe_warn_about_new_metadata(self, run, tag, version):
-        if self._warned_about_new_metadata:
-            return
-        self._warned_about_new_metadata = True
-        logger.warning(
-            "Some PR curve data is too new to be read by this version of "
-            "TensorBoard. Upgrading TensorBoard may fix this. "
-            "(sample: run %r, tag %r, data version %r)",
-            run,
-            tag,
-            version,
-        )
 
     def get_plugin_apps(self):
         """Gets all routes offered by the plugin.

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -138,7 +138,6 @@ py_library(
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/util:tb_logging",
     ],
 )
 

--- a/tensorboard/plugins/scalar/metadata.py
+++ b/tensorboard/plugins/scalar/metadata.py
@@ -17,9 +17,6 @@
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.scalar import plugin_data_pb2
-from tensorboard.util import tb_logging
-
-logger = tb_logging.get_logger()
 
 PLUGIN_NAME = "scalars"
 
@@ -60,12 +57,5 @@ def parse_plugin_metadata(content):
     result = plugin_data_pb2.ScalarPluginData.FromString(content)
     if result.version == 0:
         return result
-    else:
-        logger.warning(
-            "Unknown metadata version: %s. The latest version known to "
-            "this build of TensorBoard is %s; perhaps a newer build is "
-            "available?",
-            result.version,
-            PROTO_VERSION,
-        )
-        return result
+    # No other versions known at this time, so no migrations to do.
+    return result

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -57,6 +57,10 @@ class ScalarsPlugin(base_plugin.TBPlugin):
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
         self._data_provider = context.data_provider
+        self._version_checker = plugin_util._MetadataVersionChecker(
+            data_kind="scalar",
+            latest_known_version=0,
+        )
 
     def get_plugin_apps(self):
         return {
@@ -82,6 +86,9 @@ class ScalarsPlugin(base_plugin.TBPlugin):
         result = {run: {} for run in mapping}
         for (run, tag_to_content) in mapping.items():
             for (tag, metadatum) in tag_to_content.items():
+                md = metadata.parse_plugin_metadata(metadatum.plugin_content)
+                if not self._version_checker.ok(md.version, run, tag):
+                    continue
                 description = plugin_util.markdown_to_safe_html(
                     metadatum.description
                 )

--- a/tensorboard/plugins/text/metadata.py
+++ b/tensorboard/plugins/text/metadata.py
@@ -17,9 +17,6 @@
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.text import plugin_data_pb2
-from tensorboard.util import tb_logging
-
-logger = tb_logging.get_logger()
 
 PLUGIN_NAME = "text"
 
@@ -59,12 +56,5 @@ def parse_plugin_metadata(content):
     result = plugin_data_pb2.TextPluginData.FromString(content)
     if result.version == 0:
         return result
-    else:
-        logger.warning(
-            "Unknown metadata version: %s. The latest version known to "
-            "this build of TensorBoard is %s; perhaps a newer build is "
-            "available?",
-            result.version,
-            PROTO_VERSION,
-        )
-        return result
+    # No other versions known at this time, so no migrations to do.
+    return result

--- a/tensorboard/plugins/text_v2/text_v2_plugin.py
+++ b/tensorboard/plugins/text_v2/text_v2_plugin.py
@@ -120,6 +120,10 @@ class TextV2Plugin(base_plugin.TBPlugin):
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
         self._data_provider = context.data_provider
+        self._version_checker = plugin_util._MetadataVersionChecker(
+            data_kind="text",
+            latest_known_version=0,
+        )
 
     def frontend_metadata(self):
         return base_plugin.FrontendMetadata(
@@ -142,10 +146,14 @@ class TextV2Plugin(base_plugin.TBPlugin):
             experiment_id=experiment,
             plugin_name=metadata.PLUGIN_NAME,
         )
-        return {
-            run: list(tag_to_content)
-            for (run, tag_to_content) in mapping.items()
-        }
+        result = {run: [] for run in mapping}
+        for (run, tag_to_content) in mapping.items():
+            for (tag, metadatum) in tag_to_content.items():
+                md = metadata.parse_plugin_metadata(metadatum.plugin_content)
+                if not self._version_checker.ok(md.version, run, tag):
+                    continue
+                result[run].append(tag)
+        return result
 
     def text_impl(self, ctx, run, tag, experiment):
         all_text = self._data_provider.read_tensors(


### PR DESCRIPTION
Summary:
This abstracts over the metadata warnings for histograms and PR curves,
recently added in 5e220deb33ca and fea085ba5c5b, respectively. The
plugin code is now just a few lines. The new helper is in `plugin_util`,
but underscore-named to show that it’s meant for TensorBoard-internal
use only.

This functionality is now supported by the scalars, custom scalars,
images, audio, distributions (implicitly), histograms, text, PR curves,
mesh, and time series dashboards.

It’s not supported by the graphs dashboard, since graphs have a
non-standard summary metadata version format. It’s not supported in
hparams just because the backend is more complex with more moving parts,
so the fruit hangs not quite as low. It’s not supported in the debugger,
profile, What-If Tool, or projector dashboards because they don’t use
summaries.

Test Plan:
As is, data still renders as expected. After adding `version += 1` to
the top of `_MetadataVersionChecker.ok`, logs show:

```
plugin_util.py:219] Some scalar data is too new to be read by this version of TensorBoard. Upgrading TensorBoard may fix this. (sample: run 'hparams_demo/2/validation', tag 'epoch_accuracy', data version 1)
plugin_util.py:219] Some histogram data is too new to be read by this version of TensorBoard. Upgrading TensorBoard may fix this. (sample: run 'mnist/lr_1E-04,conv=2,fc=2', tag 'fc2/biases', data version 1)
plugin_util.py:219] Some PR curve data is too new to be read by this version of TensorBoard. Upgrading TensorBoard may fix this. (sample: run 'pr_curve_demo/mask_every_other_prediction', tag 'green/pr_curves', data version 1)
```

…and no data appears in the dashboards. Tested in all the dashboards
listed above.

wchargin-branch: plugin-common-version-warning
