### PR TITLE
sync: remove unreachable code

### DIFF
--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -86,9 +86,9 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
     // it is not definitive otherwise (i.e., query params can override it).
     // TODO(stephanwlee): enable the feature when most of the UI is actually
     // ready for usage.
-    if (enableDarkMode && false) {
-      featureFlags.enableDarkMode = true;
-    }
+    // if (enableDarkMode) {
+    //   featureFlags.enableDarkMode = true;
+    // }
 
     return featureFlags;
   }


### PR DESCRIPTION
Internally TypeScript tool complains when an unreachable code is
detected. This is a bit too strict and we get around it by simply
commenting out unwanted code.
