### PR TITLE
color grouping: fix number and add tests

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -63,11 +63,11 @@ limitations under the License.
           ></label
         >
         <ul>
-          <ng-container *ngFor="let run of colorRunsPair.runs | slice:0:10;">
+          <ng-container *ngFor="let run of colorRunsPair.runs | slice:0:5;">
             <li [title]="run.name">{{ run.name }}</li>
           </ng-container>
           <li class="more" *ngIf="colorRunsPair.runs.length > 5">
-            <em>and {{colorRunsPair.runs.length - 10 | number}} more</em>
+            <em>and {{colorRunsPair.runs.length - 5 | number}} more</em>
           </li>
           <li class="no-match" *ngIf="colorRunsPair.runs.length === 0">
             <em>No runs are in the group</em>

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -484,7 +484,15 @@ describe('regex_edit_dialog', () => {
       buildRun({id: 'run6', name: 'run6 name'}),
       buildRun({id: 'run6', name: 'run7 name'}),
     ]);
-    store.overrideSelector(getRunIdsForExperiment, ['run1', 'run2', 'run3', 'run4', 'run5', 'run6', 'run7']);
+    store.overrideSelector(getRunIdsForExperiment, [
+      'run1',
+      'run2',
+      'run3',
+      'run4',
+      'run5',
+      'run6',
+      'run7',
+    ]);
     fixture.detectChanges();
 
     const input = fixture.debugElement.query(By.css('input'));
@@ -501,6 +509,6 @@ describe('regex_edit_dialog', () => {
     const more = fixture.debugElement.query(By.css('.more'));
     const list = fixture.debugElement.queryAll(By.css('.group ul li'));
     expect(list.length).toBe(6);
-    expect(more.nativeElement.textContent).toBe("and 2 more");
+    expect(more.nativeElement.textContent).toBe('and 2 more');
   }));
 });

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -472,4 +472,35 @@ describe('regex_edit_dialog', () => {
       expect(beforeGroupContent).toBe(afterGroupContent);
     }));
   });
+
+  it('renders `and X more` when the grouping result is more than 5', fakeAsync(() => {
+    const fixture = createComponent(['rose']);
+    store.overrideSelector(getRuns, [
+      buildRun({id: 'run1', name: 'run1 name'}),
+      buildRun({id: 'run2', name: 'run2 name'}),
+      buildRun({id: 'run3', name: 'run3 name'}),
+      buildRun({id: 'run4', name: 'run4 name'}),
+      buildRun({id: 'run5', name: 'run5 name'}),
+      buildRun({id: 'run6', name: 'run6 name'}),
+      buildRun({id: 'run6', name: 'run7 name'}),
+    ]);
+    store.overrideSelector(getRunIdsForExperiment, ['run1', 'run2', 'run3', 'run4', 'run5', 'run6', 'run7']);
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input'));
+    const keyArgs: SendKeyArgs = {
+      key: '',
+      prevString: 'run',
+      type: KeyType.CHARACTER,
+      startingCursorIndex: 0,
+    };
+    sendKey(fixture, input, keyArgs);
+    tick(TEST_ONLY.INPUT_CHANGE_DEBOUNCE_INTERVAL_MS);
+    fixture.detectChanges();
+
+    const more = fixture.debugElement.query(By.css('.more'));
+    const list = fixture.debugElement.queryAll(By.css('.group ul li'));
+    expect(list.length).toBe(6);
+    expect(more.nativeElement.textContent).toBe("and 2 more");
+  }));
 });


### PR DESCRIPTION
* Motivation for features / changes
Some number is off when we truncate the runs (display at most ten or five runs in a group), now all set to 5 runs per group.  Added a test to catch this.
