### PR TITLE
routing: improve compare navigation

### DIFF
--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -54,6 +54,12 @@ export function parseCompareExperimentStr(
   });
 }
 
+export function serializeCompareExperimentParams(
+  params: Array<{alias: string; id: string}>
+): string {
+  return params.map(({alias, id}) => `${alias}:${id}`).join(',');
+}
+
 /**
  * Returns experimentIds from route parameter. For a route that does not contain
  * any experiment ids, it returns null.

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -44,6 +44,35 @@ describe('app_routing/utils', () => {
     });
   });
 
+  describe('#serializeCompareExperimentParams', () => {
+    it('serializes to empty string with an empty input', () => {
+      expect(utils.serializeCompareExperimentParams([])).toBe('');
+    });
+
+    it('serializes alias and displayName', () => {
+      const input = [
+        {alias: 'foo', id: 'bar'},
+        {alias: 'baz', id: 'baz'},
+      ];
+      expect(utils.serializeCompareExperimentParams(input)).toBe(
+        'foo:bar,baz:baz'
+      );
+    });
+
+    it('does not deduplicate or validate', () => {
+      const input = [
+        {alias: 'foo', id: 'bar'},
+        // does not deduplicate
+        {alias: 'tar', id: 'bar'},
+        {alias: 'foo', id: 'bang'},
+        {alias: '', id: ''},
+      ];
+      expect(utils.serializeCompareExperimentParams(input)).toBe(
+        'foo:bar,tar:bar,foo:bang,:'
+      );
+    });
+  });
+
   describe('#getExperimentIdsFromRouteParams', () => {
     it('returns ids from compare route', () => {
       const actual = utils.getExperimentIdsFromRouteParams(

--- a/tensorboard/webapp/app_routing/programmatical_navigation_module_test.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_module_test.ts
@@ -101,11 +101,18 @@ describe('programmatical navigation module test', () => {
     function provider2() {
       return {
         actionCreator: testAction,
-        lambda: (action: typeof testAction) => {
+        lambda: (action: typeof testAction): NavigateToCompare => {
           return {
             routeKind: RouteKind.COMPARE_EXPERIMENT,
-            routeParams: {experimentIds: 'foo'},
-          } as NavigateToCompare;
+            routeParams: {
+              aliasAndExperimentIds: [
+                {
+                  alias: 'Foo',
+                  id: 'foo',
+                },
+              ],
+            },
+          };
         },
       };
     }

--- a/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {InjectionToken} from '@angular/core';
 import {Action, ActionCreator, Creator} from '@ngrx/store';
 
-import {CompareRouteParams, ExperimentRouteParams, RouteKind} from './types';
+import {ExperimentRouteParams, RouteKind} from './types';
 
 export const NAVIGATION_PROVIDER = new InjectionToken<NavigationLambda[]>(
   '[App Routing] Programmatical Navigation Provider'
@@ -28,7 +28,9 @@ export interface NavigateToExperiment {
 
 export interface NavigateToCompare {
   routeKind: RouteKind.COMPARE_EXPERIMENT;
-  routeParams: CompareRouteParams;
+  routeParams: {
+    aliasAndExperimentIds: Array<{alias: string; id: string}>;
+  };
 }
 
 export interface NavigateToExperiments {


### PR DESCRIPTION
When wanting to navigate to a compare route with a programmatical API,
we need to form the navigation parameter correctly, knowing its encoding
scheme. Not wanting to leak the business logic for encoding alias and
id, we now changed the interface for the compare route navigation with a
translation to an AppRouting Route in the AppRouting effects.
