### PR TITLE
source code: fix dark mode support

### DIFF
--- a/tensorboard/webapp/widgets/source_code/editor_options.ts
+++ b/tensorboard/webapp/widgets/source_code/editor_options.ts
@@ -18,3 +18,7 @@ limitations under the License.
 export const DEFAULT_CODE_LANGUAGE = 'python';
 export const DEFAULT_CODE_FONT_SIZE = 10;
 export const RESIZE_DEBOUNCE_INTERVAL_MS = 50;
+
+export function getMonacoThemeString(useDarkMode: boolean): 'vs' | 'vs-dark' {
+  return useDarkMode ? 'vs-dark' : 'vs';
+}

--- a/tensorboard/webapp/widgets/source_code/source_code_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_component.ts
@@ -25,6 +25,7 @@ import {
 import {
   DEFAULT_CODE_FONT_SIZE,
   DEFAULT_CODE_LANGUAGE,
+  getMonacoThemeString,
   RESIZE_DEBOUNCE_INTERVAL_MS,
 } from './editor_options';
 
@@ -60,10 +61,6 @@ export class SourceCodeComponent implements OnChanges {
     }
   }
 
-  private getMonacoThemeString(): 'vs' | 'vs-dark' {
-    return this.useDarkMode ? 'vs-dark' : 'vs';
-  }
-
   ngOnChanges(changes: SimpleChanges): void {
     if (this.monaco === null) {
       return;
@@ -81,6 +78,7 @@ export class SourceCodeComponent implements OnChanges {
           minimap: {
             enabled: true,
           },
+          theme: getMonacoThemeString(this.useDarkMode),
         }
       );
     }
@@ -126,8 +124,8 @@ export class SourceCodeComponent implements OnChanges {
       ]);
     }
 
-    if (editorNewlyCreated || changes['useDarkMode']) {
-      this.editor.setTheme(this.getMonacoThemeString());
+    if (changes['useDarkMode']) {
+      this.monaco.editor.setTheme(getMonacoThemeString(this.useDarkMode));
     }
   }
 }

--- a/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
@@ -86,13 +86,14 @@ describe('Source Code Component', () => {
         readOnly: true,
         fontSize: 10,
         minimap: {enabled: true},
+        theme: 'vs-dark',
       }
     );
     expect(spies.editorSpy.revealLineInCenter).toHaveBeenCalledOnceWith(
       2,
       fakes.fakeMonaco.editor.ScrollType.Smooth
     );
