### PR TITLE
runs: fix run filter click target width

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -127,6 +127,10 @@ $_border-color: #0000001f;
   height: 48px;
   padding: 0 16px 0 21px;
   border-bottom: 1px solid mat-color($tb-foreground, border);
+
+  tb-filter-input {
+    flex-grow: 1;
+  }
 }
 
 // Prevents the table column for checkbox and run_color from growing beyond


### PR DESCRIPTION
Recently [1], we introduced a `<tb-input-filter>` component that replaced
the runs selector's filter input field in Time Series. That change included a
regression where the input's click target was no longer full width.

This change restores the full width click target.

Manually ran `bazel tensorboard:dev` and checked that clicking in the
space to the right of the placeholder text still focuses the run selector's
input field in the Time Series dashboard.

This bug was discovered in an offline bug hunt.

[1] https://github.com/tensorflow/tensorboard/pull/4938