### PR TITLE
flag: add feature flag for enableColorGroup

### DIFF
--- a/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
@@ -28,7 +28,10 @@ import {
 import {CardUniqueInfo, METRICS_SETTINGS_DEFAULT} from '../metrics/types';
 import * as selectors from '../selectors';
 import {getMetricsScalarSmoothing} from '../selectors';
-import {EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY} from '../webapp_data_source/tb_feature_flag_data_source_types';
+import {
+  ENABLE_COLOR_GROUP_QUERY_PARAM_KEY,
+  EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
+} from '../webapp_data_source/tb_feature_flag_data_source_types';
 import {
   DeserializedState,
   PINNED_CARDS_KEY,
@@ -86,6 +89,12 @@ export class DashboardDeepLinkProvider extends DeepLinkProvider {
         const queryParams = experimentalPlugins.map((pluginId) => {
           return {key: EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY, value: pluginId};
         });
+        if (typeof overriddenFeatureFlags.enabledColorGroup === 'boolean') {
+          queryParams.push({
+            key: ENABLE_COLOR_GROUP_QUERY_PARAM_KEY,
+            value: String(overriddenFeatureFlags.enabledColorGroup),
+          });
+        }
         return queryParams;
       })
     );

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
@@ -302,5 +302,32 @@ describe('core deeplink provider', () => {
         {key: 'experimentalPlugin', value: 'baz'},
       ]);
     });
+
+    it('serializes enableColorGroup state', () => {
+      store.overrideSelector(selectors.getOverriddenFeatureFlags, {
+        enabledColorGroup: true,
+      });
+      store.refreshState();
+
+      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
+        {key: 'enableColorGroup', value: 'true'},
+      ]);
+
+      store.overrideSelector(selectors.getOverriddenFeatureFlags, {
+        enabledColorGroup: false,
+      });
+      store.refreshState();
+
+      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
+        {key: 'enableColorGroup', value: 'false'},
+      ]);
+
+      store.overrideSelector(selectors.getOverriddenFeatureFlags, {});
+      store.refreshState();
+
+      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual(
+        []
+      );
+    });
   });
 });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {Injectable} from '@angular/core';
 
 import {
+  ENABLE_COLOR_GROUP_QUERY_PARAM_KEY,
   EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
   SCALARS_BATCH_SIZE_PARAM_KEY,
   TBFeatureFlagDataSource,
@@ -52,6 +53,11 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
       featureFlags.scalarsBatchSize = Number(
         params.get(SCALARS_BATCH_SIZE_PARAM_KEY)
       );
+    }
+
+    if (params.has(ENABLE_COLOR_GROUP_QUERY_PARAM_KEY)) {
+      featureFlags.enabledColorGroup =
+        params.get(ENABLE_COLOR_GROUP_QUERY_PARAM_KEY) !== 'false';
     }
     return featureFlags;
   }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -77,6 +77,19 @@ describe('tb_feature_flag_data_source', () => {
         });
       });
 
+      it('returns enableColorGroup from the query params', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValues(
+          new URLSearchParams('enableColorGroup=false'),
+          new URLSearchParams('enableColorGroup='),
+          new URLSearchParams('enableColorGroup=true'),
+          new URLSearchParams('enableColorGroup=foo')
+        );
+        expect(dataSource.getFeatures()).toEqual({enabledColorGroup: false});
+        expect(dataSource.getFeatures()).toEqual({enabledColorGroup: true});
+        expect(dataSource.getFeatures()).toEqual({enabledColorGroup: true});
+        expect(dataSource.getFeatures()).toEqual({enabledColorGroup: true});
+      });
+
       it('returns all flag values when they are all set', () => {
         spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams(

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -34,3 +34,5 @@ export abstract class TBFeatureFlagDataSource {
 export const EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY = 'experimentalPlugin';
 
 export const SCALARS_BATCH_SIZE_PARAM_KEY = 'scalarsBatchSize';
+
+export const ENABLE_COLOR_GROUP_QUERY_PARAM_KEY = 'enableColorGroup';


### PR DESCRIPTION
Currently, the feature flag is not configurable via URL and this change
enables the serialization and deserialization of the flag.
