### PR TITLE
Remove unnecessary statements in http_util.py.

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -197,13 +197,6 @@ def Respond(
         headers.append(("Expires", "0"))
         headers.append(("Cache-Control", "no-cache, must-revalidate"))
     if mimetype == _HTML_MIMETYPE:
-        _CSP_IMG_DOMAINS_WHITELIST
-        _CSP_STYLE_DOMAINS_WHITELIST
-        _CSP_FONT_DOMAINS_WHITELIST
-        _CSP_FRAME_DOMAINS_WHITELIST
-        _CSP_SCRIPT_DOMAINS_WHITELIST
-        _CSP_CONNECT_DOMAINS_WHITELIST
-
         frags = (
             _CSP_SCRIPT_DOMAINS_WHITELIST
             + [


### PR DESCRIPTION
There are several statements in http_util.py that are just the names of some lists.
They don't seem to have any impact.
They are likely artifacts from previous refactoring.

We remove them.