### PR TITLE
chore: prevent test log spam

### DIFF
--- a/tensorboard/webapp/widgets/source_code/load_monaco_shim_test.ts
+++ b/tensorboard/webapp/widgets/source_code/load_monaco_shim_test.ts
@@ -75,15 +75,9 @@ describe('loadMonaco shim', () => {
     expect(requireSpy).not.toHaveBeenCalled();
   });
 
-  it('rejects if require.js is unavailable', async (done) => {
+  it('rejects if require.js is unavailable', async () => {
     delete windowWithRequireAndMonaco.require;
-    // TODO(cais): Use async matchers such as toBeRejectedWithError once they
-    // are available.
-    try {
-      await loadMonaco();
-      done.fail();
-    } catch (e) {
-      done();
-    }
+
+    await expectAsync(loadMonaco()).toBeRejected();
   });
 });


### PR DESCRIPTION
Previously, we were using `async/await` and arity based jasmine async
test (i.e., `(done) => {}`). This has caused the test runner to spam the
log saying there is an uncaught exception. Instead of fighting the
runtime, we can now use more contemporary API for dealing with async
(`expectAsync`; https://jasmine.github.io/api/3.7/async-matchers.html).

Example of said log spam:
> 'DEPRECATION: An asynchronous before/it/after function took a done callback but also returned a promise. This is not supported and will stop working in the future. Either remove the done callback (recommended) or change the function to not return a promise. (in spec: loadMonaco shim rejects if require.js is unavailable)'
