### PR TITLE
fix(doc) : fix API demo of debugger V2

### DIFF
--- a/docs/debugger_v2.md
+++ b/docs/debugger_v2.md
@@ -72,7 +72,7 @@ richness of the debug information enables users to narrow in on obscure bugs.
 
 ```py
 tf.debugging.experimental.enable_dump_debug_info(
-    logdir="/tmp/tfdbg2_logdir",
+    "/tmp/tfdbg2_logdir",
     tensor_debug_mode="FULL_HEALTH",
     circular_buffer_size=-1)
 ```


### PR DESCRIPTION
The demo code is not consistent with the API and
caller will get a "TypeError: enable_dump_debug_info()
got an unexpected keyword argument 'logdir'" error.
