### PR TITLE
persistent_settings: glue config and data_source with Redux

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -119,6 +119,7 @@ tf_ng_module(
         "//tensorboard/webapp/feature_flag",
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/hparams",
+        "//tensorboard/webapp/persistent_settings",
         "//tensorboard/webapp/plugins",
         "//tensorboard/webapp/reloader",
         "//tensorboard/webapp/routes",

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -33,6 +33,7 @@ import {HeaderModule} from './header/header_module';
 import {HparamsModule} from './hparams/hparams_module';
 import {MatIconModule} from './mat_icon_module';
 import {OssPluginsModule} from './oss_plugins_module';
+import {PersistentSettingsModule} from './persistent_settings';
 import {PluginsModule} from './plugins/plugins_module';
 import {routesFactory} from './routes';
 import {RunsModule} from './runs/runs_module';
@@ -61,6 +62,7 @@ import {TensorBoardWrapperModule} from './tb_wrapper/tb_wrapper_module';
     HparamsModule,
     MatIconModule,
     PageTitleModule,
+    PersistentSettingsModule,
     PluginApiHostModule,
     PluginsModule,
     RunsModule,

--- a/tensorboard/webapp/persistent_settings/BUILD
+++ b/tensorboard/webapp/persistent_settings/BUILD
@@ -12,6 +12,8 @@ tf_ng_module(
         ":config_module",
         "//tensorboard/webapp/persistent_settings/_data_source",
         "//tensorboard/webapp/persistent_settings/_data_source:types",
+        "//tensorboard/webapp/persistent_settings/_redux:persistent_settings_actions",
+        "//tensorboard/webapp/persistent_settings/_redux:persistent_settings_effects",
         "//tensorboard/webapp/util:local_storage",
         "@npm//@angular/core",
         "@npm//@ngrx/effects",
@@ -38,7 +40,9 @@ tf_ng_module(
     ],
     deps = [
         ":config_types",
+        "//tensorboard/webapp/persistent_settings/_data_source:types",
         "@npm//@angular/core",
+        "@npm//@ngrx/store",
     ],
 )
 
@@ -63,5 +67,6 @@ tf_ng_web_test_suite(
     deps = [
         ":config_module_test_lib",
         "//tensorboard/webapp/persistent_settings/_data_source:_data_source_test_lib",
+        "//tensorboard/webapp/persistent_settings/_redux:persistent_settings_effects_test_lib",
     ],
 )

--- a/tensorboard/webapp/persistent_settings/_redux/BUILD
+++ b/tensorboard/webapp/persistent_settings/_redux/BUILD
@@ -1,0 +1,52 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_ng_module(
+    name = "persistent_settings_actions",
+    srcs = [
+        "persistent_settings_actions.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/persistent_settings/_data_source:types",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ng_module(
+    name = "persistent_settings_effects",
+    srcs = [
+        "persistent_settings_effects.ts",
+    ],
+    deps = [
+        ":persistent_settings_actions",
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/persistent_settings:config_module",
+        "//tensorboard/webapp/persistent_settings/_data_source",
+        "//tensorboard/webapp/persistent_settings/_data_source:types",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+tf_ng_module(
+    name = "persistent_settings_effects_test_lib",
+    testonly = True,
+    srcs = [
+        "persistent_settings_effects_test.ts",
+    ],
+    deps = [
+        ":persistent_settings_actions",
+        ":persistent_settings_effects",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/persistent_settings:config_module",
+        "//tensorboard/webapp/persistent_settings/_data_source:testing",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
@@ -12,7 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {createAction, props} from '@ngrx/store';
 
-export {PersistableSettings} from './_data_source/types';
-export {globalSettingsLoaded} from './_redux/persistent_settings_actions';
-export {PersistentSettingsModule} from './persistent_settings_module';
+import {PersistableSettings} from '../_data_source/types';
+
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
+
+/**
+ * Describes settings loaded from a global settings storage. Dispatched once
+ * when the application bootstraps.
+ */
+export const globalSettingsLoaded = createAction(
+  '[Persistent Settings] Global Settings Loaded',
+  props<{
+    partialSettings: Partial<PersistableSettings>;
+  }>()
+);

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
@@ -1,0 +1,124 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+import {Actions, createEffect, ofType, OnInitEffects} from '@ngrx/effects';
+import {Action, createAction, Store} from '@ngrx/store';
+import {merge, Observable} from 'rxjs';
+import {
+  buffer,
+  debounceTime,
+  delay,
+  distinctUntilChanged,
+  mergeMap,
+  share,
+  skip,
+  tap,
+} from 'rxjs/operators';
+
+import {State} from '../../app_state';
+import {PersistentSettingsConfigModule} from '../persistent_settings_config_module';
+import {PersistentSettingsDataSource} from '../_data_source/persistent_settings_data_source';
+import {globalSettingsLoaded} from './persistent_settings_actions';
+import {PersistableSettings} from '../_data_source/types';
+
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
+
+const initAction = createAction('[Persistent Settings] Effects Init');
+const DEBOUNCE_PERIOD_IN_MS = 500;
+
+/**
+ * Persistent settings effect that is responsible for bootstrapping application
+ * with the initialization and making request to change settings when selectors
+ * emit.
+ */
+@Injectable()
+export class PersistentSettingsEffects implements OnInitEffects {
+  /** @export */
+  readonly initializeAndUpdateSettings$: Observable<void> = createEffect(
+    () => {
+      const selectorsEmit$ = this.actions$.pipe(
+        ofType(initAction),
+        mergeMap(() => this.dataSource.getSettings()),
+        tap((partialSettings) => {
+          this.store.dispatch(globalSettingsLoaded({partialSettings}));
+        }),
+        // Give time for reducers to react to the action in a microtask.
+        delay(0),
+        mergeMap(() => {
+          const stateSelectors$ = this.configModule
+            .getGlobalSettingSelectors()
+            .map((selector) => {
+              return this.store.select(selector).pipe(
+                distinctUntilChanged((before, after) => {
+                  const beforeValues = Object.values(before);
+                  const afterValues = Object.values(after);
+
+                  return (
+                    beforeValues.length === afterValues.length &&
+                    beforeValues.every(
+                      (beforeValue, index) => beforeValue === afterValues[index]
+                    )
+                  );
+                }),
+                // Ignore the first value which is store's default value or value
+                // populated via query parameter.
+                // `distinctUntilChanged` does not check for equality for the first
+                // event and we intend to ignore that.
+                skip(1)
+              );
+            });
+          return merge(...stateSelectors$);
+        }),
+        // Do not create a new stream for two `pipe`s below.
+        share()
+      );
+
+      return selectorsEmit$.pipe(
+        // Buffers changes from all selectors and only emit when debounce period
+        // is over.
+        buffer(selectorsEmit$.pipe(debounceTime(DEBOUNCE_PERIOD_IN_MS))),
+        mergeMap((partialSettings) => {
+          const partialSetting: Partial<PersistableSettings> = {};
+          // Combine buffered setting changes. Last settings change would
+          // overwrite earlier changes.
+          for (const setting of partialSettings) {
+            Object.assign(partialSetting, setting);
+          }
+          return this.dataSource.setSettings(partialSetting);
+        })
+      );
+    },
+    {dispatch: false}
+  );
+
+  constructor(
+    private readonly actions$: Actions,
+    private readonly store: Store<State>,
+    private readonly configModule: PersistentSettingsConfigModule<
+      State,
+      PersistableSettings
+    >,
+    private readonly dataSource: PersistentSettingsDataSource<
+      PersistableSettings
+    >
+  ) {}
+
+  /** @export */
+  ngrxOnInitEffects(): Action {
+    return initAction();
+  }
+}
+
+export const TEST_ONLY = {initAction, DEBOUNCE_PERIOD_IN_MS};

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
@@ -139,7 +139,6 @@ describe('persistent_settings effects test', () => {
         getSettingsSpy.and.returnValue(of({}));
         action.next(TEST_ONLY.initAction());
 
-        tick();
         tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS * 2);
         expect(setSettingsSpy).not.toHaveBeenCalled();
       }));

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
@@ -1,0 +1,211 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import {provideMockActions} from '@ngrx/effects/testing';
+import {Action, createSelector, Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {EMPTY, of, ReplaySubject} from 'rxjs';
+
+import {PersistentSettingsConfigModule} from '../persistent_settings_config_module';
+import {
+  PersistentSettingsTestingDataSource,
+  PersistentSettingsTestingDataSourceModule,
+} from '../_data_source/testing';
+import {globalSettingsLoaded} from './persistent_settings_actions';
+import {
+  PersistentSettingsEffects,
+  TEST_ONLY,
+} from './persistent_settings_effects';
+
+describe('persistent_settings effects test', () => {
+  let action: ReplaySubject<Action>;
+  let dispatchSpy: jasmine.Spy;
+  let store: MockStore<any>;
+  let effects: PersistentSettingsEffects;
+  let actualActions: Action[];
+  let getSettingsSpy: jasmine.Spy;
+  let setSettingsSpy: jasmine.Spy;
+
+  const setSmoothingSelector = createSelector(
+    (s: any) => s,
+    () => ({scalarSmoothing: 0.5})
+  );
+  const setIgnoreOutliers = createSelector(
+    (s: any) => s,
+    () => ({ignoreOutliers: false})
+  );
+
+  beforeEach(async () => {
+    action = new ReplaySubject<Action>(1);
+    actualActions = [];
+
+    await TestBed.configureTestingModule({
+      imports: [
+        PersistentSettingsTestingDataSourceModule,
+        PersistentSettingsConfigModule.defineGlobalSetting(
+          setSmoothingSelector
+        ),
+        PersistentSettingsConfigModule.defineGlobalSetting(setIgnoreOutliers),
+      ],
+      providers: [
+        provideMockActions(action),
+        provideMockStore(),
+        PersistentSettingsEffects,
+        PersistentSettingsConfigModule,
+      ],
+    }).compileComponents();
+
+    store = TestBed.inject<Store<any>>(Store) as MockStore<any>;
+    dispatchSpy = spyOn(store, 'dispatch').and.callFake((action: Action) => {
+      actualActions.push(action);
+    });
+    effects = TestBed.inject(PersistentSettingsEffects);
+    const dataSource = TestBed.inject(PersistentSettingsTestingDataSource);
+    getSettingsSpy = spyOn(dataSource, 'getSettings').and.returnValue(of({}));
+    setSettingsSpy = spyOn(dataSource, 'setSettings').and.returnValue(EMPTY);
+  });
+
+  afterEach(fakeAsync(() => {
+    discardPeriodicTasks();
+  }));
+
+  describe('#initializeAndUpdateSettings$', () => {
+    beforeEach(() => {
+      effects.initializeAndUpdateSettings$.subscribe();
+    });
+
+    describe('on init', () => {
+      it('fetches user settings and emits an aciton', () => {
+        getSettingsSpy.and.returnValue(
+          of({
+            ignoreOutliers: false,
+          })
+        );
+        action.next(TEST_ONLY.initAction());
+
+        expect(actualActions).toEqual([
+          globalSettingsLoaded({
+            partialSettings: {
+              ignoreOutliers: false,
+            },
+          }),
+        ]);
+      });
+
+      it('subscribes to selector changes after initial setting is read', fakeAsync(() => {
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.1});
+        const getSettingsSubject = new ReplaySubject(1);
+
+        getSettingsSpy.and.returnValue(getSettingsSubject);
+        action.next(TEST_ONLY.initAction());
+
+        tick();
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.3});
+        store.refreshState();
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS * 2);
+        expect(setSettingsSpy).not.toHaveBeenCalled();
+
+        getSettingsSubject.next({ignoreOutliers: false});
+        getSettingsSubject.complete();
+        tick();
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.5});
+        store.refreshState();
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS * 2);
+        expect(setSettingsSpy).toHaveBeenCalledOnceWith({
+          scalarSmoothing: 0.5,
+        });
+      }));
+
+      it('ignores value emitted from initial subscription', fakeAsync(() => {
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.1});
+
+        getSettingsSpy.and.returnValue(of({}));
+        action.next(TEST_ONLY.initAction());
+
+        tick();
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS * 2);
+        expect(setSettingsSpy).not.toHaveBeenCalled();
+      }));
+    });
+
+    describe('on store changes', () => {
+      function initializeAndSubscribe() {
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.1});
+        store.overrideSelector(setIgnoreOutliers, {ignoreOutliers: false});
+        getSettingsSpy.and.returnValue(of({}));
+        action.next(TEST_ONLY.initAction());
+        tick();
+      }
+
+      it('ignores no value changes', fakeAsync(() => {
+        initializeAndSubscribe();
+
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.1});
+        store.refreshState();
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS * 2);
+        expect(setSettingsSpy).not.toHaveBeenCalled();
+
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.1});
+        store.refreshState();
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS * 2);
+        expect(setSettingsSpy).not.toHaveBeenCalled();
+      }));
+
+      it('debounces frequent changes', fakeAsync(() => {
+        initializeAndSubscribe();
+
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.3});
+        store.refreshState();
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS / 2);
+        expect(setSettingsSpy).not.toHaveBeenCalled();
+
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.5});
+        store.refreshState();
+
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS / 2);
+        expect(setSettingsSpy).not.toHaveBeenCalled();
+
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS / 2);
+        expect(setSettingsSpy).toHaveBeenCalledTimes(1);
+      }));
+
+      it('debounces all selectors and sets settings once with everything', fakeAsync(() => {
+        initializeAndSubscribe();
+
+        store.overrideSelector(setSmoothingSelector, {scalarSmoothing: 0.3});
+        store.refreshState();
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS / 2);
+        expect(setSettingsSpy).not.toHaveBeenCalled();
+
+        store.overrideSelector(setIgnoreOutliers, {ignoreOutliers: true});
+        store.refreshState();
+
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS / 2);
+        expect(setSettingsSpy).not.toHaveBeenCalled();
+
+        tick(TEST_ONLY.DEBOUNCE_PERIOD_IN_MS / 2);
+        expect(setSettingsSpy).toHaveBeenCalledOnceWith({
+          scalarSmoothing: 0.3,
+          ignoreOutliers: true,
+        });
+      }));
+    });
+  });
+});

