### PR TITLE
linked time: add basic data model

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -134,3 +134,17 @@ export const cardPinStateToggled = createAction(
   '[Metrics] Card Pin State Toggled',
   props<{cardId: CardId; canCreateNewPins: boolean; wasPinned: boolean}>()
 );
+
+export const timeSelectionChanged = createAction(
+  '[Metrics] Linked Time Selection Changed',
+  props<{
+    startStep: number;
+    startWallTime: number;
+    endStep?: number;
+    endWallTime?: number;
+  }>()
+);
+
+export const timeSelectionCleared = createAction(
+  '[Metrics] Linked Time Selection Cleared'
+);

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -210,7 +210,10 @@ function serializeCardUniqueInfo(
   return JSON.stringify([plugin, tag, runId || '', sample]);
 }
 
-const {initialState, reducers: routeContextReducer} = createRouteContextedState(
+const {initialState, reducers: routeContextReducer} = createRouteContextedState<
+  MetricsRoutefulState,
+  MetricsRoutelessState
+>(
   {
     // Backend data.
     tagMetadataLoaded: DataLoadState.NOT_LOADED,
@@ -239,8 +242,8 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState(
 
     tagFilter: '',
     tagGroupExpanded: new Map<string, boolean>(),
-  } as MetricsRoutefulState,
-
+    selectedTime: null,
+  },
   {
     timeSeriesData: {
       scalars: {},
@@ -250,7 +253,7 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState(
     settings: METRICS_SETTINGS_DEFAULT,
     settingOverrides: {},
     visibleCards: new Set<CardId>(),
-  } as MetricsRoutelessState,
+  },
 
   /** onRouteIdChanged */
   (state) => {
@@ -804,6 +807,27 @@ const reducer = createReducer(
       cardStepIndex: nextCardStepIndexMap,
       cardToPinnedCopy: nextCardToPinnedCopy,
       pinnedCardToOriginal: nextPinnedCardToOriginal,
+    };
+  }),
+  on(actions.timeSelectionChanged, (state, change) => {
+    return {
+      ...state,
+      selectedTime: {
+        start: {step: change.startStep, wallTime: change.startWallTime},
+        end:
+          change.endStep === undefined || change.endWallTime === undefined
+            ? null
+            : {
+                step: change.endStep,
+                wallTime: change.endWallTime,
+              },
+      },
+    };
+  }),
+  on(actions.timeSelectionCleared, (state) => {
+    return {
+      ...state,
+      selectedTime: null,
     };
   })
 );

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1787,4 +1787,77 @@ describe('metrics reducers', () => {
       }
     );
   });
+
+  describe('linked time features', () => {
+    describe('#timeSelectionChanged', () => {
+      it('sets the selected times value', () => {
+        const beforeState = buildMetricsState({
+          selectedTime: null,
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.timeSelectionChanged({
+            startStep: 2,
+            startWallTime: -1,
+          })
+        );
+
+        expect(nextState.selectedTime).toEqual({
+          start: {
+            step: 2,
+            wallTime: -1,
+          },
+          end: null,
+        });
+      });
+
+      it('sets `end` when both `endStep` and `endWallTime` are present', () => {
+        const state1 = buildMetricsState({
+          selectedTime: null,
+        });
+
+        const state2 = reducers(
+          state1,
+          actions.timeSelectionChanged({
+            startStep: 2,
+            startWallTime: -1,
+            endWallTime: -1,
+          })
+        );
+
+        expect(state2.selectedTime).toEqual({
+          start: {step: 2, wallTime: -1},
+          end: null,
+        });
+
+        const state3 = reducers(
+          state2,
+          actions.timeSelectionChanged({
+            startStep: 2,
+            startWallTime: -1,
+            endWallTime: -1,
+            endStep: 4,
+          })
+        );
+
+        expect(state3.selectedTime).toEqual({
+          start: {step: 2, wallTime: -1},
+          end: {step: 4, wallTime: -1},
+        });
+      });
+    });
+
+    describe('#timeSelectionCleared', () => {
+      it('clears selected time', () => {
+        const beforeState = buildMetricsState({
+          selectedTime: {start: {step: 4, wallTime: -1}, end: null},
+        });
+
+        const nextState = reducers(beforeState, actions.timeSelectionCleared());
+
+        expect(nextState.selectedTime).toBeNull();
+      });
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -31,6 +31,7 @@ import {
 import * as storeUtils from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
+  LinkedTime,
   MetricsSettings,
   MetricsState,
   METRICS_FEATURE_KEY,
@@ -331,5 +332,12 @@ export const getMetricsTagGroupExpansionState = createSelector(
   selectMetricsState,
   (state: MetricsState, tagGroup: string): boolean => {
     return Boolean(state.tagGroupExpanded.get(tagGroup));
+  }
+);
+
+export const getMetricsSelectedTime = createSelector(
+  selectMetricsState,
+  (state: MetricsState): LinkedTime | null => {
+    return state.selectedTime;
   }
 );

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -705,4 +705,34 @@ describe('metrics selectors', () => {
       );
     });
   });
+
+  describe('getMetricsSelectedTime', () => {
+    beforeEach(() => {
+      selectors.getMetricsSelectedTime.release();
+    });
+
+    it('returns `null` when selected time is null', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          selectedTime: null,
+        })
+      );
+      expect(selectors.getMetricsSelectedTime(state)).toBeNull();
+    });
+
+    it('returns value when selected time is present', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          selectedTime: {
+            start: {step: 0, wallTime: 2000},
+            end: null,
+          },
+        })
+      );
+      expect(selectors.getMetricsSelectedTime(state)).toEqual({
+        start: {step: 0, wallTime: 2000},
+        end: null,
+      });
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -126,6 +126,11 @@ export type CardStepIndexMap = Record<
   number | null
 >;
 
+export interface LinkedTime {
+  start: {step: number; wallTime: number};
+  end: {step: number; wallTime: number} | null;
+}
+
 export type CardToPinnedCard = Map<NonPinnedCardId, PinnedCardId>;
 
 export type PinnedCardToCard = Map<PinnedCardId, NonPinnedCardId>;
@@ -151,6 +156,7 @@ export interface MetricsRoutefulState {
   cardStepIndex: CardStepIndexMap;
   tagFilter: string;
   tagGroupExpanded: Map<string, boolean>;
+  selectedTime: LinkedTime | null;
 }
 
 export interface MetricsSettings {

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -89,6 +89,7 @@ function buildBlankState(): MetricsState {
     visibleCards: new Set(),
     tagFilter: '',
     tagGroupExpanded: new Map(),
+    selectedTime: null,
   };
 }
 


### PR DESCRIPTION
This change adds basic reducers for setting and changing linked time
value. The states and actions in this changeset is highly experimental
and is prone for changes in the future when we implement UI features
along with it.
