### PR TITLE
plugin api: cut tie to lodash and polymer

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -28,7 +28,6 @@ tf_ts_library(
     name = "polymer3_interop_helper",
     srcs = ["polymer3_interop_helper.ts"],
     deps = [
-        "//tensorboard/components/experimental/plugin_util:plugin_host",
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_globals",

--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -39,7 +39,7 @@ tf_ng_module(
     deps = [
         ":host_internals",
         ":message_types",
-        "//tensorboard/components/tf_storage",
+        "//tensorboard/components/tf_storage:tf_storage_lib",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "@npm//@angular/core",
@@ -74,7 +74,7 @@ tf_ng_module(
         ":message_types",
         ":plugin_host",
         ":testing",
-        "//tensorboard/components/tf_storage",
+        "//tensorboard/components/tf_storage:tf_storage_lib",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_core_testing",

--- a/tensorboard/components/experimental/plugin_util/core-host-impl.ts
+++ b/tensorboard/components/experimental/plugin_util/core-host-impl.ts
@@ -21,7 +21,7 @@ import {distinctUntilChanged, filter} from 'rxjs/operators';
 
 import {State} from '../../../webapp/app_state';
 import {getAppLastLoadedTimeInMs} from '../../../webapp/selectors';
-import * as tf_storage from '../../tf_storage';
+import * as tf_storage_utils from '../../tf_storage/storage_utils';
 import {MessageId} from './message_types';
 import {Ipc} from './plugin-host-ipc';
 
@@ -41,7 +41,7 @@ export class PluginCoreApiHostImpl {
       const result: {
         [key: string]: string;
       } = {};
-      const urlDict = tf_storage.getUrlDict();
+      const urlDict = tf_storage_utils.getUrlDict();
       for (let key in urlDict) {
         if (key.startsWith(prefix)) {
           const pluginKey = key.substring(prefix.length);

--- a/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
+++ b/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
@@ -24,8 +24,7 @@ import {
   getExperimentIdsFromRoute,
   getRuns,
 } from '../../../webapp/selectors';
-import {DataLoadState} from '../../../webapp/types/data';
-import * as tf_storage from '../../tf_storage';
+import * as tf_storage_utils from '../../tf_storage/storage_utils';
 import {PluginCoreApiHostImpl} from './core-host-impl';
 import {MessageId} from './message_types';
 import {Ipc} from './plugin-host-ipc';
@@ -248,16 +247,16 @@ describe('plugin_api_host test', () => {
             }
           );
 
-        getUrlDictSpy = spyOnProperty(tf_storage, 'getUrlDict', 'get');
+        getUrlDictSpy = spyOn(tf_storage_utils, 'getUrlDict');
       });
 
       it('returns url data from the tf storage', () => {
-        getUrlDictSpy.and.returnValue(() => ({
+        getUrlDictSpy.and.returnValue({
           globalThing: 'hey',
           'p.plugin_id.a': '1',
           'p.plugin_id.b': 'b',
           'p.another_plugn.b': '2',
-        }));
+        });
 
         coreApi.init();
         const actual = triggerGetUrlData({pluginName: 'plugin_id'});

--- a/tensorboard/components/tf_globals/BUILD
+++ b/tensorboard/components/tf_globals/BUILD
@@ -7,11 +7,18 @@ licenses(["notice"])
 tf_ts_library(
     name = "tf_globals",
     srcs = [
-        "globals.ts",
         "globals-polymer.ts",
     ],
     deps = [
+        ":tf_globals_lib",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
+    ],
+)
+
+tf_ts_library(
+    name = "tf_globals_lib",
+    srcs = [
+        "globals.ts",
     ],
 )

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -8,16 +8,27 @@ tf_ts_library(
     name = "tf_storage",
     srcs = [
         "index.ts",
-        "listeners.ts",
         "storage.ts",
         "tf-storage-polymer.ts",
     ],
     strict_checks = False,
     deps = [
-        "//tensorboard/components/tf_globals",
+        ":tf_storage_lib",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
         "@npm//@types/lodash",
         "@npm//lodash",
+    ],
+)
+
+tf_ts_library(
+    name = "tf_storage_lib",
+    srcs = [
+        "listeners.ts",
+        "storage_utils.ts",
+    ],
+    strict_checks = False,
+    deps = [
+        "//tensorboard/components/tf_globals:tf_globals_lib",
     ],
 )

--- a/tensorboard/components/tf_storage/storage_utils.ts
+++ b/tensorboard/components/tf_storage/storage_utils.ts
@@ -1,0 +1,121 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {getFakeHash, setFakeHash, useHash} from '../tf_globals/globals';
+import {addHashListener} from './listeners';
+
+/**
+ * A keyword that users cannot use, since TensorBoard uses this to store info
+ * about the active tab.
+ */
+export const TAB_KEY = '__tab__';
+
+export interface StringDict {
+  [key: string]: string;
+}
+
+// Keep an up-to-date store of URL params, which iframed plugins can request.
+let urlDict: StringDict = {};
+
+export function getUrlDict(): StringDict {
+  return urlDict;
+}
+
+export function updateUrlDict(dict: StringDict) {
+  urlDict = dict;
+}
+
+addHashListener(() => {
+  urlDict = componentToDict(readComponent());
+});
+
+/**
+ * Read component from URI (e.g. returns "events&runPrefix=train*").
+ */
+export function readComponent(): string {
+  return useHash() ? window.location.hash.slice(1) : getFakeHash();
+}
+
+/**
+ * Convert a URI Component into a dictionary of strings.
+ * Component should consist of key-value pairs joined by a delimiter
+ * with the exception of the tabName.
+ * Returns dict consisting of all key-value pairs and
+ * dict[TAB] = tabName
+ */
+export function componentToDict(component: string): StringDict {
+  const items = {} as StringDict;
+  const tokens = component.split('&');
+  tokens.forEach((token) => {
+    const kv = token.split('=');
+    // Special backwards compatibility for URI components like #scalars.
+    if (kv.length === 1) {
+      items[TAB_KEY] = kv[0];
+    } else if (kv.length === 2) {
+      items[decodeURIComponent(kv[0])] = decodeURIComponent(kv[1]);
+    }
+  });
+  return items;
+}
+
+/**
+ * Write component to URI.
+ */
+export function writeComponent(component: string, useLocationReplace = false) {
+  if (useHash()) {
+    if (useLocationReplace) {
+      const url = new URL(window.location.href);
+      url.hash = component;
+      window.history.replaceState(null, '', url.toString());
+    } else {
+      window.location.hash = component;
+    }
+  } else {
+    setFakeHash(component);
+  }
+}
+
+/**
+ * Convert dictionary of strings into a URI Component.
+ * All key value entries get added as key value pairs in the component,
+ * with the exception of a key with the TAB value, which if present
+ * gets prepended to the URI Component string for backwards compatibility
+ * reasons.
+ */
+export function dictToComponent(items: StringDict): string {
+  let component = '';
+  // Add the tab name e.g. 'events', 'images', 'histograms' as a prefix
+  // for backwards compatbility.
+  if (items[TAB_KEY] !== undefined) {
+    component += items[TAB_KEY];
+  }
+  // Join other strings with &key=value notation
+  const nonTab = Object.keys(items)
+    .map((key) => [key, items[key]])
+    .filter((pair) => pair[0] !== TAB_KEY)
+    .map((pair) => {
+      return encodeURIComponent(pair[0]) + '=' + encodeURIComponent(pair[1]);
+    })
+    .join('&');
+  return nonTab.length > 0 ? component + '&' + nonTab : component;
+}
+
+/**
+ * Delete a key from the URI.
+ */
+export function unsetFromURI(key) {
+  const items = componentToDict(readComponent());
+  delete items[key];
+  writeComponent(dictToComponent(items));
+}


### PR DESCRIPTION
Core API requires dependency on tf_storage for reading the hash and that
module depends on lodash. Lodash, technically, is not an issue but it
seems to double bundle on the dev target of the internal application and
breaks the build.

Also, this change guts the bazel dependency of plugin_host to the
polymer binary (saving changes to the plugin_host code does not trigger
rebuild of Polymer anymore!)
