### PR TITLE
Replace QueryParamsFeatureFlagDataSource.getParams() with injectable class.

### DIFF
--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -93,6 +93,7 @@ tf_ng_module(
     srcs = [
         "tb_feature_flag_data_source.ts",
         "tb_feature_flag_module.ts",
+        "query_params.ts",
     ],
     deps = [
         ":feature_flag_types",

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -91,9 +91,9 @@ tf_ng_module(
 tf_ng_module(
     name = "feature_flag",
     srcs = [
+        "query_params.ts",
         "tb_feature_flag_data_source.ts",
         "tb_feature_flag_module.ts",
-        "query_params.ts",
     ],
     deps = [
         ":feature_flag_types",

--- a/tensorboard/webapp/webapp_data_source/query_params.ts
+++ b/tensorboard/webapp/webapp_data_source/query_params.ts
@@ -1,0 +1,28 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+
+/**
+ * Save the initial URL query params before the AppRoutingEffects initialize.
+ */
+const initialURLSearchParams = new URLSearchParams(window.location.search);
+
+@Injectable()
+export class QueryParams {
+  public getParams() {
+    return initialURLSearchParams;
+  }
+}
+

--- a/tensorboard/webapp/webapp_data_source/query_params.ts
+++ b/tensorboard/webapp/webapp_data_source/query_params.ts
@@ -25,4 +25,3 @@ export class QueryParams {
     return initialURLSearchParams;
   }
 }
-

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -23,17 +23,7 @@ import {
   TBFeatureFlagDataSource,
 } from './tb_feature_flag_data_source_types';
 import {FeatureFlags} from '../feature_flag/types';
-
-/**
- * Save the initial URL query params, before the AppRoutingEffects initialize.
- */
-const initialURLSearchParams = new URLSearchParams(window.location.search);
-
-const util = {
-  getParams() {
-    return initialURLSearchParams;
-  },
-};
+import {QueryParams} from './query_params';
 
 const DARK_MODE_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 
@@ -41,9 +31,11 @@ const DARK_MODE_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 // it also sources the data from media query as well as the query parameter.
 // Decide how to move forward with more sources of the data + composability.
 @Injectable()
-export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
+export class QueryParamsFeatureFlagDataSource implements TBFeatureFlagDataSource {
+  constructor(readonly queryParamsDataSource: QueryParams) {}
+
   getFeatures(enableMediaQuery: boolean = false) {
-    const params = this.getParams();
+    const params = this.queryParamsDataSource.getParams();
     // Set feature flag value for query parameters that are explicitly
     // specified. Feature flags for unspecified query parameters remain unset so
     // their values in the underlying state are not inadvertently changed.
@@ -82,10 +74,6 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
     return featureFlags;
   }
 
-  protected getParams() {
-    return util.getParams();
-  }
-
   protected getPartialFeaturesFromMediaQuery(): {
     defaultEnableDarkMode?: boolean;
   } {
@@ -103,4 +91,4 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
   }
 }
 
-export const TEST_ONLY = {util, DARK_MODE_MEDIA_QUERY};
+export const TEST_ONLY = {DARK_MODE_MEDIA_QUERY};

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -24,7 +24,6 @@ import {
   SCALARS_BATCH_SIZE_PARAM_KEY,
   TBFeatureFlagDataSource,
 } from './tb_feature_flag_data_source_types';
-import {FeatureFlags} from '../feature_flag/types';
 import {QueryParams} from './query_params';
 
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -26,18 +26,18 @@ import {
 } from './tb_feature_flag_data_source_types';
 import {QueryParams} from './query_params';
 
-
 const DARK_MODE_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 
 // TODO(tensorboard-team): QueryParamsFeatureFlagDataSource now is a misnomer as
 // it also sources the data from media query as well as the query parameter.
 // Decide how to move forward with more sources of the data + composability.
 @Injectable()
-export class QueryParamsFeatureFlagDataSource implements TBFeatureFlagDataSource {
-  constructor(readonly queryParamsDataSource: QueryParams) {}
+export class QueryParamsFeatureFlagDataSource
+  implements TBFeatureFlagDataSource {
+  constructor(readonly queryParams: QueryParams) {}
 
   getFeatures(enableMediaQuery: boolean = false) {
-    const params = this.queryParamsDataSource.getParams();
+    const params = this.queryParams.getParams();
     // Set feature flag value for query parameters that are explicitly
     // specified. Feature flags for unspecified query parameters remain unset so
     // their values in the underlying state are not inadvertently changed.

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {TestBed} from '@angular/core/testing';
+import {QueryParams} from './query_params';
 
 import {
   QueryParamsFeatureFlagDataSource,
@@ -23,28 +24,31 @@ describe('tb_feature_flag_data_source', () => {
   describe('QueryParamsFeatureFlagDataSource', () => {
     let dataSource: QueryParamsFeatureFlagDataSource;
     let matchMediaSpy: jasmine.Spy;
+    let getParamsSpy: jasmine.Spy;
 
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        providers: [QueryParamsFeatureFlagDataSource],
+        providers: [QueryParamsFeatureFlagDataSource, QueryParams],
       }).compileComponents();
 
       dataSource = TestBed.inject(QueryParamsFeatureFlagDataSource);
       matchMediaSpy = spyOn(window, 'matchMedia').and.returnValue({
         matches: false,
       } as MediaQueryList);
+
+      getParamsSpy = spyOn(TestBed.inject(QueryParams), 'getParams').and.returnValue(new URLSearchParams(''));
     });
 
     describe('getFeatures', () => {
       it('returns empty values when params are empty', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+        getParamsSpy.and.returnValue(
           new URLSearchParams('')
         );
         expect(dataSource.getFeatures()).toEqual({});
       });
 
       it('returns enabledExperimentalPlugins from the query params', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+        getParamsSpy.and.returnValue(
           new URLSearchParams('experimentalPlugin=a&experimentalPlugin=b')
         );
         expect(dataSource.getFeatures()).toEqual({
@@ -53,28 +57,28 @@ describe('tb_feature_flag_data_source', () => {
       });
 
       it('returns inColab=false when `tensorboardColab` is empty', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+        getParamsSpy.and.returnValue(
           new URLSearchParams('tensorboardColab')
         );
         expect(dataSource.getFeatures()).toEqual({inColab: false});
       });
 
       it('returns inColab=true when `tensorboardColab` is`true`', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+        getParamsSpy.and.returnValue(
           new URLSearchParams('tensorboardColab=true')
         );
         expect(dataSource.getFeatures()).toEqual({inColab: true});
       });
 
       it('returns inColab=false when `tensorboardColab` is `false`', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+        getParamsSpy.and.returnValue(
           new URLSearchParams('tensorboardColab=false')
         );
         expect(dataSource.getFeatures()).toEqual({inColab: false});
       });
 
       it('returns scalarsBatchSize from the query params', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+        getParamsSpy.and.returnValue(
           new URLSearchParams('scalarsBatchSize=12')
         );
         expect(dataSource.getFeatures()).toEqual({
@@ -83,7 +87,7 @@ describe('tb_feature_flag_data_source', () => {
       });
 
       it('returns enableColorGroup from the query params', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValues(
+        getParamsSpy.and.returnValues(
           new URLSearchParams('enableColorGroup=false'),
           new URLSearchParams('enableColorGroup='),
           new URLSearchParams('enableColorGroup=true'),
@@ -96,7 +100,7 @@ describe('tb_feature_flag_data_source', () => {
       });
 
       it('returns enableColorGroupByRegex from the query params', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValues(
+        getParamsSpy.and.returnValues(
           new URLSearchParams('enableColorGroupByRegex=false'),
           new URLSearchParams('enableColorGroupByRegex='),
           new URLSearchParams('enableColorGroupByRegex=true'),
@@ -117,7 +121,7 @@ describe('tb_feature_flag_data_source', () => {
       });
 
       it('returns all flag values when they are all set', () => {
-        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+        getParamsSpy.and.returnValue(
           new URLSearchParams(
             'experimentalPlugin=a' +
               '&tensorboardColab' +

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -36,14 +36,15 @@ describe('tb_feature_flag_data_source', () => {
         matches: false,
       } as MediaQueryList);
 
-      getParamsSpy = spyOn(TestBed.inject(QueryParams), 'getParams').and.returnValue(new URLSearchParams(''));
+      getParamsSpy = spyOn(
+        TestBed.inject(QueryParams),
+        'getParams'
+      ).and.returnValue(new URLSearchParams(''));
     });
 
     describe('getFeatures', () => {
       it('returns empty values when params are empty', () => {
-        getParamsSpy.and.returnValue(
-          new URLSearchParams('')
-        );
+        getParamsSpy.and.returnValue(new URLSearchParams(''));
         expect(dataSource.getFeatures()).toEqual({});
       });
 
@@ -57,9 +58,7 @@ describe('tb_feature_flag_data_source', () => {
       });
 
       it('returns inColab=false when `tensorboardColab` is empty', () => {
-        getParamsSpy.and.returnValue(
-          new URLSearchParams('tensorboardColab')
-        );
+        getParamsSpy.and.returnValue(new URLSearchParams('tensorboardColab'));
         expect(dataSource.getFeatures()).toEqual({inColab: false});
       });
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_module.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_module.ts
@@ -17,12 +17,14 @@ import {NgModule} from '@angular/core';
 
 import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
 import {QueryParamsFeatureFlagDataSource} from './tb_feature_flag_data_source';
+import {QueryParams} from './query_params';
 
 @NgModule({
   providers: [
     // Provide as injectable for other app-level implementations of
     // TBFeatureFlagDataSource.
     QueryParamsFeatureFlagDataSource,
+    QueryParams,
     // Provide as the TBFeatureFlagDataSource implementation for the OSS app.
     {
       provide: TBFeatureFlagDataSource,


### PR DESCRIPTION
This PR refactors internals of a class that are referenced in several places in the Google-internal repo. I have an accompagnying CL to submit "atomically" with these changes: cl/388460177

Replace QueryParamsFeatureFlagDataSource.getParams() with a dedicated injectable QueryParams class.

QueryParams simplifies testing for some TBFeatureFlagDataSource implementations by:
1) providing a single class that needs to be mocked/stubbed.
2) eliminating the need to peek into the implementations of other TBFeatureFlagDataSource implementations.

Googlers, see the type of pattern I'm attempting to fix in this parallel internal CL:
cl/388460177
