### PR TITLE
visibility: make `tensorboard.context` public

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -163,6 +163,7 @@ py_library(
     name = "context",
     srcs = ["context.py"],
     srcs_version = "PY3",
+    visibility = ["//visibility:public"],
     deps = [
         ":auth",
     ],


### PR DESCRIPTION
Summary:
The `RequestContext` type is already public via `plugin_util.context`.
Some plugins need to access it directly to create a background context,
as done in the projector plugin or tensorflow/profiler#298. This module
is designed as a public API, so it can be made globally visible.

Googlers, see <http://cl/368909135>.

wchargin-branch: context-public
