### PR TITLE
dark mode: fix hparams, graph, mesh, and profile

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
+++ b/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
@@ -29,6 +29,7 @@ style.textContent = `
     --tb-secondary-text-color: var(--paper-grey-800);
     --tb-raised-button-shadow-color: rgba(0, 0, 0, 0.2);
     --primary-background-color: #fff;
+    --secondary-background-color: #e9e9e9;
   }
 
   :root .dark-mode {
@@ -38,7 +39,9 @@ style.textContent = `
     --tb-secondary-text-color: var(--paper-grey-400);
     --tb-raised-button-shadow-color: rgba(255, 255, 255, 0.5);
     --primary-text-color: #fff;
+    --secondary-text-color: var(--paper-grey-400);
     --primary-background-color: #303030;  /* material grey A400. */
+    --secondary-background-color: #505050;
   }
 `;
 document.head.appendChild(style);

--- a/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
+++ b/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
@@ -41,7 +41,7 @@ style.textContent = `
     --primary-text-color: #fff;
     --secondary-text-color: var(--paper-grey-400);
     --primary-background-color: #303030;  /* material grey A400. */
-    --secondary-background-color: #505050;
+    --secondary-background-color: #3a3a3a;
   }
 `;
 document.head.appendChild(style);

--- a/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.ts
@@ -32,9 +32,14 @@ class TfDashboardLayout extends PolymerElement {
     <style include="scrollbar-style"></style>
     <style>
       :host {
+        background-color: #f5f5f5;
         display: flex;
         flex-direction: row;
         height: 100%;
+      }
+
+      :host-context(body.dark-mode) {
+        background-color: var(--secondary-background-color);
       }
 
       #sidebar {

--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.ts
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.ts
@@ -146,7 +146,7 @@ class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
       }
 
       .heading {
-        background-color: inherit;
+        background-color: var(--primary-background-color);
         border: none;
         color: inherit;
         cursor: pointer;
@@ -205,7 +205,7 @@ class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
       .content {
         display: flex;
         flex-direction: column;
-        background: inherit;
+        background-color: var(--primary-background-color);
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
         border-top: none;

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -17,6 +17,10 @@ import {html} from '@polymer/polymer';
 // Please keep node font-size/classnames in sync with tf-graph-common/common.ts
 export const template = html`
   <style>
