### PR TITLE
build: patch TF python_configure to fix genrule toolchain issues

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,6 +90,13 @@ http_archive(
         "http://mirror.tensorflow.org/github.com/tensorflow/tensorflow/archive/v2.3.0.tar.gz",  # 2020-07-23
         "https://github.com/tensorflow/tensorflow/archive/v2.3.0.tar.gz",
     ],
+    patches = [
+        # Patch TF's python_configure.bzl to ensure it reconfigures its python
+        # toolchain when environment variables like `PATH` and `PYTHONPATH`
+        # change, to avoid the stale genrule py_binary issue described in:
+        # https://github.com/tensorflow/tensorboard/issues/4862
+        "//third_party:tensorflow.patch",
+    ],
 )
 
 load("@org_tensorflow//tensorflow:workspace.bzl", "tf_workspace")

--- a/third_party/tensorflow.patch
+++ b/third_party/tensorflow.patch
@@ -1,0 +1,12 @@
+--- third_party/py/python_configure.bzl	1970-01-01 00:00:00.000000000 +0000
++++ third_party/py/python_configure.bzl	1970-01-01 00:00:00.000000000 +0000
+@@ -268,6 +268,9 @@ NOTE: https://github.com/tensorflow/tensorboard/issues/4862
+
+ _ENVIRONS = [
+     BAZEL_SH,
++    "PATH",
++    "PYTHONHOME",
++    "PYTHONPATH",
+     PYTHON_BIN_PATH,
+     PYTHON_LIB_PATH,
+ ]


### PR DESCRIPTION
This is a workaround for #4862 - see that issue for all the gory details.

The tl;dr is that we want to fix an omission in the TF python configuration rules, where they only list a small number of environment variables that their [repository rules are sensitive to](https://docs.bazel.build/versions/master/skylark/lib/globals.html#repository_rule). In particular they don't include `PATH` (or `PYTHONPATH` or `PYTHONHOME`), even though these are all actually used by the toolchain resolution rules to find the active python binary and python lib directory.  So we just patch them in, which ameliorates #4862.  (In theory we could try to upstream this, but we're currently pinned to TF 2.3.0 rules and having to upgrade will probably be painful.)

Tested: ran repro script from #4862 and verified that after this change, while it still bakes the local python path into the py_binary wrapper script that's invoked by the genrule, it at least regenerates the wrapper when `PATH` changes (i.e. when switching virtualenvs) which mostly sidesteps the problem.  It would still feel more foolproof to never bake in that path at all and continue using Bazel's autodetecting python toolchain, but to do that I think we might need to migrate off of the TF workspace rules entirely.