### PR TITLE
theme: allow customizable `app-bar` theme var

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -26,9 +26,16 @@ limitations under the License.
 // Include non-theme styles for core.
 @include mat-core();
 
+// Value for `app-bar` property in $tb-background. Can specify an override in
+// _variable.scss to specifically customize this value.
+$tb-app-bar-color: mat-color($tb-primary, default) !default;
+
 $tb-dark-primary: $tb-primary !default;
 $tb-dark-accent: $tb-accent !default;
 $tb-dark-warn: $tb-warn !default;
+// Value for `app-bar` property in $tb-dark-background. Can specify an override
+// in _variable.scss to specifically customize this value.
+$tb-dark-app-bar-color: mat-color($tb-dark-primary, default) !default;
 
 $tb-theme: mat-light-theme($tb-primary, $tb-accent, $tb-warn);
 
@@ -48,7 +55,7 @@ $tb-foreground: map_merge(
 $tb-background: map_merge(
   $mat-light-theme-background,
   (
-    app-bar: mat-color($tb-primary, default),
+    app-bar: $tb-app-bar-color,
     // Default is `map.get($grey-palette, 50)`.
     background: #fff,
   )
@@ -79,7 +86,7 @@ $tb-dark-foreground: map_merge(
 $tb-dark-background: map_merge(
   map-get($tb-dark-theme, background),
   (
-    app-bar: mat-color($tb-dark-primary, default),
+    app-bar: $tb-dark-app-bar-color,
   )
 );
 $tb-dark-theme: map_merge(


### PR DESCRIPTION
This is the final iteration of the change. Previously, we had thought
that using `default` value to `mat-color` would be sufficient but we
were incorrect.

Background is the following. In other variants of TensorBoard, we
elected to use very dark primary color. It looks nice under the light
theme but under the dark theme, its lightness is too close to that of
background so we had to make its primary default color to be light. With
previous change, now, our app-bar under dark mode would be super light
which is certainly not what we had wished.

With other hackier theme template munging set aside, now, we are
choosing to declare `app-bar` as one of special variable that can be
customized like `tb-primary` that is, when provided, will be used in the
theme object.
