### PR TITLE
sync: fix the unknown input `runColorScale` issue

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
@@ -29,7 +29,6 @@ limitations under the License.
     *ngSwitchCase="PluginType.SCALARS"
     [cardId]="cardId"
     [groupName]="groupName"
-    [runColorScale]="runColorScale"
     (fullWidthChanged)="onFullWidthChanged($event)"
     (fullHeightChanged)="onFullHeightChanged($event)"
     (pinStateChanged)="onPinStateChanged()"

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -161,44 +161,4 @@ describe('card view test', () => {
       }),
     ]);
   });
-
-  it(`throttles updates to colorScale`, fakeAsync(() => {
-    store.overrideSelector(selectors.getRunColorMap, {run1: '#000'});
-    const fixture = TestBed.createComponent(CardViewContainer);
-    fixture.componentInstance.cardId = 'cardId';
-    fixture.componentInstance.pluginType = PluginType.SCALARS;
-    fixture.detectChanges();
-
-    const scalarCard = fixture.debugElement.query(By.css('scalar-card'));
-    expect(scalarCard.componentInstance.runColorScale('run1')).toBe('#000');
-
-    store.overrideSelector(selectors.getRunColorMap, {run1: '#555'});
-    store.refreshState();
-    fixture.detectChanges();
-
-    expect(scalarCard.componentInstance.runColorScale('run1')).toBe('#000');
-
-    store.overrideSelector(selectors.getRunColorMap, {run1: '#aaa'});
-    store.refreshState();
-    fixture.detectChanges();
-
-    tick(TEST_ONLY.RUN_COLOR_UPDATE_THROTTLE_TIME_IN_MS);
-    fixture.detectChanges();
-
-    expect(scalarCard.componentInstance.runColorScale('run1')).toBe('#aaa');
-    flush();
-  }));
-
-  it('getting unknown color throws error', () => {
-    store.overrideSelector(selectors.getRunColorMap, {run1: '#000'});
-    const fixture = TestBed.createComponent(CardViewContainer);
-    fixture.componentInstance.cardId = 'cardId';
-    fixture.componentInstance.pluginType = PluginType.SCALARS;
-    fixture.detectChanges();
-
-    const scalarCard = fixture.debugElement.query(By.css('scalar-card'));
-    expect(() => {
-      scalarCard.componentInstance.runColorScale('meow');
-    }).toThrowError(Error, '[Color scale] unknown runId: meow.');
-  });
 });


### PR DESCRIPTION
Internal Angular compiler caught this bug correctly and noted that the
`runColorScale` is no longer an input to the `scalar-card`. This change
addresses that.
