### PR TITLE
router: set correct initialState in reducers

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -183,10 +183,13 @@ tf_ng_module(
         ":testing",
         ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/app_routing/actions",
         "//tensorboard/webapp/util:ngrx",
         "@npm//@angular/core",
+        "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",
+        "@npm//rxjs",
     ],
 )

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
@@ -109,7 +109,7 @@ export function createRouteContextedState<
   } as FullState;
 
   const reducers = createReducer<FullState>(
-    {} as FullState,
+    initialState,
     on(navigated, (state, {before, after}) => {
       const afterRouteId = getRouteId(after.routeKind, after.params);
       const beforeRouteId = before

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
@@ -12,11 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
-import {createAction, createReducer, on} from '@ngrx/store';
+import {TestBed} from '@angular/core/testing';
+import {
+  createAction,
+  createFeatureSelector,
+  createReducer,
+  createSelector,
+  on,
+  Store,
+  StoreModule,
+} from '@ngrx/store';
+import {firstValueFrom} from 'rxjs';
 
 import {composeReducers} from '../util/ngrx';
-
 import {navigated} from './actions';
 import {
   createRouteContextedState,
@@ -323,6 +331,34 @@ describe('route_contexted_reducer_helper', () => {
       const state2 = reducers(state1, buildNavigatedToNewRouteIdAction());
 
       expect(state2.routeful).toBe(123);
+    });
+  });
+});
+
+describe('route_contexted_reducer_helper ngrx integration test', () => {
+  let store: Store;
+
+  const TEST_KEY = 'my_test';
+
+  const selectFeature = createFeatureSelector(TEST_KEY);
+  const selectAll = createSelector(selectFeature, (s) => s);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot([]),
+        StoreModule.forFeature(TEST_KEY, reducers),
+      ],
+    }).compileComponents();
+    store = TestBed.inject(Store);
+  });
+
+  it('contains correct initial value', async () => {
+    const initialState = await firstValueFrom(store.select(selectAll));
+    expect(initialState).toEqual({
+      routeful: 0,
+      notRouteful: 1,
+      privateRouteContextedState: {},
     });
   });
 });


### PR DESCRIPTION
Depending on order of definition, when using routeContextedReducerUtil,
there are cases when the initialState is completely empty. This happens
because the first instance of the initialState in the `composeReducers`
get used.

While it might be advisable not to rely on order of reducers
defined in the `composeReducers`, the order is not specified as part of
the spec and TensorBoard specifies them in arbitrary order. In such
case, we don't want a broken or misbehaving application with missing
initial value.

As such, we now populate the correct initialState and wrote appropriate
test that would have caught the issue.
