### PR TITLE
hparams: fix the parallel coordinate layout

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/BUILD
@@ -17,8 +17,8 @@ tf_ts_library(
     deps = [
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/plugins/hparams:types",
-        "//tensorboard/plugins/hparams/tf_hparams_query_pane:schema_d_ts",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_values",
+        "//tensorboard/plugins/hparams/tf_hparams_types",
         "//tensorboard/plugins/hparams/tf_hparams_utils",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
@@ -18,7 +18,7 @@ import * as d3 from 'd3';
 import * as tf_hparams_parallel_coords_plot_interaction_manager from './interaction_manager';
 import * as tf_hparams_utils from '../tf_hparams_utils/tf-hparams-utils';
 import * as tf_hparams_parallel_coords_plot_utils from './utils';
-import * as tf_hparams_query_pane from '../tf_hparams_query_pane/schema.d';
+import {Schema} from '../tf_hparams_types/types';
 import * as tf_hparams_api from '../types';
 
 export enum ScaleType {
@@ -120,7 +120,7 @@ export class Axis {
    */
   public constructor(
     svgProps: tf_hparams_parallel_coords_plot_interaction_manager.SVGProperties,
-    schema: tf_hparams_query_pane.Schema,
+    schema: Schema,
     interactionManager: tf_hparams_parallel_coords_plot_interaction_manager.InteractionManager,
     colIndex: number
   ) {
@@ -362,7 +362,7 @@ export class Axis {
     return new AlwaysPassingBrushFilter();
   }
   private readonly _svgProps: tf_hparams_parallel_coords_plot_interaction_manager.SVGProperties;
-  private readonly _schema: tf_hparams_query_pane.Schema;
+  private readonly _schema: Schema;
   private readonly _interactionManager: tf_hparams_parallel_coords_plot_interaction_manager.InteractionManager;
   private readonly _colIndex: number;
   private _isDisplayed: boolean;
@@ -379,7 +379,7 @@ export class Axis {
 export class AxesCollection {
   public constructor(
     svgProps: tf_hparams_parallel_coords_plot_interaction_manager.SVGProperties,
-    schema: tf_hparams_query_pane.Schema,
+    schema: Schema,
     interactionManager: tf_hparams_parallel_coords_plot_interaction_manager.InteractionManager
   ) {
     this._svgProps = svgProps;
@@ -556,7 +556,7 @@ export class AxesCollection {
       );
   }
   private _svgProps: tf_hparams_parallel_coords_plot_interaction_manager.SVGProperties;
-  private _schema: tf_hparams_query_pane.Schema;
+  private _schema: Schema;
   private _axes: Axis[];
   /**
    * The current assignment of stationary positions to axes.

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/interaction_manager.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/interaction_manager.ts
@@ -20,7 +20,7 @@ import * as d3 from 'd3';
 import * as tf_hparams_utils from '../tf_hparams_utils/tf-hparams-utils';
 import {AxesCollection} from './axes';
 import {LinesCollection, LineType, SessionGroupHandle} from './lines';
-import * as tf_hparams_query_pane from '../tf_hparams_query_pane/schema.d';
+import * as tf_hparams_query_pane from '../tf_hparams_types/types';
 
 import * as tf_hparams_api from '../types';
 

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/lines.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/lines.ts
@@ -22,7 +22,7 @@ import * as tf_hparams_parallel_coords_plot_utils from './utils';
 import {AxesCollection} from './axes';
 import * as tf_hparams_parallel_coords_plot_interaction_manager from './interaction_manager';
 
-import * as tf_hparams_query_pane from '../tf_hparams_query_pane/schema.d';
+import * as tf_hparams_query_pane from '../tf_hparams_types/types';
 
 import * as tf_hparams_api from '../types';
 

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/BUILD
@@ -6,13 +6,6 @@ package(default_visibility =
 licenses(["notice"])
 
 tf_ts_library(
-    name = "schema_d_ts",
-    srcs = [
-        "schema.d.ts",
-    ],
-)
-
-tf_ts_library(
     name = "tf_hparams_query_pane",
     srcs = [
         "tf-hparams-query-pane.ts",

--- a/tensorboard/plugins/hparams/tf_hparams_types/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_types/BUILD
@@ -1,0 +1,12 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard/plugins/hparams:__subpackages__"])
+
+licenses(["notice"])
+
+tf_ts_library(
+    name = "tf_hparams_types",
+    srcs = [
+        "types.d.ts",
+    ],
+)

--- a/tensorboard/plugins/hparams/tf_hparams_types/types.d.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_types/types.d.ts
@@ -12,11 +12,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
+export interface HparamInfo {
+  description: string;
+  displayName: string;
+  name: string;
+  type:
+    | 'DATA_TYPE_UNSET'
+    | 'DATA_TYPE_STRING'
+    | 'DATA_TYPE_BOOL'
+    | 'DATA_TYPE_FLOAT64';
+}
+
+export interface MetricInfo {
+  datasetType: 'DATASET_UNKNOWN' | 'DATASET_TRAINING' | 'DATASET_VALIDATION';
+  description: string;
+  displayName: string;
+  name: {tag: string; group: string};
+}
+
 export interface Schema {
   hparamColumn: Array<{
-    hparamInfo: Object;
+    hparamInfo: HparamInfo;
   }>;
   metricColumn: Array<{
-    metricInfo: Object;
+    metricInfo: MetricInfo;
   }>;
 }


### PR DESCRIPTION
Bug
---
Previously, we were setting the width of the container based on count of
all hparams and metrics without considering the visibility. This had
caused the UI to be in very awkward state where each visible hparams and
metrics are spaced a lot even if the selection count is quite low.

Fix
---
We layout the parallel coordinates based on number of visible
{hparam,metric}s. The change is a bit larger because:

- I had to add type information and refactor it a little for
  understanding the code (minimally added the types).
- Undo the performance optimization where we do not mutate the layout
  unless important piece of information in the configuration has
  changed. To detect the old configuration vs. new configuration, we
  have to now remember an additional state in the component.

Fixes #3414.

Previous:
![image](https://user-images.githubusercontent.com/2547313/118868979-b0c2de00-b899-11eb-9529-a22282b8c0c9.png)

New:
![image](https://user-images.githubusercontent.com/2547313/118868751-69d4e880-b899-11eb-80f0-292e5baf8b3b.png)
