### PR TITLE
color grouping: change tooltip wording

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 <button
   mat-icon-button
-  title="Group runs by..."
+  title="Color runs by..."
   [matMenuTriggerFor]="groupByMenu"
 >
   <mat-icon svgIcon="palette_24px"></mat-icon>


### PR DESCRIPTION
Change from "Group runs by" to "Color runs by". Align with color group by regex dialog.