### PR TITLE
color group: show message when regex does not match anything

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -44,37 +44,46 @@ limitations under the License.
   </p>
 </div>
 
-<div *ngIf="colorRunPairList.length" class="group-container">
+<div class="group-container" *ngIf="regexString">
   <h4>Color group preview</h4>
   <div class="grouping-preview">
-    <ul
-      class="group"
-      *ngFor="let colorRunsPair of colorRunPairList"
-      [ngStyle]="{borderColor: colorRunsPair.color}"
-    >
-      <li>
-        <label
-          ><span
-            class="color-swatch"
-            [ngStyle]="{backgroundColor: colorRunsPair.color}"
-          ></span
-          ><code class="group-id" [title]="colorRunsPair.groupId"
-            >{{colorRunsPair.groupId}}</code
-          ></label
-        >
-        <ul>
-          <ng-container *ngFor="let run of colorRunsPair.runs | slice:0:5;">
-            <li [title]="run.name">{{ run.name }}</li>
-          </ng-container>
-          <li class="more" *ngIf="colorRunsPair.runs.length > 5">
-            <em>and {{colorRunsPair.runs.length - 5 | number}} more</em>
-          </li>
-          <li class="no-match" *ngIf="colorRunsPair.runs.length === 0">
-            <em>No runs are in the group</em>
-          </li>
-        </ul>
-      </li>
-    </ul>
+    <div *ngIf="colorRunPairList.length; else empty" class="match-container">
+      <ul
+        class="group"
+        *ngFor="let colorRunsPair of colorRunPairList"
+        [ngStyle]="{borderColor: colorRunsPair.color}"
+      >
+        <li>
+          <label
+            ><span
+              class="color-swatch"
+              [ngStyle]="{backgroundColor: colorRunsPair.color}"
+            ></span
+            ><code class="group-id" [title]="colorRunsPair.groupId"
+              >{{colorRunsPair.groupId}}</code
+            ></label
+          >
+          <ul>
+            <ng-container *ngFor="let run of colorRunsPair.runs | slice:0:5;">
+              <li [title]="run.name">{{ run.name }}</li>
+            </ng-container>
+            <li class="more" *ngIf="colorRunsPair.runs.length > 5">
+              <em>and {{colorRunsPair.runs.length - 5 | number}} more</em>
+            </li>
+            <li class="no-match" *ngIf="colorRunsPair.runs.length === 0">
+              <em>No runs are in the group</em>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+
+    <ng-template #empty>
+      <div class="warning">
+        There are no runs matching the regex, <code>/{{regexString}}/</code>.
+        Please check if your regex string is correct.
+      </div>
+    </ng-template>
   </div>
 </div>
 

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
@@ -34,18 +34,26 @@ limitations under the License.
   h4 {
     margin-bottom: 10px;
   }
+
+  .warning {
+    @include tb-theme-foreground-prop(color, secondary-text);
+    font-size: 0.9em;
+  }
 }
 
 .grouping-preview {
   @include tb-theme-foreground-prop(border, border, 1px solid);
+  max-height: 50vh;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.match-container {
   align-items: flex-start;
   display: grid;
   flex-wrap: wrap;
   gap: 10px;
   grid-template-columns: repeat(2, minmax(50%, 1fr));
-  max-height: 50vh;
-  overflow-y: auto;
-  padding: 20px;
 }
 
 .color-swatch {

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
@@ -19,6 +19,7 @@ import {combineLatest, defer, merge, Observable, Subject} from 'rxjs';
 import {
   combineLatestWith,
   debounceTime,
+  filter,
   startWith,
   take,
   map,
@@ -75,6 +76,14 @@ export class RegexEditDialogContainer {
   readonly colorRunPairList$: Observable<ColorGroup[]> = defer(() => {
     return this.groupByRegexString$.pipe(
       debounceTime(INPUT_CHANGE_DEBOUNCE_INTERVAL_MS),
+      filter((regexString) => {
+        try {
+          const regex = new RegExp(regexString);
+          return Boolean(regex);
+        } catch (e) {
+          return false;
+        }
+      }),
       combineLatestWith(this.allRuns$, this.runIdToEid$),
       map(([regexString, allRuns, runIdToEid]) => {
         const groupBy = {

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -406,7 +406,7 @@ describe('regex_edit_dialog', () => {
       expect(groupingResult).toBeNull();
     }));
 
-    it('does not render grouping preview when no matched runs', fakeAsync(() => {
+    it('renders warning when no runs match', fakeAsync(() => {
       const fixture = createComponent(['rose']);
       store.overrideSelector(getRuns, [
         buildRun({id: 'run1', name: 'run 1'}),
@@ -426,10 +426,10 @@ describe('regex_edit_dialog', () => {
       tick(TEST_ONLY.INPUT_CHANGE_DEBOUNCE_INTERVAL_MS);
       fixture.detectChanges();
 
-      const groupingResult = fixture.debugElement.query(
-        By.css('.group-container')
+      const warning = fixture.debugElement.query(
+        By.css('.group-container .warning')
       );
-      expect(groupingResult).toBeNull();
+      expect(warning).not.toBeNull();
     }));
 
     it('does not update grouping preview on invalid regex input', fakeAsync(() => {


### PR DESCRIPTION
We show preview of what runs a regex string would match. When regex
string does not match any runs, we showed nothing in the preview
potentially confusing our users. This change now prints a warning when
non-empty regex matches no entries.

![image](https://user-images.githubusercontent.com/2547313/128567889-14b9d78c-1cd4-4330-99c3-ba1596fb586b.png)