### PR TITLE
core: fix relative redirect for /data/notifications

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -289,7 +289,13 @@ class CorePlugin(base_plugin.TBPlugin):
     @wrappers.Request.application
     def _serve_notifications(self, request):
         """Serve JSON payload of notifications to show in the UI."""
-        return utils.redirect("../notifications_note.json")
+        response = utils.redirect("../notifications_note.json")
+        # Disable Werkzeug's automatic Location header correction routine, which
+        # absolutizes relative paths "to be RFC conformant" [1], but this is
+        # based on an outdated HTTP/1.1 RFC; the current one allows them:
+        # https://tools.ietf.org/html/rfc7231#section-7.1.2
+        response.autocorrect_location_header = False
+        return response
 
 
 class CorePluginLoader(base_plugin.TBLoader):

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -353,12 +353,10 @@ class CorePluginTest(tf.test.TestCase):
     def testNotificationsRedirectSuccess(self):
         """Test that the /data/notifications endpoint redirect to /notifications_note.json."""
         response = self.server.get("/data/notifications")
-        content_type = response.headers.get("Content-Type")
-        location = response.headers.get("Location")
-
-        self.assertEqual(302, (response.status_code))
-        self.assertStartsWith(content_type, "text/html")
-        self.assertIn("/notifications_note.json", location)
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(
+            "../notifications_note.json", response.headers.get("Location")
+        )
 
 
 class CorePluginPathPrefixTest(tf.test.TestCase):


### PR DESCRIPTION
This fixes the `/data/notifications` redirect (to `../notifications_note.json`) so that it is preserved over the wire to the browser as a relative path, rather than being normalized by the server into an absolute URL.

Werkzeug, our HTTP request/response framework, does this normalization automatically to be "RFC conformant", but that's outdated; the current HTTP/1.1 RFC does [explicitly allow relative paths](https://tools.ietf.org/html/rfc7231#section-7.1.2) and browser support is apparently not an issue per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location).  We don't want the redirect to be normalized because that bakes the incoming request URL as seen by the WSGI app into our HTTP response, but that isn't necessarily the right URL for the browser to use if our WSGI app was behind a proxy.  For example, a proxy might have rewritten an `https` URL to an `http` URL before it reaches our Python app, but then telling the browser to redirect to `http://<domain>/notifications_note.json` is incorrect because it downgrades HTTPS to HTTP (and in our case, fails entirely with a CSP violation since we [set `connect-src 'self'`](https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/backend/http_util.py;l=248-249;drc=3442430b2487adac9b0107662107f0631564f394)).

Luckily, Werkzeug at least makes it easy to disable the unwanted normalization, which this PR does:
https://werkzeug.palletsprojects.com/en/1.0.x/wrappers/#werkzeug.wrappers.BaseResponse.autocorrect_location_header

Test plan: updated unit test to verify the exact Location header contents.  Also dropped the content-type check since we don't really care about the content type of the response; it should never be seen by a user.