### PR TITLE
plugin api: implement reload listener

### DIFF
--- a/tensorboard/components/experimental/plugin_lib/core.ts
+++ b/tensorboard/components/experimental/plugin_lib/core.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {sendMessage} from './plugin-guest';
+import {listen, sendMessage} from './plugin-guest';
 
 /**
  * When called from a plugin with plugin_name `N`, it returns a promise which
@@ -22,4 +22,12 @@ import {sendMessage} from './plugin-guest';
  */
 export async function getURLPluginData() {
   return sendMessage('experimental.GetURLPluginData');
+}
+
+/**
+ * Listen to when data reloads on TensorBoard. There are two ways in which
+ * data reloads--(1) automatic refresh and (2) user clicks on a reload button.
+ */
+export function setOnReload(callback: () => void) {
+  listen('experimental.DataReloaded', callback);
 }

--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -79,6 +79,7 @@ tf_ng_module(
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/runs/store:testing",
+        "//tensorboard/webapp/types",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",

--- a/tensorboard/components/experimental/plugin_util/core-host-impl.ts
+++ b/tensorboard/components/experimental/plugin_util/core-host-impl.ts
@@ -17,10 +17,10 @@ limitations under the License.
  */
 import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';
-import {distinctUntilChanged, filter, map} from 'rxjs/operators';
+import {distinctUntilChanged, filter} from 'rxjs/operators';
 
 import {State} from '../../../webapp/app_state';
-import {getLastLoadedTimeInMs} from '../../../webapp/selectors';
+import {getAppLastLoadedTimeInMs} from '../../../webapp/selectors';
 import * as tf_storage from '../../tf_storage';
 import {MessageId} from './message_types';
 import {Ipc} from './plugin-host-ipc';
@@ -52,7 +52,7 @@ export class PluginCoreApiHostImpl {
     });
 
     this.store
-      .select(getLastLoadedTimeInMs)
+      .select(getAppLastLoadedTimeInMs)
       .pipe(
         filter((lastLoadedTimeInMs) => lastLoadedTimeInMs !== null),
         distinctUntilChanged()

--- a/tensorboard/components/experimental/plugin_util/core-host-impl.ts
+++ b/tensorboard/components/experimental/plugin_util/core-host-impl.ts
@@ -16,14 +16,21 @@ limitations under the License.
  * Implements core plugin APIs.
  */
 import {Injectable} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {distinctUntilChanged, filter, map} from 'rxjs/operators';
 
-import {Ipc} from './plugin-host-ipc';
+import {State} from '../../../webapp/app_state';
+import {getPluginsListLoaded} from '../../../webapp/selectors';
 import * as tf_storage from '../../tf_storage';
 import {MessageId} from './message_types';
+import {Ipc} from './plugin-host-ipc';
 
 @Injectable({providedIn: 'root'})
 export class PluginCoreApiHostImpl {
-  constructor(private readonly ipc: Ipc) {}
+  constructor(
+    private readonly ipc: Ipc,
+    private readonly store: Store<State>
+  ) {}
 
   init() {
     this.ipc.listen(MessageId.GET_URL_DATA, (context) => {
@@ -43,5 +50,18 @@ export class PluginCoreApiHostImpl {
       }
       return result;
     });
+
+    this.store
+      .select(getPluginsListLoaded)
+      .pipe(
+        map((loaded) => {
+          return loaded.lastLoadedTimeInMs;
+        }),
+        filter((lastLoadedTimeInMs) => lastLoadedTimeInMs !== null),
+        distinctUntilChanged()
+      )
+      .subscribe(() => {
+        this.ipc.broadcast(MessageId.DATA_RELOADED, void {});
+      });
   }
 }

--- a/tensorboard/components/experimental/plugin_util/core-host-impl.ts
+++ b/tensorboard/components/experimental/plugin_util/core-host-impl.ts
@@ -20,7 +20,7 @@ import {Store} from '@ngrx/store';
 import {distinctUntilChanged, filter, map} from 'rxjs/operators';
 
 import {State} from '../../../webapp/app_state';
-import {getPluginsListLoaded} from '../../../webapp/selectors';
+import {getLastLoadedTimeInMs} from '../../../webapp/selectors';
 import * as tf_storage from '../../tf_storage';
 import {MessageId} from './message_types';
 import {Ipc} from './plugin-host-ipc';
@@ -52,11 +52,8 @@ export class PluginCoreApiHostImpl {
     });
 
     this.store
