### PR TITLE
color grouping: preserve regexString when groupBy regex is fired

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -305,8 +305,14 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
         defaultRunColorForGroupBy.delete(run.id);
       }
 
+      const updatedRegexString =
+        groupBy.key === GroupByKey.REGEX
+          ? groupBy.regexString
+          : state.colorGroupRegexString;
+
       return {
         ...state,
+        colorGroupRegexString: updatedRegexString,
         userSetGroupByKey: groupBy.key,
         defaultRunColorForGroupBy,
         groupKeyToColorString,

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -923,7 +923,7 @@ describe('runs_reducers', () => {
         ])
       );
       expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());
-      expect(nextState.data.colorGroupRegexString).toEqual('foo(\\d+)');
+      expect(nextState.data.colorGroupRegexString).toBe('foo(\\d+)');
     });
 
     it('preserves regexString when reassigning color to RUN from REGEX', () => {
@@ -974,7 +974,7 @@ describe('runs_reducers', () => {
         })
       );
 
-      expect(state3.data.colorGroupRegexString).toEqual('initial regex string');
+      expect(state3.data.colorGroupRegexString).toBe('initial regex string');
 
       // Updates colorGroupRegexString with new regexString when type GroupBy is RegexGroupBy
       const state4 = runsReducers.reducers(
@@ -984,7 +984,7 @@ describe('runs_reducers', () => {
           groupBy: {key: GroupByKey.REGEX, regexString: 'updated regexString'},
         })
       );
-      expect(state4.data.colorGroupRegexString).toEqual('updated regexString');
+      expect(state4.data.colorGroupRegexString).toBe('updated regexString');
     });
   });
 

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -923,6 +923,68 @@ describe('runs_reducers', () => {
         ])
       );
       expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());
+      expect(nextState.data.colorGroupRegexString).toEqual('foo(\\d+)');
+    });
+
+    it('preserves regexString when reassigning color to RUN from REGEX', () => {
+      const state = buildRunsState({
+        initialGroupBy: {key: GroupByKey.RUN},
+        runIds: {
+          eid1: ['run1', 'run2'],
+          eid2: ['run3', 'run4', 'run5', 'run6'],
+        },
+        runIdToExpId: {
+          run1: 'eid1',
+          run2: 'eid1',
+          run3: 'eid2',
+          run4: 'eid2',
+          run5: 'eid2',
+          run6: 'eid2',
+        },
+        runMetadata: {
+          run1: buildRun({id: 'run1', name: 'foo1bar1'}),
+          run2: buildRun({id: 'run2', name: 'foo2bar1'}),
+          run3: buildRun({id: 'run3', name: 'foo2bar2'}),
+          run4: buildRun({id: 'run4', name: 'foo2bar2bar'}),
+          run5: buildRun({id: 'run5', name: 'beta'}),
+          run6: buildRun({id: 'run6', name: 'gamma'}),
+        },
+        defaultRunColorForGroupBy: new Map([
+          ['run1', '#aaa'],
+          ['run2', '#bbb'],
+          ['run3', '#ccc'],
+          ['run4', '#ddd'],
+          ['run5', '#eee'],
+          ['run6', '#fff'],
+        ]),
+      });
+
+      const state2 = runsReducers.reducers(
+        state,
+        actions.runGroupByChanged({
+          experimentIds: ['eid1', 'eid2'],
+          groupBy: {key: GroupByKey.REGEX, regexString: 'initial regex string'},
+        })
+      );
+      const state3 = runsReducers.reducers(
+        state2,
+        actions.runGroupByChanged({
+          experimentIds: ['eid1', 'eid2'],
+          groupBy: {key: GroupByKey.RUN},
+        })
+      );
+
+      expect(state3.data.colorGroupRegexString).toEqual('initial regex string');
+
+      // Updates colorGroupRegexString with new regexString when type GroupBy is RegexGroupBy
+      const state4 = runsReducers.reducers(
+        state3,
+        actions.runGroupByChanged({
+          experimentIds: ['eid1', 'eid2'],
+          groupBy: {key: GroupByKey.REGEX, regexString: 'updated regexString'},
+        })
+      );
+      expect(state4.data.colorGroupRegexString).toEqual('updated regexString');
     });
   });
 


### PR DESCRIPTION
* Motivation for features / changes
Currently the regexString is preserved in url and can be rehydrated from url to state. Yet we miss one step to preserve the regexString in the state `colorGroupRegexString`. This pr is to fix it.

* Technical description of changes
Because of our type structure (`GroupBy` and `RegexGroupBy`), when `runGroupByChanged` is trigged and `key` attribute is `REGEX`, it will always comes with the attribute`regexString`. 
Thus we only need to consider two cases:
1. it is not group by regex: we take the current `state.colorGroupRegexString`
2. it is group by regex: we always have `regexString`. Even tho the value of `regexString` is the same as `state.colorGroupRegexString` and the assign is meaningless. Since the outcome is the same so I did not particular handle this.