+    :host-context(body.dark-mode) {
+      filter: invert(1);
+    }
+
     :host {
       display: flex;
       font-size: 20px;

--- a/tensorboard/plugins/graph/tf_graph_common/tf-graph-icon.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/tf-graph-icon.ts
@@ -36,6 +36,10 @@ class TfGraphIcon extends LegacyElementMixin(PolymerElement) {
         font-size: 0;
       }
 
+      :host-context(body.dark-mode) svg {
+        filter: invert(1);
+      }
+
       .faded-rect {
         fill: url(#rectHatch);
       }

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -113,16 +113,24 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
   static readonly template = html`
     <style>
       :host {
-        color: gray;
+        color: #555;
         display: flex;
         flex-direction: column;
         font-size: 12px;
         width: 100%;
+        --tb-graph-controls-title-color: #000;
+        --tb-graph-controls-legend-text-color: #000;
         --tb-graph-controls-text-color: #555;
         --tb-graph-controls-title-font-size: 14px;
         --tb-graph-controls-subtitle-font-size: 14px;
         --paper-input-container-shared-input-style_-_font-size: 14px;
         --paper-font-subhead_-_font-size: 14px;
+      }
+
+      :host-context(body.dark-mode) {
+        --tb-graph-controls-title-color: #fff;
+        --tb-graph-controls-legend-text-color: #f3f3f3;
+        --tb-graph-controls-text-color: #eee;
       }
 
       paper-dropdown-menu {
@@ -167,7 +175,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
       }
 
       .legend-holder {
-        background: #e9e9e9;
+        background: var(--secondary-background-color);
         box-sizing: border-box;
         color: var(--tb-graph-controls-text-color);
         width: 100%;
@@ -181,6 +189,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
         border-right: none;
         border-left: none;
         cursor: pointer;
+        color: var(--tb-graph-controls-legend-text-color);
         font: inherit;
         display: flex;
         align-items: center;
@@ -244,7 +253,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
       .title {
         font-size: var(--tb-graph-controls-title-font-size);
         margin: 8px 5px 8px 0;
-        color: black;
+        color: var(--tb-graph-controls-title-color);
       }
       .title small {
         font-weight: normal;

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.ts
@@ -31,6 +31,7 @@ class TfGraphInfo extends LegacyElementMixin(PolymerElement) {
   static readonly template = html`
     <style>
       :host {
+        background: var(--secondary-background-color);
         font-size: 12px;
         margin: 0;
         padding: 0;

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
@@ -50,7 +50,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
         float: left;
         width: 30%;
         word-wrap: break-word;
-        color: #565656;
+        color: var(--secondary-text-color);
         font-size: 11pt;
         font-weight: 400;
       }
@@ -58,7 +58,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
       .attr-right {
         margin-left: 30%;
         word-wrap: break-word;
-        color: #565656;
+        color: var(--secondary-text-color);
         font-weight: 400;
       }
 
@@ -76,7 +76,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
       }
 
       .sub-list-table-cell {
-        color: #565656;
+        color: var(--secondary-text-color);
         display: table-cell;
         font-size: 11pt;
         font-weight: 400;
@@ -86,7 +86,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
 
       paper-item {
         padding: 0;
-        background: #e9e9e9;
+        background: var(--primary-background-color);
       }
 
       paper-item-body[two-line] {
@@ -114,8 +114,8 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
       }
 
       .subtitle {
+        color: var(--secondary-text-color);
         font-size: 12pt;
-        color: #5e5e5e;
       }
 
       .controlLine {

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-list-item.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-list-item.ts
@@ -27,7 +27,7 @@ class TfNodeListItem extends LegacyElementMixin(PolymerElement) {
     <style>
       #list-item {
         width: 100%;
-        color: #565656;
+        color: var(--secondary-text-color);
         font-size: 11pt;
         font-weight: 400;
         position: relative;
@@ -36,6 +36,11 @@ class TfNodeListItem extends LegacyElementMixin(PolymerElement) {
 
       #list-item:hover {
         background-color: var(--google-yellow-100);
+      }
+
+      :host-context(body.dark-mode) #list-item:hover {
+        background-color: var(--paper-yellow-900);
+        color: #fff;
       }
 
       .clickable {

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
@@ -47,7 +47,7 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
 
       paper-item {
         padding: 0;
-        background: #e9e9e9;
+        background: var(--secondary-background-color);
       }
 
       paper-item-body[two-line] {
@@ -70,8 +70,8 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
       }
 
       .subtitle {
+        color: var(--secondary-text-color);
         font-size: 12pt;
-        color: #5e5e5e;
       }
 
       .toggle-button {
@@ -88,6 +88,14 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
       div.op-compat-display {
         margin-top: 10px;
         display: inline-block;
+      }
+
+      /**
+       * Sadly, because the whole body is inverted in color, legends also need
+       * to be inverted.
+       **/
+      :host-context(body.dark-mode) div.op-compat-display {
+        filter: invert(1);
       }
 
       svg.op-compat {

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-list-item.ts
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-list-item.ts
@@ -27,7 +27,7 @@ class TfGraphOpCompatListItem extends LegacyElementMixin(PolymerElement) {
     <style>
       #list-item {
         width: 100%;
-        color: #565656;
+        color: var(--secondary-text-color);
         font-size: 11pt;
         font-weight: 400;
         position: relative;

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
@@ -91,6 +91,12 @@ class TfHparamsParallelCoordsPlot extends LegacyElementMixin(PolymerElement) {
     <style>
       :host {
         display: block;
+        --tf-hparams-parallel-coords-plot-axis-shadow: 0 1px 0 #fff,
+          1px 0 0 #fff, 0 -1px 0 #fff, -1px 0 0 #fff;
+      }
+      :host-context(body.dark-mode) {
+        --tf-hparams-parallel-coords-plot-axis-shadow: 0 1px 0 #000,
+          1px 0 0 #000, 0 -1px 0 #000, -1px 0 0 #000;
       }
       svg {
         font: 10px sans-serif;
@@ -138,8 +144,8 @@ class TfHparamsParallelCoordsPlot extends LegacyElementMixin(PolymerElement) {
       }
 
       .axis text {
-        text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, 0 -1px 0 #fff, -1px 0 0 #fff;
-        fill: #000;
+        text-shadow: var(--tf-hparams-parallel-coords-plot-axis-shadow);
+        fill: currentColor;
         cursor: move;
       }
     </style>

--- a/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
@@ -47,6 +47,14 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
         font: 10px sans-serif;
       }
 
+      text {
+        fill: currentColor;
+      }
+
+      .frame rect {
+        stroke: currentColor;
+      }
+
       /* The closest data point marker to the mouse pointer. We use !important
          to override the inline style that sets the regular style of a marker.
       */

--- a/tensorboard/plugins/hparams/tf_hparams_table_view/tf-hparams-table-view.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_table_view/tf-hparams-table-view.ts
@@ -104,6 +104,16 @@ class TfHparamsTableView extends LegacyElementMixin(PolymerElement) {
       :host {
         display: inline;
       }
+
+      :host-context(body.dark-mode) {
+        --lumo-base-color: #303030;
+        --lumo-body-text-color: #fff;
+      }
+
+      :host-context(body.dark-mode) vaadin-grid {
+        --_lumo-grid-secondary-border-color: #505050;
+      }
+
       .table-cell {
         white-space: nowrap;
         text-overflow: ellipsis;

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-dashboard.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-dashboard.ts
@@ -164,8 +164,7 @@ class MeshDashboard extends PolymerElement {
         display: block;
         padding: 5px;
       }
-      .sidebar-section h3.title {
-        color: var(--paper-grey-800);
+      .sidebar-section h3 {
         margin: 0;
         font-weight: normal;
         font-size: 14px;

--- a/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.ts
+++ b/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.ts
@@ -49,6 +49,15 @@ class TfProfileRedirectDashboard extends LegacyElementMixin(PolymerElement) {
     </div>
 
     <style>
+      :host {
+        display: block;
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+      }
+
       .message {
         margin: 80px auto 0 auto;
         max-width: 540px;

--- a/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.ts
+++ b/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.ts
@@ -50,12 +50,7 @@ class TfProfileRedirectDashboard extends LegacyElementMixin(PolymerElement) {
 
     <style>
       :host {
-        display: block;
-        height: 100%;
-        left: 0;
-        position: absolute;
-        top: 0;
-        width: 100%;
+        display: flex;
       }
 
       .message {

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -43,9 +43,8 @@ $tb-foreground: map_merge(
 $tb-background: map_merge(
   $mat-light-theme-background,
   (
-    app-bar: mat-color($tb-primary, 700),
     // Default is `map.get($grey-palette, 50)`.
-    background: #fff,
+    background: #fff
   )
 );
 

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -43,6 +43,8 @@ $tb-foreground: map_merge(
 $tb-background: map_merge(
   $mat-light-theme-background,
   (
+    app-bar: mat-color($tb-primary, 700),
+    // Default is `map.get($grey-palette, 50)`.
     background: #fff,
   )
 );
@@ -60,8 +62,10 @@ $tb-dark-foreground: map-get($tb-dark-theme, foreground);
 $tb-dark-background: map-get($tb-dark-theme, background);
 
 @mixin tb-dark-theme {
-  @at-root :host-context(body.dark-mode) #{&} {
-    @content;
+  @each $selector in & {
+    @at-root :host-context(body.dark-mode) #{$selector} {
+      @content;
+    }
   }
 }
 


### PR DESCRIPTION
This change fixes the visuals of hparams, graph, mesh and profile
redirection plugin under the dark mode.

Do note that we did not attempt to have a generic solution for all
iframe based plugin since it becomes wildly more difficult to reliably
apply dark styles. Instead, we will show the default light mode which
will be quite jarring but that's the best we can do as of right now.
