### PR TITLE
docs: update npmi demo

### DIFF
--- a/tensorboard/plugins/npmi/csv_to_plugin_data_demo.py
+++ b/tensorboard/plugins/npmi/csv_to_plugin_data_demo.py
@@ -23,8 +23,6 @@ from absl import app
 from absl import flags
 from tensorboard.plugins.npmi import summary
 
-tf.compat.v1.enable_eager_execution()
-
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string(

--- a/tensorboard/plugins/npmi/npmi_demo.py
+++ b/tensorboard/plugins/npmi/npmi_demo.py
@@ -23,8 +23,6 @@ import numpy as np
 from tensorboard.plugins.npmi import summary
 from tensorboard.plugins.npmi import npmi_demo_data
 
-tf.compat.v1.enable_eager_execution()
-
 # Directory into which to write tensorboard data.
 LOGDIR = "/tmp/npmi_demo"
 
@@ -60,6 +58,10 @@ def setup_all(logdir, verbose=False):
 
 def main(unused_argv):
     print("Saving output to %s." % LOGDIR)
+    print(
+        "To view results in your browser, run `tensorboard --logdir %s`"
+        % LOGDIR
+    )
     setup_all(LOGDIR, verbose=True)
     print("Done. Output saved to %s." % LOGDIR)
 

--- a/tensorboard/plugins/npmi/npy_to_embedding_data_demo.py
+++ b/tensorboard/plugins/npmi/npy_to_embedding_data_demo.py
@@ -47,7 +47,7 @@ def convert_embeddings(out_path, embeddings_path):
     with open(embeddings_path, "rb") as f:
         embeddings = np.load(f)
     embeddings_tensor = tf.convert_to_tensor(embeddings)
-    writer = tf.compat.v2.summary.create_file_writer(out_path)
+    writer = tf.summary.create_file_writer(out_path)
     with writer.as_default():
         summary.npmi_embeddings(embeddings_tensor, 1)
     writer.close()


### PR DESCRIPTION
Minor updates that assume the TensorFlow installation is TF2.

Test plan
Did not check that the following targets: `:csv_to_plugin_data_demo` and
`npy_to_embedding_data_demo`, since I do not have a valid csv/npy file
for the plugin.

Manually checked that `bazel run //tensorboard/plugins/npmi:npmi_demo`
still produces a logdir that properly renders in TensorBoard when adding
`?experimentalPlugin=npmi` to the TensorBoard URL.

![image](https://user-images.githubusercontent.com/2322480/119061748-f2cb4d00-b989-11eb-8984-06df8e05cff3.png)
