### PR TITLE
sync: add missing ngrx/store/testing dep

### DIFF
--- a/tensorboard/webapp/metrics/data_source/BUILD
+++ b/tensorboard/webapp/metrics/data_source/BUILD
@@ -61,6 +61,7 @@ tf_ts_library(
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/feature_flag:testing",
         "//tensorboard/webapp/metrics:internal_types",
         "//tensorboard/webapp/util:local_storage_testing",


### PR DESCRIPTION
metrics_data_source_test now has dependency on the @ngrx/store/testing.
