### PR TITLE
Add JSDoc to DeepLinkProvider interface definition

### DIFF
--- a/tensorboard/webapp/app_routing/deep_link_provider.ts
+++ b/tensorboard/webapp/app_routing/deep_link_provider.ts
@@ -54,8 +54,8 @@ export abstract class DeepLinkProvider {
   /**
    * When the URL changes, the router dispatches a `stateRehydratedFromUrl`
    * action [1], and calls this method to generate the action's payload.
-   * Specifically, the resulting objection of this method becomes the
-   * `partialState` field on the payload.
+   * Specifically, the result of this method becomes the `partialState`
+   * field on the payload.
    *
    * [1] webapp/app_routing/actions/app_routing_actions.ts
    *

--- a/tensorboard/webapp/app_routing/deep_link_provider.ts
+++ b/tensorboard/webapp/app_routing/deep_link_provider.ts
@@ -20,11 +20,30 @@ import {State} from '../app_state';
 
 import {SerializableQueryParams} from './types';
 
+/**
+ * The `DeepLinkProvider` interface standardizes the relationship between the
+ * app state and the URL parameters.  It is expected that when either an update
+ * to the URL parameters should change app state, or, in the other direction,
+ * when an update to the state should cause a change in the URL parameters,
+ * that logic should be invoked through a `DeepLinkProvider`.
+ */
 @Injectable()
 export abstract class DeepLinkProvider {
+
+  /**
+   * Modifies the URL to match the state of the app.
+   * @param store The ngrx store containing the state of the app.
+   * @return An observable which will emit the query parameters matching the state.
+   */
   abstract serializeStateToQueryParams(
     store: Store<State>
   ): Observable<SerializableQueryParams>;
 
+  /**
+   * Given the query params, updates the ngrx state to match.
+   * @param queryParams TensorBoard URL SeralizableQueryParams that should be used
+   *     to update the app state.
+   * @return A JS object describing a patch that should be made to the ngrx state.
+   */
   abstract deserializeQueryParams(queryParams: SerializableQueryParams): object;
 }

--- a/tensorboard/webapp/app_routing/deep_link_provider.ts
+++ b/tensorboard/webapp/app_routing/deep_link_provider.ts
@@ -37,7 +37,6 @@ import {SerializableQueryParams} from './types';
  */
 @Injectable()
 export abstract class DeepLinkProvider {
-
   /**
    * Returns an Observable that the app router will listen to.  The router
    * should respond to each emission by updating the URL query params with the

--- a/tensorboard/webapp/app_routing/deep_link_provider.ts
+++ b/tensorboard/webapp/app_routing/deep_link_provider.ts
@@ -26,24 +26,44 @@ import {SerializableQueryParams} from './types';
  * to the URL parameters should change app state, or, in the other direction,
  * when an update to the state should cause a change in the URL parameters,
  * that logic should be invoked through a `DeepLinkProvider`.
+ *
+ * TensorBoard router considers the URL as a view. A subset of state
+ * gets projected onto it, just like a HTML input element. The
+ * DeepLinkProvider provides state that would be projected onto the
+ * "view" and, inversely, read state from the "view".
+ *
+ * Since the state to be reflected onto the URL bar differs by a
+ * route, we have a DeepLinkProvider per route.
  */
 @Injectable()
 export abstract class DeepLinkProvider {
 
   /**
-   * Modifies the URL to match the state of the app.
+   * Returns an Observable that the app router will listen to.  The router
+   * should respond to each emission by updating the URL query params with the
+   * new values. The emitted query params should fully replace the query params
+   * in the URL, rather than be appended to them.
+   *
    * @param store The ngrx store containing the state of the app.
-   * @return An observable which will emit the query parameters matching the state.
+   * @return An observable which will emit the query parameters to update
+   *     the URL.
    */
   abstract serializeStateToQueryParams(
     store: Store<State>
   ): Observable<SerializableQueryParams>;
 
   /**
-   * Given the query params, updates the ngrx state to match.
+   * When the URL changes, the router dispatches a `stateRehydratedFromUrl`
+   * action [1], and calls this method to generate the action's payload.
+   * Specifically, the resulting objection of this method becomes the
+   * `partialState` field on the payload.
+   *
+   * [1] webapp/app_routing/actions/app_routing_actions.ts
+   *
    * @param queryParams TensorBoard URL SeralizableQueryParams that should be used
    *     to update the app state.
-   * @return A JS object describing a patch that should be made to the ngrx state.
+   * @return A JS object to be packaged within the `stateRehydratedFromUrl`
+   *    action sufficient that the reducer should be able to update the State.
    */
   abstract deserializeQueryParams(queryParams: SerializableQueryParams): object;
 }


### PR DESCRIPTION
* Motivation for features / changes
Interfaces should have JSDoc.

* Technical description of changes
Just adds JSDoc.