### PR TITLE
sync: fix attr.disabled issue

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -60,7 +60,7 @@ limitations under the License.
         ></mat-slider>
         <ng-template #range>
           <tb-range-input
-            [disabled]="!selectTimeEnabled"
+            [attr.disabled]="!selectTimeEnabled"
             min="0"
             max="1000"
             [lowerValue]="selectedTime?.start.step || 0"


### PR DESCRIPTION
Angular, while compiling, was not able to discern that the `disabled` is
not the `Input` to `tb-range-input` although it is a valid HTML
attribute on HTMLElement. This change explicitly instructs Angular to
put the property on the attribute.

This change unblocks the sync.