### PR TITLE
rust: use `split_once` where appropriate

### DIFF
--- a/tensorboard/data/server/cli/dynamic_logdir.rs
+++ b/tensorboard/data/server/cli/dynamic_logdir.rs
@@ -67,27 +67,22 @@ impl ParsedLogdir {
             return Err(Error::EmptyLogdir);
         }
 
-        let protocol_parts: Vec<&str> = path_str.splitn(2, "://").collect();
-        if protocol_parts.len() < 2 || !is_protocol(protocol_parts[0]) {
-            // Interpret as path on disk.
-            return Ok(ParsedLogdir::Disk(path));
-        }
-
-        let (protocol, subpath) = (protocol_parts[0], protocol_parts[1]);
+        let (protocol, subpath) = match path_str.split_once("://") {
+            Some((p, s)) if is_protocol(p) => (p, s),
+            // Otherwise, interpret as path on disk.
+            _ => return Ok(ParsedLogdir::Disk(path)),
+        };
         match protocol {
-            "gs" => Ok(Self::parse_gcs(subpath)),
+            "gs" => {
+                let (bucket, prefix) = subpath.split_once('/').unwrap_or((subpath, ""));
+                let (bucket, prefix) = (bucket.to_string(), prefix.to_string());
+                Ok(ParsedLogdir::Gcs { bucket, prefix })
+            }
             _ => Err(Error::UnknownProtocol {
                 protocol: protocol.to_string(),
                 full_logdir: path,
             }),
         }
-    }
-
-    fn parse_gcs(gcs_path: &str) -> Self {
-        let mut parts = gcs_path.splitn(2, '/');
-        let bucket = parts.next().unwrap().to_string(); // splitn always yields at least one element
-        let prefix = parts.next().unwrap_or("").to_string();
-        ParsedLogdir::Gcs { bucket, prefix }
     }
 }
 


### PR DESCRIPTION
Summary:
In #4793, we lamented that [`str::split_once`] was unstable, but it’s
stabilized as of Rust 1.52.0, so we can simplify the protocol parsing
code a tiny bit.

[`str::split_once`]: https://doc.rust-lang.org/std/string/struct.String.html#method.split_once

Test Plan:
The recently added unit tests should suffice, but end-to-end tests with
the following `--logdir`s also don’t hurt:

  - a local path
  - a valid `gs://path`
  - a `notgs://` path (falls back to non-RustBoard)
  - a `not_protocol://` path (interpreted as a path on disk)

wchargin-branch: rust-split-once
