### PR TITLE
docs: update scalars demo

### DIFF
--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -42,24 +42,25 @@ def one_step(temperature, ambient_temperature, heat_coefficient, step):
       step: tf.int64 value of the current step number.  Used in the
         `summary.scalar` API.
     """
-    tf.summary.scalar(
-        name="current",
-        data=temperature,
-        step=step,
-        description="The temperature of the object, in Kelvins.",
-    )
-    # Compute how much the object's temperature differs from that of
-    #  its environment, and track this, too: likewise, as
-    # "temperature/difference_to_ambient".
-    ambient_difference = temperature - ambient_temperature
-    tf.summary.scalar(
-        name="difference_to_ambient",
-        data=ambient_difference,
-        step=step,
-        description="The difference between the ambient "
-        "temperature and the temperature of the "
-        "object under simulation, in Kelvins.",
-    )
+    with tf.name_scope("temperature"):
+        tf.summary.scalar(
+            name="current",
+            data=temperature,
+            step=step,
+            description="The temperature of the object, in Kelvins.",
+        )
+        # Compute how much the object's temperature differs from that of
+        #  its environment, and track this, too: likewise, as
+        # "temperature/difference_to_ambient".
+        ambient_difference = temperature - ambient_temperature
+        tf.summary.scalar(
+            name="difference_to_ambient",
+            data=ambient_difference,
+            step=step,
+            description="The difference between the ambient "
+            "temperature and the temperature of the "
+            "object under simulation, in Kelvins.",
+        )
     # Newton suggested that the rate of change of the temperature of
     # an object is directly proportional to this
     # `ambient_difference` above, where the proportionality constant
@@ -101,9 +102,8 @@ def run(initial_temperature, ambient_temperature, heat_coefficient):
     """
     tf.random.set_seed(0)
     temperature = tf.Variable(initial_temperature)
-    with tf.name_scope("temperature"):
-        for step in tf.range(STEPS, dtype=tf.int64):
-            one_step(temperature, ambient_temperature, heat_coefficient, step)
+    for step in tf.range(STEPS, dtype=tf.int64):
+        one_step(temperature, ambient_temperature, heat_coefficient, step)
 
 
 def run_all(logdir, verbose=False):

--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -29,9 +29,19 @@ STEPS = 1000
 
 @tf.function
 def one_step(temperature, ambient_temperature, heat_coefficient, step):
-    print("XXXXXXXXXXXXXXXXXXXXXX")
-    print("I AM BEING RETRACED!!!!!!")
-    print(temperature, ambient_temperature, heat_coefficient, step)
+    """Runs one step of the temperature simulation.
+
+    Will update the `temperature` argument with one step of heat diffusion.
+
+    Arguments:
+      temperature: The tf.Variable containing the value being updated.  Akin
+        to a weight in a model.
+      ambient_temperature: The `tf.Constant` value the temperature is being
+        drawn towards.
+      heat_coefficient: tf.Constant describing rate of diffusion.
+      step: tf.int64 value of the current step number.  Used in the
+        `summary.scalar` API.
+    """
     tf.summary.scalar(
         name="current",
         data=temperature,

--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -28,13 +28,13 @@ STEPS = 1000
 
 
 @tf.function
-def one_step(temperature, ambient_temperature, heat_coefficient, step):
+def one_step(temp, ambient_temperature, heat_coefficient, step):
     """Runs one step of the temperature simulation.
 
     Will update the `temperature` argument with one step of heat diffusion.
 
     Arguments:
-      temperature: The tf.Variable containing the value being updated.  Akin
+      temp: The tf.Variable containing the value being updated.  Akin
         to a weight in a model.
       ambient_temperature: The `tf.Constant` value the temperature is being
         drawn towards.
@@ -45,14 +45,14 @@ def one_step(temperature, ambient_temperature, heat_coefficient, step):
     with tf.name_scope("temperature"):
         tf.summary.scalar(
             name="current",
-            data=temperature,
+            data=temp,
             step=step,
             description="The temperature of the object, in Kelvins.",
         )
         # Compute how much the object's temperature differs from that of
         #  its environment, and track this, too: likewise, as
         # "temperature/difference_to_ambient".
-        ambient_difference = temperature - ambient_temperature
+        ambient_difference = temp - ambient_temperature
         tf.summary.scalar(
             name="difference_to_ambient",
             data=ambient_difference,
@@ -77,7 +77,7 @@ def one_step(temperature, ambient_temperature, heat_coefficient, step):
         description="The change in temperature from the previous "
         "step, in Kelvins.",
     )
-    temperature.assign_add(delta)
+    temp.assign_add(delta)
 
 
 def run(initial_temperature, ambient_temperature, heat_coefficient):
@@ -101,9 +101,9 @@ def run(initial_temperature, ambient_temperature, heat_coefficient):
         conductivity
     """
     tf.random.set_seed(0)
-    temperature = tf.Variable(initial_temperature)
+    temp = tf.Variable(initial_temperature)
     for step in tf.range(STEPS, dtype=tf.int64):
-        one_step(temperature, ambient_temperature, heat_coefficient, step)
+        one_step(temp, ambient_temperature, heat_coefficient, step)
 
 
 def run_all(logdir, verbose=False):

--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -127,6 +127,9 @@ def run_all(logdir, verbose=False):
                     os.path.join(logdir, run_name)
                 )
                 with writer.as_default():
+                    # Arguments wrapped in tf.constant to prevent unwanted
+                    # retracing.  See retracing logic details at
+                    # https://www.tensorflow.org/guide/function
                     run(
                         tf.constant(initial_temperature),
                         tf.constant(ambient_temperature),


### PR DESCRIPTION
Updates scalars demo to use TF2 conventions.

Somewhat of a major update.

Manually tested by running `bazel run tensorboard/plugins/scalar:scalars_demo` and checked that the demo works and produces standard visual output.
<img width="1267" alt="Screen Shot 2021-05-21 at 6 11 34 PM" src="https://user-images.githubusercontent.com/547150/119202969-fd581600-ba5f-11eb-8137-5c0aec8676b0.png">

