### PR TITLE
line chart: zoom instruction show on top of other

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.scss
@@ -100,7 +100,9 @@ th {
   right: 0;
   top: 10px;
   transition: opacity 0.5s;
+  z-index: 1;
 }
+
 .instruction-content {
   background: rgba(0, 0, 0, 0.6);
   border-radius: 5px;


### PR DESCRIPTION
Especially with the customizable interactive view, the line chart
interactive view is no longer on top of all the other DOM. This makes
our zoom instruction which should appear above all is getting clipped or
getting masked by other components. This change simply uses z-index: 1
(we do not use it elsewhere so 1 is sufficient; we rely on DOM ordering
for the most part) to lift the DOM up.
