### PR TITLE
Refactor settings in state to their own object.

### DIFF
--- a/tensorboard/webapp/reloader/reloader_component_test.ts
+++ b/tensorboard/webapp/reloader/reloader_component_test.ts
@@ -20,7 +20,11 @@ import {provideMockStore, MockStore} from '@ngrx/store/testing';
 import {ReloaderComponent} from './reloader_component';
 
 import {reload} from '../core/actions';
-import {createState, createSettingsState, createSettings} from '../settings/testing';
+import {
+  createState,
+  createSettingsState,
+  createSettings,
+} from '../settings/testing';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
@@ -57,10 +61,12 @@ describe('reloader_component', () => {
         },
         provideMockStore({
           initialState: createState(
-            createSettingsState({settings: createSettings({
-              reloadPeriodInMs: 5,
-              reloadEnabled: true,
-            })})
+            createSettingsState({
+              settings: createSettings({
+                reloadPeriodInMs: 5,
+                reloadEnabled: true,
+              }),
+            })
           ),
         }),
         ReloaderComponent,
@@ -75,10 +81,12 @@ describe('reloader_component', () => {
   it('dispatches reload action every reload period', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -102,10 +110,12 @@ describe('reloader_component', () => {
   it('disables reload when it is not enabled', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: false,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: false,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -121,10 +131,12 @@ describe('reloader_component', () => {
   it('respects reload period', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 50,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 50,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -145,10 +157,12 @@ describe('reloader_component', () => {
   it('only resets timer when store values changes', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -157,10 +171,12 @@ describe('reloader_component', () => {
     tick(4);
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     fixture.detectChanges();
@@ -172,10 +188,12 @@ describe('reloader_component', () => {
     tick(4);
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 3,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 3,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
 
@@ -191,10 +209,12 @@ describe('reloader_component', () => {
   it('does not reload if document is not visible', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -213,10 +233,12 @@ describe('reloader_component', () => {
   it('reloads when document becomes visible if missed reload', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -237,10 +259,12 @@ describe('reloader_component', () => {
   it('reloads when document becomes visible if missed reload, regardless of how long not visible', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -267,10 +291,12 @@ describe('reloader_component', () => {
   it('does not reload when document becomes visible if there was not a missed reload', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -292,10 +318,12 @@ describe('reloader_component', () => {
   it('does not reload when document becomes visible if missed reload was already handled', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: true,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -324,10 +352,12 @@ describe('reloader_component', () => {
   it('does not reload when document becomes visible if auto reload is off', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({settings: createSettings({
-          reloadPeriodInMs: 5,
-          reloadEnabled: false,
-        })})
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: false,
+          }),
+        })
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);

--- a/tensorboard/webapp/reloader/reloader_component_test.ts
+++ b/tensorboard/webapp/reloader/reloader_component_test.ts
@@ -20,7 +20,7 @@ import {provideMockStore, MockStore} from '@ngrx/store/testing';
 import {ReloaderComponent} from './reloader_component';
 
 import {reload} from '../core/actions';
-import {createState, createSettingsState} from '../settings/testing';
+import {createState, createSettingsState, createSettings} from '../settings/testing';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
@@ -57,10 +57,10 @@ describe('reloader_component', () => {
         },
         provideMockStore({
           initialState: createState(
-            createSettingsState({
+            createSettingsState({settings: createSettings({
               reloadPeriodInMs: 5,
               reloadEnabled: true,
-            })
+            })})
           ),
         }),
         ReloaderComponent,
@@ -75,10 +75,10 @@ describe('reloader_component', () => {
   it('dispatches reload action every reload period', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -102,10 +102,10 @@ describe('reloader_component', () => {
   it('disables reload when it is not enabled', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: false,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -121,10 +121,10 @@ describe('reloader_component', () => {
   it('respects reload period', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 50,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -145,10 +145,10 @@ describe('reloader_component', () => {
   it('only resets timer when store values changes', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -157,10 +157,10 @@ describe('reloader_component', () => {
     tick(4);
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     fixture.detectChanges();
@@ -172,10 +172,10 @@ describe('reloader_component', () => {
     tick(4);
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 3,
           reloadEnabled: true,
-        })
+        })})
       )
     );
 
@@ -191,10 +191,10 @@ describe('reloader_component', () => {
   it('does not reload if document is not visible', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -213,10 +213,10 @@ describe('reloader_component', () => {
   it('reloads when document becomes visible if missed reload', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -237,10 +237,10 @@ describe('reloader_component', () => {
   it('reloads when document becomes visible if missed reload, regardless of how long not visible', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -267,10 +267,10 @@ describe('reloader_component', () => {
   it('does not reload when document becomes visible if there was not a missed reload', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -292,10 +292,10 @@ describe('reloader_component', () => {
   it('does not reload when document becomes visible if missed reload was already handled', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: true,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);
@@ -324,10 +324,10 @@ describe('reloader_component', () => {
   it('does not reload when document becomes visible if auto reload is off', fakeAsync(() => {
     store.setState(
       createState(
-        createSettingsState({
+        createSettingsState({settings: createSettings({
           reloadPeriodInMs: 5,
           reloadEnabled: false,
-        })
+        })})
       )
     );
     const fixture = TestBed.createComponent(ReloaderComponent);

--- a/tensorboard/webapp/settings/_redux/settings_reducers.ts
+++ b/tensorboard/webapp/settings/_redux/settings_reducers.ts
@@ -40,7 +40,10 @@ const reducer = createReducer(
 
       return {
         ...state,
-        reloadEnabled: !state.reloadEnabled,
+        settings: {
+          ...state.settings,
+          reloadEnabled: !state.settings.reloadEnabled,
+        },
       };
     }
   ),
@@ -52,10 +55,13 @@ const reducer = createReducer(
       }
 
       const nextReloadPeriod =
-        periodInMs > 0 ? periodInMs : state.reloadPeriodInMs;
+        periodInMs > 0 ? periodInMs : state.settings.reloadPeriodInMs;
       return {
         ...state,
-        reloadPeriodInMs: nextReloadPeriod,
+        settings: {
+          ...state.settings,
+          reloadPeriodInMs: nextReloadPeriod,
+        },
       };
     }
   ),
@@ -64,10 +70,13 @@ const reducer = createReducer(
       return state;
     }
 
-    const nextPageSize = size > 0 ? size : state.pageSize;
+    const nextPageSize = size > 0 ? size : state.settings.pageSize;
     return {
       ...state,
-      pageSize: nextPageSize,
+      settings: {
+        ...state.settings,
+        pageSize: nextPageSize,
+      },
     };
   })
 );

--- a/tensorboard/webapp/settings/_redux/settings_reducers_test.ts
+++ b/tensorboard/webapp/settings/_redux/settings_reducers_test.ts
@@ -14,83 +14,89 @@ limitations under the License.
 ==============================================================================*/
 import * as actions from './settings_actions';
 import {reducers} from './settings_reducers';
-import {createSettingsState} from '../testing';
+import {createSettings, createSettingsState} from '../testing';
 import {DataLoadState} from '../../types/data';
 
 describe('settings reducer', () => {
   describe('#toggleReloadEnabled', () => {
     it('toggles reloadEnabled', () => {
-      const state1 = createSettingsState({reloadEnabled: false});
+      const state1 = createSettingsState({
+        settings: createSettings({reloadEnabled: false}),
+      });
 
       const state2 = reducers(state1, actions.toggleReloadEnabled());
 
-      expect(state2.reloadEnabled).toBe(true);
+      expect(state2.settings.reloadEnabled).toBe(true);
 
       const state3 = reducers(state2, actions.toggleReloadEnabled());
 
-      expect(state3.reloadEnabled).toBe(false);
+      expect(state3.settings.reloadEnabled).toBe(false);
     });
 
     it('does not toggle reloadEnabled if settings not loaded', () => {
       const state1 = createSettingsState({
         state: DataLoadState.NOT_LOADED,
-        reloadEnabled: false,
+        settings: createSettings({reloadEnabled: false}),
       });
       const state2 = reducers(state1, actions.toggleReloadEnabled());
-      expect(state2.reloadEnabled).toBe(false);
+      expect(state2.settings.reloadEnabled).toBe(false);
     });
 
     it('does not toggle reloadEnabled if settings loading', () => {
       const state1 = createSettingsState({
         state: DataLoadState.LOADING,
-        reloadEnabled: false,
+        settings: createSettings({reloadEnabled: false}),
       });
       const state2 = reducers(state1, actions.toggleReloadEnabled());
-      expect(state2.reloadEnabled).toBe(false);
+      expect(state2.settings.reloadEnabled).toBe(false);
     });
 
     it('toggles reloadEnabled if settings failed to load', () => {
       const state1 = createSettingsState({
         state: DataLoadState.FAILED,
-        reloadEnabled: false,
+        settings: createSettings({reloadEnabled: false}),
       });
       const state2 = reducers(state1, actions.toggleReloadEnabled());
-      expect(state2.reloadEnabled).toBe(true);
+      expect(state2.settings.reloadEnabled).toBe(true);
     });
   });
 
   describe('#changeReloadPeriod', () => {
     it('sets the reloadPeriodInMs', () => {
-      const state = createSettingsState({reloadPeriodInMs: 1});
+      const state = createSettingsState({
+        settings: createSettings({reloadPeriodInMs: 1}),
+      });
 
       const nextState = reducers(
         state,
         actions.changeReloadPeriod({periodInMs: 1000})
       );
 
-      expect(nextState.reloadPeriodInMs).toBe(1000);
+      expect(nextState.settings.reloadPeriodInMs).toBe(1000);
     });
 
     it('ignores the action when periodInMs is non-positive', () => {
-      const baseState = createSettingsState({reloadPeriodInMs: 1});
+      const baseState = createSettingsState({
+        settings: createSettings({reloadPeriodInMs: 1}),
+      });
 
       const state1 = reducers(
         baseState,
         actions.changeReloadPeriod({periodInMs: 0})
       );
-      expect(state1.reloadPeriodInMs).toBe(1);
+      expect(state1.settings.reloadPeriodInMs).toBe(1);
 
       const state2 = reducers(
         baseState,
         actions.changeReloadPeriod({periodInMs: -1000})
       );
-      expect(state2.reloadPeriodInMs).toBe(1);
+      expect(state2.settings.reloadPeriodInMs).toBe(1);
     });
 
     it('does not set the reloadPeriodInMs when settings not loaded', () => {
       const state = createSettingsState({
         state: DataLoadState.LOADING,
-        reloadPeriodInMs: 1,
+        settings: createSettings({reloadPeriodInMs: 1}),
       });
 
       const nextState = reducers(
@@ -98,28 +104,30 @@ describe('settings reducer', () => {
         actions.changeReloadPeriod({periodInMs: 1000})
       );
 
-      expect(nextState.reloadPeriodInMs).toBe(1);
+      expect(nextState.settings.reloadPeriodInMs).toBe(1);
     });
   });
 
   describe('#changePageSize', () => {
     it('sets pageSize', () => {
-      const state = createSettingsState({pageSize: 1});
+      const state = createSettingsState({
+        settings: createSettings({pageSize: 1}),
+      });
 
       const nextState = reducers(state, actions.changePageSize({size: 400}));
 
-      expect(nextState.pageSize).toBe(400);
+      expect(nextState.settings.pageSize).toBe(400);
     });
 
     it('does not set the reloadPeriodInMs when settings not loaded', () => {
       const state = createSettingsState({
         state: DataLoadState.LOADING,
-        pageSize: 1,
+        settings: createSettings({pageSize: 1}),
       });
 
       const nextState = reducers(state, actions.changePageSize({size: 400}));
 
-      expect(nextState.pageSize).toBe(1);
+      expect(nextState.settings.pageSize).toBe(1);
     });
   });
 });

--- a/tensorboard/webapp/settings/_redux/settings_selectors.ts
+++ b/tensorboard/webapp/settings/_redux/settings_selectors.ts
@@ -34,20 +34,20 @@ export const getSettingsLoadState = createSelector(
 export const getReloadEnabled = createSelector(
   selectSettingsState,
   (state: SettingsState): boolean => {
-    return state.reloadEnabled;
+    return state.settings.reloadEnabled;
   }
 );
 
 export const getReloadPeriodInMs = createSelector(
   selectSettingsState,
   (state: SettingsState): number => {
-    return state.reloadPeriodInMs;
+    return state.settings.reloadPeriodInMs;
   }
 );
 
 export const getPageSize = createSelector(
   selectSettingsState,
   (state: SettingsState): number => {
-    return state.pageSize;
+    return state.settings.pageSize;
   }
 );

--- a/tensorboard/webapp/settings/_redux/settings_types.ts
+++ b/tensorboard/webapp/settings/_redux/settings_types.ts
@@ -17,12 +17,16 @@ import {DataLoadState, LoadState} from '../../types/data';
 
 export const SETTINGS_FEATURE_KEY = 'settings';
 
-export interface SettingsState extends LoadState {
+export interface Settings {
   reloadPeriodInMs: number;
   reloadEnabled: boolean;
   // Size of a page in a general paginated view that is configurable by user via
   // settings.
   pageSize: number;
+}
+
+export interface SettingsState extends LoadState {
+  settings: Settings;
 }
 
 export interface State {
@@ -33,7 +37,9 @@ export const initialState: SettingsState = {
   state: DataLoadState.LOADED,
   lastLoadedTimeInMs: Date.now(),
 
-  reloadPeriodInMs: 30000,
-  reloadEnabled: false,
-  pageSize: 12,
+  settings: {
+    reloadPeriodInMs: 30000,
+    reloadEnabled: false,
+    pageSize: 12,
+  },
 };

--- a/tensorboard/webapp/settings/_views/settings_test.ts
+++ b/tensorboard/webapp/settings/_views/settings_test.ts
@@ -35,7 +35,7 @@ import {
   toggleReloadEnabled,
   changeReloadPeriod,
 } from '../_redux/settings_actions';
-import {createSettingsState, createState} from '../testing';
+import {createSettings, createSettingsState, createState} from '../testing';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 import {getSettingsLoadState} from '../_redux/settings_selectors';
@@ -62,8 +62,10 @@ describe('settings test', () => {
         provideMockStore({
           initialState: createState(
             createSettingsState({
-              reloadPeriodInMs: 30000,
-              reloadEnabled: true,
+              settings: createSettings({
+                reloadPeriodInMs: 30000,
+                reloadEnabled: true,
+              }),
             })
           ),
         }),
@@ -162,8 +164,10 @@ describe('settings test', () => {
     store.setState(
       createState(
         createSettingsState({
-          reloadPeriodInMs: 60000,
-          reloadEnabled: false,
+          settings: createSettings({
+            reloadPeriodInMs: 60000,
+            reloadEnabled: false,
+          }),
         })
       )
     );
@@ -223,8 +227,10 @@ describe('settings test', () => {
       store.setState(
         createState(
           createSettingsState({
-            reloadPeriodInMs: 30000,
-            reloadEnabled: false,
+            settings: createSettings({
+              reloadPeriodInMs: 30000,
+              reloadEnabled: false,
+            }),
           })
         )
       );

--- a/tensorboard/webapp/settings/testing.ts
+++ b/tensorboard/webapp/settings/testing.ts
@@ -14,10 +14,20 @@ limitations under the License.
 ==============================================================================*/
 import {DataLoadState} from '../types/data';
 import {
+  Settings,
   SettingsState,
   State,
   SETTINGS_FEATURE_KEY,
 } from './_redux/settings_types';
+
+export function createSettings(override?: Partial<Settings>) {
+  return {
+    reloadPeriodInMs: 30000,
+    reloadEnabled: true,
+    pageSize: 10,
+    ...override,
+  };
+}
 
 export function createSettingsState(
   override?: Partial<SettingsState>
@@ -25,9 +35,7 @@ export function createSettingsState(
   return {
     state: DataLoadState.LOADED,
     lastLoadedTimeInMs: 0,
-    reloadPeriodInMs: 30000,
-    reloadEnabled: true,
-    pageSize: 10,
+    settings: createSettings(),
     ...override,
   };
 }


### PR DESCRIPTION
Refactor SettingsState so that actual settings properties are in their own subproperty 'settings' of type 'Settings'.

In the future we plan to make Settings (or Partial<Settings>) the return type of any Settings-related data sources.