### PR TITLE
dark mode: support dark mode in the source-code

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
@@ -23,6 +23,8 @@ tf_ng_module(
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/widgets/source_code",
         "@npm//@angular/common",
         "@npm//@angular/core",
@@ -49,6 +51,8 @@ tf_ts_library(
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline",
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/widgets/source_code:load_monaco",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ng.html
@@ -41,6 +41,7 @@ limitations under the License.
            focusedSourceFileContent.lines !== null"
     [lines]="focusedSourceFileContent.lines"
     [focusedLineno]="focusedSourceLineSpec.lineno"
+    [useDarkMode]="useDarkMode"
   >
   </source-code>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ts
@@ -35,4 +35,7 @@ export class SourceFilesComponent {
 
   @Input()
   focusedSourceLineSpec: StackFrame | null = null;
+
+  @Input()
+  useDarkMode!: boolean;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container.ts
@@ -13,15 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Component} from '@angular/core';
-import {select, Store} from '@ngrx/store';
+import {Store} from '@ngrx/store';
+import {Observable} from 'rxjs';
 
+import {State as OtherAppState} from '../../../../../webapp/app_state';
+import {getDarkModeEnabled} from '../../../../../webapp/selectors';
 import {
   getFocusedSourceFileContent,
   getFocusedSourceLineSpec,
 } from '../../store';
-import {State} from '../../store/debugger_types';
-
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+import {State as DebuggerState} from '../../store/debugger_types';
 
 @Component({
   selector: 'tf-debugger-v2-source-files',
@@ -29,17 +30,20 @@ import {State} from '../../store/debugger_types';
     <source-files-component
       [focusedSourceFileContent]="focusedSourceFileContent$ | async"
       [focusedSourceLineSpec]="focusedSourceLineSpec$ | async"
+      [useDarkMode]="useDarkMode$ | async"
     ></source-files-component>
   `,
 })
 export class SourceFilesContainer {
-  constructor(private readonly store: Store<State>) {}
+  constructor(private readonly store: Store<DebuggerState & OtherAppState>) {}
 
-  readonly focusedSourceFileContent$ = this.store.pipe(
-    select(getFocusedSourceFileContent)
+  readonly focusedSourceFileContent$ = this.store.select(
+    getFocusedSourceFileContent
   );
 
-  readonly focusedSourceLineSpec$ = this.store.pipe(
-    select(getFocusedSourceLineSpec)
+  readonly focusedSourceLineSpec$ = this.store.select(getFocusedSourceLineSpec);
+
+  readonly useDarkMode$: Observable<boolean> = this.store.select(
+    getDarkModeEnabled
   );
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
@@ -28,7 +28,12 @@ import {
 } from '../../../../../webapp/widgets/source_code/testing';
 import {DebuggerComponent} from '../../debugger_component';
 import {DebuggerContainer} from '../../debugger_container';
-import {DataLoadState, State} from '../../store/debugger_types';
+import {getDarkModeEnabled} from '../../../../../webapp/selectors';
+import {
+  DataLoadState,
+  State as DebuggerState,
+} from '../../store/debugger_types';
+import {State as OtherAppState} from '../../../../../webapp/app_state';
 import {createDebuggerState, createState} from '../../testing';
 import {AlertsModule} from '../alerts/alerts_module';
 import {ExecutionDataModule} from '../execution_data/execution_data_module';
@@ -45,8 +50,10 @@ import {SourceFilesModule} from './source_files_module';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
+type AppState = DebuggerState & OtherAppState;
+
 describe('Source Files Container', () => {
-  let store: MockStore<State>;
+  let store: MockStore<AppState>;
   let dispatchSpy: jasmine.Spy;
 
   beforeEach(async () => {
@@ -65,8 +72,9 @@ describe('Source Files Container', () => {
       ],
       providers: [provideMockStore(), DebuggerContainer],
     }).compileComponents();
-    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    store = TestBed.inject<Store<AppState>>(Store) as MockStore<AppState>;
     dispatchSpy = spyOn(store, 'dispatch');
+    store.overrideSelector(getDarkModeEnabled, false);
   });
 
   afterEach(() => {

--- a/tensorboard/webapp/widgets/source_code/source_code_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_component.ts
@@ -21,6 +21,7 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
+
 import {
   DEFAULT_CODE_FONT_SIZE,
   DEFAULT_CODE_LANGUAGE,
@@ -43,6 +44,9 @@ export class SourceCodeComponent implements OnChanges {
   @Input()
   monaco: typeof monaco | null = null;
 
+  @Input()
+  useDarkMode!: boolean;
+
   @ViewChild('codeViewerContainer', {static: true, read: ElementRef})
   private readonly codeViewerContainer!: ElementRef<HTMLDivElement>;
 
@@ -56,33 +60,38 @@ export class SourceCodeComponent implements OnChanges {
     }
   }
 
+  private getMonacoThemeString(): 'vs' | 'vs-dark' {
+    return this.useDarkMode ? 'vs-dark' : 'vs';
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     if (this.monaco === null) {
       return;
     }
+
+    if (this.editor === null) {
+      this.editor = this.monaco.editor.create(
+        this.codeViewerContainer.nativeElement,
+        {
+          language: DEFAULT_CODE_LANGUAGE,
+          readOnly: true,
+          fontSize: DEFAULT_CODE_FONT_SIZE,
+          minimap: {
+            enabled: true,
+          },
+        }
+      );
+    }
+
     const currentLines: string[] | null = changes['monaco']
       ? this.lines
       : changes['lines']
       ? changes['lines'].currentValue
       : null;
+
     if (currentLines) {
       const value = currentLines.join('\n');
-      if (this.editor === null) {
-        this.editor = this.monaco.editor.create(
-          this.codeViewerContainer.nativeElement,
-          {
-            value,
-            language: DEFAULT_CODE_LANGUAGE,
-            readOnly: true,
-            fontSize: DEFAULT_CODE_FONT_SIZE,
-            minimap: {
-              enabled: true,
-            },
-          }
-        );
-      } else {
-        this.editor.setValue(value);
-      }
+      this.editor.setValue(value);
     }
 
     const currentFocusedLineno: number | null = changes['monaco']
@@ -121,6 +130,10 @@ export class SourceCodeComponent implements OnChanges {
           },
         },
       ]);
+    }
+
+    if (changes['useDarkMode']) {
+      this.editor.setTheme(this.getMonacoThemeString());
     }
   }
 }

--- a/tensorboard/webapp/widgets/source_code/source_code_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_component.ts
@@ -73,6 +73,7 @@ export class SourceCodeComponent implements OnChanges {
       this.editor = this.monaco.editor.create(
         this.codeViewerContainer.nativeElement,
         {
+          value: (this.lines ?? []).join('\n'),
           language: DEFAULT_CODE_LANGUAGE,
           readOnly: true,
           fontSize: DEFAULT_CODE_FONT_SIZE,
@@ -83,15 +84,8 @@ export class SourceCodeComponent implements OnChanges {
       );
     }
 
-    const currentLines: string[] | null = changes['monaco']
-      ? this.lines
-      : changes['lines']
-      ? changes['lines'].currentValue
-      : null;
-
-    if (currentLines) {
-      const value = currentLines.join('\n');
-      this.editor.setValue(value);
+    if (this.editor && changes['lines'] && this.lines) {
+      this.editor.setValue(this.lines.join('\n'));
     }
 
     const currentFocusedLineno: number | null = changes['monaco']

--- a/tensorboard/webapp/widgets/source_code/source_code_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container.ts
@@ -37,6 +37,7 @@ import {loadMonaco} from './load_monaco_shim';
       [lines]="lines"
       [focusedLineno]="focusedLineno"
       [monaco]="monaco$ | async"
+      [useDarkMode]="useDarkMode"
     ></source-code-component>
   `,
 })
@@ -48,6 +49,9 @@ export class SourceCodeContainer implements OnInit {
   // Line number to scroll to and highlight, 1-based.
   @Input()
   focusedLineno: number | null = null;
+
+  @Input()
+  useDarkMode: boolean = false;
 
   monaco$: Observable<typeof monaco> | null = null;
 

--- a/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
@@ -109,6 +109,7 @@ describe('Source Code Component', () => {
 
     beforeEach(async () => {
       fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.lines = lines1;
       fixture.detectChanges();
       await loadMonacoShim.loadMonaco();
       fixture.detectChanges();
@@ -116,7 +117,6 @@ describe('Source Code Component', () => {
 
     it('switches to a different line in the same file', () => {
       const component = fixture.componentInstance;
-      component.lines = lines1;
       component.focusedLineno = 2;
       fixture.detectChanges();
       component.focusedLineno = 1;

--- a/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
@@ -15,25 +15,45 @@ limitations under the License.
 /**
  * Unit tests for the the Source Files component and container.
  */
-import {SimpleChange} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Input, NO_ERRORS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
+import * as loadMonacoShim from './load_monaco_shim';
 import {SourceCodeComponent} from './source_code_component';
 import {SourceCodeContainer} from './source_code_container';
-import {
-  fakes,
-  setUpMonacoFakes,
-  spies,
-  tearDownMonacoFakes,
-  windowWithRequireAndMonaco,
-} from './testing';
-import * as loadMonacoShim from './load_monaco_shim';
+import {fakes, setUpMonacoFakes, spies, tearDownMonacoFakes} from './testing';
+
+@Component({
+  selector: 'testable-component',
+  template: `
+    <source-code
+      [lines]="lines"
+      [focusedLineno]="focusedLineno"
+      [useDarkMode]="useDarkMode"
+    ></source-code>
+  `,
+})
+class TestableComponent {
+  @Input()
+  lines!: string[];
+
+  @Input()
+  focusedLineno!: number;
+
+  @Input()
+  useDarkMode!: boolean;
+}
 
 describe('Source Code Component', () => {
   beforeEach(async () => {
     setUpMonacoFakes();
     await TestBed.configureTestingModule({
-      declarations: [SourceCodeComponent, SourceCodeContainer],
+      declarations: [
+        SourceCodeComponent,
+        SourceCodeContainer,
+        TestableComponent,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
 
@@ -48,20 +68,15 @@ describe('Source Code Component', () => {
   ];
 
   it('renders a file and change to a new file', async () => {
-    const fixture = TestBed.createComponent(SourceCodeComponent);
+    const fixture = TestBed.createComponent(TestableComponent);
     const component = fixture.componentInstance;
     component.lines = lines1;
     component.focusedLineno = 3;
-    await component.ngOnChanges({
-      lines: new SimpleChange(null, lines1, true),
-      focusedLineno: new SimpleChange(null, 3, true),
-    });
+    fixture.detectChanges();
+
     // Simlulate loading monaco and setting the `monaco` input after loading.
     await loadMonacoShim.loadMonaco();
-    component.monaco = windowWithRequireAndMonaco.monaco;
-    await component.ngOnChanges({
-      monaco: new SimpleChange(null, windowWithRequireAndMonaco.monaco, true),
-    });
+    fixture.detectChanges();
 
     // Initial rendering of code uses monaco editor's constructor instead of
     // using `setValue()`.
@@ -75,10 +90,7 @@ describe('Source Code Component', () => {
 
     component.lines = lines2;
     component.focusedLineno = 1;
-    await component.ngOnChanges({
-      lines: new SimpleChange(lines1, lines2, false),
-      focusedLineno: new SimpleChange(3, 1, false),
-    });
+    fixture.detectChanges();
 
     expect(spies.editorSpy.setValue).toHaveBeenCalledTimes(1);
     expect(spies.editorSpy.setValue).toHaveBeenCalledWith(
@@ -92,54 +104,53 @@ describe('Source Code Component', () => {
     expect(spies.editorSpy.deltaDecorations).toHaveBeenCalledTimes(2);
   });
 
-  it('switches to a different line in the same file', async () => {
-    const fixture = TestBed.createComponent(SourceCodeComponent);
-    const component = fixture.componentInstance;
-    await loadMonacoShim.loadMonaco();
-    component.monaco = windowWithRequireAndMonaco.monaco;
-    component.lines = lines1;
-    component.focusedLineno = 2;
-    await component.ngOnChanges({
-      lines: new SimpleChange(null, lines1, true),
-      focusedLineno: new SimpleChange(null, 2, true),
-    });
-    await component.ngOnChanges({
-      focusedLineno: new SimpleChange(2, 1, false),
+  describe('features', () => {
+    let fixture: ComponentFixture<TestableComponent>;
+
+    beforeEach(async () => {
+      fixture = TestBed.createComponent(TestableComponent);
+      fixture.detectChanges();
+      await loadMonacoShim.loadMonaco();
+      fixture.detectChanges();
     });
 
-    // setValue() shouldn't have been called because there is no change in file
-    // content.
-    expect(spies.editorSpy!.setValue).toHaveBeenCalledTimes(0);
-    expect(spies.editorSpy!.revealLineInCenter).toHaveBeenCalledTimes(2);
-    // This is the call for the old lineno.
-    expect(spies.editorSpy!.revealLineInCenter).toHaveBeenCalledWith(
-      2,
-      fakes.fakeMonaco.editor.ScrollType.Smooth
-    );
-    // This is the call for the new lineno.
-    expect(spies.editorSpy.revealLineInCenter).toHaveBeenCalledWith(
-      1,
-      fakes.fakeMonaco.editor.ScrollType.Smooth
-    );
-  });
-});
+    it('switches to a different line in the same file', () => {
+      const component = fixture.componentInstance;
+      component.lines = lines1;
+      component.focusedLineno = 2;
+      fixture.detectChanges();
+      component.focusedLineno = 1;
+      fixture.detectChanges();
 
-describe('Source Code Container', () => {
-  beforeEach(async () => {
-    setUpMonacoFakes();
-    await TestBed.configureTestingModule({
-      declarations: [SourceCodeComponent, SourceCodeContainer],
-    }).compileComponents();
-  });
+      // setValue() shouldn't have been called because there is no change in file
+      // content.
+      expect(spies.editorSpy!.setValue).toHaveBeenCalledTimes(0);
+      expect(spies.editorSpy!.revealLineInCenter).toHaveBeenCalledTimes(2);
+      // This is the call for the old lineno.
+      expect(spies.editorSpy!.revealLineInCenter).toHaveBeenCalledWith(
+        2,
+        fakes.fakeMonaco.editor.ScrollType.Smooth
+      );
+      // This is the call for the new lineno.
+      expect(spies.editorSpy.revealLineInCenter).toHaveBeenCalledWith(
+        1,
+        fakes.fakeMonaco.editor.ScrollType.Smooth
+      );
+    });
 
-  afterEach(() => {
-    tearDownMonacoFakes();
-  });
+    it('uses different theme when `useDarkMode` changes', () => {
+      const component = fixture.componentInstance;
 
-  it('calls loadMonaco() on ngOnInit()', () => {
-    const fixture = TestBed.createComponent(SourceCodeContainer);
-    const component = fixture.componentInstance;
-    component.ngOnInit();
-    expect(spies.loadMonacoSpy!).toHaveBeenCalledTimes(1);
+      component.useDarkMode = true;
+      fixture.detectChanges();
+      expect(spies.editorSpy!.setTheme).toHaveBeenCalledOnceWith('vs-dark');
+
+      component.useDarkMode = false;
+      fixture.detectChanges();
+      expect(spies.editorSpy!.setTheme.calls.allArgs()).toEqual([
+        ['vs-dark'],
+        ['vs'],
+      ]);
+    });
   });
 });

--- a/tensorboard/webapp/widgets/source_code/testing.ts
+++ b/tensorboard/webapp/widgets/source_code/testing.ts
@@ -54,6 +54,7 @@ export function setUpMonacoFakes() {
             'layout',
             'revealLineInCenter',
             'setValue',
+            'setTheme',
           ]);
           return spies.editorSpy;
         },


### PR DESCRIPTION
Debugger v2 currently shows read-only source code is its plugin with
monaco editor. Since the editor has its own theming APIs and semantics,
we need to pipe the information through to make it know about the dark
mode.