### PR TITLE
color grouping: group runs by regex

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -189,7 +189,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
       runsForAllExperiments,
       state.runIdToExpId
     );
-    Object.entries(groups).forEach(([groupId, runs]) => {
+    Object.entries(groups.matches).forEach(([groupId, runs]) => {
       const color =
         groupKeyToColorString.get(groupId) ??
         CHART_COLOR_PALLETE[
@@ -223,7 +223,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
 
       const groups = groupRuns(groupBy, allRuns, state.runIdToExpId);
 
-      Object.entries(groups).forEach(([groupId, runs]) => {
+      Object.entries(groups.matches).forEach(([groupId, runs]) => {
         const color =
           groupKeyToColorString.get(groupId) ??
           CHART_COLOR_PALLETE[

--- a/tensorboard/webapp/runs/store/utils.ts
+++ b/tensorboard/webapp/runs/store/utils.ts
@@ -43,7 +43,7 @@ export function groupRuns(
     case GroupByKey.REGEX:
       if (!groupBy.regexString) {
         //TODO(japie1235813): props users when the input is invalid
-        throw new Error('Invalid regex');
+        throw new Error('Empty regex string.');
       }
 
       // TODO(japie1235813): add additonal `\` to convert string to regex, which
@@ -52,9 +52,9 @@ export function groupRuns(
 
       try {
         new RegExp(groupBy.regexString);
-      } catch(e) {
+      } catch (e) {
         //TODO(japie1235813): props users when the input is invalid
-        throw new Error('Invalid regex');
+        throw new Error('Invalid regex.');
       }
 
       const regExp = new RegExp(groupBy.regexString);
@@ -62,10 +62,10 @@ export function groupRuns(
       let isCaptureGroup = false;
 
       for (const run of runs) {
-        let matches = (run.name).match(regExp)
-          if (matches) {
-          if(matches.length > 1) {
-            matches = matches.slice(1)
+        let matches = run.name.match(regExp);
+        if (matches) {
+          if (matches.length > 1) {
+            matches = matches.slice(1);
             isCaptureGroup = true;
           }
           const id = matches.length === 1 ? matches[0] : matches.join('_');
@@ -82,7 +82,7 @@ export function groupRuns(
         const matchedRuns = [];
         runGroups = {};
         for (const run of runs) {
-          let matches = (run.name).match(regExp)
+          let matches = run.name.match(regExp);
           if (matches) {
             matchedRuns.push(run);
             delete runGroups[run.id];

--- a/tensorboard/webapp/runs/store/utils.ts
+++ b/tensorboard/webapp/runs/store/utils.ts
@@ -42,8 +42,8 @@ export function groupRuns(
 
     case GroupByKey.REGEX:
       if (!groupBy.regexString) {
-        //TODO(japie1235813): props users when the input is invalid
-        throw new Error('Empty regex string.');
+        //TODO(japie1235813): props users the input is invalid
+        break;
       }
 
       // TODO(japie1235813): add additonal `\` to convert string to regex, which
@@ -53,8 +53,8 @@ export function groupRuns(
       try {
         new RegExp(groupBy.regexString);
       } catch (e) {
-        //TODO(japie1235813): props users when the input is invalid
-        throw new Error('Invalid regex.');
+        //TODO(japie1235813): props users the input is invalid
+        break;
       }
 
       const regExp = new RegExp(groupBy.regexString);

--- a/tensorboard/webapp/runs/store/utils.ts
+++ b/tensorboard/webapp/runs/store/utils.ts
@@ -68,7 +68,7 @@ export function groupRuns(
           // In case regex string does not have a capturing group, we use pseudo group id of `pseudo_group`.
           const id = hasCapturingGroup
             ? JSON.stringify(matchesList)
-            : ('pseudo_group' as string);
+            : 'pseudo_group';
           const runs = matches[id] || [];
           runs.push(run);
           matches[id] = runs;

--- a/tensorboard/webapp/runs/store/utils.ts
+++ b/tensorboard/webapp/runs/store/utils.ts
@@ -42,22 +42,22 @@ export function groupRuns(
 
     case GroupByKey.REGEX:
       if (!groupBy.regexString) {
-        //TODO(japie1235813): props users the input is invalid
+        //TODO(japie1235813): propagate invalidity of regex string to user more gracefully
         break;
       }
+      let regExp: RegExp;
 
       // TODO(japie1235813): add additonal `\` to convert string to regex, which
       // makes `new RegExp()` construct properly
       // For example, convert `foo\d+bar` to `foo\\d+bar`
 
       try {
-        new RegExp(groupBy.regexString);
+        regExp = new RegExp(groupBy.regexString);
       } catch (e) {
-        //TODO(japie1235813): props users the input is invalid
+        //TODO(japie1235813): propagate invalidity of regex string to user more gracefully
         break;
       }
 
-      const regExp = new RegExp(groupBy.regexString);
       // Checks if there is capture group in regex.
       let isCaptureGroup = false;
 
@@ -68,7 +68,7 @@ export function groupRuns(
             matches = matches.slice(1);
             isCaptureGroup = true;
           }
-          const id = matches.length === 1 ? matches[0] : matches.join('_');
+          const id = JSON.stringify(matches);
           const runs = runGroups[id] || [];
           runs.push(run);
           runGroups[id] = runs;

--- a/tensorboard/webapp/runs/store/utils.ts
+++ b/tensorboard/webapp/runs/store/utils.ts
@@ -67,7 +67,7 @@ export function groupRuns(
           const hasCapturingGroup = matchesList.length > 1;
           // In case regex string does not have a capturing group, we use pseudo group id of `pseudo_group`.
           const id = hasCapturingGroup
-            ? JSON.stringify(matchesList)
+            ? JSON.stringify(matchesList.slice(1))
             : 'pseudo_group';
           const runs = matches[id] || [];
           runs.push(run);

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -94,7 +94,7 @@ describe('run store utils test', () => {
     describe('by regex', () => {
       it('groups runs by regex without capture group', () => {
         const actual = groupRuns(
-          {key: GroupByKey.REGEX, regexString: '/foo\d+bar/'},
+          {key: GroupByKey.REGEX, regexString: 'foo\\d+bar'},
           [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
@@ -110,22 +110,20 @@ describe('run store utils test', () => {
         );
 
         expect(actual).toEqual({
-          'eid1/alpha': [
+          'matches': [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
-          ],
-          'eid2/beta': [
             buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
           ],
           'eid2/gamma': [
-            buildRun({id: 'eid2/gamma', name: 'foo2bar1'}),
+            buildRun({id: 'eid2/gamma', name: 'gamma'}),
           ],
         });
       });
 
       it('groups runs by regex with one capture group', () => {
         const actual = groupRuns(
-          {key: GroupByKey.REGEX, regexString: '/foo(\d+)bar/'},
+          {key: GroupByKey.REGEX, regexString: 'foo(\\d+)bar'},
           [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
@@ -143,7 +141,7 @@ describe('run store utils test', () => {
         expect(actual).toEqual({
           '1': [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
-            buildRun({id: 'eid1/beta', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
           ],
           '2': [
             buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
@@ -154,7 +152,7 @@ describe('run store utils test', () => {
 
       it('groups runs by regex with multiple capture group', () => {
         const actual = groupRuns(
-          {key: GroupByKey.REGEX, regexString: '/foo(\d+)bar(\d+)/'},
+          {key: GroupByKey.REGEX, regexString: 'foo(\\d+)bar(\\d+)'},
           [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo2bar1'}),

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -92,6 +92,54 @@ describe('run store utils test', () => {
     });
 
     describe('by regex', () => {
+      it('throws error when the regex is empty', () => {
+        let errorMessage = '';
+        try {
+          groupRuns(
+            {key: GroupByKey.REGEX, regexString: ''},
+            [
+              buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+              buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+              buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+              buildRun({id: 'eid2/gamma', name: 'gamma'}),
+            ],
+            {
+              'eid1/alpha': 'eid1',
+              'eid1/beta': 'eid1',
+              'eid2/beta': 'eid2',
+              'eid2/gamma': 'eid2',
+            }
+          );
+        } catch (error) {
+          errorMessage = error.message;
+        }
+        expect(errorMessage).toBe('Empty regex string.');
+      });
+
+      it('throws error when the regex is invalid', () => {
+        let errorMessage = '';
+        try {
+          groupRuns(
+            {key: GroupByKey.REGEX, regexString: 'foo\\d+)bar'},
+            [
+              buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+              buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+              buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+              buildRun({id: 'eid2/gamma', name: 'gamma'}),
+            ],
+            {
+              'eid1/alpha': 'eid1',
+              'eid1/beta': 'eid1',
+              'eid2/beta': 'eid2',
+              'eid2/gamma': 'eid2',
+            }
+          );
+        } catch (error) {
+          errorMessage = error.message;
+        }
+        expect(errorMessage).toBe('Invalid regex.');
+      });
+
       it('groups runs by regex without capture group', () => {
         const actual = groupRuns(
           {key: GroupByKey.REGEX, regexString: 'foo\\d+bar'},
@@ -110,14 +158,12 @@ describe('run store utils test', () => {
         );
 
         expect(actual).toEqual({
-          'matches': [
+          matches: [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
             buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
           ],
-          'eid2/gamma': [
-            buildRun({id: 'eid2/gamma', name: 'gamma'}),
-          ],
+          'eid2/gamma': [buildRun({id: 'eid2/gamma', name: 'gamma'})],
         });
       });
 
@@ -168,12 +214,8 @@ describe('run store utils test', () => {
         );
 
         expect(actual).toEqual({
-          '1_1': [
-            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
-          ],
-          '2_1': [
-            buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
-          ],
+          '1_1': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
+          '2_1': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
           '2_2': [
             buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -90,5 +90,98 @@ describe('run store utils test', () => {
         });
       });
     });
+
+    describe('by regex', () => {
+      it('groups runs by regex without capture group', () => {
+        const actual = groupRuns(
+          {key: GroupByKey.REGEX, regexString: '/foo\d+bar/'},
+          [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+            buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+            buildRun({id: 'eid2/gamma', name: 'gamma'}),
+          ],
+          {
+            'eid1/alpha': 'eid1',
+            'eid1/beta': 'eid1',
+            'eid2/beta': 'eid2',
+            'eid2/gamma': 'eid2',
+          }
+        );
+
+        expect(actual).toEqual({
+          'eid1/alpha': [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+          ],
+          'eid2/beta': [
+            buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+          ],
+          'eid2/gamma': [
+            buildRun({id: 'eid2/gamma', name: 'foo2bar1'}),
+          ],
+        });
+      });
+
+      it('groups runs by regex with one capture group', () => {
+        const actual = groupRuns(
+          {key: GroupByKey.REGEX, regexString: '/foo(\d+)bar/'},
+          [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+            buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+            buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
+          ],
+          {
+            'eid1/alpha': 'eid1',
+            'eid1/beta': 'eid1',
+            'eid2/beta': 'eid2',
+            'eid2/gamma': 'eid2',
+          }
+        );
+
+        expect(actual).toEqual({
+          '1': [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo1bar1'}),
+          ],
+          '2': [
+            buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+            buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
+          ],
+        });
+      });
+
+      it('groups runs by regex with multiple capture group', () => {
+        const actual = groupRuns(
+          {key: GroupByKey.REGEX, regexString: '/foo(\d+)bar(\d+)/'},
+          [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
+            buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
+            buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
+          ],
+          {
+            'eid1/alpha': 'eid1',
+            'eid1/beta': 'eid1',
+            'eid2/beta': 'eid2',
+            'eid2/gamma': 'eid2',
+          }
+        );
+
+        expect(actual).toEqual({
+          '1_1': [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+          ],
+          '2_1': [
+            buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
+          ],
+          '2_2': [
+            buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
+            buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
+          ],
+        });
+      });
+    });
   });
 });

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -220,12 +220,8 @@ describe('run store utils test', () => {
 
         expect(actual).toEqual({
           matches: {
-            '["1","1"]': [
-              buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
-            ],
-            '["2","1"]': [
-              buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
-            ],
+            '["1","1"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
+            '["2","1"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
             '["2","2"]': [
               buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
               buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -186,11 +186,11 @@ describe('run store utils test', () => {
 
         expect(actual).toEqual({
           matches: {
-            '["1"]': [
+            '["foo1bar","1"]': [
               buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
               buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
             ],
-            '["2"]': [
+            ' ["foo2bar","2"]': [
               buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
               buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
             ],
@@ -220,9 +220,9 @@ describe('run store utils test', () => {
 
         expect(actual).toEqual({
           matches: {
-            '["1","1"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
-            '["2","1"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
-            '["2","2"]': [
+            '["foo1bar1","1","1"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
+            '["foo2bar1","2","1"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
+            '["foo2bar2","2","2"]': [
               buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
               buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
             ],

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -190,7 +190,7 @@ describe('run store utils test', () => {
               buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
               buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
             ],
-            ' ["foo2bar","2"]': [
+            '["foo2bar","2"]': [
               buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
               buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
             ],

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -92,7 +92,7 @@ describe('run store utils test', () => {
     });
 
     describe('by regex', () => {
-      it('do not change the group when the regex is empty', () => {
+      it('does not group when the regex is empty ', () => {
         const actual = groupRuns(
           {key: GroupByKey.REGEX, regexString: ''},
           [
@@ -108,11 +108,13 @@ describe('run store utils test', () => {
             'eid2/gamma': 'eid2',
           }
         );
-        expect(actual.matches).toEqual({});
-        // expect(actual.nonMatches).toEqual([]);
+        expect(actual).toEqual({
+          matches: {},
+          nonMatches: [],
+        });
       });
 
-      it('do not change the group when the regex is invalid', () => {
+      it('does not group when the regex is invalid', () => {
         const actual = groupRuns(
           {key: GroupByKey.REGEX, regexString: 'foo\\d+)bar'},
           [
@@ -128,7 +130,10 @@ describe('run store utils test', () => {
             'eid2/gamma': 'eid2',
           }
         );
-        expect(actual.matches).toEqual({});
+        expect(actual).toEqual({
+          matches: {},
+          nonMatches: [],
+        });
       });
 
       it('groups runs by regex without capture group', () => {
@@ -148,16 +153,16 @@ describe('run store utils test', () => {
           }
         );
 
-        expect(actual.matches).toEqual({
-          matches: [
-            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
-            buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
-            buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
-          ],
+        expect(actual).toEqual({
+          matches: {
+            pseudo_group: [
+              buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+              buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+              buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+            ],
+          },
+          nonMatches: [buildRun({id: 'eid2/gamma', name: 'gamma'})],
         });
-        expect(actual.nonMatches).toEqual([
-          buildRun({id: 'eid2/gamma', name: 'gamma'}),
-        ]);
       });
 
       it('groups runs by regex with one capture group', () => {
@@ -179,19 +184,19 @@ describe('run store utils test', () => {
           }
         );
 
-        expect(actual.matches).toEqual({
-          '["1"]': [
-            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
-            buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
-          ],
-          '["2"]': [
-            buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
-            buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
-          ],
+        expect(actual).toEqual({
+          matches: {
+            '["1"]': [
+              buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+              buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+            ],
+            '["2"]': [
+              buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+              buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
+            ],
+          },
+          nonMatches: [buildRun({id: 'eid2/gamma', name: 'gamma'})],
         });
-        expect(actual.nonMatches).toEqual([
-          buildRun({id: 'eid2/alpha', name: 'alpha'}),
-        ]);
       });
 
       it('groups runs by regex with multiple capture group', () => {
@@ -213,17 +218,17 @@ describe('run store utils test', () => {
           }
         );
 
-        expect(actual.matches).toEqual({
-          '["1","1"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
-          '["2","1"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
-          '["2","2"]': [
-            buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
-            buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
-          ],
+        expect(actual).toEqual({
+          matches: {
+            '["1","1"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
+            '["2","1"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
+            '["2","2"]': [
+              buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
+              buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
+            ],
+          },
+          nonMatches: [buildRun({id: 'eid2/alpha', name: 'alpha'})],
         });
-        expect(actual.nonMatches).toEqual([
-          buildRun({id: 'eid2/alpha', name: 'alpha'}),
-        ]);
       });
     });
   });

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -195,7 +195,7 @@ describe('run store utils test', () => {
               buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
             ],
           },
-          nonMatches: [buildRun({id: 'eid2/gamma', name: 'gamma'})],
+          nonMatches: [buildRun({id: 'eid2/alpha', name: 'alpha'})],
         });
       });
 
@@ -220,8 +220,12 @@ describe('run store utils test', () => {
 
         expect(actual).toEqual({
           matches: {
-            '["foo1bar1","1","1"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
-            '["foo2bar1","2","1"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
+            '["foo1bar1","1","1"]': [
+              buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            ],
+            '["foo2bar1","2","1"]': [
+              buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
+            ],
             '["foo2bar2","2","2"]': [
               buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
               buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -175,11 +175,11 @@ describe('run store utils test', () => {
         );
 
         expect(actual).toEqual({
-          '1': [
+          '[\"1\"]': [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
           ],
-          '2': [
+          '[\"2\"]': [
             buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
           ],
@@ -204,9 +204,9 @@ describe('run store utils test', () => {
         );
 
         expect(actual).toEqual({
-          '1_1': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
-          '2_1': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
-          '2_2': [
+          '[\"1\",\"1\"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
+          '[\"2\",\"1\"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
+          '[\"2\",\"2\"]': [
             buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
           ],

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -51,7 +51,7 @@ describe('run store utils test', () => {
           }
         );
 
-        expect(actual).toEqual({
+        expect(actual.matches).toEqual({
           'eid1/alpha': [buildRun({id: 'eid1/alpha', name: 'alpha'})],
           'eid1/beta': [buildRun({id: 'eid1/beta', name: 'beta'})],
           'eid2/beta': [buildRun({id: 'eid2/beta', name: 'beta'})],
@@ -78,7 +78,7 @@ describe('run store utils test', () => {
           }
         );
 
-        expect(actual).toEqual({
+        expect(actual.matches).toEqual({
           eid1: [
             buildRun({id: 'eid1/alpha', name: 'alpha'}),
             buildRun({id: 'eid1/beta', name: 'beta'}),
@@ -108,26 +108,27 @@ describe('run store utils test', () => {
             'eid2/gamma': 'eid2',
           }
         );
-        expect(actual).toEqual({});
+        expect(actual.matches).toEqual({});
+        // expect(actual.nonMatches).toEqual([]);
       });
 
       it('do not change the group when the regex is invalid', () => {
-         const actual = groupRuns(
-            {key: GroupByKey.REGEX, regexString: 'foo\\d+)bar'},
-            [
-              buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
-              buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
-              buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
-              buildRun({id: 'eid2/gamma', name: 'gamma'}),
-            ],
-            {
-              'eid1/alpha': 'eid1',
-              'eid1/beta': 'eid1',
-              'eid2/beta': 'eid2',
-              'eid2/gamma': 'eid2',
-            }
-          );
-        expect(actual).toEqual({});
+        const actual = groupRuns(
+          {key: GroupByKey.REGEX, regexString: 'foo\\d+)bar'},
+          [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+            buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+            buildRun({id: 'eid2/gamma', name: 'gamma'}),
+          ],
+          {
+            'eid1/alpha': 'eid1',
+            'eid1/beta': 'eid1',
+            'eid2/beta': 'eid2',
+            'eid2/gamma': 'eid2',
+          }
+        );
+        expect(actual.matches).toEqual({});
       });
 
       it('groups runs by regex without capture group', () => {
@@ -147,14 +148,16 @@ describe('run store utils test', () => {
           }
         );
 
-        expect(actual).toEqual({
+        expect(actual.matches).toEqual({
           matches: [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
             buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
           ],
-          'eid2/gamma': [buildRun({id: 'eid2/gamma', name: 'gamma'})],
         });
+        expect(actual.nonMatches).toEqual([
+          buildRun({id: 'eid2/gamma', name: 'gamma'}),
+        ]);
       });
 
       it('groups runs by regex with one capture group', () => {
@@ -176,17 +179,19 @@ describe('run store utils test', () => {
           }
         );
 
-        expect(actual).toEqual({
-          '[\"1\"]': [
+        expect(actual.matches).toEqual({
+          '["1"]': [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
           ],
-          '[\"2\"]': [
+          '["2"]': [
             buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
           ],
-          'eid2/alpha': [buildRun({id: 'eid2/alpha', name: 'alpha'})],
         });
+        expect(actual.nonMatches).toEqual([
+          buildRun({id: 'eid2/alpha', name: 'alpha'}),
+        ]);
       });
 
       it('groups runs by regex with multiple capture group', () => {
@@ -208,15 +213,17 @@ describe('run store utils test', () => {
           }
         );
 
-        expect(actual).toEqual({
-          '[\"1\",\"1\"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
-          '[\"2\",\"1\"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
-          '[\"2\",\"2\"]': [
+        expect(actual.matches).toEqual({
+          '["1","1"]': [buildRun({id: 'eid1/alpha', name: 'foo1bar1'})],
+          '["2","1"]': [buildRun({id: 'eid1/beta', name: 'foo2bar1'})],
+          '["2","2"]': [
             buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
           ],
-          'eid2/alpha': [buildRun({id: 'eid2/alpha', name: 'alpha'})],
         });
+        expect(actual.nonMatches).toEqual([
+          buildRun({id: 'eid2/alpha', name: 'alpha'}),
+        ]);
       });
     });
   });

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -167,7 +167,7 @@ describe('run store utils test', () => {
 
       it('groups runs by regex with one capture group', () => {
         const actual = groupRuns(
-          {key: GroupByKey.REGEX, regexString: 'foo(\\d+)bar'},
+          {key: GroupByKey.REGEX, regexString: 'foo(\\d+)bar.*'},
           [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
@@ -186,11 +186,11 @@ describe('run store utils test', () => {
 
         expect(actual).toEqual({
           matches: {
-            '["foo1bar","1"]': [
+            '["1"]': [
               buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
               buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
             ],
-            '["foo2bar","2"]': [
+            '["2"]': [
               buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
               buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
             ],
@@ -201,7 +201,7 @@ describe('run store utils test', () => {
 
       it('groups runs by regex with multiple capture group', () => {
         const actual = groupRuns(
-          {key: GroupByKey.REGEX, regexString: 'foo(\\d+)bar(\\d+)'},
+          {key: GroupByKey.REGEX, regexString: 'foo(\\d+)bar(\\d+).*'},
           [
             buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
@@ -220,13 +220,13 @@ describe('run store utils test', () => {
 
         expect(actual).toEqual({
           matches: {
-            '["foo1bar1","1","1"]': [
+            '["1","1"]': [
               buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
             ],
-            '["foo2bar1","2","1"]': [
+            '["2","1"]': [
               buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
             ],
-            '["foo2bar2","2","2"]': [
+            '["2","2"]': [
               buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
               buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
             ],

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -92,34 +92,27 @@ describe('run store utils test', () => {
     });
 
     describe('by regex', () => {
-      it('throws error when the regex is empty', () => {
-        let errorMessage = '';
-        try {
-          groupRuns(
-            {key: GroupByKey.REGEX, regexString: ''},
-            [
-              buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
-              buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
-              buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
-              buildRun({id: 'eid2/gamma', name: 'gamma'}),
-            ],
-            {
-              'eid1/alpha': 'eid1',
-              'eid1/beta': 'eid1',
-              'eid2/beta': 'eid2',
-              'eid2/gamma': 'eid2',
-            }
-          );
-        } catch (error) {
-          errorMessage = error.message;
-        }
-        expect(errorMessage).toBe('Empty regex string.');
+      it('do not change the group when the regex is empty', () => {
+        const actual = groupRuns(
+          {key: GroupByKey.REGEX, regexString: ''},
+          [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
+            buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
+            buildRun({id: 'eid2/gamma', name: 'gamma'}),
+          ],
+          {
+            'eid1/alpha': 'eid1',
+            'eid1/beta': 'eid1',
+            'eid2/beta': 'eid2',
+            'eid2/gamma': 'eid2',
+          }
+        );
+        expect(actual).toEqual({});
       });
 
-      it('throws error when the regex is invalid', () => {
-        let errorMessage = '';
-        try {
-          groupRuns(
+      it('do not change the group when the regex is invalid', () => {
+         const actual = groupRuns(
             {key: GroupByKey.REGEX, regexString: 'foo\\d+)bar'},
             [
               buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
@@ -134,10 +127,7 @@ describe('run store utils test', () => {
               'eid2/gamma': 'eid2',
             }
           );
-        } catch (error) {
-          errorMessage = error.message;
-        }
-        expect(errorMessage).toBe('Invalid regex.');
+        expect(actual).toEqual({});
       });
 
       it('groups runs by regex without capture group', () => {

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -165,12 +165,14 @@ describe('run store utils test', () => {
             buildRun({id: 'eid1/beta', name: 'foo1bar2'}),
             buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
+            buildRun({id: 'eid2/alpha', name: 'alpha'}),
           ],
           {
             'eid1/alpha': 'eid1',
             'eid1/beta': 'eid1',
             'eid2/beta': 'eid2',
             'eid2/gamma': 'eid2',
+            'eid2/alpha': 'eid2',
           }
         );
 
@@ -183,6 +185,7 @@ describe('run store utils test', () => {
             buildRun({id: 'eid2/beta', name: 'foo2bar1'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar3'}),
           ],
+          'eid2/alpha': [buildRun({id: 'eid2/alpha', name: 'alpha'})],
         });
       });
 
@@ -194,12 +197,14 @@ describe('run store utils test', () => {
             buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
             buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
+            buildRun({id: 'eid2/alpha', name: 'alpha'}),
           ],
           {
             'eid1/alpha': 'eid1',
             'eid1/beta': 'eid1',
             'eid2/beta': 'eid2',
             'eid2/gamma': 'eid2',
+            'eid2/alpha': 'eid2',
           }
         );
 
@@ -210,6 +215,7 @@ describe('run store utils test', () => {
             buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
           ],
+          'eid2/alpha': [buildRun({id: 'eid2/alpha', name: 'alpha'})],
         });
       });
     });

--- a/tensorboard/webapp/runs/types.ts
+++ b/tensorboard/webapp/runs/types.ts
@@ -24,6 +24,11 @@ export type ExperimentIdToRunsAndMetadata = Record<
   }
 >;
 
+export interface RunGroup {
+  matches: Record<string, Run[]>;
+  nonMatches: Run[];
+}
+
 export enum SortType {
   EXPERIMENT_NAME,
   HPARAM,


### PR DESCRIPTION
* Motivation for features / changes
Color groups the runs by regex. No UI/UX involved.

* Technical description of changes
- Match regex with name (not id)
- Construct the group key by the capture groups connected with '_'
- If there are no capture group, use the matched string as the group key
- if there are no capture group, use keyword `matches` to group all matched runs
- check invalid regex
- check empty input