### PR TITLE
dark mode: improve visuals of time series plugin

### DIFF
--- a/tensorboard/webapp/metrics/views/_common.scss
+++ b/tensorboard/webapp/metrics/views/_common.scss
@@ -22,6 +22,8 @@ $metrics-min-card-width: 335px;
 $metrics-min-card-height: 320px;
 
 @mixin metrics-card-group-toolbar {
+  @include tb-theme-background-prop(background-color, background);
+  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   background-color: #fff;
   height: 42px;
   padding: 0 16px;
@@ -35,5 +37,10 @@ $metrics-min-card-height: 320px;
 @mixin metrics-card-group-count-text {
   font-size: 12px;
   font-weight: 400;
-  color: mat-color($tb-foreground, secondary-text);
+  @include tb-theme-foreground-prop(color, secondary-text);
+}
+
+@mixin metrics-card-controls {
+  @include tb-theme-foreground-prop(color, secondary-text);
+  white-space: nowrap;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_container.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_container.scss
@@ -14,8 +14,6 @@ limitations under the License.
 ==============================================================================*/
 @import 'tensorboard/webapp/theme/tb_theme';
 
-$_background: map-get($tb-theme, background);
-
 :host {
-  background-color: mat-color($_background, card);
+  @include tb-theme-background-prop(background-color, background);
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
@@ -73,13 +73,12 @@ $_title-to-heading-gap: 12px;
 }
 
 .controls {
-  color: mat-color($tb-foreground, secondary-text);
+  @include metrics-card-controls;
   grid-area: controls;
   justify-self: flex-end;
   flex-shrink: 0;
   // TODO(psybuzz) do not use negative margin.
   margin-right: -1 * $_title-to-heading-gap;
-  white-space: nowrap;
 }
 
 .spinner {

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -97,13 +97,12 @@ $_second-row-height: 15px;
 }
 
 .controls {
-  color: mat-color($tb-foreground, secondary-text);
+  @include metrics-card-controls;
   grid-area: controls;
   justify-self: flex-end;
   flex-shrink: 0;
   // TODO(psybuzz) do not use negative margin.
   margin-right: -1 * $_title-to-heading-gap;
-  white-space: nowrap;
 }
 
 .img-container {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -49,11 +49,10 @@ $_title-to-heading-gap: 12px;
 }
 
 .controls {
-  color: mat-color($tb-foreground, secondary-text);
+  @include metrics-card-controls;
   flex-shrink: 0;
   // TODO(psybuzz) do not use negative margin.
   margin-right: -1 * $_title-to-heading-gap;
-  white-space: nowrap;
 }
 
 .chart-container {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
@@ -28,7 +28,7 @@ $_background: map-get($tb-theme, background);
 }
 
 card-view {
-  border: 1px solid #ddd;
+  @include tb-theme-foreground-prop(border, border, 1px solid);
   border-radius: 4px;
   box-sizing: border-box;
   contain: strict;

--- a/tensorboard/webapp/metrics/views/main_view/card_groups_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_groups_component.scss
@@ -17,10 +17,9 @@ limitations under the License.
 
 .group-toolbar {
   @include metrics-card-group-toolbar;
+  @include tb-theme-foreground-prop(border-top, border, 1px solid);
   display: flex;
   align-items: center;
-  border-top: 1px solid mat-color($tb-foreground, border);
-  border-bottom: 1px solid mat-color($tb-foreground, border);
 }
 
 .card-group:first-of-type .group-toolbar {

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_component.scss
@@ -24,7 +24,7 @@ tb-filter-input {
 }
 
 :host {
-  color: mat-color($tb-foreground, text);
+  @include tb-theme-foreground-prop(color, text);
 
   &:not(.valid) {
     $_error-color: mat-color($tb-warn, 800);

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -15,8 +15,6 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common';
 
-$_foreground-border-color: mat-color($tb-foreground, border);
-
 :host {
   display: flex;
   flex-direction: column;
@@ -24,21 +22,20 @@ $_foreground-border-color: mat-color($tb-foreground, border);
 }
 
 .toolbar {
+  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   flex: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
   height: 48px;
   padding: 0 $metrics-preferred-gap;
-  background-color: #fff;
-  border-bottom: 1px solid $_foreground-border-color;
 
   metrics-tag-filter {
     flex: 1 1 100px;
   }
 
   .right-items {
-    border-left: 1px solid $_foreground-border-color;
+    @include tb-theme-foreground-prop(border-left, border, 1px solid);
     margin-left: $metrics-preferred-gap;
     padding-left: $metrics-preferred-gap;
   }
@@ -64,24 +61,28 @@ $_foreground-border-color: mat-color($tb-foreground, border);
   display: flex;
   flex-direction: column;
 
+  @include tb-dark-theme {
+    // There are no slate color that looks very natural and nice.
+    background-color: #3a3a3a;
+  }
+
   metrics-filtered-view,
   metrics-pinned-view {
-    border-bottom: 1px solid $_foreground-border-color;
+    @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   }
 }
 
 .sidebar {
+  @include tb-theme-foreground-prop(border-left, border, 1px solid);
   flex: 0 0 250px;
-  background-color: #fff;
-  border-left: 1px solid $_foreground-border-color;
 
   .header {
+    @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
     display: flex;
     align-items: center;
     justify-content: space-between;
     height: 42px;
     padding: 0 $metrics-preferred-gap;
-    border-bottom: 1px solid $_foreground-border-color;
 
     .title {
       font-size: 18px;
@@ -93,12 +94,16 @@ $_foreground-border-color: mat-color($tb-foreground, border);
 }
 
 /** TODO(psybuzz): consider making a tb-button instead. */
-.settings-button {
+:host .settings-button {
   color: mat-color($tb-foreground, secondary-text);
   display: inline-flex;
 
+  @include tb-dark-theme {
+    color: mat-color($tb-dark-foreground, secondary-text);
+  }
+
   &.checked {
-    background-color: mat-color($mat-gray, 300);
+    @include tb-theme-background-prop(background-color, selected-button);
     border-color: mat-color($mat-gray, 300);
   }
 

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
@@ -19,11 +19,10 @@ limitations under the License.
   @include metrics-card-group-toolbar;
   display: flex;
   align-items: center;
-  border-bottom: 1px solid mat-color($tb-foreground, border);
 }
 
 mat-icon {
-  color: mat-color($tb-foreground, secondary-text);
+  @include tb-theme-foreground-prop(color, secondary-text);
   flex: none;
   margin-right: 5px;
 }
@@ -43,7 +42,7 @@ mat-icon {
 }
 
 .empty-message {
-  color: mat-color($tb-foreground, secondary-text);
+  @include tb-theme-foreground-prop(color, secondary-text);
   text-align: center;
   padding: 16px;
   font-size: 13px;

--- a/tensorboard/webapp/metrics/views/metrics_container.scss
+++ b/tensorboard/webapp/metrics/views/metrics_container.scss
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 @import 'tensorboard/webapp/theme/tb_theme';
 
-:host {
+.plugin-view {
   display: flex;
   height: 100%;
 }
@@ -24,6 +24,11 @@ nav {
   border-right: 1px solid mat-color($tb-foreground, border);
   flex: none;
   width: 340px;
+
+  @include tb-dark-theme {
+    background-color: map-get($tb-dark-background, background);
+    border-right-color: mat-color($tb-dark-foreground, border);
+  }
 }
 
 metrics-main-view {

--- a/tensorboard/webapp/metrics/views/metrics_container.scss
+++ b/tensorboard/webapp/metrics/views/metrics_container.scss
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 @import 'tensorboard/webapp/theme/tb_theme';
 
-.plugin-view {
+:host {
   display: flex;
   height: 100%;
 }

--- a/tensorboard/webapp/metrics/views/metrics_container.ts
+++ b/tensorboard/webapp/metrics/views/metrics_container.ts
@@ -17,10 +17,12 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 @Component({
   selector: 'metrics-dashboard',
   template: `
-    <nav>
-      <runs-selector></runs-selector>
-    </nav>
-    <metrics-main-view></metrics-main-view>
+    <div class="plugin-view">
+      <nav>
+        <runs-selector></runs-selector>
+      </nav>
+      <metrics-main-view></metrics-main-view>
+    </div>
   `,
   styleUrls: ['metrics_container.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/tensorboard/webapp/metrics/views/metrics_container.ts
+++ b/tensorboard/webapp/metrics/views/metrics_container.ts
@@ -17,12 +17,10 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 @Component({
   selector: 'metrics-dashboard',
   template: `
-    <div class="plugin-view">
-      <nav>
-        <runs-selector></runs-selector>
-      </nav>
-      <metrics-main-view></metrics-main-view>
-    </div>
+    <nav>
+      <runs-selector></runs-selector>
+    </nav>
+    <metrics-main-view></metrics-main-view>
   `,
   styleUrls: ['metrics_container.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -15,17 +15,17 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
-  color: mat-color($tb-foreground, secondary-text);
+  @include tb-theme-foreground-prop(color, secondary-text);
   font-size: 12px;
 }
 
 section {
-  border-bottom: 1px solid mat-color($tb-foreground, border);
+  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   padding: 16px;
 }
 
 .section-title {
-  color: mat-color($tb-foreground, text);
+  @include tb-theme-foreground-prop(color, text);
   text-transform: uppercase;
   font-weight: 500;
   font-size: 13px;
@@ -53,12 +53,18 @@ section .control-row:not(:last-child) {
   }
 
   .slider-input {
+    background-color: inherit;
     border: 1px solid mat-color($tf-slate, 500);
     border-radius: 2px;
     box-sizing: border-box;
+    color: inherit;
     height: 100%;
     margin-left: 12px;
     padding: 0 4px;
+
+    @include tb-dark-theme {
+      border-color: mat-color($tf-slate, 700);
+    }
   }
 }
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -45,24 +45,21 @@ $_font-size: 13px;
   }
 
   mat-paginator {
-    border-top: 1px solid mat-color($tb-foreground, border);
+    @include tb-theme-foreground-prop(border-top, border, 1px solid);
     padding-bottom: 12px;
   }
 }
-
-$_border-color: #0000001f;
 
 [role='table'] {
   display: table;
   width: 100%;
 
   .header {
-    color: mat-color($tb-foreground, text);
     white-space: nowrap;
 
     // Allows table header to remain sticky to the scrollable container.
     [role='columnheader'] {
-      background-color: mat-color($tb-background, background);
+      @include tb-theme-background-prop(background-color, background);
       position: sticky;
       top: 0;
       // Unlike <thead><tr>, we need to manually "lift" the elements up so it
@@ -77,7 +74,7 @@ $_border-color: #0000001f;
     height: $_table-content-row-min-height;
 
     .column {
-      border-bottom: 1px solid $_border-color;
+      @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
       display: table-cell;
 
       padding: 5px;
@@ -106,9 +103,7 @@ $_border-color: #0000001f;
 .no-runs {
   align-items: center;
   border: 0;
-  border-bottom-width: 1px;
-  border-color: $_border-color;
-  border-style: solid;
+  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   display: flex;
   height: 48px;
   padding: 0 24px;
@@ -136,11 +131,11 @@ $_border-color: #0000001f;
 }
 
 .filter-row {
+  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   display: flex;
   align-items: center;
   height: 48px;
   padding: 0 16px 0 21px;
-  border-bottom: 1px solid mat-color($tb-foreground, border);
 
   tb-filter-input {
     flex-grow: 1;
@@ -195,5 +190,13 @@ $_border-color: #0000001f;
   .mat-checkbox-label {
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+}
+
+@include tb-dark-theme {
+  :host.flex-layout {
+    mat-paginator {
+      border-top-color: mat-color($tb-dark-foreground, border);
+    }
   }
 }

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
@@ -53,7 +53,7 @@ p {
   padding: 2px 12px;
 
   @include tb-dark-theme {
-    background-color: #f5f6f722;
+    background-color: mat-color($mat-grey, 700);
   }
 }
 

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
@@ -34,7 +34,7 @@ h3 {
 }
 
 p {
-  color: map-get($tb-foreground, text);
+  @include tb-theme-foreground-prop(color, text);
   font-size: 12px;
   line-height: 1.5;
 }
@@ -51,6 +51,10 @@ p {
   display: flex;
   justify-content: space-between;
   padding: 2px 12px;
+
+  @include tb-dark-theme {
+    background-color: #f5f6f722;
+  }
 }
 
 pre {

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -40,6 +40,7 @@ $tb-foreground: map_merge(
     link: mat-color($mat-blue, 700),
   )
 );
+
 $tb-background: map_merge(
   $mat-light-theme-background,
   (
@@ -57,9 +58,32 @@ $tb-theme: map_merge(
 );
 
 $tb-dark-theme: mat-dark-theme($tb-primary, $tb-accent, $tb-warn);
-$tb-dark-foreground: map-get($tb-dark-theme, foreground);
+$tb-dark-foreground: map_merge(
+  map-get($tb-dark-theme, foreground),
+  (
+    border: #555,
+  )
+);
 $tb-dark-background: map-get($tb-dark-theme, background);
 
+/**
+ * Mixin to facilitate styling an Angular component for the dark mode.
+ * For customization that uses theming object (tb-foreground or tb-background),
+ * please refer to `tb-theme-foreground-prop` and `tb-theme-background-prop`.
+ *
+ * For a large amount of customization, instead of the *-prop API, prefer to use
+ * this tb-dark-theme mixin.
+ *
+ * Example usage:
+ *
+ * div {
+ *   color: red;
+ *   background: blue;
+ *   @include tb-dark-theme {
+ *     background: purple;
+ *   }
+ * }
+ */
 @mixin tb-dark-theme {
   @each $selector in & {
     @at-root :host-context(body.dark-mode) #{$selector} {
@@ -68,12 +92,101 @@ $tb-dark-background: map-get($tb-dark-theme, background);
   }
 }
 
+@mixin _interal-tb-theme-prop-color(
+  $object-name,
+  $foreground-or-background,
+  $dark-foreground-or-background,
+  $property,
+  $name,
+  $value
+) {
+  $light-color: map-get($foreground-or-background, $name);
+  $dark-color: map-get($dark-foreground-or-background, $name);
+
+  @if (not $light-color) {
+    @error "Name '#{$name}' is not found in light #{$object-name}.";
+  }
+  @if (not $dark-color) {
+    @error "Name '#{$name}' is not found in dark #{$object-name}.";
+  }
+
+  #{$property}: $value $light-color;
+
+  @include tb-dark-theme {
+    #{$property}: $value $dark-color;
+  }
+}
+
+/**
+ * Styles an Angular component for a given CSS property using foreground theming
+ * dictionary. This mixin also facilitates theming for the dark mode.
+ *
+ * Example usage:
+ *
+ * div {
+ *   color: red;
+ *   @include tb-theme-foreground-prop(border-left, border, 5px solid);
+ *   // `tb-foreground` has the `border` key. Above generates:
+ *   // div[ngcomponentweirdid] {
+ *   //   border-left: 1px solid map_get($tb-foreground, border);
+ *   // }
+ *   // :host-context(body.dark-mode) div[ngcomponentweirdid] {
+ *   //   border-left: 1px solid map_get($tb-dark-foreground, border);
+ *   // }
+ *   //
+ *   // Third argument is optional. In the example below, `color` only takes
+ *   // color value so it is not needed.
+ *   @include tb-theme-foreground-prop(color, secondary-text);
+ * }
+ */
+@mixin tb-theme-foreground-prop($property, $name, $value: null) {
+  @include _interal-tb-theme-prop-color(
+    foreground,
+    $tb-foreground,
+    $tb-dark-foreground,
+    $property,
+    $name,
+    $value
+  );
+}
+
+/**
+ * Styles an Angular component for a given CSS property using background theming
+ * dictionary. This mixin also facilitates theming for the dark mode.
+ *
+ * Example usage:
+ *
+ * div {
+ *   color: red;
+ *   @include tb-theme-background-prop(backgroud-color, background);
+ *   // Above generates:
+ *   // div[ngcomponentweirdid] {
+ *   //   backgroud-color: map_get($tb-background, background);
+ *   // }
+ *   // :host-context(body.dark-mode) div[ngcomponentweirdid] {
+ *   //   backgroud-color: map_get($tb-dark-background, background);
+ *   // }
+ * }
+ */
+@mixin tb-theme-background-prop($property, $name, $value: null) {
+  @include _interal-tb-theme-prop-color(
+    background,
+    $tb-background,
+    $tb-dark-background,
+    $property,
+    $name,
+    $value
+  );
+}
+
 // Apply themed style for the global stylesheet (styles.scss).
 @mixin tb-global-themed-styles() {
   // Include all theme-styles for the components based on the current theme.
   @include angular-material-theme($tb-theme);
 
-  @include tb-dark-theme {
+  // Cannot use `tb-dark-theme` as :host-context in the global stylesheet is
+  // meaningless.
+  body.dark-mode {
     background-color: map-get($tb-dark-background, background);
 
     @include angular-material-theme($tb-dark-theme);

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -96,24 +96,24 @@ $tb-dark-background: map-get($tb-dark-theme, background);
   $object-name,
   $foreground-or-background,
   $dark-foreground-or-background,
-  $property,
-  $name,
-  $value
+  $css-property,
+  $dict-name,
+  $css-value-prefix
 ) {
-  $light-color: map-get($foreground-or-background, $name);
-  $dark-color: map-get($dark-foreground-or-background, $name);
+  $light-color: map-get($foreground-or-background, $dict-name);
+  $dark-color: map-get($dark-foreground-or-background, $dict-name);
 
   @if (not $light-color) {
-    @error "Name '#{$name}' is not found in light #{$object-name}.";
+    @error "Name '#{$dict-name}' is not found in light #{$object-name}.";
   }
   @if (not $dark-color) {
-    @error "Name '#{$name}' is not found in dark #{$object-name}.";
+    @error "Name '#{$dict-name}' is not found in dark #{$object-name}.";
   }
 
-  #{$property}: $value $light-color;
+  #{$css-property}: $css-value-prefix $light-color;
 
   @include tb-dark-theme {
-    #{$property}: $value $dark-color;
+    #{$css-property}: $css-value-prefix $dark-color;
   }
 }
 
@@ -139,14 +139,18 @@ $tb-dark-background: map-get($tb-dark-theme, background);
  *   @include tb-theme-foreground-prop(color, secondary-text);
  * }
  */
-@mixin tb-theme-foreground-prop($property, $name, $value: null) {
+@mixin tb-theme-foreground-prop(
+  $css-property,
+  $dict-name,
+  $css-value-prefix: null
+) {
   @include _interal-tb-theme-prop-color(
     foreground,
     $tb-foreground,
     $tb-dark-foreground,
-    $property,
-    $name,
-    $value
+    $css-property,
+    $dict-name,
+    $css-value-prefix
   );
 }
 
@@ -168,14 +172,18 @@ $tb-dark-background: map-get($tb-dark-theme, background);
  *   // }
  * }
  */
-@mixin tb-theme-background-prop($property, $name, $value: null) {
+@mixin tb-theme-background-prop(
+  $css-property,
+  $dict-name,
+  $css-value-prefix: null
+) {
   @include _interal-tb-theme-prop-color(
     background,
     $tb-background,
     $tb-dark-background,
-    $property,
-    $name,
-    $value
+    $css-property,
+    $dict-name,
+    $css-value-prefix
   );
 }
 

--- a/tensorboard/webapp/widgets/filter_input/filter_input_component.scss
+++ b/tensorboard/webapp/widgets/filter_input/filter_input_component.scss
@@ -20,12 +20,13 @@ limitations under the License.
 }
 
 mat-icon {
-  color: mat-color($tb-foreground, secondary-text);
+  @include tb-theme-foreground-prop(color, secondary-text);
   flex: none;
   margin-right: 5px;
 }
 
 input {
+  background-color: inherit;
   caret-color: currentColor;
   color: currentColor;
   font: inherit;


### PR DESCRIPTION
This change improves how TimeSeries dashboard looks under the dark mode.
It largely looks okay but the gpu line chart is a bit broken under it.

Do note that some of the color change will cause minor screenshot test failures.
For instance, we were using white + opacity for border color on TimeSeries
runs table which had to change to a opaque color.