### PR TITLE
pip: explicitly require Python 3.6 above

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -64,6 +64,7 @@ setup(
     },
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
+    python_requires=">=3.6",
     # PyPI package information.
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
With `python_requires`, we can disallow other versions of Pythons from
installing TensorBoard. Removal in the earlier change was done without
completely understanding its intent.
