### PR TITLE
Expose CompareExperimentStr parser as util

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -24,6 +24,17 @@ tf_ng_module(
 )
 
 tf_ng_module(
+    name = "store_only_utils",
+    srcs = [
+        "store_only_utils.ts",
+    ],
+    deps = [
+        ":internal_utils",
+        ":types",
+    ],
+)
+
+tf_ng_module(
     name = "location",
     srcs = [
         "location.ts",
@@ -173,6 +184,7 @@ tf_ng_module(
         "programmatical_navigation_module_test.ts",
         "route_contexted_reducer_helper_test.ts",
         "route_registry_module_test.ts",
+        "store_only_utils_test.ts",
     ],
     deps = [
         ":app_root",
@@ -181,6 +193,7 @@ tf_ng_module(
         ":programmatical_navigation_module",
         ":route_contexted_reducer_helper",
         ":route_registry",
+        ":store_only_utils",
         ":testing",
         ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",

--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -23,10 +23,18 @@ tf_ng_module(
     ],
 )
 
+package_group(
+    name = "store_only_utils_allowlisted",
+    packages = ["//tensorboard/webapp/app_routing/..."],
+)
+
 tf_ng_module(
     name = "store_only_utils",
     srcs = [
         "store_only_utils.ts",
+    ],
+    visibility = [
+        ":store_only_utils_allowlisted",
     ],
     deps = [
         ":internal_utils",

--- a/tensorboard/webapp/app_routing/store/BUILD
+++ b/tensorboard/webapp/app_routing/store/BUILD
@@ -13,6 +13,7 @@ tf_ts_library(
     deps = [
         ":types",
         "//tensorboard/webapp/app_routing:internal_utils",
+        "//tensorboard/webapp/app_routing:store_only_utils",
         "//tensorboard/webapp/app_routing:types",
         "//tensorboard/webapp/app_routing/actions",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -17,7 +17,6 @@ import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {
   getExperimentIdsFromRouteParams,
   getRouteId as getRouteIdFromKindAndParams,
-  parseCompareExperimentStr,
 } from '../internal_utils';
 import {CompareRouteParams, Route, RouteKind} from '../types';
 
@@ -26,6 +25,7 @@ import {
   AppRoutingState,
   State,
 } from './app_routing_types';
+import {getCompareExperimentIdAliasSpec} from '../store_only_utils';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
@@ -82,18 +82,13 @@ export const getRouteId = createSelector(
 export const getExperimentIdToAliasMap = createSelector(
   getRouteKind,
   getRouteParams,
-  (routeKind, routeParams) => {
-    const idToDisplayName: {[id: string]: string} = {};
-
+  (routeKind, routeParams): {[id: string]: string} => {
     if (routeKind !== RouteKind.COMPARE_EXPERIMENT) {
-      return idToDisplayName;
+      return {};
     }
 
     const compareParams = routeParams as CompareRouteParams;
-    const nameAndIds = parseCompareExperimentStr(compareParams.experimentIds);
-    for (const {id, name} of nameAndIds) {
-      idToDisplayName[id] = name;
-    }
-    return idToDisplayName;
+    const map = getCompareExperimentIdAliasSpec(compareParams);
+    return Object.fromEntries(map.entries());
   }
 );

--- a/tensorboard/webapp/app_routing/store_only_utils.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils.ts
@@ -21,7 +21,8 @@ import {CompareRouteParams} from './types';
 /**
  * Returns experimentId to alias information encoded in CompareRouteParams.
  *
- * Do not use this outside of _redux store.
+ * This utility is used by only limited packages. Please refer to visiblity in
+ * BUILD.
  */
 export function getCompareExperimentIdAliasSpec(
   routeParams: CompareRouteParams

--- a/tensorboard/webapp/app_routing/store_only_utils.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils.ts
@@ -1,0 +1,35 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {parseCompareExperimentStr} from './internal_utils';
+import {CompareRouteParams} from './types';
+
+// Ideally, we would not be exposing this utility method this, but there is no
+// way to share the structured information to other stores without changing
+// contract at the RouteConfig level.
+/**
+ * Returns experimentId to alias information encoded in CompareRouteParams.
+ *
+ * Do not use this outside of _redux store.
+ */
+export function getCompareExperimentIdAliasSpec(
+  routeParams: CompareRouteParams
+): Map<string, string> {
+  const idToDisplayName = new Map<string, string>();
+  const nameAndIds = parseCompareExperimentStr(routeParams.experimentIds);
+  for (const {id, name} of nameAndIds) {
+    idToDisplayName.set(id, name);
+  }
+  return idToDisplayName;
+}

--- a/tensorboard/webapp/app_routing/store_only_utils_test.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils_test.ts
@@ -1,0 +1,47 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {getCompareExperimentIdAliasSpec} from './store_only_utils';
+
+describe('app_routing store_only_utils test', () => {
+  describe('#getCompareExperimentIdAliasSpec', () => {
+    it('returns a Map that contains the experimentId to alias from CompareRouteParams', () => {
+      const map = getCompareExperimentIdAliasSpec({
+        experimentIds: 'a:123,b:345',
+      });
+      expect(map).toEqual(
+        new Map([
+          ['123', 'a'],
+          ['345', 'b'],
+        ])
+      );
+    });
+
+    it('does not check for collision', () => {
+      const map = getCompareExperimentIdAliasSpec({
+        experimentIds: 'a:123,b:123',
+      });
+      expect(map).toEqual(new Map([['123', 'b']]));
+    });
+
+    it('throws when it is empty', () => {
+      expect(() =>
+        getCompareExperimentIdAliasSpec({
+          experimentIds: '',
+        })
+      ).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Ideally, we want to populate store with an information that exists in
the comparison string. However, router only provides the information in
an opaque `experimentIds` (typed as string) without an ability to reason
with the structure inside.

Ideally, RouteParameter should have a way to construct a structured data
structure and pass it through `navigated` action but that makes
AppRoutingEffects even more complex while making the RouteConfig more
elaborate.

For now, we are exposing the utility for stores to use instead.
