### PR TITLE
dark mode: enable media query based dark mode

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -20,7 +20,7 @@ import {FeatureFlagState} from './feature_flag_types';
 export const initialState: FeatureFlagState = {
   isFeatureFlagsLoaded: false,
   defaultFlags: {
-    isAutoDarkModeAllowed: false,
+    isAutoDarkModeAllowed: true,
     enableDarkMode: false,
     enabledColorGroup: false,
     enabledExperimentalPlugins: [],

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -20,7 +20,7 @@ export function buildFeatureFlagState(
   override: Partial<FeatureFlagState> = {}
 ): FeatureFlagState {
   return {
-    isFeatureFlagsLoaded: false,
+    isFeatureFlagsLoaded: true,
     defaultFlags: buildFeatureFlag(),
     ...override,
     flagOverrides: override.flagOverrides ?? {},


### PR DESCRIPTION
This change enables the dark mode in OSS. The feature will turn on by
default when user's browser says they prefer the dark mode.

The feature can be mnaually turned off with `?darkMode=false`. In the
future, we will add a button that lets user toggle the dark mode in the
header.

