### PR TITLE
linked time: range on sidebar step selector

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -156,9 +156,7 @@ export const timeSelectionChanged = createAction(
   '[Metrics] Linked Time Selection Changed',
   props<{
     startStep: number;
-    startWallTime: number;
     endStep?: number;
-    endWallTime?: number;
   }>()
 );
 

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -96,6 +96,6 @@ export const SCALARS_SMOOTHING_MIN = 0;
 export const SCALARS_SMOOTHING_MAX = 0.999;
 
 export interface LinkedTime {
-  start: {step: number; wallTime: number};
-  end: {step: number; wallTime: number} | null;
+  start: {step: number};
+  end: {step: number} | null;
 }

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -706,32 +706,69 @@ describe('metrics selectors', () => {
     });
   });
 
-  describe('getMetricsSelectedTimeRaw', () => {
+  describe('getMetricsStepMinMax', () => {
     beforeEach(() => {
-      selectors.getMetricsSelectedTimeRaw.release();
+      selectors.getMetricsStepMinMax.release();
     });
 
-    it('returns `null` when selected time is null', () => {
+    it('returns min and max of the dataset', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          stepMinMax: {min: 10, max: 100},
+        })
+      );
+      expect(selectors.getMetricsStepMinMax(state)).toEqual({
+        min: 10,
+        max: 100,
+      });
+    });
+
+    it('returns 0 and 1000 if extremum are Infinities', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          stepMinMax: {min: Infinity, max: -Infinity},
+        })
+      );
+      expect(selectors.getMetricsStepMinMax(state)).toEqual({
+        min: 0,
+        max: 1000,
+      });
+    });
+  });
+
+  describe('getMetricsSelectedTimeSetting', () => {
+    beforeEach(() => {
+      selectors.getMetricsSelectedTimeSetting.release();
+    });
+
+    it('returns value from the dataset when selected time is null', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
           selectedTime: null,
+          stepMinMax: {
+            min: 0,
+            max: 1000,
+          },
         })
       );
-      expect(selectors.getMetricsSelectedTimeRaw(state)).toBeNull();
+      expect(selectors.getMetricsSelectedTimeSetting(state)).toEqual({
+        start: {step: 0},
+        end: {step: 1000},
+      });
     });
 
     it('returns value when selected time is present', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
           selectedTime: {
-            start: {step: 0, wallTime: 2000},
-            end: null,
+            start: {step: 0},
+            end: {step: 1},
           },
         })
       );
-      expect(selectors.getMetricsSelectedTimeRaw(state)).toEqual({
-        start: {step: 0, wallTime: 2000},
-        end: null,
+      expect(selectors.getMetricsSelectedTimeSetting(state)).toEqual({
+        start: {step: 0},
+        end: {step: 1},
       });
     });
   });
@@ -744,18 +781,8 @@ describe('metrics selectors', () => {
     it('returns `null` when selectTime is disabled even when value exists', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
-          selectedTime: {start: {step: 1, wallTime: 0}, end: null},
+          selectedTime: {start: {step: 1}, end: {step: 1}},
           selectTimeEnabled: false,
-        })
-      );
-      expect(selectors.getMetricsSelectedTime(state)).toBeNull();
-    });
-
-    it('returns `null` when selected time is null', () => {
-      const state = appStateFromMetricsState(
-        buildMetricsState({
-          selectedTime: null,
-          selectTimeEnabled: true,
         })
       );
       expect(selectors.getMetricsSelectedTime(state)).toBeNull();
@@ -765,16 +792,16 @@ describe('metrics selectors', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
           selectedTime: {
-            start: {step: 0, wallTime: 2000},
-            end: {step: 100, wallTime: 2000},
+            start: {step: 0},
+            end: {step: 100},
           },
           selectTimeEnabled: true,
           useRangeSelectTime: true,
         })
       );
       expect(selectors.getMetricsSelectedTime(state)).toEqual({
-        start: {step: 0, wallTime: 2000},
-        end: {step: 100, wallTime: 2000},
+        start: {step: 0},
+        end: {step: 100},
       });
     });
 
