### PR TITLE
Cleanup how HashDeepLinker is provided in prod and test code.

### DIFF
--- a/tensorboard/webapp/core/core_module.ts
+++ b/tensorboard/webapp/core/core_module.ts
@@ -25,8 +25,7 @@ import {
   CORE_STORE_CONFIG_TOKEN,
   getConfig,
 } from './store/core_initial_state_provider';
-import {DeepLinkModule} from '../deeplink/deeplink_module';
-import {HashDeepLinker} from '../deeplink';
+import {DeepLinkerInterface} from '../deeplink';
 
 @NgModule({
   imports: [
@@ -37,7 +36,7 @@ import {HashDeepLinker} from '../deeplink';
   providers: [
     {
       provide: CORE_STORE_CONFIG_TOKEN,
-      deps: [HashDeepLinker],
+      deps: [DeepLinkerInterface],
       useFactory: getConfig,
     },
   ],

--- a/tensorboard/webapp/core/store/core_initial_state_provider.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider.ts
@@ -25,7 +25,9 @@ export const CORE_STORE_CONFIG_TOKEN = new InjectionToken<
   StoreConfig<CoreState>
 >('Core Feature Config');
 
-export function getConfig(deepLinker: DeepLinkerInterface): StoreConfig<CoreState> {
+export function getConfig(
+  deepLinker: DeepLinkerInterface
+): StoreConfig<CoreState> {
   return {
     initialState: {
       ...initialState,

--- a/tensorboard/webapp/core/store/core_initial_state_provider.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider.ts
@@ -16,7 +16,7 @@ import {InjectionToken} from '@angular/core';
 import {StoreConfig} from '@ngrx/store';
 
 import {CoreState} from './core_types';
-import {HashDeepLinker} from '../../deeplink';
+import {DeepLinkerInterface} from '../../deeplink';
 import {initialState} from './core_types';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
@@ -25,7 +25,7 @@ export const CORE_STORE_CONFIG_TOKEN = new InjectionToken<
   StoreConfig<CoreState>
 >('Core Feature Config');
 
-export function getConfig(deepLinker: HashDeepLinker): StoreConfig<CoreState> {
+export function getConfig(deepLinker: DeepLinkerInterface): StoreConfig<CoreState> {
   return {
     initialState: {
       ...initialState,

--- a/tensorboard/webapp/core/store/core_initial_state_provider_test.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider_test.ts
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 import {getConfig} from './core_initial_state_provider';
 import {DeepLinkerInterface, SetStringOption} from '../../deeplink/types';
-import {HashDeepLinker} from '../../deeplink/hash';
 import {CoreState} from './core_types';
 
 class TestableDeepLinker implements DeepLinkerInterface {
@@ -38,11 +37,11 @@ class TestableDeepLinker implements DeepLinkerInterface {
 
 describe('core_initial_state_provider', () => {
   describe('#getConfig', () => {
-    let deeplinker: HashDeepLinker;
+    let deeplinker: TestableDeepLinker;
     let getPluginIdSpy: jasmine.Spy;
 
     beforeEach(() => {
-      deeplinker = new TestableDeepLinker() as HashDeepLinker;
+      deeplinker = new TestableDeepLinker();
       getPluginIdSpy = spyOn(deeplinker, 'getPluginId').and.returnValue('foo');
     });
 

--- a/tensorboard/webapp/core/views/hash_storage_component.ts
+++ b/tensorboard/webapp/core/views/hash_storage_component.ts
@@ -24,8 +24,7 @@ import {
   EventEmitter,
 } from '@angular/core';
 
-import {HashDeepLinker} from '../../deeplink/hash';
-import {SetStringOption} from '../../deeplink/types';
+import {DeepLinkerInterface, SetStringOption} from '../../deeplink/types';
 export enum ChangedProp {
   ACTIVE_PLUGIN,
 }
@@ -38,7 +37,7 @@ export enum ChangedProp {
 export class HashStorageComponent implements OnInit, OnChanges, OnDestroy {
   private readonly onHashChange = this.onHashChangedImpl.bind(this);
 
-  constructor(private readonly deepLinker: HashDeepLinker) {}
+  constructor(private readonly deepLinker: DeepLinkerInterface) {}
 
   @Input()
   activePluginId!: string | null;

--- a/tensorboard/webapp/core/views/hash_storage_test.ts
+++ b/tensorboard/webapp/core/views/hash_storage_test.ts
@@ -25,7 +25,7 @@ import {SetStringOption} from '../../deeplink/types';
 
 import {HashStorageContainer} from './hash_storage_container';
 import {HashStorageComponent} from './hash_storage_component';
-import {HashDeepLinker, DeepLinkerInterface} from '../../deeplink';
+import {DeepLinkerInterface} from '../../deeplink';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
@@ -52,14 +52,14 @@ describe('hash storage test', () => {
       providers: [
         provideMockStore(),
         HashStorageContainer,
-        {provide: HashDeepLinker, useClass: TestableDeeplinker},
+        {provide: DeepLinkerInterface, useClass: TestableDeeplinker},
       ],
       declarations: [HashStorageContainer, HashStorageComponent],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
 
-    const deepLinker = TestBed.inject(HashDeepLinker);
+    const deepLinker = TestBed.inject(DeepLinkerInterface);
     setPluginIdSpy = spyOn(deepLinker, 'setPluginId');
     getPluginIdSpy = spyOn(deepLinker, 'getPluginId');
   });

--- a/tensorboard/webapp/deeplink/BUILD
+++ b/tensorboard/webapp/deeplink/BUILD
@@ -28,3 +28,14 @@ tf_ng_module(
         "@npm//@types/jasmine",
     ],
 )
+
+tf_ng_module(
+    name = "testing",
+    srcs = [
+        "testing.ts",
+    ],
+    deps = [
+        ":deeplink",
+        "@npm//@angular/core",
+    ],
+)

--- a/tensorboard/webapp/deeplink/deeplink_module.ts
+++ b/tensorboard/webapp/deeplink/deeplink_module.ts
@@ -14,9 +14,10 @@ limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
 
+import {DeepLinkerInterface} from './types';
 import {HashDeepLinker} from './hash';
 
 @NgModule({
-  providers: [HashDeepLinker],
+  providers: [{provide: DeepLinkerInterface, useClass: HashDeepLinker}],
 })
 export class DeepLinkModule {}

--- a/tensorboard/webapp/deeplink/testing.ts
+++ b/tensorboard/webapp/deeplink/testing.ts
@@ -19,23 +19,25 @@ import {DeepLinkerInterface} from './';
 /**
  * Prevent reading or modification of real hashes.
  */
- @Injectable()
+@Injectable()
 export class TestableNoopHashDeepLinker implements DeepLinkerInterface {
-   getString(key: string): string {
-     return '';
-   }
-   setString(key: string, value: string): void {
-     // noop
-   }
-   getPluginId(): string {
-     return '';
-   }
-   setPluginId(pluginId: string): void {
-     // noop
-   }
- }
+  getString(key: string): string {
+    return '';
+  }
+  setString(key: string, value: string): void {
+    // noop
+  }
+  getPluginId(): string {
+    return '';
+  }
+  setPluginId(pluginId: string): void {
+    // noop
+  }
+}
 
 @NgModule({
-  providers: [{provide: DeepLinkerInterface, useClass: TestableNoopHashDeepLinker}],
+  providers: [
+    {provide: DeepLinkerInterface, useClass: TestableNoopHashDeepLinker},
+  ],
 })
 export class TestableNoopHashDeepLinkerModule {}

--- a/tensorboard/webapp/deeplink/testing.ts
+++ b/tensorboard/webapp/deeplink/testing.ts
@@ -1,0 +1,41 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Injectable, NgModule} from '@angular/core';
+import {DeepLinkerInterface} from './';
+
+/**
+ * Prevent reading or modification of real hashes.
+ */
+ @Injectable()
+class TestableNoopHashDeepLinker implements DeepLinkerInterface {
+   getString(key: string): string {
+     return '';
+   }
+   setString(key: string, value: string): void {
+     // noop
+   }
+   getPluginId(): string {
+     return '';
+   }
+   setPluginId(pluginId: string): void {
+     // noop
+   }
+ }
+
+@NgModule({
+  providers: [{provide: DeepLinkerInterface, useClass: TestableNoopHashDeepLinker}],
+})
+export class TestableNoopHashDeepLinkerModule {}

--- a/tensorboard/webapp/deeplink/testing.ts
+++ b/tensorboard/webapp/deeplink/testing.ts
@@ -20,7 +20,7 @@ import {DeepLinkerInterface} from './';
  * Prevent reading or modification of real hashes.
  */
  @Injectable()
-class TestableNoopHashDeepLinker implements DeepLinkerInterface {
+export class TestableNoopHashDeepLinker implements DeepLinkerInterface {
    getString(key: string): string {
      return '';
    }

--- a/tensorboard/webapp/deeplink/types.ts
+++ b/tensorboard/webapp/deeplink/types.ts
@@ -22,7 +22,11 @@ export interface SetStringOption {
 
 export abstract class DeepLinkerInterface {
   abstract getString(key: string): string;
-  abstract setString(key: string, value: string, options?: SetStringOption): void;
+  abstract setString(
+    key: string,
+    value: string,
+    options?: SetStringOption
+  ): void;
   abstract getPluginId(): string;
   abstract setPluginId(pluginId: string, options?: SetStringOption): void;
 }

--- a/tensorboard/webapp/deeplink/types.ts
+++ b/tensorboard/webapp/deeplink/types.ts
@@ -20,9 +20,9 @@ export interface SetStringOption {
   useLocationReplace?: boolean;
 }
 
-export interface DeepLinkerInterface {
-  getString(key: string): string;
-  setString(key: string, value: string, options?: SetStringOption): void;
-  getPluginId(): string;
-  setPluginId(pluginId: string, options?: SetStringOption): void;
+export abstract class DeepLinkerInterface {
+  abstract getString(key: string): string;
+  abstract setString(key: string, value: string, options?: SetStringOption): void;
+  abstract getPluginId(): string;
+  abstract setPluginId(pluginId: string, options?: SetStringOption): void;
 }

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -75,7 +75,7 @@ tf_ng_module(
         "//tensorboard/webapp/app_routing:route_registry",
         "//tensorboard/webapp/app_routing:types",
         "//tensorboard/webapp/core",
-        "//tensorboard/webapp/deeplink",
+        "//tensorboard/webapp/deeplink:testing",
         "//tensorboard/webapp/feature_flag",
         "//tensorboard/webapp/runs",
         "@npm//@angular/core",

--- a/tensorboard/webapp/testing/integration_test_module.ts
+++ b/tensorboard/webapp/testing/integration_test_module.ts
@@ -31,7 +31,6 @@ import {FeatureFlagModule} from '../feature_flag/feature_flag_module';
 import {RunsModule} from '../runs/runs_module';
 import {MatIconTestingModule} from './mat_icon_module';
 
-
 @Component({
   selector: 'test',
   template: 'hello',

--- a/tensorboard/webapp/testing/integration_test_module.ts
+++ b/tensorboard/webapp/testing/integration_test_module.ts
@@ -26,29 +26,11 @@ import {RouteDef} from '../app_routing/route_config_types';
 import {RouteRegistryModule} from '../app_routing/route_registry_module';
 import {RouteKind} from '../app_routing/types';
 import {CoreModule} from '../core/core_module';
-import {DeepLinkerInterface, HashDeepLinker} from '../deeplink';
+import {TestableNoopHashDeepLinkerModule} from '../deeplink/testing';
 import {FeatureFlagModule} from '../feature_flag/feature_flag_module';
 import {RunsModule} from '../runs/runs_module';
 import {MatIconTestingModule} from './mat_icon_module';
 
-/**
- * Prevent reading or modification of real hashes.
- */
-@Injectable()
-export class TestableNoopHashDeepLinker implements DeepLinkerInterface {
-  getString(key: string): string {
-    return '';
-  }
-  setString(key: string, value: string): void {
-    // noop
-  }
-  getPluginId(): string {
-    return '';
-  }
-  setPluginId(pluginId: string): void {
-    // noop
-  }
-}
 
 @Component({
   selector: 'test',
@@ -75,11 +57,11 @@ export function provideRoute(): RouteDef[] {
     CoreModule,
     AppRoutingModule,
     RunsModule,
+    TestableNoopHashDeepLinkerModule,
     RouteRegistryModule.registerRoutes(provideRoute),
     NgrxStoreModule.forRoot([]),
     NgrxEffectsModule.forRoot([]),
   ],
-  providers: [{provide: HashDeepLinker, useClass: TestableNoopHashDeepLinker}],
   declarations: [TestableComponent],
   exports: [TestableComponent],
 })


### PR DESCRIPTION
Some cleanup surrounding DeepLinkModule:
* DeepLinkerInterface is the provided token and HashDeepLinker is the implementation that the Module provides for that token.
* References to HashDeepLinker have been removed from the remainder of the code base. They use the DeepLinkerInterface instead.
* The TestableNoopHashDeepLinker has been refactored out of IntegrationTestModule to a shareable location. It's not used by anything currently in this code base but will be used by Google-internal code.