### PR TITLE
Fix PR curve plugin to display correct thresholds

### DIFF
--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -267,7 +267,7 @@ def run_all(logdir, steps, thresholds, verbose=False):
 
 def main(unused_argv):
     print("Saving output to %s." % FLAGS.logdir)
-    run_all(FLAGS.logdir, FLAGS.steps, 50, verbose=True)
+    run_all(FLAGS.logdir, FLAGS.steps, 51, verbose=True)
     print("Done. Output saved to %s." % FLAGS.logdir)
 
 

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -230,7 +230,9 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
         return {
             "wall_time": wall_time,
             "step": step,
-            "precision": data_array[metadata.PRECISION_INDEX, :end_index].tolist(),
+            "precision": data_array[
+                metadata.PRECISION_INDEX, :end_index
+            ].tolist(),
             "recall": data_array[metadata.RECALL_INDEX, :end_index].tolist(),
             "true_positives": true_positives[:end_index],
             "false_positives": false_positives[:end_index],

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -205,40 +205,36 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
         Returns:
           A PR curve entry.
         """
-        # Trim entries for which TP + FP = 0 (precision is undefined) at the tail of
-        # the data.
-        true_positives = [
-            int(v) for v in data_array[metadata.TRUE_POSITIVES_INDEX]
-        ]
-        false_positives = [
-            int(v) for v in data_array[metadata.FALSE_POSITIVES_INDEX]
-        ]
         tp_index = metadata.TRUE_POSITIVES_INDEX
         fp_index = metadata.FALSE_POSITIVES_INDEX
+        tn_index = metadata.TRUE_NEGATIVES_INDEX
+        fn_index = metadata.FALSE_NEGATIVES_INDEX
+
+        # Trim entries for which TP + FP = 0 (precision is undefined) at the tail of
+        # the data.
         positives = data_array[[tp_index, fp_index], :].astype(int).sum(axis=0)
+        # Searching from the end, find the farthest index where TP + FP = 0.
         end_index_inclusive = len(positives) - 1
         while end_index_inclusive > 0 and positives[end_index_inclusive] == 0:
             end_index_inclusive -= 1
         end_index = end_index_inclusive + 1
+        # Generate thresholds in [0, 1].
         num_thresholds = data_array.shape[1]
-        thresholds = (np.arange(1, end_index + 1) / num_thresholds).tolist()
+        thresholds = np.linspace(0.0, 1.0, num_thresholds)
+
+        true_positives = [int(v) for v in data_array[tp_index]]
+        false_positives = [int(v) for v in data_array[fp_index]]
+        true_negatives = [int(v) for v in data_array[tn_index]]
+        false_negatives = [int(v) for v in data_array[fn_index]]
 
         return {
             "wall_time": wall_time,
             "step": step,
-            "precision": data_array[
-                metadata.PRECISION_INDEX, :end_index
-            ].tolist(),
+            "precision": data_array[metadata.PRECISION_INDEX, :end_index].tolist(),
             "recall": data_array[metadata.RECALL_INDEX, :end_index].tolist(),
             "true_positives": true_positives[:end_index],
             "false_positives": false_positives[:end_index],
-            "true_negatives": [
-                int(v)
-                for v in data_array[metadata.TRUE_NEGATIVES_INDEX][:end_index]
-            ],
-            "false_negatives": [
-                int(v)
-                for v in data_array[metadata.FALSE_NEGATIVES_INDEX][:end_index]
-            ],
-            "thresholds": thresholds,
+            "true_negatives": true_negatives[:end_index],
+            "false_negatives": false_negatives[:end_index],
+            "thresholds": thresholds[:end_index].tolist(),
         }

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -214,7 +214,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
             expected_false_positives=[300, 201, 38, 2],
             expected_true_negatives=[0, 99, 262, 298],
             expected_false_negatives=[0, 24, 105, 144],
-            expected_thresholds=[0.2, 0.4, 0.6, 0.8],
+            expected_thresholds=[0.0, 0.25, 0.5, 0.75],
             pr_curve_entry=entries[0],
         )
         self.validatePrCurveEntry(
@@ -225,7 +225,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
             expected_false_positives=[300, 204, 39, 6],
             expected_true_negatives=[0, 96, 261, 294],
             expected_false_negatives=[0, 22, 105, 146],
-            expected_thresholds=[0.2, 0.4, 0.6, 0.8],
+            expected_thresholds=[0.0, 0.25, 0.5, 0.75],
             pr_curve_entry=entries[1],
         )
         self.validatePrCurveEntry(
@@ -236,7 +236,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
             expected_false_positives=[300, 185, 38, 2],
             expected_true_negatives=[0, 115, 262, 298],
             expected_false_negatives=[0, 30, 111, 146],
-            expected_thresholds=[0.2, 0.4, 0.6, 0.8],
+            expected_thresholds=[0.0, 0.25, 0.5, 0.75],
             pr_curve_entry=entries[2],
         )
 
@@ -252,7 +252,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
             expected_false_positives=[150, 105, 18, 0],
             expected_true_negatives=[0, 45, 132, 150],
             expected_false_negatives=[0, 11, 54, 70],
-            expected_thresholds=[0.2, 0.4, 0.6, 0.8],
+            expected_thresholds=[0.0, 0.25, 0.5, 0.75],
             pr_curve_entry=entries[0],
         )
         self.validatePrCurveEntry(
@@ -263,7 +263,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
             expected_false_positives=[150, 99, 21, 3],
             expected_true_negatives=[0, 51, 129, 147],
             expected_false_negatives=[0, 13, 54, 74],
-            expected_thresholds=[0.2, 0.4, 0.6, 0.8],
+            expected_thresholds=[0.0, 0.25, 0.5, 0.75],
             pr_curve_entry=entries[1],
         )
         self.validatePrCurveEntry(
@@ -274,7 +274,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
             expected_false_positives=[150, 92, 20, 1],
             expected_true_negatives=[0, 58, 130, 149],
             expected_false_negatives=[0, 14, 59, 73],
-            expected_thresholds=[0.2, 0.4, 0.6, 0.8],
+            expected_thresholds=[0.0, 0.25, 0.5, 0.75],
             pr_curve_entry=entries[2],
         )
 

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -285,6 +285,69 @@ class PrCurveTest(tf.test.TestCase):
         values = tensor_util.make_ndarray(pb.value[0].tensor)
         self.verify_float_arrays_are_equal(expected, values)
 
+    def test_predictions_at_thresholds(self):
+        num_thresholds = 5
+        # For 5 thresholds, we expect the thresholds used to be:
+        # [0.0, 0.25, 0.5, 0.75, 1.0]
+        pb = self.compute_and_check_summary_pb(
+            name="foo",
+            labels=np.array([True] * num_thresholds),
+            predictions=np.float32([0.0, 0.25, 0.5, 0.75, 1.0]),
+            num_thresholds=num_thresholds,
+        )
+        expected = [
+            [5.0, 4.0, 3.0, 2.0, 1.0],  # TP
+            [0.0, 0.0, 0.0, 0.0, 0.0],  # FP
+            [0.0, 0.0, 0.0, 0.0, 0.0],  # TN
+            [0.0, 1.0, 2.0, 3.0, 4.0],  # FN
+            [1.0, 1.0, 1.0, 1.0, 1.0],  # Precision
+            [1.0, 0.8, 0.6, 0.4, 0.2],  # Recall
+        ]
+        values = tensor_util.make_ndarray(pb.value[0].tensor)
+        self.verify_float_arrays_are_equal(expected, values)
+
+    def test_predictions_above_thresholds(self):
+        num_thresholds = 5
+        # For 5 thresholds, we expect the thresholds used to be:
+        # [0.0, 0.25, 0.5, 0.75, 1.0]
+        pb = self.compute_and_check_summary_pb(
+            name="foo",
+            labels=np.array([True] * num_thresholds),
+            predictions=np.float32([0.01, 0.26, 0.51, 0.76, 1.0]),
+            num_thresholds=num_thresholds,
+        )
+        expected = [
+            [5.0, 4.0, 3.0, 2.0, 1.0],  # TP
+            [0.0, 0.0, 0.0, 0.0, 0.0],  # FP
+            [0.0, 0.0, 0.0, 0.0, 0.0],  # TN
+            [0.0, 1.0, 2.0, 3.0, 4.0],  # FN
+            [1.0, 1.0, 1.0, 1.0, 1.0],  # Precision
+            [1.0, 0.8, 0.6, 0.4, 0.2],  # Recall
+        ]
+        values = tensor_util.make_ndarray(pb.value[0].tensor)
+        self.verify_float_arrays_are_equal(expected, values)
+
+    def test_predictions_below_thresholds(self):
+        num_thresholds = 5
+        # For 5 thresholds, we expect the thresholds used to be:
+        # [0.0, 0.25, 0.5, 0.75, 1.0]
+        pb = self.compute_and_check_summary_pb(
+            name="foo",
+            labels=np.array([True] * num_thresholds),
+            predictions=np.float32([0.0, 0.24, 0.49, 0.74, 0.99]),
+            num_thresholds=num_thresholds,
+        )
+        expected = [
+            [5.0, 3.0, 2.0, 1.0, 0.0],  # TP
+            [0.0, 0.0, 0.0, 0.0, 0.0],  # FP
+            [0.0, 0.0, 0.0, 0.0, 0.0],  # TN
+            [0.0, 2.0, 3.0, 4.0, 5.0],  # FN
+            [1.0, 1.0, 1.0, 1.0, 0.0],  # Precision
+            [1.0, 0.6, 0.4, 0.2, 0.0],  # Recall
+        ]
+        values = tensor_util.make_ndarray(pb.value[0].tensor)
+        self.verify_float_arrays_are_equal(expected, values)
+
     def test_raw_data(self):
         # We pass these raw counts and precision/recall values.
         name = "foo"


### PR DESCRIPTION
* Motivation for features / changes:
  * The thresholds generated and shown in the PR curve plugin are incorrect (AFAICT) compared to the thresholds used in the PR curve `summary.op`.
  * The thresholds used in `summary.op` are:
                `[0.0, 1/(num_thresholds-1), 2/(num_thresholds-1), ..., 1.0]`
        ... but prior to this change, the thresholds generated in `_make_pr_entry` and displayed in TensorBoard are:
        `[1/num_thresholds, 2/num_thresholds, ..., 1.0]`.

* Technical description of changes:
  * Modified `_make_pr_entry` to instead generate thresholds like `sumamry.op`, as described above.
  * Cleaned up the code in `_make_pr_entry` to be a bit easier to read / check for correctness.
  * Added tests for `summary.op` that verify the thresholds used are indeed what are described above.
  * Changed the number of thresholds used in `pr_curve_demo` from 50 to 51, since we're now including `0` in the thresholds.

* Screenshots of UI changes: N/A (UI is unchanged)

* Detailed steps to verify changes work correctly (as executed by you):
  * Ran TensorBoard with PR curve demo data and verified thresholds are [displayed correctly](https://user-images.githubusercontent.com/1388260/128239709-6ff89d50-42f5-4e50-84d8-16de0466d098.png).
  * Ran all tests in `pr_curve` directory.

* Alternate designs / implementations considered: N/A
