### PR TITLE
color grouping: set non-matched runs to light gray

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -25,7 +25,7 @@ import {createRouteContextedState} from '../../app_routing/route_contexted_reduc
 import {RouteKind} from '../../app_routing/types';
 import {DataLoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
-import {CHART_COLOR_PALLETE} from '../../util/colors';
+import {CHART_COLOR_PALLETE, NONMATCHED_COLOR} from '../../util/colors';
 import {composeReducers} from '../../util/ngrx';
 import * as runsActions from '../actions';
 import {GroupByKey, URLDeserializedState} from '../types';
@@ -269,7 +269,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
 
     // unassign color for nonmatched runs to apply default unassigned style
     for (const run of groups.nonMatches) {
-      defaultRunColorForGroupBy.delete(run.id);
+      defaultRunColorForGroupBy.set(run.id, NONMATCHED_COLOR);
     }
 
     return {
@@ -308,7 +308,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
 
       // unassign color for nonmatched runs to apply default unassigned style
       for (const run of groups.nonMatches) {
-        defaultRunColorForGroupBy.delete(run.id);
+        defaultRunColorForGroupBy.set(run.id, NONMATCHED_COLOR);
       }
 
       const updatedRegexString =

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -19,13 +19,12 @@ import {
   createReducer,
   on,
 } from '@ngrx/store';
-
 import {stateRehydratedFromUrl} from '../../app_routing/actions';
 import {createRouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
 import {RouteKind} from '../../app_routing/types';
 import {DataLoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
-import {CHART_COLOR_PALLETE, NONMATCHED_COLOR} from '../../util/colors';
+import {CHART_COLOR_PALLETE, NON_MATCHED_COLOR} from '../../util/colors';
 import {composeReducers} from '../../util/ngrx';
 import * as runsActions from '../actions';
 import {GroupByKey, URLDeserializedState} from '../types';
@@ -269,7 +268,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
 
     // unassign color for nonmatched runs to apply default unassigned style
     for (const run of groups.nonMatches) {
-      defaultRunColorForGroupBy.set(run.id, NONMATCHED_COLOR);
+      defaultRunColorForGroupBy.set(run.id, NON_MATCHED_COLOR);
     }
 
     return {
@@ -308,7 +307,7 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
 
       // unassign color for nonmatched runs to apply default unassigned style
       for (const run of groups.nonMatches) {
-        defaultRunColorForGroupBy.set(run.id, NONMATCHED_COLOR);
+        defaultRunColorForGroupBy.set(run.id, NON_MATCHED_COLOR);
       }
 
       const updatedRegexString =

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -343,8 +343,8 @@ describe('runs_reducers', () => {
             ['eid1/beta', colorUtils.CHART_COLOR_PALLETE[1]],
             ['eid2/beta', colorUtils.CHART_COLOR_PALLETE[1]],
             ['eid2/gamma', colorUtils.CHART_COLOR_PALLETE[1]],
-            ['eid2/alpha', colorUtils.NONMATCHED_COLOR],
-            ['eid2/delta', colorUtils.NONMATCHED_COLOR],
+            ['eid2/alpha', colorUtils.NON_MATCHED_COLOR],
+            ['eid2/delta', colorUtils.NON_MATCHED_COLOR],
           ])
         );
       });
@@ -922,8 +922,8 @@ describe('runs_reducers', () => {
           ['run2', colorUtils.CHART_COLOR_PALLETE[1]],
           ['run3', colorUtils.CHART_COLOR_PALLETE[1]],
           ['run4', colorUtils.CHART_COLOR_PALLETE[1]],
-          ['run5', colorUtils.NONMATCHED_COLOR],
-          ['run6', colorUtils.NONMATCHED_COLOR],
+          ['run5', colorUtils.NON_MATCHED_COLOR],
+          ['run6', colorUtils.NON_MATCHED_COLOR],
         ])
       );
       expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -312,7 +312,7 @@ describe('runs_reducers', () => {
         );
       });
 
-      it('removes color assignment for regex non-matched runs', () => {
+      it('assigns non-matched colors to regex non-matched runs', () => {
         const state = buildRunsState({
           initialGroupBy: {key: GroupByKey.REGEX, regexString: 'foo(\\d+)'},
           defaultRunColorForGroupBy: new Map([
@@ -343,6 +343,8 @@ describe('runs_reducers', () => {
             ['eid1/beta', colorUtils.CHART_COLOR_PALLETE[1]],
             ['eid2/beta', colorUtils.CHART_COLOR_PALLETE[1]],
             ['eid2/gamma', colorUtils.CHART_COLOR_PALLETE[1]],
+            ['eid2/alpha', colorUtils.NONMATCHED_COLOR],
+            ['eid2/delta', colorUtils.NONMATCHED_COLOR],
           ])
         );
       });

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -922,6 +922,8 @@ describe('runs_reducers', () => {
           ['run2', colorUtils.CHART_COLOR_PALLETE[1]],
           ['run3', colorUtils.CHART_COLOR_PALLETE[1]],
           ['run4', colorUtils.CHART_COLOR_PALLETE[1]],
+          ['run5', colorUtils.NONMATCHED_COLOR],
+          ['run6', colorUtils.NONMATCHED_COLOR],
         ])
       );
       expect(nextState.data.runColorOverrideForGroupBy).toEqual(new Map());

--- a/tensorboard/webapp/util/colors.ts
+++ b/tensorboard/webapp/util/colors.ts
@@ -22,4 +22,4 @@ export const CHART_COLOR_PALLETE = [
   '#e8710a', // Orange 600
 ];
 
-export const NONMATCHED_COLOR = '#ececec';
+export const NON_MATCHED_COLOR = '#ececec';

--- a/tensorboard/webapp/util/colors.ts
+++ b/tensorboard/webapp/util/colors.ts
@@ -21,3 +21,5 @@ export const CHART_COLOR_PALLETE = [
   '#7cb342', // Lt green 600
   '#e8710a', // Orange 600
 ];
+
+export const NONMATCHED_COLOR = '#ececec';


### PR DESCRIPTION
* Motivation for features / changes
Currently we do not set any color to non-matched runs, which makes the chart cannot be read at all. Now we set light gray (#ececec) on those non-matched ones.
<img width="732" alt="Screen Shot 2021-08-05 at 2 18 52 PM" src="https://user-images.githubusercontent.com/1131010/128423374-f52f10c7-0ea9-47d8-a670-e6bf03b1e5a5.png">

