### PR TITLE
what's new: utilize redirect for BE to read note  json file

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -289,8 +289,7 @@ class CorePlugin(base_plugin.TBPlugin):
     @wrappers.Request.application
     def _serve_notifications(self, request):
         """Serve JSON payload of notifications to show in the UI."""
-        results = {"notifications": []}
-        return http_util.Respond(request, results, "application/json")
+        return utils.redirect("notifications_note.json")
 
 
 class CorePluginLoader(base_plugin.TBLoader):

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -289,7 +289,7 @@ class CorePlugin(base_plugin.TBPlugin):
     @wrappers.Request.application
     def _serve_notifications(self, request):
         """Serve JSON payload of notifications to show in the UI."""
-        return utils.redirect("notifications_note.json")
+        return utils.redirect("../notifications_note.json")
 
 
 class CorePluginLoader(base_plugin.TBLoader):

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -358,7 +358,7 @@ class CorePluginTest(tf.test.TestCase):
 
         self.assertEqual(302, (response.status_code))
         self.assertStartsWith(content_type, "text/html")
-        redirect_link = "<a href=\"notifications_note.json\">"
+        redirect_link = '<a href="notifications_note.json">'
         self.assertIn(redirect_link, content)
 
 

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -354,12 +354,11 @@ class CorePluginTest(tf.test.TestCase):
         """Test that the /data/notifications endpoint redirect to /notifications_note.json."""
         response = self.server.get("/data/notifications")
         content_type = response.headers.get("Content-Type")
-        content = response.get_data().decode("utf-8")
+        location = response.headers.get("Location")
 
         self.assertEqual(302, (response.status_code))
         self.assertStartsWith(content_type, "text/html")
-        redirect_link = '<a href="notifications_note.json">'
-        self.assertIn(redirect_link, content)
+        self.assertIn('/notifications_note.json', location)
 
 
 class CorePluginPathPrefixTest(tf.test.TestCase):

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -358,7 +358,7 @@ class CorePluginTest(tf.test.TestCase):
 
         self.assertEqual(302, (response.status_code))
         self.assertStartsWith(content_type, "text/html")
-        self.assertIn('/notifications_note.json', location)
+        self.assertIn("/notifications_note.json", location)
 
 
 class CorePluginPathPrefixTest(tf.test.TestCase):

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -350,10 +350,16 @@ class CorePluginTest(tf.test.TestCase):
                 ["run1", "avocado", "zebra", "ox", "enigmatic", "mysterious"],
             )
 
-    def testNotifications(self):
-        """Test the format of the /data/notifications endpoint."""
-        notifications_json = self._get_json(self.server, "/data/notifications")
-        self.assertEqual(notifications_json, {"notifications": []})
+    def testNotificationsRedirectSuccess(self):
+        """Test that the /data/notifications endpoint redirect to /notifications_note.json."""
+        response = self.server.get("/data/notifications")
+        content_type = response.headers.get("Content-Type")
+        content = response.get_data().decode("utf-8")
+
+        self.assertEqual(302, (response.status_code))
+        self.assertStartsWith(content_type, "text/html")
+        redirect_link = "<a href=\"notifications_note.json\">"
+        self.assertIn(redirect_link, content)
 
 
 class CorePluginPathPrefixTest(tf.test.TestCase):


### PR DESCRIPTION
* Motivation for features / changes
We want to read the note content in BE. The design is to bundle the note json file with webfile. Thus we have /notifications_note.json to redirect to.


* Technical description of changes
  - return .json if notifications_note.json present.
  - If the file is absent, the return is 404, error of which is caught in notification_center component (_data_source/ to be specific)
  - for OSS and .dev, this endpoint should never be called