### PR TITLE
persist storage: use factory instead of selector

### DIFF
--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -68,6 +68,24 @@ export function alertActionProvider() {
   ];
 }
 
+export function getSmoothingSettingFactory() {
+  return createSelector(getMetricsScalarSmoothing, (smoothing) => {
+    return {scalarSmoothing: smoothing};
+  });
+}
+
+export function getMetricsIgnoreOutliersSettingFactory() {
+  return createSelector(getMetricsIgnoreOutliers, (ignoreOutliers) => {
+    return {ignoreOutliers};
+  });
+}
+
+export function getMetricsTooltipSortSettingFactory() {
+  return createSelector(getMetricsTooltipSort, (tooltipSort) => {
+    return {tooltipSortString: String(tooltipSort)};
+  });
+}
+
 @NgModule({
   imports: [
     CommonModule,
@@ -87,19 +105,13 @@ export function alertActionProvider() {
     EffectsModule.forFeature([MetricsEffects]),
     AlertActionModule.registerAlertActions(alertActionProvider),
     PersistentSettingsConfigModule.defineGlobalSetting(
-      createSelector(getMetricsScalarSmoothing, (smoothing) => {
-        return {scalarSmoothing: smoothing};
-      })
+      getSmoothingSettingFactory
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
-      createSelector(getMetricsIgnoreOutliers, (ignoreOutliers) => {
-        return {ignoreOutliers};
-      })
+      getMetricsIgnoreOutliersSettingFactory
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
-      createSelector(getMetricsTooltipSort, (tooltipSort) => {
-        return {tooltipSortString: String(tooltipSort)};
-      })
+      getMetricsTooltipSortSettingFactory
     ),
   ],
   providers: [

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
@@ -60,9 +60,11 @@ describe('persistent_settings effects test', () => {
       imports: [
         PersistentSettingsTestingDataSourceModule,
         PersistentSettingsConfigModule.defineGlobalSetting(
-          setSmoothingSelector
+          () => setSmoothingSelector
         ),
-        PersistentSettingsConfigModule.defineGlobalSetting(setIgnoreOutliers),
+        PersistentSettingsConfigModule.defineGlobalSetting(
+          () => setIgnoreOutliers
+        ),
       ],
       providers: [
         provideMockActions(action),

--- a/tensorboard/webapp/persistent_settings/persistent_settings_config_module.ts
+++ b/tensorboard/webapp/persistent_settings/persistent_settings_config_module.ts
@@ -21,13 +21,25 @@ import {
 
 @NgModule()
 export class PersistentSettingsConfigModule<State, Settings> {
+  private readonly globalSettingSelectors: SettingSelector<
+    State,
+    Settings
+  >[] = [];
+
   constructor(
     @Optional()
     @Inject(GLOBAL_PERSISTENT_SETTINGS_TOKEN)
-    private readonly globalSettingSelectors:
-      | SettingSelector<State, Settings>[]
-      | null
-  ) {}
+    globalSettingSelectorFactories: Array<
+      () => SettingSelector<State, Settings>
+    > | null
+  ) {
+    if (!globalSettingSelectorFactories) {
+      return;
+    }
+    this.globalSettingSelectors = globalSettingSelectorFactories.map(
+      (factory) => factory()
+    );
+  }
 
   /**
    * Returns Ngrx selectors for getting global setting values.
@@ -60,7 +72,7 @@ export class PersistentSettingsConfigModule<State, Settings> {
    * export class MyModule {}
    */
   static defineGlobalSetting<State, Settings>(
-    selector: SettingSelector<State, Settings>
+    selectorFactory: () => SettingSelector<State, Settings>
   ): ModuleWithProviders<PersistentSettingsConfigModule<any, {}>> {
     return {
       ngModule: PersistentSettingsConfigModule,
@@ -68,7 +80,7 @@ export class PersistentSettingsConfigModule<State, Settings> {
         {
           provide: GLOBAL_PERSISTENT_SETTINGS_TOKEN,
           multi: true,
-          useValue: selector,
+          useValue: selectorFactory,
         },
       ],
     };

--- a/tensorboard/webapp/persistent_settings/persistent_settings_config_module_test.ts
+++ b/tensorboard/webapp/persistent_settings/persistent_settings_config_module_test.ts
@@ -22,8 +22,8 @@ describe('persisted_settings config_module test', () => {
   async function createConfigModule(
     settingSelectors: Selector<any, Partial<PersistableSettings>>[]
   ): Promise<PersistentSettingsConfigModule<any, PersistableSettings>> {
-    const imports = settingSelectors.map(
-      PersistentSettingsConfigModule.defineGlobalSetting
+    const imports = settingSelectors.map((selector) =>
+      PersistentSettingsConfigModule.defineGlobalSetting(() => selector)
     );
     await TestBed.configureTestingModule({
       imports,


### PR DESCRIPTION
Passing a selector whose value is evaluated by invoking a method is
incompatible with AOT (ahead-of-time) compilation. This change makes
changes to the API so that it takes a factory that returns a selector.

~Test change: cl/385652976~ No longer valid.