### PR TITLE
docs: show explanation when --load_fast and --logdir_spec are passed

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -433,6 +433,15 @@ class TensorBoard(object):
                 sys.exit(1)
 
         if flags.load_fast == "auto" and _should_use_data_server(flags.logdir):
+            if flags.logdir_spec and not flags.logdir:
+                logger.info(
+                    "Warning: --logdir_spec is not supported with --load_fast "
+                    + "behavior; falling back to multiplexer. To use the data "
+                    + "server, replace --logdir_spec with --logdir."
+                )
+                ingester = local_ingester.LocalDataIngester(flags)
+                ingester.start()
+                return ingester
             try:
                 ingester = self._start_subprocess_data_ingester()
                 sys.stderr.write(_DATA_SERVER_ADVISORY_MESSAGE)


### PR DESCRIPTION
This changes the program to print a message that explicitly
indicates `--logdir_spec` is unsupported with `--load_fast`
behavior.

See https://github.com/tensorflow/tensorboard/issues/4802