### PR TITLE
Remove remnants of settings properties from core.

### DIFF
--- a/tensorboard/webapp/core/actions/BUILD
+++ b/tensorboard/webapp/core/actions/BUILD
@@ -10,7 +10,6 @@ tf_ts_library(
     ],
     deps = [
         "//tensorboard/webapp/core:types",
-        "//tensorboard/webapp/settings",
         "//tensorboard/webapp/types",
         "@npm//@ngrx/store",
     ],

--- a/tensorboard/webapp/core/actions/core_actions.ts
+++ b/tensorboard/webapp/core/actions/core_actions.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {createAction, props} from '@ngrx/store';
-import {actions as settingsActions} from '../../settings';
 import {Environment, PluginId, PluginsListing} from '../../types/api';
 
 import {PluginsListFailureCode, Run, RunId} from '../types';
@@ -21,13 +20,6 @@ import {PluginsListFailureCode, Run, RunId} from '../types';
 // HACK: Below import is for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-
-/**
- * @deprecated Use settingsActions.toggleReloadEnabled instead.
- *
- * TODO(bdubois): Delete after all callers are migrated to use settingsActions directly.
- */
-export const toggleReloadEnabled = settingsActions.toggleReloadEnabled;
 
 /**
  * User has clicked on a button in the header to change the plugin.

--- a/tensorboard/webapp/core/store/BUILD
+++ b/tensorboard/webapp/core/store/BUILD
@@ -15,7 +15,6 @@ tf_ng_module(
         "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/deeplink",
-        "//tensorboard/webapp/settings",
         "//tensorboard/webapp/types",
         "@npm//@angular/core",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 
-import {selectors as settingsSelectors} from '../../settings';
 import {Environment, PluginId, PluginsListing} from '../../types/api';
 import {DataLoadState, LoadState} from '../../types/data';
 import {
@@ -27,13 +26,6 @@ import {
 // HACK: These imports are for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
 /** @typehack */ import * as _typeHackSelector from '@ngrx/store/src/selector';
-
-/**
- * @deprecated Use settingsSelectors.getReloadEnabled instead.
- *
- * TODO(bdubois): Delete after all callers are migrated to use settingsSelectors directly.
- */
-export const getReloadEnabled = settingsSelectors.getReloadEnabled;
 
 const selectCoreState = createFeatureSelector<State, CoreState>(
   CORE_FEATURE_KEY

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -20,7 +20,6 @@ limitations under the License.
 // remove this import, and write the divergent state types explicitly here.
 import {Environment, PluginId, PluginsListing} from '../../types/api';
 import {DataLoadState, LoadState} from '../../types/data';
-import {State as SettingsState} from '../../settings';
 
 import {PluginsListFailureCode, Run, RunId} from '../types';
 
@@ -74,7 +73,7 @@ interface FailedPluginsListLoadState extends LoadState {
 
 // TODO(bdubois): Remove composition with SettingsState when appropriate callers
 // are migrated to use SettingsState directly.
-export interface State extends SettingsState {
+export interface State {
   [CORE_FEATURE_KEY]?: CoreState;
 }
 

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -71,8 +71,6 @@ interface FailedPluginsListLoadState extends LoadState {
   failureCode: PluginsListFailureCode;
 }
 
-// TODO(bdubois): Remove composition with SettingsState when appropriate callers
-// are migrated to use SettingsState directly.
 export interface State {
   [CORE_FEATURE_KEY]?: CoreState;
 }


### PR DESCRIPTION
In https://github.com/tensorflow/tensorboard/pull/5090 I moved some properties from `core` to `settings`, along with the corresponding redux. There were some compatibility shims left behind in `core` for google-internal code. Now that all google-internal code has been migrated, we remove the shims.

Tested:
* Patched this change into a local repository and verified that other versions of tensorboard still built and behaved propertly.