### PR TITLE
Use an r-string so the \n doesn't break the site.

### DIFF
--- a/tensorboard/plugins/text/summary_v2.py
+++ b/tensorboard/plugins/text/summary_v2.py
@@ -24,7 +24,7 @@ from tensorboard.util import tensor_util
 
 
 def text(name, data, step=None, description=None):
-    """Write a text summary.
+    r"""Write a text summary.
 
     See also `tf.summary.scalar`, `tf.summary.SummaryWriter`, `tf.summary.image`.
 


### PR DESCRIPTION
Fixes: https://www.tensorflow.org/api_docs/python/tf/summary/text

* Technical description of changes

The \n is interpreted by python as a new-line.
When building the site, we dedent the text. After that newline there is zero indentation.
0 is the floor, so none of the text is dedented.
When converted to markdown the 4-space indent is interpreted as preformatted text.
