### PR TITLE
color grouping: Regex edit

### DIFF
--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -469,9 +469,7 @@ describe('runs_selectors', () => {
     });
 
     it('returns default empty string if user never has set one', () => {
-      const state = buildStateFromRunsState(
-        buildRunsState({})
-      );
+      const state = buildStateFromRunsState(buildRunsState({}));
 
       expect(selectors.getColorGroupRegexString(state)).toEqual('');
     });

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -460,8 +460,6 @@ describe('runs_selectors', () => {
       const state = buildStateFromRunsState(
         buildRunsState({
           colorGroupRegexString: 'foo(\\d+)',
-          initialGroupBy: {key: GroupByKey.RUN},
-          userSetGroupByKey: GroupByKey.REGEX,
         })
       );
 
@@ -477,8 +475,6 @@ describe('runs_selectors', () => {
     it('returns regex string even if it is not user set groupby', () => {
       const state = buildStateFromRunsState(
         buildRunsState({
-          initialGroupBy: {key: GroupByKey.RUN},
-          userSetGroupByKey: GroupByKey.RUN,
           colorGroupRegexString: 'foo(\\d+)',
         })
       );

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -449,4 +449,43 @@ describe('runs_selectors', () => {
       });
     });
   });
+
+  describe('#getColorGroupRegexString', () => {
+    beforeEach(() => {
+      // Clear the memoization.
+      selectors.getColorGroupRegexString.release();
+    });
+
+    it('returns regex string when it is group by regex', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          colorGroupRegexString: 'foo(\\d+)',
+          initialGroupBy: {key: GroupByKey.RUN},
+          userSetGroupByKey: GroupByKey.REGEX,
+        })
+      );
+
+      expect(selectors.getColorGroupRegexString(state)).toEqual('foo(\\d+)');
+    });
+
+    it('returns default empty string if user never has set one', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({})
+      );
+
+      expect(selectors.getColorGroupRegexString(state)).toEqual('');
+    });
+
+    it('returns regex string even if it is not user set groupby', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          initialGroupBy: {key: GroupByKey.RUN},
+          userSetGroupByKey: GroupByKey.RUN,
+          colorGroupRegexString: 'foo(\\d+)',
+        })
+      );
+
+      expect(selectors.getColorGroupRegexString(state)).toEqual('foo(\\d+)');
+    });
+  });
 });

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -33,5 +33,7 @@ limitations under the License.
     mat-button
     mat-dialog-close
     (click)="onSaveClick(regexStringInput.value)"
-  >Save</button>
+  >
+    Save
+  </button>
 </div>

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -33,7 +33,5 @@ limitations under the License.
     mat-button
     mat-dialog-close
     (click)="onSaveClick(regexStringInput.value)"
-  >
-    Save
-  </button>
+  >Save</button>
 </div>

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
@@ -75,7 +75,7 @@ limitations under the License.
     <span>
       <mat-icon svgIcon="edit_24px"></mat-icon>
     </span>
-    <label *ngIf="regexString" >{{regexString}}</label>
+    <label *ngIf="regexString">{{regexString}}</label>
     <label *ngIf="!regexString" class="none-set-string">(none set)</label>
   </button>
 </mat-menu>

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
@@ -68,9 +68,11 @@ limitations under the License.
   </button>
   <button
     mat-menu-item
-    role="menuitemradio"
+    role="menuitem"
+    *ngIf="showGroupByRegex"
+    [attr.aria-checked]="selectedGroupBy.key === GroupByKey.REGEX"
     (click)="onRegexStringEdit()"
-    class="displayRegexString"
+    class="display-regex-string"
   >
     <span>
       <mat-icon svgIcon="edit_24px"></mat-icon>

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
@@ -66,4 +66,16 @@ limitations under the License.
     </span>
     <label>Regex</label>
   </button>
+  <button
+    mat-menu-item
+    role="menuitemradio"
+    (click)="onRegexStringEdit()"
+    class="displayRegexString"
+  >
+    <span>
+      <mat-icon svgIcon="edit_24px"></mat-icon>
+    </span>
+    <label *ngIf="regexString" >{{regexString}}</label>
+    <label *ngIf="!regexString" class="none-set-string">(none set)</label>
+  </button>
 </mat-menu>

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
@@ -70,7 +70,6 @@ limitations under the License.
     mat-menu-item
     role="menuitem"
     *ngIf="showGroupByRegex"
