### PR TITLE
hparams: rename keras.py to avoid import collision

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -198,7 +198,7 @@ py_test(
 
 py_library(
     name = "keras",
-    srcs = ["keras.py"],
+    srcs = ["_keras.py"],
     srcs_version = "PY3",
     deps = [
         ":protos_all_py_pb2",
@@ -211,7 +211,8 @@ py_library(
 py_test(
     name = "keras_test",
     size = "small",
-    srcs = ["keras_test.py"],
+    srcs = ["_keras_test.py"],
+    main = "_keras_test.py",
     srcs_version = "PY3",
     deps = [
         ":api",

--- a/tensorboard/plugins/hparams/_keras.py
+++ b/tensorboard/plugins/hparams/_keras.py
@@ -14,8 +14,7 @@
 # ==============================================================================
 """Keras integration for TensorBoard hparams.
 
-Most users should use `tensorboard.plugins.hparams.api` to access this
-module's contents.
+Use `tensorboard.plugins.hparams.api` to access this module's contents.
 """
 
 

--- a/tensorboard/plugins/hparams/_keras_test.py
+++ b/tensorboard/plugins/hparams/_keras_test.py
@@ -20,7 +20,7 @@ from unittest import mock
 from google.protobuf import text_format
 import tensorflow as tf
 
-from tensorboard.plugins.hparams import keras
+from tensorboard.plugins.hparams import _keras
 from tensorboard.plugins.hparams import metadata
 from tensorboard.plugins.hparams import plugin_data_pb2
 from tensorboard.plugins.hparams import summary_v2 as hp
@@ -50,7 +50,7 @@ class CallbackTest(tf.test.TestCase):
         )
         self.model.compile(loss="mse", optimizer=self.hparams["optimizer"])
         self.trial_id = "my_trial"
-        self.callback = keras.Callback(
+        self.callback = _keras.Callback(
             writer, self.hparams, trial_id=self.trial_id
         )
 
@@ -167,7 +167,7 @@ class CallbackTest(tf.test.TestCase):
             TypeError,
             "writer must be a `SummaryWriter` or `str`, not None",
         ):
-            keras.Callback(writer=None, hparams={})
+            _keras.Callback(writer=None, hparams={})
 
     def test_duplicate_hparam_names_across_object_and_string(self):
         hparams = {
@@ -177,7 +177,7 @@ class CallbackTest(tf.test.TestCase):
         with self.assertRaisesRegex(
             ValueError, "multiple values specified for hparam 'foo'"
         ):
-            keras.Callback(self.get_temp_dir(), hparams)
+            _keras.Callback(self.get_temp_dir(), hparams)
 
     def test_duplicate_hparam_names_from_two_objects(self):
         hparams = {
@@ -187,13 +187,13 @@ class CallbackTest(tf.test.TestCase):
         with self.assertRaisesRegex(
             ValueError, "multiple values specified for hparam 'foo'"
         ):
-            keras.Callback(self.get_temp_dir(), hparams)
+            _keras.Callback(self.get_temp_dir(), hparams)
 
     def test_invalid_trial_id(self):
         with self.assertRaisesRegex(
             TypeError, "`trial_id` should be a `str`, but got: 12"
         ):
-            keras.Callback(self.get_temp_dir(), {}, trial_id=12)
+            _keras.Callback(self.get_temp_dir(), {}, trial_id=12)
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -110,7 +110,7 @@ TensorBoard repository for an end-to-end MNIST example.
 """
 
 
-from tensorboard.plugins.hparams import keras
+from tensorboard.plugins.hparams import _keras
 from tensorboard.plugins.hparams import summary_v2
 
 
@@ -125,8 +125,8 @@ hparams_pb = summary_v2.hparams_pb
 hparams_config = summary_v2.hparams_config
 hparams_config_pb = summary_v2.hparams_config_pb
 
-KerasCallback = keras.Callback
+KerasCallback = _keras.Callback
 
 
-del keras
+del _keras
 del summary_v2

--- a/tensorboard/plugins/hparams/api_test.py
+++ b/tensorboard/plugins/hparams/api_test.py
@@ -16,7 +16,7 @@
 
 from tensorboard import test
 from tensorboard.plugins.hparams import api
-from tensorboard.plugins.hparams import keras
+from tensorboard.plugins.hparams import _keras
 from tensorboard.plugins.hparams import summary_v2
 
 
@@ -25,7 +25,7 @@ class ApiTest(test.TestCase):
         self.assertIs(api.HParam, summary_v2.HParam)
 
     def test_has_keras_dependent_attributes(self):
-        self.assertIs(api.KerasCallback, keras.Callback)
+        self.assertIs(api.KerasCallback, _keras.Callback)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This renames the `keras.py` module within the hparams plugin directory to `_keras.py` (prefix with an underscore), to avoid an import collision with the widely used `keras` package, and resolve the failure that we had to circumvent https://github.com/tensorflow/tensorboard/pull/5068.

Background: unfortunately, the way Python import resolution works, the directory of the original script that the interpreter is executing is automatically placed first in `sys.path`, so sibling modules that match the names of modules your code tries to import will magically take precedence over third-party pip-installed modules that are found later in `sys.path`.  [PEP 328](https://www.python.org/dev/peps/pep-0328/#rationale-for-absolute-imports) halfway-fixed this by ensuring standard library modules are protected from collisions, but sadly that leaves plenty of footgun left.  The worst part is that this doesn't just affect import statements directly in the script itself; it affects all transitive imports made my any dependencies your script imports.

Our specific problem is that `hparams_util.py` does `import tensorflow as tf`, and recent versions of `tf-nightly` started transitively importing `keras` to provide `tf.keras`; the fact that `keras.py` exists as a sibling to `hparams_util.py` means that it "intercepted" the import, and then `keras.py` itself imports TF, causing a circular import and broken symbol references.

We resolve this here by simply adding an underscore prefix to `keras.py` and updating the references to it accordingly.  I went with the underscore prefix since conventionally that indicates internal modules, which this is - `api.py` is the public API module - and because that provides additional protection against ever having this collide in the future, unlike something like `keras_lib.py` (imagine someday Keras adds `import keras_lib` somewhere...).

Googlers, see b/191689472.