### PR TITLE
color grouping: on clicking `Regex`, open dialog if regex string is empty

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
@@ -56,7 +56,7 @@ limitations under the License.
     role="menuitemradio"
     *ngIf="showGroupByRegex"
     [attr.aria-checked]="selectedGroupBy.key === GroupByKey.REGEX"
-    (click)="onGroupByChange.emit({key: GroupByKey.REGEX, regexString: ''})"
+    (click)="onGroupByRegexClick()"
   >
     <span>
       <mat-icon

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
@@ -53,4 +53,15 @@ export class RunsGroupMenuButtonComponent {
       data: {experimentIds: this.experimentIds},
     });
   }
+
+  onGroupByRegexClick() {
+    if (!this.regexString) {
+      this.onRegexStringEdit();
+    } else {
+      this.onGroupByChange.emit({
+        key: GroupByKey.REGEX,
+        regexString: this.regexString,
+      });
+    }
+  }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -721,8 +721,6 @@ describe('runs_table', () => {
         expect(dispatchSpy).toHaveBeenCalledWith(
           runGroupByChanged({
             experimentIds: ['book'],
-            // TODO(japie1235813): regexString is hardcoded to '' for now;
-            // should be fixed when regex support is properly implemented.
             groupBy: {key: GroupByKey.REGEX, regexString: 'run'},
           })
         );

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -730,6 +730,7 @@ describe('runs_table', () => {
         store.overrideSelector(getEnabledColorGroup, true);
         store.overrideSelector(getEnabledColorGroupByRegex, true);
         store.overrideSelector(getRunGroupBy, {key: GroupByKey.EXPERIMENT});
+        store.overrideSelector(getColorGroupRegexString, '');
         const fixture = createComponent(
           ['book'],
           [RunsTableColumn.RUN_NAME, RunsTableColumn.RUN_COLOR]

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -656,7 +656,7 @@ describe('runs_table', () => {
         }
       );
 
-      it('dispatches `runGroupByChanged` when a menu item is clicked', () => {
+      it('dispatches `runGroupByChanged` when the menu item `Run`, `Experiment`, and Edit button is clicked', () => {
         store.overrideSelector(getEnabledColorGroup, true);
         store.overrideSelector(getEnabledColorGroupByRegex, true);
         store.overrideSelector(getRunGroupBy, {key: GroupByKey.EXPERIMENT});
@@ -687,16 +687,6 @@ describe('runs_table', () => {
           })
         );
 
-        getColorGroupByHTMLElement(GroupByKey.REGEX)!.click();
-        expect(dispatchSpy).toHaveBeenCalledWith(
-          runGroupByChanged({
-            experimentIds: ['book'],
-            // TODO(japie1235813): regexString is hardcoded to '' for now;
-            // should be fixed when regex support is properly implemented.
-            groupBy: {key: GroupByKey.REGEX, regexString: ''},
-          })
-        );
-
         getColorGroupByHTMLElement('regexEdit')!.click();
         const dialogContainer = overlayContainer
           .getContainerElement()
@@ -709,6 +699,55 @@ describe('runs_table', () => {
         ] = dialogContainer!.querySelectorAll('button');
         expect(cancelButton!.textContent).toContain('Cancel');
         expect(saveButton!.textContent).toContain('Save');
+      });
+
+      it('dispatches `runGroupByChanged` on clicking `Regex` when there is a regex string', () => {
+        store.overrideSelector(getEnabledColorGroup, true);
+        store.overrideSelector(getEnabledColorGroupByRegex, true);
+        store.overrideSelector(getRunGroupBy, {key: GroupByKey.EXPERIMENT});
+        store.overrideSelector(getColorGroupRegexString, 'run');
+        const fixture = createComponent(
+          ['book'],
+          [RunsTableColumn.RUN_NAME, RunsTableColumn.RUN_COLOR]
+        );
+        fixture.detectChanges();
+
+        const menuButton = fixture.debugElement
+          .query(By.directive(RunsGroupMenuButtonContainer))
+          .query(By.css('button'));
+        menuButton.nativeElement.click();
+
+        getColorGroupByHTMLElement(GroupByKey.REGEX)!.click();
+        expect(dispatchSpy).toHaveBeenCalledWith(
+          runGroupByChanged({
+            experimentIds: ['book'],
+            // TODO(japie1235813): regexString is hardcoded to '' for now;
+            // should be fixed when regex support is properly implemented.
+            groupBy: {key: GroupByKey.REGEX, regexString: 'run'},
+          })
+        );
+      });
+
+      it('opens edit dialog on clicking `Regex` when the regex string is not set', () => {
+        store.overrideSelector(getEnabledColorGroup, true);
+        store.overrideSelector(getEnabledColorGroupByRegex, true);
+        store.overrideSelector(getRunGroupBy, {key: GroupByKey.EXPERIMENT});
+        const fixture = createComponent(
+          ['book'],
+          [RunsTableColumn.RUN_NAME, RunsTableColumn.RUN_COLOR]
+        );
+        fixture.detectChanges();
+
+        const menuButton = fixture.debugElement
+          .query(By.directive(RunsGroupMenuButtonContainer))
+          .query(By.css('button'));
+        menuButton.nativeElement.click();
+
+        getColorGroupByHTMLElement(GroupByKey.REGEX)!.click();
+        const dialogContainer = overlayContainer
+          .getContainerElement()
+          .querySelector('mat-dialog-container');
+        expect(dialogContainer).toBeTruthy();
       });
 
       it('dispatches `runGroupByChanged` when regex editing is saved', () => {


### PR DESCRIPTION
* Motivation for features / changes
Currently we have four items on the dropdown menu. The forth one is editing the regex string. However while there is no regexString and user clicks `Regex` item, we fire `groupByChanges` with empty Regex string. Now we want to prop user to input the string by opening up the dialog.
