### PR TITLE
dark mode: enable dark mode at PluginComponent

### DIFF
--- a/tensorboard/components/tf_dashboard_common/dashboard-style.ts
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.ts
@@ -64,7 +64,7 @@ registerStyleDomModule({
       }
 
       .sidebar-section {
-        border-top: solid 1px rgba(0, 0, 0, 0.12);
+        border-top: solid 1px var(--tb-ui-border);
         margin-right: 10px;
         padding: var(--sidebar-vertical-padding) 0
           var(--sidebar-vertical-padding) var(--sidebar-left-padding);
@@ -99,7 +99,7 @@ registerStyleDomModule({
       }
 
       .sidebar-section h3 {
-        color: var(--paper-grey-800);
+        color: var(--tb-secondary-text-color);
         display: block;
         font-size: 14px;
         font-weight: normal;

--- a/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
+++ b/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
@@ -24,7 +24,21 @@ style.textContent = `
     --tb-grey-lighter: #f3f3f3;
     --tb-ui-dark-accent: #757575;
     --tb-ui-light-accent: #e0e0e0;
+    --tb-ui-border: var(--paper-grey-300);
     --tb-graph-faded: #e0d4b3;
+    --tb-secondary-text-color: var(--paper-grey-800);
+    --tb-raised-button-shadow-color: rgba(0, 0, 0, 0.2);
+    --primary-background-color: #fff;
+  }
+
+  :root .dark-mode {
+    --tb-ui-border: var(--paper-grey-700);
+    --tb-ui-dark-accent: var(--paper-grey-400);
+    --tb-ui-light-accent: var(--paper-grey-600);
+    --tb-secondary-text-color: var(--paper-grey-400);
+    --tb-raised-button-shadow-color: rgba(255, 255, 255, 0.5);
+    --primary-text-color: #fff;
+    --primary-background-color: #303030;  /* material grey A400. */
   }
 `;
 document.head.appendChild(style);

--- a/tensorboard/components/tf_dashboard_common/tf-option-selector.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-option-selector.ts
@@ -46,7 +46,7 @@ class TfOptionSelector extends LegacyElementMixin(PolymerElement) {
       }
 
       h3 {
-        color: var(--paper-grey-800);
+        color: var(--tb-secondary-text-color);
         display: block;
         font-size: 14px;
         font-weight: normal;

--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.ts
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.ts
@@ -146,13 +146,14 @@ class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
       }
 
       .heading {
-        background-color: white;
+        background-color: inherit;
         border: none;
+        color: inherit;
         cursor: pointer;
         width: 100%;
         font-size: 15px;
         line-height: 1;
-        box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2);
+        box-shadow: 0 1px 5px var(--tb-raised-button-shadow-color);
         padding: 10px 15px;
         display: flex;
         align-items: center;
@@ -204,7 +205,7 @@ class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
       .content {
         display: flex;
         flex-direction: column;
-        background: white;
+        background: inherit;
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
         border-top: none;

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.ts
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.ts
@@ -76,12 +76,12 @@ class TfRunsSelector extends LegacyElementMixin(PolymerElement) {
         padding-bottom: 10px;
       }
       #top-text {
+        color: var(--tb-secondary-text-color);
         width: 100%;
         flex-grow: 0;
         flex-shrink: 0;
         padding-right: 16px;
         box-sizing: border-box;
-        color: var(--paper-grey-800);
       }
       tf-multi-checkbox {
         display: flex;
@@ -95,7 +95,7 @@ class TfRunsSelector extends LegacyElementMixin(PolymerElement) {
         color: var(--tb-ui-dark-accent);
       }
       #tooltip-help {
-        color: var(--paper-grey-800);
+        color: var(--tb-secondary-text-color);
         margin: 0;
         font-weight: normal;
         font-size: 14px;

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -144,6 +144,14 @@ class VzLineChart2<SeriesMetadata = {}> extends LegacyElementMixin(
         opacity: 0.2;
         stroke-width: 1px;
       }
+
+      .plottable .axis text {
+        fill: currentColor;
+      }
+
+      .plottable .gridlines line {
+        stroke: var(--tb-secondary-text-color);
+      }
     </style>
   `;
 

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-smoothing-input.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-smoothing-input.ts
@@ -50,7 +50,7 @@ class TfSmoothingInput extends PolymerElement {
     </div>
     <style>
       .title {
-        color: var(--paper-grey-800);
+        color: var(--tb-secondary-text-color);
         margin: 0;
         font-weight: normal;
         font-size: 14px;

--- a/tensorboard/webapp/metrics/views/metrics_container.scss
+++ b/tensorboard/webapp/metrics/views/metrics_container.scss
@@ -20,6 +20,7 @@ limitations under the License.
 }
 
 nav {
+  background-color: mat-color($tb-background, background);
   border-right: 1px solid mat-color($tb-foreground, border);
   flex: none;
   width: 340px;

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -1,8 +1,13 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
+
+tf_sass_binary(
+    name = "plugins_component_styles",
+    src = "plugins_component.scss",
+)
 
 tf_ng_module(
     name = "plugins",
@@ -12,6 +17,7 @@ tf_ng_module(
         "plugins_module.ts",
     ],
     assets = [
+        ":plugins_component_styles",
         "plugins_component.ng.html",
     ],
     deps = [

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -14,7 +14,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div #pluginContainer class="plugins">
+<div
+  #pluginContainer
+  [ngClass]="{
+    'plugins': true,
+    'is-first-party-plugin': (
+      activeKnownPlugin?.loading_mechanism.type !== LoadingMechanismType.IFRAME
+    )
+  }"
+>
   <!-- let Polymer-based components render from JS -->
   <!-- let iframe based component render from JS to prevent flickering from prop changes. -->
 

--- a/tensorboard/webapp/plugins/plugins_component.scss
+++ b/tensorboard/webapp/plugins/plugins_component.scss
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/plugins/plugins_component.scss
+++ b/tensorboard/webapp/plugins/plugins_component.scss
@@ -1,0 +1,63 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
+:host {
+  background-color: map-get($tb-background, background);
+  color: map-get($tb-foreground, text);
+  display: block;
+  position: relative;
+
+  @include tb-dark-theme {
+    // There is no great way to style iframe, especially given that they
+    // can generate nested iframes. Opt-out of styling non-first-party plugins for
+    // now.
+    .plugins.is-first-party-plugin {
+      background-color: map-get($tb-dark-background, background);
+      color: map-get($tb-dark-foreground, text);
+    }
+  }
+}
+
+.plugins {
+  height: 100%;
+  position: relative;
+}
+
+.warning {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.warning-message {
+  margin: 80px auto 0;
+  max-width: 540px;
+}
+
+.last-reload-time {
+  font-style: italic;
+}
+
+.plugins ::ng-deep {
+  iframe {
+    border: 0;
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+}

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -58,39 +58,7 @@ export enum PluginLoadState {
 @Component({
   selector: 'plugins-component',
   templateUrl: './plugins_component.ng.html',
-  styles: [
-    `
-      :host {
-        display: block;
-        position: relative;
-      }
-      .plugins {
-        height: 100%;
-        position: relative;
-      }
-      .warning {
-        background-color: #fff;
-        bottom: 0;
-        left: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
-      }
-      .warning-message {
-        margin: 80px auto 0;
-        max-width: 540px;
-      }
-      .last-reload-time {
-        font-style: italic;
-      }
-      .plugins ::ng-deep iframe {
-        border: 0;
-        display: block;
-        height: 100%;
-        width: 100%;
-      }
-    `,
-  ],
+  styleUrls: ['plugins_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PluginsComponent implements OnChanges {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -19,7 +19,6 @@ $_table-content-row-min-height: 43px;
 $_font-size: 13px;
 
 :host {
-  background-color: #fff;
   display: flex;
   flex-direction: column;
   font-size: $_font-size;

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -41,24 +41,33 @@ $tb-foreground: map_merge(
   )
 );
 
-$tb-background: map_merge(
-  $mat-light-theme-background,
-  (
-    // Default is `map.get($grey-palette, 50)`.
-    background: #fff
-  )
-);
-
 $tb-theme: map_merge(
   $tb-theme,
   (
-    background: $tb-background,
     foreground: $tb-foreground,
   )
 );
+
+$tb-background: map-get($tb-theme, background);
+
+$tb-dark-theme: mat-dark-theme($tb-primary, $tb-accent, $tb-warn);
+$tb-dark-foreground: map-get($tb-dark-theme, foreground);
+$tb-dark-background: map-get($tb-dark-theme, background);
+
+@mixin tb-dark-theme {
+  @at-root :host-context(body.dark-mode) #{&} {
+    @content;
+  }
+}
 
 // Apply themed style for the global stylesheet (styles.scss).
 @mixin tb-global-themed-styles() {
   // Include all theme-styles for the components based on the current theme.
   @include angular-material-theme($tb-theme);
+
+  @include tb-dark-theme {
+    background-color: map-get($tb-dark-background, background);
+
+    @include angular-material-theme($tb-dark-theme);
+  }
 }

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -40,15 +40,20 @@ $tb-foreground: map_merge(
     link: mat-color($mat-blue, 700),
   )
 );
+$tb-background: map_merge(
+  $mat-light-theme-background,
+  (
+    background: #fff,
+  )
+);
 
 $tb-theme: map_merge(
   $tb-theme,
   (
     foreground: $tb-foreground,
+    background: $tb-background,
   )
 );
-
-$tb-background: map-get($tb-theme, background);
 
 $tb-dark-theme: mat-dark-theme($tb-primary, $tb-accent, $tb-warn);
 $tb-dark-foreground: map-get($tb-dark-theme, foreground);


### PR DESCRIPTION
This change adds SASS variable for dark theme and conditionally applies
the dark modified styles on Angular Material components. This change
also adds imperfect theme supports on the Plugin stamper.

To exemplify its functionality, we have manually fixed the scalars
plugin as an experiment and added its changes accordingly.
After this change, scalars plugin look okay.

Do note that we had to adjust the colors to use one from variable and it
will cause certain colors to adjust in a minor way that would be caught
by the screenshot tests.