### PR TITLE
infra: add customization component

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -287,6 +287,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/core/effects:core_effects_test_lib",
         "//tensorboard/webapp/core/store:core_store_test_lib",
         "//tensorboard/webapp/core/views:test_lib",
+        "//tensorboard/webapp/customization:customization_test_lib",
         "//tensorboard/webapp/deeplink:deeplink_test_lib",
         "//tensorboard/webapp/feature_flag/effects:effects_test_lib",
         "//tensorboard/webapp/feature_flag/store:store_test_lib",

--- a/tensorboard/webapp/customization/BUILD
+++ b/tensorboard/webapp/customization/BUILD
@@ -1,0 +1,26 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_ng_module(
+    name = "customization",
+    srcs = [
+        "customizable_component.ts",
+        "customization_module.ts",
+    ],
+    deps = [     
+        "@npm//@angular/common",   
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ng_module(
+    name = "customization_test_lib",
+    testonly = True,
+    srcs = ["customization_test.ts"],
+    deps = [
+        ":customization",
+        "@npm//@angular/core",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/customization/BUILD
+++ b/tensorboard/webapp/customization/BUILD
@@ -8,8 +8,8 @@ tf_ng_module(
         "customizable_component.ts",
         "customization_module.ts",
     ],
-    deps = [     
-        "@npm//@angular/common",   
+    deps = [
+        "@npm//@angular/common",
         "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -29,49 +29,48 @@ import {
  *
  * Cookbook:
  *
- * 1. Define an empty marker class that a Component will have to implement in
- *    order to be recognized as the customization:
+ * 1. Define a customizable Component, for example a button:
  *
- *    export class SomeCustomComponentType {};
+ *    const CustomizableButton = new InjectionToken<Type<unknown>>('Customizable Button');
  *
  * 2. Where the customization point is desired, use this Component to wrap some
  *    default behavior. Bind to some possibly-empty variable with the
  *    [customizableComponent] attribute:
  *
- *    <tb-customization [customizableComponent]="customComponentIfProvided">
- *      <div>This is the default content.</div>
+ *    <tb-customization [customizableComponent]="customButtonIfProvided">
+ *      <button mat-button>I am the default button.</button>
  *    </tb-customization>
  *
  * 3. In the constructor of the component containing the customization point,
- *    optionally inject an instance of SomeCustomComponentType:
+ *    optionally inject a custom button:
  *
  *    constructor(
- *        @Optional readonly customComponentIfProvided: SomeCustomComponentType)
+ *      @Optional() @Inject(CustomizableButton)
+ *      readonly customButtonIfProvided: Type<unknown>)
  *
  * If you do not wish to customize the behavior for a certain TensorBoard
- * service, you're done. The TensorBoard service will receive the default
- * behavior.
+ * service (in this case, a button), you're done. The TensorBoard service
+ * will receive the default behavior.
  *
- * However, if you need to define a customization for a TensorBoard service:
+ * However, if you need to define a customization for the button:
  *
- * 4. Define a Component implementation of SomeCustomComponentType with the
- *    customized behavior:
+ * 4. Define a Component with your customization:
  *
  *    @Injectable()
  *    @Component({
- *      selector: 'my-custom-component',
- *      template: '<div>This is the customized content.</div>'
- *    });
- *    export class MyCustomComponent implements SomeCustomComponentType {}
+ *      selector: 'my-custom-button-component',
+ *      template: '<button mat-button>I am a special button!</button>'
+ *    })
+ *    export class MyCustomButtonComponent {}
  *
  * 5. Provide the customized Component in an NgModule:
  *
  *    @NgModule({
- *      declarations: [MyCustomComponent],
- *      entryComponents: [MyCustomComponent],
+ *      declarations: [MyCustomButtonComponent],
+ *      entryComponents: [MyCustomButtonComponent],
  *      providers: [{
- *        provide: SomeCustomComponentType,
- *        useClass: MyCustomComponent,
+ *        provide: CustomizableButton,
+ *        useClass: MyCustomButtonComponent,
  *      }]
  *    })
  */

--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -83,7 +83,7 @@ import {
   `,
 })
 export class CustomizableComponent implements OnInit {
-  @Input() customizableComponent!: {constructor: Type<unknown>} | null;
+  @Input() customizableComponent!: {constructor: Type<unknown>} | undefined;
 
   constructor(
     private readonly viewContainerRef: ViewContainerRef,

--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -12,7 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, ComponentFactoryResolver, Input, OnInit, Type, ViewContainerRef} from '@angular/core';
+import {
+  Component,
+  ComponentFactoryResolver,
+  Input,
+  OnInit,
+  Type,
+  ViewContainerRef,
+} from '@angular/core';
 
 /**
  * A Component that defines a customization point. Ideal for use for small
@@ -71,23 +78,24 @@ import {Component, ComponentFactoryResolver, Input, OnInit, Type, ViewContainerR
 @Component({
   selector: 'tb-customization',
   template: `
-      <ng-container *ngIf="!customizableComponent">
-        <ng-content></ng-content>
-      </ng-container>
+    <ng-container *ngIf="!customizableComponent">
+      <ng-content></ng-content>
+    </ng-container>
   `,
 })
 export class CustomizableComponent implements OnInit {
   @Input() customizableComponent!: {constructor: Type<unknown>} | null;
 
   constructor(
-      private readonly viewContainerRef: ViewContainerRef,
-      private readonly componentFactoryResolver: ComponentFactoryResolver) {}
+    private readonly viewContainerRef: ViewContainerRef,
+    private readonly componentFactoryResolver: ComponentFactoryResolver
+  ) {}
 
   ngOnInit() {
     if (this.customizableComponent) {
-      const componentFactory =
-          this.componentFactoryResolver.resolveComponentFactory(
-              this.customizableComponent.constructor);
+      const componentFactory = this.componentFactoryResolver.resolveComponentFactory(
+        this.customizableComponent.constructor
+      );
       this.viewContainerRef.createComponent(componentFactory);
     }
   }

--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -1,0 +1,94 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Component, ComponentFactoryResolver, Input, OnInit, Type, ViewContainerRef} from '@angular/core';
+
+/**
+ * A Component that defines a customization point. Ideal for use for small
+ * surgical customizations deep within the component hierarchy. The
+ * customizations can be provided dynamically via Angular dependency injection
+ * and providers.
+ *
+ * Cookbook:
+ *
+ * 1. Define an empty marker class that a Component will have to implement in
+ *    order to be recognized as the customization:
+ *
+ *    export class SomeCustomComponentType {};
+ *
+ * 2. Where the customization point is desired, use this Component to wrap some
+ *    default behavior. Bind to some possibly-empty variable with the
+ *    [customizableComponent] attribute:
+ *
+ *    <tb-customization [customizableComponent]="customComponentIfProvided">
+ *      <div>This is the default content.</div>
+ *    </tb-customization>
+ *
+ * 3. In the constructor of the component containing the customization point,
+ *    optionally inject an instance of SomeCustomComponentType:
+ *
+ *    constructor(
+ *        @Optional readonly customComponentIfProvided: SomeCustomComponentType)
+ *
+ * If you do not wish to customize the behavior for a certain TensorBoard
+ * service, you're done. The TensorBoard service will receive the default
+ * behavior.
+ *
+ * However, if you need to define a customization for a TensorBoard service:
+ *
+ * 4. Define a Component implementation of SomeCustomComponentType with the
+ *    customized behavior:
+ *
+ *    @Injectable()
+ *    @Component({
+ *      selector: 'my-custom-component',
+ *      template: '<div>This is the customized content.</div>'
+ *    });
+ *    export class MyCustomComponent implements SomeCustomComponentType {}
+ *
+ * 5. Provide the customized Component in an NgModule:
+ *
+ *    @NgModule({
+ *      declarations: [MyCustomComponent],
+ *      entryComponents: [MyCustomComponent],
+ *      providers: [{
+ *        provide: SomeCustomComponentType,
+ *        useClass: MyCustomComponent,
+ *      }]
+ *    })
+ */
+@Component({
+  selector: 'tb-customization',
+  template: `
+      <ng-container *ngIf="!customizableComponent">
+        <ng-content></ng-content>
+      </ng-container>
+  `,
+})
+export class CustomizableComponent implements OnInit {
+  @Input() customizableComponent!: {constructor: Type<unknown>} | null;
+
+  constructor(
+      private readonly viewContainerRef: ViewContainerRef,
+      private readonly componentFactoryResolver: ComponentFactoryResolver) {}
+
+  ngOnInit() {
+    if (this.customizableComponent) {
+      const componentFactory =
+          this.componentFactoryResolver.resolveComponentFactory(
+              this.customizableComponent.constructor);
+      this.viewContainerRef.createComponent(componentFactory);
+    }
+  }
+}

--- a/tensorboard/webapp/customization/customization_module.ts
+++ b/tensorboard/webapp/customization/customization_module.ts
@@ -22,5 +22,4 @@ import {CustomizableComponent} from './customizable_component';
   declarations: [CustomizableComponent],
   exports: [CustomizableComponent],
 })
-export class CustomizationModule {
-}
+export class CustomizationModule {}

--- a/tensorboard/webapp/customization/customization_module.ts
+++ b/tensorboard/webapp/customization/customization_module.ts
@@ -1,0 +1,26 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {CustomizableComponent} from './customizable_component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [CustomizableComponent],
+  exports: [CustomizableComponent],
+})
+export class CustomizationModule {
+}

--- a/tensorboard/webapp/customization/customization_test.ts
+++ b/tensorboard/webapp/customization/customization_test.ts
@@ -1,0 +1,121 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Component, NgModule, Optional} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+import {CustomizationModule} from './customization_module';
+
+/**
+ * Marker class for the component that can be customized in these tests.
+ * Customizations should implement this type and be provided.
+ */
+export class CustomizableComponentType {}
+
+/**
+ * Parent class that uses the <tb-customization> component.
+ */
+ @Component({
+  selector: 'parent-component',
+  template: `
+      <tb-customization [customizableComponent]="customizableComponent">
+        <div class="default">Showing Default Text!</div>
+      </tb-customization>
+  `
+})
+export class ParentComponent {
+  constructor(@Optional() readonly customizableComponent:
+                  CustomizableComponentType) {}
+}
+
+/**
+ * Imports CustomizationModule for ParentComponent.
+ */
+@NgModule({
+  imports: [CustomizationModule],
+  declarations: [ParentComponent],
+  entryComponents: [ParentComponent],
+})
+export class ParentComponentModule {
+}
+
+/**
+ * An implementation of CustomizableComponentType to be provided and injected
+ * into the ParentComponent for some tests.
+ */
+@Component({
+  selector: 'customizable-component',
+  template: `
+      <div>Showing Customized Text!</div>
+  `
+})
+export class CustomizableComponent implements CustomizableComponentType {
+}
+
+/**
+ * Declares and provides the implementation of CustomizableComponentType.
+ */
+@NgModule({
+  declarations: [CustomizableComponent],
+  entryComponents: [CustomizableComponent],
+  providers: [{
+    provide: CustomizableComponentType,
+    useClass: CustomizableComponent,
+  }]
+})
+export class CustomizableComponentModule {
+}
+
+describe('tb-customization', () => {
+  it('renders default if no customization provided', async () => {
+    await TestBed
+        .configureTestingModule({
+          imports: [
+            CustomizationModule,
+            // Note: Notably not importing the module that provides the
+            // implementation of CustomizableComponentType.
+          ],
+          declarations: [
+            ParentComponent,
+          ],
+        })
+        .compileComponents();
+
+    const fixture = TestBed.createComponent(ParentComponent);
+    fixture.detectChanges();
+    expect(fixture.debugElement.nativeElement.textContent)
+        .toBe('Showing Default Text!');
+  });
+
+  it('renders customization if provided', async () => {
+    await TestBed
+        .configureTestingModule({
+          imports: [
+            CustomizationModule,
+            // In this test we import the Module that provides an implementation
+            // of CustomizableComponentType.
+            CustomizableComponentModule,
+          ],
+          declarations: [
+            ParentComponent,
+          ],
+        })
+        .compileComponents();
+
+    const fixture = TestBed.createComponent(ParentComponent);
+    fixture.detectChanges();
+    expect(fixture.debugElement.nativeElement.textContent)
+        .toBe('Showing Customized Text!');
+  });
+});

--- a/tensorboard/webapp/customization/customization_test.ts
+++ b/tensorboard/webapp/customization/customization_test.ts
@@ -26,17 +26,18 @@ export class CustomizableComponentType {}
 /**
  * Parent class that uses the <tb-customization> component.
  */
- @Component({
+@Component({
   selector: 'parent-component',
   template: `
-      <tb-customization [customizableComponent]="customizableComponent">
-        <div class="default">Showing Default Text!</div>
-      </tb-customization>
-  `
+    <tb-customization [customizableComponent]="customizableComponent">
+      <div class="default">Showing Default Text!</div>
+    </tb-customization>
+  `,
 })
 export class ParentComponent {
-  constructor(@Optional() readonly customizableComponent:
-                  CustomizableComponentType) {}
+  constructor(
+    @Optional() readonly customizableComponent: CustomizableComponentType
+  ) {}
 }
 
 /**
@@ -47,8 +48,7 @@ export class ParentComponent {
   declarations: [ParentComponent],
   entryComponents: [ParentComponent],
 })
-export class ParentComponentModule {
-}
+export class ParentComponentModule {}
 
 /**
  * An implementation of CustomizableComponentType to be provided and injected
@@ -56,12 +56,9 @@ export class ParentComponentModule {
  */
 @Component({
   selector: 'customizable-component',
-  template: `
-      <div>Showing Customized Text!</div>
-  `
+  template: ` <div>Showing Customized Text!</div> `,
 })
-export class CustomizableComponent implements CustomizableComponentType {
-}
+export class CustomizableComponent implements CustomizableComponentType {}
 
 /**
  * Declares and provides the implementation of CustomizableComponentType.
@@ -69,53 +66,48 @@ export class CustomizableComponent implements CustomizableComponentType {
 @NgModule({
   declarations: [CustomizableComponent],
   entryComponents: [CustomizableComponent],
-  providers: [{
-    provide: CustomizableComponentType,
-    useClass: CustomizableComponent,
-  }]
+  providers: [
+    {
+      provide: CustomizableComponentType,
+      useClass: CustomizableComponent,
+    },
+  ],
 })
-export class CustomizableComponentModule {
-}
+export class CustomizableComponentModule {}
 
 describe('tb-customization', () => {
   it('renders default if no customization provided', async () => {
-    await TestBed
-        .configureTestingModule({
-          imports: [
-            CustomizationModule,
-            // Note: Notably not importing the module that provides the
-            // implementation of CustomizableComponentType.
-          ],
-          declarations: [
-            ParentComponent,
-          ],
-        })
-        .compileComponents();
+    await TestBed.configureTestingModule({
+      imports: [
+        CustomizationModule,
+        // Note: Notably not importing the module that provides the
+        // implementation of CustomizableComponentType.
+      ],
+      declarations: [ParentComponent],
+    }).compileComponents();
 
     const fixture = TestBed.createComponent(ParentComponent);
     fixture.detectChanges();
-    expect(fixture.debugElement.nativeElement.textContent)
-        .toBe('Showing Default Text!');
+    expect(fixture.debugElement.nativeElement.textContent).toBe(
+      'Showing Default Text!'
+    );
   });
 
   it('renders customization if provided', async () => {
-    await TestBed
-        .configureTestingModule({
-          imports: [
-            CustomizationModule,
-            // In this test we import the Module that provides an implementation
-            // of CustomizableComponentType.
-            CustomizableComponentModule,
-          ],
-          declarations: [
-            ParentComponent,
-          ],
-        })
-        .compileComponents();
+    await TestBed.configureTestingModule({
+      imports: [
+        CustomizationModule,
+        // In this test we import the Module that provides an implementation
+        // of CustomizableComponentType.
+        CustomizableComponentModule,
+      ],
+      declarations: [ParentComponent],
+    }).compileComponents();
 
     const fixture = TestBed.createComponent(ParentComponent);
     fixture.detectChanges();
-    expect(fixture.debugElement.nativeElement.textContent)
-        .toBe('Showing Customized Text!');
+    expect(fixture.debugElement.nativeElement.textContent).toBe(
+      'Showing Customized Text!'
+    );
   });
 });

--- a/tensorboard/webapp/customization/customization_test.ts
+++ b/tensorboard/webapp/customization/customization_test.ts
@@ -30,7 +30,8 @@ export class CustomizableComponentType {}
   selector: 'parent-component',
   template: `
     <tb-customization [customizableComponent]="customizableComponent">
-      <div class="default">Showing Default Text!</div>
+      <span>Showing </span>
+      <span>Default Text!</span>
     </tb-customization>
   `,
 })
@@ -58,7 +59,7 @@ export class ParentComponentModule {}
   selector: 'customizable-component',
   template: ` <div>Showing Customized Text!</div> `,
 })
-export class CustomizableComponent implements CustomizableComponentType {}
+export class CustomizableComponent {}
 
 /**
  * Declares and provides the implementation of CustomizableComponentType.
@@ -75,16 +76,16 @@ export class CustomizableComponent implements CustomizableComponentType {}
 })
 export class CustomizableComponentModule {}
 
+async function setUp(extraImports: any[] = []) {
+  await TestBed.configureTestingModule({
+    imports: [CustomizationModule, ...extraImports],
+    declarations: [ParentComponent],
+  }).compileComponents();
+}
+
 describe('tb-customization', () => {
   it('renders default if no customization provided', async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        CustomizationModule,
-        // Note: Notably not importing the module that provides the
-        // implementation of CustomizableComponentType.
-      ],
-      declarations: [ParentComponent],
-    }).compileComponents();
+    await setUp();
 
     const fixture = TestBed.createComponent(ParentComponent);
     fixture.detectChanges();
@@ -94,15 +95,9 @@ describe('tb-customization', () => {
   });
 
   it('renders customization if provided', async () => {
-    await TestBed.configureTestingModule({
-      imports: [
-        CustomizationModule,
-        // In this test we import the Module that provides an implementation
-        // of CustomizableComponentType.
-        CustomizableComponentModule,
-      ],
-      declarations: [ParentComponent],
-    }).compileComponents();
+    // In this test we import the Module that provides an implementation
+    // of CustomizableComponentType.
+    await setUp([CustomizableComponentModule]);
 
     const fixture = TestBed.createComponent(ParentComponent);
     fixture.detectChanges();


### PR DESCRIPTION
CustomizableComponent enables **dynamic customization** of components without having every single layer above it being aware of the change (see [Angular InjectionToken](https://angular.io/api/core/InjectionToken) for more details).

This is the first break-down step of @bmd3k's prototype for the customization approach. 

Example usage:

1. Define a customizable Component, for example adding a button:
    ```
    const CustomizableButton = new InjectionToken<Type<unknown>>('Customizable Button');
    ```

2. Where the customization point is desired, use `tb-customization` component to wrap some default behavior with the `[customizableComponent]` attribute:
     ```
     <tb-customization [customizableComponent]="customButtonIfProvided">
       <div>There is no button by default.</dev>
     </tb-customization>
    ```

3. In the constructor of the component containing the customization point, optionally inject a custom button:
    ```
    constructor(
      @Optional() @Inject(CustomizableButton) readonly customButtonIfProvided: Type<unknown>)
    ```

If you do not want any button, you're done. The TensorBoard service will use the default option (in this case displaying a message). However, if you need to add a button:

4. Define a Component with your customization:
    ```
    @Injectable()
    @Component({
       selector: 'my-custom-button-component',
       template: '<button mat-button>I am a special button!</button>'
    })
    export class MyCustomButtonComponent {}
    ```

5. Provide the customized Component in an NgModule:
    ```
    @NgModule({
      declarations: [MyCustomButtonComponent],
      entryComponents: [MyCustomButtonComponent],
      providers: [{
        provide: CustomizableButton,
        useClass: MyCustomButtonComponent,
      }]
    })
    ```