### PR TITLE
plugin-lib: expose plugin lib for consumption

### DIFF
--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -14,6 +14,7 @@ tf_ts_library(
         "plugin-guest.ts",
         "runs.ts",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/experimental/plugin_util:message",
     ],
@@ -24,6 +25,7 @@ tf_ts_library(
     srcs = [
         "polymer-interop.ts",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":plugin_lib",
     ],

--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -25,7 +25,6 @@ tf_ts_library(
     srcs = [
         "polymer-interop.ts",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         ":plugin_lib",
     ],


### PR DESCRIPTION
Bazel users with access to the TensorBoard workspace from their
repo now have visibility into `ts_library`-like targets for importing
the experimental plugin library, which were previously not
Bazel-public.