### PR TITLE
color grouping: group by regex, set non-matched runs to inactive

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -261,6 +261,10 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
       }
     });
 
+    for (const run of groups.nonMatches) {
+      defaultRunColorForGroupBy.set(run.id, '');
+    }
+
     return {
       ...state,
       defaultRunColorForGroupBy,
@@ -294,6 +298,10 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
           defaultRunColorForGroupBy.set(run.id, color);
         }
       });
+
+      for (const run of groups.nonMatches) {
+        defaultRunColorForGroupBy.set(run.id, '');
+      }
 
       return {
         ...state,

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -261,8 +261,9 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
       }
     });
 
+    // unassign color for nonmatched runs to apply default unassigned style
     for (const run of groups.nonMatches) {
-      defaultRunColorForGroupBy.set(run.id, '');
+      defaultRunColorForGroupBy.delete(run.id);
     }
 
     return {
@@ -299,8 +300,9 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
         }
       });
 
+      // unassign color for nonmatched runs to apply default unassigned style
       for (const run of groups.nonMatches) {
-        defaultRunColorForGroupBy.set(run.id, '');
+        defaultRunColorForGroupBy.delete(run.id);
       }
 
       return {

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -328,7 +328,7 @@ describe('runs_reducers', () => {
             buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
             buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
             buildRun({id: 'eid2/alpha', name: 'alpha'}),
-            buildRun({id: 'eid2/beta', name: 'beta'}),
+            buildRun({id: 'eid2/delta', name: 'delta'}),
           ],
           newRunsAndMetadata: {},
         });
@@ -343,8 +343,6 @@ describe('runs_reducers', () => {
             ['eid1/beta', colorUtils.CHART_COLOR_PALLETE[1]],
             ['eid2/beta', colorUtils.CHART_COLOR_PALLETE[1]],
             ['eid2/gamma', colorUtils.CHART_COLOR_PALLETE[1]],
-            ['eid2/alpha', ''],
-            ['eid2/beta', ''],
           ])
         );
       });
@@ -922,9 +920,6 @@ describe('runs_reducers', () => {
           ['run2', colorUtils.CHART_COLOR_PALLETE[1]],
           ['run3', colorUtils.CHART_COLOR_PALLETE[1]],
           ['run4', colorUtils.CHART_COLOR_PALLETE[1]],
-          // remove color assignments for non-matched runs
-          ['run5', ''],
-          ['run6', ''],
         ])
       );
       expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -311,6 +311,43 @@ describe('runs_reducers', () => {
           ])
         );
       });
