### PR TITLE
linked time: settings on the right pane 

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -148,3 +148,11 @@ export const timeSelectionChanged = createAction(
 export const timeSelectionCleared = createAction(
   '[Metrics] Linked Time Selection Cleared'
 );
+
+export const selectTimeEnableToggled = createAction(
+  '[Metrics] Select Time Enable Toggle'
+);
+
+export const useRangeSelectTimeToggled = createAction(
+  '[Metrics] Use Range Select Time Toggle'
+);

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -243,6 +243,8 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState<
     tagFilter: '',
     tagGroupExpanded: new Map<string, boolean>(),
     selectedTime: null,
+    selectTimeEnabled: false,
+    useRangeSelectTime: false,
   },
   {
     timeSeriesData: {
@@ -809,9 +811,16 @@ const reducer = createReducer(
       pinnedCardToOriginal: nextPinnedCardToOriginal,
     };
   }),
+  on(actions.selectTimeEnableToggled, (state) => {
+    return {
+      ...state,
+      selectTimeEnabled: !state.selectTimeEnabled,
+    };
+  }),
   on(actions.timeSelectionChanged, (state, change) => {
     return {
       ...state,
+      selectTimeEnabled: true,
       selectedTime: {
         start: {step: change.startStep, wallTime: change.startWallTime},
         end:
@@ -822,6 +831,12 @@ const reducer = createReducer(
                 wallTime: change.endWallTime,
               },
       },
+    };
+  }),
+  on(actions.useRangeSelectTimeToggled, (state) => {
+    return {
+      ...state,
+      useRangeSelectTime: !state.useRangeSelectTime,
     };
   }),
   on(actions.timeSelectionCleared, (state) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1846,6 +1846,22 @@ describe('metrics reducers', () => {
           end: {step: 4, wallTime: -1},
         });
       });
+
+      it('enables selectTimeEnabled if previously disabled', () => {
+        const beforeState = buildMetricsState({
+          selectTimeEnabled: false,
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.timeSelectionChanged({
+            startStep: 2,
+            startWallTime: -1,
+          })
+        );
+
+        expect(nextState.selectTimeEnabled).toBe(true);
+      });
     });
 
     describe('#timeSelectionCleared', () => {
@@ -1857,6 +1873,34 @@ describe('metrics reducers', () => {
         const nextState = reducers(beforeState, actions.timeSelectionCleared());
 
         expect(nextState.selectedTime).toBeNull();
+      });
+    });
+
+    describe('#selectTimeEnableToggled', () => {
+      it('toggles whether selectTime is enabled or not', () => {
+        const state1 = buildMetricsState({
+          selectTimeEnabled: false,
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+        expect(state2.selectTimeEnabled).toBe(true);
+
+        const state3 = reducers(state2, actions.selectTimeEnableToggled());
+        expect(state3.selectTimeEnabled).toBe(false);
+      });
+    });
+
+    describe('#useRangeSelectTimeToggled', () => {
+      it('toggles whether to use the range mode or not', () => {
+        const state1 = buildMetricsState({
+          useRangeSelectTime: false,
+        });
+
+        const state2 = reducers(state1, actions.useRangeSelectTimeToggled());
+        expect(state2.useRangeSelectTime).toBe(true);
+
+        const state3 = reducers(state2, actions.useRangeSelectTimeToggled());
+        expect(state3.useRangeSelectTime).toBe(false);
       });
     });
   });

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -335,9 +335,52 @@ export const getMetricsTagGroupExpansionState = createSelector(
   }
 );
 
-export const getMetricsSelectedTime = createSelector(
+export const getMetricsSelectTimeEnabled = createSelector(
+  selectMetricsState,
+  (state: MetricsState): boolean => {
+    return state.selectTimeEnabled;
+  }
+);
+
+export const getMetricsUseRangeSelectTime = createSelector(
+  selectMetricsState,
+  (state: MetricsState): boolean => {
+    return state.useRangeSelectTime;
+  }
+);
+
+/**
+ * Returns raw value of the selected time set by user. This selector is intended
+ * to used by settings panel only.
+ *
+ * @see getMetricsSelectedTime instead.
+ */
+export const getMetricsSelectedTimeRaw = createSelector(
   selectMetricsState,
   (state: MetricsState): LinkedTime | null => {
     return state.selectedTime;
+  }
+);
+
+/**
+ * Returns selected time set by user. If selectTime is disabled, it returns
+ * `null`. Also, when range selection mode is disabled, it returns `end=null`
+ * even if it has value set.
+ *
+ * Virtually all views should use this selector.
+ */
+export const getMetricsSelectedTime = createSelector(
+  selectMetricsState,
+  getMetricsSelectedTimeRaw,
+  (state: MetricsState, selectedTime: LinkedTime | null): LinkedTime | null => {
+    if (!state.selectTimeEnabled || !selectedTime) {
+      return null;
+    }
+
+    if (state.useRangeSelectTime) {
+      return selectedTime;
+    }
+
+    return {...selectedTime, end: null};
   }
 );

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -706,15 +706,56 @@ describe('metrics selectors', () => {
     });
   });
 
