### PR TITLE
histogram: axis for Angular histogram widget

### DIFF
--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -1,18 +1,29 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
+
+tf_sass_binary(
+    name = "histogram_styles",
+    src = "histogram_v2_component.scss",
+)
 
 tf_ng_module(
     name = "histogram",
     srcs = [
         "histogram_component.ts",
         "histogram_module.ts",
+        "histogram_v2_component.ts",
+    ],
+    assets = [
+        "histogram_v2_component.ng.html",
+        ":histogram_styles",
     ],
     deps = [
         ":types",
         "//tensorboard/webapp:tb_polymer_interop_types",
+        "//tensorboard/webapp/third_party:d3",
         "@npm//@angular/core",
     ],
 )
@@ -23,6 +34,7 @@ tf_ts_library(
     srcs = [
         "histogram_test.ts",
         "histogram_util_test.ts",
+        "histogram_v2_test.ts",
     ],
     deps = [
         ":histogram",
@@ -31,6 +43,7 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",
     ],
 )

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.ng.html
@@ -1,4 +1,6 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+<!--
+@license
+Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,14 +13,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
-import {NgModule} from '@angular/core';
-
-import {HistogramComponent} from './histogram_component';
-import {HistogramV2Component} from './histogram_v2_component';
-
-@NgModule({
-  declarations: [HistogramComponent, HistogramV2Component],
-  exports: [HistogramComponent, HistogramV2Component],
-})
-export class HistogramModule {}
+-->
+<div class="main">
+  <svg #xAxis class="axis x-axis"></svg>
+  <svg #yAxis class="axis y-axis"></svg>
+  <svg #content class="content"></svg>
+</div>

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.scss
@@ -1,0 +1,63 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+:host,
+.main {
+  display: inline-block;
+  height: 100%;
+  width: 100%;
+}
+
+:host {
+  box-sizing: border-box;
+  padding: 5px;
+}
+
+.main {
+  display: grid;
+  grid-template-areas:
+    'content y-axis'
+    'x-axis .';
+  grid-template-columns: 1fr 50px;
+  grid-template-rows: 1fr 30px;
+}
+
+.axis ::ng-deep {
+  .domain,
+  .axis ::ng-deep .tick text {
+    display: none;
+  }
+
+  .tick:nth-child(2n + 1) text {
+    display: initial;
+  }
+}
+
+svg {
+  height: 100%;
+  width: 100%;
+}
+
+.x-axis {
+  grid-area: x-axis;
+}
+
+.y-axis {
+  grid-area: y-axis;
+}
+
+.content {
+  grid-area: content;
+}

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.ts
@@ -1,0 +1,193 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  ViewChild,
+} from '@angular/core';
+
+import * as d3 from '../../third_party/d3';
+import {
+  ColorScale,
+  HistogramData,
+  HistogramMode,
+  TimeProperty,
+} from './histogram_types';
+
+@Component({
+  selector: 'tb-histogram-v2',
+  templateUrl: 'histogram_v2_component.ng.html',
+  styleUrls: ['histogram_v2_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HistogramV2Component implements OnChanges {
+  @ViewChild('xAxis') private readonly xAxis!: ElementRef;
+  @ViewChild('yAxis') private readonly yAxis!: ElementRef;
+  @ViewChild('content') private readonly content!: ElementRef;
+
+  @Input() mode: HistogramMode = HistogramMode.OFFSET;
+
+  @Input() timeProperty: TimeProperty = TimeProperty.STEP;
+
+  @Input() colorScale?: ColorScale;
+
+  @Input() name!: string;
+
+  @Input() data!: HistogramData;
+
+  private yScale?:
+    | d3.ScaleTime<number, number>
+    | d3.ScaleLinear<number, number>;
+
+  constructor(private readonly host: ElementRef) {}
+
+  ngOnChanges() {
+    if (this.content) {
+      this.ngAfterViewInit();
+    }
+  }
+
+  ngAfterViewInit() {
+    this.updateChart();
+  }
+
+  private updateChart() {
+    this.renderXAxis(this.data);
+    this.updateYScaleAndDomain(this.data);
+    this.renderYAxis();
+  }
+
+  private renderXAxis(data: HistogramData) {
+    const {width} = this.host.nativeElement.getBoundingClientRect();
+    const {min: xMin, max: xMax} = getMinMax(
+      data,
+      (datum) => getMin(datum.bins, (binVal) => binVal.x),
+      (datum) => getMax(datum.bins, ({x, dx}) => x + dx)
+    );
+    const xScale = d3
+      .scaleLinear()
+      .domain([xMin, xMax])
+      .nice()
+      .range([0, width]);
+    const xAxis = d3.axisBottom(xScale).ticks(Math.max(2, width / 20));
+
+    xAxis(d3.select(this.xAxis.nativeElement));
+  }
+
+  private updateYScaleAndDomain(data: HistogramData) {
+    this.yScale =
+      this.mode !== HistogramMode.OVERLAY &&
+      this.timeProperty == TimeProperty.WALL_TIME
+        ? d3.scaleTime()
+        : d3.scaleLinear();
+
+    let domain: [number, number] = [0, 1];
+    if (this.mode === HistogramMode.OVERLAY) {
+      const countMax = getMax(data, (datum) => {
+        return getMax(datum.bins, ({y}) => y);
+      });
+      domain = [0, countMax];
+    } else {
+      const yValues = data.map((datum) => {
+        switch (this.timeProperty) {
+          case TimeProperty.WALL_TIME:
+            return datum.wallTime;
+          case TimeProperty.STEP:
+            return datum.step;
+          case TimeProperty.RELATIVE:
+            return datum.wallTime - data[0]?.wallTime ?? 0;
+        }
+      });
+      const {min: yMin, max: yMax} = getMinMax(yValues, (val) => val);
+      domain = [yMin, yMax];
+    }
+    this.yScale.domain(domain);
+  }
+
+  private renderYAxis() {
+    const yScale = this.yScale!;
+    const {height} = this.host.nativeElement.getBoundingClientRect();
+    const overlayAxisHeight = height / 2.5;
+    const offsetAxisHeight =
+      this.mode === HistogramMode.OFFSET ? height - overlayAxisHeight : 0;
+    yScale.range([height - offsetAxisHeight, height]);
+
+    const yAxis = d3.axisRight(yScale).ticks(Math.max(2, height / 15));
+    // d3 on DefinitelyTyped is typed incorrectly and it does not allow function
+    // that takes (d: Data) => string to be specified in the parameter unlike
+    // the real d3.
+    const anyYAxis = yAxis as any;
+    if (this.mode === HistogramMode.OVERLAY) {
+      anyYAxis.tickFormat(d3.format('.3n'));
+    } else {
+      switch (this.timeProperty) {
+        case TimeProperty.WALL_TIME:
+          anyYAxis.tickFormat(d3.timeFormat('%m/%d %X'));
+          break;
+        case TimeProperty.STEP: {
+          anyYAxis.tickFormat(d3.format('.0f'));
+          break;
+        }
+        case TimeProperty.RELATIVE: {
+          anyYAxis.tickFormat((d: number): string => {
+            return d3.format('.1r')(d / 3.6e6) + 'h'; // Convert to hours.
+          });
+          break;
+        }
+      }
+    }
+
+    yAxis(d3.select(this.yAxis.nativeElement));
+    return yScale;
+  }
+}
+
+function getMin<T>(data: T[], valueAccessor: (val: T) => number): number {
+  return data.reduce((prevMin, value) => {
+    return Math.min(prevMin, valueAccessor(value));
+  }, Infinity);
+}
+
+function getMax<T>(data: T[], valueAccessor: (val: T) => number): number {
+  return data.reduce((prevMax, value) => {
+    return Math.max(prevMax, valueAccessor(value));
+  }, -Infinity);
+}
+
+/**
+ * Returns min and max at the same time by iterating through data once.
+ */
+function getMinMax<T>(
+  data: T[],
+  lowerValueAccessor: (val: T) => number,
+  upperValueAccessor?: (val: T) => number
+): {min: number; max: number} {
+  if (!upperValueAccessor) {
+    upperValueAccessor = lowerValueAccessor;
+  }
+
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (const datum of data) {
+    min = Math.min(min, lowerValueAccessor(datum));
+    max = Math.max(max, upperValueAccessor(datum));
+  }
+
+  return {min, max};
+}

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.ts
@@ -44,6 +44,11 @@ export class HistogramV2Component implements OnChanges {
 
   @Input() timeProperty: TimeProperty = TimeProperty.STEP;
 
+  /**
+   * TODO(tensorboard-team): VzHistogram only needs 'name', 'colorScale'
+   * properties to determine the histogram color. We could replace these with a
+   * single 'color' property to make the interface simpler.
+   */
   @Input() colorScale?: ColorScale;
 
   @Input() name!: string;
@@ -110,7 +115,7 @@ export class HistogramV2Component implements OnChanges {
           case TimeProperty.STEP:
             return datum.step;
           case TimeProperty.RELATIVE:
-            return datum.wallTime - data[0]?.wallTime ?? 0;
+            return datum.wallTime - data[0].wallTime;
         }
       });
       const {min: yMin, max: yMax} = getMinMax(yValues, (val) => val);
@@ -144,8 +149,8 @@ export class HistogramV2Component implements OnChanges {
           break;
         }
         case TimeProperty.RELATIVE: {
-          anyYAxis.tickFormat((d: number): string => {
-            return d3.format('.1r')(d / 3.6e6) + 'h'; // Convert to hours.
+          anyYAxis.tickFormat((timeDiffInMs: number): string => {
+            return d3.format('.1r')(timeDiffInMs / 3.6e6) + 'h'; // Convert to hours.
           });
           break;
         }

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
@@ -42,7 +42,7 @@ function buildHistogramDatum(
   return {
     wallTime: 1000,
     step: 0,
-    bins: new Array(10).fill(buildBin()),
+    bins: [...new Array(10)].map(() => buildBin()),
     ...override,
   };
 }

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
@@ -1,0 +1,249 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Component, DebugElement, Input} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+
+import {
+  Bin,
+  ColorScale,
+  HistogramData,
+  HistogramDatum,
+  HistogramMode,
+  TimeProperty,
+} from './histogram_types';
+import {HistogramV2Component} from './histogram_v2_component';
+
+function buildBin(override: Partial<Bin> = {}): Bin {
+  return {
+    x: 0,
+    dx: 1,
+    y: 0,
+    ...override,
+  };
+}
+
+function buildHistogramDatum(
+  override: Partial<HistogramDatum> = {}
+): HistogramDatum {
+  return {
+    wallTime: 1000,
+    step: 0,
+    bins: new Array(10).fill(buildBin()),
+    ...override,
+  };
+}
+
+// Wrapper component required to properly trigger Angular lifecycles.
+// Without it, ngOnChanges do not get triggered before ngOnInit.
+@Component({
+  selector: 'testable-tb-histogram',
+  template: `
+    <tb-histogram-v2
+      [mode]="mode"
+      [timeProperty]="timeProperty"
+      [colorScale]="colorScale"
+      [name]="name"
+      [data]="data"
+    >
+    </tb-histogram-v2>
+  `,
+  styles: [
+    `
+      tb-histogram-v2 {
+        height: 100px;
+        position: fixed;
+        width: 100px;
+      }
+    `,
+  ],
+})
+class TestableComponent {
+  @Input() mode!: HistogramMode;
+  @Input() timeProperty!: TimeProperty;
+  @Input() colorScale!: ColorScale;
+  @Input() name!: string;
+  @Input() data!: HistogramData;
+}
+
+describe('histogram v2 test', () => {
+  const byCss = {
+    X_AXIS: By.css('.x-axis'),
+    Y_AXIS: By.css('.y-axis'),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule],
+      declarations: [HistogramV2Component, TestableComponent],
+    }).compileComponents();
+  });
+
+  function createComponent(
+    name: string,
+    data: HistogramData
+  ): ComponentFixture<TestableComponent> {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.componentInstance.name = name;
+    fixture.componentInstance.data = data;
+    fixture.componentInstance.mode = HistogramMode.OFFSET;
+    fixture.componentInstance.timeProperty = TimeProperty.STEP;
+    fixture.componentInstance.colorScale = (name) => '#fff';
+    return fixture;
+  }
+
+  function getAxisLabelText(axis: DebugElement): string[] {
+    const elements = axis.nativeElement.querySelectorAll(
+      'text'
+    ) as SVGTextElement[];
+    return Array.from(elements).map((el) => el.textContent ?? '');
+  }
+
+  describe('x axis render', () => {
+    it('renders min and max of bins in scalar', () => {
+      const fixture = createComponent('foo', [
+        buildHistogramDatum({
+          step: 0,
+          bins: [buildBin({x: 1, dx: 5})],
+        }),
+        buildHistogramDatum({
+          step: 1,
+          bins: [buildBin({x: 0, dx: 100})],
+        }),
+        buildHistogramDatum({
+          step: 100,
+          bins: [buildBin({x: -100, dx: 5})],
+        }),
+      ]);
+      fixture.componentInstance.mode = HistogramMode.OFFSET;
+      fixture.componentInstance.timeProperty = TimeProperty.STEP;
+      fixture.detectChanges();
+
+      expect(
+        getAxisLabelText(fixture.debugElement.query(byCss.X_AXIS))
+      ).toEqual(['-100', '-50', '0', '50', '100']);
+    });
+  });
+
+  describe('y axis render', () => {
+    describe('offset mode', () => {
+      it('renders min and max of step in STEP mode', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({
+            step: 0,
+          }),
+          buildHistogramDatum({
+            step: 1,
+          }),
+          buildHistogramDatum({
+            step: 100,
+          }),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.detectChanges();
+
+        expect(
+          getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
+        ).toEqual(['0', '20', '40', '60', '80', '100']);
+      });
+
+      it('renders wallTime in WALL_TIME mode', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({
+            step: 0,
+            wallTime: new Date('2000-1-1').getTime(),
+          }),
+          buildHistogramDatum({
+            step: 1,
+            wallTime: new Date('2000-2-1').getTime(),
+          }),
+          buildHistogramDatum({
+            step: 100,
+            wallTime: new Date('2000-3-1').getTime(),
+          }),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.WALL_TIME;
+        fixture.detectChanges();
+
+        expect(
+          getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
+        ).toEqual([
+          '01/02 12:00:00 AM',
+          '01/09 12:00:00 AM',
+          '01/16 12:00:00 AM',
+          '01/23 12:00:00 AM',
+          '01/30 12:00:00 AM',
+          '02/06 12:00:00 AM',
+          '02/13 12:00:00 AM',
+          '02/20 12:00:00 AM',
+          '02/27 12:00:00 AM',
+        ]);
+      });
+
+      it('renders relative time from first data in RELATIVE mode', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({
+            step: 0,
+            wallTime: new Date('2000-1-1').getTime(),
+          }),
+          buildHistogramDatum({
+            step: 1,
+            wallTime: new Date('2000-2-1').getTime(),
+          }),
+          buildHistogramDatum({
+            step: 100,
+            wallTime: new Date('2000-3-1').getTime(),
+          }),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.RELATIVE;
+        fixture.detectChanges();
+
+        expect(
+          getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
+        ).toEqual(['0h', '300h', '600h', '800h', '1000h', '1000h']);
+      });
+    });
+
+    describe('overlay mode', () => {
+      it('renders bin count in scalar value from 0 to max regardless of timeProp', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({
+            step: 0,
+            bins: [buildBin({y: 10}), buildBin({y: 5})],
+          }),
+          buildHistogramDatum({
+            step: 1,
+            bins: [buildBin({y: 10}), buildBin({y: 100})],
+          }),
+          buildHistogramDatum({
+            step: 100,
+            bins: [buildBin({y: 1337})],
+          }),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OVERLAY;
+        fixture.componentInstance.timeProperty = TimeProperty.WALL_TIME;
+        fixture.detectChanges();
+
+        expect(
+          getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
+        ).toEqual(['0.00', '200', '400', '600', '800', '1.00e+3', '1.20e+3']);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This change is a start of the rewrite for the histogram widget.
Currently, the component was written as a shallow wrapper around our
Polymer based vz-histogram-timeseries component. This wrapper was not
easy enough to make changes to address some of the user feedbacks and
implement a new feature.

To that end, we are rewriting the component so bulk of the logic resides
in the Angular land without Polymer. Do note that goal is _not_ to
remove Polymer but is to have more manageable visualization code with
much better types. Even the Polymer component is a thin wrapper around
d3 and the most interesting logic resides in the `draw` method. To be
clear, we are not completely gutting out d3 as it still serves useful
purposes for axis, formatting,

This change is the first of more to follow. This change only calculates
the axis and renders the same axis as existing histogram visualization.
No component actually make use of it and you will need to manually
modify `histogram_card_component.ng.html` to make use of the new
version.
