### PR TITLE
Factor public uploader errors into their own module.

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -101,6 +101,7 @@ py_library(
     deps = [
         ":logdir_loader",
         ":upload_tracker",
+        ":uploader_errors",
         ":util",
         "//tensorboard:expect_grpc_installed",
         "//tensorboard/backend:process_graph",
@@ -307,4 +308,12 @@ py_test(
         "//tensorboard:test",
         "//tensorboard/util:grpc_util",
     ],
+)
+
+py_library(
+    name = "uploader_errors",
+    srcs = ["uploader_errors.py"],
+    srcs_version = "PY3",
+    visibility = ["//tensorboard:internal"],
+    deps = [],
 )

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -29,6 +29,7 @@ from tensorboard.uploader.proto import write_service_pb2
 from tensorboard.uploader import logdir_loader
 from tensorboard.uploader import upload_tracker
 from tensorboard.uploader import util
+from tensorboard.uploader import uploader_errors
 from tensorboard.backend import process_graph
 from tensorboard.backend.event_processing import directory_loader
 from tensorboard.backend.event_processing import event_file_loader
@@ -264,11 +265,11 @@ def update_experiment_metadata(
         grpc_util.call_with_retries(writer_client.UpdateExperiment, request)
     except grpc.RpcError as e:
         if e.code() == grpc.StatusCode.NOT_FOUND:
-            raise ExperimentNotFoundError()
+            raise uploader_errors.ExperimentNotFoundError()
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:
-            raise PermissionDeniedError()
+            raise uploader_errors.PermissionDeniedError()
         if e.code() == grpc.StatusCode.INVALID_ARGUMENT:
-            raise InvalidArgumentError(e.details())
+            raise uploader_errors.InvalidArgumentError(e.details())
         raise
 
 
@@ -292,22 +293,10 @@ def delete_experiment(writer_client, experiment_id):
         grpc_util.call_with_retries(writer_client.DeleteExperiment, request)
     except grpc.RpcError as e:
         if e.code() == grpc.StatusCode.NOT_FOUND:
-            raise ExperimentNotFoundError()
+            raise uploader_errors.ExperimentNotFoundError()
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:
-            raise PermissionDeniedError()
+            raise uploader_errors.PermissionDeniedError()
         raise
-
-
-class InvalidArgumentError(RuntimeError):
-    pass
-
-
-class ExperimentNotFoundError(RuntimeError):
-    pass
-
-
-class PermissionDeniedError(RuntimeError):
-    pass
 
 
 class _OutOfSpaceError(Exception):
@@ -560,7 +549,7 @@ class _ScalarBatchedRequestSender(object):
                 grpc_util.call_with_retries(self._api.WriteScalar, request)
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.NOT_FOUND:
-                    raise ExperimentNotFoundError()
+                    raise uploader_errors.ExperimentNotFoundError()
                 logger.error("Upload call failed with error %s", e)
 
         self._new_request()
@@ -728,7 +717,7 @@ class _TensorBatchedRequestSender(object):
                     grpc_util.call_with_retries(self._api.WriteTensor, request)
                 except grpc.RpcError as e:
                     if e.code() == grpc.StatusCode.NOT_FOUND:
-                        raise ExperimentNotFoundError()
+                        raise uploader_errors.ExperimentNotFoundError()
                     logger.error("Upload call failed with error %s", e)
 
         self._new_request()
@@ -1071,7 +1060,7 @@ class _BlobRequestSender(object):
                 blob_sequence_id = response.blob_sequence_id
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.NOT_FOUND:
-                    raise ExperimentNotFoundError()
+                    raise uploader_errors.ExperimentNotFoundError()
                 logger.error("Upload call failed with error %s", e)
                 # TODO(soergel): clean up
                 raise

--- a/tensorboard/uploader/uploader_errors.py
+++ b/tensorboard/uploader/uploader_errors.py
@@ -1,0 +1,27 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Common error types used by the uploader and helper classes."""
+
+class InvalidArgumentError(RuntimeError):
+    pass
+
+
+class ExperimentNotFoundError(RuntimeError):
+    pass
+
+
+class PermissionDeniedError(RuntimeError):
+    pass
+

--- a/tensorboard/uploader/uploader_errors.py
+++ b/tensorboard/uploader/uploader_errors.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Common error types used by the uploader and helper classes."""
 
+
 class InvalidArgumentError(RuntimeError):
     pass
 
@@ -24,4 +25,3 @@ class ExperimentNotFoundError(RuntimeError):
 
 class PermissionDeniedError(RuntimeError):
     pass
-

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -34,6 +34,7 @@ from tensorboard.uploader import flags_parser
 from tensorboard.uploader import formatters
 from tensorboard.uploader import server_info as server_info_lib
 from tensorboard.uploader import uploader as uploader_lib
+from tensorboard.uploader import uploader_errors
 from tensorboard.uploader.proto import server_info_pb2
 from tensorboard import program
 from tensorboard.plugins import base_plugin
@@ -205,12 +206,12 @@ class _DeleteExperimentIntent(_Intent):
             )
         try:
             uploader_lib.delete_experiment(api_client, experiment_id)
-        except uploader_lib.ExperimentNotFoundError:
+        except uploader_errors.ExperimentNotFoundError:
             _die(
                 "No such experiment %s. Either it never existed or it has "
                 "already been deleted." % experiment_id
             )
-        except uploader_lib.PermissionDeniedError:
+        except uploader_errors.PermissionDeniedError:
             _die(
                 "Cannot delete experiment %s because it is owned by a "
                 "different user." % experiment_id
@@ -262,17 +263,17 @@ class _UpdateMetadataIntent(_Intent):
                 name=self.name,
                 description=self.description,
             )
-        except uploader_lib.ExperimentNotFoundError:
+        except uploader_errors.ExperimentNotFoundError:
             _die(
                 "No such experiment %s. Either it never existed or it has "
                 "already been deleted." % experiment_id
             )
-        except uploader_lib.PermissionDeniedError:
+        except uploader_errors.PermissionDeniedError:
             _die(
                 "Cannot modify experiment %s because it is owned by a "
                 "different user." % experiment_id
             )
-        except uploader_lib.InvalidArgumentError as e:
+        except uploader_errors.InvalidArgumentError as e:
             _die("Server cannot modify experiment as requested: %s" % e)
         except grpc.RpcError as e:
             _die("Internal error modifying experiment: %s" % e)
@@ -442,7 +443,7 @@ class UploadIntent(_Intent):
         interrupted = False
         try:
             uploader.start_uploading()
-        except uploader_lib.ExperimentNotFoundError:
+        except uploader_errors.ExperimentNotFoundError:
             print("Experiment was deleted; uploading has been cancelled")
             return
         except KeyboardInterrupt:

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -39,6 +39,7 @@ from tensorboard.uploader import upload_tracker
 from tensorboard.uploader import uploader as uploader_lib
 from tensorboard.uploader import logdir_loader
 from tensorboard.uploader import util
+from tensorboard.uploader import uploader_errors
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import graph_pb2
 from tensorboard.compat.proto import summary_pb2
@@ -1179,7 +1180,7 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
 
         error = test_util.grpc_error(grpc.StatusCode.NOT_FOUND, "nope")
         mock_client.WriteScalar.side_effect = error
-        with self.assertRaises(uploader_lib.ExperimentNotFoundError):
+        with self.assertRaises(uploader_errors.ExperimentNotFoundError):
             sender.flush()
 
     def test_no_budget_for_base_request(self):
@@ -1551,7 +1552,7 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
 
         error = test_util.grpc_error(grpc.StatusCode.NOT_FOUND, "nope")
         mock_client.WriteTensor.side_effect = error
-        with self.assertRaises(uploader_lib.ExperimentNotFoundError):
+        with self.assertRaises(uploader_errors.ExperimentNotFoundError):
             sender.flush()
 
     def test_no_budget_for_base_request(self):
@@ -1899,7 +1900,7 @@ class DeleteExperimentTest(tf.test.TestCase):
         error = test_util.grpc_error(grpc.StatusCode.NOT_FOUND, "nope")
         mock_client.DeleteExperiment.side_effect = error
 
-        with self.assertRaises(uploader_lib.ExperimentNotFoundError):
+        with self.assertRaises(uploader_errors.ExperimentNotFoundError):
             uploader_lib.delete_experiment(mock_client, "123")
 
     def test_unauthorized(self):
@@ -1907,7 +1908,7 @@ class DeleteExperimentTest(tf.test.TestCase):
         error = test_util.grpc_error(grpc.StatusCode.PERMISSION_DENIED, "nope")
         mock_client.DeleteExperiment.side_effect = error
 
-        with self.assertRaises(uploader_lib.PermissionDeniedError):
+        with self.assertRaises(uploader_errors.PermissionDeniedError):
             uploader_lib.delete_experiment(mock_client, "123")
 
     def test_internal_error(self):
@@ -1958,7 +1959,7 @@ class UpdateExperimentMetadataTest(tf.test.TestCase):
         error = test_util.grpc_error(grpc.StatusCode.NOT_FOUND, "nope")
         mock_client.UpdateExperiment.side_effect = error
 
-        with self.assertRaises(uploader_lib.ExperimentNotFoundError):
+        with self.assertRaises(uploader_errors.ExperimentNotFoundError):
             uploader_lib.update_experiment_metadata(mock_client, "123", name="")
 
     def test_unauthorized(self):
@@ -1966,7 +1967,7 @@ class UpdateExperimentMetadataTest(tf.test.TestCase):
         error = test_util.grpc_error(grpc.StatusCode.PERMISSION_DENIED, "nope")
         mock_client.UpdateExperiment.side_effect = error
 
-        with self.assertRaises(uploader_lib.PermissionDeniedError):
+        with self.assertRaises(uploader_errors.PermissionDeniedError):
             uploader_lib.update_experiment_metadata(mock_client, "123", name="")
 
     def test_invalid_argument(self):
@@ -1976,7 +1977,7 @@ class UpdateExperimentMetadataTest(tf.test.TestCase):
         )
         mock_client.UpdateExperiment.side_effect = error
 
-        with self.assertRaises(uploader_lib.InvalidArgumentError) as cm:
+        with self.assertRaises(uploader_errors.InvalidArgumentError) as cm:
             uploader_lib.update_experiment_metadata(mock_client, "123", name="")
         msg = str(cm.exception)
         self.assertIn("too many", msg)


### PR DESCRIPTION
* Motivation for features / changes
Precondition for factoring `*BatchedRequestSender` into their own modules, so as to simplify uploader logic.  That factoring, in turn, is a precondition for enabling faster asynchronous uploads.'

* Technical description of changes
Moves public errors into their own module.

* Detailed steps to verify changes work correctly (as executed by you)
Tests still pass

* Alternate designs / implementations considered
There is also the internal _OutOfSpaceError.  It will be moved into the individual BatchedRequestSender.  There is no need to expose this error type or that is must be common across the BatchedRequestSenders