-  describe('getMetricsSelectedTime', () => {
+  describe('getMetricsSelectedTimeRaw', () => {
     beforeEach(() => {
-      selectors.getMetricsSelectedTime.release();
+      selectors.getMetricsSelectedTimeRaw.release();
     });
 
     it('returns `null` when selected time is null', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
           selectedTime: null,
+        })
+      );
+      expect(selectors.getMetricsSelectedTimeRaw(state)).toBeNull();
+    });
+
+    it('returns value when selected time is present', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          selectedTime: {
+            start: {step: 0, wallTime: 2000},
+            end: null,
+          },
+        })
+      );
+      expect(selectors.getMetricsSelectedTimeRaw(state)).toEqual({
+        start: {step: 0, wallTime: 2000},
+        end: null,
+      });
+    });
+  });
+
+  describe('getMetricsSelectedTime', () => {
+    beforeEach(() => {
+      selectors.getMetricsSelectedTime.release();
+    });
+
+    it('returns `null` when selectTime is disabled even when value exists', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          selectedTime: {start: {step: 1, wallTime: 0}, end: null},
+          selectTimeEnabled: false,
+        })
+      );
+      expect(selectors.getMetricsSelectedTime(state)).toBeNull();
+    });
+
+    it('returns `null` when selected time is null', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          selectedTime: null,
+          selectTimeEnabled: true,
         })
       );
       expect(selectors.getMetricsSelectedTime(state)).toBeNull();
@@ -725,8 +766,27 @@ describe('metrics selectors', () => {
         buildMetricsState({
           selectedTime: {
             start: {step: 0, wallTime: 2000},
-            end: null,
+            end: {step: 100, wallTime: 2000},
           },
+          selectTimeEnabled: true,
+          useRangeSelectTime: true,
+        })
+      );
+      expect(selectors.getMetricsSelectedTime(state)).toEqual({
+        start: {step: 0, wallTime: 2000},
+        end: {step: 100, wallTime: 2000},
+      });
+    });
+
+    it('removes `end` when using single step mode', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          selectedTime: {
+            start: {step: 0, wallTime: 2000},
+            end: {step: 100, wallTime: 2000},
+          },
+          selectTimeEnabled: true,
+          useRangeSelectTime: false,
         })
       );
       expect(selectors.getMetricsSelectedTime(state)).toEqual({

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -153,6 +153,8 @@ export interface MetricsRoutefulState {
   tagFilter: string;
   tagGroupExpanded: Map<string, boolean>;
   selectedTime: LinkedTime | null;
+  selectTimeEnabled: boolean;
+  useRangeSelectTime: boolean;
 }
 
 export interface MetricsSettings {

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -90,6 +90,8 @@ function buildBlankState(): MetricsState {
     tagFilter: '',
     tagGroupExpanded: new Map(),
     selectedTime: null,
+    selectTimeEnabled: false,
+    useRangeSelectTime: false,
   };
 }
 

--- a/tensorboard/webapp/metrics/views/right_pane/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/BUILD
@@ -32,6 +32,7 @@ tf_ng_module(
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/widgets/dropdown",
+        "//tensorboard/webapp/widgets/range_input",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_module.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_module.ts
@@ -23,6 +23,7 @@ import {MatSliderModule} from '@angular/material/slider';
 
 import {FeatureFlagModule} from '../../../feature_flag/feature_flag_module';
 import {DropdownModule} from '../../../widgets/dropdown/dropdown_module';
+import {RangeInputModule} from '../../../widgets/range_input/range_input_module';
 import {RightPaneComponent} from './right_pane_component';
 import {SettingsViewComponent} from './settings_view_component';
 import {SettingsViewContainer} from './settings_view_container';
@@ -44,6 +45,7 @@ import {SettingsViewContainer} from './settings_view_container';
     MatSelectModule,
     MatSliderModule,
     FeatureFlagModule,
+    RangeInputModule,
   ],
 })
 export class RightPaneModule {}

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -26,6 +26,51 @@ limitations under the License.
     >
     </tb-dropdown>
   </div>
