### PR TITLE
dark mode: specify app-bar color via `default`

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -47,7 +47,7 @@ $tb-foreground: map_merge(
 $tb-background: map_merge(
   $mat-light-theme-background,
   (
-    app-bar: mat-color($tb-primary, 700),
+    app-bar: mat-color($tb-primary, default),
     // Default is `map.get($grey-palette, 50)`.
     background: #fff,
   )
@@ -75,7 +75,7 @@ $tb-dark-foreground: map_merge(
 $tb-dark-background: map_merge(
   map-get($tb-dark-theme, background),
   (
-    app-bar: mat-color($tb-primary, 900),
+    app-bar: mat-color($tb-dark-primary, default),
   )
 );
 $tb-dark-theme: map_merge(


### PR DESCRIPTION
Color palette has a notion of `default`, `ligher`, `darker`, and `text`
and we can access the said color via name.

This change makes use of the `default` when getting the primary color.
