### PR TITLE
rust: hold commit in `Arc` instead of leaking

### DIFF
--- a/tensorboard/data/server/server.rs
+++ b/tensorboard/data/server/server.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 use std::hash::Hash;
 use std::pin::Pin;
-use std::sync::{RwLock, RwLockReadGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 use tonic::{Request, Response, Status};
 
 use crate::blob_key::BlobKey;
@@ -37,7 +37,7 @@ use data::tensor_board_data_provider_server::TensorBoardDataProvider;
 #[derive(Debug)]
 pub struct DataProviderHandler {
     pub data_location: String,
-    pub commit: &'static Commit,
+    pub commit: Arc<Commit>,
 }
 
 impl DataProviderHandler {
@@ -646,8 +646,7 @@ mod tests {
     fn sample_handler(commit: Commit) -> DataProviderHandler {
         DataProviderHandler {
             data_location: String::from("./logs/mnist"),
-            // Leak the commit object, since the Tonic server must have only 'static references.
-            commit: Box::leak(Box::new(commit)),
+            commit: Arc::new(commit),
         }
     }
 


### PR DESCRIPTION
Summary:
While watching @jonhoo’s latest [“Crust of Rust” video on atomics][jh],
I realized that we can just convert this irritating `&'static Commit`
leaked reference into a jointly owned `Arc<Commit>` while still meeting
the `T: 'static` bound for the RPC handler type. It’s not really a big
functional difference, because the commit would live for the whole
program anyway, but it’s nice to not have to worry about it. It should
also reduce the peak memory usage during tests, since we used to box up
and leak a new commit in each test case.

(In fact, this probably makes server shutdown a tad slower. If we really
wanted to recover that performance, we could make the server generic
over `T: Deref<Target = Commit>`, and pass `Box::leak(...)` in the main
program and an `Arc<Commit>` in tests. But that seems overkill; dropping
a few hash maps is probably not the end of the world.)

[jh]: https://youtu.be/rMGWeSjctlY?t=1181

wchargin-branch: rust-no-leak-commit
