### PR TITLE
color grouping: trap focus in the dialog

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -86,17 +86,17 @@ limitations under the License.
         </div>
       </ng-template>
     </div>
+  </div>
 
-    <div mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
-      <button
-        mat-raised-button
-        color="primary"
-        mat-dialog-close
-        (click)="onSaveClick(regexStringInput.value)"
-      >
-        Save
-      </button>
-    </div>
+  <div mat-dialog-actions align="end">
+    <button mat-button mat-dialog-close>Cancel</button>
+    <button
+      mat-raised-button
+      color="primary"
+      mat-dialog-close
+      (click)="onSaveClick(regexStringInput.value)"
+    >
+      Save
+    </button>
   </div>
 </div>

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,57 +45,58 @@ limitations under the License.
     </p>
   </div>
 
-<div class="group-container" *ngIf="regexString">
-  <h4>Color group preview</h4>
-  <div class="grouping-preview">
-    <div *ngIf="colorRunPairList.length; else empty" class="match-container">
-      <ul
-        class="group"
-        *ngFor="let colorRunsPair of colorRunPairList"
-        [ngStyle]="{borderColor: colorRunsPair.color}"
-      >
-        <li>
-          <label
-            ><span
-              class="color-swatch"
-              [ngStyle]="{backgroundColor: colorRunsPair.color}"
-            ></span
-            ><code class="group-id" [title]="colorRunsPair.groupId"
-              >{{colorRunsPair.groupId}}</code
-            ></label
-          >
-          <ul>
-            <ng-container *ngFor="let run of colorRunsPair.runs | slice:0:5;">
-              <li [title]="run.name">{{ run.name }}</li>
-            </ng-container>
-            <li class="more" *ngIf="colorRunsPair.runs.length > 5">
-              <em>and {{colorRunsPair.runs.length - 5 | number}} more</em>
-            </li>
-            <li class="no-match" *ngIf="colorRunsPair.runs.length === 0">
-              <em>No runs are in the group</em>
-            </li>
-          </ul>
-        </li>
-      </ul>
+  <div class="group-container" *ngIf="regexString">
+    <h4>Color group preview</h4>
+    <div class="grouping-preview">
+      <div *ngIf="colorRunPairList.length; else empty" class="match-container">
+        <ul
+          class="group"
+          *ngFor="let colorRunsPair of colorRunPairList"
+          [ngStyle]="{borderColor: colorRunsPair.color}"
+        >
+          <li>
+            <label
+              ><span
+                class="color-swatch"
+                [ngStyle]="{backgroundColor: colorRunsPair.color}"
+              ></span
+              ><code class="group-id" [title]="colorRunsPair.groupId"
+                >{{colorRunsPair.groupId}}</code
+              ></label
+            >
+            <ul>
+              <ng-container *ngFor="let run of colorRunsPair.runs | slice:0:5;">
+                <li [title]="run.name">{{ run.name }}</li>
+              </ng-container>
+              <li class="more" *ngIf="colorRunsPair.runs.length > 5">
+                <em>and {{colorRunsPair.runs.length - 5 | number}} more</em>
+              </li>
+              <li class="no-match" *ngIf="colorRunsPair.runs.length === 0">
+                <em>No runs are in the group</em>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+
+      <ng-template #empty>
+        <div class="warning">
+          There are no runs matching the regex, <code>/{{regexString}}/</code>.
+          Please check if your regex string is correct.
+        </div>
+      </ng-template>
     </div>
 
-    <ng-template #empty>
-      <div class="warning">
-        There are no runs matching the regex, <code>/{{regexString}}/</code>.
-        Please check if your regex string is correct.
-      </div>
-    </ng-template>
-  </div>
-
-  <div mat-dialog-actions align="end">
-    <button mat-button mat-dialog-close>Cancel</button>
-    <button
-      mat-raised-button
-      color="primary"
-      mat-dialog-close
-      (click)="onSaveClick(regexStringInput.value)"
-    >
-      Save
-    </button>
+    <div mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Cancel</button>
+      <button
+        mat-raised-button
+        color="primary"
+        mat-dialog-close
+        (click)="onSaveClick(regexStringInput.value)"
+      >
+        Save
+      </button>
+    </div>
   </div>
 </div>

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<div class="regex-edit-dialog">
 <h1 mat-dialog-title>Color runs by regex</h1>
 
 <mat-dialog-content>
@@ -97,4 +98,5 @@ limitations under the License.
   >
     Save
   </button>
+</div>
 </div>

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -15,35 +15,35 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="regex-edit-dialog" (focusout)="handleFocusOut()">
-<h1 mat-dialog-title>Color runs by regex</h1>
+  <h1 mat-dialog-title>Color runs by regex</h1>
 
