### PR TITLE
projector: draw transparent sprites correctly

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
@@ -122,6 +122,9 @@ function createFragmentShader() {
       // Coordinates of the vertex within the entire sprite image.
       vec2 coords =
         (gl_PointCoord + xyIndex) / vec2(spritesPerRow, spritesPerColumn);
+      if (texture2D(spriteTexture, coords).a==0.0) {
+        discard;
+      }
       gl_FragColor = vec4(vColor, 1.0) * texture2D(spriteTexture, coords);
     } else {
       bool inside = point_in_unit_circle(gl_PointCoord);


### PR DESCRIPTION
* Motivation for features / changes

In projector view, when the image sprites are transparent, transparent pixels are not rendered correctly. See images below. This change fixes this rendering issue. 

Proper rendering of transparent pixels also allow users to display non-square images as sprites, as long as they pad their image with transparent pixels.

* Technical description of changes

Added a condition to fragment shader that checks if a the texture to be rendered is transparent at that coordinate; if so, it discards the texture.

* Screenshots of UI changes

Before:
![before1](https://user-images.githubusercontent.com/17336763/126609332-ba78e999-74f2-4c83-93dd-e28eafb58da1.png)
![before2](https://user-images.githubusercontent.com/17336763/126609363-9d16b363-c3ef-4cc9-beee-9f0bbc495bc7.png)

After:
![after](https://user-images.githubusercontent.com/17336763/126609475-1e4e1fbf-f88d-4e2a-952c-26d70664255b.png)

* Detailed steps to verify changes work correctly (as executed by you)

Make some pixels in the sprites transparent.

* Alternate designs / implementations considered

I tried changing the `depthTest`, `depthWrite`, and `blending` fields of `THREE.ShaderMaterial` but nothing really worked, either there were z-index issues or transparent pixels were showing up as gray,