### PR TITLE
feature flag: add flag for controlling dark mode

### DIFF
--- a/tensorboard/webapp/feature_flag/effects/BUILD
+++ b/tensorboard/webapp/feature_flag/effects/BUILD
@@ -9,6 +9,8 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/feature_flag/actions",
+        "//tensorboard/webapp/feature_flag/store",
+        "//tensorboard/webapp/feature_flag/store:types",
         "//tensorboard/webapp/webapp_data_source:feature_flag_types",
         "@npm//@angular/core",
         "@npm//@ngrx/effects",
@@ -29,6 +31,7 @@ tf_ng_module(
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/feature_flag:testing",
         "//tensorboard/webapp/feature_flag/actions",
+        "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/feature_flag/store:types",
         "//tensorboard/webapp/webapp_data_source:feature_flag_testing",
         "@npm//@ngrx/effects",

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -24,6 +24,7 @@ import {
   TestingTBFeatureFlagDataSource,
 } from '../../webapp_data_source/tb_feature_flag_testing';
 import {partialFeatureFlagsLoaded} from '../actions/feature_flag_actions';
+import {getIsAutoDarkModeAllowed} from '../store/feature_flag_selectors';
 import {State} from '../store/feature_flag_types';
 import {buildFeatureFlag} from '../testing';
 import {FeatureFlagEffects} from './feature_flag_effects';
@@ -47,6 +48,7 @@ describe('feature_flag_effects', () => {
     effects = TestBed.inject(FeatureFlagEffects);
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dataSource = TestBed.inject(TestingTBFeatureFlagDataSource);
+    store.overrideSelector(getIsAutoDarkModeAllowed, false);
   });
 
   describe('getFeatureFlags$', () => {

--- a/tensorboard/webapp/feature_flag/store/BUILD
+++ b/tensorboard/webapp/feature_flag/store/BUILD
@@ -34,7 +34,10 @@ tf_ts_library(
     name = "testing",
     testonly = True,
     srcs = ["testing.ts"],
-    deps = [":types"],
+    deps = [
+        ":types",
+        "//tensorboard/webapp/feature_flag:testing",
+    ],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -53,6 +53,13 @@ export const getOverriddenFeatureFlags = createSelector(
   }
 );
 
+export const getIsAutoDarkModeAllowed = createSelector(
+  getFeatureFlags,
+  (flags): boolean => {
+    return flags.isAutoDarkModeAllowed;
+  }
+);
+
 export const getDarkModeEnabled = createSelector(
   getFeatureFlags,
   (flags): boolean => {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -117,6 +117,43 @@ describe('feature_flag_selectors', () => {
     });
   });
 
+  describe('#getIsAutoDarkModeAllowed', () => {
+    it('returns the proper value', () => {
+      let state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            isAutoDarkModeAllowed: true,
+          }),
+        })
+      );
+      expect(selectors.getIsAutoDarkModeAllowed(state)).toEqual(true);
+
+      state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            isAutoDarkModeAllowed: false,
+          }),
+          flagOverrides: {
+            isAutoDarkModeAllowed: true,
+          },
+        })
+      );
+      expect(selectors.getIsAutoDarkModeAllowed(state)).toEqual(true);
+
+      state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            isAutoDarkModeAllowed: false,
+          }),
+          flagOverrides: {
+            isAutoDarkModeAllowed: false,
+          },
+        })
+      );
+      expect(selectors.getIsAutoDarkModeAllowed(state)).toEqual(false);
+    });
+  });
+
   describe('#getEnabledExperimentalPlugins', () => {
     it('returns value in array', () => {
       const state = buildState(

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -20,6 +20,7 @@ import {FeatureFlagState} from './feature_flag_types';
 export const initialState: FeatureFlagState = {
   isFeatureFlagsLoaded: false,
   defaultFlags: {
+    isAutoDarkModeAllowed: false,
     enableDarkMode: false,
     enabledColorGroup: false,
     enabledExperimentalPlugins: [],

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -14,20 +14,14 @@ limitations under the License.
 ==============================================================================*/
 
 import {FeatureFlagState, FEATURE_FLAG_FEATURE_KEY} from './feature_flag_types';
+import {buildFeatureFlag} from '../testing';
 
 export function buildFeatureFlagState(
   override: Partial<FeatureFlagState> = {}
 ): FeatureFlagState {
   return {
     isFeatureFlagsLoaded: false,
-    defaultFlags: {
-      enableDarkMode: false,
-      enabledExperimentalPlugins: [],
-      inColab: false,
-      scalarsBatchSize: 1,
-      enabledColorGroup: false,
-      metricsImageSupportEnabled: true,
-    },
+    defaultFlags: buildFeatureFlag(),
     ...override,
     flagOverrides: override.flagOverrides ?? {},
   };

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -19,6 +19,7 @@ export function buildFeatureFlag(
   override: Partial<FeatureFlags> = {}
 ): FeatureFlags {
   return {
+    isAutoDarkModeAllowed: false,
     enableDarkMode: false,
     enabledColorGroup: false,
     enabledExperimentalPlugins: [],

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -17,6 +17,11 @@ export interface FeatureFlags {
   // Whether user wants to use dark mode. It can be set via browser setting
   // (media query).
   enableDarkMode: boolean;
+  // Whether the dark mode feature is enabled or disabled at the application
+  // level. Temporary flag to gate the feature until it is more feature
+  // complete (it is badly broken on Firefox). The feature is still available
+  // when using the query parameter, `?darkMode`.
+  isAutoDarkModeAllowed: boolean;
   // Whether to enable experimental semantic color grouping feature.
   enabledColorGroup: boolean;
   // experimental plugins to manually enable.

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -41,12 +41,14 @@ const DARK_MODE_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 // Decide how to move forward with more sources of the data + composability.
 @Injectable()
 export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
-  getFeatures() {
+  getFeatures(enableMediaQuery: boolean = false) {
     const params = this.getParams();
     // Set feature flag value for query parameters that are explicitly
     // specified. Feature flags for unspecified query parameters remain unset so
     // their values in the underlying state are not inadvertently changed.
-    const featureFlags: Partial<FeatureFlags> = this.getPartialFeaturesFromMediaQuery();
+    const featureFlags: Partial<FeatureFlags> = enableMediaQuery
+      ? this.getPartialFeaturesFromMediaQuery()
+      : {};
     if (params.has(EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY)) {
       featureFlags.enabledExperimentalPlugins = params.getAll(
         EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY
@@ -84,11 +86,9 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
 
     // When media query matches positively, it certainly means user wants it but
     // it is not definitive otherwise (i.e., query params can override it).
-    // TODO(stephanwlee): enable the feature when most of the UI is actually
-    // ready for usage.
-    // if (enableDarkMode) {
-    //   featureFlags.enableDarkMode = true;
-    // }
+    if (enableDarkMode) {
+      featureFlags.enableDarkMode = true;
+    }
 
     return featureFlags;
   }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -121,11 +121,11 @@ describe('tb_feature_flag_data_source', () => {
             .and.returnValue({matches: matchDarkMode} as MediaQueryList);
         }
 
-        it('returns enableDarkMode when media query matches dark mode', () => {
+        it('takes value from media query when `enableMediaQuery` is true', () => {
           fakeMediaQuery(true);
-          // TODO(stephanwlee): the feature is hard disabled for now until it
-          // actually ready. Expect this value to be `true` when ready.
-          expect(dataSource.getFeatures()).toEqual({});
+          expect(dataSource.getFeatures(true)).toEqual({
+            enableDarkMode: true,
+          });
         });
 
         it(
@@ -133,7 +133,7 @@ describe('tb_feature_flag_data_source', () => {
             'dark mode',
           () => {
             fakeMediaQuery(false);
-            expect(dataSource.getFeatures()).toEqual({});
+            expect(dataSource.getFeatures(true)).toEqual({});
           }
         );
       });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -28,7 +28,7 @@ export abstract class TBFeatureFlagDataSource {
    * The data source may leave some or all feature flags unspecified if it does
    * not have enough information to provide values.
    */
-  abstract getFeatures(): Partial<FeatureFlags>;
+  abstract getFeatures(enableMediaQuery?: boolean): Partial<FeatureFlags>;
 }
 
 export const EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY = 'experimentalPlugin';


### PR DESCRIPTION
We want to slowly enable the dark mode based on media query on
app-by-app basis. This change allows each application to configure 
whether the media query based dark mode is possible.

