### PR TITLE
Avoid using slash as division in sass

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -62,8 +62,8 @@ $_title-to-heading-gap: 12px;
   mat-spinner {
     $mat-icon-button-diameter: 40px;
     $spinner-diameter: 18px;
-    $spinner-to-container-edge: ($mat-icon-button-diameter - $spinner-diameter) /
-      2;
+    $spinner-to-container-edge: ($mat-icon-button-diameter - $spinner-diameter) *
+      0.5;
 
     // Position horizontally to be centered with the 'more options' button.
     // Position vertically to be equidistant to the chart's top/right edges.

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -21,7 +21,7 @@ limitations under the License.
 .red-dot {
   $_dim: 10px;
   background-color: mat-color($mat-red, 700);
-  border-radius: $_dim / 2;
+  border-radius: $_dim * 0.5;
   height: $_dim;
   position: absolute;
   right: 10px;

--- a/tensorboard/webapp/widgets/range_input/range_input_component.scss
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.scss
@@ -26,7 +26,7 @@ $_thumb-size: 12px;
     'slider slider';
   font-size: 0;
   min-width: 100px;
-  padding: $_thumb-size / 2;
+  padding: $_thumb-size * 0.5;
 }
 
 input {
@@ -74,7 +74,7 @@ input {
   border-radius: 100%;
   display: inline-block;
   height: $_thumb-size;
-  margin-left: -$_thumb-size / 2;
+  margin-left: -$_thumb-size * 0.5;
   position: absolute;
   top: 0;
   transform-origin: center;


### PR DESCRIPTION
Sass 1.33.0 deprecates usage of the '/' forward slash character as a
math division operator [1]. We expect a future release to remove it.
According to [2], TensorBoard is still using Sass 1.32.8 from Bazel, but
internal efforts motivate us to be ready for the upcoming Sass changes
sooner.

This fixes existing uses of '/' to use the '*' multiplication operator
instead, for now. Unfortunately there is no enforcement of avoiding the
slash-as-division until we either upgrade the Sass version used via
Bazel.

Googlers, see also cl/380056496, b/189862812

[1] https://sass-lang.com/documentation/breaking-changes/slash-div
[2] https://github.com/tensorflow/tensorboard/blob/master/WORKSPACE