### PR TITLE
color grouping: fix expid pass bug

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
@@ -35,6 +35,7 @@ import {GroupBy} from '../../types';
       [regexString]="groupByRegexString$ | async"
       [selectedGroupBy]="selectedGroupBy$ | async"
       [showGroupByRegex]="showGroupByRegex$ | async"
+      [experimentIds]="experimentIds"
       (onGroupByChange)="onGroupByChange($event)"
     ></runs-group-menu-button-component>
   `,

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -95,6 +95,9 @@ import {RunsGroupMenuButtonContainer} from './runs_group_menu_button_container';
 import {RunsTableComponent} from './runs_table_component';
 import {RunsTableContainer, TEST_ONLY} from './runs_table_container';
 import {HparamSpec, MetricSpec, RunsTableColumn} from './types';
+enum REGEXEDIT {
+  REGEXEDIT = 4,
+}
 
 @Injectable()
 class ColorPickerTestHelper {
@@ -181,6 +184,23 @@ describe('runs_table', () => {
     return Array.from(
       overlayContainer.getContainerElement().querySelectorAll('[mat-menu-item]')
     );
+  }
+
+  function getColorGroupByHTMLElement(KEY: GroupByKey | REGEXEDIT) {
+    const items = getOverlayMenuItems();
+    const [experiment, run, regex, regexEdit] = items as HTMLElement[];
+    switch (KEY) {
+      case GroupByKey.RUN:
+        return run;
+      case GroupByKey.EXPERIMENT:
+        return experiment;
+      case GroupByKey.REGEX:
+        return regex;
+      case REGEXEDIT.REGEXEDIT:
+        return regexEdit;
+      default:
+        return null;
+    }
   }
 
   beforeEach(async () => {
@@ -650,11 +670,7 @@ describe('runs_table', () => {
           .query(By.css('button'));
         menuButton.nativeElement.click();
 
-        const items = getOverlayMenuItems();
-
-        const [experiments, runs, regex, regexEdit] = items as HTMLElement[];
-        experiments.click();
-
+        getColorGroupByHTMLElement(GroupByKey.EXPERIMENT)!.click();
         expect(dispatchSpy).toHaveBeenCalledWith(
           runGroupByChanged({
             experimentIds: ['book'],
@@ -662,7 +678,7 @@ describe('runs_table', () => {
           })
         );
 
-        runs.click();
+        getColorGroupByHTMLElement(GroupByKey.RUN)!.click();
         expect(dispatchSpy).toHaveBeenCalledWith(
           runGroupByChanged({
             experimentIds: ['book'],
@@ -670,7 +686,7 @@ describe('runs_table', () => {
           })
         );
 
-        regex.click();
+        getColorGroupByHTMLElement(GroupByKey.REGEX)!.click();
         expect(dispatchSpy).toHaveBeenCalledWith(
           runGroupByChanged({
             experimentIds: ['book'],
@@ -680,7 +696,7 @@ describe('runs_table', () => {
           })
         );
 
-        regexEdit.click();
+        getColorGroupByHTMLElement(REGEXEDIT.REGEXEDIT)!.click();
         const dialogContainer = overlayContainer
           .getContainerElement()
           .querySelector('mat-dialog-container');
@@ -706,10 +722,7 @@ describe('runs_table', () => {
           .query(By.css('button'));
         menuButton.nativeElement.click();
 
-        const items = getOverlayMenuItems();
-        const [experiments, runs, regex, regexEdit] = items as HTMLElement[];
-
-        regexEdit.click();
+        getColorGroupByHTMLElement(REGEXEDIT.REGEXEDIT)!.click();
         const dialogContainer = overlayContainer
           .getContainerElement()
           .querySelector('mat-dialog-container');
@@ -726,7 +739,9 @@ describe('runs_table', () => {
         );
 
         const dialogInputDebugElement: DebugElement = new DebugElement(
-          overlayContainer.getContainerElement().querySelector('mat-dialog-container input')
+          overlayContainer
+            .getContainerElement()
+            .querySelector('mat-dialog-container input')
         );
         sendKeys(fixture, dialogInputDebugElement, 'foo(\\d+)');
 
@@ -753,10 +768,7 @@ describe('runs_table', () => {
           .query(By.css('button'));
         menuButton.nativeElement.click();
 
-        const items = getOverlayMenuItems();
-        const [experiments, runs, regex, regexEdit] = items as HTMLElement[];
-
-        regexEdit.click();
+        getColorGroupByHTMLElement(REGEXEDIT.REGEXEDIT)!.click();
         const dialogContainer = overlayContainer
           .getContainerElement()
           .querySelector('mat-dialog-container');
@@ -765,7 +777,9 @@ describe('runs_table', () => {
         );
 
         const dialogInputDebugElement: DebugElement = new DebugElement(
-          overlayContainer.getContainerElement().querySelector('mat-dialog-container input')
+          overlayContainer
+            .getContainerElement()
+            .querySelector('mat-dialog-container input')
         );
         sendKeys(fixture, dialogInputDebugElement, 'foo(\\d+)');
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {
+  DebugElement,
   Directive,
   EventEmitter,
   Injectable,
@@ -724,11 +725,11 @@ describe('runs_table', () => {
           })
         );
 
-        (overlayContainer
-          .getContainerElement()
-          .querySelector(
-            'mat-dialog-container input'
-          ) as HTMLInputElement).value = 'foo(\\d+)';
+        const dialogInputDebugElement: DebugElement = new DebugElement(
+          overlayContainer.getContainerElement().querySelector('mat-dialog-container input')
+        );
+        sendKeys(fixture, dialogInputDebugElement, 'foo(\\d+)');
+
         saveButton.click();
         expect(dispatchSpy).toHaveBeenCalledWith(
           runGroupByChanged({
@@ -763,13 +764,12 @@ describe('runs_table', () => {
           'button'
         );
 
-        (overlayContainer
-          .getContainerElement()
-          .querySelector(
-            'mat-dialog-container input'
-          ) as HTMLInputElement).value = 'foo(\\d+)';
-        cancelButton.click();
+        const dialogInputDebugElement: DebugElement = new DebugElement(
+          overlayContainer.getContainerElement().querySelector('mat-dialog-container input')
+        );
+        sendKeys(fixture, dialogInputDebugElement, 'foo(\\d+)');
 
+        cancelButton.click();
         expect(dispatchSpy).not.toHaveBeenCalledWith(
           runGroupByChanged({
             experimentIds: ['book'],

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -95,9 +95,6 @@ import {RunsGroupMenuButtonContainer} from './runs_group_menu_button_container';
 import {RunsTableComponent} from './runs_table_component';
 import {RunsTableContainer, TEST_ONLY} from './runs_table_container';
 import {HparamSpec, MetricSpec, RunsTableColumn} from './types';
-enum REGEXEDIT {
-  REGEXEDIT = 4,
-}
 
 @Injectable()
 class ColorPickerTestHelper {
@@ -186,17 +183,17 @@ describe('runs_table', () => {
     );
   }
 
-  function getColorGroupByHTMLElement(KEY: GroupByKey | REGEXEDIT) {
+  function getColorGroupByHTMLElement(key: GroupByKey | 'regexEdit'): HTMLElement | null {
     const items = getOverlayMenuItems();
     const [experiment, run, regex, regexEdit] = items as HTMLElement[];
-    switch (KEY) {
+    switch (key) {
       case GroupByKey.RUN:
         return run;
       case GroupByKey.EXPERIMENT:
         return experiment;
       case GroupByKey.REGEX:
         return regex;
-      case REGEXEDIT.REGEXEDIT:
+      case 'regexEdit':
         return regexEdit;
       default:
         return null;
@@ -696,7 +693,7 @@ describe('runs_table', () => {
           })
         );
 
-        getColorGroupByHTMLElement(REGEXEDIT.REGEXEDIT)!.click();
+        getColorGroupByHTMLElement('regexEdit')!.click();
         const dialogContainer = overlayContainer
           .getContainerElement()
           .querySelector('mat-dialog-container');
@@ -722,7 +719,7 @@ describe('runs_table', () => {
           .query(By.css('button'));
         menuButton.nativeElement.click();
 
-        getColorGroupByHTMLElement(REGEXEDIT.REGEXEDIT)!.click();
+        getColorGroupByHTMLElement('regexEdit')!.click();
         const dialogContainer = overlayContainer
           .getContainerElement()
           .querySelector('mat-dialog-container');
@@ -768,7 +765,7 @@ describe('runs_table', () => {
           .query(By.css('button'));
         menuButton.nativeElement.click();
 
-        getColorGroupByHTMLElement(REGEXEDIT.REGEXEDIT)!.click();
+        getColorGroupByHTMLElement('regexEdit')!.click();
         const dialogContainer = overlayContainer
           .getContainerElement()
           .querySelector('mat-dialog-container');

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -183,7 +183,9 @@ describe('runs_table', () => {
     );
   }
 
-  function getColorGroupByHTMLElement(key: GroupByKey | 'regexEdit'): HTMLElement | null {
+  function getColorGroupByHTMLElement(
+    key: GroupByKey | 'regexEdit'
+  ): HTMLElement | null {
     const items = getOverlayMenuItems();
     const [experiment, run, regex, regexEdit] = items as HTMLElement[];
     switch (key) {


### PR DESCRIPTION
* Motivation for features / changes
When passing down the experiment id, it was overlooked in rund_group_menu_componet, which results in `OnRegexEdit` fails to function. Added it back and attach tests about regex editing.