### PR TITLE
timeseries: persist and read settings

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {createAction, props} from '@ngrx/store';
 
 import {
+  PersistableSettings,
   TagMetadata,
   TimeSeriesRequest,
   TimeSeriesResponse,
@@ -133,4 +134,9 @@ export const metricsTagGroupExpansionChanged = createAction(
 export const cardPinStateToggled = createAction(
   '[Metrics] Card Pin State Toggled',
   props<{cardId: CardId; canCreateNewPins: boolean; wasPinned: boolean}>()
+);
+
+export const metricsPersistedSettingsRead = createAction(
+  '[Metrics] Persisted Settings Read',
+  props<{partialSettings: Partial<PersistableSettings>}>()
 );

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -136,7 +136,7 @@ export const cardPinStateToggled = createAction(
   props<{cardId: CardId; canCreateNewPins: boolean; wasPinned: boolean}>()
 );
 
-export const metricsPersistedSettingsRead = createAction(
-  '[Metrics] Persisted Settings Read',
+export const fetchPersistedSettingsSucceeded = createAction(
+  '[Metrics] Fetch Persisted Settings Succeeded',
   props<{partialSettings: Partial<PersistableSettings>}>()
 );

--- a/tensorboard/webapp/metrics/effects/BUILD
+++ b/tensorboard/webapp/metrics/effects/BUILD
@@ -8,6 +8,7 @@ tf_ng_module(
     deps = [
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/app_routing:types",
         "//tensorboard/webapp/app_routing/actions",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -302,11 +302,11 @@ export class MetricsEffects implements OnInitEffects {
           map(([, scalarSmoothing]) => ({scalarSmoothing}))
         ),
         // The smoothing value is persisted both in URL and global setting.
-        // Since we want URL one takes precedence over the global setting, when
-        // the url contains the smoothing, we write the values in the URL into
-        // LocalStorage. This is so that user does not get confused when they
-        // manually specify smoothing value in URL then remove it. To elaborate
-        // on this, imagine below:
+        // Since we want URL one to take precedence over the global setting,
+        // when the URL contains the smoothing, we write the values in the URL
+        // into LocalStorage. This is so that user does not get confused when
+        // they manually specify smoothing value in URL then remove it. To
+        // elaborate on this, imagine below:
         // 1. user drags smoothing to set it to 0.5 and persist it.
         // 2. user opens a URL (from bookmark) or manually reset smoothing to 0
         //    with `/?smoothing=0`. TensorBoard shows smoothing=0.
@@ -326,9 +326,7 @@ export class MetricsEffects implements OnInitEffects {
           }),
           filter((partialState) => {
             const hydratedSmoothing = partialState.metrics.smoothing;
-            return (
-              Number.isFinite(hydratedSmoothing) && hydratedSmoothing !== null
-            );
+            return Number.isFinite(hydratedSmoothing);
           }),
           withLatestFrom(this.store.select(getMetricsScalarSmoothing)),
           map(([, scalarSmoothing]) => ({scalarSmoothing}))
@@ -346,8 +344,7 @@ export class MetricsEffects implements OnInitEffects {
       ).pipe(
         switchMap((partialSetting: Partial<PersistableSettings>) => {
           return this.dataSource.setSettings(partialSetting);
-        }),
-        map(() => void null)
+        })
       );
     },
     {dispatch: false}
@@ -359,7 +356,7 @@ export class MetricsEffects implements OnInitEffects {
       ofType(initAction),
       switchMap(() => this.dataSource.getSettings()),
       map((partialSettings) =>
-        actions.metricsPersistedSettingsRead({partialSettings})
+        actions.fetchPersistedSettingsSucceeded({partialSettings})
       )
     );
   });

--- a/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
+++ b/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
@@ -21,7 +21,7 @@ import {getActivePlugin} from '../../core/store';
 import * as coreTesting from '../../core/testing';
 import {DataLoadState} from '../../types/data';
 import {TBHttpClientTestingModule} from '../../webapp_data_source/tb_http_client_testing';
-import {of, Subject} from 'rxjs';
+import {EMPTY, of, Subject} from 'rxjs';
 
 import {buildNavigatedAction} from '../../app_routing/testing';
 import {State} from '../../app_state';
@@ -44,9 +44,10 @@ import {
   createScalarStepData,
   provideTestingMetricsDataSource,
 } from '../testing';
-import {CardId} from '../types';
-
+import {CardId, TooltipSort, URLDeserializedState} from '../types';
 import {CardFetchInfo, MetricsEffects, TEST_ONLY} from './index';
