### PR TITLE
core: fix data load when there are no routes

### DIFF
--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -104,6 +104,8 @@ export function getRouteId(routeKind: RouteKind, params: RouteParams): string {
     }
     case RouteKind.EXPERIMENTS:
       return String(routeKind);
+    case RouteKind.NOT_SET:
+      return '__not_set';
     default:
       return '';
   }

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -47,8 +47,12 @@ export const getNextRouteForRouterOutletOnly = createSelector(
   }
 );
 
+/**
+ * Returns current RouteKind or returns `null` if route is not set at all
+ * (e.g., an application does not define any routes).
+ */
 export const getRouteKind = createSelector(getActiveRoute, (activeRoute) => {
-  return activeRoute ? activeRoute.routeKind : RouteKind.UNKNOWN;
+  return activeRoute ? activeRoute.routeKind : null;
 });
 
 export const getRouteParams = createSelector(getActiveRoute, (activeRoute) => {
@@ -63,6 +67,7 @@ export const getExperimentIdsFromRoute = createSelector(
   getRouteKind,
   getRouteParams,
   (routeKind, routeParams): string[] | null => {
+    if (routeKind === null) return null;
     return getExperimentIdsFromRouteParams(routeKind, routeParams);
   }
 );
@@ -71,6 +76,7 @@ export const getRouteId = createSelector(
   getRouteKind,
   getRouteParams,
   (routeKind, routeParams): string => {
+    if (routeKind === null) return '__no_route';
     return getRouteIdFromKindAndParams(routeKind, routeParams);
   }
 );

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -52,7 +52,7 @@ export const getNextRouteForRouterOutletOnly = createSelector(
  * (e.g., an application does not define any routes).
  */
 export const getRouteKind = createSelector(getActiveRoute, (activeRoute) => {
-  return activeRoute ? activeRoute.routeKind : null;
+  return activeRoute ? activeRoute.routeKind : RouteKind.NOT_SET;
 });
 
 export const getRouteParams = createSelector(getActiveRoute, (activeRoute) => {
@@ -67,7 +67,6 @@ export const getExperimentIdsFromRoute = createSelector(
   getRouteKind,
   getRouteParams,
   (routeKind, routeParams): string[] | null => {
-    if (routeKind === null) return null;
     return getExperimentIdsFromRouteParams(routeKind, routeParams);
   }
 );
@@ -76,7 +75,6 @@ export const getRouteId = createSelector(
   getRouteKind,
   getRouteParams,
   (routeKind, routeParams): string => {
-    if (routeKind === null) return '__no_route';
     return getRouteIdFromKindAndParams(routeKind, routeParams);
   }
 );

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -77,6 +77,16 @@ describe('app_routing_selectors', () => {
 
       expect(selectors.getRouteKind(state)).toBe(RouteKind.EXPERIMENT);
     });
+
+    it('returns `null` is it does not have an active route', () => {
+      const state = buildStateFromAppRoutingState(
+        buildAppRoutingState({
+          activeRoute: null,
+        })
+      );
+
+      expect(selectors.getRouteKind(state)).toBeNull();
+    });
   });
 
   describe('getRouteParams', () => {
@@ -145,6 +155,37 @@ describe('app_routing_selectors', () => {
       );
 
       expect(selectors.getExperimentIdToAliasMap(state)).toEqual({});
+    });
+  });
+
+  describe('getRouteId', () => {
+    beforeEach(() => {
+      selectors.getRouteId.release();
+    });
+
+    it('returns routeId from an activeRoute', () => {
+      const state = buildStateFromAppRoutingState(
+        buildAppRoutingState({
+          activeRoute: buildRoute({
+            routeKind: RouteKind.EXPERIMENT,
+            pathname: '/experiment/234',
+            params: {
+              experimentId: '234',
+            },
+            queryParams: [],
+          }),
+        })
+      );
+
+      expect(selectors.getRouteId(state)).toBe('2/234');
+    });
+
+    it('returns a predefined value when it does not have an active one', () => {
+      const state = buildStateFromAppRoutingState(
+        buildAppRoutingState({activeRoute: null})
+      );
+
+      expect(selectors.getRouteId(state)).toBe('__no_route');
     });
   });
 });

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -78,14 +78,14 @@ describe('app_routing_selectors', () => {
       expect(selectors.getRouteKind(state)).toBe(RouteKind.EXPERIMENT);
     });
 
