### PR TITLE
notification center: integrate markdown renderer

### DIFF
--- a/tensorboard/webapp/notification_center/_redux/notification_notes.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_notes.ts
@@ -19,7 +19,25 @@ export const notificationNotes = [
     category: CategoryEnum.WHATS_NEW,
     dateInMs: 1579766400000,
     title: '2.4 release',
-    content:
-      '<li>Visualize Scalars, Images, and  Histograms in one place</li><li>Custom colors for runs</li><li>Group previews</li>',
+    content: `
+  # Hello there
+
+  ## This is the markdown with \`code\`.
+
+  \`this is a pretty long inline code block. It may wrap around without any special CSS. \`
+
+  helloworldhelloworldhelloworldhelloworldhelloworldhelloworldhelloworldhelloworldhelloworldhelloworld
+
+  \`\`\`
+  code test support hehe super long
+  \`\`\`
+
+  \`\`\`
+  thisisevenworseasthereisnowhitespacebetweenwordsright
+  \`\`\`
+
+  - Visualize Scalars, Images, and  Histograms in one place
+  - Custom colors for runs
+  - Group previews`,
   },
 ] as Notification[];

--- a/tensorboard/webapp/notification_center/_views/BUILD
+++ b/tensorboard/webapp/notification_center/_views/BUILD
@@ -30,6 +30,7 @@ tf_ng_module(
         "//tensorboard/webapp/notification_center/_redux",
         "//tensorboard/webapp/notification_center/_redux:actions",
         "//tensorboard/webapp/notification_center/_redux:types",
+        "//tensorboard/webapp/widgets/markdown_renderer",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
@@ -44,7 +44,10 @@ limitations under the License.
       </div>
       <div class="content-wrapper">
         <h3 class="title">{{ notification.title }}</h3>
-        <div class="content" [innerHTML]="notification.content"></div>
+        <markdown-renderer
+          class="content"
+          [markdown]="notification.content"
+        ></markdown-renderer>
         <div class="extended-buttons">READ FULL</div>
       </div>
     </div>

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -79,3 +79,15 @@ limitations under the License.
   font-weight: 700;
   margin: 10px 0 20px;
 }
+
+// Unlike other markdown usage, we cannot make the entire notification center
+// scrollable when there is a big code block.
+.content ::ng-deep {
+  // If there is a long word without any break, we need to wrap it because the
+  // notification center content area is really small.
+  overflow-wrap: break-word;
+
+  pre {
+    overflow: auto;
+  }
+}

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {CommonModule} from '@angular/common';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {MatMenuModule} from '@angular/material/menu';
@@ -48,6 +49,7 @@ describe('notification center', () => {
           initialState: [],
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     recordedActions = [];
@@ -87,9 +89,10 @@ describe('notification center', () => {
     expect(
       notificationMenu.nativeNode.querySelector('.category-icon').textContent
     ).toBe('info_outline_24px');
-    expect(
-      notificationMenu.nativeNode.querySelector('.content').textContent
-    ).toBe('test content');
+    const markdownContentComponent = notificationMenu.nativeNode.querySelector(
+      '.content'
+    );
+    expect(markdownContentComponent.markdown).toBe('test content');
   });
 
   it('appears when unread notifications exist', () => {

--- a/tensorboard/webapp/notification_center/_views/views_module.ts
+++ b/tensorboard/webapp/notification_center/_views/views_module.ts
@@ -14,10 +14,11 @@ limitations under the License.
 ==============================================================================*/
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
 import {MatMenuModule} from '@angular/material/menu';
 
+import {MarkdownRendererModule} from '../../widgets/markdown_renderer/markdown_renderer_module';
 import {NotificationCenterComponent} from './notification_center_component';
 import {NotificationCenterContainer} from './notification_center_container';
 
@@ -27,6 +28,12 @@ import {NotificationCenterContainer} from './notification_center_container';
 @NgModule({
   declarations: [NotificationCenterContainer, NotificationCenterComponent],
   exports: [NotificationCenterContainer],
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    MatMenuModule,
+    MarkdownRendererModule,
+  ],
 })
 export class NotificationCenterViewModule {}


### PR DESCRIPTION
This change integrates the markdown renderer with the notification
center. Now the content of the notification can be any markdown string
as long as it does not contain certain dangerous elements like script
tag.

This change also makes few visual modification to the markdown renderer
for the optimal rendering in the small widthed screen.


![image](https://user-images.githubusercontent.com/2547313/114483550-6de85900-9bbd-11eb-8e73-e3e9a254b892.png)
