### PR TITLE
dark mode: improve GPU line chart under dark mode

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -107,6 +107,7 @@ limitations under the License.
       [customXFormatter]="getCustomXFormatter()"
       [ignoreYOutliers]="ignoreOutliers"
       [tooltipTemplate]="tooltip"
+      [useDarkMode]="useDarkMode"
       (onViewBoxOverridden)="isViewBoxOverridden = $event"
     ></line-chart>
   </ng-container>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -79,6 +79,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() tooltipSort!: TooltipSort;
   @Input() xAxisType!: XAxisType;
   @Input() xScaleType!: ScaleType;
+  @Input() useDarkMode!: boolean;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -39,6 +39,7 @@ import {State} from '../../../app_state';
 import {
   getCardPinnedState,
   getCurrentRouteRunSelection,
+  getDarkModeEnabled,
   getExperimentIdForRunId,
   getExperimentIdToAliasMap,
   getRun,
@@ -120,6 +121,7 @@ function areSeriesEqual(
       [tooltipSort]="tooltipSort$ | async"
       [xAxisType]="xAxisType$ | async"
       [xScaleType]="xScaleType$ | async"
+      [useDarkMode]="useDarkMode$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
     ></scalar-card-component>
@@ -166,6 +168,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
     takeWhile((visible) => !visible, true)
   );
 
+  readonly useDarkMode$ = this.store.select(getDarkModeEnabled);
   readonly ignoreOutliers$ = this.store.select(getMetricsIgnoreOutliers);
   readonly tooltipSort$ = this.store.select(getMetricsTooltipSort);
   readonly xAxisType$ = this.store.select(getMetricsXAxisType);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -97,6 +97,7 @@ class TestableLineChart {
   @Input() yScaleType!: ScaleType;
   @Input() ignoreYOutliers!: boolean;
   @Input() disableUpdate?: boolean;
+  @Input() useDarkMode?: boolean;
   @Input()
   tooltipTemplate!: TemplateRef<{data: TooltipDatum[]}>;
 
@@ -248,6 +249,7 @@ describe('scalar card', () => {
       TooltipSort.DEFAULT
     );
     store.overrideSelector(selectors.getRunColorMap, {});
+    store.overrideSelector(selectors.getDarkModeEnabled, false);
   });
 
   describe('basic renders', () => {
@@ -479,6 +481,21 @@ describe('scalar card', () => {
         ).toBe(undefined);
       }));
     });
