### PR TITLE
runs: re-assign colors on runGroupByChanged event

### DIFF
--- a/tensorboard/webapp/runs/actions/runs_actions.ts
+++ b/tensorboard/webapp/runs/actions/runs_actions.ts
@@ -20,7 +20,7 @@ import {createAction, props} from '@ngrx/store';
 
 import {SortDirection} from '../../types/ui';
 import {Run} from '../data_source/runs_data_source_types';
-import {ExperimentIdToRunsAndMetadata, SortKey} from '../types';
+import {ExperimentIdToRunsAndMetadata, GroupBy, SortKey} from '../types';
 
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
@@ -90,4 +90,9 @@ export const runColorChanged = createAction(
 export const runTableShown = createAction(
   '[Runs] Run Table Shown',
   props<{experimentIds: string[]}>()
+);
+
+export const runGroupByChanged = createAction(
+  '[Runs] Run Group By Changed',
+  props<{experimentIds: string[]; groupBy: GroupBy}>()
 );

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -208,41 +208,48 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
       groupKeyToColorString,
     };
   }),
-  on(runsActions.runGroupByChanged, (state: RunsDataState, {experimentIds, groupBy}): RunsDataState => {
-    // Reset the groupKeyToColorString
-    const groupKeyToColorString = new Map<string, string>();
-    const defaultRunColorForGroupBy = new Map(state.defaultRunColorForGroupBy);
+  on(
+    runsActions.runGroupByChanged,
+    (state: RunsDataState, {experimentIds, groupBy}): RunsDataState => {
+      // Reset the groupKeyToColorString
+      const groupKeyToColorString = new Map<string, string>();
+      const defaultRunColorForGroupBy = new Map(
+        state.defaultRunColorForGroupBy
+      );
 
-    const allRuns = experimentIds
-      .flatMap((experimentId) => {
-        return state.runIds[experimentId];
-      })
-      .map((runId) => {
-        return state.runMetadata[runId];
-      })
-      .filter(Boolean);
+      const allRuns = experimentIds
+        .flatMap((experimentId) => {
+          return state.runIds[experimentId];
+        })
+        .map((runId) => {
+          return state.runMetadata[runId];
+        })
+        .filter(Boolean);
 
-    const groups = groupRuns(groupBy, allRuns, state.runIdToExpId);
+      const groups = groupRuns(groupBy, allRuns, state.runIdToExpId);
 
-    Object.entries(groups).forEach(([groupId, runs]) => {
-      const color =
-        groupKeyToColorString.get(groupId) ??
-        CHART_COLOR_PALLETE[groupKeyToColorString.size % CHART_COLOR_PALLETE.length];
-      groupKeyToColorString.set(groupId, color);
+      Object.entries(groups).forEach(([groupId, runs]) => {
+        const color =
+          groupKeyToColorString.get(groupId) ??
+          CHART_COLOR_PALLETE[
+            groupKeyToColorString.size % CHART_COLOR_PALLETE.length
+          ];
+        groupKeyToColorString.set(groupId, color);
 
-      for (const run of runs) {
-        defaultRunColorForGroupBy.set(run.id, color);
-      }
-    });
+        for (const run of runs) {
+          defaultRunColorForGroupBy.set(run.id, color);
+        }
+      });
 
-    return {
-      ...state,
-      defaultRunColorForGroupBy,
-      groupKeyToColorString,
-      // Resets the color override when the groupBy changes.
-      runColorOverrideForGroupBy: new Map(),
-    };
-  }),
+      return {
+        ...state,
+        defaultRunColorForGroupBy,
+        groupKeyToColorString,
+        // Resets the color override when the groupBy changes.
+        runColorOverrideForGroupBy: new Map(),
+      };
+    }
+  ),
   on(runsActions.runColorChanged, (state, {runId, newColor}) => {
     const nextRunColorOverride = new Map(state.runColorOverrideForGroupBy);
     nextRunColorOverride.set(runId, newColor);

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -208,6 +208,41 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
       groupKeyToColorString,
     };
   }),
