### PR TITLE
Fix broken Angular dashboards in need of localization module

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -123,6 +123,7 @@ tf_ng_module(
         "//tensorboard/webapp/settings",
         "//tensorboard/webapp/tb_wrapper",
         "@npm//@angular/core",
+        "@npm//@angular/localize",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//rxjs",

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -123,7 +123,6 @@ tf_ng_module(
         "//tensorboard/webapp/settings",
         "//tensorboard/webapp/tb_wrapper",
         "@npm//@angular/core",
-        "@npm//@angular/localize",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//rxjs",
@@ -179,6 +178,7 @@ tf_ng_module(
     deps = [
         ":app",
         "@npm//@angular/core",
+        "@npm//@angular/localize",
         "@npm//@angular/platform-browser",
         "@npm//@angular/router",
         "@npm//zone.js",

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -13,6 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
+// Angular 9+ using Ivy apps that potentially do i18n, even transitively, must
+// import this module, which adds a global symbol at runtime.
+// https://angular.io/guide/migration-localize
+import '@angular/localize/init'
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -16,7 +16,7 @@ import {NgModule} from '@angular/core';
 // Angular 9+ using Ivy apps that potentially do i18n, even transitively, must
 // import this module, which adds a global symbol at runtime.
 // https://angular.io/guide/migration-localize
-import '@angular/localize/init'
+import '@angular/localize/init';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -13,10 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
-// Angular 9+ using Ivy apps that potentially do i18n, even transitively, must
-// import this module, which adds a global symbol at runtime.
-// https://angular.io/guide/migration-localize
-import '@angular/localize/init';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/tensorboard/webapp/bootstrap.ts
+++ b/tensorboard/webapp/bootstrap.ts
@@ -12,6 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+// Angular 9+ using Ivy apps that potentially do i18n, even transitively, must
+// import this module, which adds a global symbol at runtime.
+// https://angular.io/guide/migration-localize
+import '@angular/localize/init';
 import {platformBrowser} from '@angular/platform-browser';
 import 'zone.js/dist/zone.js'; // Angular runtime dep
 

--- a/tensorboard/webapp/dev_assets/main_dev.ts
+++ b/tensorboard/webapp/dev_assets/main_dev.ts
@@ -12,6 +12,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import '@angular/localize/init';
-
 import '../bootstrap';


### PR DESCRIPTION
Angular component-based dashboards currently fail to render. The
JS error at runtime points to the lack of an import of Angular's new
"localize" module, required for applications using Ivy and Angular 9+.
See https://angular.io/guide/migration-localize for details.

Note that the `//tensorboard:dev` target is fine. For some reason,
only the "prod" target `//tensorboard` is affected.

![image](https://user-images.githubusercontent.com/2322480/117096261-62e89a80-ad1d-11eb-8bf8-a77d0b7aac2a.png)

Manually tested by running `bazel run tensorboard -- --logdir logs --bind_all`, opening the 'Time Series' dashboard, and seeing the panel appear.

Googlers, see test sync cl/372052576