### PR TITLE
graph: fix bug in parsing of _output_shapes attr

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/common_test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common_test.ts
@@ -521,6 +521,40 @@ describe('graph tests', () => {
       ]);
     });
   });
+
+  describe('Graph Normalizing Names', () => {
+    it('handles node with empty _output_shapes attr', async () => {
+      const pbtxt = `
+        node {
+          name: "foo1"
+          op: "Add"
+          attr {
+            key: "_output_shapes"
+            value {
+            }
+          }
+        }
+      `;
+      await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+    });
+
+    it('handles node with _output_shapes attr having only single shape', async () => {
+      const pbtxt = `
+        node {
+          name: "foo1"
+          op: "Add"
+          attr {
+            key: "_output_shapes"
+            value {
+              shape {
+              }
+            }
+          }
+        }
+      `;
+      await graphDefToSlimGraph(await pbtxtToGraphDef(pbtxt));
+    });
+  });
 });
 
 async function slimGraphToHierarchy(

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -859,7 +859,7 @@ function extractOutputShapes(
   for (let i = 0; i < attr.length; i++) {
     let {key, value} = attr[i];
     if (key === OUTPUT_SHAPES_KEY) {
-      if (!value.list.shape) {
+      if (!value.list || !value.list.shape) {
         // The OUTPUT_SHAPES_KEY lacks a value. We know nothing about the shape.
         return null;
       }


### PR DESCRIPTION
This fixes an issue where the Graph dashboard would die with "Graph: Failed Normalizing names" when trying to parse a graphdef containing a node with a mis-formatted `_output_shapes` attr.  In particular, it fails if the `_output_shapes` attr doesn't contain the top-level `list` property (either it's empty, or has only other properties).  The fix is just to guard the logic by checking for that property's existence before dereferencing it.

This attr is generated when calling `as_graph_def(add_shapes=True)` and I'm pretty sure that when constructed normally it should always have the `.list.shape` property if it's present on the node at all:
- https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/python/framework/ops.py;l=3304;drc=5e0c8476f0d8473e6246897ad1065ec4621bf73e
- https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/python/framework/ops.py;l=3347;drc=5e0c8476f0d8473e6246897ad1065ec4621bf73e

However, it seems like occasionally users end up with an attr value where that isn't the case, and even in those cases we should avoid breaking the graph visualization.

Googlers, see b/160928542.