### PR TITLE
Gracefully handle cases where App Routing state is not available.

### DIFF
--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -36,14 +36,14 @@ const getAppRoutingState = createFeatureSelector<State, AppRoutingState>(
 export const getActiveRoute = createSelector(
   getAppRoutingState,
   (state: AppRoutingState) => {
-    return state.activeRoute;
+    return state?.activeRoute;
   }
 );
 
 export const getNextRouteForRouterOutletOnly = createSelector(
   getAppRoutingState,
   (state: AppRoutingState): Route | null => {
-    return state.nextRoute;
+    return state?.nextRoute;
   }
 );
 

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -54,6 +54,10 @@ describe('app_routing_selectors', () => {
         },
       });
     });
+
+    it('returns undefined if no AppRoutingState', () => {
+      expect(selectors.getActiveRoute({})).toBeUndefined();
+    });
   });
 
   describe('getRouteKind', () => {
@@ -76,6 +80,10 @@ describe('app_routing_selectors', () => {
       );
 
       expect(selectors.getRouteKind(state)).toBe(RouteKind.EXPERIMENT);
+    });
+
+    it('returns UNKNOWN route kind if no AppRoutingState', () => {
+      expect(selectors.getRouteKind({})).toEqual(RouteKind.UNKNOWN);
     });
   });
 
@@ -101,6 +109,10 @@ describe('app_routing_selectors', () => {
       expect(selectors.getRouteParams(state)).toEqual({
         experimentId: '234',
       });
+    });
+
+    it('returns no params if no AppRoutingState', () => {
+      expect(selectors.getRouteParams({})).toEqual({});
     });
   });
 
@@ -145,6 +157,10 @@ describe('app_routing_selectors', () => {
       );
 
       expect(selectors.getExperimentIdToAliasMap(state)).toEqual({});
+    });
+
+    it('returns an empty map if no AppRoutingState', () => {
+      expect(selectors.getExperimentIdToAliasMap({})).toEqual({});
     });
   });
 });


### PR DESCRIPTION
#4839 introduced a runtime dependency from plugins component on tensorboard app router. This breaks some internal versions of TensorBoard that have not yet integrated the app router.

Rather than unwind the dependency or rollback the change, we instead handle no-app-router case more gracefully. It means that there is some functionality of the plugins component that is not available to no-app-router tensorboards. I think this is ok given that the app router is becoming more-and-more critical for integrating core tensorboard functionality. I think it's ok to expect that tensorboards will need to integrate the app router if they want to unlock this (and other) functionality.