### PR TITLE
Fix BUILD for @angular/core/testing import.

### DIFF
--- a/tensorboard/webapp/customization/BUILD
+++ b/tensorboard/webapp/customization/BUILD
@@ -20,6 +20,7 @@ tf_ng_module(
     srcs = ["customization_test.ts"],
     deps = [
         ":customization",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
         "@npm//@angular/core",
         "@npm//@types/jasmine",
     ],


### PR DESCRIPTION
Explicit dependency `//tensorboard/webapp/angular:expect_angular_core_testing` for `import @angular/core/testing` is necessary for Google, (even thought it's not required for OSS).