### PR TITLE
timeseries: fix runs table scrollable issue

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -20,14 +20,19 @@ $_font-size: 13px;
 
 :host {
   background-color: #fff;
-  display: block;
+  display: flex;
+  flex-direction: column;
   font-size: $_font-size;
   overflow: hidden;
 }
 
+.filter-row {
+  flex: none;
+}
+
 .table-container {
   contain: layout paint;
-  height: 100%;
+  flex-grow: 1;
   max-width: 100%;
   overflow-x: auto;
   overflow-y: auto;


### PR DESCRIPTION
When a `<runs-table-component>` has height = 100px, the .table-container
also had height = 100px which is not what we intended. We intended it to
have 100px - heightOfFilterRow. We now use the proper flex syntax for
the proper layout.

This purely visual bug is hard to test in unit test and will be covered
via screenshot tests internally.

Fixes #5019.

