### PR TITLE
Making hparams_utils publicly visible

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -149,6 +149,9 @@ py_binary(
     name = "hparams_util",
     srcs = ["hparams_util.py"],
     srcs_version = "PY3",
+    visibility = [
+        "//visibility:public",
+    ],
     deps = [
         ":protos_all_py_pb2",
         ":summary",


### PR DESCRIPTION
* Motivation for features / changes
hparams_utils is a binary. Make its building rule publicly visible to allow other rules to depend on it (e.g. to package it).
* Technical description of changes

* Screenshots of UI changes
None.
* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
