### PR TITLE
core: no data warning message UI fix

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.scss
+++ b/tensorboard/webapp/plugins/plugins_component.scss
@@ -37,6 +37,7 @@ limitations under the License.
 }
 
 .warning {
+  @include tb-theme-background-prop(background, background);
   bottom: 0;
   left: 0;
   position: absolute;


### PR DESCRIPTION
This change fixes the UI when data reload fails. Previously, without an
opaque background, the warning message awkwardly printed on top of
existing dashboard making the UI very janky.

By placing a color on the background, we now have the UI that we
intended.

Previously:
![image](https://user-images.githubusercontent.com/2547313/128381836-2dcf6e0d-aa4d-40ad-a18a-65b4528ee65a.png)


New:
![image](https://user-images.githubusercontent.com/2547313/128381534-406f4996-a26a-4186-9260-720894f20456.png)
