### PR TITLE
router: expose getExperimentIdsFromRouteParams and getRouteId

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -38,6 +38,7 @@ tf_ng_module(
     ],
     deps = [
         ":internal_utils",
+        ":programmatical_navigation_module",
         ":types",
     ],
 )

--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -38,7 +38,6 @@ tf_ng_module(
     ],
     deps = [
         ":internal_utils",
-        ":programmatical_navigation_module",
         ":types",
     ],
 )

--- a/tensorboard/webapp/app_routing/store_only_utils.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils.ts
@@ -18,8 +18,7 @@ import {
   parseCompareExperimentStr,
   serializeCompareExperimentParams,
 } from './internal_utils';
-import {CompareRouteParams, RouteKind, RouteParams} from './types';
-import {ProgrammaticalNavigation} from './programmatical_navigation_types';
+import {CompareRouteParams, Route} from './types';
 
 // Ideally, we would not be exposing this utility method this, but there is no
 // way to share the structured information to other stores without changing
@@ -41,18 +40,6 @@ export function getCompareExperimentIdAliasSpec(
   return idToDisplayName;
 }
 
-function getRouteParamsFromNavigation(
-  navigation: ProgrammaticalNavigation
-): RouteParams {
-  return navigation.routeKind === RouteKind.COMPARE_EXPERIMENT
-    ? {
-        experimentIds: serializeCompareExperimentParams(
-          navigation.routeParams.aliasAndExperimentIds
-        ),
-      }
-    : navigation.routeParams;
-}
-
 /**
  * Returns experimentIds from navigation.
  *
@@ -60,11 +47,11 @@ function getRouteParamsFromNavigation(
  * BUILD.
  */
 export function getExperimentIdsFromNavigation(
-  navigation: ProgrammaticalNavigation
+  navigation: Route
 ): string[] | null {
   return getExperimentIdsFromRouteParams(
     navigation.routeKind,
-    getRouteParamsFromNavigation(navigation)
+    navigation.params
   );
 }
 