+
+      it('removes color assignment for regex non-matched runs', () => {
+        const state = buildRunsState({
+          initialGroupBy: {key: GroupByKey.REGEX, regexString: 'foo(\\d+)'},
+          defaultRunColorForGroupBy: new Map([
+            ['foo', '#aaa'],
+            ['bar', '#aaa'],
+          ]),
+        });
+        const action = actions.fetchRunsSucceeded({
+          experimentIds: ['eid1', 'eid2'],
+          runsForAllExperiments: [
+            buildRun({id: 'eid1/alpha', name: 'foo1bar1'}),
+            buildRun({id: 'eid1/beta', name: 'foo2bar1'}),
+            buildRun({id: 'eid2/beta', name: 'foo2bar2'}),
+            buildRun({id: 'eid2/gamma', name: 'foo2bar2bar'}),
+            buildRun({id: 'eid2/alpha', name: 'alpha'}),
+            buildRun({id: 'eid2/beta', name: 'beta'}),
+          ],
+          newRunsAndMetadata: {},
+        });
+
+        const nextState = runsReducers.reducers(state, action);
+
+        expect(nextState.data.defaultRunColorForGroupBy).toEqual(
+          new Map([
+            ['foo', '#aaa'],
+            ['bar', '#aaa'],
+            ['eid1/alpha', colorUtils.CHART_COLOR_PALLETE[0]],
+            ['eid1/beta', colorUtils.CHART_COLOR_PALLETE[1]],
+            ['eid2/beta', colorUtils.CHART_COLOR_PALLETE[1]],
+            ['eid2/gamma', colorUtils.CHART_COLOR_PALLETE[1]],
+            ['eid2/alpha', ''],
+            ['eid2/beta', ''],
+          ])
+        );
+      });
     });
 
     it('auto-selects new runs if total num <= N', () => {
@@ -826,6 +863,68 @@ describe('runs_reducers', () => {
           ['run2', colorUtils.CHART_COLOR_PALLETE[1]],
           ['run3', colorUtils.CHART_COLOR_PALLETE[2]],
           ['run4', colorUtils.CHART_COLOR_PALLETE[3]],
+        ])
+      );
+      expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());
+    });
+
+    it('reassigns color to REGEX from RUN', () => {
+      const state = buildRunsState({
+        initialGroupBy: {key: GroupByKey.RUN},
+        runIds: {
+          eid1: ['run1', 'run2'],
+          eid2: ['run3', 'run4', 'run5', 'run6'],
+        },
+        runIdToExpId: {
+          run1: 'eid1',
+          run2: 'eid1',
+          run3: 'eid2',
+          run4: 'eid2',
+          run5: 'eid2',
+          run6: 'eid2',
+        },
+        runMetadata: {
+          run1: buildRun({id: 'run1', name: 'foo1bar1'}),
+          run2: buildRun({id: 'run2', name: 'foo2bar1'}),
+          run3: buildRun({id: 'run3', name: 'foo2bar2'}),
+          run4: buildRun({id: 'run4', name: 'foo2bar2bar'}),
+          run5: buildRun({id: 'run5', name: 'beta'}),
+          run6: buildRun({id: 'run6', name: 'gamma'}),
+        },
+        defaultRunColorForGroupBy: new Map([
+          ['run1', '#aaa'],
+          ['run2', '#bbb'],
+          ['run3', '#ccc'],
+          ['run4', '#ddd'],
+          ['run5', '#eee'],
+          ['run6', '#fff'],
+        ]),
+      });
+
+      const nextState = runsReducers.reducers(
+        state,
+        actions.runGroupByChanged({
+          experimentIds: ['eid1', 'eid2'],
+          groupBy: {key: GroupByKey.REGEX, regexString: 'foo(\\d+)'},
+        })
+      );
+
+      expect(nextState.data.userSetGroupByKey).toEqual(GroupByKey.REGEX);
+      expect(nextState.data.groupKeyToColorString).toEqual(
+        new Map([
+          ['["1"]', colorUtils.CHART_COLOR_PALLETE[0]],
+          ['["2"]', colorUtils.CHART_COLOR_PALLETE[1]],
+        ])
+      );
+      expect(nextState.data.defaultRunColorForGroupBy).toEqual(
+        new Map([
+          ['run1', colorUtils.CHART_COLOR_PALLETE[0]],
+          ['run2', colorUtils.CHART_COLOR_PALLETE[1]],
+          ['run3', colorUtils.CHART_COLOR_PALLETE[1]],
+          ['run4', colorUtils.CHART_COLOR_PALLETE[1]],
+          // remove color assignments for non-matched runs
+          ['run5', ''],
+          ['run6', ''],
         ])
       );
       expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());


### PR DESCRIPTION
* Motivation for features / changes
We want to remove the color assignments for the non-matched runs; this will mark them as "inactive" and apply gray borders on them.
This improves the ux of the group by regex functionality. 

* Screenshots of UI changes
Before: 
![Screen Shot 2021-07-07 at 5 56 20 PM](https://user-images.githubusercontent.com/1131010/124845948-a42f3d80-df4c-11eb-87c2-7f1c3331a3f5.png)
After: 
![Screen Shot 2021-07-07 at 5 56 40 PM](https://user-images.githubusercontent.com/1131010/124845966-b01aff80-df4c-11eb-9a47-5926d49d2dd5.png)

