### PR TITLE
runs: fully implement color group by UI

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -379,6 +379,7 @@ tf_svg_bundle(
         "@com_google_material_design_icon//:clear_24px.svg",
         "@com_google_material_design_icon//:close_24px.svg",
         "@com_google_material_design_icon//:content_copy_24px.svg",
+        "@com_google_material_design_icon//:done_24px.svg",
         "@com_google_material_design_icon//:edit_24px.svg",
         "@com_google_material_design_icon//:error_24px.svg",
         "@com_google_material_design_icon//:expand_less_24px.svg",

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -9,6 +9,11 @@ tf_sass_binary(
     src = "runs_table_component.scss",
 )
 
+tf_sass_binary(
+    name = "runs_group_menu_button_styles",
+    src = "runs_group_menu_button_component.scss",
+)
+
 tf_ng_module(
     name = "runs_table",
     srcs = [
@@ -20,6 +25,7 @@ tf_ng_module(
         "types.ts",
     ],
     assets = [
+        ":runs_group_menu_button_styles",
         ":runs_table_styles",
         "runs_table_component.ng.html",
     ],
@@ -41,6 +47,7 @@ tf_ng_module(
         "//tensorboard/webapp/runs:types",
         "//tensorboard/webapp/runs/actions",
         "//tensorboard/webapp/runs/data_source",
+        "//tensorboard/webapp/runs/store:selectors",
         "//tensorboard/webapp/runs/store:types",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/types:ui",

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
@@ -1,0 +1,39 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
+::ng-deep .run-table-color-group-by {
+  $_icon-size: 20px;
+  font-size: 16px;
+
+  .label {
+    color: mat-color($tb-foreground, secondary-text);
+    font-size: 0.9em;
+    margin: 10px 0;
+    padding: 0 16px;
+    pointer-events: none;
+  }
+
+  button {
+    display: grid;
+    gap: 2px 10px;
+    grid-template-columns: $_icon-size auto;
+  }
+
+  mat-icon {
+    height: $_icon-size;
+    width: $_icon-size;
+  }
+}

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
@@ -12,7 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+
+import {GroupBy, GroupByKey} from '../../types';
 
 @Component({
   selector: 'runs-group-menu-button-component',
@@ -24,18 +32,58 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
     >
       <mat-icon svgIcon="palette_24px"></mat-icon>
     </button>
-    <mat-menu #groupByMenu="matMenu">
-      <button mat-menu-item>
-        <span>Experiments</span>
+    <mat-menu #groupByMenu="matMenu" class="run-table-color-group-by">
+      <div class="label">Color runs by</div>
+      <button
+        mat-menu-item
+        role="menuitemradio"
+        (click)="onGroupByChange.emit({key: GroupByKey.EXPERIMENT})"
+      >
+        <span>
+          <mat-icon
+            *ngIf="selectedGroupBy.key === GroupByKey.EXPERIMENT"
+            svgIcon="done_24px"
+          ></mat-icon>
+        </span>
+        <label>Experiments</label>
       </button>
-      <button mat-menu-item>
-        <span>Runs</span>
+      <button
+        mat-menu-item
+        role="menuitemradio"
+        (click)="onGroupByChange.emit({key: GroupByKey.RUN})"
+      >
+        <span>
+          <mat-icon
+            *ngIf="selectedGroupBy.key === GroupByKey.RUN"
+            svgIcon="done_24px"
+          ></mat-icon>
+        </span>
+        <label>Runs</label>
       </button>
-      <button mat-menu-item>
-        <span>Regex</span>
+      <button
+        mat-menu-item
+        role="menuitemradio"
+        (click)="onGroupByChange.emit({key: GroupByKey.REGEX, regexString: ''})"
+      >
+        <span>
+          <mat-icon
+            *ngIf="selectedGroupBy.key === GroupByKey.REGEX"
+            svgIcon="done_24px"
+          ></mat-icon>
+        </span>
+        <label>Regex</label>
       </button>
     </mat-menu>
   `,
+  styleUrls: ['runs_group_menu_button_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RunsGroupMenuButtonComponent {}
+export class RunsGroupMenuButtonComponent {
+  readonly GroupByKey = GroupByKey;
+
+  @Input()
+  selectedGroupBy!: GroupBy;
+
+  @Output()
+  onGroupByChange = new EventEmitter<GroupBy>();
+}

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
@@ -37,6 +37,7 @@ import {GroupBy, GroupByKey} from '../../types';
       <button
         mat-menu-item
         role="menuitemradio"
+        [attr.aria-checked]="selectedGroupBy.key === GroupByKey.EXPERIMENT"
         (click)="onGroupByChange.emit({key: GroupByKey.EXPERIMENT})"
       >
         <span>
@@ -45,11 +46,12 @@ import {GroupBy, GroupByKey} from '../../types';
             svgIcon="done_24px"
           ></mat-icon>
         </span>
-        <label>Experiments</label>
+        <label>Experiment</label>
       </button>
       <button
         mat-menu-item
         role="menuitemradio"
+        [attr.aria-checked]="selectedGroupBy.key === GroupByKey.RUN"
         (click)="onGroupByChange.emit({key: GroupByKey.RUN})"
       >
         <span>
@@ -58,11 +60,12 @@ import {GroupBy, GroupByKey} from '../../types';
             svgIcon="done_24px"
           ></mat-icon>
         </span>
-        <label>Runs</label>
+        <label>Run</label>
       </button>
       <button
         mat-menu-item
         role="menuitemradio"
+        [attr.aria-checked]="selectedGroupBy.key === GroupByKey.REGEX"
         (click)="onGroupByChange.emit({key: GroupByKey.REGEX, regexString: ''})"
       >
         <span>

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
@@ -12,19 +12,43 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {Store} from '@ngrx/store';
+import {Observable} from 'rxjs';
 
 import {State} from '../../../app_state';
+import {runGroupByChanged} from '../../actions';
+import {getRunGroupBy} from '../../store/runs_selectors';
+import {GroupBy} from '../../types';
 
 /**
  * Renders run grouping menu controls.
  */
 @Component({
   selector: 'runs-group-menu-button',
-  template: `<runs-group-menu-button-component></runs-group-menu-button-component>`,
+  template: `
+    <runs-group-menu-button-component
+      [selectedGroupBy]="selectedGroupBy$ | async"
+      (onGroupByChange)="onGroupByChange($event)"
+    ></runs-group-menu-button-component>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RunsGroupMenuButtonContainer {
+  @Input() experimentIds!: string[];
+
   constructor(private readonly store: Store<State>) {}
+
+  readonly selectedGroupBy$: Observable<GroupBy> = this.store.select(
+    getRunGroupBy
+  );
+
+  onGroupByChange(groupBy: GroupBy) {
+    this.store.dispatch(
+      runGroupByChanged({
+        experimentIds: this.experimentIds,
+        groupBy,
+      })
+    );
+  }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -109,6 +109,7 @@ limitations under the License.
           <span *ngSwitchCase="RunsTableColumn.RUN_COLOR">
             <runs-group-menu-button
               *ngIf="showGroupControl"
+              [experimentIds]="experimentIds"
             ></runs-group-menu-button>
           </span>
         </ng-container>

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
@@ -84,6 +84,7 @@ export class RunsTableComponent implements OnChanges {
   readonly RunsTableColumn = RunsTableColumn;
   readonly SortType = SortType;
 
+  @Input() experimentIds!: string[];
   @Input() showExperimentName!: boolean;
   @Input() columns!: RunsTableColumn[];
   @Input() hparamColumns!: HparamSpec[];

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -190,6 +190,7 @@ function matchFilter(
   selector: 'runs-table',
   template: `
     <runs-table-component
+      [experimentIds]="experimentIds"
       [useFlexibleLayout]="useFlexibleLayout"
       [numSelectedItems]="numSelectedItems$ | async"
       [columns]="columns"

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -580,37 +580,47 @@ describe('runs_table', () => {
         ).toEqual(['Experiments', 'Runs', 'Regex']);
       });
 
-      it('renders a check for a menu item that has groupBy', () => {
-        store.overrideSelector(getEnabledColorGroup, true);
-        store.overrideSelector(getRunGroupBy, {key: GroupByKey.EXPERIMENT});
-        const fixture = createComponent(
-          ['book'],
-          [RunsTableColumn.RUN_NAME, RunsTableColumn.RUN_COLOR]
-        );
-        fixture.detectChanges();
+      it(
+        'renders a check icon and aria-checked for the current groupBy menu ' +
+          'item',
+        () => {
+          store.overrideSelector(getEnabledColorGroup, true);
+          store.overrideSelector(getRunGroupBy, {key: GroupByKey.EXPERIMENT});
+          const fixture = createComponent(
+            ['book'],
+            [RunsTableColumn.RUN_NAME, RunsTableColumn.RUN_COLOR]
+          );
+          fixture.detectChanges();
 
-        const menuButton = fixture.debugElement
-          .query(By.directive(RunsGroupMenuButtonContainer))
-          .query(By.css('button'));
-        menuButton.nativeElement.click();
+          const menuButton = fixture.debugElement
+            .query(By.directive(RunsGroupMenuButtonContainer))
+            .query(By.css('button'));
+          menuButton.nativeElement.click();
 
-        const items = getOverlayMenuItems();
+          const items = getOverlayMenuItems();
 
-        expect(
-          items.map((element) => Boolean(element.querySelector('mat-icon')))
-        ).toEqual([true, false, false]);
+          expect(
+            items.map((element) => element.getAttribute('aria-checked'))
+          ).toEqual(['true', 'false', 'false']);
+          expect(
+            items.map((element) => Boolean(element.querySelector('mat-icon')))
+          ).toEqual([true, false, false]);
 
-        store.overrideSelector(getRunGroupBy, {
-          key: GroupByKey.REGEX,
-          regexString: 'hello',
-        });
-        store.refreshState();
-        fixture.detectChanges();
+          store.overrideSelector(getRunGroupBy, {
+            key: GroupByKey.REGEX,
+            regexString: 'hello',
+          });
+          store.refreshState();
+          fixture.detectChanges();
 
-        expect(
-          items.map((element) => Boolean(element.querySelector('mat-icon')))
-        ).toEqual([false, false, true]);
-      });
+          expect(
+            items.map((element) => element.getAttribute('aria-checked'))
+          ).toEqual(['false', 'false', 'true']);
+          expect(
+            items.map((element) => Boolean(element.querySelector('mat-icon')))
+          ).toEqual([false, false, true]);
+        }
+      );
 
       it('dispatches `runGroupByChanged` when a menu item is clicked', () => {
         store.overrideSelector(getEnabledColorGroup, true);

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -560,7 +560,7 @@ describe('runs_table', () => {
         expect(menuButton).toBeTruthy();
       });
 
-      it('renders "experiments", "runs" and "regex"', () => {
+      it('renders "Experiment", "Run" and "Regex"', () => {
         store.overrideSelector(getEnabledColorGroup, true);
         const fixture = createComponent(
           ['book'],
@@ -577,7 +577,7 @@ describe('runs_table', () => {
 
         expect(
           items.map((element) => element.querySelector('label')!.textContent)
-        ).toEqual(['Experiments', 'Runs', 'Regex']);
+        ).toEqual(['Experiment', 'Run', 'Regex']);
       });
 
       it(

--- a/tensorboard/webapp/testing/mat_icon_module.ts
+++ b/tensorboard/webapp/testing/mat_icon_module.ts
@@ -27,6 +27,7 @@ const KNOWN_SVG_ICON = new Set([
   'clear_24px',
   'close_24px',
   'content_copy_24px',
+  'done_24px',
   'edit_24px',
   'error_24px',
   'expand_less_24px',

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -178,6 +178,10 @@ def tensorboard_js_workspace():
                 "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.2/image/svg/production/ic_palette_24px.svg",
                 "https://raw.githubusercontent.com/google/material-design-icons/3.0.2/image/svg/production/ic_palette_24px.svg",
             ],
+            "f1f1a9f32a0488db0541fc9a8b9475ea9739335aa022d69799f9f42859042761": [
+                "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.2/action/svg/production/ic_done_24px.svg",
+                "https://raw.githubusercontent.com/google/material-design-icons/3.0.2/action/svg/production/ic_done_24px.svg",
+            ],
         },
         rename = {
             "ic_arrow_downward_24px.svg": "arrow_downward_24px.svg",
@@ -187,6 +191,7 @@ def tensorboard_js_workspace():
             "ic_chevron_right_24px.svg": "chevron_right_24px.svg",
             "ic_clear_24px.svg": "clear_24px.svg",
             "ic_content_copy_24px.svg": "content_copy_24px.svg",
+            "ic_done_24px.svg": "done_24px.svg",
             "ic_error_24px.svg": "error_24px.svg",
             "ic_expand_less_24px.svg": "expand_less_24px.svg",
             "ic_expand_more_24px.svg": "expand_more_24px.svg",


### PR DESCRIPTION
This change introduces:
- checkbox for displaying the selected groupBy setting
- dispatch actions when you use a menu item

![image](https://user-images.githubusercontent.com/2547313/118730807-0b523080-b7ed-11eb-943e-1086a6f333c6.png)

With this change, now, colorBy "runs" and "experiments" are functional.