### PR TITLE
Fix sync by removing tf_storage dep

### DIFF
--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -39,7 +39,6 @@ tf_ng_module(
     deps = [
         ":host_internals",
         ":message_types",
-        "//tensorboard/components/tf_storage",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp:tb_polymer_interop_types",


### PR DESCRIPTION
Internal targets are currently broken by the sync because of
attempts to load lodash 2x. This removes the dep on tf_storage
from the Angular plugin host module, leaving no more than 1
place where tf_storage is included in the Blaze dep path.

Test sync cl/373696993