### PR TITLE
color group: set run color for ones without color assignment

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
@@ -72,7 +72,9 @@ export class CardViewContainer {
       map((colorMap) => {
         return (runId: string) => {
           if (!colorMap.hasOwnProperty(runId)) {
-            throw new Error(`[Color scale] unknown runId: ${runId}.`);
+            // Assign white when no colors are assigned to a run by user or
+            // by color grouping scheme.
+            return '#fff';
           }
           return colorMap[runId];
         };


### PR DESCRIPTION
With the color groupign feature, not all runs have color assigned. For
those without a color assignment, we would like to show gray or white
color and it is now a responsibility of the view to choose the color.
This change makes it so that when a color is not present in the
assignment map, we return `#fff` instead of throwing an invariant error.
