### PR TITLE
deflag: remove enableFastChart feature flag.

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -63,10 +63,3 @@ export const getEnabledExperimentalPlugins = createSelector(
 export const getIsInColab = createSelector(getFeatureFlags, (flags) => {
   return flags.inColab;
 });
-
-export const getIsGpuChartEnabled = createSelector(
-  getFeatureFlags,
-  (flags): boolean => {
-    return flags.enableGpuChart;
-  }
-);

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -116,30 +116,4 @@ describe('feature_flag_selectors', () => {
       expect(selectors.getIsInColab(state)).toEqual(false);
     });
   });
-
-  describe('#getIsGpuChartEnabled', () => {
-    it('returns value in the store', () => {
-      const state1 = buildState(
-        buildFeatureFlagState({
-          defaultFlags: buildFeatureFlag({
-            enableGpuChart: false,
-          }),
-        })
-      );
-      const actual1 = selectors.getIsGpuChartEnabled(state1);
-
-      expect(actual1).toBe(false);
-
-      const state2 = buildState(
-        buildFeatureFlagState({
-          defaultFlags: buildFeatureFlag({
-            enableGpuChart: true,
-          }),
-        })
-      );
-      const actual2 = selectors.getIsGpuChartEnabled(state2);
-
-      expect(actual2).toBe(true);
-    });
-  });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -22,16 +22,16 @@ describe('feature_flag_selectors', () => {
       const state = buildState(
         buildFeatureFlagState({
           defaultFlags: buildFeatureFlag({
-            enableGpuChart: true,
+            enabledExperimentalPlugins: [],
           }),
           flagOverrides: {
-            enableGpuChart: false,
+            enabledExperimentalPlugins: ['foo'],
           },
         })
       );
 
       expect(selectors.getFeatureFlags(state)).toEqual(
-        buildFeatureFlag({enableGpuChart: false})
+        buildFeatureFlag({enabledExperimentalPlugins: ['foo']})
       );
     });
 
@@ -67,16 +67,16 @@ describe('feature_flag_selectors', () => {
       const state = buildState(
         buildFeatureFlagState({
           defaultFlags: buildFeatureFlag({
-            enableGpuChart: true,
+            enabledExperimentalPlugins: [],
           }),
           flagOverrides: {
-            enableGpuChart: false,
+            enabledExperimentalPlugins: ['foo'],
           },
         })
       );
       const actual = selectors.getOverriddenFeatureFlags(state);
 
-      expect(actual).toEqual({enableGpuChart: false});
+      expect(actual).toEqual({enabledExperimentalPlugins: ['foo']});
     });
   });
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -22,7 +22,6 @@ export const initialState: FeatureFlagState = {
   defaultFlags: {
     enabledExperimentalPlugins: [],
     inColab: false,
-    enableGpuChart: true,
     scalarsBatchSize: undefined,
   },
   flagOverrides: {},

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -22,7 +22,6 @@ export function buildFeatureFlagState(
     isFeatureFlagsLoaded: false,
     defaultFlags: {
       enabledExperimentalPlugins: [],
-      enableGpuChart: false,
       inColab: false,
       scalarsBatchSize: 1,
     },

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -21,7 +21,6 @@ export function buildFeatureFlag(
   return {
     enabledExperimentalPlugins: [],
     inColab: false,
-    enableGpuChart: false,
     scalarsBatchSize: undefined,
     ...override,
   };

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -18,8 +18,6 @@ export interface FeatureFlags {
   enabledExperimentalPlugins: string[];
   // Whether the TensorBoard is being run inside Colab output cell.
   inColab: boolean;
-  // Whether to enable our experimental GPU line chart.
-  enableGpuChart: boolean;
   // Maximum number of runs to include in a request to get scalar data.
   // `undefined` indicates that we should rely on defaults defined in the
   // dashboards code.

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
@@ -28,10 +28,7 @@ import {
 import {CardUniqueInfo, METRICS_SETTINGS_DEFAULT} from '../metrics/types';
 import * as selectors from '../selectors';
 import {getMetricsScalarSmoothing} from '../selectors';
-import {
-  EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
-  GPU_LINE_CHART_QUERY_PARAM_KEY,
-} from '../webapp_data_source/tb_feature_flag_data_source_types';
+import {EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY} from '../webapp_data_source/tb_feature_flag_data_source_types';
 import {
   DeserializedState,
   PINNED_CARDS_KEY,
@@ -89,12 +86,6 @@ export class DashboardDeepLinkProvider extends DeepLinkProvider {
         const queryParams = experimentalPlugins.map((pluginId) => {
           return {key: EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY, value: pluginId};
         });
-        if (overriddenFeatureFlags.enableGpuChart !== undefined) {
-          queryParams.push({
-            key: GPU_LINE_CHART_QUERY_PARAM_KEY,
-            value: String(overriddenFeatureFlags.enableGpuChart),
-          });
-        }
         return queryParams;
       })
     );

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
@@ -302,32 +302,5 @@ describe('core deeplink provider', () => {
         {key: 'experimentalPlugin', value: 'baz'},
       ]);
     });
-
-    it('serializes enabled fast chart state', () => {
-      store.overrideSelector(selectors.getOverriddenFeatureFlags, {
-        enableGpuChart: false,
-      });
-      store.refreshState();
-
-      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
-        {key: 'fastChart', value: 'false'},
-      ]);
-
-      store.overrideSelector(selectors.getOverriddenFeatureFlags, {
-        enableGpuChart: true,
-      });
-      store.refreshState();
-
-      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
-        {key: 'fastChart', value: 'true'},
-      ]);
-    });
-
-    it('omits fast chart state if it is not overridden by user and has default value', () => {
-      store.overrideSelector(selectors.getOverriddenFeatureFlags, {});
-      store.refreshState();
-
-      expect(queryParamsSerialized).toEqual([[]]);
-    });
   });
 });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -16,7 +16,6 @@ import {Injectable} from '@angular/core';
 
 import {
   EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
-  GPU_LINE_CHART_QUERY_PARAM_KEY,
   SCALARS_BATCH_SIZE_PARAM_KEY,
   TBFeatureFlagDataSource,
 } from './tb_feature_flag_data_source_types';
