### PR TITLE
runs: create groupBy override vs. initial value

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -46,7 +46,7 @@ const {
     runColorOverrideForGroupBy: new Map(),
     defaultRunColorForGroupBy: new Map(),
     groupKeyToColorString: new Map(),
-    groupBy: {key: GroupByKey.RUN},
+    initialGroupBy: {key: GroupByKey.RUN},
   },
   {
     runIds: {},
@@ -185,7 +185,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
     const defaultRunColorForGroupBy = new Map(state.defaultRunColorForGroupBy);
 
     const groups = groupRuns(
-      state.groupBy,
+      state.userSetGroupBy ?? state.initialGroupBy,
       runsForAllExperiments,
       state.runIdToExpId
     );
@@ -238,7 +238,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
 
       return {
         ...state,
-        groupBy,
+        userSetGroupBy: groupBy,
         defaultRunColorForGroupBy,
         groupKeyToColorString,
         // Resets the color override when the groupBy changes.

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -191,7 +191,7 @@ describe('runs_reducers', () => {
 
     it('assigns default color to new runs', () => {
       const state = buildRunsState({
-        groupBy: {
+        initialGroupBy: {
           key: GroupByKey.RUN,
         },
         defaultRunColorForGroupBy: new Map([
@@ -252,7 +252,10 @@ describe('runs_reducers', () => {
     describe('advanced grouping', () => {
       it('assigns default color to by experiment', () => {
         const state = buildRunsState({
-          groupBy: {
+          initialGroupBy: {
+            key: GroupByKey.RUN,
+          },
+          userSetGroupBy: {
             key: GroupByKey.EXPERIMENT,
           },
           defaultRunColorForGroupBy: new Map([
@@ -706,7 +709,7 @@ describe('runs_reducers', () => {
   describe('on runGroupByChanged', () => {
     it('reassigns color to EXPERIMENT from RUN', () => {
       const state = buildRunsState({
-        groupBy: {key: GroupByKey.RUN},
+        initialGroupBy: {key: GroupByKey.RUN},
         runIds: {
           eid1: ['run1', 'run2'],
           eid2: ['run3', 'run4'],
@@ -746,7 +749,10 @@ describe('runs_reducers', () => {
         })
       );
 
-      expect(nextState.data.groupBy).toEqual({key: GroupByKey.EXPERIMENT});
+      expect(nextState.data.initialGroupBy).toEqual({key: GroupByKey.RUN});
+      expect(nextState.data.userSetGroupBy).toEqual({
+        key: GroupByKey.EXPERIMENT,
+      });
       expect(nextState.data.groupKeyToColorString).toEqual(
         new Map([
           ['eid1', colorUtils.CHART_COLOR_PALLETE[0]],
@@ -766,7 +772,8 @@ describe('runs_reducers', () => {
 
     it('reassigns color to RUN from EXPERIMENT', () => {
       const state = buildRunsState({
-        groupBy: {key: GroupByKey.EXPERIMENT},
+        initialGroupBy: {key: GroupByKey.EXPERIMENT},
+        userSetGroupBy: {key: GroupByKey.EXPERIMENT},
         runIds: {
           eid1: ['run1', 'run2'],
           eid2: ['run3', 'run4'],
@@ -804,7 +811,7 @@ describe('runs_reducers', () => {
         })
       );
 
-      expect(nextState.data.groupBy).toEqual({key: GroupByKey.RUN});
+      expect(nextState.data.userSetGroupBy).toEqual({key: GroupByKey.RUN});
       expect(nextState.data.groupKeyToColorString).toEqual(
         new Map([
           ['run1', colorUtils.CHART_COLOR_PALLETE[0]],

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -114,12 +114,30 @@ export const getRunSelectionMap = createSelector(
 );
 
 /**
+ * Returns user defined run grouping setting.
+ *
+ * User can define it by either specifying it in URL or by interacting with the
+ * color group by menu. Returns `null` if user has not defined one and is
+ * currently its default.
+ *
+ * @see getRunGroupBy for actual groupBy that you should use for a view. This
+ * selector was meant to be for settings persistence.
+ */
+export const getRunUserSetGroupBy = createSelector(
+  getDataState,
+  (dataState: RunsDataState): GroupBy | null => {
+    return dataState.userSetGroupBy ?? null;
+  }
+);
+
+/**
  * Returns current run grouping setting.
  */
 export const getRunGroupBy = createSelector(
+  getRunUserSetGroupBy,
   getDataState,
-  (dataState: RunsDataState): GroupBy => {
-    return dataState.groupBy;
+  (userSetGroupBy: GroupBy | null, dataState: RunsDataState): GroupBy => {
+    return userSetGroupBy ?? dataState.initialGroupBy;
   }
 );
 

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -366,18 +366,61 @@ describe('runs_selectors', () => {
     );
   });
 
+  describe('#getRunUserSetGroupBy', () => {
+    beforeEach(() => {
+      // Clear the memoization.
+      selectors.getRunUserSetGroupBy.release();
+    });
+
+    it('returns groupBy set by user when it is present', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          userSetGroupBy: {
+            key: GroupByKey.REGEX,
+            regexString: 'hello',
+          },
+          initialGroupBy: {
+            key: GroupByKey.RUN,
+          },
+        })
+      );
+
+      expect(selectors.getRunUserSetGroupBy(state)).toEqual({
+        key: GroupByKey.REGEX,
+        regexString: 'hello',
+      });
+    });
+
+    it('returns null if user never has set one', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          userSetGroupBy: undefined,
+          initialGroupBy: {
+            key: GroupByKey.RUN,
+          },
+        })
+      );
+
+      expect(selectors.getRunUserSetGroupBy(state)).toBe(null);
+    });
+  });
+
   describe('#getRunGroupBy', () => {
     beforeEach(() => {
       // Clear the memoization.
+      selectors.getRunUserSetGroupBy.release();
       selectors.getRunGroupBy.release();
     });
 
-    it('returns color map by runs', () => {
+    it('returns groupBy set by user when it is present', () => {
       const state = buildStateFromRunsState(
         buildRunsState({
-          groupBy: {
+          userSetGroupBy: {
             key: GroupByKey.REGEX,
             regexString: 'hello',
+          },
+          initialGroupBy: {
+            key: GroupByKey.RUN,
           },
         })
       );
@@ -385,6 +428,21 @@ describe('runs_selectors', () => {
       expect(selectors.getRunGroupBy(state)).toEqual({
         key: GroupByKey.REGEX,
         regexString: 'hello',
+      });
+    });
+
+    it('returns initial group by if user never has set one', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          userSetGroupBy: undefined,
+          initialGroupBy: {
+            key: GroupByKey.RUN,
+          },
+        })
+      );
+
+      expect(selectors.getRunGroupBy(state)).toEqual({
+        key: GroupByKey.RUN,
       });
     });
   });

--- a/tensorboard/webapp/runs/store/runs_types.ts
+++ b/tensorboard/webapp/runs/store/runs_types.ts
@@ -50,7 +50,8 @@ export interface RunsDataRoutefulState {
   defaultRunColorForGroupBy: Map<RunId, string>;
   runColorOverrideForGroupBy: Map<RunId, string>;
   groupKeyToColorString: Map<string, string>;
-  groupBy: GroupBy;
+  userSetGroupBy?: GroupBy;
+  initialGroupBy: GroupBy;
 }
 
 export interface RunsDataRoutelessState {

--- a/tensorboard/webapp/runs/store/testing.ts
+++ b/tensorboard/webapp/runs/store/testing.ts
@@ -59,7 +59,7 @@ export function buildRunsState(
       runColorOverrideForGroupBy: new Map(),
       defaultRunColorForGroupBy: new Map(),
       groupKeyToColorString: new Map(),
-      groupBy: {key: GroupByKey.RUN},
+      initialGroupBy: {key: GroupByKey.RUN},
       ...dataOverride,
     },
     ui: {


### PR DESCRIPTION
When we work on our setting persistence, we want to be able to change
our default behavior. However, if we always persist the groupBy value in
the store to the URL, current business logic will be ingrained into
every dashboard URLs and its bookmark can lead to a case where we cannot
change our default behavior.

this change simply refactors so initial value of `groupBy` is separated
from the overridden value.
