### PR TITLE
sync: fix object property accessor

### DIFF
--- a/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source.ts
@@ -331,11 +331,10 @@ export class TBMetricsDataSource implements MetricsDataSource {
     serialized: string
   ): Partial<PersistableSettings> {
     const settings: Partial<PersistableSettings> = {};
-    let unsanitizedObject: Record<string, string | number | boolean>;
+    let unsanitizedObject: Partial<SerializableSettings>;
     try {
-      unsanitizedObject = JSON.parse(serialized) as Record<
-        string,
-        string | number | boolean
+      unsanitizedObject = JSON.parse(serialized) as Partial<
+        SerializableSettings
       >;
     } catch (e) {
       return settings;


### PR DESCRIPTION
`unsanitizedObject` was typed as a Record or just an object whose
property we are trying to access. To make it survive the mangling, we
need to supply proper typing information for the `JSON.parse`d object
which is now assigned as `SerializableSettings` which is capable of
surviving the mangling (`declare`d).

This change unblocks the sync.
