### PR TITLE
histogram: render Overlay and Offset charts

### DIFF
--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -24,6 +24,7 @@ tf_ng_module(
         ":types",
         "//tensorboard/webapp:tb_polymer_interop_types",
         "//tensorboard/webapp/third_party:d3",
+        "@npm//@angular/common",
         "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/widgets/histogram/histogram_module.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_module.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
 import {HistogramComponent} from './histogram_component';
@@ -20,5 +21,6 @@ import {HistogramV2Component} from './histogram_v2_component';
 @NgModule({
   declarations: [HistogramComponent, HistogramV2Component],
   exports: [HistogramComponent, HistogramV2Component],
+  imports: [CommonModule],
 })
 export class HistogramModule {}

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.ng.html
@@ -41,7 +41,6 @@ limitations under the License.
         <path
           [attr.d]="getHistogramPath(datum)"
           [style.color]="getHistogramFill(datum)"
-          stroke=""
         ></path>
       </g>
     </g>

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.ng.html
@@ -14,8 +14,36 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div class="main">
+<div [class]="'main ' + mode + ' ' + timeProperty">
   <svg #xAxis class="axis x-axis"></svg>
   <svg #yAxis class="axis y-axis"></svg>
-  <svg #content class="content"></svg>
+  <svg #content class="content">
+    <g class="grid">
+      <g
+        *ngFor="let tick of getGridTickYLocs()"
+        [attr.transform]="'translate(0, ' + tick + ')'"
+      >
+        <line class="tick" x2="100%"></line>
+      </g>
+    </g>
+
+    <g class="histograms">
+      <g
+        *ngFor="let datum of data; trackBy: trackByWallTime;"
+        [attr.transform]="getGroupTransform(datum)"
+        class="histogram"
+      >
+        <line
+          *ngIf="mode === HistogramMode.OFFSET"
+          class="baseline"
+          x2="100%"
+        ></line>
+        <path
+          [attr.d]="getHistogramPath(datum)"
+          [style.color]="getHistogramFill(datum)"
+          stroke=""
+        ></path>
+      </g>
+    </g>
+  </svg>
 </div>

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.scss
@@ -12,6 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
+$_tick-color: #ddd;
 
 :host,
 .main {
@@ -22,7 +25,7 @@ limitations under the License.
 
 :host {
   box-sizing: border-box;
-  padding: 5px;
+  padding: 10px;
 }
 
 .main {
@@ -32,11 +35,17 @@ limitations under the License.
     'x-axis .';
   grid-template-columns: 1fr 50px;
   grid-template-rows: 1fr 30px;
+
+  &.wall_time {
+    grid-template-columns: 1fr 75px;
+  }
 }
 
 .axis ::ng-deep {
+  @include tb-theme-foreground-prop(color, secondary-text);
+
   .domain,
-  .axis ::ng-deep .tick text {
+  .tick text {
     display: none;
   }
 
@@ -58,6 +67,45 @@ svg {
   grid-area: y-axis;
 }
 
+.content .tick,
+.axis ::ng-deep .tick line {
+  stroke: $_tick-color;
+}
+
 .content {
   grid-area: content;
+
+  .tick {
+    stroke-width: 1px;
+    stroke-dasharray: 2;
+  }
+
+  path {
+    stroke-opacity: 0.5;
+  }
+
+  .baseline {
+    stroke: #000;
+    stroke-width: 1px;
+    stroke-opacity: 0.1;
+    width: 100%;
+  }
+}
+
+// Offset mode customizations.
+.offset .content path {
+  fill: currentColor;
+  stroke: #fff;
+}
+
+// Overlay mode customizations.
+.overlay {
+  .x-axis ::ng-deep .tick line {
+    display: none;
+  }
+
+  .content path {
+    fill-opacity: 0;
+    stroke: currentColor;
+  }
 }

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
@@ -135,7 +135,7 @@ describe('histogram v2 test', () => {
 
       expect(
         getAxisLabelText(fixture.debugElement.query(byCss.X_AXIS))
-      ).toEqual(['-100', '-50', '0', '50', '100']);
+      ).toEqual(['-100', '0', '100']);
     });
   });
 
@@ -184,15 +184,9 @@ describe('histogram v2 test', () => {
         expect(
           getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
         ).toEqual([
-          '01/02 12:00:00 AM',
-          '01/09 12:00:00 AM',
-          '01/16 12:00:00 AM',
-          '01/23 12:00:00 AM',
-          '01/30 12:00:00 AM',
-          '02/06 12:00:00 AM',
-          '02/13 12:00:00 AM',
-          '02/20 12:00:00 AM',
-          '02/27 12:00:00 AM',
+          '01/01 12:00:00 AM',
+          '02/01 12:00:00 AM',
+          '03/01 12:00:00 AM',
         ]);
       });
 
@@ -217,7 +211,7 @@ describe('histogram v2 test', () => {
 
         expect(
           getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
-        ).toEqual(['0h', '300h', '600h', '800h', '1000h', '1000h']);
+        ).toEqual(['0h', '600h', '1000h']);
       });
     });
 
@@ -243,7 +237,7 @@ describe('histogram v2 test', () => {
 
         expect(
           getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
-        ).toEqual(['0.00', '200', '400', '600', '800', '1.00e+3', '1.20e+3']);
+        ).toEqual(['0.00', '500', '1.00e+3']);
       });
     });
   });
