### PR TITLE
docs: update histogram demo to TF2

### DIFF
--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -18,7 +18,6 @@
 
 from absl import app
 import tensorflow as tf
-import os
 
 # Directory into which to write tensorboard data.
 LOGDIR = "/tmp/histograms_demo"

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -23,6 +23,7 @@ import os
 # Directory into which to write tensorboard data.
 LOGDIR = "/tmp/histograms_demo"
 
+
 def run(k):
     # Make a normal distribution, with a shifting mean
     mean_moving_normal = tf.random.normal(shape=[1000], mean=(5 * k), stddev=1)
@@ -99,16 +100,18 @@ def run(k):
         "two normal distributions.",
     )
 
+
 def run_all(logdir, num_summaries=400):
     """Generate a bunch of histogram data, and write it to logdir."""
     tf.random.set_seed(0)
-    writer = tf.summary.create_file_writer(os.path.join(logdir, 'my_run_name'))
+    writer = tf.summary.create_file_writer(os.path.join(logdir, "my_run_name"))
     with writer.as_default():
         for step in range(num_summaries):
             tf.summary.experimental.set_step(step)
             k = step / float(num_summaries)
             run(k)
             writer.flush()
+
 
 def main(unused_argv):
     print("Running histograms demo. Output saving to %s." % LOGDIR)

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -18,12 +18,12 @@
 
 from absl import app
 import tensorflow as tf
+import os
 
 # Directory into which to write tensorboard data.
 LOGDIR = "/tmp/histograms_demo"
 
 def run(k):
-    tf.random.set_seed(0)
     # Make a normal distribution, with a shifting mean
     mean_moving_normal = tf.random.normal(shape=[1000], mean=(5 * k), stddev=1)
 
@@ -99,11 +99,10 @@ def run(k):
         "two normal distributions.",
     )
 
-def run_all(logdir, verbose=False, num_summaries=400):
+def run_all(logdir, num_summaries=400):
     """Generate a bunch of histogram data, and write it to logdir."""
-    del verbose
-
-    writer = tf.summary.create_file_writer(logdir)
+    tf.random.set_seed(0)
+    writer = tf.summary.create_file_writer(os.path.join(logdir, 'my_run_name'))
     with writer.as_default():
         for step in range(num_summaries):
             tf.summary.experimental.set_step(step)

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -28,6 +28,7 @@ def run(k, step):
     """
     Arguments:
         k: a float in the range [0, 1] that affects the histogram values written by the run.
+        step: an integer value to use for writing summaries.
     """
     # Make a normal distribution, with a shifting mean
     mean_moving_normal = tf.random.normal(shape=[1000], mean=(5 * k), stddev=1)
@@ -117,19 +118,19 @@ def run(k, step):
 def run_all(logdir, num_summaries=400):
     """Generate a bunch of histogram data, and write it to logdir."""
     tf.random.set_seed(0)
-    writer = tf.summary.create_file_writer(os.path.join(logdir, "my_run_name"))
+    writer = tf.summary.create_file_writer(logdir)
     with writer.as_default():
         for step in range(num_summaries):
             k = step / float(num_summaries)
             run(k, step)
             writer.flush()
     print(
-        "To view results in your browser, run `tensorboard --logdir %s/my_run_name`"
+        "To view results in your browser, run `tensorboard --logdir %s`"
         % LOGDIR
     )
     print(
         "Logs can be uploaded publicly to TensorBoard.dev via "
-        + "`tensorboard dev upload --logdir %s/my_run_name`" % LOGDIR
+        + "`tensorboard dev upload --logdir %s`" % LOGDIR
     )
 
 

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -25,6 +25,10 @@ LOGDIR = "/tmp/histograms_demo"
 
 
 def run(k, step):
+    """
+    Arguments:
+        k: a float in the range [0, 1] that affects the histogram values written by the run.
+    """
     # Make a normal distribution, with a shifting mean
     mean_moving_normal = tf.random.normal(shape=[1000], mean=(5 * k), stddev=1)
 

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -19,24 +19,16 @@
 from absl import app
 import tensorflow as tf
 
