### PR TITLE
linked time: scalar single time step visuals

### DIFF
--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -94,3 +94,8 @@ export interface URLDeserializedState {
 
 export const SCALARS_SMOOTHING_MIN = 0;
 export const SCALARS_SMOOTHING_MAX = 0.999;
+
+export interface LinkedTime {
+  start: {step: number; wallTime: number};
+  end: {step: number; wallTime: number} | null;
+}

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -23,6 +23,7 @@ import {
   CardMetadata,
   CardUniqueInfo,
   HistogramMode,
+  LinkedTime,
   NonPinnedCardId,
   PinnedCardId,
   TooltipSort,
@@ -31,7 +32,6 @@ import {
 import * as storeUtils from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
-  LinkedTime,
   MetricsSettings,
   MetricsState,
   METRICS_FEATURE_KEY,

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -34,6 +34,7 @@ import {
   PinnedCardId,
   TooltipSort,
   XAxisType,
+  LinkedTime,
 } from '../internal_types';
 
 export const METRICS_FEATURE_KEY = 'metrics';
@@ -125,11 +126,6 @@ export type CardStepIndexMap = Record<
   NonPinnedCardId | PinnedCardId,
   number | null
 >;
-
-export interface LinkedTime {
-  start: {step: number; wallTime: number};
-  end: {step: number; wallTime: number} | null;
-}
 
 export type CardToPinnedCard = Map<NonPinnedCardId, PinnedCardId>;
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -109,6 +109,7 @@ limitations under the License.
       [tooltipTemplate]="tooltip"
       [useDarkMode]="useDarkMode"
       (onViewBoxOverridden)="isViewBoxOverridden = $event"
+      [customVisTemplate]="lineChartCustomVis"
     ></line-chart>
   </ng-container>
 
@@ -157,3 +158,25 @@ limitations under the License.
     </table>
   </ng-template>
 </div>
+
+<ng-template
+  #lineChartCustomVis
+  let-viewExtent="viewExtent"
+  let-domDim="domDimension"
+  let-xScale="xScale"
+>
+  <ng-container *ngIf="selectedTime">
+    <div *ngIf="!selectedTime.end" class="selected-time-single">
+      <div
+        class="selected-time-line"
+        [style.left]="
+          xScale.forward(
+            viewExtent.x,
+            [0, domDim.width],
+            selectedTime.start.step
+          ) + 'px'
+        "
+      ></div>
+    </div>
+  </ng-container>
+</ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -113,3 +113,20 @@ $_title-to-heading-gap: 12px;
     box-shadow: inset 0 0 0 1px #fff;
   }
 }
+
+.selected-time-single {
+  height: 100%;
+  position: relative;
+  width: 100%;
+
+  .selected-time-line {
+    $_border-width: 2px;
+    border-left: $_border-width dashed currentColor;
+    height: 100%;
+    // border is 2px.
+    // Center the line by offseting 1px to the left since the width of the
+    margin-left: -$_border-width / 2;
+    position: absolute;
+    width: 0;
+  }
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -37,7 +37,7 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
-import {TooltipSort, XAxisType} from '../../types';
+import {LinkedTime, TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
@@ -80,6 +80,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() xAxisType!: XAxisType;
   @Input() xScaleType!: ScaleType;
   @Input() useDarkMode!: boolean;
+  @Input() selectedTime!: LinkedTime | null;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -42,6 +42,7 @@ import {
   getDarkModeEnabled,
   getExperimentIdForRunId,
   getExperimentIdToAliasMap,
+  getMetricsSelectedTime,
   getRun,
   getRunColorMap,
   getVisibleCardIdSet,
@@ -61,7 +62,7 @@ import {
   getMetricsXAxisType,
   RunToSeries,
 } from '../../store';
-import {CardId, CardMetadata, XAxisType} from '../../types';
+import {CardId, CardMetadata, LinkedTime, XAxisType} from '../../types';
 import {CardRenderer} from '../metrics_view_types';
 import {getTagDisplayName} from '../utils';
 import {DataDownloadDialogContainer} from './data_download_dialog_container';
@@ -122,6 +123,7 @@ function areSeriesEqual(
       [xAxisType]="xAxisType$ | async"
       [xScaleType]="xScaleType$ | async"
       [useDarkMode]="useDarkMode$ | async"
+      [selectedTime]="selectedTime$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
     ></scalar-card-component>
@@ -157,6 +159,16 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
   isPinned$?: Observable<boolean>;
   dataSeries$?: Observable<ScalarCardDataSeries[]>;
   chartMetadataMap$?: Observable<ScalarCardSeriesMetadataMap>;
+
+  readonly selectedTime$: Observable<LinkedTime | null> = combineLatest([
+    this.store.select(getMetricsSelectedTime),
+    this.store.select(getMetricsXAxisType),
+  ]).pipe(
+    map(([selectedTime, xAxisType]) => {
+      if (xAxisType !== XAxisType.STEP) return null;
+      return selectedTime;
+    })
+  );
 
   readonly isCardVisible$ = this.store.select(getVisibleCardIdSet).pipe(
     map((visibleSet) => {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -46,6 +46,17 @@ limitations under the License.
       (onViewExtentChange)="onViewBoxChanged($event)"
       (onViewExtentReset)="viewBoxReset()"
     ></line-chart-interactive-view>
+    <div *ngIf="customVisTemplate" class="custom-vis">
+      <ng-container
+        [ngTemplateOutlet]="customVisTemplate"
+        [ngTemplateOutletContext]="{
+          xScale: xScale,
+          yScale: yScale,
+          domDimension: domDimensions.main,
+          viewExtent: viewBox
+        }"
+      ></ng-container>
+    </div>
   </div>
   <line-chart-axis
     #yAxis

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -44,6 +44,7 @@ limitations under the License.
   position: relative;
   overflow: hidden;
 
+  .custom-vis,
   canvas,
   svg,
   line-chart-grid-view,
@@ -53,6 +54,13 @@ limitations under the License.
     position: absolute;
     top: 0;
     width: 100%;
+  }
+
+  .custom-vis {
+    // custom-vis shows on top of interactive-view but we still need to give
+    // mouse interactions to the interactive-view. Currently, the contract is
+    // that you can only supply purely visual UI on top of the line chart.
+    pointer-events: none;
   }
 }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -23,6 +23,7 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
+  TemplateRef,
   ViewChild,
 } from '@angular/core';
 import {Observable, ReplaySubject} from 'rxjs';
@@ -59,6 +60,13 @@ interface DomDimensions {
   xAxis: {width: number; height: number};
 }
 
+export interface TemplateContext {
+  yScale: Scale;
+  xScale: Scale;
+  viewExtent: Extent;
+  domDimension: {width: number; height: number};
+}
+
 @Component({
   selector: 'line-chart',
   templateUrl: 'line_chart_component.ng.html',
@@ -80,6 +88,14 @@ export class LineChartComponent
 
   @ViewChild('chartEl', {static: false, read: ElementRef})
   private chartEl?: ElementRef<HTMLCanvasElement | SVGElement>;
+
+  /**
+   * Optional ngTemplate that renders on top of line chart (not axis). This
+   * template is rendered on top of interactive layer and can mask other
+   * contents. Do note that this component may not intercept pointer-events.
+   */
+  @Input()
+  customVisTemplate?: TemplateRef<TemplateContext>;
 
   @Input()
   useDarkMode: boolean = false;


### PR DESCRIPTION
This change adds a vertical bar when there is a single time step
selected by a user. To accomplish this change, we are expanding the
APIs of the `line_chart_component` to allow for visual customization
which `scalar_card` uses to render the vertical bar.

This is first of many to follow so it, by no means, is ready for
consumption.

![image](https://user-images.githubusercontent.com/2547313/128078836-a4be342c-1c69-47f3-8158-93f914706f89.png)