@@ -311,11 +305,7 @@ describe('histogram v2 test', () => {
         // max (-300, 300) which has the same spacing as the WALL_TIME.
         expect(
           getGroupTransforms(fixture.debugElement.query(byCss.HISTOGRAMS))
-        ).toEqual([
-          'translate(0, 20)',
-          'translate(0, 27.5)',
-          'translate(0, 50)',
-        ]);
+        ).toEqual(['translate(0, 35)', 'translate(0, 20)', 'translate(0, 50)']);
       });
 
       it('renders histogram in the "count" coordinate system', () => {

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
@@ -83,6 +83,7 @@ describe('histogram v2 test', () => {
   const byCss = {
     X_AXIS: By.css('.x-axis'),
     Y_AXIS: By.css('.y-axis'),
+    HISTOGRAMS: By.css('.histograms'),
   };
 
   beforeEach(async () => {
@@ -243,6 +244,134 @@ describe('histogram v2 test', () => {
         expect(
           getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
         ).toEqual(['0.00', '200', '400', '600', '800', '1.00e+3', '1.20e+3']);
+      });
+    });
+  });
+
+  describe('histogram render', () => {
+    function getGroupTransforms(element: DebugElement): string[] {
+      const transforms: string[] = [];
+      for (const debugEl of element.queryAll(By.css('.histogram'))) {
+        transforms.push(debugEl.attributes['transform']!);
+      }
+      return transforms;
+    }
+
+    function getHistogramPaths(element: DebugElement): string[] {
+      const pathD: string[] = [];
+      for (const debugEl of element.queryAll(By.css('path'))) {
+        pathD.push(debugEl.attributes['d']!);
+      }
+      return pathD;
+    }
+
+    describe('offset mode', () => {
+      it('positions group by their position in temporal axis', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0}),
+          buildHistogramDatum({step: 5}),
+          buildHistogramDatum({step: 10}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.detectChanges();
+
+        expect(
+          getGroupTransforms(fixture.debugElement.query(byCss.HISTOGRAMS))
+        ).toEqual([
+          // The content box is 30x50 pixels and because we need to render 2.5D
+          // on 2D screen, we give height / 2.5 space for histogram slices to
+          // render. 50 / 2.5 = 20 so effectively, step=0 is rendered at 20px
+          // from the top.
+          'translate(0, 20)',
+          'translate(0, 35)',
+          'translate(0, 50)',
+        ]);
+      });
+
+      it('moves the group position depending on the timeProperty', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: -200}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.detectChanges();
+
+        fixture.componentInstance.timeProperty = TimeProperty.WALL_TIME;
+        fixture.detectChanges();
+        expect(
+          getGroupTransforms(fixture.debugElement.query(byCss.HISTOGRAMS))
+        ).toEqual(['translate(0, 35)', 'translate(0, 20)', 'translate(0, 50)']);
+
+        fixture.componentInstance.timeProperty = TimeProperty.RELATIVE;
+        fixture.detectChanges();
+        // Even the RELATIVE time property takes minimum relative value to the
+        // max (-300, 300) which has the same spacing as the WALL_TIME.
+        expect(
+          getGroupTransforms(fixture.debugElement.query(byCss.HISTOGRAMS))
+        ).toEqual([
+          'translate(0, 20)',
+          'translate(0, 27.5)',
+          'translate(0, 50)',
+        ]);
+      });
+
+      it('renders histogram in the "count" coordinate system', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({
+            step: 0,
+            bins: [
+              buildBin({x: 0, dx: 10, y: 5}),
+              buildBin({x: 10, dx: 10, y: 10}),
+              buildBin({x: 20, dx: 10, y: 100}),
+            ],
+          }),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.detectChanges();
+
+        expect(
+          getHistogramPaths(fixture.debugElement.query(byCss.HISTOGRAMS))
+          // Do note that the histogram is rendered in 30x50 pixel box with
+          // 20 pixel max height for each histogram. So, with max_y = 100,
+          // y=0 is rendered at 0 while y=100 is rendered at -20.
+          // Since max_x - min_x = 30, which is equal to that of width of the
+          // element, we have x coordinate equal to pixel coordinate.
+          //
+          // M5,0: Starts from <center of first bin=5, pixel(0)>
+          // L5,-1: Line to <center of first bin=5, pixel(y_0)>
+          // L15,-2: Line to <pixel(15), pixel(y_1)>
+          // L25,-20: Line to <pixel(25), pixel(y_2)>
+          // L25,0: Last line back down to 0. <pixel(25), pixel(0)>
+        ).toEqual(['M5,0L5,-1L15,-2L25,-20L25,0Z']);
+      });
+    });
+
+    describe('overlay mode', () => {
+      it('renders histogram in the "count" coordinate system', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({
+            step: 0,
+            bins: [
+              buildBin({x: 0, dx: 10, y: 5}),
+              buildBin({x: 10, dx: 10, y: 10}),
+              buildBin({x: 20, dx: 10, y: 100}),
+            ],
+          }),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OVERLAY;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.detectChanges();
+
+        // Again, rendered in 30x50 box and histogram now spans 50px high!
+        // Do note that, unlike offset, <0, 0> starts from top-left corner so
+        // <0, 50> is the bottom.
+        expect(
+          getHistogramPaths(fixture.debugElement.query(byCss.HISTOGRAMS))
+        ).toEqual(['M5,50L5,47.5L15,45L25,0L25,50Z']);
       });
     });
   });


### PR DESCRIPTION
This change builds on top of the Angular version of the histograms
component where we had axex rendering implemented. This change finally
draws the histogram like the Polymer counterpart. Most of the UX
considerations are mostly replica of that of Polymer part and I did not
intend to have much changes besides minor color changes (now use theme
variable instead of hardcoded hex value).

This change does not include:
- interaction like tooltips
- redraw on resize

![image](https://user-images.githubusercontent.com/2547313/127409404-98b010d7-beb9-4d4a-8b3f-2af2abce0f59.png)
![image](https://user-images.githubusercontent.com/2547313/127409432-7112a5a5-b360-45d4-a463-8bd808eeaef4.png)
