### PR TITLE
timeseries: state for remembering vis filter

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -19,7 +19,13 @@ import {
   TimeSeriesRequest,
   TimeSeriesResponse,
 } from '../data_source';
-import {CardId, HistogramMode, TooltipSort, XAxisType} from '../internal_types';
+import {
+  CardId,
+  HistogramMode,
+  PluginType,
+  TooltipSort,
+  XAxisType,
+} from '../internal_types';
 
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
@@ -133,6 +139,17 @@ export const metricsTagGroupExpansionChanged = createAction(
 export const cardPinStateToggled = createAction(
   '[Metrics] Card Pin State Toggled',
   props<{cardId: CardId; canCreateNewPins: boolean; wasPinned: boolean}>()
+);
+
+export const metricsToggleVisiblePlugin = createAction(
+  '[Metrics] Toggle Visible Plugin',
+  props<{
+    plugin: PluginType;
+  }>()
+);
+
+export const metricsShowAllPlugins = createAction(
+  '[Metrics] Toggle Show All Plugins'
 );
 
 export const timeSelectionChanged = createAction(

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -245,6 +245,7 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState<
     selectedTime: null,
     selectTimeEnabled: false,
     useRangeSelectTime: false,
+    filteredPluginTypes: new Set(),
   },
   {
     timeSeriesData: {
@@ -844,7 +845,22 @@ const reducer = createReducer(
       ...state,
       selectedTime: null,
     };
-  })
+  }),
+  on(actions.metricsToggleVisiblePlugin, (state, {plugin}) => {
+    const nextFilteredPluginTypes = new Set(state.filteredPluginTypes);
+    if (nextFilteredPluginTypes.has(plugin)) {
+      nextFilteredPluginTypes.delete(plugin);
+    } else {
+      nextFilteredPluginTypes.add(plugin);
+    }
+    return {...state, filteredPluginTypes: nextFilteredPluginTypes};
+  }),
+  on(
+    actions.metricsShowAllPlugins,
+    (state): MetricsState => {
+      return {...state, filteredPluginTypes: new Set()};
+    }
+  )
 );
 
 export function reducers(state: MetricsState | undefined, action: Action) {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1904,4 +1904,45 @@ describe('metrics reducers', () => {
       });
     });
   });
+
+  describe('plugin filtering feature', () => {
+    describe('#metricsToggleVisiblePlugin', () => {
+      it('toggles plugin types', () => {
+        const state1 = buildMetricsState({
+          filteredPluginTypes: new Set([PluginType.IMAGES]),
+        });
+
+        const state2 = reducers(
+          state1,
+          actions.metricsToggleVisiblePlugin({
+            plugin: PluginType.SCALARS,
+          })
+        );
+        expect(state2.filteredPluginTypes).toEqual(
+          new Set([PluginType.SCALARS, PluginType.IMAGES])
+        );
+
+        const state3 = reducers(
+          state2,
+          actions.metricsToggleVisiblePlugin({
+            plugin: PluginType.IMAGES,
+          })
+        );
+        expect(state3.filteredPluginTypes).toEqual(
+          new Set([PluginType.SCALARS])
+        );
+      });
+    });
+
+    describe('#metricsShowAllPlugins', () => {
+      it('clears all filtered plugin types', () => {
+        const before = buildMetricsState({
+          filteredPluginTypes: new Set([PluginType.IMAGES]),
+        });
+
+        const after = reducers(before, actions.metricsShowAllPlugins());
+        expect(after.filteredPluginTypes).toEqual(new Set());
+      });
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -26,6 +26,7 @@ import {
   LinkedTime,
   NonPinnedCardId,
   PinnedCardId,
+  PluginType,
   TooltipSort,
   XAxisType,
 } from '../internal_types';
@@ -382,5 +383,12 @@ export const getMetricsSelectedTime = createSelector(
     }
 
     return {...selectedTime, end: null};
+  }
+);
+
+export const getMetricsFilteredPluginTypes = createSelector(
+  selectMetricsState,
+  (state: MetricsState): Set<PluginType> => {
+    return state.filteredPluginTypes;
   }
 );

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -795,4 +795,21 @@ describe('metrics selectors', () => {
       });
     });
   });
+
+  describe('getMetricsFilteredPluginTypes', () => {
+    beforeEach(() => {
+      selectors.getMetricsFilteredPluginTypes.release();
+    });
+
+    it('returns current visualization filters', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          filteredPluginTypes: new Set([PluginType.SCALARS]),
+        })
+      );
+      expect(selectors.getMetricsFilteredPluginTypes(state)).toEqual(
+        new Set([PluginType.SCALARS])
+      );
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -155,6 +155,7 @@ export interface MetricsRoutefulState {
   selectedTime: LinkedTime | null;
   selectTimeEnabled: boolean;
   useRangeSelectTime: boolean;
+  filteredPluginTypes: Set<PluginType>;
 }
 
 export interface MetricsSettings {

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -92,6 +92,7 @@ function buildBlankState(): MetricsState {
     selectedTime: null,
     selectTimeEnabled: false,
     useRangeSelectTime: false,
+    filteredPluginTypes: new Set(),
   };
 }
 


### PR DESCRIPTION
This change introduces state in the Metric reducers to remember which
visualizations user wants to view.

UI that leverages the state will come in a following change.

Demo of final experience:
![image](https://user-images.githubusercontent.com/2547313/128943239-f36885b3-9a6a-4034-b253-de649243a40a.png)
