### PR TITLE
range_input: fix floating point noise

### DIFF
--- a/tensorboard/webapp/widgets/range_input/range_input_component.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ts
@@ -210,9 +210,14 @@ export class RangeInputComponent implements OnInit, OnDestroy {
       xPositionInPercent = compensatedRelativeXInPx / (right - left);
     }
 
-    return this.getClippedValue(
+    const newValue = this.getClippedValue(
       this.min + (this.max - this.min) * xPositionInPercent
     );
+
+    // Make sure floating point arithmatic does not pollute the number with
+    // noise (e.g., 0.2 + 0.1 = 0.30000000000000004; we don't want 4e-17). Clip
+    // to 10th decimal.
+    return Number(newValue.toFixed(10));
   }
 
   /**

--- a/tensorboard/webapp/widgets/range_input/range_input_test.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_test.ts
@@ -194,7 +194,7 @@ describe('range input test', () => {
       // range-input starts from 100px and ends at 300px so 102px is about 2%
       // from left edge.
       moveThumb(leftThumb, 102);
-      // Without our logic to round, lowerValue woudl be 0.10200000000000001.
+      // Without our logic to round, lowerValue would be 0.10200000000000001.
       expect(onValue).toHaveBeenCalledWith({
         lowerValue: 0.102,
         upperValue: 0.3,

--- a/tensorboard/webapp/widgets/range_input/range_input_test.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_test.ts
@@ -181,6 +181,26 @@ describe('range input test', () => {
       expect(onValue).toHaveBeenCalledWith({lowerValue: -4, upperValue: 1});
     });
 
+    it('rounds number to filter out floating point math noise', () => {
+      const {fixture, onValue} = createComponent({
+        min: 0.1,
+        max: 0.3,
+        lowerValue: 0.1,
+        upperValue: 0.3,
+        tickCount: null,
+      });
+      const [leftThumb] = getThumbs(fixture);
+      startMovingThumb(leftThumb);
+      // range-input starts from 100px and ends at 300px so 102px is about 2%
+      // from left edge.
+      moveThumb(leftThumb, 102);
+      // Without our logic to round, lowerValue woudl be 0.10200000000000001.
+      expect(onValue).toHaveBeenCalledWith({
+        lowerValue: 0.102,
+        upperValue: 0.3,
+      });
+    });
+
     it('compensates position of mousedown relative to thumb center', () => {
       const {fixture, onValue} = createComponent({
         lowerValue: -1,


### PR DESCRIPTION
In some combinations of width of the widget, `min`, and `max`, the widget
emitted `value` event whose payload contained floating point math noises.
This is natural in JavaScript (and Python) where it uses IEEE 754. This made
UX quite janky as scrolling through the range input would all of the
sudden emit very long numeric string.

This change attempts to filter out the arithmetic noise simply by
truncating to 10th signficant decimals.

Example of bad case:
![image](https://user-images.githubusercontent.com/2547313/128552925-2a0c4bbb-55ac-43a1-9d72-dfef3f41b7ca.png)
