### PR TITLE
histogram: re-render on resize

### DIFF
--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -24,6 +24,7 @@ tf_ng_module(
         ":types",
         "//tensorboard/webapp:tb_polymer_interop_types",
         "//tensorboard/webapp/third_party:d3",
+        "//tensorboard/webapp/widgets:resize_detector",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],

--- a/tensorboard/webapp/widgets/histogram/histogram_module.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_module.ts
@@ -15,12 +15,13 @@ limitations under the License.
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
+import {ResizeDetectorModule} from '../resize_detector_module';
 import {HistogramComponent} from './histogram_component';
 import {HistogramV2Component} from './histogram_v2_component';
 
 @NgModule({
   declarations: [HistogramComponent, HistogramV2Component],
   exports: [HistogramComponent, HistogramV2Component],
-  imports: [CommonModule],
+  imports: [CommonModule, ResizeDetectorModule],
 })
 export class HistogramModule {}

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.ng.html
@@ -14,7 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div [class]="'main ' + mode + ' ' + timeProperty">
+<div
+  [class]="'main ' + mode + ' ' + timeProperty"
+  detectResize
+  (onResize)="onResize()"
+>
   <svg #xAxis class="axis x-axis"></svg>
   <svg #yAxis class="axis y-axis"></svg>
   <svg #content class="content">

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.ts
@@ -156,6 +156,12 @@ export class HistogramV2Component implements OnChanges {
     return yScale.ticks().map((tick) => yScale(tick));
   }
 
+  onResize() {
+    this.updateClientRects();
+    this.updateChart();
+    this.changeDetector.detectChanges();
+  }
+
   private getTimeValue(datum: HistogramDatum): number {
     switch (this.timeProperty) {
       case TimeProperty.WALL_TIME:

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, DebugElement, Input} from '@angular/core';
+import {Component, DebugElement, Input, NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -90,6 +90,7 @@ describe('histogram v2 test', () => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule],
       declarations: [HistogramV2Component, TestableComponent],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
 


### PR DESCRIPTION
This change integrates new histogram visualizer with ResizeDetector, a
directive that lets Angular component detect resizes.

After detecting resize, we re-measure the DOM, sets value on scale, then
trigger re-render.
