### PR TITLE
route: omit displayName from routeId.

### DIFF
--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -95,13 +95,12 @@ export function getExperimentIdsFromRouteParams(
  */
 export function getRouteId(routeKind: RouteKind, params: RouteParams): string {
   switch (routeKind) {
-    case RouteKind.COMPARE_EXPERIMENT: {
-      const typedParams = params as CompareRouteParams;
-      return `${routeKind}/${typedParams.experimentIds}`;
-    }
+    case RouteKind.COMPARE_EXPERIMENT:
     case RouteKind.EXPERIMENT: {
-      const typedParams = params as ExperimentRouteParams;
-      return `${routeKind}/${typedParams.experimentId}`;
+      const experimentIds =
+        getExperimentIdsFromRouteParams(routeKind, params) ?? [];
+      experimentIds.sort();
+      return `${routeKind}/${experimentIds.join(',')}`;
     }
     case RouteKind.EXPERIMENTS:
       return String(routeKind);

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -112,7 +112,7 @@ describe('app_routing/utils', () => {
       {
         kind: RouteKind.COMPARE_EXPERIMENT,
         params: {experimentIds: 'bar:123'},
-        expectedVal: `${RouteKind.COMPARE_EXPERIMENT}/bar:123`,
+        expectedVal: `${RouteKind.COMPARE_EXPERIMENT}/123`,
       },
       {
         kind: RouteKind.EXPERIMENTS,
@@ -136,15 +136,26 @@ describe('app_routing/utils', () => {
       });
     });
 
-    it('uniquely differentiate compare of same eids when display names differ', () => {
-      const id1 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
-        experimentIds: 'foo:123',
+    describe('COMPARE route', () => {
+      it('returns stable id as long as id sets are the same', () => {
+        const id1 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
+          experimentIds: 'foo:123,bar:456',
+        });
+        const id2 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
+          experimentIds: 'bar:456,foo:123',
+        });
+        expect(id1).toBe(id2);
       });
-      const id2 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
-        experimentIds: 'bar:123',
+
+      it('does not differentiate compare of same eids with different display names', () => {
+        const id1 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
+          experimentIds: 'foo:123',
+        });
+        const id2 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
+          experimentIds: 'bar:123',
+        });
+        expect(id1).toBe(id2);
       });
-      expect(id1).toBe(`${RouteKind.COMPARE_EXPERIMENT}/foo:123`);
-      expect(id2).toBe(`${RouteKind.COMPARE_EXPERIMENT}/bar:123`);
     });
   });
 


### PR DESCRIPTION
RouteId is a unique opaque identifier for a route. Previously, we
included display names as part of the unique identifier but we decided
to drop it for improve the UX.

Specifically, we would like to be able to let user change display name
dynamically without causing a routeId changes (which will cause router
to actually do a route change).
