### PR TITLE
runs: fix the colorMap override feature

### DIFF
--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -167,8 +167,8 @@ export const getRunColorMap = createSelector(
   getDataState,
   (state: RunsDataState): Record<string, string> => {
     const map = new Map([
-      ...state.runColorOverrideForGroupBy,
       ...state.defaultRunColorForGroupBy,
+      ...state.runColorOverrideForGroupBy,
     ]);
     const colorObject: Record<string, string> = {};
     map.forEach((value, key) => {

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -342,22 +342,28 @@ describe('runs_selectors', () => {
       });
     });
 
-    it('combines override with the default colors', () => {
-      const state = buildStateFromRunsState(
-        buildRunsState({
-          runColorOverrideForGroupBy: new Map([
-            ['foo', '#aaa'],
-            ['bar', '#bbb'],
-          ]),
-          defaultRunColorForGroupBy: new Map([['foo', '#000']]),
-        })
-      );
+    it(
+      'combines override with the default colors where override takes ' +
+        'precedence',
+      () => {
+        const state = buildStateFromRunsState(
+          buildRunsState({
+            runColorOverrideForGroupBy: new Map([['foo', '#aaa']]),
+            defaultRunColorForGroupBy: new Map([
+              ['foo', '#000'],
+              ['bar', '#bbb'],
+            ]),
+          })
+        );
 
-      expect(selectors.getRunColorMap(state)).toEqual({
-        foo: '#000',
-        bar: '#bbb',
-      });
-    });
+        expect(selectors.getRunColorMap(state)).toEqual({
+          // "#aaa" comes from the override for `foo`.
+          foo: '#aaa',
+          // "#bbb" is un-overridden default color of `bar`.
+          bar: '#bbb',
+        });
+      }
+    );
   });
 
   describe('#getRunGroupBy', () => {


### PR DESCRIPTION
PR #4966 inadvertently changed the order of the spread operations and
changed the test specs changing the desired behavior.

This change restores it and makes the color override win over the
default value.
