### PR TITLE
dark mode; allow dark theme to use different vars

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -26,6 +26,10 @@ limitations under the License.
 // Include non-theme styles for core.
 @include mat-core();
 
+$tb-dark-primary: $tb-primary !default;
+$tb-dark-accent: $tb-accent !default;
+$tb-dark-warn: $tb-warn !default;
+
 $tb-theme: mat-light-theme($tb-primary, $tb-accent, $tb-warn);
 
 // Overriding mat-light-theme-foreground variables.
@@ -57,7 +61,11 @@ $tb-theme: map_merge(
   )
 );
 
-$tb-dark-theme: mat-dark-theme($tb-primary, $tb-accent, $tb-warn);
+$tb-dark-theme: mat-dark-theme(
+  $tb-dark-primary,
+  $tb-dark-accent,
+  $tb-dark-warn
+);
 $tb-dark-foreground: map_merge(
   map-get($tb-dark-theme, foreground),
   (

--- a/tensorboard/webapp/theme/_variable.scss
+++ b/tensorboard/webapp/theme/_variable.scss
@@ -18,3 +18,6 @@ limitations under the License.
 $tb-primary: mat-palette($tf-orange, 700, 400, 800);
 $tb-accent: mat-palette($tf-orange);
 $tb-warn: mat-palette($mat-red);
+
+$tb-dark-primary: mat-palette($tf-orange, 800, 600, 900);
+$tb-dark-accent: $tb-dark-primary;


### PR DESCRIPTION
Theme objects are created from `tb` variables like `$tb-primary`,
`$tb-accent` and others. These variables, however, may not look the best
again the dark background and we have to support different values for
dark version.

This change makes sure that the variable like `$tb-dark-primary` are
defined if it is not already defined to their light counter part,
`$tb-primary`.

This change applies the change by making the primary color a bit darker
orange, making it look better against the dark theme.
