### PR TITLE
projector: allow lib to be side loaded

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -88,8 +88,10 @@ tf_ts_library(
     deps = [":sptree"],
 )
 
+################# Standalone development #################
+
 tf_js_binary(
-    name = "standalone_bundle",
+    name = "standalone_bundle_no_vendor",
     compile = 1,
     entry_point = "bundle.ts",
     includes_polymer = True,
@@ -98,7 +100,16 @@ tf_js_binary(
     ],
 )
 
-################# Standalone development #################
+genrule(
+    name = "standalone_bundle_js",
+    srcs = [
+        # DO NOT SORT.
+        # internal: umap_runtime_dep
+        ":standalone_bundle_no_vendor.js",
+    ],
+    outs = ["standalone_bundle.js"],
+    cmd = "cat $(SRCS) > $@",
+)
 
 tf_web_library(
     name = "standalone_lib",


### PR DESCRIPTION
Internally, libraries like UMAP and threejs are loaded a bit differently
and the proxy genrule allows us to precisely add and side load the
runtime dependencies.
