### PR TITLE
sync: add missing ngrx store dep

### DIFF
--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -78,6 +78,7 @@ tf_ng_module(
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/runs/store:testing",
         "//tensorboard/webapp/types",
         "@npm//@angular/core",


### PR DESCRIPTION
Internal quirk requires explicit dependency on `@ngrx/store/testing`.