@@ -74,11 +61,6 @@ export function getExperimentIdsFromNavigation(
  * This utility is used by only limited packages. Please refer to visiblity in
  * BUILD.
  */
-export function getRouteIdFromNavigation(
-  navigation: ProgrammaticalNavigation
-): string {
-  return getRouteId(
-    navigation.routeKind,
-    getRouteParamsFromNavigation(navigation)
-  );
+export function getRouteIdFromNavigation(navigation: Route): string {
+  return getRouteId(navigation.routeKind, navigation.params);
 }

--- a/tensorboard/webapp/app_routing/store_only_utils.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils.ts
@@ -12,8 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {parseCompareExperimentStr} from './internal_utils';
-import {CompareRouteParams} from './types';
+import {
+  getExperimentIdsFromRouteParams,
+  getRouteId,
+  parseCompareExperimentStr,
+  serializeCompareExperimentParams,
+} from './internal_utils';
+import {CompareRouteParams, RouteKind, RouteParams} from './types';
+import {ProgrammaticalNavigation} from './programmatical_navigation_types';
 
 // Ideally, we would not be exposing this utility method this, but there is no
 // way to share the structured information to other stores without changing
@@ -33,4 +39,46 @@ export function getCompareExperimentIdAliasSpec(
     idToDisplayName.set(id, name);
   }
   return idToDisplayName;
+}
+
+function getRouteParamsFromNavigation(
+  navigation: ProgrammaticalNavigation
+): RouteParams {
+  return navigation.routeKind === RouteKind.COMPARE_EXPERIMENT
+    ? {
+        experimentIds: serializeCompareExperimentParams(
+          navigation.routeParams.aliasAndExperimentIds
+        ),
+      }
+    : navigation.routeParams;
+}
+
+/**
+ * Returns experimentIds from navigation.
+ *
+ * This utility is used by only limited packages. Please refer to visiblity in
+ * BUILD.
+ */
+export function getExperimentIdsFromNavigation(
+  navigation: ProgrammaticalNavigation
+): string[] | null {
+  return getExperimentIdsFromRouteParams(
+    navigation.routeKind,
+    getRouteParamsFromNavigation(navigation)
+  );
+}
+
+/**
+ * Returns routeId from navigation.
+ *
+ * This utility is used by only limited packages. Please refer to visiblity in
+ * BUILD.
+ */
+export function getRouteIdFromNavigation(
+  navigation: ProgrammaticalNavigation
+): string {
+  return getRouteId(
+    navigation.routeKind,
+    getRouteParamsFromNavigation(navigation)
+  );
 }

--- a/tensorboard/webapp/app_routing/store_only_utils_test.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils_test.ts
@@ -13,7 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {getCompareExperimentIdAliasSpec} from './store_only_utils';
+import {
+  getCompareExperimentIdAliasSpec,
+  getExperimentIdsFromNavigation,
+  getRouteIdFromNavigation,
+} from './store_only_utils';
+import {RouteKind} from './types';
 
 describe('app_routing store_only_utils test', () => {
   describe('#getCompareExperimentIdAliasSpec', () => {
@@ -42,6 +47,68 @@ describe('app_routing store_only_utils test', () => {
           experimentIds: '',
         })
       ).toThrow();
+    });
+  });
+
+  describe('#getExperimentIdsFromNavigation', () => {
+    it('returns experiment ids from COMPARE_EXPERIMENT route', () => {
+      const actual = getExperimentIdsFromNavigation({
+        routeKind: RouteKind.COMPARE_EXPERIMENT,
+        routeParams: {
+          aliasAndExperimentIds: [
+            {alias: 'bar', id: '1'},
+            {alias: 'omega', id: '2'},
+          ],
+        },
+      });
+      expect(actual).toEqual(['1', '2']);
+    });
+
+    it('returns experiment id from EXPERIMENT route', () => {
+      const actual = getExperimentIdsFromNavigation({
+        routeKind: RouteKind.EXPERIMENT,
+        routeParams: {experimentId: '1234'},
+      });
+      expect(actual).toEqual(['1234']);
+    });
+
+    it('returns null from EXPERIMENTS route', () => {
+      const actual = getExperimentIdsFromNavigation({
+        routeKind: RouteKind.EXPERIMENTS,
+        routeParams: {},
+      });
+      expect(actual).toBeNull();
+    });
+  });
+
+  describe('#getRouteIdFromNavigation', () => {
+    it('returns route ids from COMPARE_EXPERIMENT route', () => {
+      const actual = getRouteIdFromNavigation({
+        routeKind: RouteKind.COMPARE_EXPERIMENT,
+        routeParams: {
+          aliasAndExperimentIds: [
+            {alias: 'bar', id: '1'},
+            {alias: 'omega', id: '2'},
+          ],
+        },
+      });
+      expect(actual).toEqual(`${RouteKind.COMPARE_EXPERIMENT}/1,2`);
+    });
+
+    it('returns route id from EXPERIMENT route', () => {
+      const actual = getRouteIdFromNavigation({
+        routeKind: RouteKind.EXPERIMENT,
+        routeParams: {experimentId: '1234'},
+      });
+      expect(actual).toEqual(`${RouteKind.EXPERIMENT}/1234`);
+    });
+
+    it('returns route id from EXPERIMENTS route', () => {
+      const actual = getRouteIdFromNavigation({
+        routeKind: RouteKind.EXPERIMENTS,
+        routeParams: {},
+      });
+      expect(actual).toEqual(`${RouteKind.EXPERIMENTS}`);
     });
   });
 });

--- a/tensorboard/webapp/app_routing/store_only_utils_test.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils_test.ts
@@ -18,6 +18,7 @@ import {
   getExperimentIdsFromNavigation,
   getRouteIdFromNavigation,
 } from './store_only_utils';
