### PR TITLE
what's new: adjust notification api path to absolute path

### DIFF
--- a/tensorboard/webapp/notification_center/_data_source/notification_center_data_source.ts
+++ b/tensorboard/webapp/notification_center/_data_source/notification_center_data_source.ts
@@ -31,7 +31,7 @@ export class TBNotificationCenterDataSource
   constructor(private readonly http: TBHttpClient) {}
 
   fetchNotifications(): Observable<NotificationCenterResponse> {
-    return this.http.get<NotificationCenterResponse>(`data/notifications`);
+    return this.http.get<NotificationCenterResponse>(`/data/notifications`);
   }
 
   updateLastReadTimeStampToNow(): Observable<number> {

--- a/tensorboard/webapp/notification_center/_data_source/notification_center_data_source_test.ts
+++ b/tensorboard/webapp/notification_center/_data_source/notification_center_data_source_test.ts
@@ -53,7 +53,7 @@ describe('TBNotificationCenterDataSource test', () => {
   it('fetches empty notifications', () => {
     const resultSpy = jasmine.createSpy();
     dataSource.fetchNotifications().subscribe(resultSpy);
-    const req = httpMock.expectOne('data/notifications');
+    const req = httpMock.expectOne('/data/notifications');
     req.flush({notifications: [{}]});
 
     expect(resultSpy).toHaveBeenCalledWith({notifications: [{}]});
@@ -62,7 +62,7 @@ describe('TBNotificationCenterDataSource test', () => {
   it('fetches non-empty notifications', () => {
     const resultSpy = jasmine.createSpy();
     dataSource.fetchNotifications().subscribe(resultSpy);
-    const req = httpMock.expectOne('data/notifications');
+    const req = httpMock.expectOne('/data/notifications');
     req.flush(buildNotificationResponse());
 
     expect(resultSpy).toHaveBeenCalledWith(buildNotificationResponse());
@@ -71,7 +71,7 @@ describe('TBNotificationCenterDataSource test', () => {
   it('throws error when notification fetch failed', () => {
     const error = new ErrorEvent('Request failed');
     const errorResponse = {
-      url: 'data/notifications',
+      url: '/data/notifications',
       status: 123,
       statusText: 'something went wrong',
     };
@@ -79,7 +79,7 @@ describe('TBNotificationCenterDataSource test', () => {
     const errorSpy = jasmine.createSpy();
 
     dataSource.fetchNotifications().subscribe(resultSpy, errorSpy);
-    httpMock.expectOne('data/notifications').error(error, errorResponse);
+    httpMock.expectOne('/data/notifications').error(error, errorResponse);
 
     const httpErrorResponse = new HttpErrorResponse({
       error,


### PR DESCRIPTION
* Motivation for features / changes
Change the api path for reading the notification note file.
We only have one note file per environment and it should be a fixed path and should not depends on the experiment id params etc.

* Technical description of changes
Now we called `....com/experiment/:id/data/notification` and it will direct to `....com/experiment/:id/notifications_note.json`
while what we actually want is  call `....com/data/notification` and redirect to  `....com/notifications_note.json`
