### PR TITLE
runs: add groupBy enum and state to the reducer

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -26,6 +26,7 @@ import {SortDirection} from '../../types/ui';
 import * as colorUtils from '../../util/colors';
 import {composeReducers} from '../../util/ngrx';
 import * as runsActions from '../actions';
+import {GroupByKey} from '../types';
 import {
   MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT,
   RunsDataState,
@@ -186,6 +187,7 @@ const {
     hparamFilters: new Map(),
     metricFilters: new Map(),
     runColorOverride: new Map(),
+    groupBy: GroupByKey.RUN,
   } as RunsUiRoutefulState,
   {
     hparamDefaultFilters: new Map(),

--- a/tensorboard/webapp/runs/store/runs_types.ts
+++ b/tensorboard/webapp/runs/store/runs_types.ts
@@ -20,7 +20,7 @@ import {RouteContextedState} from '../../app_routing/route_contexted_reducer_hel
 import {LoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
 import {HparamValue} from '../data_source/runs_data_source_types';
-import {SortKey} from '../types';
+import {GroupByKey, SortKey} from '../types';
 
 export {Domain, DomainType} from '../data_source/runs_data_source_types';
 
@@ -70,6 +70,7 @@ export interface RunsUiRoutefulState {
   regexFilter: string;
   sort: {key: SortKey | null; direction: SortDirection};
   runColorOverride: Map<RunId, string>;
+  groupBy: GroupByKey;
 }
 
 export interface RunsUiRoutelessState {

--- a/tensorboard/webapp/runs/store/testing.ts
+++ b/tensorboard/webapp/runs/store/testing.ts
@@ -17,6 +17,7 @@ limitations under the License.
  */
 
 import {SortDirection} from '../../types/ui';
+import {GroupByKey} from '../types';
 import {
   Run,
   RunsDataState,
@@ -63,6 +64,7 @@ export function buildRunsState(
       sort: {key: null, direction: SortDirection.UNSET},
       defaultRunColor: new Map(),
       runColorOverride: new Map(),
+      groupBy: GroupByKey.RUN,
       ...uiOverride,
     },
   };

--- a/tensorboard/webapp/runs/types.ts
+++ b/tensorboard/webapp/runs/types.ts
@@ -45,3 +45,13 @@ export type SortKey =
   | HparamsSortKey
   | MetricsSortKey
   | {type: SortType.RUN_NAME | SortType.EXPERIMENT_NAME};
+
+export enum GroupByKey {
+  // Group runs by run names.
+  RUN,
+  // Group all runs under the same experimentId is grouped as a group.
+  EXERPIMENT,
+  // Group runs by regex that matches on the run name. The specification for
+  // the grouping is to be defined.
+  REGEX,
+}


### PR DESCRIPTION
This change simply readies the runs redux state from understanding the
notion of the color grouping.
