### PR TITLE
core: re-enable CorePluginTest and consolidate test cases

### DIFF
--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -260,9 +260,9 @@ class CorePluginExperimentMetadataTest(tf.test.TestCase):
         self.assertEqual(parsed_object["creation_time"], 1234.5)
 
 
-class CorePluginTestBase(object):
+class CorePluginTest(tf.test.TestCase):
     def setUp(self):
-        super(CorePluginTestBase, self).setUp()
+        super().setUp()
         self.logdir = self.get_temp_dir()
         self.multiplexer = event_multiplexer.EventMultiplexer()
         provider = data_provider.MultiplexerDataProvider(
@@ -276,9 +276,6 @@ class CorePluginTestBase(object):
         self.plugin = core_plugin.CorePlugin(context)
         app = application.TensorBoardWSGI([self.plugin])
         self.server = werkzeug_test.Client(app, wrappers.BaseResponse)
-
-    def create_multiplexer(self):
-        raise NotImplementedError()
 
     def _add_run(self, run_name):
         run_path = os.path.join(self.logdir, run_name)


### PR DESCRIPTION
This re-enables the test cases that were previously under `CorePluginTestBase`, which wasn't actually being executed - it used to be a common base class in between two subclasses that actually were `tf.test.TestCase` instances, but these subclasses were removed in #3539 without converting the parent class into a `TestCase` in its own right.

In addition, I've refactored the test cases to consolidate most of them into a single `CorePluginTest` class for simplicity, since they have a lot of common functionality and IMO they were just making it harder to understand where to add a new test method.  See individual commits for each consolidation step that was made.