### PR TITLE
color grouping: move regexfilter attribute from runUi to runData

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -253,7 +253,13 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
     nextRunColorOverride.set(runId, newColor);
 
     return {...state, runColorOverrideForGroupBy: nextRunColorOverride};
-  })
+  }),
+  on(runsActions.runSelectorRegexFilterChanged, (state, action) => {
+    return {
+      ...state,
+      regexFilter: action.regexString,
+    };
+  }),
 );
 
 const routeStatefulDataReducers = composeReducers(
@@ -274,7 +280,6 @@ const {
       pageIndex: 0,
       pageSize: 10,
     },
-    regexFilter: '',
     sort: initialSort,
   },
   {}
@@ -297,7 +302,6 @@ const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(
   on(runsActions.runSelectorRegexFilterChanged, (state, action) => {
     return {
       ...state,
-      regexFilter: action.regexString,
       paginationOption: {
         ...state.paginationOption,
         // Reset the page index to 0 to emulate mat-table behavior.

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -259,7 +259,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
       ...state,
       regexFilter: action.regexString,
     };
-  }),
+  })
 );
 
 const routeStatefulDataReducers = composeReducers(

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -47,6 +47,8 @@ const {
     defaultRunColorForGroupBy: new Map(),
     groupKeyToColorString: new Map(),
     initialGroupBy: {key: GroupByKey.RUN},
+    colorGroupRegexString: '',
+    regexFilter: '',
   },
   {
     runIds: {},

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -611,21 +611,20 @@ describe('runs_reducers', () => {
 
   describe('runSelectorRegexFilterChanged', () => {
     it('updates the regex filter', () => {
-      const state = buildRunsState(undefined, {
+      const state = buildRunsState( {
         regexFilter: 'foo',
-      });
+      },undefined,);
 
       const nextState = runsReducers.reducers(
         state,
         actions.runSelectorRegexFilterChanged({regexString: 'foo rocks'})
       );
 
-      expect(nextState.ui.regexFilter).toBe('foo rocks');
+      expect(nextState.data.regexFilter).toBe('foo rocks');
     });
 
     it('resets the pagination index', () => {
-      const state = buildRunsState(undefined, {
-        regexFilter: 'foo',
+      const state = buildRunsState({regexFilter: 'foo'}, {
         paginationOption: {
           pageSize: 10,
           pageIndex: 100,

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -611,9 +611,12 @@ describe('runs_reducers', () => {
 
   describe('runSelectorRegexFilterChanged', () => {
     it('updates the regex filter', () => {
-      const state = buildRunsState( {
-        regexFilter: 'foo',
-      },undefined,);
+      const state = buildRunsState(
+        {
+          regexFilter: 'foo',
+        },
+        undefined
+      );
 
       const nextState = runsReducers.reducers(
         state,
@@ -624,12 +627,15 @@ describe('runs_reducers', () => {
     });
 
     it('resets the pagination index', () => {
-      const state = buildRunsState({regexFilter: 'foo'}, {
-        paginationOption: {
-          pageSize: 10,
-          pageIndex: 100,
-        },
-      });
+      const state = buildRunsState(
+        {regexFilter: 'foo'},
+        {
+          paginationOption: {
+            pageSize: 10,
+            pageIndex: 100,
+          },
+        }
+      );
 
       const nextState = runsReducers.reducers(
         state,

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -141,6 +141,16 @@ export const getRunGroupBy = createSelector(
   }
 );
 
+/**
+ * Returns Observable that emits regex filter on the run selector.
+ */
+export const getRunSelectorRegexFilter = createSelector(
+  getDataState,
+  (state: RunsDataState): string => {
+    return state.regexFilter;
+  }
+);
+
 const getUiState = createSelector(
   getRunsState,
   (state: RunsState): RunsUiState => {
@@ -155,16 +165,6 @@ export const getRunSelectorPaginationOption = createSelector(
   getUiState,
   (state: RunsUiState): {pageIndex: number; pageSize: number} => {
     return state.paginationOption;
-  }
-);
-
-/**
- * Returns Observable that emits regex filter on the run selector.
- */
-export const getRunSelectorRegexFilter = createSelector(
-  getUiState,
-  (state: RunsUiState): string => {
-    return state.regexFilter;
   }
 );
 

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -290,7 +290,7 @@ describe('runs_selectors', () => {
 
     it('returns regex filter', () => {
       const state = buildStateFromRunsState(
-        buildRunsState(undefined, {regexFilter: 'meow'})
+        buildRunsState({regexFilter: 'meow'}, undefined)
       );
 
       expect(selectors.getRunSelectorRegexFilter(state)).toBe('meow');

--- a/tensorboard/webapp/runs/store/runs_types.ts
+++ b/tensorboard/webapp/runs/store/runs_types.ts
@@ -52,6 +52,8 @@ export interface RunsDataRoutefulState {
   groupKeyToColorString: Map<string, string>;
   userSetGroupBy?: GroupBy;
   initialGroupBy: GroupBy;
+  colorGroupRegexString: string;
+  regexFilter: string;
 }
 
 export interface RunsDataRoutelessState {
@@ -82,7 +84,6 @@ export type RunsDataState = RouteContextedState<
 
 export interface RunsUiRoutefulState {
   paginationOption: {pageIndex: number; pageSize: number};
-  regexFilter: string;
   sort: {key: SortKey | null; direction: SortDirection};
 }
 

--- a/tensorboard/webapp/runs/store/testing.ts
+++ b/tensorboard/webapp/runs/store/testing.ts
@@ -60,11 +60,12 @@ export function buildRunsState(
       defaultRunColorForGroupBy: new Map(),
       groupKeyToColorString: new Map(),
       initialGroupBy: {key: GroupByKey.RUN},
+      colorGroupRegexString: '',
+      regexFilter: '',
       ...dataOverride,
     },
     ui: {
       paginationOption: {pageIndex: 0, pageSize: 0},
-      regexFilter: '',
       sort: {key: null, direction: SortDirection.UNSET},
       ...uiOverride,
     },


### PR DESCRIPTION
* Motivation for features / changes
One of the two color grouping by regex ui option is to align the filter run regex and color grouping regex.
Move the regexFilter attribute from ui state to data state.

