### PR TITLE
rust: upgrade to Rust 1.52.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,11 @@ jobs:
       matrix:
         mode: ['native']
         platform: ['ubuntu-16.04', 'macos-10.15']
-        rust_version: ['1.51.0']
+        rust_version: ['1.52.0']
         include:
           - mode: 'universal'
             platform: 'ubuntu-16.04'
-            rust_version: '1.51.0'
+            rust_version: '1.52.0'
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        rust_version: ['1.51.0']
+        rust_version: ['1.52.0']
         cargo_raze_version: ['0.12.0']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e

--- a/third_party/rust.bzl
+++ b/third_party/rust.bzl
@@ -21,5 +21,5 @@ load("//third_party/rust:crates.bzl", "raze_fetch_remote_crates")
 
 def tensorboard_rust_workspace():
     """TensorBoard Rust dependencies."""
-    rust_repositories(version = "1.51.0")
+    rust_repositories(version = "1.52.0")
     raze_fetch_remote_crates()


### PR DESCRIPTION
Summary:
Rust 1.52 is out! The [release notes] have the rundown, but I’m excited
in particular for [`str::split_once`] and a [caching fix for Clippy].

[release notes]: https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html
[`str::split_once`]: https://doc.rust-lang.org/std/primitive.str.html#method.split_once
[caching fix for Clippy]: https://github.com/rust-lang/rust-clippy/issues/4612

wchargin-branch: rust-v1.52.0
