### PR TITLE
router: warn user if there are unsaved edits when navigating away 

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -11,6 +11,7 @@ tf_ng_module(
     ],
     deps = [
         ":app_root",
+        ":dirty_updates_registry",
         ":location",
         ":programmatical_navigation_module",
         ":route_registry",

--- a/tensorboard/webapp/app_routing/app_routing_module.ts
+++ b/tensorboard/webapp/app_routing/app_routing_module.ts
@@ -18,6 +18,7 @@ import {StoreModule} from '@ngrx/store';
 
 import {AppRootModule} from './app_root_module';
 import {AppRoutingEffects} from './effects';
+import {DirtyUpdatesRegistryModule} from './dirty_updates_registry_module';
 import {LocationModule} from './location_module';
 import {ProgrammaticalNavigationModule} from './programmatical_navigation_module';
 import {RouteRegistryModule} from './route_registry_module';
@@ -32,6 +33,6 @@ import {APP_ROUTING_FEATURE_KEY} from './store/app_routing_types';
     AppRootModule,
     LocationModule,
   ],
-  providers: [ProgrammaticalNavigationModule],
+  providers: [DirtyUpdatesRegistryModule, ProgrammaticalNavigationModule],
 })
 export class AppRoutingModule {}

--- a/tensorboard/webapp/app_routing/effects/BUILD
+++ b/tensorboard/webapp/app_routing/effects/BUILD
@@ -13,6 +13,7 @@ tf_ng_module(
     deps = [
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/app_routing:app_root",
+        "//tensorboard/webapp/app_routing:dirty_updates_registry",
         "//tensorboard/webapp/app_routing:internal_utils",
         "//tensorboard/webapp/app_routing:location",
         "//tensorboard/webapp/app_routing:programmatical_navigation_module",
@@ -38,6 +39,7 @@ tf_ng_module(
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/app_routing:app_root",
+        "//tensorboard/webapp/app_routing:dirty_updates_registry",
         "//tensorboard/webapp/app_routing:location",
         "//tensorboard/webapp/app_routing:programmatical_navigation_module",
         "//tensorboard/webapp/app_routing:route_registry",

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
 import {Action, createAction, Store} from '@ngrx/store';
-import {merge, Observable, of} from 'rxjs';
+import {combineLatest, merge, Observable, of} from 'rxjs';
 import {
   debounceTime,
   delay,
@@ -40,6 +40,7 @@ import {
   serializeCompareExperimentParams,
 } from '../internal_utils';
 import {Location} from '../location';
+import {DirtyUpdatesRegistryModule} from '../dirty_updates_registry_module';
 import {ProgrammaticalNavigationModule} from '../programmatical_navigation_module';
 import {RouteConfigs} from '../route_config';
 import {RouteRegistryModule} from '../route_registry_module';
@@ -64,6 +65,7 @@ export class AppRoutingEffects {
     private readonly actions$: Actions,
     private readonly store: Store<State>,
     private readonly location: Location,
+    private readonly dirtyUpdatesRegistry: DirtyUpdatesRegistryModule<State>,
     registry: RouteRegistryModule,
     private readonly programmaticalNavModule: ProgrammaticalNavigationModule,
     private readonly appRootProvider: AppRootProvider
@@ -198,8 +200,28 @@ export class AppRoutingEffects {
    * @export
    */
   navigate$ = createEffect(() => {
+    const hasDirtyUpdates$ = combineLatest(
+      this.dirtyUpdatesRegistry
+        .getDirtyUpdatesSelectors()
+        .map((selector) => this.store.select(selector))
+    ).pipe(
+      map(
+        (updates) =>
+          updates[0].experimentIds !== undefined &&
+          updates[0].experimentIds.length > 0
+      )
+    );
     const dispatchNavigating$ = this.validatedRoute$.pipe(
-      tap(({routeMatch, options}) => {
+      withLatestFrom(hasDirtyUpdates$),
+      filter(([, hasDirtyUpdates]) => {
+        if (hasDirtyUpdates) {
+          return window.confirm(
+            'You have unsaved edits, are you sure you want to discard them?'
+          );
+        }
+        return true;
+      }),
+      tap(([{routeMatch, options}]) => {
         if (options.browserInitiated && routeMatch.deepLinkProvider) {
           // Query paramter formed by the redirector is passed to the
           // deserializer instead of one from Location.getSearch(). This
@@ -223,7 +245,7 @@ export class AppRoutingEffects {
           );
         }
       }),
-      switchMap(({routeMatch, options}) => {
+      switchMap(([{routeMatch, options}]) => {
         const navigationOptions = {
           replaceState: options.replaceState ?? false,
         };


### PR DESCRIPTION
Warn user with `window.confirm` if there are unsaved edits when navigating away from the current route:
- If user confirms, discards the edits and navigate to the new route;
- Otherwise discontinue the `dispatchNavigating$`.

Tested locally in TensorBoard.corp: https://screencast.googleplex.com/cast/NjQ0NTg4OTcxNzUzNDcyMHxhNjFjMTViOS0zZQ