-    it('returns `null` is it does not have an active route', () => {
+    it('returns `NOT_SET` is it does not have an active route', () => {
       const state = buildStateFromAppRoutingState(
         buildAppRoutingState({
           activeRoute: null,
         })
       );
 
-      expect(selectors.getRouteKind(state)).toBeNull();
+      expect(selectors.getRouteKind(state)).toBe(RouteKind.NOT_SET);
     });
   });
 
@@ -180,12 +180,12 @@ describe('app_routing_selectors', () => {
       expect(selectors.getRouteId(state)).toBe('2/234');
     });
 
-    it('returns a predefined value when it does not have an active one', () => {
+    it('returns "__not_set" when it does not have an active one', () => {
       const state = buildStateFromAppRoutingState(
         buildAppRoutingState({activeRoute: null})
       );
 
-      expect(selectors.getRouteId(state)).toBe('__no_route');
+      expect(selectors.getRouteId(state)).toBe('__not_set');
     });
   });
 });

--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -32,6 +32,8 @@ export enum RouteKind {
   EXPERIMENT,
   COMPARE_EXPERIMENT,
   // Router has not yet bootstrapped and RouteKind is not set yet.
+  // Temporary enum values until we can remove special cases in core_effects to
+  // handle TensorBoard applications with no routes defined.
   NOT_SET,
 }
 

--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -26,10 +26,13 @@ export interface RouteParams {
 }
 
 export enum RouteKind {
+  // Route is defined and is not known to the application.
   UNKNOWN,
   EXPERIMENTS,
   EXPERIMENT,
   COMPARE_EXPERIMENT,
+  // Router has not yet bootstrapped and RouteKind is not set yet.
+  NOT_SET,
 }
 
 export const DEFAULT_EXPERIMENT_ID = 'defaultExperimentId';

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -84,7 +84,7 @@ const DASHBOARD_ROUTE_KIND = new Set([
   // Temporary. Not all TensorBoard uses router and, without using router, we
   // still need to fetch plugins listing and runs when we first load. `null`
   // signifies 'route not set'.
-  null,
+  RouteKind.NOT_SET,
 ]);
 
 @Injectable()

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -81,6 +81,10 @@ const ALIAS_CHANGE_RUNS_RELOAD_THROTTLE_IN_MS = 500;
 const DASHBOARD_ROUTE_KIND = new Set([
   RouteKind.COMPARE_EXPERIMENT,
   RouteKind.EXPERIMENT,
+  // Temporary. Not all TensorBoard uses router and, without using router, we
+  // still need to fetch plugins listing and runs when we first load. `null`
+  // signifies 'route not set'.
+  null,
 ]);
 
 @Injectable()

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -735,7 +735,7 @@ describe('core_effects', () => {
     });
 
     it('fetches runs and plugins listing', fakeAsync(() => {
-      store.overrideSelector(getRouteKind, null);
+      store.overrideSelector(getRouteKind, RouteKind.NOT_SET);
       store.overrideSelector(getRouteId, 'foo');
       store.overrideSelector(getPluginsListLoaded, {
         state: DataLoadState.NOT_LOADED,


### PR DESCRIPTION
In certain variants of TensorBoard, there are no routes defined for the
router. In this case, the application assumes that the backend knows how
to attain experiment id from the URL and, thus, we should assume that it
is about the same as RouteKind.EXPERIMENT. Because we have a strict
filter on fetching runs and plugins listing for only dashboard route
kinds, the legacy flow is broken so we would like to reinstate some part
of that by formalizing "no routes set" which is defined with RouteKind
=== RouteKind.NOT_SET.

Test sync: cl/381353956
