### PR TITLE
styles: refactor how material comps are styled

### DIFF
--- a/tensorboard/webapp/styles.scss
+++ b/tensorboard/webapp/styles.scss
@@ -14,3 +14,5 @@ limitations under the License.
 ==============================================================================*/
 
 @import 'tensorboard/webapp/theme/tb_theme';
+
+@include tb-global-themed-styles();

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -57,5 +57,8 @@ $tb-theme: map_merge(
   )
 );
 
-// Include all theme-styles for the components based on the current theme.
-@include angular-material-theme($tb-theme);
+// Apply themed style for the global stylesheet (styles.scss).
+@mixin tb-global-themed-styles() {
+  // Include all theme-styles for the components based on the current theme.
+  @include angular-material-theme($tb-theme);
+}


### PR DESCRIPTION
Currently, loading the tb_themes SASS module re-creates Angular material
theme style rules and cause Angular inline CSSes to repeatedly include
those styles when the component actually use those material components.

