### PR TITLE
Import RouteRegistryModule from AppRoutingModule since it is a runtime dependency.

### DIFF
--- a/tensorboard/webapp/app_routing/app_routing_module.ts
+++ b/tensorboard/webapp/app_routing/app_routing_module.ts
@@ -20,11 +20,13 @@ import {AppRootModule} from './app_root_module';
 import {AppRoutingEffects} from './effects';
 import {LocationModule} from './location_module';
 import {ProgrammaticalNavigationModule} from './programmatical_navigation_module';
+import {RouteRegistryModule} from './route_registry_module';
 import {reducers} from './store/app_routing_reducers';
 import {APP_ROUTING_FEATURE_KEY} from './store/app_routing_types';
 
 @NgModule({
   imports: [
+    RouteRegistryModule,
     StoreModule.forFeature(APP_ROUTING_FEATURE_KEY, reducers),
     EffectsModule.forFeature([AppRoutingEffects]),
     AppRootModule,


### PR DESCRIPTION
In a couple Google-internal CLs (including one I'm now working on) we've noticed that RouteRegistryModule has to be imported whenever AppRoutingModule is imported. This is because RouteRegistryModule is a runtime dependency of AppRoutingModule's features. Instead AppRoutingModule should import RouteRegistryModule directly.