### PR TITLE
timeseries: add data source for persisting setting

### DIFF
--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -44,7 +44,6 @@ tf_ts_library(
     ],
     visibility = ["//tensorboard/webapp/metrics:__subpackages__"],
     deps = [
-        "//tensorboard/webapp/metrics/data_source:types",
         "//tensorboard/webapp/widgets/histogram:types",
     ],
 )

--- a/tensorboard/webapp/metrics/data_source/BUILD
+++ b/tensorboard/webapp/metrics/data_source/BUILD
@@ -14,6 +14,8 @@ tf_ng_module(
     deps = [
         ":backend_types",
         ":types",
+        "//tensorboard/webapp/metrics:internal_types",
+        "//tensorboard/webapp/util:local_storage",
         "//tensorboard/webapp/webapp_data_source:http_client",
         "@npm//@angular/core",
         "@npm//rxjs",
@@ -26,6 +28,7 @@ tf_ts_library(
         "types.ts",
     ],
     deps = [
+        "//tensorboard/webapp/metrics:internal_types",
         "@npm//rxjs",
     ],
 )
@@ -52,6 +55,8 @@ tf_ts_library(
         ":data_source",
         ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/metrics:internal_types",
+        "//tensorboard/webapp/util:local_storage_testing",
         "//tensorboard/webapp/webapp_data_source:http_client_testing",
         "@npm//@types/jasmine",
     ],

--- a/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
@@ -372,9 +372,16 @@ export class TBMetricsDataSource implements MetricsDataSource {
           value = TooltipSort.NEAREST;
           break;
         default:
-        // Deliberately fallthrough; may have TooltipSort from a newer version
-        // of TensorBoard where there is an enum that this version is unaware
-        // of.
+          if (TooltipSort[unsanitizedObject.tooltipSort]) {
+            const _ = unsanitizedObject.tooltipSort as never;
+            throw new RangeError(
+              `TooltipSort persistence case not handled properly: ${unsanitizedObject.tooltipSort}`
+            );
+          } else {
+            // Deliberately fallthrough; may have TooltipSort from a newer version
+            // of TensorBoard where there is an enum that this version is unaware
+            // of.
+          }
       }
       if (value !== null) {
         settings.tooltipSort = value;

--- a/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
@@ -13,10 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
-import {TBHttpClient} from '../../webapp_data_source/tb_http_client';
-import {forkJoin, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
+import {forkJoin, Observable, of} from 'rxjs';
+import {map, tap} from 'rxjs/operators';
 
+import {LocalStorage} from '../../util/local_storage';
+import {TBHttpClient} from '../../webapp_data_source/tb_http_client';
+import {TooltipSort} from '../internal_types';
 import {
   BackendTagMetadata,
   BackendTimeSeriesRequest,
@@ -37,9 +39,21 @@ import {
   TagToRunSampledInfo,
   TimeSeriesRequest,
   TimeSeriesResponse,
+  PersistableSettings,
 } from './types';
 
 const HTTP_PATH_PREFIX = 'data/plugin/timeseries';
+const LOCAL_STORAGE_KEY = '_tb_global_settings';
+
+/**
+ * `declare` so it does not get mangled or mangled differently when
+ * compiler changes.
+ */
+declare interface SerializableSettings {
+  scalarSmoothing?: number;
+  tooltipSort?: string;
+  ignoreOutliers?: boolean;
+}
 
 function parseRunId(runId: string): {run: string; experimentId: string} {
   const slashIndex = runId.indexOf('/');
@@ -168,7 +182,10 @@ function buildCombinedTagMetadata(results: TagMetadata[]): TagMetadata {
  */
 @Injectable()
 export class TBMetricsDataSource implements MetricsDataSource {
-  constructor(private readonly http: TBHttpClient) {}
+  constructor(
+    private readonly http: TBHttpClient,
+    private readonly localStorage: LocalStorage
+  ) {}
 
   fetchTagMetadata(experimentIds: string[]) {
     const fetches = experimentIds.map((experimentId) => {
@@ -296,4 +313,95 @@ export class TBMetricsDataSource implements MetricsDataSource {
     const params = new URLSearchParams({tag, run, format: downloadType});
     return `/experiment/${experimentId}/data/plugin/${pluginAndRoute}?${params}`;
   }
+
+  private serializeSettings(settings: Partial<PersistableSettings>): string {
+    const serializableSettings: SerializableSettings = {
+      ignoreOutliers: settings.ignoreOutliers,
+      scalarSmoothing: settings.scalarSmoothing,
+      // TooltipSort is a string enum and has string values; no need to
+      // serialize it differently to account for their unintended changes.
+      tooltipSort: settings.tooltipSort,
+    };
+    return JSON.stringify(serializableSettings);
+  }
+
+  private deserializeSettings(
+    serialized: string
+  ): Partial<PersistableSettings> {
+    const settings: Partial<PersistableSettings> = {};
+    let unsanitizedObject: Record<string, string | number | boolean>;
+    try {
+      unsanitizedObject = JSON.parse(serialized) as Record<
+        string,
+        string | number | boolean
+      >;
+    } catch (e) {
+      return settings;
+    }
+
+    if (
+      unsanitizedObject.hasOwnProperty('scalarSmoothing') &&
+      typeof unsanitizedObject.scalarSmoothing === 'number'
+    ) {
+      settings.scalarSmoothing = unsanitizedObject.scalarSmoothing;
+    }
+
+    if (
+      unsanitizedObject.hasOwnProperty('ignoreOutliers') &&
+      typeof unsanitizedObject.ignoreOutliers === 'boolean'
+    ) {
+      settings.ignoreOutliers = unsanitizedObject.ignoreOutliers;
+    }
+
+    if (
+      unsanitizedObject.hasOwnProperty('tooltipSort') &&
+      typeof unsanitizedObject.tooltipSort === 'string'
+    ) {
+      let value: TooltipSort | null = null;
+      switch (unsanitizedObject.tooltipSort) {
+        case TooltipSort.ASCENDING:
+          value = TooltipSort.ASCENDING;
+          break;
+        case TooltipSort.DESCENDING:
+          value = TooltipSort.DESCENDING;
+          break;
+        case TooltipSort.DEFAULT:
+          value = TooltipSort.DEFAULT;
+          break;
+        case TooltipSort.NEAREST:
+          value = TooltipSort.NEAREST;
+          break;
+        default:
+        // Deliberately fallthrough; may have TooltipSort from a newer version
+        // of TensorBoard where there is an enum that this version is unaware
+        // of.
+      }
+      if (value !== null) {
+        settings.tooltipSort = value;
+      }
+    }
+
+    return settings;
+  }
+
+  setSettings(partialSetting: Partial<PersistableSettings>): Observable<void> {
+    return this.getSettings().pipe(
+      tap((currentPartialSettings) => {
+        this.localStorage.setItem(
+          LOCAL_STORAGE_KEY,
+          this.serializeSettings({...currentPartialSettings, ...partialSetting})
+        );
+      }),
+      map(() => void null)
+    );
+  }
+
+  getSettings(): Observable<Partial<PersistableSettings>> {
+    const persisted = this.localStorage.getItem(LOCAL_STORAGE_KEY) ?? '{}';
+    return of(this.deserializeSettings(persisted));
+  }
 }
+
+export const TEST_ONLY = {
+  LOCAL_STORAGE_KEY,
+};

--- a/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
@@ -374,16 +374,9 @@ export class TBMetricsDataSource implements MetricsDataSource {
           value = TooltipSort.NEAREST;
           break;
         default:
-          if (TooltipSort[unsanitizedObject.tooltipSort]) {
-            const _ = unsanitizedObject.tooltipSort as never;
-            throw new RangeError(
-              `TooltipSort persistence case not handled properly: ${unsanitizedObject.tooltipSort}`
-            );
-          } else {
-            // Deliberately fallthrough; may have TooltipSort from a newer version
-            // of TensorBoard where there is an enum that this version is unaware
-            // of.
-          }
+        // Deliberately fallthrough; may have TooltipSort from a newer version
+        // of TensorBoard where there is an enum that this version is unaware
+        // of.
       }
       if (value !== null) {
         settings.tooltipSort = value;

--- a/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
@@ -43,7 +43,9 @@ import {
 } from './types';
 
 const HTTP_PATH_PREFIX = 'data/plugin/timeseries';
-const LOCAL_STORAGE_KEY = '_tb_global_settings';
+
+// Key for partial settings state persisted in LocalStorage.
+const LOCAL_STORAGE_KEY = '_tb_global_settings.timeseries';
 
 /**
  * `declare` so it does not get mangled or mangled differently when

--- a/tensorboard/webapp/metrics/data_source/metrics_data_source_test.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source_test.ts
@@ -374,12 +374,12 @@ describe('TBMetricsDataSource test', () => {
     });
 
     it('returns an empty value when the serialized state is empty', async () => {
-      getItemSpy.and.returnValue(undefined);
+      getItemSpy.and.returnValue(null);
       const value = await dataSource.getSettings().toPromise();
       expect(value).toEqual({});
     });
 
-    it('returns an empty state  when serialized state is not an object', async () => {
+    it('returns an empty state when serialized state is not an object', async () => {
       getItemSpy.and.returnValue('malformedjson');
       const value = await dataSource.getSettings().toPromise();
       expect(value).toEqual({});

--- a/tensorboard/webapp/metrics/data_source/types.ts
+++ b/tensorboard/webapp/metrics/data_source/types.ts
@@ -165,11 +165,11 @@ export interface ImageStepDatum {
   imageId: ImageId;
 }
 
-export type PersistableSettings = {
+export interface PersistableSettings {
   scalarSmoothing: number;
   tooltipSort: TooltipSort;
   ignoreOutliers: boolean;
-};
+}
 
 export abstract class MetricsDataSource {
   abstract fetchTagMetadata(experimentIds: string[]): Observable<TagMetadata>;

--- a/tensorboard/webapp/metrics/data_source/types.ts
+++ b/tensorboard/webapp/metrics/data_source/types.ts
@@ -14,6 +14,10 @@ limitations under the License.
 ==============================================================================*/
 import {Observable} from 'rxjs';
 
+import {PluginType, TooltipSort} from '../internal_types';
+
+export {PluginType} from '../internal_types';
+
 export const METRICS_PLUGIN_ID = 'timeseries';
 
 export type RunToTags = {
@@ -45,12 +49,6 @@ export type SampledTagMetadata = {
   tagDescriptions: TagToDescription;
   tagRunSampledInfo: TagToRunSampledInfo;
 };
-
-export enum PluginType {
-  SCALARS = 'scalars',
-  HISTOGRAMS = 'histograms',
-  IMAGES = 'images',
-}
 
 export function isPluginType(text: string): text is PluginType {
   return (
@@ -167,6 +165,12 @@ export interface ImageStepDatum {
   imageId: ImageId;
 }
 
+export type PersistableSettings = {
+  scalarSmoothing: number;
+  tooltipSort: TooltipSort;
+  ignoreOutliers: boolean;
+};
+
 export abstract class MetricsDataSource {
   abstract fetchTagMetadata(experimentIds: string[]): Observable<TagMetadata>;
   abstract fetchTimeSeries(
@@ -179,6 +183,18 @@ export abstract class MetricsDataSource {
     runId: string,
     downloadType: 'json' | 'csv'
   ): string;
+  abstract getSettings(): Observable<Partial<PersistableSettings>>;
+  /**
+   * Design choice: instead of having the API broken down to a setting (e.g.,
+   * one for setting the smoothing vs. tooltip sorting) or take arbitrary
+   * key-value, we decided to take the delta of the settings that needs to
+   * change. This is in anticipation of different storage mechanisms for hosted
+   * TensorBoard services where we would have a RPC that would only take a
+   * delta.
+   */
+  abstract setSettings(
+    partialSettings: Partial<PersistableSettings>
+  ): Observable<void>;
 }
 
 export function isFailedTimeSeriesResponse(

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -22,6 +22,10 @@ export enum PluginType {
   IMAGES = 'images',
 }
 
+// When adding a new value to the enum, please implement the deserializer on
+// data_source/metrics_data_source.ts.
+// When editing a value of the enum, please write a backward compatible
+// deserializer in data_source/metrics_data_source.ts.
 export enum TooltipSort {
   DEFAULT = 'default',
   ASCENDING = 'ascending',

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -14,9 +14,13 @@ limitations under the License.
 ==============================================================================*/
 import {HistogramMode} from '../widgets/histogram/histogram_types';
 
-import {PluginType} from './data_source/types';
-
 export {HistogramMode};
+
+export enum PluginType {
+  SCALARS = 'scalars',
+  HISTOGRAMS = 'histograms',
+  IMAGES = 'images',
+}
 
 export enum TooltipSort {
   DEFAULT = 'default',

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
 import {DataLoadState} from '../types/data';
-import {of} from 'rxjs';
+import {of, Observable} from 'rxjs';
 
 import {State} from '../app_state';
 import {HistogramMode} from '../widgets/histogram/histogram_types';
@@ -24,6 +24,7 @@ import {
   ImageId,
   ImageStepDatum,
   MetricsDataSource,
+  PersistableSettings,
   PluginType,
   ScalarStepDatum,
   TagMetadata as DataSourceTagMetadata,
@@ -303,6 +304,14 @@ export class TestingMetricsDataSource implements MetricsDataSource {
     downloadType: 'json' | 'csv'
   ) {
     return '';
+  }
+
+  setSettings(partialSetting: Partial<PersistableSettings>): Observable<void> {
+    return of();
+  }
+
+  getSettings(): Observable<Partial<PersistableSettings>> {
+    return of({});
   }
 }
 

--- a/tensorboard/webapp/util/BUILD
+++ b/tensorboard/webapp/util/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -57,6 +57,24 @@ tf_ts_library(
         "//tensorboard/webapp/app_routing/store",
         "//tensorboard/webapp/runs/store:selectors",
         "@npm//@ngrx/store",
+    ],
+)
+
+tf_ng_module(
+    name = "local_storage",
+    srcs = ["local_storage.ts"],
+    deps = [
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ng_module(
+    name = "local_storage_testing",
+    testonly = True,
+    srcs = ["local_storage_testing.ts"],
+    deps = [
+        ":local_storage",
+        "@npm//@angular/core",
     ],
 )
 

--- a/tensorboard/webapp/util/local_storage.ts
+++ b/tensorboard/webapp/util/local_storage.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,15 +12,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {NgModule} from '@angular/core';
+import {Injectable, NgModule} from '@angular/core';
 
-import {LocalStorageModule} from '../../util/local_storage';
-import {TBHttpClientModule} from '../../webapp_data_source/tb_http_client_module';
-import {TBMetricsDataSource} from './metrics_data_source';
-import {MetricsDataSource} from './types';
+@Injectable()
+export class LocalStorage {
+  setItem(key: string, value: string): void {
+    localStorage.setItem(key, value);
+  }
+
+  getItem(key: string): string {
+    return localStorage.getItem(key) ?? '';
+  }
+
+  removeItem(key: string): void {
+    localStorage.removeItem(key);
+  }
+}
 
 @NgModule({
-  imports: [TBHttpClientModule, LocalStorageModule],
-  providers: [{provide: MetricsDataSource, useClass: TBMetricsDataSource}],
+  providers: [LocalStorage],
 })
-export class MetricsDataSourceModule {}
+export class LocalStorageModule {}

--- a/tensorboard/webapp/util/local_storage.ts
+++ b/tensorboard/webapp/util/local_storage.ts
@@ -20,8 +20,8 @@ export class LocalStorage {
     localStorage.setItem(key, value);
   }
 
-  getItem(key: string): string {
-    return localStorage.getItem(key) ?? '';
+  getItem(key: string): string | null {
+    return localStorage.getItem(key);
   }
 
   removeItem(key: string): void {

--- a/tensorboard/webapp/util/local_storage_testing.ts
+++ b/tensorboard/webapp/util/local_storage_testing.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,15 +12,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {NgModule} from '@angular/core';
+import {Injectable, NgModule} from '@angular/core';
 
-import {LocalStorageModule} from '../../util/local_storage';
-import {TBHttpClientModule} from '../../webapp_data_source/tb_http_client_module';
-import {TBMetricsDataSource} from './metrics_data_source';
-import {MetricsDataSource} from './types';
+import {LocalStorage} from './local_storage';
+
+@Injectable()
+export class TestingLocalStorage {
+  setItem(key: string, value: string): void {}
+  getItem(key: string): string {
+    return '';
+  }
+  removeItem(key: string): void {}
+}
 
 @NgModule({
-  imports: [TBHttpClientModule, LocalStorageModule],
-  providers: [{provide: MetricsDataSource, useClass: TBMetricsDataSource}],
+  providers: [
+    TestingLocalStorage,
+    {provide: LocalStorage, useExisting: TestingLocalStorage},
+  ],
 })
-export class MetricsDataSourceModule {}
+export class LocalStorageTestingModule {}


### PR DESCRIPTION
Background
----------
Currently, TensorBoard forgets settings (at least on the Angular side)
when browser refreshes and even for the ones that are persisted in the
URLs do not carry over to other experiments or other TensorBoard browser
tabs.

This change
-----------
This change is a part of the greater effort to mitigate the usability
issue by persisted few settings (for now) to LocalStorage. Do note that
this is not a panacea as users can change port number and the states
will be forgotten.

The DataSource API is created with hosted services in mind where we may
add a HTTP API or DataProvider API for persisting user settings.
