### PR TITLE
router: allow programmatical route definition

### DIFF
--- a/tensorboard/webapp/app_routing/route_config_test.ts
+++ b/tensorboard/webapp/app_routing/route_config_test.ts
@@ -562,7 +562,7 @@ describe('route config', () => {
       );
     });
 
-    it('handles parameter is opaque string in path parts', () => {
+    it('handles an opaque parameter in path parts', () => {
       const config = new RouteConfigs([
         {
           path: '/tb/:first/hey/:second/',

--- a/tensorboard/webapp/app_routing/route_config_types.ts
+++ b/tensorboard/webapp/app_routing/route_config_types.ts
@@ -47,9 +47,39 @@ export interface ConcreteRouteDef {
 }
 
 export interface RedirectionRouteDef {
-  routeKind: null;
+  routeKind?: null;
   path: string;
   redirectionPath: string;
 }
 
-export type RouteDef = ConcreteRouteDef | RedirectionRouteDef;
+export interface ProgrammticRedirectionRouteDef {
+  /**
+   * A path that should activate the route definition. A Parameter, see
+   * definition in `ConcreteRouteDef`, is only used as a wild card and its value
+   * is not used meaningfully as all raw `pathParts` are passed to the
+   * `redirector`.
+   */
+  path: string;
+  /**
+   * A function that returns, from a pathParts, a new pathParts it should
+   * redirect to.
+   */
+  redirector: (pathParts: string[]) => string[];
+}
+
+export type RouteDef =
+  | ConcreteRouteDef
+  | RedirectionRouteDef
+  | ProgrammticRedirectionRouteDef;
+
+export function isConcreteRouteDef(
+  definition: RouteDef
+): definition is ConcreteRouteDef {
+  return (definition as ConcreteRouteDef).routeKind != undefined;
+}
+
+export function isStaticRedirectionRouteDef(
+  definition: RouteDef
+): definition is RedirectionRouteDef {
+  return (definition as RedirectionRouteDef).redirectionPath !== undefined;
+}

--- a/tensorboard/webapp/app_routing/route_config_types.ts
+++ b/tensorboard/webapp/app_routing/route_config_types.ts
@@ -47,6 +47,9 @@ export interface ConcreteRouteDef {
 }
 
 export interface RedirectionRouteDef {
+  // TODO(tensorboard-team): drop this property as it is not used for any other
+  // purposes when all instances of RedirectionRouteDef does not specify the
+  // value `null`. In the intrim, having both `undefined` or `null` is okay.
   routeKind?: null;
   path: string;
   redirectionPath: string;
@@ -63,6 +66,10 @@ export interface ProgrammticRedirectionRouteDef {
   /**
    * A function that returns, from a pathParts, a new pathParts it should
    * redirect to.
+   *
+   * A PathPart is a list of pathname parts already delimited by "/". If you
+   * want a trailing slash, you will need to have an empty item at the end of
+   * the list. e.g., `/foo/bar/` => `['foo', 'bar', '']`.
    */
   redirector: (pathParts: string[]) => string[];
 }
@@ -75,7 +82,11 @@ export type RouteDef =
 export function isConcreteRouteDef(
   definition: RouteDef
 ): definition is ConcreteRouteDef {
-  return (definition as ConcreteRouteDef).routeKind != undefined;
+  const maybeConcreteDef = definition as ConcreteRouteDef;
+  return (
+    maybeConcreteDef.routeKind !== undefined &&
+    maybeConcreteDef.routeKind !== null
+  );
 }
 
 export function isStaticRedirectionRouteDef(

--- a/tensorboard/webapp/app_routing/route_registry_module.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module.ts
@@ -22,7 +22,7 @@ import {
 } from '@angular/core';
 
 import {RouteConfigs} from './route_config';
-import {RouteDef} from './route_config_types';
+import {isConcreteRouteDef, RouteDef} from './route_config_types';
 import {ROUTE_CONFIGS_TOKEN} from './route_registry_types';
 import {RouteKind} from './types';
 
@@ -48,7 +48,7 @@ export class RouteRegistryModule {
     }
     this.routeConfigs = new RouteConfigs(configs);
     configs.forEach((config) => {
-      if (config.routeKind !== null) {
+      if (isConcreteRouteDef(config)) {
         this.routeKindToNgComponent.set(config.routeKind, config.ngComponent);
       }
     });


### PR DESCRIPTION
Previously, we only allowed very static route definition. Concrete route
aside, even the redirection route definition took path for "from" and
"to".

However, there now are the cases when we want to redirect, depending on
incomign path parts, redirect to different paths or route kinds. Now,
with this change, you can specify a definition that would be invoked on
a path match by invoking app specified `redirector`.

* Motivation for features / changes

* Technical description of changes

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
