### PR TITLE
Move settings tests into top-level tf_ng_web_test_suite.

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -324,6 +324,8 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/runs/store:testing",
         "//tensorboard/webapp/runs/views/runs_selector:runs_selector_test",
         "//tensorboard/webapp/runs/views/runs_table:runs_table_test",
+        "//tensorboard/webapp/settings/_redux:_redux_test",
+        "//tensorboard/webapp/settings/_views:test_lib",
         "//tensorboard/webapp/tbdev_upload:test_lib",
         "//tensorboard/webapp/util:util_tests",
         "//tensorboard/webapp/webapp_data_source:feature_flag_test_lib",

--- a/tensorboard/webapp/settings/BUILD
+++ b/tensorboard/webapp/settings/BUILD
@@ -16,14 +16,6 @@ tf_ng_module(
     ],
 )
 
-tf_ng_web_test_suite(
-    name = "karma_test",
-    deps = [
-        "//tensorboard/webapp/settings/_redux:_redux_test",
-        "//tensorboard/webapp/settings/_views:test_lib",
-    ],
-)
-
 tf_ts_library(
     name = "testing",
     testonly = True,

--- a/tensorboard/webapp/settings/BUILD
+++ b/tensorboard/webapp/settings/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_web_test_suite", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 


### PR DESCRIPTION
Move settings tests into top-level tf_ng_web_test_suite. I either forget to run the settings tests or, if I'm working on settings features, I forget to run the top-level tests.
