### PR TITLE
debugger: deflake debugger v2 test

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
@@ -15,29 +15,17 @@ limitations under the License.
 /**
  * Unit tests for the Debugger Container.
  */
-import {CommonModule} from '@angular/common';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-
 import {Store} from '@ngrx/store';
-import {provideMockStore, MockStore} from '@ngrx/store/testing';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
 
 import {debuggerLoaded} from './actions';
 import {DebuggerComponent} from './debugger_component';
 import {DebuggerContainer} from './debugger_container';
 import {DataLoadState, State} from './store/debugger_types';
 import {createDebuggerState, createState} from './testing';
-import {AlertsModule} from './views/alerts/alerts_module';
-import {ExecutionDataModule} from './views/execution_data/execution_data_module';
-import {GraphExecutionsModule} from './views/graph_executions/graph_executions_module';
-import {GraphModule} from './views/graph/graph_module';
-import {InactiveModule} from './views/inactive/inactive_module';
-import {TimelineContainer} from './views/timeline/timeline_container';
-import {SourceFilesModule} from './views/source_files/source_files_module';
-import {StackTraceModule} from './views/stack_trace/stack_trace_module';
-import {TimelineModule} from './views/timeline/timeline_module';
-
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Debugger Container', () => {
   let store: MockStore<State>;
@@ -46,24 +34,13 @@ describe('Debugger Container', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [DebuggerComponent, DebuggerContainer],
-      imports: [
-        AlertsModule,
-        CommonModule,
-        ExecutionDataModule,
-        GraphExecutionsModule,
-        GraphModule,
-        InactiveModule,
-        SourceFilesModule,
-        StackTraceModule,
-        TimelineModule,
-      ],
       providers: [
         provideMockStore({
           initialState: createState(createDebuggerState()),
         }),
         DebuggerContainer,
-        TimelineContainer,
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');


### PR DESCRIPTION
Now that the debugger v2 depend on the feature flag feature (dark mode
in the SourceFileContainer), we have to provide appropriate stub or
remove it in the `import` path. This change refactors how the test is
authored so we do not have to stub out selectors from other containers.

Source of the error
===================

The error of 'accessing property `defaultFlags` of
undefined' was happening reliably but was throwing in the `afterEach`
which has made the test runtime/reporter behavior flaky (when we were
lucky, the test failed and when we were unlucky, the exception slipped
through the crease). We were able to get the error reliably when run
with `runs_per_test=100` though.

More importantly, the source of the error is the structure of the test.
The unit test had imported the real sub modules and has loaded the
real source-file-container which DebuggerComponent happens to use. This
has made the real implementation of the source-file-container access the
real data without appropriate stub implementation provided via
`overrideSelector`. To fix this, we had made sure no extraneous modules
are loaded as part of the test and only focus on the implementation
current module provides.