-      .select(getPluginsListLoaded)
+      .select(getLastLoadedTimeInMs)
       .pipe(
-        map((loaded) => {
-          return loaded.lastLoadedTimeInMs;
-        }),
         filter((lastLoadedTimeInMs) => lastLoadedTimeInMs !== null),
         distinctUntilChanged()
       )

--- a/tensorboard/components/experimental/plugin_util/message_types.ts
+++ b/tensorboard/components/experimental/plugin_util/message_types.ts
@@ -16,4 +16,5 @@ export enum MessageId {
   RUNS_CHANGED = 'experimental.RunsChanged',
   GET_RUNS = 'experimental.GetRuns',
   GET_URL_DATA = 'experimental.GetURLPluginData',
+  DATA_RELOADED = 'experimental.DataReloaded',
 }

--- a/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
+++ b/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
@@ -20,7 +20,7 @@ import {of} from 'rxjs';
 import {State} from '../../../webapp/app_state';
 import {buildRun} from '../../../webapp/runs/store/testing';
 import {
-  getLastLoadedTimeInMs,
+  getAppLastLoadedTimeInMs,
   getExperimentIdsFromRoute,
   getRuns,
 } from '../../../webapp/selectors';
@@ -53,7 +53,7 @@ describe('plugin_api_host test', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getExperimentIdsFromRoute, ['e1']);
     store.overrideSelector(getRuns, []);
-    store.overrideSelector(getLastLoadedTimeInMs, null);
+    store.overrideSelector(getAppLastLoadedTimeInMs, null);
     selectSpy = spyOn(store, 'select').and.callThrough();
 
     const ipc = TestBed.inject(Ipc);
