### PR TITLE
fix build and lint errors in google3

### DIFF
--- a/tensorboard/webapp/core/BUILD
+++ b/tensorboard/webapp/core/BUILD
@@ -19,7 +19,7 @@ tf_ng_module(
     ],
 )
 
-tf_ts_library(
+tf_ng_module(
     name = "types",
     srcs = [
         "types.ts",

--- a/tensorboard/webapp/core/views/page_title_container.ts
+++ b/tensorboard/webapp/core/views/page_title_container.ts
@@ -72,6 +72,9 @@ export class PageTitleContainer {
   private readonly experimentName$ = this.getExperimentId$.pipe(
     filter(Boolean),
     mergeMap((experimentId) => {
+      // Selectors with props are deprecated (getExperiment):
+      // https://github.com/ngrx/platform/issues/2980
+      // tslint:disable-next-line:deprecation
       return this.store.select(getExperiment, {experimentId});
     }),
     map((experiment) => (experiment ? experiment.name : null))
@@ -96,6 +99,8 @@ export class PageTitleContainer {
 
   constructor(
     private readonly store: Store<State>,
-    @Optional() @Inject(TB_BRAND_NAME) private readonly customBrandName: string
+    @Optional()
+    @Inject(TB_BRAND_NAME)
+    private readonly customBrandName: string | null
   ) {}
 }

--- a/tensorboard/webapp/core/views/page_title_container.ts
+++ b/tensorboard/webapp/core/views/page_title_container.ts
@@ -101,6 +101,6 @@ export class PageTitleContainer {
     private readonly store: Store<State>,
     @Optional()
     @Inject(TB_BRAND_NAME)
-    private readonly customBrandName: string | null
+    private readonly customBrandName: string | undefined
   ) {}
 }


### PR DESCRIPTION
Fixes for:
- Deprecation warnings for selectors with props (GetExperiment)
- Type error for `customBrandName` (should accept `null`)
- `TB_BRAND_NAME` initialization error ([details](https://fusion2.corp.google.com/invocations/dfcc9be9-250e-4bf8-8182-b7588ea9267b/targets/%2F%2Fthird_party%2Ftensorboard%2Fwebapp%2Fcore%2Fviews:test_lib;config=b7b0423d5e2c3613de291426e5174dedca769b7600ec4129989b00744534613e/log))
