### PR TITLE
routing: permit registering RouteKind.UNKNOWN

### DIFF
--- a/tensorboard/webapp/app_routing/route_registry_module.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module.ts
@@ -48,7 +48,7 @@ export class RouteRegistryModule {
     }
     this.routeConfigs = new RouteConfigs(configs);
     configs.forEach((config) => {
-      if (config.routeKind) {
+      if (config.routeKind !== null) {
         this.routeKindToNgComponent.set(config.routeKind, config.ngComponent);
       }
     });

--- a/tensorboard/webapp/app_routing/route_registry_module_test.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module_test.ts
@@ -31,6 +31,12 @@ class Experiment {}
 })
 class Experiments {}
 
+@Component({
+  selector: 'not_found',
+  template: 'Unknown route',
+})
+class NotFound {}
+
 describe('route_registry_module', () => {
   let registry: RouteRegistryModule;
 
@@ -47,12 +53,17 @@ describe('route_registry_module', () => {
           path: '/experiments',
           ngComponent: Experiments,
         },
+        {
+          routeKind: RouteKind.UNKNOWN,
+          path: '/crabs',
+          ngComponent: NotFound,
+        },
       ];
     }
 
     await TestBed.configureTestingModule({
       imports: [RouteRegistryModule.registerRoutes(routeFactory)],
-      declarations: [Experiments, Experiment],
+      declarations: [Experiments, Experiment, NotFound],
     }).compileComponents();
 
     registry = TestBed.inject<RouteRegistryModule>(RouteRegistryModule);
@@ -66,7 +77,9 @@ describe('route_registry_module', () => {
       expect(registry.getNgComponentByRouteKind(RouteKind.EXPERIMENTS)).toBe(
         Experiments
       );
-      expect(registry.getNgComponentByRouteKind(RouteKind.UNKNOWN)).toBeNull();
+      expect(registry.getNgComponentByRouteKind(RouteKind.UNKNOWN)).toBe(
+        NotFound
+      );
     });
   });
 });


### PR DESCRIPTION
tensorboard.dev will set up a `Not found` page for all unknown routes by default.