### PR TITLE
hparams: prevent experimentIds mutation

### DIFF
--- a/tensorboard/webapp/hparams/_redux/utils.ts
+++ b/tensorboard/webapp/hparams/_redux/utils.ts
@@ -22,7 +22,7 @@ import {
 } from '../types';
 
 export function getIdFromExperimentIds(experimentIds: string[]): string {
-  return JSON.stringify(experimentIds.sort());
+  return JSON.stringify([...experimentIds].sort());
 }
 
 export function combineDefaultHparamFilters(

--- a/tensorboard/webapp/hparams/_redux/utils_test.ts
+++ b/tensorboard/webapp/hparams/_redux/utils_test.ts
@@ -31,6 +31,12 @@ describe('hparams/_redux/utils test', () => {
         '["1","bar","foo"]'
       );
     });
+
+    it('does not mutate the original experimentIds', () => {
+      const experimentIds = ['b', 'a'];
+      getIdFromExperimentIds(experimentIds);
+      expect(experimentIds).toEqual(['b', 'a']);
+    });
   });
 
   describe('#combineDefaultHparamFilters', () => {


### PR DESCRIPTION
The utility used in the selector was mutating the list of experimentIds
passed. This is not an allowed operation especially in the view where
this selector was being used and experimentIds was passed as a prop.
