### PR TITLE
dark mode: fix UI in Firefox

### DIFF
--- a/tensorboard/components/polymer/BUILD
+++ b/tensorboard/components/polymer/BUILD
@@ -25,6 +25,16 @@ tf_ts_library(
 )
 
 tf_ts_library(
+    name = "dark_mode_mixin",
+    srcs = [
+        "dark_mode_mixin.ts",
+    ],
+    deps = [
+        "@npm//@polymer/polymer",
+    ],
+)
+
+tf_ts_library(
     name = "legacy_element_mixin",
     srcs = [
         "legacy_element_mixin.ts",

--- a/tensorboard/components/polymer/dark_mode_mixin.ts
+++ b/tensorboard/components/polymer/dark_mode_mixin.ts
@@ -1,0 +1,62 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {PolymerElement} from '@polymer/polymer';
+
+/**
+ * Polymer mixin replacement for `:host-context(body.dark-mode)`.
+ *-
+ * Unfortunately, Firefox does not support `:host-context()` and cannot use the
+ * WebComponent way of styling shadow DOMs with context for ancestor [1][2].
+ * To work around the issue, we are creating a WebComponent mixin that adds
+ * class `dark-mode` to `:host` when body contains the class, `.dark-mode`.
+ *
+ * Unfortunately, due to our infamiliarity with mixins, our types are imperfect.
+ *
+ * [1]: https://developer.mozilla.org/en-US/docs/Web/CSS/:host-context()
+ * [2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1082060
+ */
+export function DarkModeMixin<T extends PolymerElement>(
+  Base: new () => PolymerElement
+): new () => T {
+  return (class Foo extends Base {
+    private observer?: MutationObserver;
+
+    connectedCallback() {
+      super.connectedCallback();
+      this._maybeSetDarkMode();
+
+      this.observer = new MutationObserver((mutations) => {
+        const classChanged = mutations.some((mutation) => {
+          return mutation.attributeName === 'class';
+        });
+        if (classChanged) this._maybeSetDarkMode();
+      });
+      this.observer.observe(document.body, {attributes: true});
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.observer?.disconnect();
+    }
+
+    private _maybeSetDarkMode() {
+      this.classList.toggle(
+        'dark-mode',
+        document.body.classList.contains('dark-mode')
+      );
+    }
+  } as unknown) as new () => T;
+}

--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -24,6 +24,7 @@ tf_ts_library(
     ],
     strict_checks = False,
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:irons_and_papers",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/components/polymer:paper_inky_focus_behavior",

--- a/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
+++ b/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
@@ -30,6 +30,7 @@ style.textContent = `
     --tb-raised-button-shadow-color: rgba(0, 0, 0, 0.2);
     --primary-background-color: #fff;
     --secondary-background-color: #e9e9e9;
+    --tb-layout-background-color: #f5f5f5;
   }
 
   :root .dark-mode {
@@ -42,6 +43,7 @@ style.textContent = `
     --secondary-text-color: var(--paper-grey-400);
     --primary-background-color: #303030;  /* material grey A400. */
     --secondary-background-color: #3a3a3a;
+    --tb-layout-background-color: #3a3a3a;
   }
 `;
 document.head.appendChild(style);

--- a/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.ts
@@ -18,9 +18,10 @@ import {customElement} from '@polymer/decorators';
 
 import './tensorboard-color';
 import './scrollbar-style';
+import {DarkModeMixin} from '../polymer/dark_mode_mixin';
 
 @customElement('tf-dashboard-layout')
-class TfDashboardLayout extends PolymerElement {
+class TfDashboardLayout extends DarkModeMixin(PolymerElement) {
   static readonly template = html`
     <div id="sidebar">
       <slot name="sidebar"></slot>
@@ -38,7 +39,7 @@ class TfDashboardLayout extends PolymerElement {
         height: 100%;
       }
 
-      :host-context(body.dark-mode) {
+      :host(.dark-mode) {
         background-color: var(--secondary-background-color);
       }
 

--- a/tensorboard/plugins/graph/tf_graph/BUILD
+++ b/tensorboard/plugins/graph/tf_graph/BUILD
@@ -14,6 +14,7 @@ tf_ts_library(
     ],
     strict_checks = False,
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:irons_and_papers",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/components/tb_debug",

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -17,7 +17,7 @@ import {html} from '@polymer/polymer';
 // Please keep node font-size/classnames in sync with tf-graph-common/common.ts
 export const template = html`
   <style>
-    :host-context(body.dark-mode) {
+    :host(.dark-mode) {
       filter: invert(1);
     }
 

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -31,13 +31,14 @@ import * as tf_graph_minimap from '../tf_graph_common/minimap';
 import * as tf_graph_render from '../tf_graph_common/render';
 import {template} from './tf-graph-scene.html';
 
+import {DarkModeMixin} from '../../../components/polymer/dark_mode_mixin';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import {TfGraphScene} from '../tf_graph_common/tf-graph-scene';
 import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-graph-scene')
 class TfGraphScene2
-  extends LegacyElementMixin(PolymerElement)
+  extends LegacyElementMixin(DarkModeMixin(PolymerElement))
   implements TfGraphScene {
   static readonly template = template;
 

--- a/tensorboard/plugins/graph/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/BUILD
@@ -32,6 +32,7 @@ tf_ts_library(
     strict_checks = False,
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:dom",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/components/tb_debug",

--- a/tensorboard/plugins/graph/tf_graph_common/tf-graph-icon.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/tf-graph-icon.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import {PolymerElement, html} from '@polymer/polymer';
 import {computed, customElement, property} from '@polymer/decorators';
 
+import {DarkModeMixin} from '../../../components/polymer/dark_mode_mixin';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import '../../../components/tf_dashboard_common/tensorboard-color';
 
@@ -29,14 +30,14 @@ export enum GraphIconType {
   SUMMARY = 'SUMMARY',
 }
 @customElement('tf-graph-icon')
-class TfGraphIcon extends LegacyElementMixin(PolymerElement) {
+class TfGraphIcon extends LegacyElementMixin(DarkModeMixin(PolymerElement)) {
   static readonly template = html`
     <style>
       :host {
         font-size: 0;
       }
 
-      :host-context(body.dark-mode) svg {
+      :host(.dark-mode) svg {
         filter: invert(1);
       }
 

--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -11,6 +11,7 @@ tf_ts_library(
     ],
     strict_checks = False,
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:irons_and_papers",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/components/tb_debug",

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -27,6 +27,7 @@ import * as tf_graph_util from '../tf_graph_common/util';
 import '../../../components/tf_dashboard_common/tensorboard-color';
 import '../tf_graph_common/tf-graph-icon';
 import '../tf_graph_node_search/tf-graph-node-search';
+import {DarkModeMixin} from '../../../components/polymer/dark_mode_mixin';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import {ColorBy} from '../tf_graph_common/view_types';
 
@@ -109,7 +110,9 @@ const GRADIENT_COMPATIBLE_COLOR_BY: Set<ColorBy> = new Set([
   ColorBy.MEMORY,
 ]);
 @customElement('tf-graph-controls')
-class TfGraphControls extends LegacyElementMixin(PolymerElement) {
+class TfGraphControls extends LegacyElementMixin(
+  DarkModeMixin(PolymerElement)
+) {
   static readonly template = html`
     <style>
       :host {
@@ -127,7 +130,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
         --paper-font-subhead_-_font-size: 14px;
       }
 
-      :host-context(body.dark-mode) {
+      :host(.dark-mode) {
         --tb-graph-controls-title-color: #fff;
         --tb-graph-controls-legend-text-color: #f3f3f3;
         --tb-graph-controls-text-color: #eee;

--- a/tensorboard/plugins/graph/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/BUILD
@@ -13,6 +13,7 @@ tf_ts_library(
     ],
     strict_checks = False,
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:dom",
         "//tensorboard/components/polymer:irons_and_papers",
         "//tensorboard/components/polymer:legacy_element_mixin",

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-list-item.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-list-item.ts
@@ -18,11 +18,12 @@ import {customElement, property} from '@polymer/decorators';
 import '../../../components/tf_dashboard_common/tensorboard-color';
 import '../tf_graph_common/tf-node-icon';
 
+import {DarkModeMixin} from '../../../components/polymer/dark_mode_mixin';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import {ColorBy} from '../tf_graph_common/view_types';
 
 @customElement('tf-node-list-item')
-class TfNodeListItem extends LegacyElementMixin(PolymerElement) {
+class TfNodeListItem extends LegacyElementMixin(DarkModeMixin(PolymerElement)) {
   static readonly template = html`
     <style>
       #list-item {
@@ -38,7 +39,7 @@ class TfNodeListItem extends LegacyElementMixin(PolymerElement) {
         background-color: var(--google-yellow-100);
       }
 
-      :host-context(body.dark-mode) #list-item:hover {
+      :host(.dark-mode) #list-item:hover {
         background-color: var(--paper-yellow-900);
         color: #fff;
       }

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
@@ -12,6 +12,7 @@ tf_ts_library(
     ],
     strict_checks = False,
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:irons_and_papers",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/components/tf_dashboard_common",

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.ts
@@ -24,9 +24,12 @@ import * as tf_graph_hierarchy from '../tf_graph_common/hierarchy';
 import * as tf_graph_render from '../tf_graph_common/render';
 
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {DarkModeMixin} from '../../../components/polymer/dark_mode_mixin';
 
 @customElement('tf-graph-op-compat-card')
-class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
+class TfGraphOpCompatCard extends LegacyElementMixin(
+  DarkModeMixin(PolymerElement)
+) {
   static readonly template = html`
     <style>
       :host {
@@ -94,7 +97,7 @@ class TfGraphOpCompatCard extends LegacyElementMixin(PolymerElement) {
        * Sadly, because the whole body is inverted in color, legends also need
        * to be inverted.
        **/
-      :host-context(body.dark-mode) div.op-compat-display {
+      :host(.dark-mode) div.op-compat-display {
         filter: invert(1);
       }
 

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/BUILD
@@ -15,6 +15,7 @@ tf_ts_library(
     ],
     strict_checks = False,
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/plugins/hparams:types",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_values",

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
@@ -65,6 +65,7 @@ import {html, PolymerElement} from '@polymer/polymer';
 import * as d3 from 'd3';
 import * as _ from 'lodash';
 
+import {DarkModeMixin} from '../../../components/polymer/dark_mode_mixin';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 import '../tf_hparams_session_group_values/tf-hparams-session-group-values';
 import {HparamInfo, MetricInfo, Schema} from '../tf_hparams_types/types';
@@ -83,7 +84,9 @@ interface Option {
 }
 
 @customElement('tf-hparams-parallel-coords-plot')
-class TfHparamsParallelCoordsPlot extends LegacyElementMixin(PolymerElement) {
+class TfHparamsParallelCoordsPlot extends LegacyElementMixin(
+  DarkModeMixin(PolymerElement)
+) {
   static readonly template = html`
     <div id="container">
       <svg id="svg"></svg>
@@ -94,7 +97,7 @@ class TfHparamsParallelCoordsPlot extends LegacyElementMixin(PolymerElement) {
         --tf-hparams-parallel-coords-plot-axis-shadow: 0 1px 0 #fff,
           1px 0 0 #fff, 0 -1px 0 #fff, -1px 0 0 #fff;
       }
-      :host-context(body.dark-mode) {
+      :host(.dark-mode) {
         --tf-hparams-parallel-coords-plot-axis-shadow: 0 1px 0 #000,
           1px 0 0 #000, 0 -1px 0 #000, -1px 0 0 #000;
       }

--- a/tensorboard/plugins/hparams/tf_hparams_table_view/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_table_view/BUILD
@@ -12,6 +12,7 @@ tf_ts_library(
     ],
     strict_checks = False,
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:dom",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_details",

--- a/tensorboard/plugins/hparams/tf_hparams_table_view/tf-hparams-table-view.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_table_view/tf-hparams-table-view.ts
@@ -21,9 +21,12 @@ import * as PolymerDom from '../../../components/polymer/dom';
 import '../tf_hparams_session_group_details/tf-hparams-session-group-details';
 import * as tf_hparams_utils from '../tf_hparams_utils/tf-hparams-utils';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
+import {DarkModeMixin} from '../../../components/polymer/dark_mode_mixin';
 
 @customElement('tf-hparams-table-view')
-class TfHparamsTableView extends LegacyElementMixin(PolymerElement) {
+class TfHparamsTableView extends LegacyElementMixin(
+  DarkModeMixin(PolymerElement)
+) {
   static readonly template = html`
     <vaadin-grid
       class="session-group-table"
@@ -105,12 +108,12 @@ class TfHparamsTableView extends LegacyElementMixin(PolymerElement) {
         display: inline;
       }
 
-      :host-context(body.dark-mode) {
+      :host(.dark-mode) {
         --lumo-base-color: #303030;
         --lumo-body-text-color: #fff;
       }
 
-      :host-context(body.dark-mode) vaadin-grid {
+      :host(.dark-mode) vaadin-grid {
         --_lumo-grid-secondary-border-color: #505050;
       }
 

--- a/tensorboard/webapp/core/views/dark_mode_supporter_container.ts
+++ b/tensorboard/webapp/core/views/dark_mode_supporter_container.ts
@@ -33,6 +33,8 @@ import {getDarkModeEnabled} from '../../selectors';
 export class DarkModeSupportContainer {
   constructor(store: Store<State>) {
     store.select(getDarkModeEnabled).subscribe((darkMode) => {
+      // When changing the class name `dark-mode`, we need to update the
+      // DarkModeMixin which relies on the class name.
       document.body.classList.toggle('dark-mode', darkMode);
     });
   }


### PR DESCRIPTION
Firefox does not support `:host-context()` selector which is crucial for
the Polymer theme support. To work around it, we are introducing a
mixin that grabs a value from the `body` and append a class name
accordingly.