-from tensorboard.plugins.histogram import summary as histogram_summary
-
 # Directory into which to write tensorboard data.
 LOGDIR = "/tmp/histograms_demo"
 
-
-def run_all(logdir, verbose=False, num_summaries=400):
-    """Generate a bunch of histogram data, and write it to logdir."""
-    del verbose
-
-    tf.compat.v1.set_random_seed(0)
-
-    k = tf.compat.v1.placeholder(tf.float32)
-
+def run(k):
+    tf.random.set_seed(0)
     # Make a normal distribution, with a shifting mean
     mean_moving_normal = tf.random.normal(shape=[1000], mean=(5 * k), stddev=1)
+
     # Record that distribution into a histogram summary
-    histogram_summary.op(
+    tf.summary.histogram(
         "normal/moving_mean",
         mean_moving_normal,
         description="A normal distribution whose mean changes " "over time.",
@@ -45,7 +37,7 @@ def run_all(logdir, verbose=False, num_summaries=400):
     # Make a normal distribution with shrinking variance
     shrinking_normal = tf.random.normal(shape=[1000], mean=0, stddev=1 - (k))
     # Record that distribution too
-    histogram_summary.op(
+    tf.summary.histogram(
         "normal/shrinking_variance",
         shrinking_normal,
         description="A normal distribution whose variance "
@@ -55,7 +47,7 @@ def run_all(logdir, verbose=False, num_summaries=400):
     # Let's combine both of those distributions into one dataset
     normal_combined = tf.concat([mean_moving_normal, shrinking_normal], 0)
     # We add another histogram summary to record the combined distribution
-    histogram_summary.op(
+    tf.summary.histogram(
         "normal/bimodal",
         normal_combined,
         description="A combination of two normal distributions, "
@@ -67,7 +59,7 @@ def run_all(logdir, verbose=False, num_summaries=400):
 
     # Add a gamma distribution
     gamma = tf.random.gamma(shape=[1000], alpha=k)
-    histogram_summary.op(
+    tf.summary.histogram(
         "gamma",
         gamma,
         description="A gamma distribution whose shape "
@@ -75,8 +67,8 @@ def run_all(logdir, verbose=False, num_summaries=400):
     )
 
     # And a poisson distribution
-    poisson = tf.compat.v1.random_poisson(shape=[1000], lam=k)
-    histogram_summary.op(
+    poisson = tf.random.poisson(shape=[1000], lam=k)
+    tf.summary.histogram(
         "poisson",
         poisson,
         description="A Poisson distribution, which only "
@@ -85,7 +77,7 @@ def run_all(logdir, verbose=False, num_summaries=400):
 
     # And a uniform distribution
     uniform = tf.random.uniform(shape=[1000], maxval=k * 10)
-    histogram_summary.op(
+    tf.summary.histogram(
         "uniform", uniform, description="A simple uniform distribution."
     )
 
@@ -98,7 +90,7 @@ def run_all(logdir, verbose=False, num_summaries=400):
         uniform,
     ]
     all_combined = tf.concat(all_distributions, 0)
-    histogram_summary.op(
+    tf.summary.histogram(
         "all_combined",
         all_combined,
         description="An amalgamation of five distributions: a "
@@ -107,19 +99,17 @@ def run_all(logdir, verbose=False, num_summaries=400):
         "two normal distributions.",
     )
 
-    summaries = tf.compat.v1.summary.merge_all()
+def run_all(logdir, verbose=False, num_summaries=400):
+    """Generate a bunch of histogram data, and write it to logdir."""
+    del verbose
 
-    # Setup a session and summary writer
-    sess = tf.compat.v1.Session()
-    writer = tf.summary.FileWriter(logdir)
-
-    # Setup a loop and write the summaries to disk
-    N = num_summaries
-    for step in range(N):
-        k_val = step / float(N)
-        summ = sess.run(summaries, feed_dict={k: k_val})
-        writer.add_summary(summ, global_step=step)
-
+    writer = tf.summary.create_file_writer(logdir)
+    with writer.as_default():
+        for step in range(num_summaries):
+            tf.summary.experimental.set_step(step)
+            k = step / float(num_summaries)
+            run(k)
+            writer.flush()
 
 def main(unused_argv):
     print("Running histograms demo. Output saving to %s." % LOGDIR)

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -24,7 +24,7 @@ import os
 LOGDIR = "/tmp/histograms_demo"
 
 
-def run(k):
+def run(k, step):
     # Make a normal distribution, with a shifting mean
     mean_moving_normal = tf.random.normal(shape=[1000], mean=(5 * k), stddev=1)
 
@@ -33,6 +33,7 @@ def run(k):
         "normal/moving_mean",
         mean_moving_normal,
         description="A normal distribution whose mean changes " "over time.",
+        step=step,
     )
 
     # Make a normal distribution with shrinking variance
@@ -43,6 +44,7 @@ def run(k):
         shrinking_normal,
         description="A normal distribution whose variance "
         "shrinks over time.",
+        step=step,
     )
 
     # Let's combine both of those distributions into one dataset
@@ -56,6 +58,7 @@ def run(k):
         "shrinking variance. The result is a "
         "distribution that starts as unimodal and "
         "becomes more and more bimodal over time.",
+        step=step,
     )
 
     # Add a gamma distribution
@@ -65,6 +68,7 @@ def run(k):
         gamma,
         description="A gamma distribution whose shape "
         "parameter, α, changes over time.",
+        step=step,
     )
 
     # And a poisson distribution
@@ -74,12 +78,13 @@ def run(k):
         poisson,
         description="A Poisson distribution, which only "
         "takes on integer values.",
+        step=step,
     )
 
     # And a uniform distribution
     uniform = tf.random.uniform(shape=[1000], maxval=k * 10)
     tf.summary.histogram(
-        "uniform", uniform, description="A simple uniform distribution."
+        "uniform", uniform, description="A simple uniform distribution.", step=step,
     )
 
     # Finally, combine everything together!
@@ -98,6 +103,7 @@ def run(k):
         "uniform distribution, a gamma "
         "distribution, a Poisson distribution, and "
         "two normal distributions.",
+        step=step,
     )
 
 
@@ -107,10 +113,17 @@ def run_all(logdir, num_summaries=400):
     writer = tf.summary.create_file_writer(os.path.join(logdir, "my_run_name"))
     with writer.as_default():
         for step in range(num_summaries):
-            tf.summary.experimental.set_step(step)
             k = step / float(num_summaries)
-            run(k)
+            run(k, step)
             writer.flush()
+    print(
+        "To view results in your browser, run `tensorboard --logdir %s/my_run_name`"
+        % LOGDIR
+    )
+    print(
+        "Logs can be uploaded publicly to TensorBoard.dev via "
+        + "`tensorboard dev upload --logdir %s/my_run_name`" % LOGDIR
+    )
 
 
 def main(unused_argv):

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -84,7 +84,10 @@ def run(k, step):
     # And a uniform distribution
     uniform = tf.random.uniform(shape=[1000], maxval=k * 10)
     tf.summary.histogram(
-        "uniform", uniform, description="A simple uniform distribution.", step=step,
+        "uniform",
+        uniform,
+        description="A simple uniform distribution.",
+        step=step,
     )
 
     # Finally, combine everything together!


### PR DESCRIPTION
Update TF1 to TF2 style

Test plan:
Manually ran the demo with `bazel run //tensorboard/plugins/histrogram:histrogram_demo`
![Screen Shot 2021-05-24 at 1 29 26 PM](https://user-images.githubusercontent.com/1131010/119404024-10ebc280-bc94-11eb-8e48-4e5c55d4e5bc.png)
