### PR TITLE
dark mode: fix text plugin under dark mode

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
+++ b/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
@@ -44,6 +44,10 @@ style.textContent = `
     --primary-background-color: #303030;  /* material grey A400. */
     --secondary-background-color: #3a3a3a;
     --tb-layout-background-color: #3a3a3a;
+    /* Overrides paper-material */
+    --shadow-elevation-2dp_-_box-shadow: 0 2px 2px 0 rgba(255, 255, 255, 0.14),
+      0 1px 5px 0 rgba(255, 255, 255, 0.12),
+      0 3px 1px -2px rgba(255, 255, 255, 0.2);
   }
 `;
 document.head.appendChild(style);

--- a/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
+++ b/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
@@ -57,11 +57,11 @@ class TfMarkdownView extends LegacyElementMixin(PolymerElement) {
       #markdown table th,
       #markdown table td {
         padding: 6px 13px;
-        border: 1px solid #dfe2e5;
+        border: 1px solid var(--tb-ui-border, #dfe2e5);
       }
       #markdown table tr {
-        background-color: #fff;
-        border-top: 1px solid #c6cbd1;
+        background-color: inherit;
+        border-top: 1px solid var(--tb-ui-border, #c6cbd1);
       }
     </style>
   `;

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.ts
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.ts
@@ -72,7 +72,7 @@ class TfTextLoader extends LegacyElementMixin(PolymerElement) {
         border-color: var(--tb-text-loader-outline);
       }
       .text {
-        background-color: white;
+        background-color: inherit;
         border-radius: 0 3px 3px 3px;
         padding: 5px;
         word-break: break-word;
@@ -81,7 +81,7 @@ class TfTextLoader extends LegacyElementMixin(PolymerElement) {
         background-color: var(--tb-ui-light-accent);
         border-bottom: none;
         border-radius: 3px 3px 0 0;
-        border: 1px solid #ccc;
+        border: 1px solid var(--tb-ui-border);
         display: inline-block;
         font-size: 12px;
         font-style: italic;


### PR DESCRIPTION
We had previously not tested the plugin thoroughly enough and have
missed its dark mode-ification. This change simply addresses UX issue
under dark mode and screenshots will be applied separately.

![image](https://user-images.githubusercontent.com/2547313/123993229-1b7b3500-d981-11eb-8deb-d90bdbe32d8d.png)
