### PR TITLE
Fix sync errors about property renaming and linting

### DIFF
--- a/tensorboard/webapp/widgets/filter_input/filter_input_component.ts
+++ b/tensorboard/webapp/widgets/filter_input/filter_input_component.ts
@@ -43,7 +43,7 @@ export class FilterInputComponent {
   @Input() placeholder: string = '';
 
   @ViewChild(MatAutocompleteTrigger)
-  private autocompleteTrigger!: MatAutocompleteTrigger;
+  private readonly autocompleteTrigger!: MatAutocompleteTrigger;
 
   onInputKeyUp(event: KeyboardEvent) {
     if (event.key === 'Enter') {

--- a/tensorboard/webapp/widgets/filter_input/filter_input_test.ts
+++ b/tensorboard/webapp/widgets/filter_input/filter_input_test.ts
@@ -114,9 +114,9 @@ describe('filter input widget', () => {
 
     sendKey(fixture, input, {
       type: KeyType.SPECIAL,
-      prevString: input.properties.value,
+      prevString: input.properties['value'],
       key: 'Enter',
-      startingCursorIndex: input.properties.selectionStart,
+      startingCursorIndex: input.properties['selectionStart'],
     });
 
     const options2 = getAutocompleteOptions(overlayContainer);


### PR DESCRIPTION
The sync broke in https://github.com/tensorflow/tensorboard/pull/4938
because of property renaming-related errors. This change also fixes a
minor lint warning.

Test sync cl/374274713