### PR TITLE
app routing: fix case when there are no selectors on registry

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -299,6 +299,28 @@ describe('app_routing_effects', () => {
         store.refreshState();
       });
 
+      it('does not break when there are no dirty experiments selectors', () => {
+        const registryModule = TestBed.inject(DirtyUpdatesRegistryModule);
+        spyOn(registryModule, 'getDirtyUpdatesSelectors').and.returnValue([]);
+
+        action.next(
+          actions.navigationRequested({
+            pathname: '/experiment/meow',
+          })
+        );
+
+        expect(actualActions).toEqual([
+          actions.navigating({
+            after: buildRoute({
+              routeKind: RouteKind.EXPERIMENT,
+              params: {experimentId: 'meow'},
+              pathname: '/experiment/meow',
+              queryParams: [],
+            }),
+          }),
+        ]);
+      });
+
       it('warns user when navigating away', () => {
         spyOn(window, 'confirm');
         action.next(


### PR DESCRIPTION
In case there are no dirty update selectors specified, the whole
AppRoutingEffects broke as we are waiting on `combineLatest` on an empty
list which never emits. This change fixes that by only conditionally
waiting on the selectors when they are non-empty
