### PR TITLE
router: allow onRouteIdChange to reason with route

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -130,6 +130,7 @@ tf_ts_library(
     ],
     deps = [
         ":internal_utils",
+        ":types",
         "//tensorboard/webapp/app_routing/actions",
         "@npm//@ngrx/store",
     ],

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
@@ -40,6 +40,7 @@ import {ActionReducer, createReducer, on} from '@ngrx/store';
 
 import {navigated} from './actions';
 import {getRouteId} from './internal_utils';
+import {Route} from './types';
 
 // `privateRouteContextedState` loosely typed only for ease of writing tests.
 // Otherwise, all the reducers that has routeful state has to change the test
@@ -93,7 +94,8 @@ export function createRouteContextedState<
   routefulInitialState: RoutefulState,
   nonRoutefulInitialState: NonRoutefulState,
   onRouteIdChanged?: (
-    state: RouteContextedState<RoutefulState, NonRoutefulState>
+    state: RouteContextedState<RoutefulState, NonRoutefulState>,
+    newRoute: Route
   ) => RouteContextedState<RoutefulState, NonRoutefulState>
 ): {
   initialState: RouteContextedState<RoutefulState, NonRoutefulState>;
@@ -155,7 +157,7 @@ export function createRouteContextedState<
       };
 
       if (onRouteIdChanged) {
-        return onRouteIdChanged(nextFullState);
+        return onRouteIdChanged(nextFullState, after);
       }
       return nextFullState;
     })

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
@@ -312,7 +312,7 @@ describe('route_contexted_reducer_helper', () => {
       const {initialState, reducers: routeReducers} = createRouteContextedState<
         RoutefulState,
         NonRoutefulState
-      >({routeful: 0}, {notRouteful: 1}, (state) => {
+      >({routeful: 0}, {notRouteful: 1}, (state, route) => {
         return {...state, routeful: 999};
       });
 
@@ -331,6 +331,51 @@ describe('route_contexted_reducer_helper', () => {
       const state2 = reducers(state1, buildNavigatedToNewRouteIdAction());
 
       expect(state2.routeful).toBe(123);
+    });
+
+    it('allows transformation with route information', () => {
+      const {initialState, reducers: routeReducers} = createRouteContextedState<
+        RoutefulState,
+        NonRoutefulState
+      >({routeful: 0}, {notRouteful: 1}, (state, route) => {
+        return {
+          ...state,
+          routeful: route.routeKind === RouteKind.EXPERIMENTS ? 0 : 999,
+        };
+      });
+
+      const noopReducer = createReducer<ContextedState>(initialState);
+
+      const reducers = composeReducers(routeReducers, noopReducer);
+
+      const state1 = {
+        routeful: 0,
+        notRouteful: 1,
+      };
+      const state2 = reducers(
+        state1,
+        navigated({
+          before: null,
+          after: buildRoute({
+            routeKind: RouteKind.EXPERIMENTS,
+          }),
+        })
+      );
+      expect(state2.routeful).toBe(0);
+
+      const state3 = reducers(
+        state1,
+        navigated({
+          before: buildRoute({
+            routeKind: RouteKind.EXPERIMENTS,
+          }),
+          after: buildRoute({
+            routeKind: RouteKind.COMPARE_EXPERIMENT,
+            params: {experimentIds: 'e1:1,e2:2'},
+          }),
+        })
+      );
+      expect(state3.routeful).toBe(999);
     });
   });
 });

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
@@ -340,7 +340,7 @@ describe('route_contexted_reducer_helper', () => {
       >({routeful: 0}, {notRouteful: 1}, (state, route) => {
         return {
           ...state,
-          routeful: route.routeKind === RouteKind.EXPERIMENTS ? 0 : 999,
+          routeful: route.routeKind === RouteKind.EXPERIMENTS ? 7 : 999,
         };
       });
 
@@ -361,7 +361,7 @@ describe('route_contexted_reducer_helper', () => {
           }),
         })
       );
-      expect(state2.routeful).toBe(0);
+      expect(state2.routeful).toBe(7);
 
       const state3 = reducers(
         state1,


### PR DESCRIPTION
Previously, the optional third parameter to the route contexted reducer
helper only allowed the utility to specify a state [re]setter that
reasons with the state alone. However, there are cases when we need to
set the initial value of a store based on the routeKind. For instance,
we would like our colorGroup settings to be `GroupBy.EXPERIMENT` when
user is navigating to an `COMPARE_EXPERIMENT` routeKind while keeping
it `GroupBy.RUN` in other cases. Since the initial state is a function
of the new route (`routeKind`, really), this change expands the
API signature to allow for reasoning with the route.
