### PR TITLE
types: improve TbHttpClient types

### DIFF
--- a/tensorboard/webapp/webapp_data_source/tb_http_client.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client.ts
@@ -85,7 +85,8 @@ export class TBHttpClient implements TBHttpClientInterface {
 
   post<ResponseType>(
     path: string,
-    body: Parameters<typeof HttpClient.prototype.post>[1],
+    // Angular's HttpClient is typed exactly this way.
+    body: any | null,
     options: PostOptions = {}
   ): Observable<ResponseType> {
     options = withXsrfHeader(options);
@@ -113,7 +114,8 @@ export class TBHttpClient implements TBHttpClientInterface {
 
   put<ResponseType>(
     path: string,
-    body: Parameters<typeof HttpClient.prototype.put>[1],
+    // Angular's HttpClient is typed exactly this way.
+    body: any | null,
     options: PutOptions = {}
   ): Observable<ResponseType> {
     return this.http.put<ResponseType>(

--- a/tensorboard/webapp/webapp_data_source/tb_http_client.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client.ts
@@ -85,7 +85,7 @@ export class TBHttpClient implements TBHttpClientInterface {
 
   post<ResponseType>(
     path: string,
-    body: FormData,
+    body: Parameters<typeof HttpClient.prototype.post>[1],
     options: PostOptions = {}
   ): Observable<ResponseType> {
     options = withXsrfHeader(options);
@@ -113,7 +113,7 @@ export class TBHttpClient implements TBHttpClientInterface {
 
   put<ResponseType>(
     path: string,
-    body: any,
+    body: Parameters<typeof HttpClient.prototype.put>[1],
     options: PutOptions = {}
   ): Observable<ResponseType> {
     return this.http.put<ResponseType>(


### PR DESCRIPTION
Currently, we manually typed the bodies of `put` and `post`. Instead, we
want to extend that of the `HttpClient` so we now do that.