@@ -48,10 +47,6 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
     }
     if (params.has('tensorboardColab')) {
       featureFlags.inColab = params.get('tensorboardColab') === 'true';
-    }
-    if (params.has(GPU_LINE_CHART_QUERY_PARAM_KEY)) {
-      featureFlags.enableGpuChart =
-        params.get(GPU_LINE_CHART_QUERY_PARAM_KEY) === 'true';
     }
     if (params.has(SCALARS_BATCH_SIZE_PARAM_KEY)) {
       featureFlags.scalarsBatchSize = Number(

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -68,27 +68,6 @@ describe('tb_feature_flag_data_source', () => {
         expect(dataSource.getFeatures()).toEqual({inColab: false});
       });
 
-      it('returns enableGpuChart=false when `fastChart` is empty', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
-          new URLSearchParams('fastChart=')
-        );
-        expect(dataSource.getFeatures()).toEqual({enableGpuChart: false});
-      });
-
-      it('returns enableGpuChart=true when `fastChart` is `true`', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
-          new URLSearchParams('fastChart=true')
-        );
-        expect(dataSource.getFeatures()).toEqual({enableGpuChart: true});
-      });
-
-      it('returns enableGpuChart=false when `fastChart` is "false"', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
-          new URLSearchParams('fastChart=false')
-        );
-        expect(dataSource.getFeatures()).toEqual({enableGpuChart: false});
-      });
-
       it('returns scalarsBatchSize from the query params', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('scalarsBatchSize=12')
@@ -110,7 +89,6 @@ describe('tb_feature_flag_data_source', () => {
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: ['a'],
           inColab: false,
-          enableGpuChart: true,
           scalarsBatchSize: 16,
         });
       });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -33,6 +33,4 @@ export abstract class TBFeatureFlagDataSource {
 
 export const EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY = 'experimentalPlugin';
 
-export const GPU_LINE_CHART_QUERY_PARAM_KEY = 'fastChart';
-
 export const SCALARS_BATCH_SIZE_PARAM_KEY = 'scalarsBatchSize';


### PR DESCRIPTION
After launching the GPU line chart, we now disallow falling back to the
old Polymer based implementation.

