### PR TITLE
🍒: OSS TensorBoard page title should be `TensorBoard` (#5190)

### DIFF
--- a/tensorboard/webapp/core/views/page_title_test.ts
+++ b/tensorboard/webapp/core/views/page_title_test.ts
@@ -187,3 +187,47 @@ describe('page title test with custom brand names', () => {
     expect(spy).toHaveBeenCalledWith('TensorBoard.corp');
   });
 });
+
+describe('page title test for OSS TensorBoard', () => {
+  let store: MockStore<State>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PageTitleModule],
+      declarations: [TestingComponent],
+      providers: [
+        provideMockStore(),
+        {
+          provide: TB_BRAND_NAME,
+          useValue: 'TensorBoard',
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    store.overrideSelector(getRouteKind, RouteKind.EXPERIMENTS);
+    store.overrideSelector(getExperimentIdsFromRoute, []);
+    store.overrideSelector(getExperiment, null);
+    store.overrideSelector(getEnvironment, {
+      data_location: 'my-location',
+      window_title: '',
+    });
+  });
+
+  it('uses `TensorBoard` for experiment page title', () => {
+    const spy = spyOn(TEST_ONLY.utils, 'setDocumentTitle');
+    store.overrideSelector(getRouteKind, RouteKind.EXPERIMENT);
+    store.overrideSelector(getExperimentIdsFromRoute, ['defaultExperimentId']);
+    store.overrideSelector(
+      getExperiment,
+      buildExperiment({
+        name: '', // OSS default experiment name is ''
+      })
+    );
+    const fixture = TestBed.createComponent(TestingComponent);
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalledWith('TensorBoard');
+  });
+});

--- a/tensorboard/webapp/experiments/store/experiments_reducers.ts
+++ b/tensorboard/webapp/experiments/store/experiments_reducers.ts
@@ -25,7 +25,7 @@ import {ExperimentsDataState, ExperimentsState} from './experiments_types';
 
 const defaultExperiment = {
   id: DEFAULT_EXPERIMENT_ID,
-  name: 'Default experiment',
+  name: '',
   start_time: 0,
 };
 


### PR DESCRIPTION
Cherry-pick #5190.

Only internal (corp) version should show experiment name on the tab title.

Tested locally:
<img width="1436" alt="Screen Shot 2021-08-04 at 10 40 41 AM" src="https://user-images.githubusercontent.com/15273931/128255266-1d9b4940-e561-4034-aa9a-3eaead1be954.png">
