### PR TITLE
cleanup(line-chart): use un-deprecated API

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -90,7 +90,7 @@ function updatePolylineGeometry(
       new Float32Array(numVertices * 3),
       3
     );
-    geometry.addAttribute('position', positionAttributes);
+    geometry.setAttribute('position', positionAttributes);
   }
   const values = positionAttributes.array as number[];
   for (let index = 0; index < numVertices; index++) {
@@ -153,7 +153,7 @@ function updateThickPolylineGeometry(
       new Float32Array(numCoordinates),
       3
     );
-    geometry.addAttribute('position', positionAttributes);
+    geometry.setAttribute('position', positionAttributes);
   }
 
   const values = positionAttributes.array as Float32Array;


### PR DESCRIPTION
In the new GPU line chart, we were using the `addAttribute` API of
three's which is now throwing a deprecation warning on the console when
testing. This change uses the new `setAttribute`.
