### PR TITLE
settings: add redux state for global state

### DIFF
--- a/tensorboard/webapp/settings/BUILD
+++ b/tensorboard/webapp/settings/BUILD
@@ -18,6 +18,7 @@ tf_ng_module(
 tf_ng_web_test_suite(
     name = "karma_test",
     deps = [
+        "//tensorboard/webapp/settings/_redux:test_lib",
         "//tensorboard/webapp/settings/_views:test_lib",
     ],
 )

--- a/tensorboard/webapp/settings/BUILD
+++ b/tensorboard/webapp/settings/BUILD
@@ -9,6 +9,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/core",
+        "//tensorboard/webapp/settings/_redux",
         "//tensorboard/webapp/settings/_views",
         "@npm//@angular/core",
     ],

--- a/tensorboard/webapp/settings/_redux/BUILD
+++ b/tensorboard/webapp/settings/_redux/BUILD
@@ -1,0 +1,40 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
+
+package(default_visibility = ["//tensorboard/webapp/settings:__subpackages__"])
+
+tf_ng_module(
+    name = "_redux",
+    srcs = [
+        "settings_actions.ts",
+        "settings_data_module.ts",
+        "settings_reducers.ts",
+        "settings_types.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/metrics:types",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+tf_ng_module(
+    name = "test_lib",
+    testonly = True,
+    srcs = [
+        "settings_reducers_test.ts",
+        "settings_selectors_test.ts",
+        "testing.ts",
+    ],
+    deps = [
+        ":_redux",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "@npm//@angular/common",
+        "@npm//@angular/compiler",
+        "@npm//@angular/core",
+        "@npm//@angular/forms",
+        "@npm//@angular/platform-browser",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/settings/_redux/BUILD
+++ b/tensorboard/webapp/settings/_redux/BUILD
@@ -29,6 +29,7 @@ tf_ng_module(
     deps = [
         ":_redux",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/metrics:types",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",

--- a/tensorboard/webapp/settings/_redux/BUILD
+++ b/tensorboard/webapp/settings/_redux/BUILD
@@ -8,6 +8,7 @@ tf_ng_module(
         "settings_actions.ts",
         "settings_data_module.ts",
         "settings_reducers.ts",
+        "settings_selectors.ts",
         "settings_types.ts",
     ],
     deps = [

--- a/tensorboard/webapp/settings/_redux/settings_actions.ts
+++ b/tensorboard/webapp/settings/_redux/settings_actions.ts
@@ -12,18 +12,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {NgModule} from '@angular/core';
+import {createAction, props} from '@ngrx/store';
 
-import {CoreModule} from '../core/core_module';
-import {SettingsModule as DataModule} from './_redux/settings_data_module';
-import {SettingsModule as ViewModule} from './_views/settings_module';
+import {TooltipSort} from '../../metrics/types';
 
-@NgModule({
-  exports: [ViewModule],
-  imports: [
-    // Uses core redux state.
-    CoreModule,
-    DataModule,
-  ],
-})
-export class SettingsModule {}
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
+
+export const tooltipSortChanged = createAction(
+  '[Settings] Global TimeSeries Tooltip Sort Setting Changed',
+  props<{sort: TooltipSort}>()
+);
+
+export const scalarSmoothingChanged = createAction(
+  '[Settings] Global TimeSeries Scalar Smoothing Setting Changed',
+  props<{smoothing: number}>()
+);
+
+export const ignoreOutliersToggled = createAction(
+  '[Settings] Global TimeSeries Ignore Outlier Setting Toggled'
+);

--- a/tensorboard/webapp/settings/_redux/settings_data_module.ts
+++ b/tensorboard/webapp/settings/_redux/settings_data_module.ts
@@ -13,17 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
+import {StoreModule} from '@ngrx/store';
 
-import {CoreModule} from '../core/core_module';
-import {SettingsModule as DataModule} from './_redux/settings_data_module';
-import {SettingsModule as ViewModule} from './_views/settings_module';
+import {reducers} from './settings_reducers';
+import {SETTINGS_FEATURE_KEY} from './settings_types';
 
 @NgModule({
-  exports: [ViewModule],
-  imports: [
-    // Uses core redux state.
-    CoreModule,
-    DataModule,
-  ],
+  imports: [StoreModule.forFeature(SETTINGS_FEATURE_KEY, reducers)],
 })
 export class SettingsModule {}

--- a/tensorboard/webapp/settings/_redux/settings_effects.ts
+++ b/tensorboard/webapp/settings/_redux/settings_effects.ts
@@ -1,0 +1,37 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Injectable} from '@angular/core';
+import {createAction, Action} from '@ngrx/store';
+import {Actions, ofType, createEffect} from '@ngrx/effects';
+import {map} from 'rxjs/operators';
+
+import {scalarSmoothingChanged} from './settings_actions';
+
+@Injectable()
+export class SettingsEffects {
+  /** @export */
+  readonly setSettingsToLocalStorage$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(scalarSmoothingChanged),
+      map(() => {
+        const features = this.dataSource.getFeatures();
+        return partialFeatureFlagsLoaded({features});
+      })
+    )
+  );
+
+  constructor(private readonly actions$: Actions) {}
+}

--- a/tensorboard/webapp/settings/_redux/settings_reducers.ts
+++ b/tensorboard/webapp/settings/_redux/settings_reducers.ts
@@ -1,0 +1,64 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Action, createReducer, on} from '@ngrx/store';
+
+import * as actions from './settings_actions';
+import {DEFAULT_TIMESERIES_SETTINGS, SettingsState} from './settings_types';
+
+const reducer = createReducer<SettingsState>(
+  {
+    timeSeries: DEFAULT_TIMESERIES_SETTINGS,
+  },
+  on(
+    actions.tooltipSortChanged,
+    (state: SettingsState, {sort}): SettingsState => {
+      return {
+        ...state,
+        timeSeries: {
+          ...state.timeSeries,
+          tooltipSort: sort,
+        },
+      };
+    }
+  ),
+  on(
+    actions.scalarSmoothingChanged,
+    (state: SettingsState, {smoothing}): SettingsState => {
+      return {
+        ...state,
+        timeSeries: {
+          ...state.timeSeries,
+          scalarSmoothing: smoothing,
+        },
+      };
+    }
+  ),
+  on(
+    actions.ignoreOutliersToggled,
+    (state: SettingsState): SettingsState => {
+      return {
+        ...state,
+        timeSeries: {
+          ...state.timeSeries,
+          ignoreOutliers: !state.timeSeries.ignoreOutliers,
+        },
+      };
+    }
+  )
+);
+
+export function reducers(state: SettingsState | undefined, action: Action) {
+  return reducer(state, action);
+}

--- a/tensorboard/webapp/settings/_redux/settings_reducers_test.ts
+++ b/tensorboard/webapp/settings/_redux/settings_reducers_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {TooltipSort} from '../../metrics/internal_types';
+import {TooltipSort} from '../../metrics/types';
 import {
   ignoreOutliersToggled,
   scalarSmoothingChanged,

--- a/tensorboard/webapp/settings/_redux/settings_reducers_test.ts
+++ b/tensorboard/webapp/settings/_redux/settings_reducers_test.ts
@@ -1,0 +1,77 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {TooltipSort} from '../../metrics/internal_types';
+import {
+  ignoreOutliersToggled,
+  scalarSmoothingChanged,
+  tooltipSortChanged,
+} from './settings_actions';
+import {reducers} from './settings_reducers';
+import {buildSettingsState, buildTimeSeriesSettings} from './testing';
+
+describe('setings reducers test', () => {
+  describe('#tooltipSortChanged', () => {
+    it('changes the setting', () => {
+      const state = buildSettingsState({
+        timeSeries: buildTimeSeriesSettings({
+          tooltipSort: TooltipSort.ASCENDING,
+        }),
+      });
+
+      const nextState = reducers(
+        state,
+        tooltipSortChanged({
+          sort: TooltipSort.DEFAULT,
+        })
+      );
+
+      expect(nextState.timeSeries.tooltipSort).toBe(TooltipSort.DEFAULT);
+    });
+  });
+
+  describe('#scalarSmoothingChanged', () => {
+    it('changes the setting', () => {
+      const state = buildSettingsState({
+        timeSeries: buildTimeSeriesSettings({
+          scalarSmoothing: 0.1,
+        }),
+      });
+
+      const nextState = reducers(
+        state,
+        scalarSmoothingChanged({
+          smoothing: 0.4,
+        })
+      );
+
+      expect(nextState.timeSeries.scalarSmoothing).toBe(0.4);
+    });
+  });
+
+  describe('#ignoreOutliersToggled', () => {
+    it('changes the setting', () => {
+      const state = buildSettingsState({
+        timeSeries: buildTimeSeriesSettings({
+          ignoreOutliers: true,
+        }),
+      });
+
+      const nextState = reducers(state, ignoreOutliersToggled());
+
+      expect(nextState.timeSeries.ignoreOutliers).toBe(false);
+    });
+  });
+});

--- a/tensorboard/webapp/settings/_redux/settings_selectors.ts
+++ b/tensorboard/webapp/settings/_redux/settings_selectors.ts
@@ -1,0 +1,50 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {createFeatureSelector, createSelector} from '@ngrx/store';
+
+import {TooltipSort} from '../../metrics/types';
+import {State, SettingsState, SETTINGS_FEATURE_KEY} from './settings_types';
+
+const selectSettingsState = createFeatureSelector<State, SettingsState>(
+  SETTINGS_FEATURE_KEY
+);
+
+const selectTimeSeriesSettings = createSelector(
+  selectSettingsState,
+  (state: SettingsState) => {
+    return state.timeSeries;
+  }
+);
+
+export const getGlobalTimeSeriesSmoothing = createSelector(
+  selectTimeSeriesSettings,
+  (state: SettingsState['timeSeries']): number => {
+    return state.scalarSmoothing;
+  }
+);
+
+export const getGlobalTimeSeriesTooltipSort = createSelector(
+  selectTimeSeriesSettings,
+  (state: SettingsState['timeSeries']): TooltipSort => {
+    return state.tooltipSort;
+  }
+);
+
+export const getGlobalTimeSeriesIgnoreOutliers = createSelector(
+  selectTimeSeriesSettings,
+  (state: SettingsState['timeSeries']): boolean => {
+    return state.ignoreOutliers;
+  }
+);

--- a/tensorboard/webapp/settings/_redux/settings_selectors.ts
+++ b/tensorboard/webapp/settings/_redux/settings_selectors.ts
@@ -17,34 +17,45 @@ import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {TooltipSort} from '../../metrics/types';
 import {State, SettingsState, SETTINGS_FEATURE_KEY} from './settings_types';
 
+// HACK: These imports are for type inference.
+// https://github.com/bazelbuild/rules_nodejs/issues/1013
+/** @typehack */ import * as _typeHackSelector from '@ngrx/store/src/selector';
+
 const selectSettingsState = createFeatureSelector<State, SettingsState>(
   SETTINGS_FEATURE_KEY
 );
 
-const selectTimeSeriesSettings = createSelector(
-  selectSettingsState,
-  (state: SettingsState) => {
-    return state.timeSeries;
-  }
-);
+const selectTimeSeriesSettings = createSelector<
+  State,
+  SettingsState,
+  SettingsState['timeSeries']
+>(selectSettingsState, (state: SettingsState): SettingsState['timeSeries'] => {
+  return state.timeSeries;
+});
 
-export const getGlobalTimeSeriesSmoothing = createSelector(
-  selectTimeSeriesSettings,
-  (state: SettingsState['timeSeries']): number => {
-    return state.scalarSmoothing;
-  }
-);
+export const getGlobalTimeSeriesSmoothing = createSelector<
+  State,
+  SettingsState['timeSeries'],
+  number
+>(selectTimeSeriesSettings, (state: SettingsState['timeSeries']): number => {
+  return state.scalarSmoothing;
+});
 
-export const getGlobalTimeSeriesTooltipSort = createSelector(
+export const getGlobalTimeSeriesTooltipSort = createSelector<
+  State,
+  SettingsState['timeSeries'],
+  TooltipSort
+>(
   selectTimeSeriesSettings,
   (state: SettingsState['timeSeries']): TooltipSort => {
     return state.tooltipSort;
   }
 );
 
-export const getGlobalTimeSeriesIgnoreOutliers = createSelector(
-  selectTimeSeriesSettings,
-  (state: SettingsState['timeSeries']): boolean => {
-    return state.ignoreOutliers;
-  }
-);
+export const getGlobalTimeSeriesIgnoreOutliers = createSelector<
+  State,
+  SettingsState['timeSeries'],
+  boolean
+>(selectTimeSeriesSettings, (state: SettingsState['timeSeries']): boolean => {
+  return state.ignoreOutliers;
+});

--- a/tensorboard/webapp/settings/_redux/settings_selectors_test.ts
+++ b/tensorboard/webapp/settings/_redux/settings_selectors_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {TooltipSort} from '../../metrics/internal_types';
+import {TooltipSort} from '../../metrics/types';
 import {
   getGlobalTimeSeriesIgnoreOutliers,
   getGlobalTimeSeriesSmoothing,

--- a/tensorboard/webapp/settings/_redux/settings_selectors_test.ts
+++ b/tensorboard/webapp/settings/_redux/settings_selectors_test.ts
@@ -1,0 +1,79 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {TooltipSort} from '../../metrics/internal_types';
+import {
+  getGlobalTimeSeriesIgnoreOutliers,
+  getGlobalTimeSeriesSmoothing,
+  getGlobalTimeSeriesTooltipSort,
+} from './settings_selectors';
+import {
+  buildSettingsState,
+  buildState,
+  buildTimeSeriesSettings,
+} from './testing';
+
+describe('setings selectors test', () => {
+  describe('#getGlobalTimeSeriesSmoothing', () => {
+    beforeEach(() => {
+      getGlobalTimeSeriesSmoothing.release();
+    });
+
+    it('returns smoothing settings', () => {
+      const state = buildState(
+        buildSettingsState({
+          timeSeries: buildTimeSeriesSettings({
+            scalarSmoothing: 0.5,
+          }),
+        })
+      );
+      expect(getGlobalTimeSeriesSmoothing(state)).toBe(0.5);
+    });
+  });
+
+  describe('#getGlobalTimeSeriesTooltipSort', () => {
+    beforeEach(() => {
+      getGlobalTimeSeriesTooltipSort.release();
+    });
+
+    it('returns smoothing settings', () => {
+      const state = buildState(
+        buildSettingsState({
+          timeSeries: buildTimeSeriesSettings({
+            tooltipSort: TooltipSort.NEAREST,
+          }),
+        })
+      );
+      expect(getGlobalTimeSeriesTooltipSort(state)).toBe(TooltipSort.NEAREST);
+    });
+  });
+
+  describe('#getGlobalTimeSeriesIgnoreOutliers', () => {
+    beforeEach(() => {
+      getGlobalTimeSeriesIgnoreOutliers.release();
+    });
+
+    it('returns smoothing settings', () => {
+      const state = buildState(
+        buildSettingsState({
+          timeSeries: buildTimeSeriesSettings({
+            ignoreOutliers: true,
+          }),
+        })
+      );
+      expect(getGlobalTimeSeriesIgnoreOutliers(state)).toBe(true);
+    });
+  });
+});

--- a/tensorboard/webapp/settings/_redux/settings_types.ts
+++ b/tensorboard/webapp/settings/_redux/settings_types.ts
@@ -1,0 +1,43 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TooltipSort} from '../../metrics/types';
+
+export const SETTINGS_FEATURE_KEY = 'globlalSettings';
+
+export interface SettingsState {
+  /**
+   * Design consideration
+   * Following states are closely related to timeSeries/metrics feature and can
+   * be moved to that feature accordingly. However, because settings is shared
+   * by TensorBoard variants and not all versions has dependency on metrics
+   * feature, without DI to programmatically inject templates, we added
+   * inter-experiment global settings here, instead.
+   */
+  timeSeries: {
+    tooltipSort: TooltipSort;
+    ignoreOutliers: boolean;
+    scalarSmoothing: number;
+  };
+}
+
+export interface State {
+  [SETTINGS_FEATURE_KEY]?: SettingsState;
+}
+
+export const DEFAULT_TIMESERIES_SETTINGS: SettingsState['timeSeries'] = {
+  tooltipSort: TooltipSort.DESCENDING,
+  ignoreOutliers: false,
+  scalarSmoothing: 0,
+};

--- a/tensorboard/webapp/settings/_redux/settings_types.ts
+++ b/tensorboard/webapp/settings/_redux/settings_types.ts
@@ -37,7 +37,7 @@ export interface State {
 }
 
 export const DEFAULT_TIMESERIES_SETTINGS: SettingsState['timeSeries'] = {
-  tooltipSort: TooltipSort.DESCENDING,
-  ignoreOutliers: false,
-  scalarSmoothing: 0,
+  tooltipSort: TooltipSort.DEFAULT,
+  ignoreOutliers: true,
+  scalarSmoothing: 0.6,
 };

--- a/tensorboard/webapp/settings/_redux/testing.ts
+++ b/tensorboard/webapp/settings/_redux/testing.ts
@@ -1,0 +1,44 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TooltipSort} from '../../metrics/types';
+import {State, SettingsState, SETTINGS_FEATURE_KEY} from './settings_types';
+
+export function buildTimeSeriesSettings(
+  override: Partial<SettingsState['timeSeries']> = {}
+): SettingsState['timeSeries'] {
+  return {
+    tooltipSort: TooltipSort.NEAREST,
+    ignoreOutliers: false,
+    scalarSmoothing: 0.2,
+    ...override,
+  };
+}
+
+export function buildSettingsState(
+  override: Partial<SettingsState> = {}
+): SettingsState {
+  return {
+    timeSeries: buildTimeSeriesSettings(),
+    ...override,
+  };
+}
+
+export function buildState(settingsState: SettingsState): State {
+  return {
+    [SETTINGS_FEATURE_KEY]: {
+      ...settingsState,
+    },
+  };
+}

--- a/tensorboard/webapp/settings/_views/BUILD
+++ b/tensorboard/webapp/settings/_views/BUILD
@@ -1,6 +1,6 @@
 load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
-package(default_visibility = ["//tensorboard:internal"])
+package(default_visibility = ["//tensorboard/webapp/settings:__subpackages__"])
 
 tf_ng_module(
     name = "_views",


### PR DESCRIPTION
Motivation
----------
In the multi-experiment version of TensorBoard, settings in the metrics
dashboard "resets" to its default values every time a new experiment
opens. Users got a bit uncomfortable doing that so we want to improve
the UX by remembering user's inter-experiment global settings.

This change
-----------
This change simply adds the redux state but we eventually want to
remember the settings via localStorage. While this solution is not a
panacea (we still forget when user rotates port number), this can
improve certain experience drastically.

Again, this change only adds redux state, reducers, actions, and
selectors.

Discussion
----------
For consumer of the selector, it is quite hard to now mix the
globalSetting + per-experiment override. In fact, you really need three
selectors that purportedly do the similar things:
- one for getting the global setting (needed for
  settings view component).
- one for getting and rendering per-experiment setting (needed for rendering right nav).
- one for mixing the two and just getting the, for example, smoothing.

For providing the third kind of selector, we may wanto to provide a
composite selector that grabs state from two different features.
However, placement of said selector is murky and such selector creates
dependencies on multiple DataNgModule.

Plan
----
- write the persistence via LocalStorage
- read the persisted data from LocalStorage and bootstrap the data from it
- change the runs_type to have `null`able values for redundant setting
  - change right nav and views to mix the data accordingly
- Introduce UI affordance to change the global settings in the settings dialog
 (conditionally rendered based on plugins listing)