### PR TITLE
docs: update example plugin demos

### DIFF
--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/demo.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/demo.py
@@ -21,10 +21,6 @@ import tensorflow as tf
 from tensorboard_plugin_example import summary_v2
 
 
-tf.compat.v1.enable_eager_execution()
-tf = tf.compat.v2
-
-
 def main(unused_argv):
     writer = tf.summary.create_file_writer("demo_logs")
     with writer.as_default():

--- a/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/demo.py
+++ b/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/demo.py
@@ -26,10 +26,6 @@ from absl import app
 import tensorflow as tf
 
 
-tf.compat.v1.enable_eager_execution()
-tf = tf.compat.v2
-
-
 def main(unused_argv):
     writer = tf.summary.create_file_writer("demo_logs")
     with writer.as_default():


### PR DESCRIPTION
Minor updates to example plugin demos to assume that
TF1 is no longer used.