@@ -272,19 +272,19 @@ describe('plugin_api_host test', () => {
       it('calls callback when last updated time changes', () => {
         coreApi.init();
 
-        store.overrideSelector(getLastLoadedTimeInMs, null);
+        store.overrideSelector(getAppLastLoadedTimeInMs, null);
         store.refreshState();
         expect(broadcastSpy).toHaveBeenCalledTimes(0);
 
-        store.overrideSelector(getLastLoadedTimeInMs, 1);
+        store.overrideSelector(getAppLastLoadedTimeInMs, 1);
         store.refreshState();
         expect(broadcastSpy).toHaveBeenCalledTimes(1);
 
-        store.overrideSelector(getLastLoadedTimeInMs, 1);
+        store.overrideSelector(getAppLastLoadedTimeInMs, 1);
         store.refreshState();
         expect(broadcastSpy).toHaveBeenCalledTimes(1);
 
-        store.overrideSelector(getLastLoadedTimeInMs, 2);
+        store.overrideSelector(getAppLastLoadedTimeInMs, 2);
         store.refreshState();
         expect(broadcastSpy).toHaveBeenCalledTimes(2);
       });

--- a/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
+++ b/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
@@ -20,7 +20,7 @@ import {of} from 'rxjs';
 import {State} from '../../../webapp/app_state';
 import {buildRun} from '../../../webapp/runs/store/testing';
 import {
-  getPluginsListLoaded,
+  getLastLoadedTimeInMs,
   getExperimentIdsFromRoute,
   getRuns,
 } from '../../../webapp/selectors';
@@ -53,11 +53,7 @@ describe('plugin_api_host test', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getExperimentIdsFromRoute, ['e1']);
     store.overrideSelector(getRuns, []);
-    store.overrideSelector(getPluginsListLoaded, {
-      state: DataLoadState.NOT_LOADED,
-      failureCode: null,
-      lastLoadedTimeInMs: null,
-    });
+    store.overrideSelector(getLastLoadedTimeInMs, null);
     selectSpy = spyOn(store, 'select').and.callThrough();
 
     const ipc = TestBed.inject(Ipc);
@@ -276,35 +272,19 @@ describe('plugin_api_host test', () => {
       it('calls callback when last updated time changes', () => {
         coreApi.init();
 
-        store.overrideSelector(getPluginsListLoaded, {
-          state: DataLoadState.NOT_LOADED,
-          failureCode: null,
-          lastLoadedTimeInMs: null,
-        });
+        store.overrideSelector(getLastLoadedTimeInMs, null);
         store.refreshState();
         expect(broadcastSpy).toHaveBeenCalledTimes(0);
 
-        store.overrideSelector(getPluginsListLoaded, {
-          state: DataLoadState.LOADED,
-          failureCode: null,
-          lastLoadedTimeInMs: 1,
-        });
+        store.overrideSelector(getLastLoadedTimeInMs, 1);
         store.refreshState();
         expect(broadcastSpy).toHaveBeenCalledTimes(1);
 
-        store.overrideSelector(getPluginsListLoaded, {
-          state: DataLoadState.LOADED,
-          failureCode: null,
-          lastLoadedTimeInMs: 1,
-        });
+        store.overrideSelector(getLastLoadedTimeInMs, 1);
         store.refreshState();
         expect(broadcastSpy).toHaveBeenCalledTimes(1);
 
-        store.overrideSelector(getPluginsListLoaded, {
-          state: DataLoadState.LOADED,
-          failureCode: null,
-          lastLoadedTimeInMs: 2,
-        });
+        store.overrideSelector(getLastLoadedTimeInMs, 2);
         store.refreshState();
         expect(broadcastSpy).toHaveBeenCalledTimes(2);
       });

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -53,6 +53,7 @@ tf_ng_module(
     deps = [
         "//tensorboard/webapp/alert/store",
         "//tensorboard/webapp/app_routing/store",
+        "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/experiments/store:selectors",
         "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/metrics/store",

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -35,7 +35,10 @@ export const getPluginsListLoaded = createSelector(
   (state: CoreState): PluginsListLoadState => state.pluginsListLoaded
 );
 
-export const getLastLoadedTimeInMs = createSelector(
+// TODO(tensorboard-team): AppLastLoaded is currently derived from plugins listing loaded
+// state which should be disentangled. Fix this by having a separate state for remembering
+// when the application data was last loaded.
+export const getAppLastLoadedTimeInMs = createSelector(
   getPluginsListLoaded,
   (loadedState: PluginsListLoadState): number | null =>
     loadedState.lastLoadedTimeInMs

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -12,16 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {createFeatureSelector, createSelector} from '@ngrx/store';
 
-import {createSelector, createFeatureSelector} from '@ngrx/store';
 import {Environment, PluginId, PluginsListing} from '../../types/api';
 import {
   CoreState,
-  State,
   CORE_FEATURE_KEY,
   PluginsListLoadState,
+  State,
 } from './core_types';
-import {Run, RunId} from '../types';
 
 // HACK: These imports are for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
@@ -34,6 +33,12 @@ const selectCoreState = createFeatureSelector<State, CoreState>(
 export const getPluginsListLoaded = createSelector(
   selectCoreState,
   (state: CoreState): PluginsListLoadState => state.pluginsListLoaded
+);
+
+export const getLastLoadedTimeInMs = createSelector(
+  getPluginsListLoaded,
+  (loadedState: PluginsListLoadState): number | null =>
+    loadedState.lastLoadedTimeInMs
 );
 
 export const getActivePlugin = createSelector(

--- a/tensorboard/webapp/selectors.ts
+++ b/tensorboard/webapp/selectors.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 export * from './alert/store/alert_selectors';
 export * from './app_routing/store/app_routing_selectors';
+export * from './core/store/core_selectors';
 export * from './experiments/store/experiments_selectors';
 export * from './feature_flag/store/feature_flag_selectors';
 export * from './metrics/store/metrics_selectors';


### PR DESCRIPTION
This change introduces `tb_plugin_lib.experimental.core.setOnReload(()
=> {})` API. It gets invoked when TensorBoard finishes reloading the
data automatically and manually.
