### PR TITLE
sync: add missing dep on angular/core

### DIFF
--- a/tensorboard/webapp/notification_center/_views/BUILD
+++ b/tensorboard/webapp/notification_center/_views/BUILD
@@ -59,6 +59,7 @@ tf_ts_library(
         "//tensorboard/webapp/notification_center/_redux:types",
         "//tensorboard/webapp/testing:mat_icon",
         "@npm//@angular/common",
+        "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",


### PR DESCRIPTION
Now that we use the NO_SCHEMA_ERROR from `@angular/core`, we need the explicit dep.