### PR TITLE
debugger-v2: refresh data on change plugin

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -279,8 +279,23 @@ export class DebuggerEffects {
   }
 
   private onCoreReload(): Observable<void> {
-    return this.actions$.pipe(
-      ofType(manualReload, reload, changePlugin),
+    return merge(
+      this.actions$.pipe(ofType(manualReload, reload)),
+      // Load the debugger data if it was never loaded before and now becomes
+      // an active plugin.
+      this.actions$.pipe(ofType(changePlugin)).pipe(
+        // We use debugger runs loaded state as a proxy to the debugger state
+        // being or not.
+        withLatestFrom(this.store.select(getDebuggerRunsLoaded)),
+        filter(([, loadState]) => {
+          return (
+            loadState.state === DataLoadState.NOT_LOADED ||
+            (loadState.state === DataLoadState.FAILED &&
+              loadState.lastLoadedTimeInMs === null)
+          );
+        })
+      )
+    ).pipe(
       withLatestFrom(this.store.select(getActivePlugin)),
       filter(([, plugin]) => plugin === PLUGIN_ID),
       tap(() => this.store.dispatch(debuggerDataPollOnset())),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -285,7 +285,7 @@ export class DebuggerEffects {
       // an active plugin.
       this.actions$.pipe(ofType(changePlugin)).pipe(
         // We use debugger runs loaded state as a proxy to the debugger state
-        // being or not.
+        // being loaded.
         withLatestFrom(this.store.select(getDebuggerRunsLoaded)),
         filter(([, loadState]) => {
           return (

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -31,7 +31,11 @@ import {
 } from 'rxjs/operators';
 
 import {State as AppState} from '../../../../webapp/app_state';
-import {manualReload, reload} from '../../../../webapp/core/actions';
+import {
+  changePlugin,
+  manualReload,
+  reload,
+} from '../../../../webapp/core/actions';
 import {getActivePlugin} from '../../../../webapp/core/store';
 import {
   alertsOfTypeLoaded,
@@ -276,7 +280,7 @@ export class DebuggerEffects {
 
   private onCoreReload(): Observable<void> {
     return this.actions$.pipe(
-      ofType(manualReload, reload),
+      ofType(manualReload, reload, changePlugin),
       withLatestFrom(this.store.select(getActivePlugin)),
       filter(([, plugin]) => plugin === PLUGIN_ID),
       tap(() => this.store.dispatch(debuggerDataPollOnset())),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -18,7 +18,11 @@ import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {empty, Observable, of, ReplaySubject, timer} from 'rxjs';
 import {take} from 'rxjs/operators';
-import {manualReload, reload} from '../../../../webapp/core/actions';
+import {
+  changePlugin,
+  manualReload,
+  reload,
+} from '../../../../webapp/core/actions';
 import {
   alertsOfTypeLoaded,
   alertTypeFocusToggled,
@@ -637,6 +641,7 @@ describe('Debugger effects', () => {
       debuggerLoaded(),
       reload(),
       manualReload(),
+      changePlugin({plugin: 'hello'}),
     ] as Action[]) {
       it(`run list loading on ${triggerAction.type}: empty runs`, () => {
         const fetchRuns = createFetchRunsSpy({});
@@ -782,6 +787,26 @@ describe('Debugger effects', () => {
           ]);
         }
       );
+    }
+
+    for (const triggerAction of [
+      reload(),
+      manualReload(),
+      changePlugin({plugin: 'hello'}),
+    ]) {
+      describe(`for action: ${triggerAction.type}`, () => {
+        it(`ignores action when debugger plugin is not active`, () => {
+          const fetchRuns = createFetchRunsSpy({});
+          store.overrideSelector(getActivePlugin, 'unknown');
+          store.overrideSelector(getDebuggerRunListing, {});
+          store.refreshState();
+
+          action.next(triggerAction);
+
+          expect(fetchRuns).not.toHaveBeenCalled();
+          expect(dispatchedActions).toEqual([]);
+        });
+      });
     }
 
     for (const dataAlreadyExists of [false, true]) {


### PR DESCRIPTION
This change is a follow up to #4929 where we are:
- adding a test for reload actions whilst the plugin is inactive
- adds `changePlugin` as a condition for refreshing the data to follow the
  timeseries.
