### PR TITLE
color group: improve visuals of the component

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -58,7 +58,7 @@ limitations under the License.
             class="color-swatch"
             [ngStyle]="{backgroundColor: colorRunsPair.color}"
           ></span
-          ><code name="group-id" [title]="colorRunsPair.groupId"
+          ><code class="group-id" [title]="colorRunsPair.groupId"
             >{{colorRunsPair.groupId}}</code
           ></label
         >

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
@@ -62,6 +62,10 @@ ul {
   padding: 0;
 }
 
+mat-form-field {
+  width: 100%;
+}
+
 .group {
   @include tb-theme-foreground-prop(border, border, 1px solid);
   border-radius: 3px;

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
@@ -46,6 +46,16 @@ const INPUT_CHANGE_DEBOUNCE_INTERVAL_MS = 500;
     (onSave)="onSave($event)"
     (regexInputOnChange)="onRegexInputOnChange($event)"
   ></regex-edit-dialog-component>`,
+  styles: [
+    `
+      :host,
+      regex-edit-dialog-component {
+        display: block;
+        width: 100;
+        height: 100%;
+      }
+    `,
+  ],
 })
 export class RegexEditDialogContainer {
   private readonly experimentIds: string[];

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
@@ -51,8 +51,8 @@ const INPUT_CHANGE_DEBOUNCE_INTERVAL_MS = 500;
       :host,
       regex-edit-dialog-component {
         display: block;
-        width: 100;
         height: 100%;
+        width: 100%;
       }
     `,
   ],

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ts
@@ -47,9 +47,7 @@ export class RunsGroupMenuButtonComponent {
     // data pass in the experiment id
     const dialogRef = this.dialog.open(RegexEditDialogContainer, {
       maxHeight: '95vh',
-      minHeight: '500px',
       maxWidth: '80vw',
-      minWidth: '600px',
       data: {experimentIds: this.experimentIds},
     });
   }


### PR DESCRIPTION
This change improves visual aspect of the color group. Specifically, it
improves the dialog under very narrow screen.

Before:
![image](https://user-images.githubusercontent.com/2547313/128096305-03ae88cb-59ad-40cc-9434-53705269da99.png)
![image](https://user-images.githubusercontent.com/2547313/128096377-39f45159-0995-4ab1-b37b-3f69a2023692.png)


After:
![image](https://user-images.githubusercontent.com/2547313/128096086-7e13cad3-dffe-406c-ad32-1090880a7a2e.png)
