### PR TITLE
example_raw_scalars: include plugin API

### DIFF
--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -1,8 +1,15 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
+
+tf_js_binary(
+    name = "plugin_lib_bin",
+    compile = True,
+    entry_point = "polymer-interop.ts",
+    deps = [":plugin_lib_polymer_interop_internal"],
+)
 
 # TODO(psybuzz): create a NPM package when a better requirement comes up using
 # tf_js_binary.

--- a/tensorboard/examples/plugins/example_raw_scalars/BUILD
+++ b/tensorboard/examples/plugins/example_raw_scalars/BUILD
@@ -9,6 +9,36 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
+genrule(
+    name = "lib_copy",
+    srcs = [
+        "//tensorboard/components/experimental/plugin_lib:plugin_lib_bin.js",
+    ],
+    outs = [
+        "tensorboard_plugin_example_raw_scalars/static/lib.js",
+    ],
+    cmd = "cat $(SRCS) > $@",
+)
+
+sh_binary(
+    name = "develop",
+    srcs = [
+        "develop.sh",
+    ],
+    data = [
+        "setup.py",
+        ":lib_copy",
+        "//tensorboard/pip_package",
+    ] + glob([
+        "tensorboard_plugin_example_raw_scalars/*.py",
+        "tensorboard_plugin_example_raw_scalars/static/**",
+    ]),
+    tags = [
+        "manual",
+        "support_notf",
+    ],
+)
+
 sh_test(
     name = "smoke_test",
     size = "large",

--- a/tensorboard/examples/plugins/example_raw_scalars/README.md
+++ b/tensorboard/examples/plugins/example_raw_scalars/README.md
@@ -4,7 +4,7 @@
 
 In this example, we render a run selector dropdown component. When the user selects a run, it shows a preview of all scalar data for tags within it. For a complete guide to plugin development, see [ADDING_A_PLUGIN](../../../../ADDING_A_PLUGIN.md).
 
-![Screenshot](../../../../docs/images/example_raw_scalars.png "Raw scalars example")
+![Screenshot](../../../../docs/images/example_raw_scalars.png 'Raw scalars example')
 
 All files under [`static/*`][static-dir] are served as static assets, with the frontend entry point being [`static/index.js`][static-index-js]. The plugin backend serves scalar summaries (e.g. values written by [`tf.summary.scalar`][summary_scalar_docs]) from runs within the `--logdir` passed to TensorBoard.
 
@@ -19,15 +19,15 @@ To generate some scalar summaries, you can run the [`demo.py`](tensorboard_plugi
 [summary_scalar_docs]: https://www.tensorflow.org/api_docs/python/tf/summary
 [keras_scalars_tutorial]: https://www.tensorflow.org/tensorboard/scalars_and_keras
 
-Copy the directory `tensorboard/examples/plugins/example_raw_scalars` into a desired folder. In a virtualenv with TensorBoard installed, run:
-
-```
-python setup.py develop
+```sh
+bazel run tensorboard/examples/plugins/example_raw_scalars:develop
+# Or, use ibazel for auto-compile on source changes.
+# ibazel run tensorboard/examples/plugins/example_raw_scalars:develop
 ```
 
 This will link the plugin into your virtualenv. Then, just run
 
-```
+```sh
 tensorboard --logdir /tmp/runs_containing_scalars
 ```
 
@@ -35,7 +35,7 @@ and open TensorBoard to see the raw scalars example tab.
 
 After making changes to [`static/index.js`](./tensorboard_plugin_example_raw_scalars/static/index.js) or adding assets to `static/`, you can refresh the page in your browser to see your changes. Modifying the backend requires restarting the TensorBoard process.
 
-To uninstall, you can run
+To uninstall, you can simply remove the virtualenv or run
 
 ```
 python setup.py develop --uninstall

--- a/tensorboard/examples/plugins/example_raw_scalars/develop.sh
+++ b/tensorboard/examples/plugins/example_raw_scalars/develop.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+ORIGINAL_PWD="$(dirname $PWD)"
+workdir="/tmp/tensorboard/example/demo"
+
+rm -rf "${workdir}"
+mkdir -p "${workdir}"
+cd "${workdir}"
+
+cp -LR "$ORIGINAL_PWD/org_tensorflow_tensorboard/tensorboard/examples/plugins/example_raw_scalars" '.'
+cd example_raw_scalars
+
+python setup.py develop

--- a/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/static/index.js
+++ b/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/static/index.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // =============================================================================
+// Loads TensorBoard library on the window object.
+import './lib.js';
 
 import * as Model from './model.js';
 import * as Views from './views.js';
@@ -46,8 +48,14 @@ export async function render() {
   // Call once for the initial view.
   updatePreviewBound();
 
+  const updatedTime = document.createElement('p');
+  tb_plugin_lib.experimental.core.setOnReload(() => {
+    updatedTime.textContent = `Reloaded at ${new Date().toLocaleString()}`;
+  });
+
   document.body.appendChild(stylesheet);
   document.body.appendChild(header);
+  document.body.appendChild(updatedTime);
   document.body.appendChild(runSelector);
   document.body.appendChild(previewContainer);
 }


### PR DESCRIPTION
TensorBoard has an experimental iframe API to get runs and get notified
when data refreshes. This change adds the iframe API library to the
example so we can better test and showcase the APIs.

Now that we need to include a built library, we now need to do some
JavaScript "building" requiring a bit more involved
`python setup.py develop` incantation. This change introduces bazel target,
`ibazel run tensorboard/examples/plugins/example_raw_scalars:develop`
that helps with the development of the example plugin.

Reviewer: this may violate the principle of the example; the example is no
longer portable, i.e., you cannot just copy the folder and expect to run the
plugin. While we lose the portability here, the basic example still has that
capability and I think it is nice to exemplify our plugin APIs in an example.
Please let me know if this PR is something to be avoided.