### PR TITLE
line chart: improve major axis for numbers

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
@@ -133,7 +133,8 @@ export function getTicksForLinearScale(
       // Put it in the middle. If the flooredNumber is 231.041, then put the axis label
       // at 231.0415 which is not the most ideal but certainly better than 231.041.
       start: flooredNumber,
-      tickFormattedString: formatter.formatShort(flooredNumber),
+      tickFormattedString:
+        flooredNumber === 0 ? '—' : formatter.formatShort(flooredNumber),
     });
   }
 
@@ -144,11 +145,22 @@ export function getTicksForLinearScale(
       const diff = val - flooredMajorVal;
       if (diff >= 0 && diff < maximumDiff) {
         // `diff` can have very minute number because of IEEE 754.
-        const remainder = String(val).slice(String(flooredMajorVal).length);
-        minor.push({
-          value: val,
-          tickFormattedString: `…${remainder || '0'}`,
-        });
+
+        // When major axis is `0`, there is no right way to truncate it. Use the
+        // real formatter in that case.
+        if (flooredMajorVal === 0) {
+          minor.push({
+            value: val,
+            tickFormattedString: formatter.formatTick(val),
+          });
+        } else {
+          const remainder = String(val).slice(String(flooredMajorVal).length);
+          minor.push({
+            value: val,
+            tickFormattedString: `…${remainder || '0'}`,
+          });
+        }
+
         break;
       }
     }

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
@@ -288,6 +288,52 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
           {value: 1.94516, tickFormattedString: '…6'},
         ]);
       });
+
+      it('handles 0 and small number close to 0 well', () => {
+        const {major, minor} = getTicksForLinearScale(
+          scale,
+          scale.defaultFormatter,
+          2,
+          [0, 0.0001999]
+        );
+        expect(major).toEqual([
+          {start: 0, tickFormattedString: '0'},
+          {start: 0.0001, tickFormattedString: '1e-4'},
+        ]);
+        expect(minor).toEqual([
+          {value: 0, tickFormattedString: '…0'},
+          {value: 0.0001, tickFormattedString: '…0'},
+        ]);
+      });
+
+      it('handles extent close to 0s well', () => {
+        const {major, minor} = getTicksForLinearScale(
+          scale,
+          scale.defaultFormatter,
+          2,
+          [0.000001, 0.0001999]
+        );
+        expect(major).toEqual([{start: 0.0001, tickFormattedString: '1e-4'}]);
+        expect(minor).toEqual([{value: 0.0001, tickFormattedString: '…0'}]);
+      });
+
+      it('handles negative extent close to 0s well', () => {
+        const {major, minor} = getTicksForLinearScale(
+          scale,
+          scale.defaultFormatter,
+          2,
+          [-0.000001999, -0.00001]
+        );
+
+        expect(major).toEqual([
+          {start: -0.000005, tickFormattedString: '-5e-6'},
+          {start: -0.00001, tickFormattedString: '-1e-5'},
+        ]);
+        expect(minor).toEqual([
+          {value: -0.000005, tickFormattedString: '…5'},
+          {value: -0.00001, tickFormattedString: '…0'},
+        ]);
+      });
     });
   });
 });

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
@@ -208,6 +208,20 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       ]);
     });
 
+    it('handles extents with 0 and larger number', () => {
+      const {major, minor} = getTicksForLinearScale(
+        scale,
+        scale.defaultFormatter,
+        2,
+        [0, 3.2105]
+      );
+      expect(major).toEqual([]);
+      expect(minor).toEqual([
+        {value: 0, tickFormattedString: '0'},
+        {value: 2, tickFormattedString: '2'},
+      ]);
+    });
+
     describe('very small differences', () => {
       it('creates a major tick since very long minor tick labels are not legible', () => {
         const {major, minor} = getTicksForLinearScale(
@@ -297,12 +311,31 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
           [0, 0.0001999]
         );
         expect(major).toEqual([
-          {start: 0, tickFormattedString: '0'},
+          {start: 0, tickFormattedString: '—'},
           {start: 0.0001, tickFormattedString: '1e-4'},
         ]);
         expect(minor).toEqual([
-          {value: 0, tickFormattedString: '…0'},
+          {value: 0, tickFormattedString: '0'},
           {value: 0.0001, tickFormattedString: '…0'},
+        ]);
+      });
+
+      it('handles 0 and small number close to 0 well (more minor ticks)', () => {
+        const {major, minor} = getTicksForLinearScale(
+          scale,
+          scale.defaultFormatter,
+          4,
+          [0, 0.00019999999495]
+        );
+        expect(major).toEqual([
+          {start: 0, tickFormattedString: '—'},
+          {start: 0.0001, tickFormattedString: '1e-4'},
+        ]);
+        expect(minor).toEqual([
+          {value: 0, tickFormattedString: '0'},
+          {value: 0.00005, tickFormattedString: '5e-5'},
+          {value: 0.0001, tickFormattedString: '…0'},
+          {value: 0.00015, tickFormattedString: '…5'},
         ]);
       });
 


### PR DESCRIPTION
When the extents are small and is close to 0, we were falling into the
case where major axes were missing and minor axis formats were simply
off. They were supposed to have truncated number but instead had
`.…0000535` because we were removing common prefix between "0" and
"0.0000535" and blindly adding `…` in it.

This change addresses the corner case by adding test specs and special
casing major ticks being `0`s.

Previous:
![image](https://user-images.githubusercontent.com/2547313/119203382-c0802500-ba47-11eb-9f00-04a95d041088.png)

New:
![image](https://user-images.githubusercontent.com/2547313/119203346-ac3c2800-ba47-11eb-80ba-df85de97fe78.png)
