### PR TITLE
cleanup: remove vestigial hparams from runs reducer

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -183,17 +183,13 @@ const {
     sort: {
       key: null,
       direction: SortDirection.UNSET,
-    },
-    hparamFilters: new Map(),
-    metricFilters: new Map(),
-    runColorOverride: new Map(),
+    } as RunsUiRoutefulState['sort'],
+    runColorOverride: new Map<string, string>(),
     groupBy: GroupByKey.RUN,
-  } as RunsUiRoutefulState,
+  },
   {
-    hparamDefaultFilters: new Map(),
-    metricDefaultFilters: new Map(),
-    defaultRunColor: new Map(),
-  } as RunsUiRoutelessState
+    defaultRunColor: new Map<string, string>(),
+  }
 );
 
 const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -170,6 +170,10 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
   })
 );
 
+const initialSort: RunsUiRoutefulState['sort'] = {
+  key: null,
+  direction: SortDirection.UNSET,
+};
 const {
   initialState: uiInitialState,
   reducers: uiRouteContextReducers,
@@ -180,10 +184,7 @@ const {
       pageSize: 10,
     },
     regexFilter: '',
-    sort: {
-      key: null,
-      direction: SortDirection.UNSET,
-    } as RunsUiRoutefulState['sort'],
+    sort: initialSort,
     runColorOverride: new Map<string, string>(),
     groupBy: GroupByKey.RUN,
   },


### PR DESCRIPTION
Runs reducers no longer contain the hparam and metric filters yet we
still were providing their default values. This change removes it and
removes type casting which is faulty.
