### PR TITLE
ci: pin tf-nightly to 20210614

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tf_version_id: ['tf-nightly', 'notf']
+        tf_version_id: ['tf-nightly==2.6.0.dev20210614', 'notf']
         python_version: ['3.7']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
+  # See https://github.com/tensorflow/tensorboard/pull/5068.
+  TENSORFLOW_VERSION: 'tf-nightly==2.6.0.dev20210614'
 
 jobs:
   build:
@@ -40,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tf_version_id: ['tensorflow', 'notf']
+        tf_version_id: ['tf', 'notf']
         python_version: ['3.7']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -75,7 +77,7 @@ jobs:
             "common --remote_upload_local_results=true" \
             ;
       - name: 'Install TensorFlow'
-        run: pip install "${{ matrix.tf_version_id }}"
+        run: pip install "${TENSORFLOW_VERSION}"
         if: matrix.tf_version_id != 'notf'
       - name: 'Install Python dependencies'
         run: |
@@ -96,10 +98,16 @@ jobs:
       - name: 'Bazel: test (non-TensorFlow only)'
         run: bazel test //tensorboard/... --test_tag_filters="support_notf"
         if: matrix.tf_version_id == 'notf'
-      - name: 'Bazel: run Pip package test'
+      - name: 'Bazel: run Pip package test (with TensorFlow support)'
         run: |
           bazel run //tensorboard/pip_package:test_pip_package -- \
-            --tf-version "${{ matrix.tf_version_id }}"
+            --tf-version "${TENSORFLOW_VERSION}"
+        if: matrix.tf_version_id != 'notf'
+      - name: 'Bazel: run Pip package test (non-TensorFlow only)'
+        run: |
+          bazel run //tensorboard/pip_package:test_pip_package -- \
+            --tf-version notf"
+        if: matrix.tf_version_id == 'notf'
       - name: 'Bazel: run manual tests'
         run: |
           bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tf_version_id: ['tf-nightly==2.6.0.dev20210614', 'notf']
+        tf_version_id: ['tensorflow', 'notf']
         python_version: ['3.7']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: 'Bazel: run Pip package test (non-TensorFlow only)'
         run: |
           bazel run //tensorboard/pip_package:test_pip_package -- \
-            --tf-version notf"
+            --tf-version notf
         if: matrix.tf_version_id == 'notf'
       - name: 'Bazel: run manual tests'
         run: |


### PR DESCRIPTION
With the latest nightly (20210616), TensorBoard CI fails because hparams
API fails to load properly when importing TensorFlow inside TensorBoard
project.

Specifically, below fails.

```sh
# cd into TensorBoard repository
cd tensorboard
python
>>> import tensorflow as tf
```

This may have to do with summaries are exported under TensorFlow and
requires a bit more precise diagnosis. Until then, we will pin the
tf-nightly to the last good version.

Suspected breaking change: https://github.com/tensorflow/tensorflow/commit/2e6acf753381cb7902017bcab03e204bb41b7091
