### PR TITLE
infra: remove JSCompiler from Vulcanize

### DIFF
--- a/tensorboard/defs/internal/html.bzl
+++ b/tensorboard/defs/internal/html.bzl
@@ -128,7 +128,13 @@ tb_combine_html = rule(
             """,
         ),
         "data": attr.label_list(allow_files = True),
-        "deps": attr.label_list(aspects = [closure_js_aspect], mandatory = True),
+        "deps": attr.label_list(
+            aspects = [closure_js_aspect],
+            mandatory = True,
+            doc = """Dependencies of `input_path` that provides `webfiles`.
+                Normally, they should be targets using `tf_web_library`s.
+            """,
+        ),
         "_Vulcanize": attr.label(
             default = Label("//tensorboard/java/org/tensorflow/tensorboard/vulcanize:Vulcanize"),
             executable = True,

--- a/tensorboard/defs/internal/html.bzl
+++ b/tensorboard/defs/internal/html.bzl
@@ -1,0 +1,133 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rule for building the HTML binary."""
+
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_aspect")
+load("@io_bazel_rules_closure//closure/private:defs.bzl", "collect_js", "long_path", "unfurl")
+
+def _tb_combine_html_impl(ctx):
+    """Compiles HTMLs into one HTML.
+
+    The rule outputs a HTML that resolves all HTML `rel=import` statements into
+    one document. The rule also combines content of all script elements to a
+    JavaScript file when `js_path` is specified.
+    """
+
+    deps = unfurl(ctx.attr.deps, provider = "webfiles")
+    manifests = depset(order = "postorder")
+    files = depset()
+    webpaths = depset()
+    for dep in deps:
+        manifests = depset(transitive = [manifests, dep.webfiles.manifests])
+        webpaths = depset(transitive = [webpaths, dep.webfiles.webpaths])
+        files = depset(transitive = [files, dep.data_runfiles.files])
+    webpaths = depset([ctx.attr.output_path], transitive = [webpaths])
+    closure_js_library = collect_js(
+        unfurl(ctx.attr.deps, provider = "closure_js_library"),
+    )
+
+    # vulcanize
+    ignore_regexs_file_set = depset()
+    ignore_regexs_file_path = "NO_REGEXS"
+    ctx.actions.run(
+        inputs = depset(transitive = [
+            manifests,
+            files,
+        ]).to_list(),
+        outputs = [ctx.outputs.html, ctx.outputs.js],
+        executable = ctx.executable._Vulcanize,
+        arguments = ([
+                         ctx.attr.input_path,
+                         ctx.attr.output_path,
+                         ctx.attr.js_path,
+                         ctx.outputs.html.path,
+                         ctx.outputs.js.path,
+                     ] +
+                     [f.path for f in manifests.to_list()]),
+        mnemonic = "Vulcanize",
+        progress_message = "Vulcanizing %s" % ctx.attr.input_path,
+    )
+
+    # webfiles manifest
+    manifest_srcs = [struct(
+        path = ctx.outputs.html.path,
+        longpath = long_path(ctx, ctx.outputs.html),
+        webpath = ctx.attr.output_path,
+    )]
+
+    if ctx.attr.js_path:
+        manifest_srcs.append(
+            struct(
+                path = ctx.outputs.js.path,
+                longpath = long_path(ctx, ctx.outputs.js),
+                webpath = ctx.attr.js_path,
+            ),
+        )
+
+    manifest = ctx.actions.declare_file("%s.pbtxt" % ctx.label.name)
+    ctx.actions.write(
+        output = manifest,
+        content = struct(
+            label = str(ctx.label),
+            src = manifest_srcs,
+        ).to_proto(),
+    )
+    manifests = depset([manifest], transitive = [manifests])
+
+    transitive_runfiles = depset()
+    for dep in deps:
+        transitive_runfiles = depset(transitive = [
+            transitive_runfiles,
+            dep.data_runfiles.files,
+        ])
+
+    return struct(
+        files = depset([ctx.outputs.html, ctx.outputs.js]),
+        webfiles = struct(
+            manifest = manifest,
+            manifests = manifests,
+            webpaths = webpaths,
+            dummy = ctx.outputs.html,
+        ),
+        runfiles = ctx.runfiles(
+            files = ctx.files.data + [
+                manifest,
+                ctx.outputs.html,
+                ctx.outputs.js,
+            ],
+            transitive_files = transitive_runfiles,
+        ),
+    )
+
+tb_combine_html = rule(
+    implementation = _tb_combine_html_impl,
+    attrs = {
+        "input_path": attr.string(mandatory = True),
+        "output_path": attr.string(mandatory = True),
+        # If specified, it extracts scripts into {name}.js and inserts <script src="{js_path}">.
+        "js_path": attr.string(),
+        "data": attr.label_list(allow_files = True),
+        "deps": attr.label_list(aspects = [closure_js_aspect], mandatory = True),
+        "_Vulcanize": attr.label(
+            default = Label("//tensorboard/java/org/tensorflow/tensorboard/vulcanize:Vulcanize"),
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    outputs = {
+        "html": "%{name}.html",
+        "js": "%{name}.js",
+    },
+)

--- a/tensorboard/defs/internal/html.bzl
+++ b/tensorboard/defs/internal/html.bzl
@@ -39,8 +39,6 @@ def _tb_combine_html_impl(ctx):
     )
 
     # vulcanize
-    ignore_regexs_file_set = depset()
-    ignore_regexs_file_path = "NO_REGEXS"
     ctx.actions.run(
         inputs = depset(transitive = [
             manifests,
@@ -114,10 +112,21 @@ def _tb_combine_html_impl(ctx):
 tb_combine_html = rule(
     implementation = _tb_combine_html_impl,
     attrs = {
-        "input_path": attr.string(mandatory = True),
-        "output_path": attr.string(mandatory = True),
-        # If specified, it extracts scripts into {name}.js and inserts <script src="{js_path}">.
-        "js_path": attr.string(),
+        "input_path": attr.string(
+            mandatory = True,
+            doc = """Entry point webpath of a HTML.""",
+        ),
+        "output_path": attr.string(
+            mandatory = True,
+            doc = """Webpath of an output file. Do not confuse with the output
+                HTML filename which is `{name}.html`.
+            """,
+        ),
+        "js_path": attr.string(
+            doc = """If specified, rule extracts all scripts into {name}.js and
+                inserts `<script src="{js_path}">`.
+            """,
+        ),
         "data": attr.label_list(allow_files = True),
         "deps": attr.label_list(aspects = [closure_js_aspect], mandatory = True),
         "_Vulcanize": attr.label(

--- a/tensorboard/defs/internal/html.bzl
+++ b/tensorboard/defs/internal/html.bzl
@@ -15,7 +15,7 @@
 """Rule for building the HTML binary."""
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_aspect")
-load("@io_bazel_rules_closure//closure/private:defs.bzl", "collect_js", "long_path", "unfurl")
+load("@io_bazel_rules_closure//closure/private:defs.bzl", "collect_js", "long_path", "unfurl")  # buildifier: disable=bzl-visibility
 
 def _tb_combine_html_impl(ctx):
     """Compiles HTMLs into one HTML.

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -25,6 +25,7 @@ load("@io_bazel_rules_closure//closure/private:defs.bzl",
      "difference",
      "long_path",
      "unfurl")
+load("//tensorboard/defs/internal:html.bzl", _tb_combine_html = "tb_combine_html")
 
 def _tf_web_library(ctx):
   if not ctx.attr.srcs:
@@ -270,3 +271,5 @@ tf_web_library = rule(
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
     },
 )
+
+tb_combine_html = _tb_combine_html

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
@@ -13,10 +13,8 @@ java_binary(
     deps = [
         "@com_google_guava",
         "@com_google_protobuf//:protobuf_java",
-        "@io_bazel_rules_closure//closure/compiler",
         "@io_bazel_rules_closure//java/io/bazel/rules/closure:webpath",
         "@io_bazel_rules_closure//java/io/bazel/rules/closure/webfiles:build_info_java_proto",
-        "@io_bazel_rules_closure//java/org/jsoup/nodes",
         "@org_jsoup",
     ],
 )

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -21,7 +21,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.TextFormat;
 import io.bazel.rules.closure.Webpath;
@@ -36,10 +35,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,8 +67,6 @@ public final class Vulcanize {
   private static final Set<String> legalese = new HashSet<>();
   private static final List<String> licenses = new ArrayList<>();
   private static final List<Webpath> stack = new ArrayList<>();
-  private static final Map<Webpath, String> sourcesFromScriptTags = new LinkedHashMap<>();
-  private static final Map<Webpath, Node> sourceTags = new LinkedHashMap<>();
   private static Webpath outputPath;
   private static Node firstScript;
   private static Node licenseComment;
@@ -269,16 +264,6 @@ public final class Vulcanize {
     return result;
   }
 
-  private static Optional<String> getAttrTransitive(Node node, String attr) {
-    while (node != null) {
-      if (node.hasAttr(attr)) {
-        return Optional.of(node.attr(attr));
-      }
-      node = node.parent();
-    }
-    return Optional.absent();
-  }
-
   private static Node replaceNode(Node oldNode, Node newNode) {
     oldNode.replaceWith(newNode);
     return newNode;
@@ -300,16 +285,6 @@ public final class Vulcanize {
 
   private static Webpath me() {
     return Iterables.getLast(stack);
-  }
-
-  private static Webpath makeSyntheticName(String extension) {
-    String me = me().toString();
-    Webpath result = Webpath.get(me + extension);
-    int n = 2;
-    while (sourcesFromScriptTags.containsKey(result)) {
-      result = Webpath.get(String.format("%s-%d%s", me, n++, extension));
-    }
-    return result;
   }
 
   private static void rootifyAttribute(Node node, String attribute) {
@@ -334,16 +309,6 @@ public final class Vulcanize {
    */
   private static Boolean isAbsolutePath(Webpath path) {
     return path.isAbsolute() || ABS_URI_PATTERN.matcher(path.toString()).find();
-  }
-
-  private static String getInlineScriptFromNode(Node node) {
-    StringBuilder sb = new StringBuilder();
-    for (Node child : node.childNodes()) {
-      if (child instanceof DataNode) {
-        sb.append(((DataNode) child).getWholeData());
-      }
-    }
-    return sb.toString();
   }
 
   private static Document parse(byte[] bytes) {

--- a/tensorboard/plugins/graph/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/BUILD
@@ -1,6 +1,5 @@
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
-load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs/internal:html.bzl", "tb_combine_html")
+load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/graph/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/BUILD
@@ -1,6 +1,6 @@
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+load("//tensorboard/defs/internal:html.bzl", "tb_combine_html")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -42,9 +42,8 @@ tf_web_library(
     ],
 )
 
-tensorboard_html_binary(
+tb_combine_html(
     name = "binary",
-    compile = False,
     input_path = "/tf-graph-app.html",
     output_path = "/index.html",
     deps = [

--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -1,5 +1,5 @@
 load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+load("//tensorboard/defs/internal:html.bzl", "tb_combine_html")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -16,9 +16,8 @@ tf_web_library(
     path = "/tf-projector",
 )
 
-tensorboard_html_binary(
+tb_combine_html(
     name = "projector_binary",
-    compile = False,
     input_path = "/tf-projector/tf-projector-plugin.html",
     js_path = "/projector_binary.js",
     output_path = "/tf-projector/projector_binary.html",

--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -1,5 +1,4 @@
-load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs/internal:html.bzl", "tb_combine_html")
+load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -1,6 +1,6 @@
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+load("//tensorboard/defs/internal:html.bzl", "tb_combine_html")
 
 package(default_visibility = ["//tensorboard/plugins/projector:__subpackages__"])
 
@@ -113,9 +113,8 @@ tf_web_library(
     ],
 )
 
-tensorboard_html_binary(
+tb_combine_html(
     name = "standalone",
-    compile = False,
     input_path = "/standalone_lib.html",
     js_path = "/standalone.js",
     output_path = "/standalone.html",

--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -1,6 +1,5 @@
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
-load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs/internal:html.bzl", "tb_combine_html")
+load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
 
 package(default_visibility = ["//tensorboard/plugins/projector:__subpackages__"])
 

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -1,7 +1,7 @@
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_sass_library", "tf_svg_bundle")
 load("//tensorboard/defs:js.bzl", "tf_resource_digest_suffixer")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+load("//tensorboard/defs/internal:html.bzl", "tb_combine_html")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -234,7 +234,7 @@ tf_web_library(
 )
 
 # A Vulcanized html binary for the complete app (both Angular and Polymer parts)
-tensorboard_html_binary(
+tb_combine_html(
     name = "index_suffixless",
     input_path = "/index_polymer3.inlined.html",
     # Do note that JavaScript filename is created off of `name` of this target yet the

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -1,7 +1,6 @@
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_sass_library", "tf_svg_bundle")
 load("//tensorboard/defs:js.bzl", "tf_resource_digest_suffixer")
-load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs/internal:html.bzl", "tb_combine_html")
+load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 


### PR DESCRIPTION
TensorBoard no longer uses JSCompiler in a meaningful way. For the most
TypeScript/JavaScript source, we use rollup via rules_nodejs. Hence, we
now remove the JSCompiler portion from the Vulcanization.

Soon after, vulcanize.bzl will be completely removed accordingly.

- [x] test sync: http://cl/370090328