--- a/tensorboard/webapp/persistent_settings/persistent_settings_module.ts
+++ b/tensorboard/webapp/persistent_settings/persistent_settings_module.ts
@@ -13,9 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
+import {EffectsModule} from '@ngrx/effects';
 
 import {PersistentSettingsConfigModule} from './persistent_settings_config_module';
 import {PersistentSettingsDataSourceModule} from './_data_source/persistent_settings_data_source_module';
+import {PersistentSettingsEffects} from './_redux/persistent_settings_effects';
 
 /**
  * Persistent Settings module is responsible for persisting and loading settings
@@ -27,7 +29,10 @@ import {PersistentSettingsDataSourceModule} from './_data_source/persistent_sett
  * features.
  */
 @NgModule({
-  imports: [PersistentSettingsDataSourceModule],
+  imports: [
+    EffectsModule.forFeature([PersistentSettingsEffects]),
+    PersistentSettingsDataSourceModule,
+  ],
   providers: [PersistentSettingsConfigModule],
 })
 export class PersistentSettingsModule {}


### PR DESCRIPTION
This change includes Redux changes that glues the Settings configuration
with DataSource. When there are configurations for global settings, the effects
now subscribe to the store changes, and when value changes, we persist the
setting in the local storage using the DataSource.

Note that this change does not yet migrate Metrics or notification_center to
use the new persistent_settings.