### PR TITLE
router: redirect with query parameter

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -201,8 +201,19 @@ export class AppRoutingEffects {
     const dispatchNavigating$ = this.validatedRoute$.pipe(
       tap(({routeMatch, options}) => {
         if (options.browserInitiated && routeMatch.deepLinkProvider) {
+          // Query paramter formed by the redirector is passed to the
+          // deserializer instead of one from Location.getSearch(). This
+          // behavior emulates redirected URL to be on the URL bar such as
+          // "/compare?foo=bar" based on information provided by redirector (do
+          // note that location.getSearch() will return current query parameter
+          // which is pre-redirection URL).
+          const queryParams =
+            routeMatch.originateFromRedirection &&
+            routeMatch.redirectionOnlyQueryParams
+              ? routeMatch.redirectionOnlyQueryParams
+              : this.location.getSearch();
           const rehydratingState = routeMatch.deepLinkProvider.deserializeQueryParams(
-            this.location.getSearch()
+            queryParams
           );
           this.store.dispatch(
             stateRehydratedFromUrl({

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -89,6 +89,23 @@ describe('app_routing_effects', () => {
             deserializeQueryParams: deserializeQueryParamsSpy,
           },
         },
+        {
+          path: '/redirect_no_query/:wildcard',
+          redirector: (pathParts: string[]) => {
+            return {
+              pathParts: pathParts.slice(1),
+            };
+          },
+        },
+        {
+          path: '/redirect_query/:wildcard',
+          redirector: (pathParts: string[]) => {
+            return {
+              pathParts: pathParts.slice(1),
+              queryParams: [{key: 'hard', value: 'coded'}],
+            };
+          },
+        },
       ];
     }
 
@@ -517,6 +534,103 @@ describe('app_routing_effects', () => {
           }),
         ]);
       }));
+
+      describe('programmatical navigation integration', () => {
+        it('redirects without query parameter', fakeAsync(() => {
+          getPathSpy.and.returnValue('/redirect_no_query/compare');
+          getSearchSpy.and.returnValue([]);
+          deserializeQueryParamsSpy.and.returnValue({});
+
+          action.next(effects.ngrxOnInitEffects());
+
+          tick();
+
+          expect(actualActions).toEqual([
+            actions.stateRehydratedFromUrl({
+              routeKind: RouteKind.COMPARE_EXPERIMENT,
+              partialState: {},
+            }),
+            actions.navigating({
+              after: buildRoute({
+                routeKind: RouteKind.COMPARE_EXPERIMENT,
+                params: {},
+                pathname: '/compare',
+                queryParams: [],
+                navigationOptions: {
+                  replaceState: true,
+                },
+              }),
+            }),
+            jasmine.any(Object),
+          ]);
+        }));
+
+        it('redirects with query parameter', fakeAsync(() => {
+          getPathSpy.and.returnValue('/redirect_query/compare');
+          getSearchSpy.and.returnValue([{key: 'not', value: 'used'}]);
+          // Query paramter formed by the redirector is passed to the
+          // deserializer instead of one from Location.getSearch(). This
+          // behavior emulates redirected URL to be on the URL bar. That is,
+          // when passing through the redirection flow, the actual URL on the
+          // location bar is pre-redirection, "/redirect_query/compare". If
+          // redirector wants to "set" href to "/compare?foo=bar", the query
+          // parameter has to come from the redirector, not from the URL bar.
+          deserializeQueryParamsSpy
+            .withArgs([{key: 'hard', value: 'coded'}])
+            .and.returnValue({good: 'value'})
+            .and.throwError('Invalid');
+          serializeStateToQueryParamsSpy.and.returnValue(of([]));
+
+          action.next(effects.ngrxOnInitEffects());
+
+          tick();
+
+          expect(actualActions).toEqual([
+            actions.stateRehydratedFromUrl({
+              routeKind: RouteKind.COMPARE_EXPERIMENT,
+              partialState: {good: 'value'},
+            }),
+            actions.navigating({
+              after: buildRoute({
+                routeKind: RouteKind.COMPARE_EXPERIMENT,
+                params: {},
+                pathname: '/compare',
+                queryParams: [],
+                navigationOptions: {
+                  replaceState: true,
+                },
+              }),
+            }),
+            jasmine.any(Object),
+          ]);
+        }));
+
+        it('redirects with query parameter to no deepLinkProvider', fakeAsync(() => {
+          getPathSpy.and.returnValue('/redirect_query/experiments');
+          getSearchSpy.and.returnValue([{key: 'not', value: 'used'}]);
+          deserializeQueryParamsSpy.and.throwError('Invalid');
+          serializeStateToQueryParamsSpy.and.throwError('Invalid');
+
+          action.next(effects.ngrxOnInitEffects());
+
+          tick();
+
+          expect(actualActions).toEqual([
+            actions.navigating({
+              after: buildRoute({
+                routeKind: RouteKind.EXPERIMENTS,
+                params: {},
+                pathname: '/experiments',
+                queryParams: [],
+                navigationOptions: {
+                  replaceState: true,
+                },
+              }),
+            }),
+            jasmine.any(Object),
+          ]);
+        }));
+      });
     });
 
     it('resolves pathname from navigationRequest', () => {

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -90,6 +90,11 @@ describe('app_routing_effects', () => {
           },
         },
         {
+          routeKind: RouteKind.UNKNOWN,
+          path: '/no_deeplink_unknown_route',
+          ngComponent: TestableComponent,
+        },
+        {
           path: '/redirect_no_query/:wildcard',
           redirector: (pathParts: string[]) => {
             return {
@@ -595,6 +600,10 @@ describe('app_routing_effects', () => {
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {},
                 pathname: '/compare',
+                // Query parameter comes from DeepLinkProvider
+                // (serializeStateToQueryParamsSpy) in this case, not
+                // redirector. Query parameter of redirector is fed into
+                // deserializer instead.
                 queryParams: [],
                 navigationOptions: {
                   replaceState: true,
@@ -606,7 +615,9 @@ describe('app_routing_effects', () => {
         }));
 
         it('redirects with query parameter to no deepLinkProvider', fakeAsync(() => {
-          getPathSpy.and.returnValue('/redirect_query/experiments');
+          getPathSpy.and.returnValue(
+            '/redirect_query/no_deeplink_unknown_route'
+          );
           getSearchSpy.and.returnValue([{key: 'not', value: 'used'}]);
           deserializeQueryParamsSpy.and.throwError('Invalid');
           serializeStateToQueryParamsSpy.and.throwError('Invalid');
@@ -618,9 +629,9 @@ describe('app_routing_effects', () => {
           expect(actualActions).toEqual([
             actions.navigating({
               after: buildRoute({
-                routeKind: RouteKind.EXPERIMENTS,
+                routeKind: RouteKind.UNKNOWN,
                 params: {},
-                pathname: '/experiments',
+                pathname: '/no_deeplink_unknown_route',
                 queryParams: [],
                 navigationOptions: {
                   replaceState: true,

--- a/tensorboard/webapp/app_routing/route_config.ts
+++ b/tensorboard/webapp/app_routing/route_config.ts
@@ -20,7 +20,7 @@ import {
   RedirectionRouteDef,
   RouteDef,
 } from './route_config_types';
-import {Route, RouteKind, RouteParams} from './types';
+import {Route, RouteKind, RouteParams, SerializableQueryParams} from './types';
 
 interface NegativeMatch {
   result: false;
@@ -31,6 +31,7 @@ interface PositiveMatch {
   params: RouteParams;
   pathParts: string[];
   isRedirection: boolean;
+  redirectionQueryParams?: SerializableQueryParams;
 }
 
 type Match = NegativeMatch | PositiveMatch;
@@ -256,22 +257,39 @@ class ProgrammaticalRedirectionRouteConfigMatcher extends RouteConfigMatcher {
 
     if (!match.result) return match;
 
-    const newPathParts = this.definition.redirector(pathParts);
+    const {pathParts: newPathParts, queryParams} = this.definition.redirector(
+      pathParts
+    );
     return {
       result: true,
       params: match.params,
       pathParts: newPathParts,
       isRedirection: true,
+      redirectionQueryParams: queryParams,
     };
   }
 }
 
-export interface RouteMatch {
+interface BaseRedirectionRouteMatch {
   routeKind: Route['routeKind'];
   pathname: Route['pathname'];
+  // Route parameters. An object. Its keys are defined to be parameter defined
+  // in the path spec while their respective values are string.
   params: Route['params'];
   deepLinkProvider: ConcreteRouteDef['deepLinkProvider'] | null;
+  originateFromRedirection: boolean;
 }
+
+export interface NonRedirectionRouteMatch extends BaseRedirectionRouteMatch {
+  originateFromRedirection: false;
+}
+
+export interface RedirectionRouteMatch extends BaseRedirectionRouteMatch {
+  originateFromRedirection: true;
+  redirectionOnlyQueryParams?: Route['queryParams'];
+}
+
+export type RouteMatch = NonRedirectionRouteMatch | RedirectionRouteMatch;
 
 export class RouteConfigs {
   private readonly routeKindToConcreteConfigMatchers: Map<
@@ -354,17 +372,22 @@ export class RouteConfigs {
 
     let pathParts = getPathParts(navigation.pathname);
     let redirectionCount = 0;
+    let wasRedirected = false;
+    let redirectionOnlyQueryParams:
+      | undefined
+      | SerializableQueryParams = undefined;
 
     while (true) {
-      let wasRedirected = false;
-
+      let hasMatch = false;
       for (const matcher of this.configMatchers) {
         const match = matcher.match(pathParts);
         if (match.result) {
+          hasMatch = true;
           const {params, pathParts: newPathParts, isRedirection} = match;
           if (isRedirection) {
             pathParts = newPathParts;
             wasRedirected = true;
+            redirectionOnlyQueryParams = match.redirectionQueryParams;
             break;
           }
 
@@ -375,19 +398,37 @@ export class RouteConfigs {
           }
 
           const {definition} = matcher;
-          return {
+          const base = {
             routeKind: definition.routeKind,
             params,
             pathname: getPathFromParts(newPathParts),
             deepLinkProvider: definition.deepLinkProvider || null,
           };
+          if (!wasRedirected) {
+            return {
+              ...base,
+              originateFromRedirection: false,
+            };
+          }
+          return {
+            ...base,
+            originateFromRedirection: true,
+            redirectionOnlyQueryParams,
+          };
         }
       }
+
+      if (!hasMatch) {
+        redirectionOnlyQueryParams = undefined;
+        break;
+      }
+
       if (wasRedirected) {
         redirectionCount++;
       }
-      if (redirectionCount > this.maxRedirection || !wasRedirected) {
+      if (redirectionCount > this.maxRedirection) {
         // If not redirected, no need to rematch the routes. Abort.
+        redirectionOnlyQueryParams = undefined;
         break;
       }
     }
@@ -402,12 +443,24 @@ export class RouteConfigs {
 
     if (this.defaultRouteConfig) {
       const {definition} = this.defaultRouteConfig;
-      return {
+      const base = {
         routeKind: definition.routeKind,
-        params: {},
+        deepLinkProvider: definition.deepLinkProvider ?? null,
         pathname: definition.path,
-        deepLinkProvider: definition.deepLinkProvider || null,
+        params: {},
       };
+      return wasRedirected
+        ? {
+            ...base,
+            pathname: definition.path,
+            params: {},
+            originateFromRedirection: true,
+            redirectionOnlyQueryParams: undefined,
+          }
+        : {
+            ...base,
+            originateFromRedirection: false,
+          };
     }
 
     return null;
@@ -431,6 +484,7 @@ export class RouteConfigs {
       params,
       pathname: getPathFromParts(match.pathParts),
       deepLinkProvider: matcher.definition.deepLinkProvider || null,
+      originateFromRedirection: false,
     };
   }
 }

--- a/tensorboard/webapp/app_routing/route_config.ts
+++ b/tensorboard/webapp/app_routing/route_config.ts
@@ -418,17 +418,12 @@ export class RouteConfigs {
         }
       }
 
-      if (!hasMatch) {
-        redirectionOnlyQueryParams = undefined;
-        break;
-      }
-
       if (wasRedirected) {
         redirectionCount++;
       }
-      if (redirectionCount > this.maxRedirection) {
+
+      if (!hasMatch || redirectionCount > this.maxRedirection) {
         // If not redirected, no need to rematch the routes. Abort.
-        redirectionOnlyQueryParams = undefined;
         break;
       }
     }
@@ -443,24 +438,13 @@ export class RouteConfigs {
 
     if (this.defaultRouteConfig) {
       const {definition} = this.defaultRouteConfig;
-      const base = {
+      return {
         routeKind: definition.routeKind,
         deepLinkProvider: definition.deepLinkProvider ?? null,
         pathname: definition.path,
         params: {},
+        originateFromRedirection: wasRedirected,
       };
-      return wasRedirected
-        ? {
-            ...base,
-            pathname: definition.path,
-            params: {},
-            originateFromRedirection: true,
-            redirectionOnlyQueryParams: undefined,
-          }
-        : {
-            ...base,
-            originateFromRedirection: false,
-          };
     }
 
     return null;

--- a/tensorboard/webapp/app_routing/route_config_test.ts
+++ b/tensorboard/webapp/app_routing/route_config_test.ts
@@ -509,7 +509,6 @@ describe('route config', () => {
         buildRouteMatch({
           pathname: '/c',
           originateFromRedirection: true,
-          redirectionOnlyQueryParams: undefined,
         })
       );
     });
@@ -683,6 +682,34 @@ describe('route config', () => {
           params: {},
           originateFromRedirection: true,
           redirectionOnlyQueryParams: [{key: 'hello', value: 'world'}],
+        })
+      );
+    });
+
+    it('drops programmatical query parameter if redirected to static one', () => {
+      const config = new RouteConfigs([
+        {
+          path: '/tb/:eid',
+          redirector: (paths) => {
+            return {
+              pathParts: [paths[1]],
+              queryParams: [{key: 'goodbye', value: 'world'}],
+            };
+          },
+        },
+        buildRedirectionRouteDef({
+          path: '/hello',
+          redirectionPath: '/tensorboard',
+        }),
+        buildConcreteRouteDef({path: '/tensorboard'}),
+      ]);
+
+      expect(config.match(buildNavigation({pathname: '/tb/hello'}))).toEqual(
+        buildRouteMatch({
+          pathname: '/tensorboard',
+          params: {},
+          originateFromRedirection: true,
+          redirectionOnlyQueryParams: undefined,
         })
       );
     });

--- a/tensorboard/webapp/app_routing/route_config_types.ts
+++ b/tensorboard/webapp/app_routing/route_config_types.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {Component, Type} from '@angular/core';
 
 import {DeepLinkProvider} from './deep_link_provider';
-import {RouteKind} from './types';
+import {RouteKind, SerializableQueryParams} from './types';
 
 export interface ConcreteRouteDef {
   routeKind: RouteKind;
@@ -71,7 +71,9 @@ export interface ProgrammticRedirectionRouteDef {
    * want a trailing slash, you will need to have an empty item at the end of
    * the list. e.g., `/foo/bar/` => `['foo', 'bar', '']`.
    */
-  redirector: (pathParts: string[]) => string[];
+  redirector: (
+    pathParts: string[]
+  ) => {pathParts: string[]; queryParams?: SerializableQueryParams};
 }
 
 export type RouteDef =


### PR DESCRIPTION
This change adds advanced feature to the router where a redirector can
redirect to a path with query parameter.

Imagine following use case. We want to add a nice redirection route
where, depending on path part value, we can redirect to EXPERIMENT or
EXPERIMENTS and, in the latter case, from the path part value, we'd like
to also pre-populate the user token. This would require
DeepLinkProvider-like module that would also reason and pre-populate
state from a path part (as opposed to value in the query parameter) and
that's farther in the realm of possible designs than what is proposed
here.

Here, we are proposing that the redirector can create almost
`Navigation` like payload where it can specify both pathname and query
parameter to a next route. Do note that this feature is clamped down to
only programmatical navigation and we have no plans to expand scope of
other route definitions.
