### PR TITLE
rust: handle new Clippy lints for Rust 1.52

### DIFF
--- a/tensorboard/data/server/commit.rs
+++ b/tensorboard/data/server/commit.rs
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 //! Shared state for sampled data available to readers.
+#![allow(clippy::len_without_is_empty)] // https://github.com/rust-lang/rust-clippy/issues/7191
 
 use bytes::Bytes;
 use std::collections::HashMap;

--- a/tensorboard/data/server/data_compat.rs
+++ b/tensorboard/data/server/data_compat.rs
@@ -898,7 +898,7 @@ mod tests {
             let plugin_data = result.plugin_data.unwrap();
             assert_eq!(plugin_data.plugin_name, plugin_names::IMAGES);
             let plugin_content = pb::ImagePluginData::decode(&plugin_data.content[..]).unwrap();
-            assert_eq!(plugin_content.converted_to_tensor, true);
+            assert!(plugin_content.converted_to_tensor);
         }
 
         #[test]
@@ -949,7 +949,7 @@ mod tests {
             let plugin_data = result.plugin_data.unwrap();
             assert_eq!(plugin_data.plugin_name, plugin_names::AUDIO);
             let plugin_content = pb::AudioPluginData::decode(&plugin_data.content[..]).unwrap();
-            assert_eq!(plugin_content.converted_to_tensor, true);
+            assert!(plugin_content.converted_to_tensor);
         }
 
         #[test]

--- a/tensorboard/data/server/gcs/client.rs
+++ b/tensorboard/data/server/gcs/client.rs
@@ -59,6 +59,8 @@ impl Client {
             .build()
             .map_err(ClientError)?;
         let token_store = Arc::new(TokenStore::new(creds));
+        #[allow(clippy::inconsistent_struct_constructor)]
+        // ^ https://github.com/rust-lang/rust-clippy/issues/7192
         Ok(Self { http, token_store })
     }
 }

--- a/tensorboard/data/server/gcs/gsutil.rs
+++ b/tensorboard/data/server/gcs/gsutil.rs
@@ -20,8 +20,8 @@ use std::io::Write;
 
 use rustboard_core::gcs;
 
-#[clap(name = "gsutil")]
 #[derive(Clap, Debug)]
+#[clap(name = "gsutil")]
 struct Opts {
     #[clap(long, default_value = "info")]
     log_level: String,


### PR DESCRIPTION
Summary:
Some nice fixes, some annoying suppressions.

Test Plan:
Running `cargo clippy --tests --all` now exits cleanly on Rust 1.52.0
(current stable) and Rust 1.53.0-beta.2 (4bac69dd2 2021-05-07).

wchargin-branch: rust-clippy-1.52.0