@@ -782,15 +809,15 @@ describe('metrics selectors', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
           selectedTime: {
-            start: {step: 0, wallTime: 2000},
-            end: {step: 100, wallTime: 2000},
+            start: {step: 0},
+            end: {step: 100},
           },
           selectTimeEnabled: true,
           useRangeSelectTime: false,
         })
       );
       expect(selectors.getMetricsSelectedTime(state)).toEqual({
-        start: {step: 0, wallTime: 2000},
+        start: {step: 0},
         end: null,
       });
     });

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -131,6 +131,11 @@ export type CardToPinnedCard = Map<NonPinnedCardId, PinnedCardId>;
 
 export type PinnedCardToCard = Map<PinnedCardId, NonPinnedCardId>;
 
+export interface StoreInternalLinkedTime {
+  start: {step: number};
+  end: {step: number};
+}
+
 export interface MetricsRoutefulState {
   tagMetadataLoaded: DataLoadState;
   tagMetadata: TagMetadata;
@@ -152,10 +157,15 @@ export interface MetricsRoutefulState {
   cardStepIndex: CardStepIndexMap;
   tagFilter: string;
   tagGroupExpanded: Map<string, boolean>;
-  selectedTime: LinkedTime | null;
+  selectedTime: StoreInternalLinkedTime | null;
   selectTimeEnabled: boolean;
   useRangeSelectTime: boolean;
   filteredPluginTypes: Set<PluginType>;
+  // Minimum and maximum step number across all TimeSeries data.
+  stepMinMax: {
+    min: number;
+    max: number;
+  };
 }
 
 export interface MetricsSettings {

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -93,6 +93,7 @@ function buildBlankState(): MetricsState {
     selectTimeEnabled: false,
     useRangeSelectTime: false,
     filteredPluginTypes: new Set(),
+    stepMinMax: {min: Infinity, max: -Infinity},
   };
 }
 

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -92,7 +92,14 @@ describe('metrics right_pane', () => {
       store.overrideSelector(selectors.getIsLinkedTimeEnabled, false);
       store.overrideSelector(selectors.getMetricsSelectTimeEnabled, false);
       store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-      store.overrideSelector(selectors.getMetricsSelectedTimeRaw, null);
+      store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
+        start: {step: 0},
+        end: {step: 1000},
+      });
+      store.overrideSelector(selectors.getMetricsStepMinMax, {
+        min: 0,
+        max: 5000,
+      });
     });
 
     function getMatSliderValue(el: DebugElement): string {
@@ -379,7 +386,10 @@ describe('metrics right_pane', () => {
 
         it('dispatches actions when step changes when making single step change', () => {
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-          store.overrideSelector(selectors.getMetricsSelectedTimeRaw, null);
+          store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
+            start: {step: 0},
+            end: {step: 1000},
+          });
           const fixture = TestBed.createComponent(SettingsViewContainer);
           fixture.detectChanges();
 
@@ -393,16 +403,14 @@ describe('metrics right_pane', () => {
           expect(dispatchSpy).toHaveBeenCalledOnceWith(
             actions.timeSelectionChanged({
               startStep: 5,
-              startWallTime: 0,
               endStep: undefined,
-              endWallTime: undefined,
             })
           );
         });
 
-        it('keeps existing endStep when single step range changes', () => {
+        it('sets endStep to undefined when single step range changes', () => {
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-          store.overrideSelector(selectors.getMetricsSelectedTimeRaw, {
+          store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
             start: {step: 0, wallTime: -1},
             end: {step: 100, wallTime: 100},
           });
@@ -419,9 +427,7 @@ describe('metrics right_pane', () => {
           expect(dispatchSpy).toHaveBeenCalledOnceWith(
             actions.timeSelectionChanged({
               startStep: 5,
-              startWallTime: 0,
-              endStep: 100,
-              endWallTime: 100,
+              endStep: undefined,
             })
           );
         });
@@ -444,7 +450,10 @@ describe('metrics right_pane', () => {
 
         it('dispatches actions when step changes when making range step change', () => {
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
-          store.overrideSelector(selectors.getMetricsSelectedTimeRaw, null);
+          store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
+            start: {step: 0},
+            end: {step: 0},
+          });
           const fixture = TestBed.createComponent(SettingsViewContainer);
           fixture.detectChanges();
 
@@ -459,9 +468,7 @@ describe('metrics right_pane', () => {
           expect(dispatchSpy).toHaveBeenCalledOnceWith(
             actions.timeSelectionChanged({
               startStep: 10,
-              startWallTime: 0,
               endStep: 200,
-              endWallTime: 0,
             })
           );
         });

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -51,8 +51,8 @@ limitations under the License.
           *ngIf="!useRangeSelectTime; else range"
           [disabled]="!selectTimeEnabled"
           color="primary"
-          [min]="0"
-          [max]="1000"
+          [min]="stepMinMax.min"
+          [max]="stepMinMax.max"
           [step]="1"
           [value]="selectedTime?.start.step"
           [thumbLabel]="true"
@@ -61,10 +61,10 @@ limitations under the License.
         <ng-template #range>
           <tb-range-input
             [attr.disabled]="!selectTimeEnabled"
-            min="0"
-            max="1000"
-            [lowerValue]="selectedTime?.start.step || 0"
-            [upperValue]="selectedTime?.end?.step"
+            [min]="stepMinMax.min"
+            [max]="stepMinMax.max"
+            [lowerValue]="selectedTime?.start.step"
+            [upperValue]="selectedTime?.end?.step "
             (value)="onStepRangeChanged($event)"
           ></tb-range-input>
         </ng-template>

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -64,6 +64,7 @@ export class SettingsViewComponent {
   @Input() selectTimeEnabled!: boolean;
   @Input() useRangeSelectTime!: boolean;
   @Input() selectedTime!: LinkedTime | null;
+  @Input() stepMinMax!: {min: number; max: number};
 
   @Output() selectTimeEnableToggled = new EventEmitter<void>();
   @Output() useRangeSelectTimeToggled = new EventEmitter<void>();
@@ -160,12 +161,8 @@ export class SettingsViewComponent {
 
   onStepStartChanged(stepValue: number) {
     this.selectTimeChanged.emit({
+      start: {step: stepValue},
       end: null,
-      ...this.selectedTime,
-      start: {
-        step: stepValue,
-        wallTime: 0,
-      },
     });
   }
 
@@ -177,14 +174,8 @@ export class SettingsViewComponent {
     upperValue: number;
   }) {
     this.selectTimeChanged.emit({
-      start: {
-        step: lowerValue,
-        wallTime: 0,
-      },
-      end: {
-        step: upperValue,
-        wallTime: 0,
-      },
+      start: {step: lowerValue},
+      end: {step: upperValue},
     });
   }
 }

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -66,6 +66,7 @@ import {HistogramMode, LinkedTime, TooltipSort, XAxisType} from '../../types';
       [selectTimeEnabled]="selectTimeEnabled$ | async"
       [selectedTime]="selectedTime$ | async"
       [useRangeSelectTime]="useRangeSelectTime$ | async"
+      [stepMinMax]="stepMinMax$ | async"
       (selectTimeEnableToggled)="onSelectTimeEnableToggled()"
       (useRangeSelectTimeToggled)="onUseRangeSelectTimeToggled()"
       (selectTimeChanged)="onSelectTimeChanged($event)"
@@ -87,8 +88,9 @@ export class SettingsViewContainer {
     selectors.getMetricsUseRangeSelectTime
   );
   readonly selectedTime$ = this.store.select(
-    selectors.getMetricsSelectedTimeRaw
+    selectors.getMetricsSelectedTimeSetting
   );
+  readonly stepMinMax$ = this.store.select(selectors.getMetricsStepMinMax);
 
   readonly isImageSupportEnabled$ = this.store
     .select(selectors.getIsFeatureFlagsLoaded)
@@ -183,9 +185,7 @@ export class SettingsViewContainer {
     this.store.dispatch(
       timeSelectionChanged({
         startStep: newValue.start.step,
-        startWallTime: newValue.start.wallTime,
         endStep: newValue.end?.step,
-        endWallTime: newValue.end?.wallTime,
       })
     );
   }


### PR DESCRIPTION
This change introduces a new state that keeps track of minimum and
maximum step values from all time series data. This is so we can render
the range_input with its minimum and maximum according to the data.

This change also updates the data structure on the `LinkedTime` to drop
`wallTime` field which is not used meaningfully and only causes the data
inconsistency.
