### PR TITLE
theme: color all links in header as white

### DIFF
--- a/tensorboard/webapp/header/header_component.scss
+++ b/tensorboard/webapp/header/header_component.scss
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
 mat-toolbar {
   align-items: center;
   color: #fff;
@@ -45,4 +47,12 @@ settings-button {
   font-size: 14px;
   height: 100%;
   overflow: hidden;
+}
+
+:host a {
+  color: inherit;
+
+  @include tb-dark-theme {
+    color: inherit;
+  }
 }


### PR DESCRIPTION
Previously, we set the global anchor element style to appeared blue and
purple (for visited links). This has impacted how links are drawn in the
header which we wanted to keep as white (for saliency with the header
color).

For un-visited links, this should have no changes but will change
visited links back to our normal color.