+import {buildRoute} from './testing';
 import {RouteKind} from './types';
 
 describe('app_routing store_only_utils test', () => {
@@ -52,62 +53,76 @@ describe('app_routing store_only_utils test', () => {
 
   describe('#getExperimentIdsFromNavigation', () => {
     it('returns experiment ids from COMPARE_EXPERIMENT route', () => {
-      const actual = getExperimentIdsFromNavigation({
-        routeKind: RouteKind.COMPARE_EXPERIMENT,
-        routeParams: {
-          aliasAndExperimentIds: [
-            {alias: 'bar', id: '1'},
-            {alias: 'omega', id: '2'},
-          ],
-        },
-      });
+      const actual = getExperimentIdsFromNavigation(
+        buildRoute({
+          routeKind: RouteKind.COMPARE_EXPERIMENT,
+          params: {experimentIds: 'e1:1,e2:2'},
+          pathname: '/compare',
+          queryParams: [],
+        })
+      );
       expect(actual).toEqual(['1', '2']);
     });
 
     it('returns experiment id from EXPERIMENT route', () => {
-      const actual = getExperimentIdsFromNavigation({
-        routeKind: RouteKind.EXPERIMENT,
-        routeParams: {experimentId: '1234'},
-      });
+      const actual = getExperimentIdsFromNavigation(
+        buildRoute({
+          routeKind: RouteKind.EXPERIMENT,
+          params: {experimentId: '1234'},
+          pathname: '/experiment',
+          queryParams: [],
+        })
+      );
       expect(actual).toEqual(['1234']);
     });
 
     it('returns null from EXPERIMENTS route', () => {
-      const actual = getExperimentIdsFromNavigation({
-        routeKind: RouteKind.EXPERIMENTS,
-        routeParams: {},
-      });
+      const actual = getExperimentIdsFromNavigation(
+        buildRoute({
+          routeKind: RouteKind.EXPERIMENTS,
+          params: {},
+          pathname: '/experiments',
+          queryParams: [],
+        })
+      );
       expect(actual).toBeNull();
     });
   });
 
   describe('#getRouteIdFromNavigation', () => {
     it('returns route ids from COMPARE_EXPERIMENT route', () => {
-      const actual = getRouteIdFromNavigation({
-        routeKind: RouteKind.COMPARE_EXPERIMENT,
-        routeParams: {
-          aliasAndExperimentIds: [
-            {alias: 'bar', id: '1'},
-            {alias: 'omega', id: '2'},
-          ],
-        },
-      });
+      const actual = getRouteIdFromNavigation(
+        buildRoute({
+          routeKind: RouteKind.COMPARE_EXPERIMENT,
+          params: {experimentIds: 'e1:1,e2:2'},
+          pathname: '/compare',
+          queryParams: [],
+        })
+      );
       expect(actual).toEqual(`${RouteKind.COMPARE_EXPERIMENT}/1,2`);
     });
 
     it('returns route id from EXPERIMENT route', () => {
-      const actual = getRouteIdFromNavigation({
-        routeKind: RouteKind.EXPERIMENT,
-        routeParams: {experimentId: '1234'},
-      });
+      const actual = getRouteIdFromNavigation(
+        buildRoute({
+          routeKind: RouteKind.EXPERIMENT,
+          params: {experimentId: '1234'},
+          pathname: '/experiment',
+          queryParams: [],
+        })
+      );
       expect(actual).toEqual(`${RouteKind.EXPERIMENT}/1234`);
     });
 
     it('returns route id from EXPERIMENTS route', () => {
-      const actual = getRouteIdFromNavigation({
-        routeKind: RouteKind.EXPERIMENTS,
-        routeParams: {},
-      });
+      const actual = getRouteIdFromNavigation(
+        buildRoute({
+          routeKind: RouteKind.EXPERIMENTS,
+          params: {},
+          pathname: '/experiments',
+          queryParams: [],
+        })
+      );
       expect(actual).toEqual(`${RouteKind.EXPERIMENTS}`);
     });
   });


### PR DESCRIPTION
Expose `getExperimentIdsFromRouteParams` and `getRouteId` as external utils, `experimentIds` and `routeId` will be able to be retrieved from navigation.
