### PR TITLE
source-code: bug fix where dark mode did not apply

### DIFF
--- a/tensorboard/webapp/widgets/source_code/source_code_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_component.ts
@@ -68,6 +68,7 @@ export class SourceCodeComponent implements OnChanges {
     if (this.monaco === null) {
       return;
     }
+    const editorNewlyCreated = changes['monaco'] && this.editor === null;
 
     if (this.editor === null) {
       this.editor = this.monaco.editor.create(
@@ -84,16 +85,15 @@ export class SourceCodeComponent implements OnChanges {
       );
     }
 
-    if (this.editor && changes['lines'] && this.lines) {
+    if (changes['lines'] && this.lines) {
       this.editor.setValue(this.lines.join('\n'));
     }
 
-    const currentFocusedLineno: number | null = changes['monaco']
-      ? this.focusedLineno
-      : changes['focusedLineno']
-      ? changes['focusedLineno'].currentValue
-      : null;
-    if (currentFocusedLineno && this.lines && this.monaco !== null) {
+    const currentFocusedLineno: number | null =
+      editorNewlyCreated || changes['focusedLineno']
+        ? this.focusedLineno
+        : null;
+    if (currentFocusedLineno && this.lines) {
       this.editor.revealLineInCenter(
         currentFocusedLineno,
         this.monaco.editor.ScrollType.Smooth
@@ -126,7 +126,7 @@ export class SourceCodeComponent implements OnChanges {
       ]);
     }
 
-    if (changes['useDarkMode']) {
+    if (editorNewlyCreated || changes['useDarkMode']) {
       this.editor.setTheme(this.getMonacoThemeString());
     }
   }

--- a/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
@@ -67,6 +67,34 @@ describe('Source Code Component', () => {
     'model.add(tf.keras.layers.Dense(1))',
   ];
 
+  it('creates editor with proper paremeter', async () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    const component = fixture.componentInstance;
+    component.lines = lines1;
+    component.focusedLineno = 2;
+    component.useDarkMode = true;
+    fixture.detectChanges();
+    // Simlulate loading monaco and setting the `monaco` input after loading.
+    await loadMonacoShim.loadMonaco();
+    fixture.detectChanges();
+
+    expect(fakes.fakeMonaco.editor.create).toHaveBeenCalledOnceWith(
+      jasmine.any(HTMLElement),
+      {
+        value: 'import tensorflow as tf\n\nprint("hello, world")',
+        language: 'python',
+        readOnly: true,
+        fontSize: 10,
+        minimap: {enabled: true},
+      }
+    );
+    expect(spies.editorSpy.revealLineInCenter).toHaveBeenCalledOnceWith(
+      2,
+      fakes.fakeMonaco.editor.ScrollType.Smooth
+    );
+    expect(spies.editorSpy.setTheme).toHaveBeenCalledOnceWith('vs-dark');
+  });
+
   it('renders a file and change to a new file', async () => {
     const fixture = TestBed.createComponent(TestableComponent);
     const component = fixture.componentInstance;
@@ -139,15 +167,17 @@ describe('Source Code Component', () => {
     });
 
     it('uses different theme when `useDarkMode` changes', () => {
+      // Forget the calls from initialization.
+      spies.editorSpy.setTheme.calls.reset();
       const component = fixture.componentInstance;
 
       component.useDarkMode = true;
       fixture.detectChanges();
-      expect(spies.editorSpy!.setTheme).toHaveBeenCalledOnceWith('vs-dark');
+      expect(spies.editorSpy.setTheme).toHaveBeenCalledOnceWith('vs-dark');
 
       component.useDarkMode = false;
       fixture.detectChanges();
-      expect(spies.editorSpy!.setTheme.calls.allArgs()).toEqual([
+      expect(spies.editorSpy.setTheme.calls.allArgs()).toEqual([
         ['vs-dark'],
         ['vs'],
       ]);

--- a/tensorboard/webapp/widgets/source_code/testing.ts
+++ b/tensorboard/webapp/widgets/source_code/testing.ts
@@ -46,18 +46,21 @@ export const windowWithRequireAndMonaco: any = window;
 
 export function setUpMonacoFakes() {
   async function fakeLoadMonaco() {
+    const create = jasmine
+      .createSpy('fakeMonaco.editor.create')
+      .and.callFake(() => {
+        spies.editorSpy = jasmine.createSpyObj('editorSpy', [
+          'deltaDecorations',
+          'layout',
+          'revealLineInCenter',
+          'setValue',
+          'setTheme',
+        ]);
+        return spies.editorSpy;
+      });
     fakes.fakeMonaco = {
       editor: {
-        create: () => {
-          spies.editorSpy = jasmine.createSpyObj('editorSpy', [
-            'deltaDecorations',
-            'layout',
-            'revealLineInCenter',
-            'setValue',
-            'setTheme',
-          ]);
-          return spies.editorSpy;
-        },
+        create,
         createDiffEditor: () => {
           spies.diffEditorSpy = jasmine.createSpyObj('diffEditorSpy', [
             'layout',


### PR DESCRIPTION
Previously, when manually tested against the only user of the feature,
the source-code component lazily created the monaco editor when the data
was present. However, as I have refactored the code a little bit, the
assumption has toppled and resulted in a bug where initial values are
not set properly. The order of events are following:

- source-code component gets mounted and `ngOnChanges` get triggered
  with the theme value. Because the monaco is not fetched yet by the
  container, it early returns and theme value never gets set.
- when source-code container finally loads the monaco editor,
  ngOnChanges only include the value, `monaco`, and our theme applier
  never gets triggered.

Fix this by detecting the condition in which we have to apply the
settings to the editor.

