### PR TITLE
chore: require node.js 12.21.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,7 +46,11 @@ http_archive(
     ],
 )
 
-load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
+
+node_repositories(
+    node_version = "12.21.0",
+)
 
 yarn_install(
     name = "npm",


### PR DESCRIPTION
By default, no matter what version of Node you have installed,
rules_nodejs loads node 12.13.0. This version is not too compatible with
the newer dependencies (a package may use `engine` on package.json to
denote compatibility with a version of a node runtime). This change
bumps the node requirement to 12.21.0 which is good enough for our use
case.