### PR TITLE
time series: ignore case when matching tags

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/filter_input_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_container.ts
@@ -69,7 +69,7 @@ export class MetricsFilterInputContainer {
       map<[string[], string], [string[], RegExp | null]>(
         ([tags, tagFilter]) => {
           try {
-            const regex = new RegExp(tagFilter);
+            const regex = new RegExp(tagFilter, 'i');
             return [tags, regex];
           } catch (e) {
             return [tags, null];

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
@@ -155,6 +155,21 @@ describe('metrics filter input', () => {
       ).toEqual(['tagA/Images', 'tagB/meow/cat']);
     });
 
+    it('filters by regex ignoring casing', () => {
+      store.overrideSelector(selectors.getMetricsTagFilter, '[ib]');
+      const fixture = TestBed.createComponent(MetricsFilterInputContainer);
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.focus();
+      fixture.detectChanges();
+
+      const options = getAutocompleteOptions(overlayContainer);
+      expect(
+        options.map((option) => option.nativeElement.textContent)
+      ).toEqual(['tagA/Images', 'tagB/meow/cat']);
+    });
+
     it('responds to input changes', () => {
       store.overrideSelector(selectors.getMetricsTagFilter, '');
       const fixture = TestBed.createComponent(MetricsFilterInputContainer);

--- a/tensorboard/webapp/metrics/views/main_view/filtered_view_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filtered_view_container.ts
@@ -74,7 +74,7 @@ export class FilteredViewContainer {
     }),
     map(([cardList, tagFilter]) => {
       try {
-        return {cardList, regex: new RegExp(tagFilter)};
+        return {cardList, regex: new RegExp(tagFilter, 'i')};
       } catch (e) {
         return {cardList, regex: null};
       }

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -938,6 +938,18 @@ describe('metrics main view', () => {
       ]);
     });
 
+    fit('ignores case when matching the regex', () => {
+      store.overrideSelector(selectors.getMetricsTagFilter, 'taga');
+      const fixture = TestBed.createComponent(MainViewContainer);
+      fixture.detectChanges();
+
+      expect(getCardGroupNames(getFilterViewContainer(fixture))).toEqual([]);
+      expect(getFilterviewCardContents(fixture)).toEqual([
+        'scalars: card1',
+        'images: card2',
+      ]);
+    });
+
     it('hides the main, pinned views while the filter view is active', () => {
       store.overrideSelector(selectors.getMetricsTagFilter, 'tagA');
       const fixture = TestBed.createComponent(MainViewContainer);

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -938,7 +938,7 @@ describe('metrics main view', () => {
       ]);
     });
 
-    fit('ignores case when matching the regex', () => {
+    it('ignores case when matching the regex', () => {
       store.overrideSelector(selectors.getMetricsTagFilter, 'taga');
       const fixture = TestBed.createComponent(MainViewContainer);
       fixture.detectChanges();


### PR DESCRIPTION
This change ignores casing when matching tags with regex or strings.
