### PR TITLE
histogram: actually enable SummaryV2OpGraphTest

### DIFF
--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -176,11 +176,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
         return self.histogram_event(*args, **kwargs).summary
 
     def histogram_event(self, *args, **kwargs):
-        kwargs.setdefault("step", 1)
-        writer = tf2.summary.create_file_writer(self.get_temp_dir())
-        with writer.as_default():
-            summary.histogram(*args, **kwargs)
-        writer.close()
+        self.write_histogram_event(*args, **kwargs)
         event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), "*")))
         self.assertEqual(len(event_files), 1)
         events = list(tf.compat.v1.train.summary_iterator(event_files[0]))


### PR DESCRIPTION
The `write_histogram_event` method in the `SummaryV2OpGraphTest` test case is defined in order to override functionality in the parent class (`SummaryV2OpTest`, the non-graph-mode version), but the parent class never actually called that method, so the child class was essentially just a repeat of the parent test case rather than actually testing graph mode behavior.

This fixes that oversight. I spot-checked for other instances of this pattern and they look correctly structured:
https://cs.opensource.google/search?ss=tensorflow%2Ftensorboard&q=file:summary_test%5C.py%20write_%5Ba-z%5D%2B_event