### PR TITLE
runs: prevent sort when filter button is clicked

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -123,11 +123,13 @@ limitations under the License.
       >
         <span class="name">{{ column.displayName || column.name }}</span>
         <ng-container *ngIf="column.filter">
+          <!-- stopPropagation prevents click from sorting. -->
           <button
             mat-icon-button
             [matMenuTriggerFor]="filterMenu"
             i18n-aria-label="A button that opens a menu that lets user set hparam filter conditions"
             [attr.aria-label]="'Filter hparam ' + (column.displayName || column.name)"
+            (click)="$event.stopPropagation()"
           >
             <mat-icon svgIcon="filter_alt_24px"></mat-icon>
           </button>
@@ -188,11 +190,13 @@ limitations under the License.
       >
         <span class="name">{{ column.displayName || column.tag }}</span>
         <ng-container *ngIf="column.filter">
+          <!-- stopPropagation prevents click from sorting. -->
           <button
             mat-icon-button
             [matMenuTriggerFor]="filterMenu"
             i18n-aria-label="A button that opens a menu that lets user set metric filter conditions"
             [attr.aria-label]="'Filter metric ' + (column.displayName || column.tag)"
+            (click)="$event.stopPropagation()"
           >
             <mat-icon svgIcon="filter_alt_24px"></mat-icon>
           </button>

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -2453,6 +2453,45 @@ describe('runs_table', () => {
           );
         });
       });
+
+      it('does not sort because you click on the filter menu button', () => {
+        store.overrideSelector(
+          getRunHparamFilterMap,
+          buildHparamFilterMap([
+            [
+              'foo',
+              buildDiscreteFilter({
+                possibleValues: ['faz', 'bar', 'baz'],
+              }),
+            ],
+          ])
+        );
+        store.overrideSelector(
+          getRunMetricFilterMap,
+          buildMetricFilterMap([
+            [
+              'acc',
+              buildIntervalFilter({
+                includeUndefined: false,
+                filterLowerValue: 0.25,
+                filterUpperValue: 1,
+              }),
+            ],
+          ])
+        );
+        const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
+        fixture.detectChanges();
+
+        const columnHeaders = fixture.nativeElement.querySelectorAll(
+          Selector.HEADER_COLUMN
+        );
+        columnHeaders[3].querySelector('button').click();
+        columnHeaders[4].querySelector('button').click();
+
+        for (const [action] of dispatchSpy.calls.allArgs()) {
+          expect(action.type).not.toBe(runSelectorSortChanged.type);
+        }
+      });
     });
 
     function setNoFilterHparamsAndMetrics(


### PR DESCRIPTION
Currently, the interactable elements are stacked on top of each other on
the runs table; sort -> filter button. Without the stopPropagation,
clicking on a filter menu button will trigger a sort which is not what
we want.
