### PR TITLE
histogram: avoid data transfer overhead for TPU outside compilation (3rd edition)

### DIFF
--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -198,6 +198,10 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
         with tf.name_scope("scope"):
             self.assertEqual("scope/a", self.histogram("a", []).value[0].tag)
 
+    def test_scoped_tag_empty_scope(self):
+        with tf.name_scope(""):
+            self.assertEqual("a", self.histogram("a", []).value[0].tag)
+
     def test_step(self):
         event = self.histogram_event("a", [], step=333)
         self.assertEqual(333, event.step)

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -176,11 +176,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
         return self.histogram_event(*args, **kwargs).summary
 
     def histogram_event(self, *args, **kwargs):
-        kwargs.setdefault("step", 1)
-        writer = tf2.summary.create_file_writer(self.get_temp_dir())
-        with writer.as_default():
-            summary.histogram(*args, **kwargs)
-        writer.close()
+        self.write_histogram_event(*args, **kwargs)
         event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), "*")))
         self.assertEqual(len(event_files), 1)
         events = list(tf.compat.v1.train.summary_iterator(event_files[0]))

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -25,6 +25,7 @@ have the same value, then there is one bucket whose left and right
 endpoints are the same (the shape is `[1, 3]`).
 """
 
+import contextlib
 
 import numpy as np
 
@@ -113,34 +114,59 @@ def histogram(name, data, step=None, buckets=None, description=None):
         or tf.summary.summary_scope
     )
 
+    # Try to capture current name scope so we can re-enter it below within our
+    # histogram_summary helper. We do this to avoid having the `tf.cond` below
+    # insert an extra `cond` into the tag name.
+    # TODO(https://github.com/tensorflow/tensorboard/issues/2885): Remove this
+    # special handling once the format no longer requires dynamic output shapes.
+    if hasattr(tf, "get_current_name_scope"):
+        # Enter empty context first to "escape" to root of name scope hierarchy
+        # and avoid nesting when we re-enter the desired name scope.
+        name_scope_cms = [
+            tf.name_scope(""),
+            tf.name_scope(tf.get_current_name_scope()),
+        ]
+    else:
+        name_scope_cms = []
+
     def histogram_summary(data, buckets, histogram_metadata, step):
-        with summary_scope(
-            name, "histogram_summary", values=[data, buckets, step]
-        ) as (tag, _):
-            # Defer histogram bucketing logic by passing it as a callable to write(),
-            # wrapped in a LazyTensorCreator for backwards compatibility, so that we
-            # only do this work when summaries are actually written.
-            @lazy_tensor_creator.LazyTensorCreator
-            def lazy_tensor():
-                return _buckets(data, buckets)
+        with contextlib.ExitStack() as stack:
+            for cm in name_scope_cms:
+                stack.enter_context(cm)
+            with summary_scope(
+                name, "histogram_summary", values=[data, buckets, step]
+            ) as (tag, _):
+                # Defer histogram bucketing logic by passing it as a callable to
+                # write(), wrapped in a LazyTensorCreator for backwards
+                # compatibility, so that we only do this work when summaries are
+                # actually written.
+                @lazy_tensor_creator.LazyTensorCreator
+                def lazy_tensor():
+                    return _buckets(data, buckets)
 
-            return tf.summary.write(
-                tag=tag,
-                tensor=lazy_tensor,
-                step=step,
-                metadata=summary_metadata,
-            )
+                return tf.summary.write(
+                    tag=tag,
+                    tensor=lazy_tensor,
+                    step=step,
+                    metadata=summary_metadata,
+                )
 
-    # `_buckets()` has dynamic output shapes which is not supported on TPU's. As so, place
-    # the bucketing ops on outside compilation cluster so that the function in executed on CPU.
-    # TODO(https://github.com/tensorflow/tensorboard/issues/2885): Remove this special
-    # handling once dynamic shapes are supported on TPU's.
+    # `_buckets()` has dynamic output shapes which is not supported on TPU's.
+    # To address this, explicitly mark this logic for outside compilation so it
+    # will be executed on the CPU, and skip it entirely if we aren't actually
+    # recording summaries to avoid overhead of transferring data.
+    # TODO(https://github.com/tensorflow/tensorboard/issues/2885): Remove this
+    # special handling once the format no longer requires dynamic output shapes.
     if isinstance(
         tf.distribute.get_strategy(),
         (tf.distribute.experimental.TPUStrategy, tf.distribute.TPUStrategy),
     ):
-        return tf.compat.v1.tpu.outside_compilation(
-            histogram_summary, data, buckets, summary_metadata, step
+        return tf.cond(
+            tf.summary.should_record_summaries(),
+            lambda: tf.compat.v1.tpu.outside_compilation(
+                histogram_summary, data, buckets, summary_metadata, step
+            ),
+            lambda: False,
         )
     return histogram_summary(data, buckets, summary_metadata, step)
 


### PR DESCRIPTION
_Note: This is my third attempt to land this change; the previous attempts (first edition #5066 and second edition #5093) had to be reverted due to internal test failures - see b/194203115._

This updates the histogram summary TPU outside compilation workaround logic (needed until #2885 is fixed) so that we only invoke it when summaries will actually be written, to avoid the overhead of transferring data to the CPU only to be discarded.

cc @kenfranko 

The delta from the previous edition, #5093, is as follows:

- I realized that the graph mode test was disabled; I've re-enabled it in #5155 (also included in this PR as the first commit)
- Once that test is active, it exposes two failure modes of the previous scope-preservation logic I added in the second edition (to avoid the tag name changes from the first edition). This PR adds test coverage and fixes for those:
    - `tf.get_current_name_scope()` sometimes returns None, contradicting its docstring. I actually fixed this already in https://github.com/tensorflow/tensorflow/commit/9b0d6e168e16d585c5c953e1da8bf8083d23fc82 but we still include a patch to handle it for compatibility with the current TF release
    - The trick of re-entering the root scope first and then the original scope (relative to the root scope) doesn't actually work, since instead of re-entering the scope, the auto-incrementing logic "protects" us from a scope collision and results in `<original_scope>_1` instead. Instead, we can use a trailing slash on the scope name to indicate an "absolute" scope, which also avoids the auto-incrementing logic. I'd hoped to avoid this weird legacy magical behavior, which is why I did the root scope re-entry in the first place, but I don't see any better options.

For googlers, internal tests: cl/381296270
