### PR TITLE
dark mode: disable media query based feature

### DIFF
--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -84,7 +84,9 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
 
     // When media query matches positively, it certainly means user wants it but
     // it is not definitive otherwise (i.e., query params can override it).
-    if (enableDarkMode) {
+    // TODO(stephanwlee): enable the feature when most of the UI is actually
+    // ready for usage.
+    if (enableDarkMode && false) {
       featureFlags.enableDarkMode = true;
     }
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -123,11 +123,9 @@ describe('tb_feature_flag_data_source', () => {
 
         it('returns enableDarkMode when media query matches dark mode', () => {
           fakeMediaQuery(true);
-          expect(dataSource.getFeatures()).toEqual({
-            // TODO(stephanwlee): the feature is hard disabled for now until it
-            // actually ready. Expect this value to be `true` when ready.
-            enableDarkMode: false,
-          });
+          // TODO(stephanwlee): the feature is hard disabled for now until it
+          // actually ready. Expect this value to be `true` when ready.
+          expect(dataSource.getFeatures()).toEqual({});
         });
 
         it(

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -121,11 +121,12 @@ describe('tb_feature_flag_data_source', () => {
             .and.returnValue({matches: matchDarkMode} as MediaQueryList);
         }
 
-        // TODO(stephanwlee): disabled while working on the feature.
-        xit('returns enableDarkMode when media query matches dark mode', () => {
+        it('returns enableDarkMode when media query matches dark mode', () => {
           fakeMediaQuery(true);
           expect(dataSource.getFeatures()).toEqual({
-            enableDarkMode: true,
+            // TODO(stephanwlee): the feature is hard disabled for now until it
+            // actually ready. Expect this value to be `true` when ready.
+            enableDarkMode: false,
           });
         });
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -121,7 +121,8 @@ describe('tb_feature_flag_data_source', () => {
             .and.returnValue({matches: matchDarkMode} as MediaQueryList);
         }
 
-        it('returns enableDarkMode when media query matches dark mode', () => {
+        // TODO(stephanwlee): disabled while working on the feature.
+        xit('returns enableDarkMode when media query matches dark mode', () => {
           fakeMediaQuery(true);
           expect(dataSource.getFeatures()).toEqual({
             enableDarkMode: true,


### PR DESCRIPTION
We are not actually ready to turn on the feature in OSS for people who
are using media query and is using tb-nightly regularly. Until we are
more ready with integration tests, we will disable the media query based
automatic enablement of the dark mode feature.
mode feature
