### PR TITLE
color grouping: default group by experiment on comparison view

### DIFF
--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -36,6 +36,22 @@ export function buildRoute(routeOverride: Partial<Route> = {}): Route {
   };
 }
 
+export function buildCompareRoute(
+  experimentIds: string[],
+  routeOverride: Partial<Route> = {}
+): Route {
+  return {
+    routeKind: RouteKind.COMPARE_EXPERIMENT,
+    pathname: '/campare',
+    params: {experimentIds: experimentIds.join(',')},
+    queryParams: [],
+    navigationOptions: {
+      replaceState: false,
+    },
+    ...routeOverride,
+  };
+}
+
 export function buildNavigatedAction(routeOverride: Partial<Route> = {}) {
   return navigated({
     before: null,

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -37,13 +37,13 @@ export function buildRoute(routeOverride: Partial<Route> = {}): Route {
 }
 
 export function buildCompareRoute(
-  experimentIds: string[],
+  aliasAndExperimentIds: string[],
   routeOverride: Partial<Route> = {}
 ): Route {
   return {
     routeKind: RouteKind.COMPARE_EXPERIMENT,
     pathname: '/campare',
-    params: {experimentIds: experimentIds.join(',')},
+    params: {experimentIds: aliasAndExperimentIds.join(',')},
     queryParams: [],
     navigationOptions: {
       replaceState: false,

--- a/tensorboard/webapp/runs/store/BUILD
+++ b/tensorboard/webapp/runs/store/BUILD
@@ -91,6 +91,7 @@ tf_ts_library(
         ":testing",
         ":types",
         ":utils",
+        "//tensorboard/webapp/app_routing:testing",
         "//tensorboard/webapp/app_routing:types",
         "//tensorboard/webapp/app_routing/actions",
         "//tensorboard/webapp/runs:types",

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -235,15 +235,15 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
     const groupKeyToColorString = new Map(state.groupKeyToColorString);
     const defaultRunColorForGroupBy = new Map(state.defaultRunColorForGroupBy);
 
-    let groupby = state.initialGroupBy;
+    let groupBy = state.initialGroupBy;
     if (state.userSetGroupByKey !== null) {
-      groupby = createGroupBy(
+      groupBy = createGroupBy(
         state.userSetGroupByKey,
         state.colorGroupRegexString
       );
     }
     const groups = groupRuns(
-      groupby,
+      groupBy,
       runsForAllExperiments,
       state.runIdToExpId
     );

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -19,6 +19,7 @@ import {
   createReducer,
   on,
 } from '@ngrx/store';
+
 import {stateRehydratedFromUrl} from '../../app_routing/actions';
 import {createRouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
 import {RouteKind} from '../../app_routing/types';
@@ -60,7 +61,6 @@ const {
     selectionState: new Map<string, Map<string, boolean>>(),
   },
   (state, route) => {
-    console.log('route:', route);
     return {
       ...state,
       initialGroupBy: {

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -966,7 +966,9 @@ describe('runs_reducers', () => {
         ])
       );
     });
+  });
 
+  describe('when freshly navigating', () => {
     it('sets initial groupby to EXPERIMENT on experiment comparion', () => {
       const state = buildRunsState({
         initialGroupBy: {key: GroupByKey.RUN},
@@ -982,10 +984,10 @@ describe('runs_reducers', () => {
         })
       );
 
-      expect(nextState.data.initialGroupBy.key).toEqual(GroupByKey.EXPERIMENT);
+      expect(nextState.data.initialGroupBy.key).toBe(GroupByKey.EXPERIMENT);
     });
 
-    it('preserves userSetGroupByKey on comparision view navigation', () => {
+    it('preserves userSetGroupByKey set on prior navigation to the same route', () => {
       const state = buildRunsState({
         initialGroupBy: {key: GroupByKey.EXPERIMENT},
         userSetGroupByKey: GroupByKey.RUN,
@@ -1007,8 +1009,8 @@ describe('runs_reducers', () => {
         })
       );
 
-      expect(state3.data.initialGroupBy.key).toEqual(GroupByKey.EXPERIMENT);
-      expect(state3.data.userSetGroupByKey).toEqual(GroupByKey.RUN);
+      expect(state3.data.initialGroupBy.key).toBe(GroupByKey.EXPERIMENT);
+      expect(state3.data.userSetGroupByKey).toBe(GroupByKey.RUN);
     });
 
     it('sets groupby to RUN on single experiment', () => {
@@ -1026,7 +1028,7 @@ describe('runs_reducers', () => {
         })
       );
 
-      expect(nextState.data.initialGroupBy.key).toEqual(GroupByKey.RUN);
+      expect(nextState.data.initialGroupBy.key).toBe(GroupByKey.RUN);
     });
   });
 });


### PR DESCRIPTION
* Motivation for features / changes
When it's experiment comparison view, we want to color group by experiment even thought the user has not explicitly set it.

* Technical description of changes
   - check and update `initialGroupBy` on `createRouteContextedState`. It checks the routekind everytime the route changes.
   - Also fixes groupruns bug: when userSetGroupByKey is 0, it means group by run. However the previous logic does not correctly check null and misjudge group by run as invalid.
