### PR TITLE
Provide QueryParamsFeatureFlagDataSource implementation

### DIFF
--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_module.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_module.ts
@@ -20,6 +20,10 @@ import {QueryParamsFeatureFlagDataSource} from './tb_feature_flag_data_source';
 
 @NgModule({
   providers: [
+    // Provide as injectable for other app-level implementations of
+    // TBFeatureFlagDataSource.
+    QueryParamsFeatureFlagDataSource,
+    // Provide as the TBFeatureFlagDataSource implementation for the OSS app.
     {
       provide: TBFeatureFlagDataSource,
       useClass: QueryParamsFeatureFlagDataSource,


### PR DESCRIPTION
Provide QueryParamsFeatureFlagDataSource implementation in its raw form in addition to providing it as an implementation of TBFeatureFlagDataSource.

This allows other app-level implementations of TBFeatureFlagDataSource to inject QueryParamsFeatureFlagDataSource as a dependency and reuse the logic.

Longer term we have discussed possibly providing multiple TBFeatureFlagDataSource implementations and joining them at a higher level.