### PR TITLE
Revert "histogram: avoid data transfer overhead for TPU outside compilation"

### DIFF
--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -131,22 +131,16 @@ def histogram(name, data, step=None, buckets=None, description=None):
                 metadata=summary_metadata,
             )
 
-    # `_buckets()` has dynamic output shapes which is not supported on TPU's.
-    # To address this, explicitly mark this logic for outside compilation so it
-    # will be executed on the CPU, and skip it entirely if we aren't actually
-    # recording summaries to avoid overhead of transferring data.
-    # TODO(https://github.com/tensorflow/tensorboard/issues/2885): Remove this
-    # special handling once the format no longer requires dynamic output shapes.
+    # `_buckets()` has dynamic output shapes which is not supported on TPU's. As so, place
+    # the bucketing ops on outside compilation cluster so that the function in executed on CPU.
+    # TODO(https://github.com/tensorflow/tensorboard/issues/2885): Remove this special
+    # handling once dynamic shapes are supported on TPU's.
     if isinstance(
         tf.distribute.get_strategy(),
         (tf.distribute.experimental.TPUStrategy, tf.distribute.TPUStrategy),
     ):
-        return tf.cond(
-            tf.summary.should_record_summaries(),
-            lambda: tf.compat.v1.tpu.outside_compilation(
-                histogram_summary, data, buckets, summary_metadata, step
-            ),
-            lambda: False,
+        return tf.compat.v1.tpu.outside_compilation(
+            histogram_summary, data, buckets, summary_metadata, step
         )
     return histogram_summary(data, buckets, summary_metadata, step)
 


### PR DESCRIPTION
Reverts tensorflow/tensorboard#5066. Broke AutoOutsideCompilationWithKerasTest in internal CI: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/tests/automatic_outside_compilation_test.py

Needs further investigation before relanding.