### PR TITLE
color grouping: group by regex, fill example and some diaglog wording

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -14,6 +14,11 @@ tf_sass_binary(
     src = "runs_group_menu_button_component.scss",
 )
 
+tf_sass_binary(
+    name = "regex_edit_dialog_styles",
+    src = "regex_edit_dialog_component.scss",
+)
+
 tf_ng_module(
     name = "runs_table",
     srcs = [
@@ -27,6 +32,7 @@ tf_ng_module(
         "types.ts",
     ],
     assets = [
+        ":regex_edit_dialog_styles",
         ":runs_group_menu_button_styles",
         ":runs_table_styles",
         "regex_edit_dialog.ng.html",

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -14,12 +14,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<h1 mat-dialog-title>Color runs by regex</h1>
+
 <mat-dialog-content>
+  <p>Enter a regex with capturing groups to match against run names:</p>
   <mat-form-field>
     <input
       matInput
       #regexStringInput
-      placeholder="(\w+/).+"
       value="{{ regexString }}"
       (keydown.enter)="onEnter($event.target.value)"
       cdkFocusInitial
@@ -27,10 +29,23 @@ limitations under the License.
   </mat-form-field>
 </mat-dialog-content>
 
-<div mat-dialog-actions>
+<div class="example-details">
+  <p>
+    Each matching run will be assigned a color based on the "key" formed by its
+    matches to the capturing groups. <br />
+    <button mat-stroked-button (click)="fillExample()">
+      Try <code>(train|eval)</code>
+    </button>
+    to assign all runs containing <code>train</code> to one color and all runs
+    containing <code>eval</code> to another color.
+  </p>
+</div>
+
+<div mat-dialog-actions align="end">
   <button mat-button mat-dialog-close>Cancel</button>
   <button
-    mat-button
+    mat-raised-button
+    color="primary"
     mat-dialog-close
     (click)="onSaveClick(regexStringInput.value)"
   >

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -33,7 +33,7 @@ limitations under the License.
   <p>
     Each matching run will be assigned a color based on the "key" formed by its
     matches to the capturing groups. <br />
-    <button mat-stroked-button (click)="fillExample()">
+    <button (click)="fillExample('(train|eval)')">
       Try <code>(train|eval)</code>
     </button>
     to assign all runs containing <code>train</code> to one color and all runs

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
@@ -1,0 +1,29 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
+.example-details {
+  button {
+    background-color: transparent;
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    text-decoration: underline;
+    color: map-get($tb-foreground, link);
+    &:visited {
+      color: map-get($tb-foreground, link-visited);
+    }
+  }
+}

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
@@ -21,9 +21,9 @@ limitations under the License.
     border: none;
     cursor: pointer;
     text-decoration: underline;
-    color: map-get($tb-foreground, link);
+    @include tb-theme-foreground-prop(color, link);
     &:visited {
-      color: map-get($tb-foreground, link-visited);
+      @include tb-theme-foreground-prop(color, link-visited);
     }
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
@@ -43,4 +43,8 @@ export class RegexEditDialogComponent {
   onSaveClick(regexString: string) {
     this.onSave.emit(regexString);
   }
+
+  fillExample(): void {
+    this.regexString = '(train|eval)';
+  }
 }

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
@@ -24,6 +24,7 @@ import {MatDialogRef} from '@angular/material/dialog';
 @Component({
   selector: 'regex-edit-dialog-component',
   templateUrl: 'regex_edit_dialog.ng.html',
+  styleUrls: ['regex_edit_dialog_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RegexEditDialogComponent {
@@ -44,7 +45,7 @@ export class RegexEditDialogComponent {
     this.onSave.emit(regexString);
   }
 
-  fillExample(): void {
-    this.regexString = '(train|eval)';
+  fillExample(regexExample: string): void {
+    this.regexString = regexExample;
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -240,4 +240,18 @@ describe('regex_edit_dialog', () => {
       })
     );
   });
+
+  it('fills example', () => {
+    const fixture = createComponent(['rose']);
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(
+      By.css('.example-details button')
+    );
+    button.nativeElement.click();
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input'));
+    expect(input.nativeElement.value).toBe('(train|eval)');
+  });
 });

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -700,9 +700,11 @@ describe('runs_table', () => {
           .getContainerElement()
           .querySelector('mat-dialog-container');
         expect(dialogContainer).toBeTruthy();
-        const [cancelButton, saveButton] = dialogContainer!.querySelectorAll(
-          'button'
-        );
+        const [
+          fillExampleButton,
+          cancelButton,
+          saveButton,
+        ] = dialogContainer!.querySelectorAll('button');
         expect(cancelButton!.textContent).toContain('Cancel');
         expect(saveButton!.textContent).toContain('Save');
       });
@@ -725,9 +727,11 @@ describe('runs_table', () => {
         const dialogContainer = overlayContainer
           .getContainerElement()
           .querySelector('mat-dialog-container');
-        const [cancelButton, saveButton] = dialogContainer!.querySelectorAll(
-          'button'
-        );
+        const [
+          fillExampleButton,
+          cancelButton,
+          saveButton,
+        ] = dialogContainer!.querySelectorAll('button');
 
         saveButton.click();
         expect(dispatchSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
* Motivation for features / changes
- move cancel/save buttons to the right bottom
- add title and intro paragraph (see doc)
- click `Try (...)` to fill the example

<img width="720" alt="Screen Shot 2021-07-16 at 11 38 25 PM" src="https://user-images.githubusercontent.com/1131010/126028355-e8a229da-5935-4392-a6f2-6acf2988ff35.png">

Note:
- UI finalization WIP and screenshot tests come later
- live grouping result updates not included
