### PR TITLE
pip: relax `pandas` dep to 1.x

### DIFF
--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -17,7 +17,7 @@
 
 # For tests
 grpcio-testing==1.24.3
-pandas==1.0.3
+pandas~=1.0
 # For gfile S3 test
 boto3==1.9.86
 moto==1.3.7


### PR DESCRIPTION
Summary:
Running `pip install pandas==1.0.3` on Python 3.9 hangs for a few
minutes and then crashes with 20K lines of C compilation errors. The
latest version of `pandas` works with 3.9, but not with 3.6, which we
also support (and run in CI). This patch relaxes our dep to `~=1.0`,
which should pick an appropriate version in both 3.6 and 3.9.

wchargin-branch: pip-pandas-1.x
