### PR TITLE
infra: remove the closure/goog/deps.js dep

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
@@ -41,7 +41,6 @@ filegroup(
         "@com_google_javascript_closure_compiler_externs",
         "externs.js",
         "@com_google_javascript_closure_library//:closure/goog/base.js",
-        "@com_google_javascript_closure_library//:closure/goog/deps.js",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
As part of the Closure compiler cleanup, we are asked to remove the dep.

Relates to cl/369541878.