### PR TITLE
scalar: fix axis label on Firefox

### DIFF
--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -169,7 +169,11 @@ export class LineChart {
     this.xAccessor = xComponents.accessor;
     this.xScale = xComponents.scale;
     this.xAxis = xComponents.axis;
-    (this.xAxis.margin(0) as Plottable.Axes.Numeric).tickLabelPadding(3);
+    // Default margin is 15 pixels but we do not need it. Setting it to zero
+    // makes space calculation a bit too tight and hide axis label by mistake.
+    // To workaround the tight tolerance issue, we add 1px of margin.
+    // See https://github.com/tensorflow/tensorboard/issues/5077.
+    (this.xAxis.margin(1) as Plottable.Axes.Numeric).tickLabelPadding(3);
     if (xAxisFormatter) {
       this.xAxis.formatter(xAxisFormatter);
     }


### PR DESCRIPTION
Please see #5077 for more details. Because of the tight tolerance,
Plottable was setting `visibility: hidden` on the axis label when it
really shouldn't since we have sufficient space.

Fixes #5077.