### PR TITLE
rust: switch `sync_all` calls to `flush`

### DIFF
--- a/tensorboard/data/server/cli.rs
+++ b/tensorboard/data/server/cli.rs
@@ -279,7 +279,7 @@ fn die_after_stdin() {
 fn write_port_file(path: &Path, port: u16) -> std::io::Result<()> {
     let mut f = File::create(path)?;
     writeln!(f, "{}", port)?;
-    f.sync_all()?;
+    f.flush()?;
     Ok(())
 }
 
@@ -288,7 +288,7 @@ fn write_startup_error(path: Option<&Path>, error: &str) {
     let write_to_file = |path: &Path| -> std::io::Result<()> {
         let mut f = File::create(path)?;
         writeln!(f, "{}", error)?;
-        f.sync_all()?;
+        f.flush()?;
         Ok(())
     };
     if let Some(p) = path {

--- a/tensorboard/data/server/disk_logdir.rs
+++ b/tensorboard/data/server/disk_logdir.rs
@@ -120,7 +120,7 @@ mod tests {
         {
             let mut f = File::create(run_dir.join("foo.tfevents.123"))?;
             f.write_all(b"hello")?;
-            f.sync_all()?;
+            f.flush()?;
         }
 
         let disk_logdir = DiskLogdir::new(logdir.to_path_buf());

--- a/tensorboard/data/server/logdir.rs
+++ b/tensorboard/data/server/logdir.rs
@@ -256,23 +256,23 @@ mod tests {
         let mut root_file = File::create(logdir.path().join("tfevents.123"))?;
         root_file.write_scalar(&tag, Step(0), WallTime::new(1234.0).unwrap(), 0.75)?;
         root_file.write_scalar(&tag, Step(1), WallTime::new(1235.0).unwrap(), 0.875)?;
-        root_file.sync_all()?;
+        root_file.flush()?;
         drop(root_file);
 
         let mut train_file1 = File::create(train_dir.join("tfevents.234"))?;
         train_file1.write_scalar(&tag, Step(4), WallTime::new(2234.0).unwrap(), 0.125)?;
         train_file1.write_scalar(&tag, Step(5), WallTime::new(2235.0).unwrap(), 0.25)?;
-        train_file1.sync_all()?;
+        train_file1.flush()?;
         drop(train_file1);
 
         let mut train_file2 = File::create(train_dir.join("tfevents.345"))?;
         train_file2.write_scalar(&tag, Step(6), WallTime::new(2236.0).unwrap(), 0.375)?;
-        train_file2.sync_all()?;
+        train_file2.flush()?;
         drop(train_file2);
 
         let mut test_file = File::create(test_dir.join("tfevents.456"))?;
         test_file.write_scalar(&tag, Step(8), WallTime::new(3456.0).unwrap(), 0.5)?;
-        test_file.sync_all()?;
+        test_file.flush()?;
         drop(test_file);
 
         // decoy file

--- a/tensorboard/data/server/logdir.rs
+++ b/tensorboard/data/server/logdir.rs
@@ -237,6 +237,7 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
     use std::fs::{self, File};
+    use std::io::Write;
 
     use crate::disk_logdir::DiskLogdir;
     use crate::types::{Step, Tag, WallTime};

--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -485,8 +485,8 @@ mod test {
         f2.write_scalar(&tag, Step(3), WallTime::new(2347.0).unwrap(), 0.85)?;
         f2.write_scalar(&tag, Step(4), WallTime::new(2348.0).unwrap(), 0.90)?;
         // flush, so that the data's there when we read it
-        f1.into_inner()?.sync_all()?;
-        f2.into_inner()?.sync_all()?;
+        f1.into_inner()?.flush()?;
+        f2.into_inner()?.flush()?;
 
         let mut loader = RunLoader::new(run.clone(), Arc::new(PluginSamplingHint::default()));
         let logdir = DiskLogdir::new(logdir.path().to_path_buf());
@@ -668,7 +668,7 @@ mod test {
             ..Default::default()
         })?;
         // flush, so that the data's there when we read it
-        f.into_inner()?.sync_all()?;
+        f.into_inner()?.flush()?;
 
         let run = Run("train".to_string());
         let mut loader = RunLoader::new(run.clone(), Arc::new(PluginSamplingHint::default()));
@@ -772,7 +772,7 @@ mod test {
             Bytes::from_static(b"<sample model graph>"),
         )?;
         // flush, so that the data's there when we read it
-        f1.into_inner()?.sync_all()?;
+        f1.into_inner()?.flush()?;
 
         let plugin_sampling_hint: PluginSamplingHint = "scalars=2".parse().unwrap();
 

--- a/tensorboard/data/server/run.rs
+++ b/tensorboard/data/server/run.rs
@@ -419,7 +419,7 @@ mod test {
     use super::*;
     use bytes::Bytes;
     use std::fs::File;
-    use std::io::BufWriter;
+    use std::io::{BufWriter, Write};
 
     use crate::commit::Commit;
     use crate::data_compat::plugin_names;


### PR DESCRIPTION
Summary:
For `--port-file` and `--error-file`, we only need output data to be
flushed to the operating system, not to actual disk. In addition to
making things a bit faster, `/dev/null` can now be used with these
arguments without raising `EINVAL`.

Uses not in `cli.rs` are all in tests.

Test Plan:
Running the data server with `--logdir /tmp/foo --port-file /dev/null`
now works as desired, and normally running `tensorboard` works, too.

wchargin-branch: rust-flush