-    expect(spies.editorSpy.setTheme).toHaveBeenCalledOnceWith('vs-dark');
+    expect(fakes.fakeMonaco.editor.setTheme).not.toHaveBeenCalled();
   });
 
   it('renders a file and change to a new file', async () => {
@@ -168,16 +169,18 @@ describe('Source Code Component', () => {
 
     it('uses different theme when `useDarkMode` changes', () => {
       // Forget the calls from initialization.
-      spies.editorSpy.setTheme.calls.reset();
+      fakes.fakeMonaco.editor.setTheme.calls.reset();
       const component = fixture.componentInstance;
 
       component.useDarkMode = true;
       fixture.detectChanges();
-      expect(spies.editorSpy.setTheme).toHaveBeenCalledOnceWith('vs-dark');
+      expect(fakes.fakeMonaco.editor.setTheme).toHaveBeenCalledOnceWith(
+        'vs-dark'
+      );
 
       component.useDarkMode = false;
       fixture.detectChanges();
-      expect(spies.editorSpy.setTheme.calls.allArgs()).toEqual([
+      expect(fakes.fakeMonaco.editor.setTheme.calls.allArgs()).toEqual([
         ['vs-dark'],
         ['vs'],
       ]);

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_component.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_component.ts
@@ -23,6 +23,7 @@ import {
 } from '@angular/core';
 import {
   DEFAULT_CODE_FONT_SIZE,
+  getMonacoThemeString,
   RESIZE_DEBOUNCE_INTERVAL_MS,
 } from './editor_options';
 
@@ -62,6 +63,9 @@ export class SourceCodeDiffComponent implements OnChanges {
   @Input()
   monaco: typeof monaco | null = null;
 
+  @Input()
+  useDarkMode!: boolean;
+
   @ViewChild('codeViewerContainer', {static: true, read: ElementRef})
   private readonly codeViewerContainer!: ElementRef<HTMLDivElement>;
 
@@ -91,6 +95,7 @@ export class SourceCodeDiffComponent implements OnChanges {
             enabled: true,
           },
           renderSideBySide: this.renderSideBySide,
+          theme: getMonacoThemeString(this.useDarkMode),
         }
       );
     }
@@ -104,6 +109,10 @@ export class SourceCodeDiffComponent implements OnChanges {
 
     if (changes['renderSideBySide']) {
       this.editor.updateOptions({renderSideBySide: this.renderSideBySide});
+    }
+
+    if (changes['useDarkMode']) {
+      this.monaco.editor.setTheme(getMonacoThemeString(this.useDarkMode));
     }
   }
 }

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
@@ -32,6 +32,7 @@ import {loadMonaco} from './load_monaco_shim';
       [secondText]="secondText"
       [renderSideBySide]="renderSideBySide"
       [monaco]="monaco$ | async"
+      [useDarkMode]="useDarkMode"
     ></source-code-diff-component>
   `,
   styles: [
@@ -53,6 +54,9 @@ export class SourceCodeDiffContainer implements OnInit {
 
   @Input()
   renderSideBySide: boolean = true;
+
+  @Input()
+  useDarkMode: boolean = false;
 
   monaco$: Observable<typeof monaco> | null = null;
 

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
@@ -12,19 +12,40 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ChangeDetectorRef, NO_ERRORS_SCHEMA} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  Input,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import * as loadMonacoShim from './load_monaco_shim';
 import {SourceCodeDiffComponent} from './source_code_diff_component';
 import {SourceCodeDiffContainer} from './source_code_diff_container';
-import {setUpMonacoFakes, spies, tearDownMonacoFakes} from './testing';
+import {fakes, setUpMonacoFakes, spies, tearDownMonacoFakes} from './testing';
+
+// Does not use OnPush change detector, making it easier to test with.
+@Component({
+  selector: 'testable-component',
+  template: `
+    <source-code-diff [useDarkMode]="useDarkMode"></source-code-diff>
+  `,
+})
+class TestableComponent {
+  @Input()
+  useDarkMode?: boolean;
+}
 
 describe('Source Code Diff', () => {
   beforeEach(async () => {
     setUpMonacoFakes();
     await TestBed.configureTestingModule({
-      declarations: [SourceCodeDiffComponent, SourceCodeDiffContainer],
+      declarations: [
+        TestableComponent,
+        SourceCodeDiffComponent,
+        SourceCodeDiffContainer,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
@@ -106,5 +127,27 @@ describe('Source Code Diff', () => {
     const component = fixture.componentInstance;
     component.ngOnInit();
     expect(spies.loadMonacoSpy!).toHaveBeenCalledTimes(1);
+  });
+
+  describe('useDarkMode', () => {
+    it('updates theme when useDarkMode changes', async () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      const component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      await loadMonacoShim.loadMonaco();
+      fixture.detectChanges();
+
+      component.useDarkMode = true;
+      fixture.detectChanges();
+
+      component.useDarkMode = false;
+      fixture.detectChanges();
+
+      expect(fakes.fakeMonaco.editor.setTheme.calls.allArgs()).toEqual([
+        ['vs-dark'],
+        ['vs'],
+      ]);
+    });
   });
 });

--- a/tensorboard/webapp/widgets/source_code/testing.ts
+++ b/tensorboard/webapp/widgets/source_code/testing.ts
@@ -54,7 +54,6 @@ export function setUpMonacoFakes() {
           'layout',
           'revealLineInCenter',
           'setValue',
-          'setTheme',
         ]);
         return spies.editorSpy;
       });
@@ -77,6 +76,7 @@ export function setUpMonacoFakes() {
           Immediate: 1,
           Smooth: 0,
         },
+        setTheme: jasmine.createSpy('monaco.editor.setTheme'),
       },
       Range: FakeRange,
     };


### PR DESCRIPTION
Apparently, monaco does not let each editor specify theme but rather it
is specified at the global scope: `monaco.editor.setTheme` vs.
`monaco.editor.create().setTheme()`. Interestingly, `create` method does
take an additional `theme` property so you may be able to customize it
at the creation time but when user wants to toggle dark mode and thus
circulate VS code theme, we _may_ get into trouble.

For now, this change simply fixes the breakge by properly using the API.