+
+    it('sets useDarkMode when using dark mode', fakeAsync(() => {
+      store.overrideSelector(selectors.getDarkModeEnabled, false);
+      const fixture = createComponent('card1');
+      fixture.detectChanges();
+
+      const lineChartEl = fixture.debugElement.query(Selector.LINE_CHART);
+      expect(lineChartEl.componentInstance.useDarkMode).toBe(false);
+
+      store.overrideSelector(selectors.getDarkModeEnabled, true);
+      store.refreshState();
+      fixture.detectChanges();
+
+      expect(lineChartEl.componentInstance.useDarkMode).toBe(true);
+    }));
   });
 
   describe('displayName', () => {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/chart.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/chart.ts
@@ -72,6 +72,8 @@ export class ChartImpl implements Chart {
       }
     }
 
+    this.renderer.setUseDarkMode(option.useDarkMode);
+
     this.seriesLineView = new SeriesLineView({
       renderer: this.renderer,
       coordinator: this.coordinator,
@@ -137,6 +139,11 @@ export class ChartImpl implements Chart {
 
   setData(data: DataSeries[]) {
     this.seriesLineView.setData(data);
+    this.scheduleRepaint();
+  }
+
+  setUseDarkMode(useDarkMode: boolean) {
+    this.renderer.setUseDarkMode(useDarkMode);
     this.scheduleRepaint();
   }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/chart_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/chart_types.ts
@@ -35,6 +35,8 @@ export interface Chart {
 
   setYScaleType(type: ScaleType): void;
 
+  setUseDarkMode(useDarkMode: boolean): void;
+
   dispose(): void;
 }
 
@@ -45,6 +47,7 @@ export interface ChartCallbacks {
 export interface BaseChartOptions {
   callbacks: ChartCallbacks;
   domDimension: Dimension;
+  useDarkMode: boolean;
 }
 
 export interface SvgChartOptions extends BaseChartOptions {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/integration_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/integration_test.ts
@@ -48,6 +48,7 @@ describe('line_chart_v2/lib/integration test', () => {
       container: dom,
       callbacks,
       domDimension: {width: 200, height: 100},
+      useDarkMode: false,
     });
     chart.setXScaleType(ScaleType.LINEAR);
     chart.setYScaleType(ScaleType.LINEAR);

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -362,6 +362,64 @@ describe('line_chart_v2/lib/renderer test', () => {
       assertMaterial(lineObject, '#00ff00', true);
     });
 
+    describe('opacity support', () => {
+      it('sets opacity adjusted color against #fff when using light mode', () => {
+        renderer.setUseDarkMode(false);
+        renderer.createOrUpdateLineObject(
+          null,
+          new Float32Array([0, 5, 5, 50]),
+          {visible: true, color: '#0f0', width: 3, opacity: 0.2}
+        );
+
+        const lineObject = scene.children[0] as THREE.Mesh;
+        assertMaterial(lineObject, '#ccffcc', true);
+      });
+
+      it('sets opacity adjusted color against dark when using dark mode', () => {
+        renderer.setUseDarkMode(true);
+        renderer.createOrUpdateLineObject(
+          null,
+          new Float32Array([0, 5, 5, 50]),
+          {visible: true, color: '#0f0', width: 3, opacity: 0.2}
+        );
+
+        const lineObject = scene.children[0] as THREE.Mesh;
+        assertMaterial(lineObject, '#334d33', true);
+      });
+
+      it('updates color when tweaking opacity', () => {
+        const object1 = renderer.createOrUpdateLineObject(
+          null,
+          new Float32Array([0, 10, 10, 100]),
+          {visible: true, color: '#f00', width: 6, opacity: 0.1}
+        );
+
+        const object2 = renderer.createOrUpdateLineObject(
+          object1,
+          new Float32Array(0),
+          {
+            visible: true,
+            color: '#f00',
+            width: 6,
+            opacity: 0.5,
+          }
+        );
+
+        const lineObject2 = scene.children[0] as THREE.Mesh;
+        assertMaterial(lineObject2, '#ff8080', true);
+
+        renderer.createOrUpdateLineObject(object2, new Float32Array(0), {
+          visible: true,
+          color: '#f00',
+          width: 6,
+          opacity: 1,
+        });
+
+        const lineObject3 = scene.children[0] as THREE.Mesh;
+        assertMaterial(lineObject3, '#ff0000', true);
+      });
+    });
+
     it('updates object when going from non-emtpy polyline to an empty one', () => {
       const cacheObject = renderer.createOrUpdateLineObject(
         null,

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
@@ -82,6 +82,8 @@ export interface ObjectRenderer<CacheValue = {}> {
   flush(): void;
 
   destroyObject(cachedValue: CacheValue): void;
+
+  setUseDarkMode(useDarkMode: boolean): void;
 }
 
 interface PaintOption {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -76,6 +76,11 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
     this.svg.removeChild(cachedValue.dom);
   }
 
+  setUseDarkMode(useDarkMode: boolean): void {
+    // No need to do anything for SVG render since the color will be inherited
+    // at CSS level anyways.
+  }
+
   private createPathDString(polyline: Polyline): string {
     if (!polyline.length) {
       return '';

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -305,7 +305,7 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
   }
 
   setUseDarkMode(useDarkMode: boolean): void {
-    this.backgroundColor = useDarkMode ? '#303030' : '#ffffff';
+    this.backgroundColor = useDarkMode ? '#303030' : '#fff';
     // Normally, we should invoke `setClearColor` but we are using
     // `alpha: false` mode in threejs (transparent) so it does not matter.
   }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/message_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/message_types.ts
@@ -27,6 +27,7 @@ export enum HostToGuestEvent {
   VIEW_BOX_UPDATED,
   INIT,
   DOM_RESIZED,
+  DARK_MODE_UPDATED,
 }
 
 export interface InitMessage {
@@ -36,6 +37,7 @@ export interface InitMessage {
   dim: Dimension;
   // Cannot support SVG in the offscreen.
   rendererType: RendererType.WEBGL;
+  useDarkMode: boolean;
 }
 
 export interface UpdateViewBoxMessage {
@@ -66,12 +68,18 @@ export interface ScaleUpdateMessage {
   scaleType: ScaleType;
 }
 
+export interface DarkModeUpdatedMessage {
+  type: HostToGuestEvent.DARK_MODE_UPDATED;
+  useDarkMode: boolean;
+}
+
 export type HostToGuestMessage =
-  | UpdateViewBoxMessage
+  | DarkModeUpdatedMessage
   | ResizeMessage
   | ScaleUpdateMessage
+  | SeriesMetadataChangedMessage
   | SeriesUpdateMessage
-  | SeriesMetadataChangedMessage;
+  | UpdateViewBoxMessage;
 
 export enum GuestToMainType {
   ON_REDRAW_END,

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart.ts
@@ -68,6 +68,7 @@ export class WorkerChart implements Chart {
       devicePixelRatio: window.devicePixelRatio,
       dim: options.domDimension,
       rendererType: options.type,
+      useDarkMode: options.useDarkMode,
     };
 
     this.workerInstance.postMessage(initMessage, [canvas, channel.port2]);
@@ -119,6 +120,13 @@ export class WorkerChart implements Chart {
       // Need to transfer the ownership to the worker.
       [compactData.flattenedSeries]
     );
+  }
+
+  setUseDarkMode(useDarkMode: boolean): void {
+    this.sendMessage({
+      type: HostToGuestEvent.DARK_MODE_UPDATED,
+      useDarkMode,
+    });
   }
 
   private sendMessage(

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_bridge.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_bridge.ts
@@ -29,7 +29,13 @@ self.addEventListener('message', (event: MessageEvent) => {
 });
 
 function createPortHandler(port: MessagePort, initMessage: InitMessage) {
-  const {canvas, devicePixelRatio, dim, rendererType} = initMessage;
+  const {
+    canvas,
+    devicePixelRatio,
+    dim,
+    rendererType,
+    useDarkMode,
+  } = initMessage;
 
   const lineChartCallbacks = {
     onDrawEnd: () => {
@@ -48,6 +54,7 @@ function createPortHandler(port: MessagePort, initMessage: InitMessage) {
         callbacks: lineChartCallbacks,
         container: canvas,
         devicePixelRatio,
+        useDarkMode,
       };
       break;
     default:
@@ -77,6 +84,10 @@ function createPortHandler(port: MessagePort, initMessage: InitMessage) {
       }
       case HostToGuestEvent.DOM_RESIZED: {
         lineChart.resize(message.dim);
+        break;
+      }
+      case HostToGuestEvent.DARK_MODE_UPDATED: {
+        lineChart.setUseDarkMode(message.useDarkMode);
         break;
       }
       case HostToGuestEvent.SCALE_UPDATED: {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_test.ts
@@ -47,6 +47,21 @@ describe('line_chart_v2/lib/worker_chart test', () => {
       callbacks: {onDrawEnd: onDrawEndSpy},
       container: document.createElement('canvas'),
       domDimension: {width: 100, height: 200},
+      useDarkMode: false,
+    });
+  });
+
+  it('posts dark mode change messages', () => {
+    chart.setUseDarkMode(false);
+    expect(channelTxSpy).toHaveBeenCalledWith({
+      type: HostToGuestEvent.DARK_MODE_UPDATED,
+      useDarkMode: false,
+    });
+
+    chart.setUseDarkMode(true);
+    expect(channelTxSpy).toHaveBeenCalledWith({
+      type: HostToGuestEvent.DARK_MODE_UPDATED,
+      useDarkMode: true,
     });
   });
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 <div
-  class="container"
+  [ngClass]="{'container': true, 'dark-mode': useDarkMode}"
   detectResize
   (onResize)="onViewResize()"
   [resizeEventDebouncePeriodInMs]="0"

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -12,13 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
 :host {
   contain: strict;
   display: inline-block;
 }
 
 .container {
-  background: #fff;
+  background: inherit;
   display: grid;
   height: 100%;
   overflow: hidden;
@@ -28,6 +30,13 @@ limitations under the License.
     'dot xaxis';
   grid-template-columns: 50px 1fr;
   grid-auto-rows: 1fr 30px;
+
+  // Unlike other Angular components, we may use this component outside
+  // of the Angular app and want to control the dark mode styling based on
+  // the component prop alone.
+  &.dark-mode {
+    color: map-get($tb-dark-foreground, text);
+  }
 }
 
 .series-view {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -82,6 +82,9 @@ export class LineChartComponent
   private chartEl?: ElementRef<HTMLCanvasElement | SVGElement>;
 
   @Input()
+  useDarkMode: boolean = false;
+
+  @Input()
   preferredRendererType: RendererType = RendererType.WEBGL;
 
   @Input()
@@ -146,6 +149,7 @@ export class LineChartComponent
   private isMetadataUpdated = false;
   private isFixedViewBoxUpdated = false;
   private isViewBoxOverridden = false;
+  private useDarkModeUpdated = false;
   // Must set the default view box since it is an optional input and won't trigger
   // onChanges.
   private isViewBoxChanged = true;
@@ -182,6 +186,10 @@ export class LineChartComponent
 
     if (changes['seriesMetadataMap']) {
       this.isMetadataUpdated = true;
+    }
+
+    if (changes['useDarkMode']) {
+      this.useDarkModeUpdated = true;
     }
 
     if (this.scaleUpdated) {
@@ -281,6 +289,7 @@ export class LineChartComponent
           container: this.chartEl!.nativeElement as SVGElement,
           callbacks,
           domDimension: this.domDimensions.main,
+          useDarkMode: this.useDarkMode,
         };
         break;
       }
@@ -291,6 +300,7 @@ export class LineChartComponent
           devicePixelRatio: window.devicePixelRatio,
           callbacks,
           domDimension: this.domDimensions.main,
+          useDarkMode: this.useDarkMode,
         };
         break;
       default:
@@ -351,6 +361,11 @@ export class LineChartComponent
     if (this.isDataUpdated) {
       this.isDataUpdated = false;
       this.lineChart.setData(this.seriesData);
+    }
+
+    if (this.useDarkModeUpdated) {
+      this.useDarkModeUpdated = false;
+      this.lineChart.setUseDarkMode(this.useDarkMode);
     }
 
     if (this.isFixedViewBoxUpdated && this.fixedViewBox) {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -53,6 +53,7 @@ class FakeGridComponent {
       [seriesMetadataMap]="seriesMetadataMap"
       [yScaleType]="yScaleType"
       [fixedViewBox]="fixedViewBox"
+      [useDarkMode]="useDarkMode"
     ></line-chart>
   `,
   styles: [
@@ -83,6 +84,9 @@ class TestableComponent {
 
   @Input()
   disableUpdate?: boolean;
+
+  @Input()
+  useDarkMode: boolean = false;
 
   // WebGL one is harder to test.
   preferredRendererType = RendererType.SVG;
@@ -614,6 +618,34 @@ describe('line_chart_v2/line_chart test', () => {
         [true],
         [false],
       ]);
+    });
+  });
+
+  describe('dark mode support', () => {
+    it('sets class dark-mode', () => {
+      const fixture = createComponent({
+        seriesData: [
+          buildSeries({
+            id: 'foo',
+            points: [
+              {x: 0, y: 0},
+              {x: 1, y: -1},
+              {x: 2, y: 1},
+            ],
+          }),
+        ],
+        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+        yScaleType: ScaleType.LINEAR,
+      });
+      fixture.componentInstance.useDarkMode = false;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.dark-mode'))).toBeFalsy();
+
+      fixture.componentInstance.useDarkMode = true;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.dark-mode'))).toBeTruthy();
     });
   });
 });

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
@@ -22,6 +22,7 @@ limitations under the License.
 
 .major-label,
 text {
+  fill: currentColor;
   font-size: 11px;
   user-select: none;
 }
@@ -136,6 +137,13 @@ text {
   grid-template-columns: 30px minmax(auto, 100px);
   height: 30px;
   margin: 10px 20px;
+
+  input {
+    background-color: inherit;
+    border-radius: 4px;
+    border-style: solid;
+    color: inherit;
+  }
 }
 
 .extent-edit-control {


### PR DESCRIPTION
Since we had to enable the transparency mode on the GPU line chart for
the grid line, the task got a lot easier; we just have to set the
background and color to inherit from ancestor. Yes, GPU line chart is 
snappier with alpha channel turned off but gridding and what not is very
convenient with alpha channel.

Even with the opacity, we still have to propagate it since we calculate
a concrete opaque color value for WebGL renderer and it needs to 
know the color mode in order to properly calculate the concrete color.

![image](https://user-images.githubusercontent.com/2547313/120866493-eaa40d80-c544-11eb-8401-9d4bb5b60920.png)
