### PR TITLE
app_routing: expose symbols

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -8,13 +8,16 @@ tf_ng_module(
     name = "app_routing",
     srcs = [
         "app_routing_module.ts",
+        "index.ts",
     ],
     deps = [
         ":app_root",
         ":dirty_updates_registry",
+        ":internal_utils",
         ":location",
         ":programmatical_navigation_module",
         ":route_registry",
+        ":types",
         "//tensorboard/webapp/app_routing/effects",
         "//tensorboard/webapp/app_routing/store",
         "//tensorboard/webapp/app_routing/store:types",

--- a/tensorboard/webapp/app_routing/index.ts
+++ b/tensorboard/webapp/app_routing/index.ts
@@ -1,0 +1,16 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+export {parseCompareExperimentStr} from './internal_utils';
+export * from './types';


### PR DESCRIPTION
This change exports public symbols of the AppRouting component. Notably,
it currently exports all the public types and exposes an utility that
would be used when defining a route.
