### PR TITLE
type: missing optional injectable is null

### DIFF
--- a/tensorboard/webapp/core/views/page_title_container.ts
+++ b/tensorboard/webapp/core/views/page_title_container.ts
@@ -102,6 +102,5 @@ export class PageTitleContainer {
     @Optional()
     @Inject(TB_BRAND_NAME)
     private readonly customBrandName: string | null
-  ) {
-  }
+  ) {}
 }

--- a/tensorboard/webapp/core/views/page_title_container.ts
+++ b/tensorboard/webapp/core/views/page_title_container.ts
@@ -101,6 +101,7 @@ export class PageTitleContainer {
     private readonly store: Store<State>,
     @Optional()
     @Inject(TB_BRAND_NAME)
-    private readonly customBrandName: string | undefined
-  ) {}
+    private readonly customBrandName: string | null
+  ) {
+  }
 }


### PR DESCRIPTION
`customBrandName` which is an optional injectable is currently typed as
`undefined`. Empirically, when there are no provider, it actually
returns `null` instead.
