### PR TITLE
plugin-api: fix getURLPluginData()

### DIFF
--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -39,9 +39,10 @@ tf_ng_module(
     deps = [
         ":host_internals",
         ":message_types",
-        "//tensorboard/components/tf_storage:tf_storage_lib",
+        "//tensorboard/components/tf_storage",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp:tb_polymer_interop_types",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//rxjs",

--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -78,6 +78,7 @@ tf_ng_module(
         "//tensorboard/components/tf_storage:tf_storage_lib",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp:tb_polymer_interop_types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/runs/store:testing",

--- a/tensorboard/components/experimental/plugin_util/core-host-impl.ts
+++ b/tensorboard/components/experimental/plugin_util/core-host-impl.ts
@@ -21,7 +21,7 @@ import {distinctUntilChanged, filter} from 'rxjs/operators';
 
 import {State} from '../../../webapp/app_state';
 import {getAppLastLoadedTimeInMs} from '../../../webapp/selectors';
-import * as tf_storage_utils from '../../tf_storage/storage_utils';
+import {TfStorageElement} from '../../../webapp/tb_polymer_interop_types';
 import {MessageId} from './message_types';
 import {Ipc} from './plugin-host-ipc';
 
@@ -33,6 +33,7 @@ export class PluginCoreApiHostImpl {
   ) {}
 
   init() {
+    const tfStorage: TfStorageElement = document.createElement('tf-storage');
     this.ipc.listen(MessageId.GET_URL_DATA, (context) => {
       if (!context) {
         return;
@@ -41,7 +42,7 @@ export class PluginCoreApiHostImpl {
       const result: {
         [key: string]: string;
       } = {};
-      const urlDict = tf_storage_utils.getUrlDict();
+      const urlDict = tfStorage.tf_storage.getUrlHashDict();
       for (let key in urlDict) {
         if (key.startsWith(prefix)) {
           const pluginKey = key.substring(prefix.length);

--- a/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
+++ b/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
@@ -24,7 +24,6 @@ import {
   getExperimentIdsFromRoute,
   getRuns,
 } from '../../../webapp/selectors';
-import * as tf_storage_utils from '../../tf_storage/storage_utils';
 import {PluginCoreApiHostImpl} from './core-host-impl';
 import {MessageId} from './message_types';
 import {Ipc} from './plugin-host-ipc';
@@ -236,7 +235,6 @@ describe('plugin_api_host test', () => {
       let triggerGetUrlData: (context: {
         pluginName: string;
       }) => Record<string, string> = () => ({});
-      let getUrlDictSpy: jasmine.Spy;
 
       beforeEach(() => {
         listenSpy
@@ -246,17 +244,23 @@ describe('plugin_api_host test', () => {
               triggerGetUrlData = callback;
             }
           );
-
-        getUrlDictSpy = spyOn(tf_storage_utils, 'getUrlDict');
       });
 
       it('returns url data from the tf storage', () => {
-        getUrlDictSpy.and.returnValue({
-          globalThing: 'hey',
-          'p.plugin_id.a': '1',
-          'p.plugin_id.b': 'b',
-          'p.another_plugn.b': '2',
-        });
+        // Do not rely on Polymer bundle in the test.
+        const createElementSpy = spyOn(document, 'createElement');
+        createElementSpy.withArgs('tf-storage').and.returnValue({
+          tf_storage: {
+            getUrlHashDict: () => {
+              return {
+                'globalThing': 'hey',
+                'p.plugin_id.a': '1',
+                'p.plugin_id.b': 'b',
+                'p.another_plugn.b': '2',
+              }
+            },
+          },
+        } as any);
 
         coreApi.init();
         const actual = triggerGetUrlData({pluginName: 'plugin_id'});

--- a/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
+++ b/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
@@ -24,6 +24,7 @@ import {
   getExperimentIdsFromRoute,
   getRuns,
 } from '../../../webapp/selectors';
+import {TfStorageElement} from '../../../webapp/tb_polymer_interop_types';
 import {PluginCoreApiHostImpl} from './core-host-impl';
 import {MessageId} from './message_types';
 import {Ipc} from './plugin-host-ipc';
@@ -249,18 +250,18 @@ describe('plugin_api_host test', () => {
       it('returns url data from the tf storage', () => {
         // Do not rely on Polymer bundle in the test.
         const createElementSpy = spyOn(document, 'createElement');
-        createElementSpy.withArgs('tf-storage').and.returnValue({
+        createElementSpy.withArgs('tf-storage').and.returnValue(({
           tf_storage: {
             getUrlHashDict: () => {
               return {
-                'globalThing': 'hey',
+                globalThing: 'hey',
                 'p.plugin_id.a': '1',
                 'p.plugin_id.b': 'b',
                 'p.another_plugn.b': '2',
-              }
+              };
             },
           },
-        } as any);
+        } as unknown) as TfStorageElement);
 
         coreApi.init();
         const actual = triggerGetUrlData({pluginName: 'plugin_id'});

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -31,6 +31,8 @@ import {
   writeComponent,
 } from './storage_utils';
 
+export {getUrlDict as getUrlHashDict} from './storage_utils';
+
 /**
  * The name of the property for users to set on a Polymer component
  * in order for its stored properties to be stored in the URI unambiguously.

--- a/tensorboard/webapp/tb_polymer_interop_types.ts
+++ b/tensorboard/webapp/tb_polymer_interop_types.ts
@@ -44,17 +44,14 @@ export interface SetStringOption {
   useLocationReplace?: boolean;
 }
 
-export interface TfStorage {
-  /** @export */
+export declare interface TfStorage {
   setString(key: string, value: string, options?: SetStringOption): void;
-  /** @export */
   getString(key: string): string;
-  /** @export */
   migrateLegacyURLScheme(): void;
+  getUrlHashDict(): Record<string, string>;
 }
 
-export interface TfStorageElement extends HTMLElement {
-  /** @export */
+export declare interface TfStorageElement extends HTMLElement {
   tf_storage: TfStorage;
 }
 


### PR DESCRIPTION
Currently, `getURLPluginData()` always returns empty data, because its
code path has `useHash() === false`. "core-host-impl.ts" directly imports
Polymer's `tf_storage_utils`, producing a separate scope with state that
is not shared with the Polymer side. When `deeplink/hash.ts` sets the flag
via `document.createElement('tf-globals').tf_globals.setUseHash(true)`,
the variable that updates is different from the one that is read by the
plugin host.

This change makes the plugin host read Polymer state via manually
instantiating a Polymer CustomElement, rather than via direct import.

Googlers, see b/187854773 and test sync cl/373276716

For reference, there are 2 ways for an Angular TS module to use a Polymer TS module.
A) direct import
```ts
import * as globals from 'tf_globals';
globals.useHash();
```

B) access through CustomElement
```ts
import * as tf_globals from 'tf_globals';
@customElement('tf-globals')
class TfGlobals extends PolymerElement {
  _template = null;
  tf_globals = tf_globals;
}
document.createElement('tf-globals').tf_globals.useHash();
```

After TS+Closure compilation, these 2 methods result in separate copies of the Polymer code, each with its individual scope. Angular code using method A) will not be sharing the same state as Polymer components.  We should prefer doing method B).