### PR TITLE
Minor tweaks to the appearance of sidebar and button-toggle

### DIFF
--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -99,5 +99,5 @@ export const initialState: CoreState = {
   },
   polymerInteropRuns: [],
   polymerInteropRunSelection: new Set(),
-  sideBarWidthInPercent: 30,
+  sideBarWidthInPercent: 20,
 };

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 <div class="toolbar">
   <metrics-tag-filter></metrics-tag-filter>
-  <mat-button-toggle-group class="filter-view" multiple>
+  <mat-button-toggle-group class="filter-view" multiple appearance="standard">
     <mat-button-toggle
       [checked]="filteredPluginTypes.size === 0"
       (click)="onPluginTypeAllToggled.emit()"


### PR DESCRIPTION
This change is a combination of two very minor commits that tweaks visuals of recently introduced components.

Specifically,
- button-toggle in metrics now have consistent appearance inside Google and in OSS
- sidebar default width is smaller 

I plan on merging these with rebase instead of squash. 