### PR TITLE
lint: fix g3-no-void-expression lint failure

### DIFF
--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_directive.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_directive.ts
@@ -53,7 +53,9 @@ export class IntersectionObserverDirective implements OnDestroy {
 
   waitForEventForTestOnly(): Promise<void> {
     return new Promise((resolve) => {
-      return this.onEvent$.pipe(take(1)).subscribe(() => resolve());
+      return this.onEvent$.pipe(take(1)).subscribe(() => {
+        resolve();
+      });
     });
   }
 }


### PR DESCRIPTION
See [g3-no-void-expression](go/tslintrule/g3-no-void-expression) for details.