### PR TITLE
linked time: range view for scalars

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -167,18 +167,35 @@ limitations under the License.
   let-xScale="xScale"
 >
   <ng-container *ngIf="selectedTime">
-    <div *ngIf="!selectedTime.end" class="selected-time-single">
-      <div
-        class="selected-time-line"
-        [style.left]="
-          xScale.forward(
-            viewExtent.x,
-            [0, domDim.width],
-            selectedTime.start.step
-          ) + 'px'
-        "
-      ></div>
-    </div>
+    <div
+      [ngClass]="{
+        'out-of-selected-time': true,
+        start: true,
+        range: !!selectedTime.end
+      }"
+      [style.width]="
+        xScale.forward(
+          viewExtent.x,
+          [0, domDim.width],
+          selectedTime.start.step
+        ) + 'px'
+      "
+    ></div>
+    <div
+      *ngIf="selectedTime.end"
+      [ngClass]="{
+        'out-of-selected-time': true,
+        end: true,
+        range: true
+      }"
+      [style.left]="
+        xScale.forward(
+          viewExtent.x,
+          [0, domDim.width],
+          selectedTime.end.step
+        ) + 'px'
+      "
+    ></div>
   </ng-container>
 </ng-template>
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -114,20 +114,35 @@ $_title-to-heading-gap: 12px;
   }
 }
 
-.selected-time-single {
+.out-of-selected-time {
+  border: 0 dashed currentColor;
   height: 100%;
-  position: relative;
-  width: 100%;
+  position: absolute;
 
-  .selected-time-line {
-    $_border-width: 2px;
-    border-left: $_border-width dashed currentColor;
-    height: 100%;
-    // border is 2px.
-    // Center the line by offseting 1px to the left since the width of the
+  $_border-width: 2px;
+
+  &.start {
+    border-right-width: $_border-width;
     margin-left: -$_border-width / 2;
-    position: absolute;
-    width: 0;
+
+    &.range {
+      left: 0;
+    }
+  }
+
+  &.end {
+    border-left-width: $_border-width;
+    margin-right: -$_border-width / 2;
+    right: 0;
+  }
+
+  &.range {
+    // Replace this with backdrop-filter if opacity works.
+    background-color: rgba(255, 255, 255, 0.5);
+
+    @include tb-dark-theme {
+      background-color: rgba(0, 0, 0, 0.4);
+    }
   }
 }
 


### PR DESCRIPTION
This change implements visual for the ranged time selection for the
scalars visualization.

![image](https://user-images.githubusercontent.com/2547313/128553944-edb881ba-5432-47af-a382-4f6e149bee0d.png)

Ideally, I want the content of the line chart to have opacity preferably without changing the implementation of the line_chart_component but I could not get the `backdrop-filter: opacity` to work (it seems to be about opacity or strength of the filter?) and the only thing that I could find was this opaque overlay. If you know of a better way, I am all ears for the suggestion. 