### PR TITLE
theme: style mat-button not as hyperlink

### DIFF
--- a/tensorboard/webapp/header/header_component.scss
+++ b/tensorboard/webapp/header/header_component.scss
@@ -48,11 +48,3 @@ settings-button {
   height: 100%;
   overflow: hidden;
 }
-
-:host a {
-  color: inherit;
-
-  @include tb-dark-theme {
-    color: inherit;
-  }
-}

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -223,7 +223,7 @@ $tb-dark-theme: map_merge(
   // Include all theme-styles for the components based on the current theme.
   @include angular-material-theme($tb-theme);
 
-  a {
+  a:not(.mat-button, .mat-icon-button) {
     color: map-get($tb-foreground, link);
 
     &:visited {
@@ -236,7 +236,7 @@ $tb-dark-theme: map_merge(
   body.dark-mode {
     background-color: map-get($tb-dark-background, background);
 
-    a {
+    a:not(.mat-button, .mat-icon-button) {
       color: map-get($tb-dark-foreground, link);
 
       &:visited {


### PR DESCRIPTION
There are some cases when a hyperlink is visually styled as a material
button. Due to our recent changes that globally style all hyperlinks,
those hyperlink-mat-buttons were also styled like one and it has caused
visual jank. This change undoes that by styling hyperlinks without
mat-*-button classes as hyperlink.

Prior to this change, "Learn More" below were styled as purple.
![image](https://user-images.githubusercontent.com/2547313/125374329-a5d97680-e33b-11eb-9eee-f010103891d6.png)
