### PR TITLE
runs: add selector for groupBy.

### DIFF
--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -16,7 +16,7 @@ import {createFeatureSelector, createSelector} from '@ngrx/store';
 
 import {DataLoadState, LoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
-import {SortKey} from '../types';
+import {GroupBy, SortKey} from '../types';
 import {
   Run,
   RunsDataState,
@@ -110,6 +110,16 @@ export const getRunSelectionMap = createSelector(
   ): Map<string, boolean> => {
     const stateKey = serializeExperimentIds(props.experimentIds);
     return dataState.selectionState.get(stateKey) || new Map();
+  }
+);
+
+/**
+ * Returns current run grouping setting.
+ */
+export const getRunGroupBy = createSelector(
+  getDataState,
+  (dataState: RunsDataState): GroupBy => {
+    return dataState.groupBy;
   }
 );
 

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {DataLoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
-import {SortType} from '../types';
+import {GroupByKey, SortType} from '../types';
 import * as selectors from './runs_selectors';
 import {buildRun, buildRunsState, buildStateFromRunsState} from './testing';
 
@@ -356,6 +356,29 @@ describe('runs_selectors', () => {
       expect(selectors.getRunColorMap(state)).toEqual({
         foo: '#000',
         bar: '#bbb',
+      });
+    });
+  });
+
+  describe('#getRunGroupBy', () => {
+    beforeEach(() => {
+      // Clear the memoization.
+      selectors.getRunGroupBy.release();
+    });
+
+    it('returns color map by runs', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          groupBy: {
+            key: GroupByKey.REGEX,
+            regexString: 'hello',
+          },
+        })
+      );
+
+      expect(selectors.getRunGroupBy(state)).toEqual({
+        key: GroupByKey.REGEX,
+        regexString: 'hello',
       });
     });
   });


### PR DESCRIPTION
Previously, we did not need to use the groupBy information in the view.
Now that we do (need to render the selected groupBy setting in the
menu), we are exposing the public API for views to read the state.
