### PR TITLE
Ensure name and description are set in the exporter mask

### DIFF
--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -311,6 +311,8 @@ class _ListIntent(_Intent):
             channel
         )
         fieldmask = experiment_pb2.ExperimentMask(
+            name=True,
+            description=True,
             create_time=True,
             update_time=True,
             num_runs=True,

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -204,7 +204,7 @@ class UploadIntentTest(tf.test.TestCase):
             mock_stdout_write.call_args_list[-1][0][0],
         )
 
-    def testListIntendSetsExperimentMask(self):
+    def testListIntentSetsExperimentMask(self):
         mock_server_info = mock.MagicMock()
         mock_channel = mock.MagicMock()
         expected_mask = experiment_pb2.ExperimentMask(
@@ -224,9 +224,10 @@ class UploadIntentTest(tf.test.TestCase):
         ):
             intent = uploader_subcommand._ListIntent()
             intent.execute(mock_server_info, mock_channel)
-            actual_mask = exporter_lib.list_experiments.call_args[1]["fieldmask"]
+            actual_mask = exporter_lib.list_experiments.call_args[1][
+                "fieldmask"
+            ]
             self.assertEquals(actual_mask, expected_mask)
-
 
 
 if __name__ == "__main__":

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -159,7 +159,7 @@ class UploadIntentTest(tf.test.TestCase):
             intent.execute(server_info, mock_channel)
         mock_experiment_url_callback.assert_called_once_with(expected_url)
 
-    def tstUploadIntentDryRunNonOneShotInterrupted(self):
+    def testUploadIntentDryRunNonOneShotInterrupted(self):
         mock_server_info = mock.MagicMock()
         mock_channel = mock.MagicMock()
         mock_stdout_write = mock.MagicMock()

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -20,10 +20,12 @@ from unittest import mock
 
 import tensorflow as tf
 
+from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import server_info_pb2
 from tensorboard.uploader.proto import write_service_pb2
 from tensorboard.uploader.proto import write_service_pb2_grpc
 from tensorboard.uploader import dry_run_stubs
+from tensorboard.uploader import exporter as exporter_lib
 from tensorboard.uploader import uploader as uploader_lib
 from tensorboard.uploader import uploader_subcommand
 from tensorboard.plugins.histogram import metadata as histograms_metadata
@@ -157,7 +159,7 @@ class UploadIntentTest(tf.test.TestCase):
             intent.execute(server_info, mock_channel)
         mock_experiment_url_callback.assert_called_once_with(expected_url)
 
-    def testUploadIntentDryRunNonOneShotInterrupted(self):
+    def tstUploadIntentDryRunNonOneShotInterrupted(self):
         mock_server_info = mock.MagicMock()
         mock_channel = mock.MagicMock()
         mock_stdout_write = mock.MagicMock()
@@ -201,6 +203,30 @@ class UploadIntentTest(tf.test.TestCase):
             "\nInterrupted. View your TensorBoard at ",
             mock_stdout_write.call_args_list[-1][0][0],
         )
+
+    def testListIntendSetsExperimentMask(self):
+        mock_server_info = mock.MagicMock()
+        mock_channel = mock.MagicMock()
+        expected_mask = experiment_pb2.ExperimentMask(
+            name=True,
+            description=True,
+            create_time=True,
+            update_time=True,
+            num_runs=True,
+            num_tags=True,
+            num_scalars=True,
+            total_tensor_bytes=True,
+            total_blob_bytes=True,
+        )
+        with mock.patch.object(
+            exporter_lib,
+            "list_experiments",
+        ):
+            intent = uploader_subcommand._ListIntent()
+            intent.execute(mock_server_info, mock_channel)
+            actual_mask = exporter_lib.list_experiments.call_args[1]["fieldmask"]
+            self.assertEquals(actual_mask, expected_mask)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ensure that both name and description are returned when using the tensorboard dev list command.

A recent refactoring that enforced a more consistent use of the fieldmask wasn't aware of this call site, and we had no tests.