### PR TITLE
feat: resizable input widget

### DIFF
--- a/tensorboard/webapp/widgets/BUILD
+++ b/tensorboard/webapp/widgets/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_web_test_suite", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -42,5 +42,13 @@ tf_ng_module(
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
+    ],
+)
+
+tf_ng_web_test_suite(
+    name = "karma_test",
+    deps = [
+        ":resize_detector_test",
+        "//tensorboard/webapp/widgets/resizable_input:resizable_input_tests",
     ],
 )

--- a/tensorboard/webapp/widgets/resizable_input/BUILD
+++ b/tensorboard/webapp/widgets/resizable_input/BUILD
@@ -1,0 +1,34 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])
+
+tf_ng_module(
+    name = "resizable_input",
+    srcs = [
+        "resizable_input_component.ts",
+        "resizable_input_module.ts",
+    ],
+    deps = [
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ts_library(
+    name = "resizable_input_tests",
+    testonly = True,
+    srcs = [
+        "resizable_input_test.ts",
+    ],
+    deps = [
+        ":resizable_input",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/testing:dom",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/widgets/resizable_input/resizable_input_component.ts
+++ b/tensorboard/webapp/widgets/resizable_input/resizable_input_component.ts
@@ -1,0 +1,60 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {EventEmitter, Component, Input, Output} from '@angular/core';
+
+@Component({
+  selector: 'resizable-input',
+  template: `<span
+    [class]="{'single-line': singleLine, 'multi-line': !singleLine}"
+    contenteditable
+    (keydown)="onKeyDown.emit($event)"
+    (keyup)="onKeyUp.emit($event)"
+    (input)="onInput.emit($event)"
+    >{{ value }}</span
+  >`,
+  styles: [
+    `
+      .multi-line {
+        white-space: pre-line;
+      }
+
+      .single-line {
+        white-space: nowrap;
+      }
+
+      /* <br> is created by browser so angular is unaware of it. */
+      .single-line ::ng-deep br {
+        display: none;
+      }
+    `,
+  ],
+})
+export class ResizableInputComponent {
+  @Input()
+  value!: string;
+
+  @Input()
+  singleLine: boolean = true;
+
+  @Output()
+  onInput = new EventEmitter<InputEvent>();
+
+  @Output()
+  onKeyDown = new EventEmitter<KeyboardEvent>();
+
+  @Output()
+  onKeyUp = new EventEmitter<KeyboardEvent>();
+}

--- a/tensorboard/webapp/widgets/resizable_input/resizable_input_module.ts
+++ b/tensorboard/webapp/widgets/resizable_input/resizable_input_module.ts
@@ -1,0 +1,26 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {ResizableInputComponent} from './resizable_input_component';
+
+@NgModule({
+  declarations: [ResizableInputComponent],
+  imports: [CommonModule],
+  exports: [ResizableInputComponent],
+})
+export class ResizableInputModule {}

--- a/tensorboard/webapp/widgets/resizable_input/resizable_input_test.ts
+++ b/tensorboard/webapp/widgets/resizable_input/resizable_input_test.ts
@@ -1,0 +1,114 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, Input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {KeyType, sendKey} from '../../testing/dom';
+import {ResizableInputComponent} from './resizable_input_component';
+
+@Component({
+  selector: 'testable-component',
+  template: ` <resizable-input
+    [value]="value"
+    (onKeyDown)="onKeyDown($event)"
+    (onInput)="onInput($event)"
+  ></resizable-input>`,
+})
+export class TestableComponent {
+  @Input()
+  value!: string;
+
+  @Input()
+  onKeyDown!: (event: KeyboardEvent) => void;
+
+  @Input()
+  onInput!: (event: InputEvent) => void;
+}
+
+qdescribe('resizable input widget', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestableComponent, ResizableInputComponent],
+    }).compileComponents();
+  });
+
+  describe('render', () => {
+    it('renders `value` properly', () => {
+      const fixture = TestBed.createComponent(ResizableInputComponent);
+      fixture.componentInstance.value = 'foo';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.innerText).toBe('foo');
+    });
+
+    it('updates content when `value` changes', () => {
+      const fixture = TestBed.createComponent(ResizableInputComponent);
+      fixture.componentInstance.value = 'foo';
+      fixture.detectChanges();
+
+      fixture.componentInstance.value = 'bar';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.innerText).toBe('bar');
+    });
+
+    describe('single line mode', () => {
+      it('ignores newline and brs', () => {
+        const fixture = TestBed.createComponent(ResizableInputComponent);
+        fixture.componentInstance.value = 'foo\n\nhello';
+        fixture.componentInstance.singleLine = true;
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.innerText).toBe('foo hello');
+      });
+    });
+
+    describe('multi line mode', () => {
+      it('allows content to have new lines', () => {
+        const fixture = TestBed.createComponent(ResizableInputComponent);
+        fixture.componentInstance.value = 'foo\n\nhello';
+        fixture.componentInstance.singleLine = false;
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.innerText).toBe('foo\n\nhello');
+      });
+    });
+  });
+
+  describe('events', () => {
+    it('propagates events in the span', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      const onInputSpy = jasmine.createSpy();
+      const onKeyDownSpy = jasmine.createSpy();
+      fixture.componentInstance.value = 'hello';
+      fixture.componentInstance.onInput = onInputSpy;
+      fixture.componentInstance.onKeyDown = onKeyDownSpy;
+      fixture.detectChanges();
+
+      const inputDebugEl = fixture.debugElement.query(By.css('span'));
+      sendKey(fixture, inputDebugEl, {
+        type: KeyType.CHARACTER,
+        key: 'w',
+        prevString: 'hellow',
+        startingCursorIndex: 5,
+      });
+
+      expect(onInputSpy).toHaveBeenCalledTimes(1);
+      expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
TensorBoard has needs for an `<input>` that can tightly wrap its value.
`<input>` on the other hand has very fixed width and, when content is
longer than its width, it can have horizontal scroll inside.

This new widget will be used shortly in the experiment header.
