### PR TITLE
what's new: small cosmetic changes to improve readability

### DIFF
--- a/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
@@ -39,7 +39,7 @@ limitations under the License.
         </ng-container>
         <span *ngIf="notification.icon">・</span>
         <span [title]="notification.dateInMs | date:'full'"
-          >{{ notification.dateInMs | date:'medium'}}</span
+          >{{ notification.dateInMs | date:'EEE MMM d, y'}}</span
         >
       </div>
       <div class="content-wrapper">

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.ng.html
@@ -39,7 +39,7 @@ limitations under the License.
         </ng-container>
         <span *ngIf="notification.icon">・</span>
         <span [title]="notification.dateInMs | date:'full'"
-          >{{ notification.dateInMs | date:'EEE MMM d, y'}}</span
+          >{{ notification.dateInMs | date:'fullDate'}}</span
         >
       </div>
       <div class="content-wrapper">

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -31,8 +31,8 @@ limitations under the License.
 
 ::ng-deep .notification-menu.mat-menu-panel {
   font-size: 13px;
-  max-width: 500px;
-  width: 500px;
+  max-width: 350px;
+  width: 350px;
 }
 
 .menu-item {
@@ -63,7 +63,7 @@ limitations under the License.
 }
 
 .title {
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.33;
   margin: 15px 0 0 0;
 }

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -30,8 +30,9 @@ limitations under the License.
 }
 
 ::ng-deep .notification-menu.mat-menu-panel {
-  font-size: 10px;
-  width: 350px;
+  font-size: 13px;
+  max-width: 500px;
+  width: 500px;
 }
 
 .menu-item {
@@ -44,7 +45,7 @@ limitations under the License.
 }
 
 .notification-menu {
-  font-size: 10px;
+  font-size: 13px;
 }
 
 .category-icon {
@@ -62,20 +63,20 @@ limitations under the License.
 }
 
 .title {
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.33;
   margin: 15px 0 0 0;
 }
 
 .content {
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.33;
   margin: 0;
   text-indent: 0;
 }
 
 .extended-buttons {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 700;
   margin: 10px 0 20px;
   a {


### PR DESCRIPTION
Suggesting a few small tweaks to make it a little easier to read the contents:

- Widens the dialog from 280px to 350px (the 350px width was being suppressed due to mat-menu-panel max-width)
- Adjusts font sizes to be 13px throughout for consistency w/ rest of TB in body text (e.g. run selector uses 13px, so does the "data location").
- Use a more coarse-grained date format. Including the exact time of the notification is a little misleading since it suggests a precision that we don't really support (since the notification isn't "held back" until that time, and the push isn't going to happen at the exact time of the notification). If we have more time-critical notifications in the future we could always revisit, and the full timestamp is available as a tooltip still.

Before:

![image](https://user-images.githubusercontent.com/710113/117855844-c142db00-b23f-11eb-9221-e88fe0c626b4.png)

After:
![Screen Shot 2021-05-12 at 4 41 38 PM](https://user-images.githubusercontent.com/710113/118057502-fbe06c80-b340-11eb-9e86-d10e6b22d179.png)
