### PR TITLE
router: support conditional navigations and empty experiment names

### DIFF
--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -41,11 +41,6 @@ export function parseCompareExperimentStr(
     }
     const name = nameToIdStr.slice(0, colonIndex);
     const id = nameToIdStr.slice(colonIndex + 1);
-
-    if (!name) {
-      throw new Error(`Expect name to be non-falsy: ${nameToIdStr}`);
-    }
-
     if (!id) {
       throw new Error(`Expect id to be non-falsy: ${nameToIdStr}`);
     }

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -37,10 +37,21 @@ describe('app_routing/utils', () => {
       ).toEqual([{name: 'exp1', id: 'foo:my-universe:123'}]);
     });
 
+    it('parses experiments with no name', () => {
+      expect(
+        utils.parseCompareExperimentStr(
+          'exp1:foo,:universe:bar,:baz:my-universe:123'
+        )
+      ).toEqual([
+        {name: 'exp1', id: 'foo'},
+        {name: '', id: 'universe:bar'},
+        {name: '', id: 'baz:my-universe:123'},
+      ]);
+    });
+
     it('throws error when the map is malformed', () => {
       expect(() => utils.parseCompareExperimentStr('exp1')).toThrow();
       expect(() => utils.parseCompareExperimentStr('exp1:')).toThrow();
-      expect(() => utils.parseCompareExperimentStr('foo,bar,baz')).toThrow();
     });
   });
 

--- a/tensorboard/webapp/app_routing/programmatical_navigation_module.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_module.ts
@@ -83,7 +83,7 @@ export class ProgrammaticalNavigationModule {
   >(
     providerFactory: () => {
       actionCreator: AC;
-      lambda: (action: U) => ProgrammaticalNavigation;
+      lambda: (action: U) => ProgrammaticalNavigation | null;
     }
   ): ModuleWithProviders<ProgrammaticalNavigationModule> {
     return {

--- a/tensorboard/webapp/app_routing/programmatical_navigation_module_test.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_module_test.ts
@@ -85,6 +85,26 @@ describe('programmatical navigation module test', () => {
     expect(module.getNavigation(otherTestAction())).toBe(null);
   });
 
+  it('returns null when lambda does not provide a navigation', async () => {
+    function provider() {
+      return {
+        actionCreator: testAction,
+        lambda: (action: typeof testAction) => null,
+      };
+    }
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ProgrammaticalNavigationModule.registerProgrammaticalNavigation(
+          provider
+        ),
+      ],
+    }).compileComponents();
+
+    const module = TestBed.inject(ProgrammaticalNavigationModule);
+    expect(module.getNavigation(testAction())).toBe(null);
+  });
+
   it('throws invariant error if same action is registered twice', async () => {
     function provider1() {
       return {

--- a/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
@@ -45,5 +45,10 @@ export type ProgrammaticalNavigation =
 
 export interface NavigationLambda {
   actionCreator: ActionCreator<string, Creator>;
-  lambda(action: Action): ProgrammaticalNavigation;
+  /**
+   * The function that determines the navigation to be performed when the action
+   * is triggered. May return `null` to indicate that no navigation should
+   * occur.
+   */
+  lambda(action: Action): ProgrammaticalNavigation | null;
 }

--- a/tensorboard/webapp/app_routing/store_only_utils.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils.ts
@@ -34,7 +34,9 @@ export function getCompareExperimentIdAliasSpec(
   const idToDisplayName = new Map<string, string>();
   const nameAndIds = parseCompareExperimentStr(routeParams.experimentIds);
   for (const {id, name} of nameAndIds) {
-    idToDisplayName.set(id, name);
+    if (name) {
+      idToDisplayName.set(id, name);
+    }
   }
   return idToDisplayName;
 }

--- a/tensorboard/webapp/app_routing/store_only_utils_test.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils_test.ts
@@ -42,6 +42,13 @@ describe('app_routing store_only_utils test', () => {
       expect(map).toEqual(new Map([['123', 'b']]));
     });
 
+    it('does not include empty aliases', () => {
+      const map = getCompareExperimentIdAliasSpec({
+        experimentIds: 'a:123,:345',
+      });
+      expect(map).toEqual(new Map([['123', 'a']]));
+    });
+
     it('throws when it is empty', () => {
       expect(() =>
         getCompareExperimentIdAliasSpec({


### PR DESCRIPTION
This includes 2 changes to the app router.

- The 'compare' route now accepts a URL that defines experiments with
  an 'id' and no display 'name' / alias. For example,
  'http://localhost/compare/:unnamedExpId,baseline:secondNamedExpId'
- Registering a `ProgrammaticalNavigation` now allows providing a
  lambda which may conditionally return `null`, to indicate that a
  navigation should not occur when the specified action is fired.

These changes are a step towards allowing a TensorBoard app to craft a
URL that automatically uses default experiment aliases computed at
runtime without the URL having to specify them.

Googlers, see b/195683550 and proof of concept cl/389664527