### PR TITLE
docs: mark RustBoard status as shipped

### DIFF
--- a/docs/design/rustboard.md
+++ b/docs/design/rustboard.md
@@ -2,7 +2,7 @@
 
 @wchargin, 2020-10-29
 
-**Status:** Implementation in progress.
+**Status:** Shipped in TensorBoard 2.5.0.
 
 ## Purpose
 


### PR DESCRIPTION
Summary:
This shipped to users in TensorBoard 2.5.0 and is on by default. We’ve
heard of a few issues but nothing show-stopping, so it seems appropriate
to update this status accordingly.

wchargin-branch: rustboard-status-shipped
