### PR TITLE
type: better type Polymer-Angular interops

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_sass_library", "tf_svg_bundle")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_sass_library", "tf_svg_bundle", "tf_ts_library")
 load("//tensorboard/defs:js.bzl", "tf_resource_digest_suffixer")
 load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
 
@@ -71,6 +71,13 @@ tf_ng_module(
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
+    ],
+)
+
+tf_ts_library(
+    name = "tb_polymer_interop_types",
+    srcs = [
+        "tb_polymer_interop_types.ts",
     ],
 )
 

--- a/tensorboard/webapp/core/effects/BUILD
+++ b/tensorboard/webapp/core/effects/BUILD
@@ -10,6 +10,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:tb_polymer_interop_types",
         "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import '../../tb_polymer_interop_types';
+
 import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Actions, ofType, createEffect} from '@ngrx/effects';
@@ -26,6 +28,7 @@ import {
   distinctUntilChanged,
   take,
 } from 'rxjs/operators';
+
 import {
   coreLoaded,
   environmentLoaded,

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -54,7 +54,7 @@ export class CoreEffects {
   // Ngrx assumes all Effect classes have properties that inherit from the base
   // JS Object. `tf_backend` does not, so we wrap it.
   private readonly tfBackend = {
-    ref: (document.createElement('tf-backend') as any).tf_backend,
+    ref: document.createElement('tf-backend').tf_backend,
   };
 
   /**

--- a/tensorboard/webapp/deeplink/BUILD
+++ b/tensorboard/webapp/deeplink/BUILD
@@ -11,6 +11,7 @@ tf_ng_module(
         "types.ts",
     ],
     deps = [
+        "//tensorboard/webapp:tb_polymer_interop_types",
         "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/deeplink/hash.ts
+++ b/tensorboard/webapp/deeplink/hash.ts
@@ -15,33 +15,20 @@ limitations under the License.
 
 import {Injectable} from '@angular/core';
 
+import {TfStorageElement} from '../tb_polymer_interop_types';
 import {DeepLinkerInterface, SetStringOption} from './types';
 
 // TODO(tensorboard-team): merge this module with tf_storage/storage.ts when
 // tf_ts_library can be referenced by tf_web_library.
 const TAB = '__tab__';
 
-interface TfGlobalsElement extends HTMLElement {
-  tf_globals: {
-    setUseHash(use: boolean): void;
-  };
-}
-
-interface TfStorageElement extends HTMLElement {
-  tf_storage: {
-    setString(key: string, value: string, options?: SetStringOption): void;
-    getString(key: string): string;
-    migrateLegacyURLScheme(): void;
-  };
-}
-
 @Injectable()
 export class HashDeepLinker implements DeepLinkerInterface {
   private readonly tfStorage: TfStorageElement;
 
   constructor() {
-    this.tfStorage = document.createElement('tf-storage') as TfStorageElement;
-    const tfGlobals = document.createElement('tf-globals') as TfGlobalsElement;
+    this.tfStorage = document.createElement('tf-storage');
+    const tfGlobals = document.createElement('tf-globals');
 
     // Note: `migrateLegacyURLScheme()` must be called before `setUseHash`, so
     // that tfStorage reads from the actual URL, not the fake hash for tests

--- a/tensorboard/webapp/tb_polymer_interop_types.ts
+++ b/tensorboard/webapp/tb_polymer_interop_types.ts
@@ -13,10 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 declare global {
-  interface Document {
-    createElement(name: 'tf-backend'): TfBackendElement;
-    createElement(name: 'tf-globals'): TfGlobalsElement;
-    createElement(name: 'tf-storage'): TfStorageElement;
+  // createElement type uses the TagNameMap underneath and returns the right type.
+  interface HTMLElementTagNameMap {
+    'tf-backend': TfBackendElement;
+    'tf-globals': TfGlobalsElement;
+    'tf-storage': TfStorageElement;
   }
 }
 

--- a/tensorboard/webapp/tb_polymer_interop_types.ts
+++ b/tensorboard/webapp/tb_polymer_interop_types.ts
@@ -1,0 +1,73 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+declare global {
+  interface Document {
+    createElement(name: 'tf-backend'): TfBackendElement;
+    createElement(name: 'tf-globals'): TfGlobalsElement;
+    createElement(name: 'tf-storage'): TfStorageElement;
+  }
+}
+
+export interface TfGlobals {
+  /** @export */
+  setUseHash(use: boolean): void;
+}
+
+export interface TfGlobalsElement extends HTMLElement {
+  /** @export */
+  tf_globals: TfGlobals;
+}
+
+export interface SetStringOption {
+  /** @export */
+  defaultValue?: string;
+  /**
+   * When true, setting the string does not push a new state onto the history.
+   * i.e., it uses `history.replaceState` instead of `history.pushState`.
+   * @export
+   */
+  useLocationReplace?: boolean;
+}
+
+export interface TfStorage {
+  /** @export */
+  setString(key: string, value: string, options?: SetStringOption): void;
+  /** @export */
+  getString(key: string): string;
+  /** @export */
+  migrateLegacyURLScheme(): void;
+}
+
+export interface TfStorageElement extends HTMLElement {
+  /** @export */
+  tf_storage: TfStorage;
+}
+
+export interface Store {
+  /** @export */
+  refresh(): Promise<void>;
+}
+
+export interface TfBackend {
+  /** @export */
+  environmentStore: Store;
+  /** @export */
+  runsStore: Store;
+}
+
+export interface TfBackendElement extends HTMLElement {
+  /** @export */
+  tf_backend: TfBackend;
+}

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -10,6 +10,7 @@ tf_ng_module(
     ],
     deps = [
         ":http_client",
+        "//tensorboard/webapp:tb_polymer_interop_types",
         "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import '../tb_polymer_interop_types';
+
 import {Injectable} from '@angular/core';
 import {from, forkJoin, throwError, Observable} from 'rxjs';
 import {catchError, map} from 'rxjs/operators';
@@ -52,7 +54,7 @@ export class TBServerError {
 @Injectable()
 export class TBServerDataSource {
   // TODO(soergel): implements WebappDataSource
-  private tfBackend = (document.createElement('tf-backend') as any).tf_backend;
+  private tfBackend = document.createElement('tf-backend').tf_backend;
 
   constructor(private http: TBHttpClient) {}
 


### PR DESCRIPTION
Currently, the Polymer interop components like `tf-storage` are poorly
typed. While we try to type them better, they are not properly
typed/annotated that more advanced compiler wrongly mangles the symbol.

This change makes the interop components Klutz friendly.