### PR TITLE
core: fix the plugin selector color

### DIFF
--- a/tensorboard/webapp/header/plugin_selector_component.scss
+++ b/tensorboard/webapp/header/plugin_selector_component.scss
@@ -140,7 +140,7 @@ mat-option {
       }
 
       .mat-tab-header-pagination {
-        background-color: mat-color($tb-primary, 700);
+        background-color: mat-color($tb-primary);
       }
     }
   }


### PR DESCRIPTION
To fix the wrong width calculation on the mat-tab-header, we use a weird
technique with opaque background. The color we picked wrongly set the
`700` causing a visual jank in an internal version.

Was able to confirm that omitting `700` suffices.

Example of the bad color:
![image](https://user-images.githubusercontent.com/2547313/115906820-e7354680-a41c-11eb-8ee3-3b8f1cc583c8.png)
