### PR TITLE
ci: set manual Rust toolchains as default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust_version }}
+          default: true
       - name: 'Install Python packaging deps'
         run: |
           python -m pip install -U pip
@@ -255,6 +256,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust_version }}
+          default: true
+          components: rustfmt, clippy
       - name: 'Install cargo-raze'
         run: cargo install cargo-raze --version ${{ matrix.cargo_raze_version }}
       - name: 'Run Rustfmt'


### PR DESCRIPTION
Summary:
It looks like GitHub Linux VMs have Rust [installed by default][1], so
when we use `actions-rs/toolchain` to install toolchains at a later
version, we need to explicitly set them as default, and also install any
needed extra components (rustfmt, clippy).

[1]: https://github.com/actions/virtual-environments/blob/ff9f3f0a8bc69e64fad8790abcc61ff266277b76/images/linux/Ubuntu2004-README.md

wchargin-branch: ci-rust-toolchain-default
