### PR TITLE
line-chart: set attribute when data is loaded once

### DIFF
--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -229,13 +229,13 @@ export function DataLoaderBehavior<Item, Data>(
                   this.onLoadFinish();
                 }
                 this._loadDataAsync = null;
+                this.dataLoadedAtLeastOnce = true;
               }
               const isDataFetchPending = Array.from(
                 this._dataLoadState.values()
               ).includes(LoadState.LOADING);
               if (!isDataFetchPending) {
                 this.dataLoading = false;
-                this.dataLoadedAtLeastOnce = true;
               }
             }
           );

--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -91,6 +91,7 @@ export function DataLoaderBehavior<Item, Data>(
     requestData: RequestDataCallback<Item, Data>;
 
     dataLoading = false;
+    dataLoadedAtLeastOnce = false;
 
     // The standard Node.isConnected doesn't seem to be set reliably, so we
     // wire up our own property manually.
@@ -234,6 +235,7 @@ export function DataLoaderBehavior<Item, Data>(
               ).includes(LoadState.LOADING);
               if (!isDataFetchPending) {
                 this.dataLoading = false;
+                this.dataLoadedAtLeastOnce = true;
               }
             }
           );

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.ts
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.ts
@@ -71,6 +71,7 @@ class _TfLineChartDataLoader<ScalarMetadata>
       <vz-line-chart2
         id="chart"
         data-loading$="[[dataLoading]]"
+        data-loaded-once$="[[dataLoadedAtLeastOnce]]"
         color-scale="[[colorScale]]"
         default-x-range="[[defaultXRange]]"
         default-y-range="[[defaultYRange]]"


### PR DESCRIPTION
For better WebDriver testing, we would like to distinguish not_loaded,
loading, and loaded_at_least_once. By using a separate attribute on the
vz-line-chart, we were able to discern these differing states and
ultimately made our tests a bit more stable.

This change introduces another internal state in the
data-loader-behavior with which we can set the attribute onto the
vz-line-chart.