### PR TITLE
projector: simplify demo using fake data

### DIFF
--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -112,7 +112,5 @@ py_binary(
     srcs_version = "PY3",
     deps = [
         ":projector",
-        "//tensorboard:expect_tensorflow_datasets_installed",
-        "//tensorboard:expect_tensorflow_installed",
     ],
 )


### PR DESCRIPTION
This slims down the projector plugin using totally fake data, rather than training a real embedding, so that it can be run much more quickly and easily.  As such we convert it from using a `tf.Checkpoint` to just providing the `tensor.tsv` file of tensor data.  The realistic walkthrough is still available as the full tutorial here: https://www.tensorflow.org/tensorboard/tensorboard_projector_plugin

The fake embedding is just generated by using length-26 vectors representing which ASCII lowercase letters appear in the label, so "proximity" in the vector space is roughly representative of "how similar is the letter distribution of these two words".  This generates something that at least looks roughly plausible in PCA (full screenshot below).  It's quite likely that with a little more tweaking this would generate a more aesthetically pleasing distribution.

I haven't tested how this looks in T-SNE or UMAP since those appear to be broken at HEAD right now.

![image](https://user-images.githubusercontent.com/710113/119210611-fa5e2500-ba61-11eb-8adf-fe672be39f5a.png)