+  <div
+    class="control-row linked-time"
+    *ngIf="isLinkedTimeFeatureEnabled && xAxisType == XAxisType.STEP"
+  >
+    <label>Link visualization by step</label>
+    <div class="controls">
+      <div>
+        <mat-checkbox
+          [checked]="selectTimeEnabled"
+          (change)="selectTimeEnableToggled.emit()"
+          >Enabled</mat-checkbox
+        >
+      </div>
+      <div>
+        <mat-checkbox
+          [checked]="useRangeSelectTime"
+          (change)="useRangeSelectTimeToggled.emit()"
+          >Use range</mat-checkbox
+        >
+      </div>
+      <div class="step-selector">
+        <mat-slider
+          *ngIf="!useRangeSelectTime; else range"
+          [disabled]="!selectTimeEnabled"
+          color="primary"
+          [min]="0"
+          [max]="1000"
+          [step]="1"
+          [value]="selectedTime?.start.step"
+          [thumbLabel]="true"
+          (input)="onStepStartChanged($event.value)"
+        ></mat-slider>
+        <ng-template #range>
+          <tb-range-input
+            [disabled]="!selectTimeEnabled"
+            min="0"
+            max="1000"
+            [lowerValue]="selectedTime?.start.step || 0"
+            [upperValue]="selectedTime?.end?.step"
+            (value)="onStepRangeChanged($event)"
+          ></tb-range-input>
+        </ng-template>
+      </div>
+    </div>
+  </div>
 </section>
 
 <section class="scalars">

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -98,3 +98,18 @@ mat-slider {
 tb-dropdown {
   display: block;
 }
+
+.linked-time {
+  .step-selector {
+    padding: 0 10px;
+  }
+
+  mat-slider,
+  tb-range-input {
+    width: 100%;
+  }
+
+  .controls {
+    padding: 5px;
+  }
+}

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -29,6 +29,7 @@ import {
   HistogramMode,
   SCALARS_SMOOTHING_MAX,
   TooltipSort,
+  LinkedTime,
   XAxisType,
 } from '../../types';
 
@@ -59,6 +60,15 @@ const MAX_SMOOTHING_SLIDER_VALUE = 0.99;
 export class SettingsViewComponent {
   constructor(@Inject(LOCALE_ID) private readonly locale: string) {}
 
+  @Input() isLinkedTimeFeatureEnabled!: boolean;
+  @Input() selectTimeEnabled!: boolean;
+  @Input() useRangeSelectTime!: boolean;
+  @Input() selectedTime!: LinkedTime | null;
+
+  @Output() selectTimeEnableToggled = new EventEmitter<void>();
+  @Output() useRangeSelectTimeToggled = new EventEmitter<void>();
+  @Output() selectTimeChanged = new EventEmitter<LinkedTime>();
+
   @Input() isImageSupportEnabled!: boolean;
 
   readonly TooltipSortDropdownOptions: DropdownOption[] = [
@@ -73,6 +83,7 @@ export class SettingsViewComponent {
   @Input() ignoreOutliers!: boolean;
   @Output() ignoreOutliersChanged = new EventEmitter<void>();
 
+  readonly XAxisType = XAxisType;
   readonly XAxisTypeDropdownOptions: DropdownOption[] = [
     {value: XAxisType.STEP, displayText: 'Step'},
     {value: XAxisType.RELATIVE, displayText: 'Relative'},
@@ -145,6 +156,36 @@ export class SettingsViewComponent {
       // The slider cannot fit 3 decimals.
       '1.0-2'
     );
+  }
+
+  onStepStartChanged(stepValue: number) {
+    this.selectTimeChanged.emit({
+      end: null,
+      ...this.selectedTime,
+      start: {
+        step: stepValue,
+        wallTime: 0,
+      },
+    });
+  }
+
+  onStepRangeChanged({
+    lowerValue,
+    upperValue,
+  }: {
+    lowerValue: number;
+    upperValue: number;
+  }) {
+    this.selectTimeChanged.emit({
+      start: {
+        step: lowerValue,
+        wallTime: 0,
+      },
+      end: {
+        step: upperValue,
+        wallTime: 0,
+      },
+    });
   }
 }
 


### PR DESCRIPTION
This change adds initial visual shim of the settings for the linked time
that conditionally renders if the feature is enabled and if current time
unit is STEP.

Do note that we are still fiddling with the data model and UI affordance
so the code is highly experimental. This change is not the completed 
feature as it is missing an ability to accurately set `min` and `max` on
step ranges. The feature will be more complete in the follow ups.

![image](https://user-images.githubusercontent.com/2547313/128545439-94e2af10-6599-46a9-b781-24c02fb9fadf.png)
