### PR TITLE
color grouping: rehydrated regexString from url

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -19,7 +19,6 @@ import {
   createReducer,
   on,
 } from '@ngrx/store';
-
 import {stateRehydratedFromUrl} from '../../app_routing/actions';
 import {createRouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
 import {RouteKind} from '../../app_routing/types';
@@ -105,8 +104,14 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
       return state;
     }
 
+    const regexString =
+      groupBy.key === GroupByKey.REGEX
+        ? groupBy.regexString
+        : state.colorGroupRegexString;
+
     return {
       ...state,
+      colorGroupRegexString: regexString,
       userSetGroupByKey: groupBy.key ?? null,
     };
   }),

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -19,6 +19,7 @@ import {
   createReducer,
   on,
 } from '@ngrx/store';
+
 import {stateRehydratedFromUrl} from '../../app_routing/actions';
 import {createRouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
 import {RouteKind} from '../../app_routing/types';

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -1060,6 +1060,57 @@ describe('runs_reducers', () => {
         ])
       );
     });
+
+    it('sets regexString on groupBy REGEX', () => {
+      const state = buildRunsState({
+        initialGroupBy: {key: GroupByKey.EXPERIMENT},
+        userSetGroupByKey: GroupByKey.RUN,
+        runIds: {
+          eid1: ['run1', 'run2'],
+          eid2: ['run3', 'run4'],
+        },
+        runIdToExpId: {
+          run1: 'eid1',
+          run2: 'eid1',
+          run3: 'eid2',
+          run4: 'eid2',
+        },
+        runMetadata: {
+          run1: buildRun({id: 'run1'}),
+          run2: buildRun({id: 'run2'}),
+          run3: buildRun({id: 'run3'}),
+          run4: buildRun({id: 'run4'}),
+        },
+        groupKeyToColorString: new Map([
+          ['run1', '#aaa'],
+          ['run2', '#bbb'],
+          ['run3', '#ccc'],
+          ['run4', '#ddd'],
+        ]),
+        defaultRunColorForGroupBy: new Map([
+          ['run1', '#aaa'],
+          ['run2', '#bbb'],
+          ['run3', '#ccc'],
+          ['run4', '#ddd'],
+        ]),
+        runColorOverrideForGroupBy: new Map([['run1', '#ccc']]),
+      });
+
+      const partialState: URLDeserializedState = {
+        runs: {
+          groupBy: {key: GroupByKey.REGEX, regexString: 'regex string'},
+        },
+      };
+      const nextState = runsReducers.reducers(
+        state,
+        stateRehydratedFromUrl({
+          routeKind: RouteKind.COMPARE_EXPERIMENT,
+          partialState,
+        })
+      );
+
+      expect(nextState.data.colorGroupRegexString).toBe('regex string');
+    });
   });
 
   describe('when freshly navigating', () => {

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -1064,36 +1064,6 @@ describe('runs_reducers', () => {
     it('sets regexString on groupBy REGEX', () => {
       const state = buildRunsState({
         initialGroupBy: {key: GroupByKey.EXPERIMENT},
-        userSetGroupByKey: GroupByKey.RUN,
-        runIds: {
-          eid1: ['run1', 'run2'],
-          eid2: ['run3', 'run4'],
-        },
-        runIdToExpId: {
-          run1: 'eid1',
-          run2: 'eid1',
-          run3: 'eid2',
-          run4: 'eid2',
-        },
-        runMetadata: {
-          run1: buildRun({id: 'run1'}),
-          run2: buildRun({id: 'run2'}),
-          run3: buildRun({id: 'run3'}),
-          run4: buildRun({id: 'run4'}),
-        },
-        groupKeyToColorString: new Map([
-          ['run1', '#aaa'],
-          ['run2', '#bbb'],
-          ['run3', '#ccc'],
-          ['run4', '#ddd'],
-        ]),
-        defaultRunColorForGroupBy: new Map([
-          ['run1', '#aaa'],
-          ['run2', '#bbb'],
-          ['run3', '#ccc'],
-          ['run4', '#ddd'],
-        ]),
-        runColorOverrideForGroupBy: new Map([['run1', '#ccc']]),
       });
 
       const partialState: URLDeserializedState = {


### PR DESCRIPTION
* Motivation for features / changes
Currently when users click buttons to save regexString, we preserve this information in the url. Yet when the browser refreshed afterward, we did not rehydrate the string back to our state and the information disappears. This pr aims to address that.

* Technical description of changes