-    [attr.aria-checked]="selectedGroupBy.key === GroupByKey.REGEX"
     (click)="onRegexStringEdit()"
     class="display-regex-string"
   >

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
@@ -36,4 +36,11 @@ limitations under the License.
     height: $_icon-size;
     width: $_icon-size;
   }
+
+  .displayRegexString {
+    padding-left: 40px;
+    .none-set-string {
+      color: gray
+    }
+  }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
@@ -40,7 +40,7 @@ limitations under the License.
   .displayRegexString {
     padding-left: 40px;
     .none-set-string {
-      color: gray
+      color: gray;
     }
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
@@ -40,7 +40,7 @@ limitations under the License.
   .display-regex-string {
     padding-left: 40px;
     .none-set-string {
-      color: map-get($tb-foreground, secondary-text);
+      @include tb-theme-foreground-prop(color, secondary-text);
     }
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
@@ -37,10 +37,10 @@ limitations under the License.
     width: $_icon-size;
   }
 
-  .displayRegexString {
+  .display-regex-string {
     padding-left: 40px;
     .none-set-string {
-      color: gray;
+      color: map-get($tb-foreground, secondary-text);
     }
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
@@ -19,8 +19,10 @@ import {
   Input,
   Output,
 } from '@angular/core';
+import {MatDialog} from '@angular/material/dialog';
 
 import {GroupBy, GroupByKey} from '../../types';
+import {RegexEditDialogContainer} from './regex_edit_dialog_container';
 
 @Component({
   selector: 'runs-group-menu-button-component',
@@ -31,9 +33,21 @@ import {GroupBy, GroupByKey} from '../../types';
 export class RunsGroupMenuButtonComponent {
   readonly GroupByKey = GroupByKey;
 
+  @Input() experimentIds!: string[];
+  @Input() regexString!: string;
   @Input() selectedGroupBy!: GroupBy;
   @Input() showGroupByRegex!: boolean;
 
   @Output()
   onGroupByChange = new EventEmitter<GroupBy>();
+
+  constructor(public dialog: MatDialog) {}
+
+  onRegexStringEdit() {
+    // data pass in the experiment id
+    const dialogRef = this.dialog.open(RegexEditDialogContainer, {
+      width: '1050px',
+      data: {experimentIds: [this.experimentIds]},
+    });
+  }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
@@ -47,7 +47,7 @@ export class RunsGroupMenuButtonComponent {
     // data pass in the experiment id
     const dialogRef = this.dialog.open(RegexEditDialogContainer, {
       width: '1050px',
-      data: {experimentIds: [this.experimentIds]},
+      data: {experimentIds: this.experimentIds},
     });
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
@@ -41,12 +41,15 @@ export class RunsGroupMenuButtonComponent {
   @Output()
   onGroupByChange = new EventEmitter<GroupBy>();
 
-  constructor(public dialog: MatDialog) {}
+  constructor(private readonly dialog: MatDialog) {}
 
   onRegexStringEdit() {
     // data pass in the experiment id
     const dialogRef = this.dialog.open(RegexEditDialogContainer, {
-      width: '1050px',
+      maxHeight: '95vh',
+      minHeight: '500px',
+      maxWidth: '80vw',
+      minWidth: '600px',
       data: {experimentIds: this.experimentIds},
     });
   }

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
@@ -19,7 +19,7 @@ import {Observable} from 'rxjs';
 import {State} from '../../../app_state';
 import {getEnabledColorGroupByRegex} from '../../../selectors';
 import {runGroupByChanged} from '../../actions';
-import {getRunGroupBy} from '../../store/runs_selectors';
+import {getColorGroupRegexString, getRunGroupBy} from '../../store/runs_selectors';
 import {GroupBy} from '../../types';
 
 /**
@@ -29,6 +29,7 @@ import {GroupBy} from '../../types';
   selector: 'runs-group-menu-button',
   template: `
     <runs-group-menu-button-component
+      [regexString]="groupByRegexString$ | async"
       [selectedGroupBy]="selectedGroupBy$ | async"
       [showGroupByRegex]="showGroupByRegex$ | async"
       (onGroupByChange)="onGroupByChange($event)"
@@ -48,6 +49,9 @@ export class RunsGroupMenuButtonContainer {
   readonly selectedGroupBy$: Observable<GroupBy> = this.store.select(
     getRunGroupBy
   );
+
+  readonly groupByRegexString$: Observable<string> =
+    this.store.select(getColorGroupRegexString);
 
   onGroupByChange(groupBy: GroupBy) {
     this.store.dispatch(

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
@@ -19,7 +19,10 @@ import {Observable} from 'rxjs';
 import {State} from '../../../app_state';
 import {getEnabledColorGroupByRegex} from '../../../selectors';
 import {runGroupByChanged} from '../../actions';
-import {getColorGroupRegexString, getRunGroupBy} from '../../store/runs_selectors';
+import {
+  getColorGroupRegexString,
+  getRunGroupBy,
+} from '../../store/runs_selectors';
 import {GroupBy} from '../../types';
 
 /**
@@ -50,8 +53,9 @@ export class RunsGroupMenuButtonContainer {
     getRunGroupBy
   );
 
-  readonly groupByRegexString$: Observable<string> =
-    this.store.select(getColorGroupRegexString);
+  readonly groupByRegexString$: Observable<string> = this.store.select(
+    getColorGroupRegexString
+  );
 
   onGroupByChange(groupBy: GroupBy) {
     this.store.dispatch(

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -609,7 +609,7 @@ describe('runs_table', () => {
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))
-          ).toEqual(['true', 'false', 'false', 'false']);
+          ).toEqual(['true', 'false', 'false', null]);
           expect(
             items.map((element) => Boolean(element.querySelector('mat-icon')))
           ).toEqual([true, false, false, true]);
@@ -623,7 +623,7 @@ describe('runs_table', () => {
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))
-          ).toEqual(['false', 'false', 'true', 'true']);
+          ).toEqual(['false', 'false', 'true', null]);
           expect(
             items.map((element) => Boolean(element.querySelector('mat-icon')))
           ).toEqual([false, false, true, true]);

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -605,7 +605,11 @@ describe('runs_table', () => {
             .query(By.css('button'));
           menuButton.nativeElement.click();
 
-          const items = Array.from(overlayContainer.getContainerElement().querySelectorAll('[role="menuitemradio"]'));
+          const items = Array.from(
+            overlayContainer
+              .getContainerElement()
+              .querySelectorAll('[role="menuitemradio"]')
+          );
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -89,7 +89,6 @@ import {DomainType} from '../../data_source/runs_data_source_types';
 import {MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT, Run} from '../../store/runs_types';
 import {buildRun} from '../../store/testing';
 import {GroupByKey, SortType} from '../../types';
-import {RegexEditDialogContainer} from './regex_edit_dialog_container';
 import {RunsGroupMenuButtonComponent} from './runs_group_menu_button_component';
 import {RunsGroupMenuButtonContainer} from './runs_group_menu_button_container';
 import {RunsTableComponent} from './runs_table_component';
@@ -677,9 +676,12 @@ describe('runs_table', () => {
         );
 
         regexEdit.click();
-        const dialogContainer = overlayContainer.getContainerElement().querySelector('mat-dialog-container');
+        const dialogContainer = overlayContainer
+          .getContainerElement()
+          .querySelector('mat-dialog-container');
         expect(dialogContainer).toBeTruthy();
-        expect(dialogContainer!.textContent).toContain('Save')
+        expect(dialogContainer!.textContent).toContain('Save');
+        expect(dialogContainer!.textContent).toContain('Cancel');
       });
 
       it(

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -186,6 +186,7 @@ describe('runs_table', () => {
     await TestBed.configureTestingModule({
       imports: [
         MatCheckboxModule,
+        MatDialogModule,
         MatIconTestingModule,
         MatMenuModule,
         MatPaginatorModule,
@@ -195,7 +196,6 @@ describe('runs_table', () => {
         NoopAnimationsModule,
         FilterInputModule,
         RangeInputModule,
-        MatDialogModule,
       ],
       declarations: [
         RunsGroupMenuButtonComponent,
@@ -609,7 +609,7 @@ describe('runs_table', () => {
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))
-          ).toEqual(['true', 'false', 'false', null]);
+          ).toEqual(['true', 'false', 'false', 'false']);
           expect(
             items.map((element) => Boolean(element.querySelector('mat-icon')))
           ).toEqual([true, false, false, true]);
@@ -623,7 +623,7 @@ describe('runs_table', () => {
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))
-          ).toEqual(['false', 'false', 'true', null]);
+          ).toEqual(['false', 'false', 'true', 'true']);
           expect(
             items.map((element) => Boolean(element.querySelector('mat-icon')))
           ).toEqual([false, false, true, true]);
@@ -680,8 +680,11 @@ describe('runs_table', () => {
           .getContainerElement()
           .querySelector('mat-dialog-container');
         expect(dialogContainer).toBeTruthy();
-        expect(dialogContainer!.textContent).toContain('Save');
-        expect(dialogContainer!.textContent).toContain('Cancel');
+        const [cancelButton, saveButton] = dialogContainer!.querySelectorAll(
+          'button'
+        );
+        expect(cancelButton!.textContent).toBe('Cancel');
+        expect(saveButton!.textContent).toBe('Save');
       });
 
       it(

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -27,6 +27,7 @@ import {
   TestBed,
 } from '@angular/core/testing';
 import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatDialogModule} from '@angular/material/dialog';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatPaginatorModule} from '@angular/material/paginator';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
@@ -52,6 +53,7 @@ import {
 } from '../../../hparams/testing';
 import {DiscreteFilter, IntervalFilter} from '../../../hparams/types';
 import {
+  getColorGroupRegexString,
   getCurrentRouteRunSelection,
   getEnabledColorGroup,
   getEnabledColorGroupByRegex,
@@ -87,6 +89,7 @@ import {DomainType} from '../../data_source/runs_data_source_types';
 import {MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT, Run} from '../../store/runs_types';
 import {buildRun} from '../../store/testing';
 import {GroupByKey, SortType} from '../../types';
+import {RegexEditDialogContainer} from './regex_edit_dialog_container';
 import {RunsGroupMenuButtonComponent} from './runs_group_menu_button_component';
 import {RunsGroupMenuButtonContainer} from './runs_group_menu_button_container';
 import {RunsTableComponent} from './runs_table_component';
@@ -193,6 +196,7 @@ describe('runs_table', () => {
         NoopAnimationsModule,
         FilterInputModule,
         RangeInputModule,
+        MatDialogModule,
       ],
       declarations: [
         RunsGroupMenuButtonComponent,
@@ -209,6 +213,7 @@ describe('runs_table', () => {
     actualActions = [];
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    overlayContainer = TestBed.inject(OverlayContainer);
     store.overrideSelector(getRuns, []);
     store.overrideSelector(getRunsLoadState, {
       state: DataLoadState.NOT_LOADED,
@@ -252,6 +257,7 @@ describe('runs_table', () => {
     store.overrideSelector(getEnabledColorGroup, false);
     store.overrideSelector(getEnabledColorGroupByRegex, false);
     store.overrideSelector(getRunGroupBy, {key: GroupByKey.RUN});
+    store.overrideSelector(getColorGroupRegexString, '');
     dispatchSpy = spyOn(store, 'dispatch').and.callFake((action: Action) => {
       actualActions.push(action);
     });
@@ -561,7 +567,7 @@ describe('runs_table', () => {
         expect(menuButton).toBeTruthy();
       });
 
-      it('renders "Experiment", "Run", and "Regex"', () => {
+      it('renders "Experiment", "Run", "Regex", and "(none set)"', () => {
         store.overrideSelector(getEnabledColorGroup, true);
         store.overrideSelector(getEnabledColorGroupByRegex, true);
         const fixture = createComponent(
@@ -579,7 +585,7 @@ describe('runs_table', () => {
 
         expect(
           items.map((element) => element.querySelector('label')!.textContent)
-        ).toEqual(['Experiment', 'Run', 'Regex']);
+        ).toEqual(['Experiment', 'Run', 'Regex', '(none set)']);
       });
 
       it(
@@ -604,10 +610,10 @@ describe('runs_table', () => {
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))
-          ).toEqual(['true', 'false', 'false']);
+          ).toEqual(['true', 'false', 'false', null]);
           expect(
             items.map((element) => Boolean(element.querySelector('mat-icon')))
-          ).toEqual([true, false, false]);
+          ).toEqual([true, false, false, true]);
 
           store.overrideSelector(getRunGroupBy, {
             key: GroupByKey.REGEX,
@@ -618,10 +624,10 @@ describe('runs_table', () => {
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))
-          ).toEqual(['false', 'false', 'true']);
+          ).toEqual(['false', 'false', 'true', null]);
           expect(
             items.map((element) => Boolean(element.querySelector('mat-icon')))
-          ).toEqual([false, false, true]);
+          ).toEqual([false, false, true, true]);
         }
       );
 
@@ -642,7 +648,7 @@ describe('runs_table', () => {
 
         const items = getOverlayMenuItems();
 
-        const [experiments, runs, regex] = items as HTMLElement[];
+        const [experiments, runs, regex, regexEdit] = items as HTMLElement[];
         experiments.click();
 
         expect(dispatchSpy).toHaveBeenCalledWith(
@@ -669,6 +675,11 @@ describe('runs_table', () => {
             groupBy: {key: GroupByKey.REGEX, regexString: ''},
           })
         );
+
+        regexEdit.click();
+        const dialogContainer = overlayContainer.getContainerElement().querySelector('mat-dialog-container');
+        expect(dialogContainer).toBeTruthy();
+        expect(dialogContainer!.textContent).toContain('Save')
       });
 
       it(

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -605,14 +605,14 @@ describe('runs_table', () => {
             .query(By.css('button'));
           menuButton.nativeElement.click();
 
-          const items = getOverlayMenuItems();
+          const items = Array.from(overlayContainer.getContainerElement().querySelectorAll('[role="menuitemradio"]'));
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))
-          ).toEqual(['true', 'false', 'false', null]);
+          ).toEqual(['true', 'false', 'false']);
           expect(
             items.map((element) => Boolean(element.querySelector('mat-icon')))
-          ).toEqual([true, false, false, true]);
+          ).toEqual([true, false, false]);
 
           store.overrideSelector(getRunGroupBy, {
             key: GroupByKey.REGEX,
@@ -623,10 +623,10 @@ describe('runs_table', () => {
 
           expect(
             items.map((element) => element.getAttribute('aria-checked'))
-          ).toEqual(['false', 'false', 'true', null]);
+          ).toEqual(['false', 'false', 'true']);
           expect(
             items.map((element) => Boolean(element.querySelector('mat-icon')))
-          ).toEqual([false, false, true, true]);
+          ).toEqual([false, false, true]);
         }
       );
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -683,8 +683,8 @@ describe('runs_table', () => {
         const [cancelButton, saveButton] = dialogContainer!.querySelectorAll(
           'button'
         );
-        expect(cancelButton!.textContent).toBe('Cancel');
-        expect(saveButton!.textContent).toBe('Save');
+        expect(cancelButton!.textContent).toContain('Cancel');
+        expect(saveButton!.textContent).toContain('Save');
       });
 
       it(


### PR DESCRIPTION
* Motivation for features / changes!
add regex edit row to the dropdown
click to pop out the dialog
if there is no regexString set, display "(none set)" text

* Screenshots of UI changes
![Bm3KCvG5tqprpzY](https://user-images.githubusercontent.com/1131010/125365074-78cf9880-e328-11eb-8228-91c533bc935f.png)

* Detailed steps to verify changes work correctly (as executed by you)
1. apply `?enableColorGroupByRegex=true` in url
2. navigate to TIME SERIES and click palette icon
3. click the last row (pencil icon) and text (none set)