-<mat-dialog-content>
-  <p>Enter a regex with capturing groups to match against run names:</p>
-  <mat-form-field>
-    <input
-      matInput
-      #regexStringInput
-      value="{{ regexString }}"
-      (keydown.enter)="onEnter($event.target.value)"
-      (input)="regexInputChange($event.target.value)"
-      i18n-aria-label="Color Runs by Regex Query"
-      aria-label="Color Runs by Regex Query"
-      cdkFocusInitial
-    />
-  </mat-form-field>
-</mat-dialog-content>
+  <mat-dialog-content>
+    <p>Enter a regex with capturing groups to match against run names:</p>
+    <mat-form-field>
+      <input
+        matInput
+        #regexStringInput
+        value="{{ regexString }}"
+        (keydown.enter)="onEnter($event.target.value)"
+        (input)="regexInputChange($event.target.value)"
+        i18n-aria-label="Color Runs by Regex Query"
+        aria-label="Color Runs by Regex Query"
+        cdkFocusInitial
+      />
+    </mat-form-field>
+  </mat-dialog-content>
 
-<div class="example-details">
-  <p>
-    Each matching run will be assigned a color based on the "key" formed by its
-    matches to the capturing groups. <br />
-    <button (click)="fillExample('(train|eval)')">
-      Try <code>(train|eval)</code>
-    </button>
-    to assign all runs containing <code>train</code> to one color and all runs
-    containing <code>eval</code> to another color.
-  </p>
-</div>
+  <div class="example-details">
+    <p>
+      Each matching run will be assigned a color based on the "key" formed by
+      its matches to the capturing groups. <br />
+      <button (click)="fillExample('(train|eval)')">
+        Try <code>(train|eval)</code>
+      </button>
+      to assign all runs containing <code>train</code> to one color and all runs
+      containing <code>eval</code> to another color.
+    </p>
+  </div>
 
 <div class="group-container" *ngIf="regexString">
   <h4>Color group preview</h4>
@@ -86,17 +86,16 @@ limitations under the License.
       </div>
     </ng-template>
   </div>
-</div>
 
-<div mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close>Cancel</button>
-  <button
-    mat-raised-button
-    color="primary"
-    mat-dialog-close
-    (click)="onSaveClick(regexStringInput.value)"
-  >
-    Save
-  </button>
-</div>
+  <div mat-dialog-actions align="end">
+    <button mat-button mat-dialog-close>Cancel</button>
+    <button
+      mat-raised-button
+      color="primary"
+      mat-dialog-close
+      (click)="onSaveClick(regexStringInput.value)"
+    >
+      Save
+    </button>
+  </div>
 </div>

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div class="regex-edit-dialog">
+<div class="regex-edit-dialog" (focusout)="handleFocusOut()">
 <h1 mat-dialog-title>Color runs by regex</h1>
 
 <mat-dialog-content>

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
@@ -13,11 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   EventEmitter,
   Input,
   Output,
+  ViewChild,
 } from '@angular/core';
 import {MatDialogRef} from '@angular/material/dialog';
 import {Run} from '../../types';