+import {stateRehydratedFromUrl} from '../../app_routing/actions';
+import {RouteKind} from '../../app_routing/types';
 
 describe('metrics effects', () => {
   let dataSource: MetricsDataSource;
@@ -82,211 +83,267 @@ describe('metrics effects', () => {
     dataSource = TestBed.inject(MetricsDataSource);
     store.overrideSelector(selectors.getExperimentIdsFromRoute, null);
     store.overrideSelector(selectors.getRouteId, 'route1');
-    effects.allEffects$.subscribe();
+    store.overrideSelector(selectors.getMetricsIgnoreOutliers, false);
+    store.overrideSelector(selectors.getMetricsScalarSmoothing, 0.3);
+    store.overrideSelector(
+      selectors.getMetricsTooltipSort,
+      TooltipSort.DEFAULT
+    );
   });
 
-  describe('loadTagMetadata', () => {
-    let fetchTagMetadataSpy: jasmine.Spy;
-    let fetchTagMetadataSubject: Subject<TagMetadata>;
-
+  describe('#dataEffects', () => {
     beforeEach(() => {
-      fetchTagMetadataSubject = new Subject();
-      fetchTagMetadataSpy = spyOn(
-        dataSource,
-        'fetchTagMetadata'
-      ).and.returnValue(fetchTagMetadataSubject);
+      effects.dataEffects$.subscribe();
     });
 
-    it('loads TagMetadata on dashboard open if data is not loaded', () => {
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, null);
-      store.overrideSelector(
-        getMetricsTagMetadataLoaded,
-        DataLoadState.NOT_LOADED
-      );
-      store.overrideSelector(getActivePlugin, null);
-      store.refreshState();
+    describe('loadTagMetadata', () => {
+      let fetchTagMetadataSpy: jasmine.Spy;
+      let fetchTagMetadataSubject: Subject<TagMetadata>;
 
-      expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
+      beforeEach(() => {
+        fetchTagMetadataSubject = new Subject();
+        fetchTagMetadataSpy = spyOn(
+          dataSource,
+          'fetchTagMetadata'
+        ).and.returnValue(fetchTagMetadataSubject);
+      });
 
-      // Assume activePlugin's initial bootstrap occurs by the time we init.
-      store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.refreshState();
-      actions$.next(TEST_ONLY.initAction());
-
-      expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
-
-      // Assume experimentIds in the activeRoute are set on navigation.
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
-      store.refreshState();
-      actions$.next(buildNavigatedAction());
-
-      fetchTagMetadataSubject.next(buildDataSourceTagMetadata());
-
-      expect(fetchTagMetadataSpy).toHaveBeenCalled();
-      expect(actualActions).toEqual([
-        actions.metricsTagMetadataRequested(),
-        actions.metricsTagMetadataLoaded({
-          tagMetadata: buildDataSourceTagMetadata(),
-        }),
-      ]);
-    });
-
-    it('loads TagMetadata when switching to dashboard with experiment', () => {
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
-      store.overrideSelector(
-        getMetricsTagMetadataLoaded,
-        DataLoadState.NOT_LOADED
-      );
-      store.overrideSelector(getActivePlugin, null);
-      store.refreshState();
-
-      expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
-
-      // Assume activePlugin's initial bootstrap occurs by the time we init.
-      store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.refreshState();
-      actions$.next(coreActions.changePlugin({plugin: METRICS_PLUGIN_ID}));
-
-      fetchTagMetadataSubject.next(buildDataSourceTagMetadata());
-
-      expect(fetchTagMetadataSpy).toHaveBeenCalled();
-      expect(actualActions).toEqual([
-        actions.metricsTagMetadataRequested(),
-        actions.metricsTagMetadataLoaded({
-          tagMetadata: buildDataSourceTagMetadata(),
-        }),
-      ]);
-    });
-
-    it('does not fetch TagMetadata if data was loaded when opening', () => {
-      store.overrideSelector(getMetricsTagMetadataLoaded, DataLoadState.LOADED);
-      store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.refreshState();
-      actions$.next(TEST_ONLY.initAction());
-
-      fetchTagMetadataSubject.next(buildDataSourceTagMetadata());
-
-      expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
-    });
-
-    it('does not fetch TagMetadata if data was loading when opening', () => {
-      store.overrideSelector(
-        getMetricsTagMetadataLoaded,
-        DataLoadState.LOADING
-      );
-      store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.refreshState();
-      actions$.next(TEST_ONLY.initAction());
-
-      fetchTagMetadataSubject.next(buildDataSourceTagMetadata());
-
-      expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
-    });
-  });
-
-  describe('reloading', () => {
-    let fetchTagMetadataSpy: jasmine.Spy;
-    let fetchTimeSeriesSpy: jasmine.Spy;
-    let selectSpy: jasmine.Spy;
-
-    beforeEach(() => {
-      fetchTagMetadataSpy = spyOn(
-        dataSource,
-        'fetchTagMetadata'
-      ).and.returnValue(of(buildDataSourceTagMetadata()));
-      fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries');
-      selectSpy = spyOn(store, 'select').and.callThrough();
-    });
-
-    function provideCardFetchInfo(
-      specs: Array<Partial<CardFetchInfo> & {id: CardId}>
-    ) {
-      for (const {id, ...rest} of specs) {
-        selectSpy.withArgs(TEST_ONLY.getCardFetchInfo, id).and.returnValue(
-          of({
-            id,
-            plugin: PluginType.SCALARS,
-            tag: 'tagA',
-            runId: null,
-            sample: undefined,
-            loadState: DataLoadState.NOT_LOADED,
-            ...rest,
-          })
-        );
-      }
-    }
-
-    function buildTimeSeriesResponse() {
-      return {
-        plugin: PluginType.SCALARS,
-        tag: 'tagA',
-        sample: undefined,
-        runToSeries: {
-          run1: createScalarStepData(),
-        },
-      };
-    }
-
-    const reloadSpecs = [
-      {reloadAction: coreActions.manualReload, reloadName: 'manual reload'},
-      {reloadAction: coreActions.reload, reloadName: 'auto reload'},
-    ];
-    for (const {reloadAction, reloadName} of reloadSpecs) {
-      it(`re-fetches data on ${reloadName}, while dashboard is open`, () => {
-        store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+      it('loads TagMetadata on dashboard open if data is not loaded', () => {
+        store.overrideSelector(selectors.getExperimentIdsFromRoute, null);
         store.overrideSelector(
           getMetricsTagMetadataLoaded,
-          DataLoadState.LOADED
+          DataLoadState.NOT_LOADED
         );
-        store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-        store.overrideSelector(
-          selectors.getVisibleCardIdSet,
-          new Set(['card1', 'card2'])
-        );
-        provideCardFetchInfo([{id: 'card1'}, {id: 'card2'}]);
+        store.overrideSelector(getActivePlugin, null);
         store.refreshState();
-        fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
 
-        actions$.next(reloadAction());
+        expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+
+        // Assume activePlugin's initial bootstrap occurs by the time we init.
+        store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
+        store.refreshState();
+        actions$.next(TEST_ONLY.initAction());
+
+        expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+
+        // Assume experimentIds in the activeRoute are set on navigation.
+        store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+        store.refreshState();
+        actions$.next(buildNavigatedAction());
+
+        fetchTagMetadataSubject.next(buildDataSourceTagMetadata());
 
         expect(fetchTagMetadataSpy).toHaveBeenCalled();
-        expect(fetchTimeSeriesSpy).toHaveBeenCalledTimes(2);
         expect(actualActions).toEqual([
           actions.metricsTagMetadataRequested(),
           actions.metricsTagMetadataLoaded({
             tagMetadata: buildDataSourceTagMetadata(),
           }),
-
-          // Currently we expect 2x the same requests if the cards are the same.
-          // Ideally we should dedupe requests for the same info.
-          actions.multipleTimeSeriesRequested({
-            requests: [
-              {
-                plugin: PluginType.SCALARS as MultiRunPluginType,
-                tag: 'tagA',
-                experimentIds: ['exp1'],
-                sample: undefined,
-              },
-              {
-                plugin: PluginType.SCALARS as MultiRunPluginType,
-                tag: 'tagA',
-                experimentIds: ['exp1'],
-                sample: undefined,
-              },
-            ],
-          }),
-          actions.fetchTimeSeriesLoaded({response: buildTimeSeriesResponse()}),
-          actions.fetchTimeSeriesLoaded({response: buildTimeSeriesResponse()}),
         ]);
       });
 
-      it(`re-fetches data on ${reloadName}, only for non-loading cards`, () => {
+      it('loads TagMetadata when switching to dashboard with experiment', () => {
         store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+        store.overrideSelector(
+          getMetricsTagMetadataLoaded,
+          DataLoadState.NOT_LOADED
+        );
+        store.overrideSelector(getActivePlugin, null);
+        store.refreshState();
+
+        expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+
+        // Assume activePlugin's initial bootstrap occurs by the time we init.
+        store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
+        store.refreshState();
+        actions$.next(coreActions.changePlugin({plugin: METRICS_PLUGIN_ID}));
+
+        fetchTagMetadataSubject.next(buildDataSourceTagMetadata());
+
+        expect(fetchTagMetadataSpy).toHaveBeenCalled();
+        expect(actualActions).toEqual([
+          actions.metricsTagMetadataRequested(),
+          actions.metricsTagMetadataLoaded({
+            tagMetadata: buildDataSourceTagMetadata(),
+          }),
+        ]);
+      });
+
+      it('does not fetch TagMetadata if data was loaded when opening', () => {
+        store.overrideSelector(
+          getMetricsTagMetadataLoaded,
+          DataLoadState.LOADED
+        );
+        store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
+        store.refreshState();
+        actions$.next(TEST_ONLY.initAction());
+
+        fetchTagMetadataSubject.next(buildDataSourceTagMetadata());
+
+        expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+      });
+
+      it('does not fetch TagMetadata if data was loading when opening', () => {
+        store.overrideSelector(
+          getMetricsTagMetadataLoaded,
+          DataLoadState.LOADING
+        );
+        store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
+        store.refreshState();
+        actions$.next(TEST_ONLY.initAction());
+
+        fetchTagMetadataSubject.next(buildDataSourceTagMetadata());
+
+        expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+      });
+    });
+
+    describe('reloading', () => {
+      let fetchTagMetadataSpy: jasmine.Spy;
+      let fetchTimeSeriesSpy: jasmine.Spy;
+      let selectSpy: jasmine.Spy;
+
+      beforeEach(() => {
+        fetchTagMetadataSpy = spyOn(
+          dataSource,
+          'fetchTagMetadata'
+        ).and.returnValue(of(buildDataSourceTagMetadata()));
+        fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries');
+        selectSpy = spyOn(store, 'select').and.callThrough();
+      });
+
+      function provideCardFetchInfo(
+        specs: Array<Partial<CardFetchInfo> & {id: CardId}>
+      ) {
+        for (const {id, ...rest} of specs) {
+          selectSpy.withArgs(TEST_ONLY.getCardFetchInfo, id).and.returnValue(
+            of({
+              id,
+              plugin: PluginType.SCALARS,
+              tag: 'tagA',
+              runId: null,
+              sample: undefined,
+              loadState: DataLoadState.NOT_LOADED,
+              ...rest,
+            })
+          );
+        }
+      }
+
+      function buildTimeSeriesResponse() {
+        return {
+          plugin: PluginType.SCALARS,
+          tag: 'tagA',
+          sample: undefined,
+          runToSeries: {
+            run1: createScalarStepData(),
+          },
+        };
+      }
+
+      const reloadSpecs = [
+        {reloadAction: coreActions.manualReload, reloadName: 'manual reload'},
+        {reloadAction: coreActions.reload, reloadName: 'auto reload'},
+      ];
+      for (const {reloadAction, reloadName} of reloadSpecs) {
+        it(`re-fetches data on ${reloadName}, while dashboard is open`, () => {
+          store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+          store.overrideSelector(
+            getMetricsTagMetadataLoaded,
+            DataLoadState.LOADED
+          );
+          store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
+          store.overrideSelector(
+            selectors.getVisibleCardIdSet,
+            new Set(['card1', 'card2'])
+          );
+          provideCardFetchInfo([{id: 'card1'}, {id: 'card2'}]);
+          store.refreshState();
+          fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
+
+          actions$.next(reloadAction());
+
+          expect(fetchTagMetadataSpy).toHaveBeenCalled();
+          expect(fetchTimeSeriesSpy).toHaveBeenCalledTimes(2);
+          expect(actualActions).toEqual([
+            actions.metricsTagMetadataRequested(),
+            actions.metricsTagMetadataLoaded({
+              tagMetadata: buildDataSourceTagMetadata(),
+            }),
+
+            // Currently we expect 2x the same requests if the cards are the same.
+            // Ideally we should dedupe requests for the same info.
+            actions.multipleTimeSeriesRequested({
+              requests: [
+                {
+                  plugin: PluginType.SCALARS as MultiRunPluginType,
+                  tag: 'tagA',
+                  experimentIds: ['exp1'],
+                  sample: undefined,
+                },
+                {
+                  plugin: PluginType.SCALARS as MultiRunPluginType,
+                  tag: 'tagA',
+                  experimentIds: ['exp1'],
+                  sample: undefined,
+                },
+              ],
+            }),
+            actions.fetchTimeSeriesLoaded({
+              response: buildTimeSeriesResponse(),
+            }),
+            actions.fetchTimeSeriesLoaded({
+              response: buildTimeSeriesResponse(),
+            }),
+          ]);
+        });
+
+        it(`re-fetches data on ${reloadName}, only for non-loading cards`, () => {
+          store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+          store.overrideSelector(
+            getMetricsTagMetadataLoaded,
+            DataLoadState.LOADING
+          );
+          store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
+          store.overrideSelector(
+            selectors.getVisibleCardIdSet,
+            new Set(['card1', 'card2'])
+          );
+          provideCardFetchInfo([
+            {id: 'card1', loadState: DataLoadState.LOADED},
+            {id: 'card2', loadState: DataLoadState.LOADING},
+          ]);
+          store.refreshState();
+          fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
+
+          actions$.next(reloadAction());
+
+          expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
+          expect(fetchTimeSeriesSpy).toHaveBeenCalledTimes(1);
+          expect(actualActions).toEqual([
+            actions.multipleTimeSeriesRequested({
+              requests: [
+                {
+                  plugin: PluginType.SCALARS as MultiRunPluginType,
+                  tag: 'tagA',
+                  experimentIds: ['exp1'],
+                  sample: undefined,
+                },
+              ],
+            }),
+            actions.fetchTimeSeriesLoaded({
+              response: buildTimeSeriesResponse(),
+            }),
+          ]);
+        });
+      }
+
+      it('does not re-fetch data on reload, if open and already loading', () => {
         store.overrideSelector(
           getMetricsTagMetadataLoaded,
           DataLoadState.LOADING
@@ -297,340 +354,213 @@ describe('metrics effects', () => {
           new Set(['card1', 'card2'])
         );
         provideCardFetchInfo([
-          {id: 'card1', loadState: DataLoadState.LOADED},
+          {id: 'card1', loadState: DataLoadState.LOADING},
           {id: 'card2', loadState: DataLoadState.LOADING},
         ]);
         store.refreshState();
         fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
 
-        actions$.next(reloadAction());
+        actions$.next(coreActions.manualReload());
+        actions$.next(coreActions.reload());
 
         expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
-        expect(fetchTimeSeriesSpy).toHaveBeenCalledTimes(1);
-        expect(actualActions).toEqual([
-          actions.multipleTimeSeriesRequested({
-            requests: [
-              {
-                plugin: PluginType.SCALARS as MultiRunPluginType,
-                tag: 'tagA',
-                experimentIds: ['exp1'],
-                sample: undefined,
-              },
-            ],
-          }),
-          actions.fetchTimeSeriesLoaded({response: buildTimeSeriesResponse()}),
-        ]);
-      });
-    }
-
-    it('does not re-fetch data on reload, if open and already loading', () => {
-      store.overrideSelector(
-        getMetricsTagMetadataLoaded,
-        DataLoadState.LOADING
-      );
-      store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.overrideSelector(
-        selectors.getVisibleCardIdSet,
-        new Set(['card1', 'card2'])
-      );
-      provideCardFetchInfo([
-        {id: 'card1', loadState: DataLoadState.LOADING},
-        {id: 'card2', loadState: DataLoadState.LOADING},
-      ]);
-      store.refreshState();
-      fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
-
-      actions$.next(coreActions.manualReload());
-      actions$.next(coreActions.reload());
-
-      expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
-      expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
-    });
-
-    it('does not re-fetch tag metadata if dashboard is inactive', () => {
-      store.overrideSelector(getActivePlugin, null);
-      store.refreshState();
-
-      actions$.next(coreActions.manualReload());
-      actions$.next(coreActions.reload());
-
-      expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
-    });
-
-    it('does not re-fetch time series, if no cards are visible', () => {
-      store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set([]));
-      store.refreshState();
-      fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
-
-      actions$.next(coreActions.manualReload());
-      actions$.next(coreActions.reload());
-
-      expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
-    });
-
-    it('does not re-fetch time series, until a valid experiment id', () => {
-      // Reset any `getExperimentIdsFromRoute` overrides above.
-      store.resetSelectors();
-      store.overrideSelector(selectors.getRouteId, 'route1');
-      store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
-      provideCardFetchInfo([{id: 'card1', loadState: DataLoadState.LOADED}]);
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, null);
-      store.refreshState();
-      fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
-
-      actions$.next(coreActions.manualReload());
-      actions$.next(coreActions.reload());
-
-      expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
-
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
-      store.refreshState();
-
-      actions$.next(coreActions.manualReload());
-      actions$.next(coreActions.reload());
-
-      expect(fetchTimeSeriesSpy).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe('loadTimeSeriesForVisibleCardsWithoutData', () => {
-    let fetchTimeSeriesSpy: jasmine.Spy;
-    const runToSeries = {run1: createScalarStepData()};
-    const sampleBackendResponses: TimeSeriesResponse[] = [
-      {
-        plugin: PluginType.SCALARS,
-        tag: 'scalarTag',
-        runToSeries: runToSeries,
-      },
-      {
-        plugin: PluginType.SCALARS,
-        tag: 'scalarTag2',
-        runToSeries: runToSeries,
-      },
-    ];
-
-    it('does not fetch when nothing is visible', () => {
-      fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries').and.returnValue(
-        of(sampleBackendResponses)
-      );
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
-      store.overrideSelector(TEST_ONLY.getCardFetchInfo, {
-        id: 'card1',
-        plugin: PluginType.SCALARS,
-        tag: 'tagA',
-        runId: null,
-        loadState: DataLoadState.NOT_LOADED,
-      });
-      store.refreshState();
-
-      actions$.next(
-        actions.cardVisibilityChanged({
-          enteredCards: new Set(),
-          exitedCards: new Set(),
-        })
-      );
-
-      expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
-    });
-
-    it('fetches only once when hiding then showing a card', () => {
-      fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries').and.returnValue(
-        of(sampleBackendResponses)
-      );
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
-      store.overrideSelector(TEST_ONLY.getCardFetchInfo, {
-        id: 'card1',
-        plugin: PluginType.SCALARS,
-        tag: 'tagA',
-        runId: null,
-        loadState: DataLoadState.NOT_LOADED,
+        expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
       });
 
-      store.overrideSelector(
-        selectors.getVisibleCardIdSet,
-        new Set<string>([])
-      );
-      store.refreshState();
-      actions$.next(
-        actions.cardVisibilityChanged({
-          enteredCards: new Set(),
-          exitedCards: new Set(['card1']),
-        })
-      );
+      it('does not re-fetch tag metadata if dashboard is inactive', () => {
+        store.overrideSelector(getActivePlugin, null);
+        store.refreshState();
 
-      expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
+        actions$.next(coreActions.manualReload());
+        actions$.next(coreActions.reload());
 
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
-      store.refreshState();
-      actions$.next(
-        actions.cardVisibilityChanged({
-          enteredCards: new Set(['card1']),
-          exitedCards: new Set(),
-        })
-      );
-
-      const expectedRequest = {
-        plugin: PluginType.SCALARS as MultiRunPluginType,
-        tag: 'tagA',
-        experimentIds: ['exp1'],
-        sample: undefined,
-      };
-      expect(fetchTimeSeriesSpy.calls.count()).toBe(1);
-      expect(fetchTimeSeriesSpy).toHaveBeenCalledWith([expectedRequest]);
-      expect(actualActions).toEqual([
-        actions.multipleTimeSeriesRequested({requests: [expectedRequest]}),
-        actions.fetchTimeSeriesLoaded({response: sampleBackendResponses[0]}),
-      ]);
-    });
-
-    it('does not fetch when a loaded card exits and re-enters', () => {
-      fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries').and.returnValue(
-        of(sampleBackendResponses)
-      );
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
-      store.overrideSelector(TEST_ONLY.getCardFetchInfo, {
-        id: 'card1',
-        plugin: PluginType.SCALARS,
-        tag: 'tagA',
-        runId: null,
-        loadState: DataLoadState.LOADED,
+        expect(fetchTagMetadataSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
       });
 
-      // Initial load.
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
-      store.refreshState();
-      actions$.next(
-        actions.cardVisibilityChanged({
-          enteredCards: new Set(['card1']),
-          exitedCards: new Set(),
-        })
-      );
+      it('does not re-fetch time series, if no cards are visible', () => {
+        store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
+        store.overrideSelector(selectors.getVisibleCardIdSet, new Set([]));
+        store.refreshState();
+        fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
 
-      expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
+        actions$.next(coreActions.manualReload());
+        actions$.next(coreActions.reload());
 
-      // Exit.
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set([]));
-      store.refreshState();
-      actions$.next(
-        actions.cardVisibilityChanged({
-          enteredCards: new Set(),
-          exitedCards: new Set(['card1']),
-        })
-      );
+        expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
+      });
 
-      expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
+      it('does not re-fetch time series, until a valid experiment id', () => {
+        // Reset any `getExperimentIdsFromRoute` overrides above.
+        store.resetSelectors();
+        store.overrideSelector(selectors.getRouteId, 'route1');
+        store.overrideSelector(getActivePlugin, METRICS_PLUGIN_ID);
+        store.overrideSelector(
+          selectors.getVisibleCardIdSet,
+          new Set(['card1'])
+        );
+        provideCardFetchInfo([{id: 'card1', loadState: DataLoadState.LOADED}]);
+        store.overrideSelector(selectors.getExperimentIdsFromRoute, null);
+        store.refreshState();
+        fetchTimeSeriesSpy.and.returnValue(of([buildTimeSeriesResponse()]));
 
-      // Re-enter.
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
-      store.refreshState();
-      actions$.next(
-        actions.cardVisibilityChanged({
-          enteredCards: new Set(['card1']),
-          exitedCards: new Set(),
-        })
-      );
+        actions$.next(coreActions.manualReload());
+        actions$.next(coreActions.reload());
 
-      expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
-      expect(actualActions).toEqual([]);
+        expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
+
+        store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+        store.refreshState();
+
+        actions$.next(coreActions.manualReload());
+        actions$.next(coreActions.reload());
+
+        expect(fetchTimeSeriesSpy).toHaveBeenCalledTimes(2);
+      });
     });
 
-    it('fetches multiple card data', () => {
-      store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
-      const selectSpy = spyOn(store, 'select').and.callThrough();
-      selectSpy.withArgs(TEST_ONLY.getCardFetchInfo, 'card1').and.returnValue(
-        of({
+    describe('loadTimeSeriesForVisibleCardsWithoutData', () => {
+      let fetchTimeSeriesSpy: jasmine.Spy;
+      const runToSeries = {run1: createScalarStepData()};
+      const sampleBackendResponses: TimeSeriesResponse[] = [
+        {
+          plugin: PluginType.SCALARS,
+          tag: 'scalarTag',
+          runToSeries: runToSeries,
+        },
+        {
+          plugin: PluginType.SCALARS,
+          tag: 'scalarTag2',
+          runToSeries: runToSeries,
+        },
+      ];
+
+      it('does not fetch when nothing is visible', () => {
+        fetchTimeSeriesSpy = spyOn(
+          dataSource,
+          'fetchTimeSeries'
+        ).and.returnValue(of(sampleBackendResponses));
+        store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+        store.overrideSelector(TEST_ONLY.getCardFetchInfo, {
           id: 'card1',
           plugin: PluginType.SCALARS,
           tag: 'tagA',
           runId: null,
-          sample: undefined,
           loadState: DataLoadState.NOT_LOADED,
-        })
-      );
-      selectSpy.withArgs(TEST_ONLY.getCardFetchInfo, 'card2').and.returnValue(
-        of({
-          id: 'card2',
-          plugin: PluginType.IMAGES,
-          tag: 'tagB',
-          runId: 'run1',
-          sample: 5,
-          loadState: DataLoadState.NOT_LOADED,
-        })
-      );
+        });
+        store.refreshState();
 
-      const expectedRequests = [
-        {
+        actions$.next(
+          actions.cardVisibilityChanged({
+            enteredCards: new Set(),
+            exitedCards: new Set(),
+          })
+        );
+
+        expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+      });
+
+      it('fetches only once when hiding then showing a card', () => {
+        fetchTimeSeriesSpy = spyOn(
+          dataSource,
+          'fetchTimeSeries'
+        ).and.returnValue(of(sampleBackendResponses));
+        store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+        store.overrideSelector(TEST_ONLY.getCardFetchInfo, {
+          id: 'card1',
+          plugin: PluginType.SCALARS,
+          tag: 'tagA',
+          runId: null,
+          loadState: DataLoadState.NOT_LOADED,
+        });
+
+        store.overrideSelector(
+          selectors.getVisibleCardIdSet,
+          new Set<string>([])
+        );
+        store.refreshState();
+        actions$.next(
+          actions.cardVisibilityChanged({
+            enteredCards: new Set(),
+            exitedCards: new Set(['card1']),
+          })
+        );
+
+        expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+
+        store.overrideSelector(
+          selectors.getVisibleCardIdSet,
+          new Set(['card1'])
+        );
+        store.refreshState();
+        actions$.next(
+          actions.cardVisibilityChanged({
+            enteredCards: new Set(['card1']),
+            exitedCards: new Set(),
+          })
+        );
+
+        const expectedRequest = {
           plugin: PluginType.SCALARS as MultiRunPluginType,
           tag: 'tagA',
           experimentIds: ['exp1'],
           sample: undefined,
-        },
-        {
-          plugin: PluginType.IMAGES as SingleRunPluginType,
-          tag: 'tagB',
-          runId: 'run1',
-          sample: 5,
-        },
-      ];
-      fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries');
-      fetchTimeSeriesSpy
-        .withArgs([expectedRequests[0]])
-        .and.returnValue(of([sampleBackendResponses[0]]));
-      fetchTimeSeriesSpy
-        .withArgs([expectedRequests[1]])
-        .and.returnValue(of([sampleBackendResponses[1]]));
+        };
+        expect(fetchTimeSeriesSpy.calls.count()).toBe(1);
+        expect(fetchTimeSeriesSpy).toHaveBeenCalledWith([expectedRequest]);
+        expect(actualActions).toEqual([
+          actions.multipleTimeSeriesRequested({requests: [expectedRequest]}),
+          actions.fetchTimeSeriesLoaded({response: sampleBackendResponses[0]}),
+        ]);
+      });
 
-      store.overrideSelector(
-        selectors.getVisibleCardIdSet,
-        new Set(['card1', 'card2'])
-      );
-      store.refreshState();
-      actions$.next(
-        actions.cardVisibilityChanged({
-          enteredCards: new Set(['card1', 'card2']),
-          exitedCards: new Set(),
-        })
-      );
+      it('does not fetch when a loaded card exits and re-enters', () => {
+        fetchTimeSeriesSpy = spyOn(
+          dataSource,
+          'fetchTimeSeries'
+        ).and.returnValue(of(sampleBackendResponses));
+        store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+        store.overrideSelector(TEST_ONLY.getCardFetchInfo, {
+          id: 'card1',
+          plugin: PluginType.SCALARS,
+          tag: 'tagA',
+          runId: null,
+          loadState: DataLoadState.LOADED,
+        });
 
-      expect(fetchTimeSeriesSpy.calls.allArgs()).toEqual([
-        [[expectedRequests[0]]],
-        [[expectedRequests[1]]],
-      ]);
-      expect(actualActions).toEqual([
-        actions.multipleTimeSeriesRequested({requests: expectedRequests}),
-        actions.fetchTimeSeriesLoaded({response: sampleBackendResponses[0]}),
-        actions.fetchTimeSeriesLoaded({response: sampleBackendResponses[1]}),
-      ]);
-    });
-
-    const metaSpec = [
-      {loadState: DataLoadState.FAILED, tag: 'failed'},
-      {loadState: DataLoadState.LOADED, tag: 'loaded'},
-      {loadState: DataLoadState.LOADING, tag: 'loading'},
-    ];
-    for (const spec of metaSpec) {
-      const {loadState, tag} = spec;
-      const title = `should not fetch when load state is ${tag}`;
-      it(title, () => {
-        const selectSpy = spyOn(store, 'select').and.callThrough();
-        selectSpy.withArgs(TEST_ONLY.getCardFetchInfo, 'card1').and.returnValue(
-          of({
-            id: 'card1',
-            plugin: PluginType.SCALARS,
-            tag: 'tagA',
-            loadState,
+        // Initial load.
+        store.overrideSelector(
+          selectors.getVisibleCardIdSet,
+          new Set(['card1'])
+        );
+        store.refreshState();
+        actions$.next(
+          actions.cardVisibilityChanged({
+            enteredCards: new Set(['card1']),
+            exitedCards: new Set(),
           })
         );
-        fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries');
 
+        expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+
+        // Exit.
+        store.overrideSelector(selectors.getVisibleCardIdSet, new Set([]));
+        store.refreshState();
+        actions$.next(
+          actions.cardVisibilityChanged({
+            enteredCards: new Set(),
+            exitedCards: new Set(['card1']),
+          })
+        );
+
+        expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([]);
+
+        // Re-enter.
         store.overrideSelector(
           selectors.getVisibleCardIdSet,
           new Set(['card1'])
@@ -646,6 +576,224 @@ describe('metrics effects', () => {
         expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
         expect(actualActions).toEqual([]);
       });
-    }
+
+      it('fetches multiple card data', () => {
+        store.overrideSelector(selectors.getExperimentIdsFromRoute, ['exp1']);
+        const selectSpy = spyOn(store, 'select').and.callThrough();
+        selectSpy.withArgs(TEST_ONLY.getCardFetchInfo, 'card1').and.returnValue(
+          of({
+            id: 'card1',
+            plugin: PluginType.SCALARS,
+            tag: 'tagA',
+            runId: null,
+            sample: undefined,
+            loadState: DataLoadState.NOT_LOADED,
+          })
+        );
+        selectSpy.withArgs(TEST_ONLY.getCardFetchInfo, 'card2').and.returnValue(
+          of({
+            id: 'card2',
+            plugin: PluginType.IMAGES,
+            tag: 'tagB',
+            runId: 'run1',
+            sample: 5,
+            loadState: DataLoadState.NOT_LOADED,
+          })
+        );
+
+        const expectedRequests = [
+          {
+            plugin: PluginType.SCALARS as MultiRunPluginType,
+            tag: 'tagA',
+            experimentIds: ['exp1'],
+            sample: undefined,
+          },
+          {
+            plugin: PluginType.IMAGES as SingleRunPluginType,
+            tag: 'tagB',
+            runId: 'run1',
+            sample: 5,
+          },
+        ];
+        fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries');
+        fetchTimeSeriesSpy
+          .withArgs([expectedRequests[0]])
+          .and.returnValue(of([sampleBackendResponses[0]]));
+        fetchTimeSeriesSpy
+          .withArgs([expectedRequests[1]])
+          .and.returnValue(of([sampleBackendResponses[1]]));
+
+        store.overrideSelector(
+          selectors.getVisibleCardIdSet,
+          new Set(['card1', 'card2'])
+        );
+        store.refreshState();
+        actions$.next(
+          actions.cardVisibilityChanged({
+            enteredCards: new Set(['card1', 'card2']),
+            exitedCards: new Set(),
+          })
+        );
+
+        expect(fetchTimeSeriesSpy.calls.allArgs()).toEqual([
+          [[expectedRequests[0]]],
+          [[expectedRequests[1]]],
+        ]);
+        expect(actualActions).toEqual([
+          actions.multipleTimeSeriesRequested({requests: expectedRequests}),
+          actions.fetchTimeSeriesLoaded({response: sampleBackendResponses[0]}),
+          actions.fetchTimeSeriesLoaded({response: sampleBackendResponses[1]}),
+        ]);
+      });
+
+      const metaSpec = [
+        {loadState: DataLoadState.FAILED, tag: 'failed'},
+        {loadState: DataLoadState.LOADED, tag: 'loaded'},
+        {loadState: DataLoadState.LOADING, tag: 'loading'},
+      ];
+      for (const spec of metaSpec) {
+        const {loadState, tag} = spec;
+        const title = `should not fetch when load state is ${tag}`;
+        it(title, () => {
+          const selectSpy = spyOn(store, 'select').and.callThrough();
+          selectSpy
+            .withArgs(TEST_ONLY.getCardFetchInfo, 'card1')
+            .and.returnValue(
+              of({
+                id: 'card1',
+                plugin: PluginType.SCALARS,
+                tag: 'tagA',
+                loadState,
+              })
+            );
+          fetchTimeSeriesSpy = spyOn(dataSource, 'fetchTimeSeries');
+
+          store.overrideSelector(
+            selectors.getVisibleCardIdSet,
+            new Set(['card1'])
+          );
+          store.refreshState();
+          actions$.next(
+            actions.cardVisibilityChanged({
+              enteredCards: new Set(['card1']),
+              exitedCards: new Set(),
+            })
+          );
+
+          expect(fetchTimeSeriesSpy).not.toHaveBeenCalled();
+          expect(actualActions).toEqual([]);
+        });
+      }
+    });
+  });
+
+  describe('#readSettingsFromStorage', () => {
+    let getSettingsSpy: jasmine.Spy;
+    beforeEach(() => {
+      effects.readSettingsFromStorage$.subscribe((action) => {
+        actualActions.push(action);
+      });
+      getSettingsSpy = spyOn(dataSource, 'getSettings');
+    });
+
+    it('dispatches `metricsPersistedSettingsRead` on init', () => {
+      getSettingsSpy.and.returnValue(
+        of({
+          ignoreOutliers: false,
+        })
+      );
+      actions$.next(TEST_ONLY.initAction());
+
+      expect(actualActions).toEqual([
+        actions.metricsPersistedSettingsRead({
+          partialSettings: {
+            ignoreOutliers: false,
+          },
+        }),
+      ]);
+    });
+  });
+
+  describe('#setSettingsToStorage', () => {
+    let setSettingsSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      effects.setSettingsToStorage$.subscribe();
+      setSettingsSpy = spyOn(dataSource, 'setSettings').and.returnValue(EMPTY);
+    });
+
+    describe('on metricsChangeScalarSmoothing', () => {
+      it('sets smoothing to the storage', () => {
+        store.overrideSelector(selectors.getMetricsScalarSmoothing, 0.1);
+        store.refreshState();
+        actions$.next(
+          actions.metricsChangeScalarSmoothing({
+            smoothing: 0.1,
+          })
+        );
+
+        expect(setSettingsSpy).toHaveBeenCalledOnceWith({
+          scalarSmoothing: 0.1,
+        });
+      });
+    });
+
+    describe('on stateRehydratedFromUrl', () => {
+      it('sets smoothing from URL to localStorage to avoid user confusion', () => {
+        store.overrideSelector(selectors.getMetricsScalarSmoothing, 1);
+        store.refreshState();
+
+        const routePartialState: URLDeserializedState = {
+          metrics: {
+            pinnedCards: [],
+            smoothing: 1337,
+          },
+        };
+        actions$.next(
+          stateRehydratedFromUrl({
+            routeKind: RouteKind.EXPERIMENT,
+            partialState: routePartialState,
+          })
+        );
+
+        // Even though user has passed 1337, reducer clips the value to 1 and
+        // this is validating that we are indeed setting the clipped version of
+        // the smoothing value instead of a weird number.
+        expect(setSettingsSpy).toHaveBeenCalledOnceWith({
+          scalarSmoothing: 1,
+        });
+      });
+    });
+
+    describe('on metricsChangeTooltipSort', () => {
+      it('sets tooltipSort to the storage', () => {
+        store.overrideSelector(
+          selectors.getMetricsTooltipSort,
+          TooltipSort.NEAREST
+        );
+        store.refreshState();
+        actions$.next(
+          actions.metricsChangeTooltipSort({
+            sort: TooltipSort.NEAREST,
+          })
+        );
+
+        expect(setSettingsSpy).toHaveBeenCalledOnceWith({
+          tooltipSort: TooltipSort.NEAREST,
+        });
+      });
+    });
+
+    describe('on metricsToggleIgnoreOutliers', () => {
+      it('sets ignoreOutliers to the storage', () => {
+        store.overrideSelector(selectors.getMetricsIgnoreOutliers, true);
+        store.refreshState();
+        actions$.next(actions.metricsToggleIgnoreOutliers());
+
+        expect(setSettingsSpy).toHaveBeenCalledOnceWith({
+          ignoreOutliers: true,
+        });
+      });
+    });
   });
 });

--- a/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
+++ b/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
@@ -696,7 +696,7 @@ describe('metrics effects', () => {
       getSettingsSpy = spyOn(dataSource, 'getSettings');
     });
 
-    it('dispatches `metricsPersistedSettingsRead` on init', () => {
+    it('dispatches `fetchPersistedSettingsSucceeded` on init', () => {
       getSettingsSpy.and.returnValue(
         of({
           ignoreOutliers: false,
@@ -705,7 +705,7 @@ describe('metrics effects', () => {
       actions$.next(TEST_ONLY.initAction());
 
       expect(actualActions).toEqual([
-        actions.metricsPersistedSettingsRead({
+        actions.fetchPersistedSettingsSucceeded({
           partialSettings: {
             ignoreOutliers: false,
           },

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -338,7 +338,7 @@ const reducer = createReducer(
       settings: newSettings,
     };
   }),
-  on(actions.metricsPersistedSettingsRead, (state, {partialSettings}) => {
+  on(actions.fetchPersistedSettingsSucceeded, (state, {partialSettings}) => {
     return {
       ...state,
       settings: {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -338,6 +338,15 @@ const reducer = createReducer(
       settings: newSettings,
     };
   }),
+  on(actions.metricsPersistedSettingsRead, (state, {partialSettings}) => {
+    return {
+      ...state,
+      settings: {
+        ...state.settings,
+        ...partialSettings,
+      },
+    };
+  }),
   on(coreActions.reload, coreActions.manualReload, (state) => {
     const nextTagMetadataLoaded =
       state.tagMetadataLoaded === DataLoadState.LOADING

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1691,7 +1691,7 @@ describe('metrics reducers', () => {
     });
   });
 
-  describe('#metricsPersistedSettingsRead', () => {
+  describe('#fetchPersistedSettingsSucceeded', () => {
     it('adds partial state from the action to the settings', () => {
       const beforeState = buildMetricsState({
         settings: buildMetricsSettingsState({
@@ -1703,7 +1703,7 @@ describe('metrics reducers', () => {
 
       const nextState = reducers(
         beforeState,
-        actions.metricsPersistedSettingsRead({
+        actions.fetchPersistedSettingsSucceeded({
           partialSettings: {
             scalarSmoothing: 0,
             ignoreOutliers: true,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1690,4 +1690,30 @@ describe('metrics reducers', () => {
       expect(nextState.settings.scalarSmoothing).toBe(0.232);
     });
   });
+
+  describe('#metricsPersistedSettingsRead', () => {
+    it('adds partial state from the action to the settings', () => {
+      const beforeState = buildMetricsState({
+        settings: buildMetricsSettingsState({
+          scalarSmoothing: 0.3,
+          ignoreOutliers: false,
+          tooltipSort: TooltipSort.ASCENDING,
+        }),
+      });
+
+      const nextState = reducers(
+        beforeState,
+        actions.metricsPersistedSettingsRead({
+          partialSettings: {
+            scalarSmoothing: 0,
+            ignoreOutliers: true,
+          },
+        })
+      );
+
+      expect(nextState.settings.scalarSmoothing).toBe(0);
+      expect(nextState.settings.ignoreOutliers).toBe(true);
+      expect(nextState.settings.tooltipSort).toBe(TooltipSort.ASCENDING);
+    });
+  });
 });


### PR DESCRIPTION
This is a continuation of #4991 where we are attempting to persist
several settings from TimeSeries to improve frustrating user experience
of having to reset settings over and over.

This change integrates the DataSource with the MetricsEffects so persist
new settings when it changes and bootstrap the application state from
the state in the LocalStorage.

Product choice: this change persist the smoothing value user may provide
in the URL since it felt more natural that way.
