### PR TITLE
widget: intersection observer directive

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -334,6 +334,8 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/widgets:resize_detector_testing",
         "//tensorboard/webapp/widgets/filter_input:filter_input_test",
         "//tensorboard/webapp/widgets/histogram:histogram_test",
+        "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_test",
+        "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",
         "//tensorboard/webapp/widgets/line_chart_v2:line_chart_v2_tests",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:lib_tests",
         "//tensorboard/webapp/widgets/line_chart_v2/lib/renderer:renderer_test",

--- a/tensorboard/webapp/widgets/intersection_observer/BUILD
+++ b/tensorboard/webapp/widgets/intersection_observer/BUILD
@@ -1,0 +1,44 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])
+
+tf_ng_module(
+    name = "intersection_observer",
+    srcs = [
+        "intersection_observer_directive.ts",
+        "intersection_observer_module.ts",
+    ],
+    deps = [
+        "@npm//@angular/core",
+        "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "intersection_observer_test",
+    testonly = True,
+    srcs = [
+        "intersection_observer_test.ts",
+    ],
+    deps = [
+        ":intersection_observer",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "@npm//@angular/core",
+        "@npm//@types/jasmine",
+    ],
+)
+
+tf_ng_module(
+    name = "intersection_observer_testing",
+    testonly = True,
+    srcs = [
+        "intersection_observer_testing_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+    ],
+)

--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_directive.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_directive.ts
@@ -1,0 +1,59 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  OnDestroy,
+  Output,
+} from '@angular/core';
+import {Subject} from 'rxjs';
+import {take, takeUntil} from 'rxjs/operators';
+
+/**
+ * A directive that calls `onVisibilityChange` when element visiblity changes.
+ */
+@Directive({selector: '[observeIntersection]'})
+export class IntersectionObserverDirective implements OnDestroy {
+  @Output() onVisibilityChange = new EventEmitter<{visible: boolean}>();
+
+  private readonly ngUnsubscribe$ = new Subject();
+  private readonly onEvent$ = new Subject<IntersectionObserverEntry[]>();
+
+  constructor(ref: ElementRef) {
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      this.onEvent$.next(entries);
+    });
+    intersectionObserver.observe(ref.nativeElement);
+    this.ngUnsubscribe$.subscribe(() => {
+      intersectionObserver.unobserve(ref.nativeElement);
+    });
+    this.onEvent$.pipe(takeUntil(this.ngUnsubscribe$)).subscribe((entries) => {
+      const lastEntry = entries.slice(-1)[0];
+      this.onVisibilityChange.emit({visible: lastEntry.isIntersecting});
+    });
+  }
+
+  ngOnDestroy() {
+    this.ngUnsubscribe$.next();
+    this.ngUnsubscribe$.complete();
+  }
+
+  waitForEventForTestOnly(): Promise<void> {
+    return new Promise((resolve) => {
+      return this.onEvent$.pipe(take(1)).subscribe(() => resolve());
+    });
+  }
+}

--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_module.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_module.ts
@@ -1,0 +1,23 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+
+import {IntersectionObserverDirective} from './intersection_observer_directive';
+
+@NgModule({
+  exports: [IntersectionObserverDirective],
+  declarations: [IntersectionObserverDirective],
+})
+export class IntersectionObserverModule {}

--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_testing_module.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_testing_module.ts
@@ -1,0 +1,39 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Directive, EventEmitter, NgModule, Output} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+@Directive({selector: '[observeIntersection]'})
+class IntersectionObserverTestingDirective {
+  @Output() onVisibilityChange = new EventEmitter<{visible: boolean}>();
+
+  simulateVisibilityChange(visible: boolean) {
+    this.onVisibilityChange.emit({visible});
+  }
+}
+
+@NgModule({
+  exports: [IntersectionObserverTestingDirective],
+  declarations: [IntersectionObserverTestingDirective],
+})
+export class IntersectionObserverTestingModule {
+  simulateVisibilityChange<T>(fixture: ComponentFixture<T>, visible: boolean) {
+    const directive = fixture.debugElement
+      .query(By.directive(IntersectionObserverTestingDirective))
+      .injector.get(IntersectionObserverTestingDirective);
+    directive.simulateVisibilityChange(visible);
+  }
+}


### PR DESCRIPTION
TensorBoard had use IntersectionObserver so optimize for rendering.
Since we have done that manually several times, we are now widgetizing
it so it is easier to create an element that would use the relatively
new browser API.
