### PR TITLE
dark mode: improve viz UX under dark mode

### DIFF
--- a/tensorboard/plugins/distribution/vz_distribution_chart/vz-distribution-chart.ts
+++ b/tensorboard/plugins/distribution/vz_distribution_chart/vz-distribution-chart.ts
@@ -178,6 +178,9 @@ class _VzDistributionChart
         flex-grow: 1;
         flex-shrink: 1;
       }
+      .plottable .axis text {
+        fill: currentColor;
+      }
     </style>
   `;
 

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/BUILD
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/BUILD
@@ -9,6 +9,7 @@ tf_ts_library(
     srcs = ["vz-histogram-timeseries.ts"],
     strict_checks = False,
     deps = [
+        "//tensorboard/components/polymer:dark_mode_mixin",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.ts
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.ts
@@ -17,6 +17,7 @@ import {PolymerElement, html} from '@polymer/polymer';
 import {customElement, observe, property} from '@polymer/decorators';
 import * as d3Typed from 'd3';
 
+import {DarkModeMixin} from '../../../components/polymer/dark_mode_mixin';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 
 // Copied from `tf-histogram-dashboard/histogramCore`; TODO(wchargin):
@@ -45,7 +46,7 @@ export interface VzHistogramTimeseries extends HTMLElement {
 
 @customElement('vz-histogram-timeseries')
 class _VzHistogramTimeseries
-  extends LegacyElementMixin(PolymerElement)
+  extends LegacyElementMixin(DarkModeMixin(PolymerElement))
   implements VzHistogramTimeseries {
   static readonly template = html`
     <div id="tooltip"><span></span></div>
@@ -65,11 +66,23 @@ class _VzHistogramTimeseries
 
     <style>
       :host {
+        color: #aaa;
         display: flex;
         flex-direction: column;
         flex-grow: 1;
         flex-shrink: 1;
         position: relative;
+        --vz-histogram-timeseries-hover-bg-color: #fff;
+        --vz-histogram-timeseries-outline-color: #fff;
+        --vz-histogram-timeseries-hover-outline-color: #000;
+      }
+
+      :host(.dark-mode) {
+        --vz-histogram-timeseries-hover-bg-color: var(
+          --primary-background-color
+        );
+        --vz-histogram-timeseries-outline-color: var(--paper-grey-600);
+        --vz-histogram-timeseries-hover-outline-color: #fff;
       }
 
       svg {
@@ -79,6 +92,10 @@ class _VzHistogramTimeseries
         width: 100%;
         flex-grow: 1;
         flex-shrink: 1;
+      }
+
+      text {
+        fill: currentColor;
       }
 
       #tooltip {
@@ -116,7 +133,7 @@ class _VzHistogramTimeseries
       }
 
       .hover.hover-closest circle {
-        fill: black !important;
+        fill: var(--vz-histogram-timeseries-hover-outline-color) !important;
       }
 
       .hover.hover-closest text {
@@ -130,12 +147,12 @@ class _VzHistogramTimeseries
 
       .outline {
         fill: none;
-        stroke: white;
+        stroke: var(--vz-histogram-timeseries-outline-color);
         stroke-opacity: 0.5;
       }
 
       .outline.outline-hover {
-        stroke: black !important;
+        stroke: var(--vz-histogram-timeseries-hover-outline-color) !important;
         stroke-opacity: 1;
       }
 
@@ -166,13 +183,20 @@ class _VzHistogramTimeseries
       .x-axis-hover line,
       .y-axis-hover line,
       .y-slice-axis-hover line {
-        stroke: black;
+        stroke: currentColor;
       }
 
       .x-axis-hover rect,
       .y-axis-hover rect,
       .y-slice-axis-hover rect {
-        fill: white;
+        fill: var(--vz-histogram-timeseries-hover-bg-color);
+      }
+
+      #tooltip,
+      .x-axis-hover text,
+      .y-axis-hover text,
+      .y-slice-axis-hover text {
+        color: var(--vz-histogram-timeseries-hover-outline-color);
       }
 
       .axis {
@@ -548,7 +572,7 @@ class _VzHistogramTimeseries
             ')'
         )
         .style('stroke', function (d) {
-          return mode === 'offset' ? 'white' : fillColor(timeAccessor(d));
+          return mode === 'offset' ? '' : fillColor(timeAccessor(d));
         })
         .style('fill-opacity', function (d) {
           return mode === 'offset' ? 1 : 0;

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -157,12 +157,20 @@ tf_ng_module(
     ],
 )
 
+tf_sass_binary(
+    name = "run_name_styles",
+    src = "run_name_component.scss",
+)
+
 tf_ng_module(
     name = "run_name",
     srcs = [
         "run_name_component.ts",
         "run_name_container.ts",
         "run_name_module.ts",
+    ],
+    assets = [
+        ":run_name_styles",
     ],
     deps = [
         ":utils",

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
@@ -54,7 +54,6 @@ $_title-to-heading-gap: 12px;
   display: flex;
   white-space: nowrap;
   font-size: 13px;
-  color: mat-color($tb-foreground, secondary-text);
 
   .dot {
     flex: none;

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -91,8 +91,8 @@ $_second-row-height: 15px;
 
 .run,
 .step {
+  @include tb-theme-foreground-prop(color, secondary-text);
   font-size: 13px;
-  color: mat-color($tb-foreground, secondary-text);
   height: $_second-row-height;
 }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/run_name_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/run_name_component.scss
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,14 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+@import 'tensorboard/webapp/theme/tb_theme';
 
-@Component({
-  selector: 'card-run-name-component',
-  template: '{{ name }}',
-  styleUrls: ['run_name_component.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-export class RunNameComponent {
-  @Input() name!: string;
+:host {
+  @include tb-theme-foreground-prop(color, secondary-text);
 }


### PR DESCRIPTION
- Histograms: hover color and default outline color are now more dark
mode friendly. Hover colors are white while outline colors are more
subdued.
- Distribution: axes are now visible
- Time series: histograms' and image cards' subtitles are now properly
colored

### Histogram
Before
![image](https://user-images.githubusercontent.com/2547313/122631687-2f21c400-d082-11eb-8326-593072176539.png)

After
![image](https://user-images.githubusercontent.com/2547313/122631615-b884c680-d081-11eb-8573-32ba921360ff.png)

### Distribution
Before
![image](https://user-images.githubusercontent.com/2547313/122631693-38ab2c00-d082-11eb-89e2-95a85fc03e32.png)

After
![image](https://user-images.githubusercontent.com/2547313/122631642-e833ce80-d081-11eb-8ca3-c99b1775fb32.png)

### TimeSeries
Before
![image](https://user-images.githubusercontent.com/2547313/122631676-1fa27b00-d082-11eb-91bd-dd8d28104422.png)

After
![image](https://user-images.githubusercontent.com/2547313/122631646-fbdf3500-d081-11eb-9dee-1fef4bd304ab.png)
