### PR TITLE
dark mode: fix link styling

### DIFF
--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
@@ -40,7 +40,6 @@ p {
 }
 
 .anchor-text {
-  color: map-get($tb-foreground, link);
   text-decoration: none;
 }
 
@@ -73,12 +72,14 @@ code {
 }
 
 .close-button {
-  color: map-get($tb-foreground, secondary-text);
+  @include tb-theme-foreground-prop(color, secondary-text);
   text-transform: uppercase;
   margin-right: 8px;
 }
 
-.learn-more-button {
-  color: map-get($tb-foreground, link);
+// Overly increase specificity to work around material component styling under
+// dark mode.
+:host .learn-more-button {
+  @include tb-theme-foreground-prop(color, link);
   text-transform: uppercase;
 }

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -42,6 +42,7 @@ $tb-foreground: map_merge(
     // TB specific variable.
     border: #ebebeb,
     link: mat-color($mat-blue, 700),
+    link-visited: mat-color($mat-purple, 700),
   )
 );
 $tb-background: map_merge(
@@ -70,6 +71,9 @@ $tb-dark-foreground: map_merge(
   map-get($tb-dark-theme, foreground),
   (
     border: #555,
+    disabled-text: mat-color($mat-gray, 700),
+    link: mat-color($mat-blue, 400),
+    link-visited: mat-color($mat-purple, 300),
   )
 );
 $tb-dark-background: map_merge(
@@ -212,10 +216,26 @@ $tb-dark-theme: map_merge(
   // Include all theme-styles for the components based on the current theme.
   @include angular-material-theme($tb-theme);
 
+  a {
+    color: map-get($tb-foreground, link);
+
+    &:visited {
+      color: map-get($tb-foreground, link-visited);
+    }
+  }
+
   // Cannot use `tb-dark-theme` as :host-context in the global stylesheet is
   // meaningless.
   body.dark-mode {
     background-color: map-get($tb-dark-background, background);
+
+    a {
+      color: map-get($tb-dark-foreground, link);
+
+      &:visited {
+        color: map-get($tb-dark-foreground, link-visited);
+      }
+    }
 
     @include angular-material-theme($tb-dark-theme);
   }


### PR DESCRIPTION
This change fixes link styling globally.

Unlike in other places, we decided to take a little bit more global
approach in styling the anchor elements as correct styling for all links
is a bit tedious.

This change applies the fix to the tbdev upload dialog component.

![image](https://user-images.githubusercontent.com/2547313/121254917-acb62a80-c85f-11eb-9f35-19dc39a4f759.png)