@@ -41,6 +44,9 @@ export class RegexEditDialogComponent {
   @Output() onSave = new EventEmitter<string>();
   @Output() regexInputOnChange = new EventEmitter<string>();
 
+  timeOutId = 0;
+  @ViewChild("regexStringInput", { static: false }) regexStringInput!: ElementRef;
+
   constructor(
     public readonly dialogRef: MatDialogRef<RegexEditDialogComponent>
   ) {}
@@ -60,5 +66,24 @@ export class RegexEditDialogComponent {
 
   regexInputChange(regexString: string) {
     this.regexInputOnChange.emit(regexString);
+  }
+
+  resetFocus() {
+    let activeElement = document.activeElement;
+    if (!activeElement) {
+      return;
+    }
+
+    const input = this.regexStringInput.nativeElement;
+    if (input) {
+      if (!activeElement.contains(input)) {
+        (input as HTMLElement).focus();
+      }
+    }
+  }
+
+  handleFocusOut() {
+    clearTimeout(this.timeOutId);
+    this.timeOutId = setTimeout(this.resetFocus.bind(this), 0);
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
@@ -44,10 +44,13 @@ export class RegexEditDialogComponent {
   @Output() regexInputOnChange = new EventEmitter<string>();
 
   timeOutId = 0;
-  @ViewChild('regexStringInput', {static: false}) regexStringInput!: ElementRef;
+  @ViewChild('regexStringInput', {static: true}) regexStringInput!: ElementRef<
+    HTMLInputElement
+  >;
 
   constructor(
-    public readonly dialogRef: MatDialogRef<RegexEditDialogComponent>
+    public readonly dialogRef: MatDialogRef<RegexEditDialogComponent>,
+    private readonly hostElRef: ElementRef
   ) {}
 
   onEnter(regexString: string) {
@@ -68,16 +71,9 @@ export class RegexEditDialogComponent {
   }
 
   resetFocus() {
-    let activeElement = document.activeElement;
-    if (!activeElement) {
-      return;
-    }
-
-    const input = this.regexStringInput.nativeElement;
-    if (input) {
-      if (!activeElement.contains(input)) {
-        (input as HTMLElement).focus();
-      }
+    if (!this.hostElRef.nativeElement.contains(document.activeElement)) {
+      const input = this.regexStringInput.nativeElement;
+      input.focus();
     }
   }
 

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ElementRef,

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
@@ -45,7 +45,7 @@ export class RegexEditDialogComponent {
   @Output() regexInputOnChange = new EventEmitter<string>();
 
   timeOutId = 0;
-  @ViewChild("regexStringInput", { static: false }) regexStringInput!: ElementRef;
+  @ViewChild('regexStringInput', {static: false}) regexStringInput!: ElementRef;
 
   constructor(
     public readonly dialogRef: MatDialogRef<RegexEditDialogComponent>

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
@@ -53,6 +53,13 @@ export class RegexEditDialogComponent {
     private readonly hostElRef: ElementRef
   ) {}
 
+  private resetFocus() {
+    if (!this.hostElRef.nativeElement.contains(document.activeElement)) {
+      const input = this.regexStringInput.nativeElement;
+      input.focus();
+    }
+  }
+
   onEnter(regexString: string) {
     this.onSaveClick(regexString);
     this.dialogRef.close();
@@ -68,13 +75,6 @@ export class RegexEditDialogComponent {
 
   regexInputChange(regexString: string) {
     this.regexInputOnChange.emit(regexString);
-  }
-
-  resetFocus() {
-    if (!this.hostElRef.nativeElement.contains(document.activeElement)) {
-      const input = this.regexStringInput.nativeElement;
-      input.focus();
-    }
   }
 
   handleFocusOut() {

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
@@ -20,11 +20,10 @@ import {
   combineLatestWith,
   debounceTime,
   filter,
+  map,
   startWith,
   take,
-  map,
 } from 'rxjs/operators';
-
 import {State} from '../../../app_state';
 import {CHART_COLOR_PALLETE} from '../../../util/colors';
 import {runGroupByChanged} from '../../actions';
@@ -34,10 +33,17 @@ import {
   getRuns,
 } from '../../store/runs_selectors';
 import {groupRuns} from '../../store/utils';
-import {Run, GroupByKey} from '../../types';
+import {GroupByKey, Run} from '../../types';
 import {ColorGroup} from './regex_edit_dialog_component';
 
 const INPUT_CHANGE_DEBOUNCE_INTERVAL_MS = 500;
+
+function isWithinDialog(activeElement: Element) {
+  console.log("----isWithinDialog-----");
+  console.log(activeElement);
+  console.log(activeElement.closest('.regex-edit-dialog'));
+  return activeElement.closest('.regex-edit-dialog') ? true : false;
+}
 
 @Component({
   selector: 'regex-edit-dialog',
@@ -142,6 +148,30 @@ export class RegexEditDialogContainer {
         return runsList.flat();
       })
     );
+  }
+  ngOnInit() {
+    // window.addEventListener('Click', this.onClick);
+    document.addEventListener('focusin', this.onFocusChange, true);
+  }
+
+  onFocusChange() {
+    console.log('onFocusChange');
+    // check activeelement
+    // if outside dialog --> moveback
+    let activeElement = document.activeElement;
+    if (!activeElement) {
+      return;
+    }
+    if (!isWithinDialog(activeElement)) {
+      console.log("focus change");
+      const input = document.querySelector('mat-form-field input');
+      if (input) {
+        (input as HTMLElement).focus();
+        console.log("new focus? ", document.activeElement);
+      };
+    } else {
+      console.log("do nothing?");
+    }
   }
 
   onRegexInputOnChange(regexString: string) {

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
@@ -24,6 +24,7 @@ import {
   startWith,
   take,
 } from 'rxjs/operators';
+
 import {State} from '../../../app_state';
 import {CHART_COLOR_PALLETE} from '../../../util/colors';
 import {runGroupByChanged} from '../../actions';

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
@@ -38,13 +38,6 @@ import {ColorGroup} from './regex_edit_dialog_component';
 
 const INPUT_CHANGE_DEBOUNCE_INTERVAL_MS = 500;
 
-function isWithinDialog(activeElement: Element) {
-  console.log("----isWithinDialog-----");
-  console.log(activeElement);
-  console.log(activeElement.closest('.regex-edit-dialog'));
-  return activeElement.closest('.regex-edit-dialog') ? true : false;
-}
-
 @Component({
   selector: 'regex-edit-dialog',
   template: `<regex-edit-dialog-component

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
@@ -149,30 +149,6 @@ export class RegexEditDialogContainer {
       })
     );
   }
-  ngOnInit() {
-    // window.addEventListener('Click', this.onClick);
-    document.addEventListener('focusin', this.onFocusChange, true);
-  }
-
-  onFocusChange() {
-    console.log('onFocusChange');
-    // check activeelement
-    // if outside dialog --> moveback
-    let activeElement = document.activeElement;
-    if (!activeElement) {
-      return;
-    }
-    if (!isWithinDialog(activeElement)) {
-      console.log("focus change");
-      const input = document.querySelector('mat-form-field input');
-      if (input) {
-        (input as HTMLElement).focus();
-        console.log("new focus? ", document.activeElement);
-      };
-    } else {
-      console.log("do nothing?");
-    }
-  }
 
   onRegexInputOnChange(regexString: string) {
     this.tentativeRegexString$.next(regexString);

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -524,6 +524,6 @@ describe('regex_edit_dialog', () => {
     fixture.detectChanges();
 
     expect(document.activeElement).toBe(input.nativeElement);
-    tick(500);
+    discardPeriodicTasks();
   }));
 });

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -511,4 +511,19 @@ describe('regex_edit_dialog', () => {
     expect(list.length).toBe(6);
     expect(more.nativeElement.textContent).toBe('and 2 more');
   }));
+
+  it('makes focus stay in the regex dialog', fakeAsync(() => {
+    const fixture = createComponent(['rose']);
+    fixture.detectChanges();
+    const input = fixture.debugElement.query(By.css('input'));
+    // Works around for input element focus initial (cdkFocusInitial)
+    input.nativeElement.focus();
+
+    const div = document.createElement('div');
+    div.focus();
+    fixture.detectChanges();
+
+    expect(document.activeElement).toBe(input.nativeElement);
+    tick(500);
+  }));
 });

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -14,10 +14,10 @@ limitations under the License.
 ==============================================================================*/
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {
-  TestBed,
-  fakeAsync,
-  tick,
   discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick,
 } from '@angular/core/testing';
 import {
   MatDialogModule,
@@ -30,22 +30,21 @@ import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-
 import {State} from '../../../app_state';
 import {
-  getRuns,
-  getRunIdsForExperiment,
   getColorGroupRegexString,
+  getRunIdsForExperiment,
+  getRuns,
 } from '../../../selectors';
 import {KeyType, sendKey, SendKeyArgs} from '../../../testing/dom';
 import {runGroupByChanged} from '../../actions';
+import {buildRun} from '../../store/testing';
 import {GroupByKey} from '../../types';
 import {RegexEditDialogComponent} from './regex_edit_dialog_component';
 import {
   RegexEditDialogContainer,
   TEST_ONLY,
 } from './regex_edit_dialog_container';
-import {buildRun} from '../../store/testing';
 
 describe('regex_edit_dialog', () => {
   let actualActions: Action[];
@@ -518,10 +517,12 @@ describe('regex_edit_dialog', () => {
     const input = fixture.debugElement.query(By.css('input'));
     // Works around for input element focus initial (cdkFocusInitial)
     input.nativeElement.focus();
+    tick();
 
-    const div = document.createElement('div');
-    div.focus();
-    fixture.detectChanges();
+    const inputDummy = document.createElement('input');
+    document.body.append(inputDummy);
+    inputDummy.focus();
+    tick();
 
     expect(document.activeElement).toBe(input.nativeElement);
     discardPeriodicTasks();


### PR DESCRIPTION
* Motivation for features / changes
Under some scenario (the filter run regex has been edited), when users hit ctrl+z, the focus goes back to the filter run input and the dialog input lost the focus. Although we do not prevent the ctrl+z happen, we can exam what is the new activeElement and move the focus back if the new activeElement is not within the regex dialog.

* Technical description of changes
Listen to regex dialog component `focusout` event firing 
use timeout to wait for the `activeElement` to move from the input to new one (Step 2 to 3 in the below flow)

Focus change event sequence: (credit to @stephanwlee)
1. user tabs from input
2. foucsout (or blur); activeElement is still the input
3. focus actually moves and updates activeElement to the next focusable element.
4. focusin (or focus on that specific focusable element)