+  on(runsActions.runGroupByChanged, (state: RunsDataState, {experimentIds, groupBy}): RunsDataState => {
+    // Reset the groupKeyToColorString
+    const groupKeyToColorString = new Map<string, string>();
+    const defaultRunColorForGroupBy = new Map(state.defaultRunColorForGroupBy);
+
+    const allRuns = experimentIds
+      .flatMap((experimentId) => {
+        return state.runIds[experimentId];
+      })
+      .map((runId) => {
+        return state.runMetadata[runId];
+      })
+      .filter(Boolean);
+
+    const groups = groupRuns(groupBy, allRuns, state.runIdToExpId);
+
+    Object.entries(groups).forEach(([groupId, runs]) => {
+      const color =
+        groupKeyToColorString.get(groupId) ??
+        CHART_COLOR_PALLETE[groupKeyToColorString.size % CHART_COLOR_PALLETE.length];
+      groupKeyToColorString.set(groupId, color);
+
+      for (const run of runs) {
+        defaultRunColorForGroupBy.set(run.id, color);
+      }
+    });
+
+    return {
+      ...state,
+      defaultRunColorForGroupBy,
+      groupKeyToColorString,
+      // Resets the color override when the groupBy changes.
+      runColorOverrideForGroupBy: new Map(),
+    };
+  }),
   on(runsActions.runColorChanged, (state, {runId, newColor}) => {
     const nextRunColorOverride = new Map(state.runColorOverrideForGroupBy);
     nextRunColorOverride.set(runId, newColor);

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -218,13 +218,8 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
       );
 
       const allRuns = experimentIds
-        .flatMap((experimentId) => {
-          return state.runIds[experimentId];
-        })
-        .map((runId) => {
-          return state.runMetadata[runId];
-        })
-        .filter(Boolean);
+        .flatMap((experimentId) => state.runIds[experimentId])
+        .map((runId) => state.runMetadata[runId]);
 
       const groups = groupRuns(groupBy, allRuns, state.runIdToExpId);
 
@@ -243,6 +238,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
 
       return {
         ...state,
+        groupBy,
         defaultRunColorForGroupBy,
         groupKeyToColorString,
         // Resets the color override when the groupBy changes.

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -746,6 +746,7 @@ describe('runs_reducers', () => {
         })
       );
 
+      expect(nextState.data.groupBy).toEqual({key: GroupByKey.EXPERIMENT});
       expect(nextState.data.groupKeyToColorString).toEqual(
         new Map([
           ['eid1', colorUtils.CHART_COLOR_PALLETE[0]],
@@ -803,6 +804,7 @@ describe('runs_reducers', () => {
         })
       );
 
+      expect(nextState.data.groupBy).toEqual({key: GroupByKey.RUN});
       expect(nextState.data.groupKeyToColorString).toEqual(
         new Map([
           ['run1', colorUtils.CHART_COLOR_PALLETE[0]],

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -702,4 +702,124 @@ describe('runs_reducers', () => {
       );
     });
   });
+
+  describe('on runGroupByChanged', () => {
+    it('reassigns color to EXPERIMENT from RUN', () => {
+      const state = buildRunsState({
+        groupBy: {key: GroupByKey.RUN},
+        runIds: {
+          eid1: ['run1', 'run2'],
+          eid2: ['run3', 'run4'],
+        },
+        runIdToExpId: {
+          run1: 'eid1',
+          run2: 'eid1',
+          run3: 'eid2',
+          run4: 'eid2',
+        },
+        runMetadata: {
+          run1: buildRun({id: 'run1'}),
+          run2: buildRun({id: 'run2'}),
+          run3: buildRun({id: 'run3'}),
+          run4: buildRun({id: 'run4'}),
+        },
+        groupKeyToColorString: new Map([
+          ['run1', '#aaa'],
+          ['run2', '#bbb'],
+          ['run3', '#ccc'],
+          ['run4', '#ddd'],
+        ]),
+        defaultRunColorForGroupBy: new Map([
+          ['run1', '#aaa'],
+          ['run2', '#bbb'],
+          ['run3', '#ccc'],
+          ['run4', '#ddd'],
+        ]),
+        runColorOverrideForGroupBy: new Map([['run1', '#aaa']]),
+      });
+
+      const nextState = runsReducers.reducers(
+        state,
+        actions.runGroupByChanged({
+          experimentIds: ['eid1', 'eid2'],
+          groupBy: {key: GroupByKey.EXPERIMENT},
+        })
+      );
+
+      expect(nextState.data.groupKeyToColorString).toEqual(
+        new Map([
+          ['eid1', colorUtils.CHART_COLOR_PALLETE[0]],
+          ['eid2', colorUtils.CHART_COLOR_PALLETE[1]],
+        ])
+      );
+      expect(nextState.data.defaultRunColorForGroupBy).toEqual(
+        new Map([
+          ['run1', colorUtils.CHART_COLOR_PALLETE[0]],
+          ['run2', colorUtils.CHART_COLOR_PALLETE[0]],
+          ['run3', colorUtils.CHART_COLOR_PALLETE[1]],
+          ['run4', colorUtils.CHART_COLOR_PALLETE[1]],
+        ])
+      );
+      expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());
+    });
+
+    it('reassigns color to RUN from EXPERIMENT', () => {
+      const state = buildRunsState({
+        groupBy: {key: GroupByKey.EXPERIMENT},
+        runIds: {
+          eid1: ['run1', 'run2'],
+          eid2: ['run3', 'run4'],
+        },
+        runIdToExpId: {
+          run1: 'eid1',
+          run2: 'eid1',
+          run3: 'eid2',
+          run4: 'eid2',
+        },
+        runMetadata: {
+          run1: buildRun({id: 'run1'}),
+          run2: buildRun({id: 'run2'}),
+          run3: buildRun({id: 'run3'}),
+          run4: buildRun({id: 'run4'}),
+        },
+        groupKeyToColorString: new Map([
+          ['eid1', '#aaa'],
+          ['eid2', '#bbb'],
+        ]),
+        defaultRunColorForGroupBy: new Map([
+          ['run1', '#aaa'],
+          ['run2', '#aaa'],
+          ['run3', '#bbb'],
+          ['run4', '#bbb'],
+        ]),
+        runColorOverrideForGroupBy: new Map([['run1', '#ccc']]),
+      });
+
+      const nextState = runsReducers.reducers(
+        state,
+        actions.runGroupByChanged({
+          experimentIds: ['eid1', 'eid2'],
+          groupBy: {key: GroupByKey.RUN},
+        })
+      );
+
+      expect(nextState.data.groupKeyToColorString).toEqual(
+        new Map([
+          ['run1', colorUtils.CHART_COLOR_PALLETE[0]],
+          ['run2', colorUtils.CHART_COLOR_PALLETE[1]],
+          ['run3', colorUtils.CHART_COLOR_PALLETE[2]],
+          ['run4', colorUtils.CHART_COLOR_PALLETE[3]],
+        ])
+      );
+      expect(nextState.data.defaultRunColorForGroupBy).toEqual(
+        new Map([
+          ['run1', colorUtils.CHART_COLOR_PALLETE[0]],
+          ['run2', colorUtils.CHART_COLOR_PALLETE[1]],
+          ['run3', colorUtils.CHART_COLOR_PALLETE[2]],
+          ['run4', colorUtils.CHART_COLOR_PALLETE[3]],
+        ])
+      );
+      expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());
+    });
+  });
 });


### PR DESCRIPTION
This change implements the color reassignment when the groupBy state
changes.

Product consideration:
- while we can keep the run color override, we are starting by resetting
all the manual changes for now.
