### PR TITLE
settings: persist settings in storage

### DIFF
--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -50,9 +50,13 @@ export class OSSSettingsConverter extends SettingsConverter<
       // TooltipSort is a string enum and has string values; no need to
       // serialize it differently to account for their unintended changes.
       tooltipSort: settings.tooltipSortString,
+      autoReload: settings.autoReload,
+      autoReloadPeriodInMs: settings.autoReloadPeriodInMs,
+      paginationSize: settings.pageSize,
     };
     return serializableSettings;
   }
+
   backendToUi(backendSettings: Partial<BackendSettings>): PersistableSettings {
     const settings: Partial<PersistableSettings> = {};
     if (
@@ -74,6 +78,27 @@ export class OSSSettingsConverter extends SettingsConverter<
       typeof backendSettings.tooltipSort === 'string'
     ) {
       settings.tooltipSortString = backendSettings.tooltipSort;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('autoReload') &&
+      typeof backendSettings.autoReload === 'boolean'
+    ) {
+      settings.autoReload = backendSettings.autoReload;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('autoReloadPeriodInMs') &&
+      typeof backendSettings.autoReloadPeriodInMs === 'number'
+    ) {
+      settings.autoReloadPeriodInMs = backendSettings.autoReloadPeriodInMs;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('paginationSize') &&
+      typeof backendSettings.paginationSize === 'number'
+    ) {
+      settings.pageSize = backendSettings.paginationSize;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -99,6 +99,38 @@ describe('persistent_settings data_source test', () => {
 
         expect(actual).toEqual({});
       });
+
+      it('gets settings related props from local storage', async () => {
+        getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
+          JSON.stringify({
+            autoReload: false,
+            autoReloadPeriodInMs: -1,
+            paginationSize: 1000,
+          })
+        );
+
+        const actual = await firstValueFrom(dataSource.getSettings());
+
+        expect(actual).toEqual({
+          autoReload: false,
+          autoReloadPeriodInMs: -1,
+          pageSize: 1000,
+        });
+      });
+
+      it('discards value if it does not match the type information in settings', async () => {
+        getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
+          JSON.stringify({
+            autoReload: 'false',
+            autoReloadPeriodInMs: '10',
+            paginationSize: true,
+          })
+        );
+
+        const actual = await firstValueFrom(dataSource.getSettings());
+
+        expect(actual).toEqual({});
+      });
     });
 
     describe('#setSettings', () => {

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -24,6 +24,9 @@ export declare interface BackendSettings {
   scalarSmoothing?: number;
   tooltipSort?: string;
   ignoreOutliers?: boolean;
+  autoReload?: boolean;
+  autoReloadPeriodInMs?: number;
+  paginationSize?: number;
 }
 
 /**
@@ -35,4 +38,7 @@ export interface PersistableSettings {
   scalarSmoothing?: number;
   tooltipSortString?: string;
   ignoreOutliers?: boolean;
+  autoReload?: boolean;
+  autoReloadPeriodInMs?: number;
+  pageSize?: number;
 }

--- a/tensorboard/webapp/persistent_settings/_redux/BUILD
+++ b/tensorboard/webapp/persistent_settings/_redux/BUILD
@@ -20,7 +20,6 @@ tf_ng_module(
     ],
     deps = [
         ":persistent_settings_actions",
-        "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/persistent_settings:config_module",
         "//tensorboard/webapp/persistent_settings/_data_source",
         "//tensorboard/webapp/persistent_settings/_data_source:types",

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
@@ -27,7 +27,6 @@ import {
   tap,
 } from 'rxjs/operators';
 
-import {State} from '../../app_state';
 import {PersistentSettingsConfigModule} from '../persistent_settings_config_module';
 import {PersistentSettingsDataSource} from '../_data_source/persistent_settings_data_source';
 import {globalSettingsLoaded} from './persistent_settings_actions';
@@ -105,9 +104,9 @@ export class PersistentSettingsEffects implements OnInitEffects {
 
   constructor(
     private readonly actions$: Actions,
-    private readonly store: Store<State>,
+    private readonly store: Store<{}>,
     private readonly configModule: PersistentSettingsConfigModule<
-      State,
+      {},
       PersistableSettings
     >,
     private readonly dataSource: PersistentSettingsDataSource<

--- a/tensorboard/webapp/persistent_settings/index.ts
+++ b/tensorboard/webapp/persistent_settings/index.ts
@@ -16,3 +16,4 @@ limitations under the License.
 export {PersistableSettings} from './_data_source/types';
 export {globalSettingsLoaded} from './_redux/persistent_settings_actions';
 export {PersistentSettingsModule} from './persistent_settings_module';
+export {PersistentSettingsConfigModule} from './persistent_settings_config_module';

--- a/tensorboard/webapp/settings/BUILD
+++ b/tensorboard/webapp/settings/BUILD
@@ -9,6 +9,7 @@ tf_ng_module(
         "settings_module.ts",
     ],
     deps = [
+        "//tensorboard/webapp/persistent_settings",
         "//tensorboard/webapp/settings/_redux",
         "//tensorboard/webapp/settings/_views",
         "@npm//@angular/core",

--- a/tensorboard/webapp/settings/_redux/BUILD
+++ b/tensorboard/webapp/settings/_redux/BUILD
@@ -14,6 +14,7 @@ tf_ng_module(
     ],
     visibility = ["//tensorboard:internal"],
     deps = [
+        "//tensorboard/webapp/persistent_settings",
         "//tensorboard/webapp/types",
         "@npm//@ngrx/store",
     ],
@@ -28,6 +29,7 @@ tf_ts_library(
     visibility = ["//tensorboard:internal"],
     deps = [
         ":_redux",
+        "//tensorboard/webapp/persistent_settings",
         "//tensorboard/webapp/settings:testing",
         "//tensorboard/webapp/types",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/settings/settings_module.ts
+++ b/tensorboard/webapp/settings/settings_module.ts
@@ -13,14 +13,57 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
-import {StoreModule} from '@ngrx/store';
+import {createSelector, StoreModule} from '@ngrx/store';
 
 import {SettingsModule as ViewModule} from './_views/settings_module';
 import {reducers} from './_redux/settings_reducers';
-import {SETTINGS_FEATURE_KEY} from './_redux/settings_types';
+import {SETTINGS_FEATURE_KEY, State} from './_redux/settings_types';
+import {
+  PersistableSettings,
+  PersistentSettingsConfigModule,
+} from '../persistent_settings';
+import {
+  getPageSize,
+  getReloadEnabled,
+  getReloadPeriodInMs,
+} from './_redux/settings_selectors';
+
+/** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store';
+
+export function createAutoReloadSettingSelector() {
+  return createSelector(getReloadEnabled, (autoReload) => {
+    return {autoReload};
+  });
+}
+
+export function createAutoReloadPeriodInMsSelector() {
+  return createSelector(getReloadPeriodInMs, (autoReloadPeriodInMs) => {
+    return {autoReloadPeriodInMs};
+  });
+}
+
+export function createPageSizeSelector() {
+  return createSelector(getPageSize, (pageSize) => {
+    return {pageSize};
+  });
+}
 
 @NgModule({
   exports: [ViewModule],
-  imports: [StoreModule.forFeature(SETTINGS_FEATURE_KEY, reducers)],
+  imports: [
+    StoreModule.forFeature(SETTINGS_FEATURE_KEY, reducers),
+    PersistentSettingsConfigModule.defineGlobalSetting<
+      State,
+      PersistableSettings
+    >(createAutoReloadSettingSelector),
+    PersistentSettingsConfigModule.defineGlobalSetting<
+      State,
+      PersistableSettings
+    >(createAutoReloadPeriodInMsSelector),
+    PersistentSettingsConfigModule.defineGlobalSetting<
+      State,
+      PersistableSettings
+    >(createPageSizeSelector),
+  ],
 })
 export class SettingsModule {}


### PR DESCRIPTION
With this change, now we remember reload, reload period, and pagination
size in our persistent setting storage system (LocalStorage for now).
