### PR TITLE
timeseries: correctly fix fit-to-domain

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -23,10 +23,10 @@ limitations under the License.
   <span class="controls">
     <button
       mat-icon-button
-      [disabled]="!isViewBoxOverridden"
+      [disabled]="!lineChart || !(lineChart.getIsViewBoxOverridden() | async)"
       (click)="resetDomain()"
       [title]="
-          isViewBoxOverridden ?
+          !lineChart || !(lineChart.getIsViewBoxOverridden() | async) ?
               'Fit line chart domains to data' :
               'Line chart is already fitted to data. When data updates, the line chart '
                 + 'will auto fit to its domain.'

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -82,9 +82,6 @@ export class ScalarCardComponent<Downloader> {
   @ViewChild(LineChartComponent)
   lineChart?: LineChartComponent;
 
-  // Controls whether to enable/disable the fit-to-domain button.
-  isViewBoxOverridden: boolean = false;
-
   constructor(private readonly ref: ElementRef, private dialog: MatDialog) {}
 
   yScaleType = ScaleType.LINEAR;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -182,10 +182,10 @@ describe('scalar card', () => {
       // would be populated by ViewChild decorator.
       scalarCardComponent.componentInstance.lineChart =
         lineChartComponent.componentInstance;
+      // lineChart property is now set; let the template re-render with
+      // `lineChart` checks correctly return the right value.
+      lineChartComponent.componentInstance.changeDetectorRef.markForCheck();
     }
-    // lineChart property is now set; let the template re-render with
-    // `lineChart` checks correctly return the right value.
-    lineChartComponent.componentInstance.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     return fixture;
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -36,7 +36,7 @@ import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {of, ReplaySubject} from 'rxjs';
+import {Observable, of, ReplaySubject} from 'rxjs';
 
 import {State} from '../../../app_state';
 import {Run} from '../../../runs/store/runs_types';
@@ -104,8 +104,10 @@ class TestableLineChart {
   @Input() tooltipDataForTesting: TooltipDatum[] = [];
   @Input() cursorLocForTesting: {x: number; y: number} = {x: 0, y: 0};
 
-  getIsViewBoxOverridden() {
-    return false;
+  private isViewBoxOverridden = new ReplaySubject<boolean>(1);
+
+  getIsViewBoxOverridden(): Observable<boolean> {
+    return this.isViewBoxOverridden;
   }
 
   viewBoxReset() {}
@@ -181,6 +183,10 @@ describe('scalar card', () => {
       scalarCardComponent.componentInstance.lineChart =
         lineChartComponent.componentInstance;
     }
+    // lineChart property is now set; let the template re-render with
+    // `lineChart` checks correctly return the right value.
+    lineChartComponent.componentInstance.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
     return fixture;
   }
 
@@ -1563,7 +1569,7 @@ describe('scalar card', () => {
   });
 
   describe('fit to domain', () => {
-    it('disables the fit to domain when data fits doamin already', fakeAsync(() => {
+    it('disables the fit to domain when data fits domain already', fakeAsync(() => {
       const runToSeries = {
         run1: [{wallTime: 2, value: 1, step: 1}],
       };
@@ -1574,17 +1580,18 @@ describe('scalar card', () => {
         null /* metadataOverride */,
         runToSeries
       );
+      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
 
       const fixture = createComponent('card1');
       const lineChart = fixture.debugElement.query(Selector.LINE_CHART);
 
-      lineChart.componentInstance.onViewBoxOverridden.emit(false);
+      lineChart.componentInstance.getIsViewBoxOverridden().next(false);
       fixture.detectChanges();
 
       const fitToDomain = fixture.debugElement.query(Selector.FIT_TO_DOMAIN);
       expect(fitToDomain.properties['disabled']).toBe(true);
 
-      lineChart.componentInstance.onViewBoxOverridden.emit(true);
+      lineChart.componentInstance.getIsViewBoxOverridden().next(true);
       fixture.detectChanges();
 
       expect(fitToDomain.properties['disabled']).toBe(false);
@@ -1606,7 +1613,7 @@ describe('scalar card', () => {
       const fixture = createComponent('card1');
 
       const lineChart = fixture.debugElement.query(Selector.LINE_CHART);
-      lineChart.componentInstance.onViewBoxOverridden.emit(true);
+      lineChart.componentInstance.getIsViewBoxOverridden().next(true);
       fixture.detectChanges();
 
       const viewBoxResetSpy = spyOn(

--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -33,6 +33,7 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2/sub_view",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//rxjs",
     ],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -18,15 +18,14 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
-  Output,
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
+import {Observable, ReplaySubject} from 'rxjs';
 
 import {ChartImpl} from './lib/chart';
 import {Chart} from './lib/chart_types';
@@ -111,8 +110,7 @@ export class LineChartComponent
   @Input()
   tooltipTemplate?: TooltipTemplate;
 
-  @Output()
-  onViewBoxOverridden = new EventEmitter<boolean>();
+  private onViewBoxOverridden = new ReplaySubject<boolean>(1);
 
   /**
    * Optional parameter to tweak whether to propagate update to line chart implementation.
@@ -157,7 +155,7 @@ export class LineChartComponent
 
   ngOnInit() {
     // Let the parent component know if its initial value.
-    this.onViewBoxOverridden.emit(this.isViewBoxOverridden);
+    this.onViewBoxOverridden.next(this.isViewBoxOverridden);
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -399,8 +397,12 @@ export class LineChartComponent
     const prevValue = this.isViewBoxOverridden;
     this.isViewBoxOverridden = newValue;
     if (prevValue !== newValue) {
-      this.onViewBoxOverridden.emit(newValue);
+      this.onViewBoxOverridden.next(newValue);
     }
+  }
+
+  getIsViewBoxOverridden(): Observable<boolean> {
+    return this.onViewBoxOverridden;
   }
 
   onViewBoxChangedFromAxis(extent: [number, number], axis: 'x' | 'y') {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -53,7 +53,6 @@ class FakeGridComponent {
       [seriesMetadataMap]="seriesMetadataMap"
       [yScaleType]="yScaleType"
       [fixedViewBox]="fixedViewBox"
-      (onViewBoxOverridden)="onViewBoxOverridden && onViewBoxOverridden($event)"
     ></line-chart>
   `,
   styles: [
@@ -84,9 +83,6 @@ class TestableComponent {
 
   @Input()
   disableUpdate?: boolean;
-
-  @Input()
-  onViewBoxOverridden?: (overridden: boolean) => void;
 
   // WebGL one is harder to test.
   preferredRendererType = RendererType.SVG;
@@ -127,7 +123,6 @@ describe('line_chart_v2/line_chart test', () => {
     yScaleType: ScaleType;
     fixedViewBox?: Extent;
     disableUpdate?: boolean;
-    onViewBoxOverridden?: (overridden: boolean) => void;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
     fixture.componentInstance.seriesData = input.seriesData;
@@ -140,10 +135,6 @@ describe('line_chart_v2/line_chart test', () => {
 
     if (input.disableUpdate !== undefined) {
       fixture.componentInstance.disableUpdate = input.disableUpdate;
-    }
-
-    if (input.onViewBoxOverridden) {
-      fixture.componentInstance.onViewBoxOverridden = input.onViewBoxOverridden;
     }
 
     return fixture;
@@ -582,7 +573,7 @@ describe('line_chart_v2/line_chart test', () => {
     });
   });
 
-  describe('#isViewBoxOverridden', () => {
+  describe('#getIsViewBoxOverridden', () => {
     it('emits when viewBox changes', () => {
       const onViewBoxOverridden = jasmine.createSpy();
       const fixture = createComponent({
@@ -598,10 +589,13 @@ describe('line_chart_v2/line_chart test', () => {
         ],
         seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
         yScaleType: ScaleType.LINEAR,
-        onViewBoxOverridden,
       });
       fixture.componentInstance.yScaleType = ScaleType.LINEAR;
       fixture.detectChanges();
+
+      fixture.componentInstance.chart
+        .getIsViewBoxOverridden()
+        .subscribe(onViewBoxOverridden);
 
       // Initial value.
       expect(onViewBoxOverridden).toHaveBeenCalledOnceWith(false);


### PR DESCRIPTION
In #4890, we incorrectly fixed the issue where scalar-card-component
does not update its DOM based on changes.

Background
----------------
while gory details are not yet known personally to me,
Angular, roughly speaking, has very strict condition in which it will
update the DOM. To name a few I know, they are (1) browser event, (2)
async (e.g., setTimeout), and (3) async pipe. In the earlier change, we
assumed that the `@Output` is one of them but it does not appear so.

Assumption
---------------
Angular updates DOM top to bottom (component tree wise) and
even if child component communicate information upwards when it mounts,
it _can_ be too late for parent component to actually apply the update
to the DOM.

Fix: we now use the AsyncPipe and Observable to communicate the
information upwards from a child component.

Why is this correct?
--------------------
AsyncPipe, on next value, interacts with the change detector[1]. Also,
this is a pattern that, sometimes, CDK components use[2]. Please see
public methods like `attachments` or `backdropClick`. At first, I was
curious why CDK did not use `Output` but now it starts to click a
little.

Test Case
---------
1. Launch TensorBoard and go to TimeSeries
2. Set the tag filter so only one scalar card matches the filter
3. Type a typo so nothing matches
4. Remove that single character typo
5. Repeat 3-4 to see the fit-to-domain turn solid (without this patch)

[1]: https://github.com/angular/angular/blob/master/packages/common/src/pipes/async_pipe.ts#L146
[2]: https://material.angular.io/cdk/overlay/api