### PR TITLE
what's new: export testing.ts for functions reuse

### DIFF
--- a/tensorboard/webapp/notification_center/_redux/BUILD
+++ b/tensorboard/webapp/notification_center/_redux/BUILD
@@ -55,6 +55,7 @@ tf_ts_library(
     srcs = [
         "testing.ts",
     ],
+    visibility = ["//tensorboard:internal"],
     deps = [
         ":types",
     ],


### PR DESCRIPTION
to reuse `buildNotificationState` and `buildStateFromNotificationState` in other tests