### PR TITLE
Remove unneeded `tf.io.gfile.file_exists` checks

### DIFF
--- a/tensorboard/compat/tensorflow_stub/io/gfile_s3_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_s3_test.py
@@ -97,8 +97,7 @@ class GFileTest(unittest.TestCase):
     def testMakeDirsAlreadyExists(self):
         temp_dir = self._CreateDeepS3Structure()
         new_dir = self._PathJoin(temp_dir, "bar", "baz")
-        with self.assertRaises(errors.AlreadyExistsError):
-            gfile.makedirs(new_dir)
+        gfile.makedirs(new_dir)
 
     @mock_s3
     def testWalk(self):

--- a/tensorboard/compat/tensorflow_stub/io/gfile_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_test.py
@@ -78,8 +78,7 @@ class GFileTest(tb_test.TestCase):
         temp_dir = self.get_temp_dir()
         self._CreateDeepDirectoryStructure(temp_dir)
         new_dir = os.path.join(temp_dir, "bar", "baz")
-        with self.assertRaises(errors.AlreadyExistsError):
-            gfile.makedirs(new_dir)
+        gfile.makedirs(new_dir)
 
     def testWalk(self):
         temp_dir = self.get_temp_dir()

--- a/tensorboard/summary/writer/event_file_writer.py
+++ b/tensorboard/summary/writer/event_file_writer.py
@@ -69,8 +69,7 @@ class EventFileWriter(object):
             pending events and summaries to disk.
         """
         self._logdir = logdir
-        if not tf.io.gfile.exists(logdir):
-            tf.io.gfile.makedirs(logdir)
+        tf.io.gfile.makedirs(logdir)
         self._file_name = (
             os.path.join(
                 logdir,


### PR DESCRIPTION
`tf.io.gfile.makedirs` correctly handles existing directories so this PR removes unnecessary calls to `tf.io.gfile.file_exists`. This can be beneficial when working with object storage where listing files or checking for the existence of a directory might be expensive.