### PR TITLE
Import PluginApiHostModule at app level. Do not assume it exists in PluginsComponent.

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -93,6 +93,7 @@ tf_ng_module(
         ":oss_plugins_module",
         ":selectors",
         ":store_module",
+        "//tensorboard/components/experimental/plugin_util:plugin_host",
         "//tensorboard/webapp/alert",
         "//tensorboard/webapp/alert/views:alert_snackbar",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -31,6 +31,7 @@ import {HeaderModule} from './header/header_module';
 import {MatIconModule} from './mat_icon_module';
 import {OssPluginsModule} from './oss_plugins_module';
 import {PluginsModule} from './plugins/plugins_module';
+import {PluginApiHostModule} from '../components/experimental/plugin_util/plugin_api_host_module';
 import {routesFactory} from './routes';
 import {RunsModule} from './runs/runs_module';
 import {SettingsModule} from './settings/settings_module';
@@ -58,6 +59,7 @@ import {HparamsModule} from './hparams/hparams_module';
     HparamsModule,
     MatIconModule,
     PageTitleModule,
+    PluginApiHostModule,
     PluginsModule,
     RunsModule,
     SettingsModule,

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -24,6 +24,7 @@ import {
   ElementRef,
   Input,
   OnChanges,
+  Optional,
   SimpleChanges,
   ViewChild,
   ComponentFactoryResolver,
@@ -96,7 +97,7 @@ export class PluginsComponent implements OnChanges {
   constructor(
     private readonly componentFactoryResolver: ComponentFactoryResolver,
     private readonly pluginRegistry: PluginRegistryModule,
-    private readonly pluginApiHost: PluginApiHostModule
+    @Optional() private readonly pluginApiHost: PluginApiHostModule
   ) {}
 
   @ViewChild('pluginContainer', {static: true, read: ElementRef})
@@ -225,6 +226,12 @@ export class PluginsComponent implements OnChanges {
         break;
       }
       case LoadingMechanismType.IFRAME: {
+        if (!this.pluginApiHost) {
+          // In order to support iframe-based plugins the top-level module
+          // (often named 'AppModule') needs to import PluginApiHostModule.
+          throw Error(`IFRAME-based plugins not supported: ${plugin.id}`);
+        }
+
         pluginElement = document.createElement('iframe');
         // Ideally should use the DOMSanitizer but it is not usable in TypeScript.
         pluginElement.setAttribute(

--- a/tensorboard/webapp/plugins/plugins_module.ts
+++ b/tensorboard/webapp/plugins/plugins_module.ts
@@ -23,10 +23,6 @@ import {PluginRegistryModule} from './plugin_registry_module';
 @NgModule({
   declarations: [PluginsContainer, PluginsComponent],
   exports: [PluginsContainer],
-  imports: [
-    CoreModule,
-    CommonModule,
-    PluginRegistryModule,
-  ],
+  imports: [CoreModule, CommonModule, PluginRegistryModule],
 })
 export class PluginsModule {}

--- a/tensorboard/webapp/plugins/plugins_module.ts
+++ b/tensorboard/webapp/plugins/plugins_module.ts
@@ -19,7 +19,6 @@ import {PluginsContainer} from './plugins_container';
 import {PluginsComponent} from './plugins_component';
 import {CoreModule} from '../core/core_module';
 import {PluginRegistryModule} from './plugin_registry_module';
-import {PluginApiHostModule} from '../../components/experimental/plugin_util/plugin_api_host_module';
 
 @NgModule({
   declarations: [PluginsContainer, PluginsComponent],
@@ -28,7 +27,6 @@ import {PluginApiHostModule} from '../../components/experimental/plugin_util/plu
     CoreModule,
     CommonModule,
     PluginRegistryModule,
-    PluginApiHostModule,
   ],
 })
 export class PluginsModule {}


### PR DESCRIPTION
#4839 introduced a transitive runtime dependency from PluginsComponent on tensorboard app router and runs module. This breaks some internal versions of TensorBoard that have not yet integrated the app router or the runs module.

We relax the dependency of PluginsComponent on PluginApiHostModule, making it optional. PluginApiHostModule is no longer imported by PluginsModule, thus breaking the dependency completely for internal versions of TensorBoard. In the case of core OSS TensorBoard, we instead import PluginApiHostModule from the top-level AppModule.

This supercedes #4866.