### PR TITLE
color grouping: generate preview for example filling

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.ts
@@ -56,6 +56,7 @@ export class RegexEditDialogComponent {
 
   fillExample(regexExample: string): void {
     this.regexString = regexExample;
+    this.regexInputChange(regexExample);
   }
 
   regexInputChange(regexString: string) {

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -265,7 +265,7 @@ describe('regex_edit_dialog', () => {
     );
   });
 
-  it('fills example', () => {
+  it('fills example and generates warning', () => {
     const fixture = createComponent(['rose']);
     fixture.detectChanges();
 
@@ -277,7 +277,35 @@ describe('regex_edit_dialog', () => {
 
     const input = fixture.debugElement.query(By.css('input'));
     expect(input.nativeElement.value).toBe('(train|eval)');
+    const warning = fixture.debugElement.queryAll(By.css('.warning'));
+    expect(warning).toBeTruthy();
   });
+
+  it('fills example and generates group preview', fakeAsync(() => {
+    const fixture = createComponent(['rose']);
+    store.overrideSelector(getRuns, [
+      buildRun({id: 'run1', name: 'run 1'}),
+      buildRun({id: 'run2', name: 'run 2'}),
+    ]);
+    store.overrideSelector(getColorGroupRegexString, 'run');
+    fixture.detectChanges();
+    tick(TEST_ONLY.INPUT_CHANGE_DEBOUNCE_INTERVAL_MS);
+    fixture.detectChanges();
+
+    const button = fixture.debugElement.query(
+      By.css('.example-details button')
+    );
+    button.nativeElement.click();
+    fixture.detectChanges();
+
+    const groupingResult = fixture.debugElement.query(
+      By.css('.group-container')
+    );
+    expect(groupingResult).not.toBeNull();
+    const groups = fixture.debugElement.queryAll(By.css('.group'));
+    expect(groups.length).toBe(1);
+    tick(500);
+  }));
 
   describe('live grouping result preview', () => {
     it('renders grouping result based on regex in store', fakeAsync(() => {

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -304,7 +304,7 @@ describe('regex_edit_dialog', () => {
     expect(groupingResult).not.toBeNull();
     const groups = fixture.debugElement.queryAll(By.css('.group'));
     expect(groups.length).toBe(1);
-    tick(500);
+    discardPeriodicTasks();
   }));
 
   describe('live grouping result preview', () => {


### PR DESCRIPTION
* Motivation for features / changes
Previously we listen to `input` of the input, it does not get triggered when user click `try (train|eval)` button, which modify the input value. Now we manually trigger `regexInputChange` method when the `try` button is clicked.
