### PR TITLE
runs: filter based on experiment name and classic name

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -457,11 +457,20 @@ export class RunsTableContainer implements OnInit, OnDestroy {
           RunsTableColumn.EXPERIMENT_NAME
         );
         return items.filter((item) => {
+          // For some reason, TypeScript is faulty and cannot coerce the type to
+          // non-null inspite the `if (!regex)` above.
+          regex = regex!;
+
           if (!shouldIncludeExperimentName) {
-            return regex!.test(item.run.name);
+            return regex.test(item.run.name);
           }
+
+          const legacyRunName = `${item.experimentName}/${item.run.name}`;
           return (
-            regex!.test(item.run.name) || regex!.test(item.experimentAlias)
+            regex.test(item.run.name) ||
+            regex.test(item.experimentAlias) ||
+            regex.test(item.experimentName) ||
+            regex.test(legacyRunName)
           );
         });
       }),

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -1338,6 +1338,11 @@ describe('runs_table', () => {
 
       // Alias for Harry Potter contains "z". If we were matching against
       // alias + run name, Harry Potter should not match below.
+      // This regex matches:
+      // - (Harry P)*o*tter/The Chamber of S(ecrets)
+      // - (The L)ord of the rings/The S(ilmarillion)
+      // and does not match
+      // - HPz/The Chamber of S(ecrets) because of "[^z]+".
       store.overrideSelector(getRunSelectorRegexFilter, 'o[^z]+/.+S[ei]');
       store.refreshState();
       fixture.detectChanges();


### PR DESCRIPTION
In older TensorBoard, our run names, in experiment aware world, used to
have run names prefixed with experiment name to uniquely identify a run
in an experiment. Our users may expect that behavior in our run selector
so we implement to match the older behavior.
