### PR TITLE
what's new: add full note link attribute

### DIFF
--- a/tensorboard/webapp/notification_center/_data_source/backend_types.ts
+++ b/tensorboard/webapp/notification_center/_data_source/backend_types.ts
@@ -31,6 +31,7 @@ export interface BackendNotification {
   dateInMs: number;
   title: string;
   content: string;
+  fullNoteLink?: string;
 }
 
 /**

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
@@ -48,7 +48,7 @@ limitations under the License.
           class="content"
           [markdown]="notification.content"
         ></markdown-renderer>
-        <div class="extended-buttons">READ FULL</div>
+        <div class="extended-buttons"><a *ngIf="notification.fullNoteLink" href="{{notification.fullNoteLink}}">READ FULL</a></div>
       </div>
     </div>
   </div>

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
@@ -53,7 +53,7 @@ limitations under the License.
             *ngIf="notification.fullNoteLink"
             href="{{notification.fullNoteLink}}"
             target="_blank"
-            rel="noreferrer noopener" 
+            rel="noreferrer noopener"
             >READ FULL</a
           >
         </div>

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
@@ -48,7 +48,13 @@ limitations under the License.
           class="content"
           [markdown]="notification.content"
         ></markdown-renderer>
-        <div class="extended-buttons"><a *ngIf="notification.fullNoteLink" href="{{notification.fullNoteLink}}">READ FULL</a></div>
+        <div class="extended-buttons">
+          <a
+            *ngIf="notification.fullNoteLink"
+            href="{{notification.fullNoteLink}}"
+            >READ FULL</a
+          >
+        </div>
       </div>
     </div>
   </div>

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
@@ -52,6 +52,8 @@ limitations under the License.
           <a
             *ngIf="notification.fullNoteLink"
             href="{{notification.fullNoteLink}}"
+            target="_blank"
+            rel="noreferrer noopener" 
             >READ FULL</a
           >
         </div>

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -78,6 +78,10 @@ limitations under the License.
   font-size: 12px;
   font-weight: 700;
   margin: 10px 0 20px;
+  a {
+    text-decoration: inherit;
+    color: inherit;
+  }
 }
 
 // Unlike other markdown usage, we cannot make the entire notification center

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -121,6 +121,7 @@ describe('notification center', () => {
       store.overrideSelector(selectors.getLastReadTime, 0);
       const fixture = TestBed.createComponent(NotificationCenterContainer);
       fixture.detectChanges();
+
       const reddot = fixture.debugElement.query(By.css('.red-dot'));
       expect(reddot).toBeTruthy();
     });
@@ -137,8 +138,43 @@ describe('notification center', () => {
       store.overrideSelector(selectors.getLastReadTime, 1);
       const fixture = TestBed.createComponent(NotificationCenterContainer);
       fixture.detectChanges();
+
       const reddot = fixture.debugElement.query(By.css('.red-dot'));
       expect(reddot).toBeNull();
+    });
+  });
+  describe('full note link', () => {
+    it('does not appear when the link is provided', () => {
+      store.overrideSelector(selectors.getNotifications, [
+        {
+          category: CategoryEnum.WHATS_NEW,
+          dateInMs: 1,
+          title: 'test title',
+          content: 'test content',
+          fullNoteLink: 'http://google.com',
+        },
+      ]);
+      const fixture = TestBed.createComponent(NotificationCenterContainer);
+      fixture.detectChanges();
+
+      const linkElement = fixture.debugElement.query(By.css('.extended-buttons a'));
+      expect(linkElement).toBeTruthy();
+    });
+
+    it('does not appear when the link is provided', () => {
+      store.overrideSelector(selectors.getNotifications, [
+        {
+          category: CategoryEnum.WHATS_NEW,
+          dateInMs: 1,
+          title: 'test title',
+          content: 'test content'
+        },
+      ]);
+      const fixture = TestBed.createComponent(NotificationCenterContainer);
+      fixture.detectChanges();
+
+      const linkElement = fixture.debugElement.query(By.css('.extended-buttons a'));
+      expect(linkElement).toBeNull();
     });
   });
 });

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -155,7 +155,7 @@ describe('notification center', () => {
         },
       ]);
       const fixture = TestBed.createComponent(NotificationCenterContainer);
-    fixture.detectChanges();
+      fixture.detectChanges();
       const menuButton = fixture.debugElement.query(
         By.css('[aria-label="Display notification messages"]')
       );

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -155,6 +155,11 @@ describe('notification center', () => {
         },
       ]);
       const fixture = TestBed.createComponent(NotificationCenterContainer);
+    fixture.detectChanges();
+      const menuButton = fixture.debugElement.query(
+        By.css('[aria-label="Display notification messages"]')
+      );
+      menuButton.nativeElement.click();
       fixture.detectChanges();
 
       const linkElement = fixture.debugElement.query(
@@ -173,6 +178,12 @@ describe('notification center', () => {
         },
       ]);
       const fixture = TestBed.createComponent(NotificationCenterContainer);
+      fixture.detectChanges();
+
+      const menuButton = fixture.debugElement.query(
+        By.css('[aria-label="Display notification messages"]')
+      );
+      menuButton.nativeElement.click();
       fixture.detectChanges();
 
       const linkElement = fixture.debugElement.query(

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -167,7 +167,7 @@ describe('notification center', () => {
       );
 
       expect(linkElement).toBeTruthy();
-      expect(linkElement.nativeElement.href).toEqual('http://google.com');
+      expect(linkElement.nativeElement.href).toEqual('https://google.com/');
     });
 
     it('does not appear when the link is provided', () => {

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -144,7 +144,7 @@ describe('notification center', () => {
     });
   });
   describe('full note link', () => {
-    it('does not appear when the link is provided', () => {
+    it('appears when the link is provided', () => {
       store.overrideSelector(selectors.getNotifications, [
         {
           category: CategoryEnum.WHATS_NEW,

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -157,7 +157,9 @@ describe('notification center', () => {
       const fixture = TestBed.createComponent(NotificationCenterContainer);
       fixture.detectChanges();
 
-      const linkElement = fixture.debugElement.query(By.css('.extended-buttons a'));
+      const linkElement = fixture.debugElement.query(
+        By.css('.extended-buttons a')
+      );
       expect(linkElement).toBeTruthy();
     });
 
@@ -167,13 +169,15 @@ describe('notification center', () => {
           category: CategoryEnum.WHATS_NEW,
           dateInMs: 1,
           title: 'test title',
-          content: 'test content'
+          content: 'test content',
         },
       ]);
       const fixture = TestBed.createComponent(NotificationCenterContainer);
       fixture.detectChanges();
 
-      const linkElement = fixture.debugElement.query(By.css('.extended-buttons a'));
+      const linkElement = fixture.debugElement.query(
+        By.css('.extended-buttons a')
+      );
       expect(linkElement).toBeNull();
     });
   });

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -151,7 +151,7 @@ describe('notification center', () => {
           dateInMs: 1,
           title: 'test title',
           content: 'test content',
-          fullNoteLink: 'http://google.com',
+          fullNoteLink: 'https://google.com',
         },
       ]);
       const fixture = TestBed.createComponent(NotificationCenterContainer);
@@ -165,7 +165,9 @@ describe('notification center', () => {
       const linkElement = fixture.debugElement.query(
         By.css('.extended-buttons a')
       );
+
       expect(linkElement).toBeTruthy();
+      expect(linkElement.nativeElement.href).toEqual('http://google.com');
     });
 
     it('does not appear when the link is provided', () => {
@@ -189,10 +191,11 @@ describe('notification center', () => {
       const linkElement = fixture.debugElement.query(
         By.css('.extended-buttons a')
       );
+
       expect(linkElement).toBeNull();
     });
 
-    it('does not appear when the link is suspicious', () => {
+    fit('does not appear when the link is suspicious', () => {
       store.overrideSelector(selectors.getNotifications, [
         {
           category: CategoryEnum.WHATS_NEW,
@@ -214,7 +217,9 @@ describe('notification center', () => {
       const linkElement = fixture.debugElement.query(
         By.css('.extended-buttons a')
       );
-      expect(linkElement).toBeNull();
+
+      expect(linkElement).toBeTruthy();
+      expect(linkElement.nativeElement.href).toContain('unsafe:');
     });
   });
 });

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -191,5 +191,30 @@ describe('notification center', () => {
       );
       expect(linkElement).toBeNull();
     });
+
+    it('does not appear when the link is suspicious', () => {
+      store.overrideSelector(selectors.getNotifications, [
+        {
+          category: CategoryEnum.WHATS_NEW,
+          dateInMs: 1,
+          title: 'test title',
+          content: 'test content',
+          fullNoteLink: "data:text/html,<script>alert('hi');</script>",
+        },
+      ]);
+      const fixture = TestBed.createComponent(NotificationCenterContainer);
+      fixture.detectChanges();
+
+      const menuButton = fixture.debugElement.query(
+        By.css('[aria-label="Display notification messages"]')
+      );
+      menuButton.nativeElement.click();
+      fixture.detectChanges();
+
+      const linkElement = fixture.debugElement.query(
+        By.css('.extended-buttons a')
+      );
+      expect(linkElement).toBeNull();
+    });
   });
 });

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -195,7 +195,7 @@ describe('notification center', () => {
       expect(linkElement).toBeNull();
     });
 
-    fit('does not appear when the link is suspicious', () => {
+    it('does not appear when the link is suspicious', () => {
       store.overrideSelector(selectors.getNotifications, [
         {
           category: CategoryEnum.WHATS_NEW,


### PR DESCRIPTION
* Motivation for features / changes
Remove full note link button when there is not

* Technical description of changes
  - add attribute in BE type
  - render <a> only when the attribute shows
  - if not, the `extended-button` element still renders for css convenience (need margin at the bottom of the menu)

TODO: valid link based on the future requirement (open new page or new route for the full note) 

* Screenshots of UI changes

without link
![Screen Shot 2021-04-27 at 10 27 55 AM](https://user-images.githubusercontent.com/1131010/116291535-8d4cbd80-a749-11eb-9e93-7c05282e7fa7.png)
with link
![Screen Shot 2021-04-27 at 10 35 48 AM](https://user-images.githubusercontent.com/1131010/116291547-90e04480-a749-11eb-8730-1c0ec5951bc4.png)
click full note link (test link)
https://user-images.githubusercontent.com/1131010/116291559-92aa0800-a749-11eb-98a7-0959464696be.mov

