### PR TITLE
types: declare types to be public

### DIFF
--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -34,11 +34,21 @@ export enum RouteKind {
 
 export const DEFAULT_EXPERIMENT_ID = 'defaultExperimentId';
 
-export interface CompareRouteParams {
+/**
+ * `declare` to express this as a public API that is not to be mangleable.
+ * Because `experimentIds` are declared in routes as string literals, we cannot
+ * mangle the property name.
+ */
+export declare interface CompareRouteParams {
   experimentIds: string;
 }
 
-export interface ExperimentRouteParams {
+/**
+ * `declare` to express this as a public API that is not to be mangleable.
+ * Because `experimentIds` are declared in routes as string literals, we cannot
+ * mangle the property name.
+ */
+export declare interface ExperimentRouteParams {
   experimentId: string;
 }
 

--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-export interface Experiment {
+export declare interface Experiment {
   id: string;
   name: string;
   start_time: number;


### PR DESCRIPTION
- experiments/types which is used to type the backend response should
  not be mangled.
- route parameter, since defined as strings in the route configurations,
  cannot be mangled.
