### PR TITLE
dark mode: apply color on warning message

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.scss
+++ b/tensorboard/webapp/plugins/plugins_component.scss
@@ -45,6 +45,7 @@ limitations under the License.
 }
 
 .warning-message {
+  @include tb-theme-foreground-prop(color, text);
   margin: 80px auto 0;
   max-width: 540px;
 }


### PR DESCRIPTION
This change applies proper `color` on `.warning-message`. Warning
message is not a plugin content and thus is not getting proper `color`
set when in dark mode.

Before: 
![image](https://user-images.githubusercontent.com/2547313/124183838-a5a0c780-da6d-11eb-979e-0eb8e67a89b0.png)

After:
![image](https://user-images.githubusercontent.com/2547313/124183193-bef54400-da6c-11eb-8300-ecb424c3499f.png)
