### PR TITLE
dark mode: improve app-header under dark mode

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -81,6 +81,11 @@ tf_ts_library(
     ],
 )
 
+tf_sass_binary(
+    name = "app_styles",
+    src = "app_container.scss",
+)
+
 # Angular module for the top-level app component together with all of its
 # injectable dependencies.  I.e., the entire Angular app.
 tf_ng_module(
@@ -90,7 +95,7 @@ tf_ng_module(
         "app_module.ts",
     ],
     assets = [
-        "app_container.css",
+        ":app_styles",
         "app_container.ng.html",
     ],
     deps = [

--- a/tensorboard/webapp/app_container.scss
+++ b/tensorboard/webapp/app_container.scss
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
 html,
 body {
   font-family: Roboto, sans-serif;
@@ -31,6 +33,10 @@ app-header {
   box-shadow: 0 1px 3px 3px rgba(0, 0, 0, 0.25);
   flex: 0 0;
   z-index: 1; /* The box shadow needs to extend out of the app-header. */
+
+  @include tb-dark-theme {
+    box-shadow: 0 1px 3px 3px rgba(#fff, 0.1);
+  }
 }
 
 main {

--- a/tensorboard/webapp/header/BUILD
+++ b/tensorboard/webapp/header/BUILD
@@ -5,8 +5,13 @@ package(default_visibility = ["//tensorboard:internal"])
 licenses(["notice"])
 
 tf_sass_binary(
-    name = "styles",
+    name = "plugin_selector_styles",
     src = "plugin_selector_component.scss",
+)
+
+tf_sass_binary(
+    name = "header_styles",
+    src = "header_component.scss",
 )
 
 tf_ng_module(
@@ -20,7 +25,8 @@ tf_ng_module(
         "types.ts",
     ],
     assets = [
-        ":styles",
+        ":plugin_selector_styles",
+        ":header_styles",
         "plugin_selector_component.ng.html",
     ],
     deps = [

--- a/tensorboard/webapp/header/header_component.scss
+++ b/tensorboard/webapp/header/header_component.scss
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,24 +12,37 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-@import 'tensorboard/webapp/theme/tb_theme';
-
-/* Override material styling with more precise selector. */
-:host button.mat-stroked-button {
-  background-color: mat-color($tb-primary, 500);
-  border: 1px solid map-get($tb-foreground, border);
-
-  @include tb-dark-theme {
-    background-color: mat-color($tb-primary, 800);
-  }
+mat-toolbar {
+  align-items: center;
+  color: #fff;
+  display: flex;
+  height: 64px;
+  overflow: hidden;
+  width: 100%;
 }
 
-.button-contents {
+tbdev-upload-button.shown {
+  margin: 0 8px 0 16px;
+}
+
+.brand,
+.readme,
+app-header-reload,
+settings-button {
+  flex: 0 0 auto;
+}
+
+.brand {
+  letter-spacing: -0.025em;
+  margin-left: 10px;
+  text-rendering: optimizeLegibility;
+}
+
+.plugins {
   align-items: center;
   display: flex;
-  text-transform: uppercase;
-}
-
-mat-icon {
-  margin-right: 6px;
+  flex: 1 1 auto;
+  font-size: 14px;
+  height: 100%;
+  overflow: hidden;
 }

--- a/tensorboard/webapp/header/header_component.ts
+++ b/tensorboard/webapp/header/header_component.ts
@@ -17,7 +17,7 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'app-header',
   template: `
-    <mat-toolbar color="primary">
+    <mat-toolbar>
       <span class="brand">TensorBoard</span>
       <plugin-selector class="plugins"></plugin-selector>
       <tbdev-upload-button></tbdev-upload-button>
@@ -35,42 +35,6 @@ import {Component} from '@angular/core';
       </a>
     </mat-toolbar>
   `,
-  styles: [
-    `
-      mat-toolbar {
-        align-items: center;
-        display: flex;
-        height: 64px;
-        overflow: hidden;
-        width: 100%;
-      }
-
-      tbdev-upload-button.shown {
-        margin: 0 8px 0 16px;
-      }
-
-      .brand,
-      .readme,
-      app-header-reload,
-      settings-button {
-        flex: 0 0 auto;
-      }
-
-      .brand {
-        letter-spacing: -0.025em;
-        margin-left: 10px;
-        text-rendering: optimizeLegibility;
-      }
-
-      .plugins {
-        align-items: center;
-        display: flex;
-        flex: 1 1 auto;
-        font-size: 14px;
-        height: 100%;
-        overflow: hidden;
-      }
-    `,
-  ],
+  styleUrls: ['header_component.css'],
 })
 export class HeaderComponent {}

--- a/tensorboard/webapp/header/plugin_selector_component.scss
+++ b/tensorboard/webapp/header/plugin_selector_component.scss
@@ -57,7 +57,7 @@ mat-option {
   // Override mat-tab styling. By default, mat-tab has the right styling but,
   // here, we are using it under dark header background. Must invert the color.
 
-  &.mat-primary .mat-ink-bar {
+  &.mat-primary .mat-tab-list .mat-ink-bar {
     background-color: currentColor;
   }
 
@@ -140,7 +140,7 @@ mat-option {
       }
 
       .mat-tab-header-pagination {
-        background-color: mat-color($tb-primary);
+        @include tb-theme-background-prop(background-color, app-bar);
       }
     }
   }

--- a/tensorboard/webapp/theme/_tb_palette.scss
+++ b/tensorboard/webapp/theme/_tb_palette.scss
@@ -44,15 +44,15 @@ $tf-slate: (
    several orange values, but only one of them (--tb-orange-strong) is used
    widely. */
 $tf-orange: (
-  100: mat-color($mat-orange, 500),
-  200: mat-color($mat-orange, 500),
-  300: mat-color($mat-orange, 500),
-  400: mat-color($mat-orange, 500),
+  100: mat-color($mat-orange, 100),
+  200: mat-color($mat-orange, 200),
+  300: mat-color($mat-orange, 300),
+  400: mat-color($mat-orange, 400),
   500: mat-color($mat-orange, 500),
-  600: mat-color($mat-orange, 700),
+  600: mat-color($mat-orange, 600),
   700: mat-color($mat-orange, 700),
-  800: mat-color($mat-orange, 700),
-  900: mat-color($mat-orange, 700),
+  800: mat-color($mat-orange, 800),
+  900: mat-color($mat-orange, 900),
   contrast: (
     100: $dark-primary-text,
     200: $dark-primary-text,

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -40,12 +40,12 @@ $tb-foreground: map_merge(
     link: mat-color($mat-blue, 700),
   )
 );
-
 $tb-background: map_merge(
   $mat-light-theme-background,
   (
+    app-bar: mat-color($tb-primary, 700),
     // Default is `map.get($grey-palette, 50)`.
-    background: #fff
+    background: #fff,
   )
 );
 
@@ -64,7 +64,19 @@ $tb-dark-foreground: map_merge(
     border: #555,
   )
 );
-$tb-dark-background: map-get($tb-dark-theme, background);
+$tb-dark-background: map_merge(
+  map-get($tb-dark-theme, background),
+  (
+    app-bar: mat-color($tb-primary, 900),
+  )
+);
+$tb-dark-theme: map_merge(
+  $tb-dark-theme,
+  (
+    background: $tb-dark-background,
+    foreground: $tb-dark-foreground,
+  )
+);
 
 /**
  * Mixin to facilitate styling an Angular component for the dark mode.

--- a/tensorboard/webapp/theme/_variable.scss
+++ b/tensorboard/webapp/theme/_variable.scss
@@ -15,6 +15,6 @@ limitations under the License.
 @import 'tensorboard/webapp/angular_material_theming';
 @import 'tensorboard/webapp/theme/tb_palette';
 
-$tb-primary: mat-palette($tf-orange, 700, 400, 700);
+$tb-primary: mat-palette($tf-orange, 700, 400, 800);
 $tb-accent: mat-palette($tf-orange);
 $tb-warn: mat-palette($mat-red);


### PR DESCRIPTION
This change fixes the style of app-header under the dark mode.
Previously, it was a bit too bright for the dark mode and, as such, we
now use more darker material orange. This improves legibility of the
font as it increases the contrast with the white font.
