### PR TITLE
timeseries: fix fit-to-domain state issue

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -23,14 +23,14 @@ limitations under the License.
   <span class="controls">
     <button
       mat-icon-button
-      [disabled]="!seriesDataList || !seriesDataList.length || (newLineChart && !newLineChart.getIsViewBoxOverridden())"
+      [disabled]="!seriesDataList || !seriesDataList.length || !isViewBoxOverridden"
       (click)="resetDomain()"
       [title]="
-            (newLineChart && !newLineChart.getIsViewBoxOverridden()) ?
-                'Line chart is already fitted to data. When data updates, the line chart '
-                + 'will auto fit to its domain.' :
-                'Fit line chart domains to data'
-        "
+          isViewBoxOverridden ?
+              'Fit line chart domains to data' :
+              'Line chart is already fitted to data. When data updates, the line chart '
+                + 'will auto fit to its domain.'
+      "
       i18n-aria-label="A button that resets line chart domain to the data"
       aria-label="Fit line chart domains to data"
     >
@@ -108,6 +108,7 @@ limitations under the License.
       [customXFormatter]="xAxisType === XAxisType.RELATIVE ? relativeXFormatter : undefined"
       [ignoreYOutliers]="ignoreOutliers"
       [tooltipTemplate]="tooltip"
+      (onViewBoxOverridden)="isViewBoxOverridden = $event"
     ></line-chart>
 
     <ng-template #legacyChart>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -163,6 +163,9 @@ export class ScalarCardComponent<Downloader> {
   @ViewChild(NewLineChartComponent)
   newLineChart?: NewLineChartComponent;
 
+  // Controls whether to enable/disable the fit-to-domain button.
+  isViewBoxOverridden: boolean = !this.gpuLineChartEnabled;
+
   constructor(private readonly ref: ElementRef, private dialog: MatDialog) {}
 
   yAxisType = YAxisType.LINEAR;


### PR DESCRIPTION
In a rare case, the ScalarCardComponent does not read the correct value
from the `newLineChart && newLineChart.getIsViewBoxOverridden()` causing
the fit-to-domain button to have the wrong state (enabled when it should
be disabled). This bug was identified in our screenshot based test where
this hard to reproduce timing issue was found.

Fixed the issue by manually propagating the view box overridden state
using the `Output()` which seems to have made the screenshot test very
stable (150 runs).

Relates to b/185595590.