### PR TITLE
linked time: marker when extent is outside of linked time

### DIFF
--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -143,11 +143,17 @@ export function buildDataSourceTagMetadata(): DataSourceTagMetadata {
   };
 }
 
+export function buildScalarStepData(
+  override: Partial<ScalarStepDatum> = {}
+): ScalarStepDatum {
+  return {step: 0, wallTime: 123, value: 42, ...override};
+}
+
 export function createScalarStepData(): ScalarStepDatum[] {
   return [
-    {step: 0, wallTime: 123, value: 42},
-    {step: 1, wallTime: 124, value: -42},
-    {step: 99, wallTime: 125, value: 0},
+    buildScalarStepData({step: 0, wallTime: 123, value: 42}),
+    buildScalarStepData({step: 1, wallTime: 124, value: -42}),
+    buildScalarStepData({step: 99, wallTime: 125, value: 0}),
   ];
 }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -181,6 +181,28 @@ tf_ng_module(
     ],
 )
 
+tf_sass_binary(
+    name = "vis_selected_time_clipped_styles",
+    src = "vis_selected_time_clipped_component.scss",
+)
+
+tf_ng_module(
+    name = "vis_selected_time_clipped",
+    srcs = [
+        "vis_selected_time_clipped_component.ts",
+        "vis_selected_time_clipped_module.ts",
+    ],
+    assets = [
+        ":vis_selected_time_clipped_styles",
+    ],
+    deps = [
+        "//tensorboard/webapp/angular:expect_angular_material_icon",
+        "//tensorboard/webapp/metrics:types",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)
+
 tf_ts_library(
     name = "scalar_card_types",
     srcs = [
@@ -225,6 +247,7 @@ tf_ng_module(
         ":data_download_dialog",
         ":scalar_card_types",
         ":utils",
+        ":vis_selected_time_clipped",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -15,11 +15,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="heading">
-  <tb-truncated-path
-    class="tag"
-    title="{{ tag }}"
-    value="{{ title }}"
-  ></tb-truncated-path>
+  <span class="name">
+    <tb-truncated-path
+      class="tag"
+      title="{{ tag }}"
+      value="{{ title }}"
+    ></tb-truncated-path>
+    <vis-selected-time-clipped
+      *ngIf="selectedTime && selectedTime.clipped"
+    ></vis-selected-time-clipped>
+  </span>
   <span class="controls">
     <button
       mat-icon-button
@@ -173,10 +178,10 @@ limitations under the License.
         start: true,
         range: !!selectedTime.end
       }"
-      [style.width]="
+      [style.right]="
         xScale.forward(
           viewExtent.x,
-          [0, domDim.width],
+          [domDim.width, 0],
           selectedTime.start.step
         ) + 'px'
       "

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -34,10 +34,22 @@ $_title-to-heading-gap: 12px;
 
   align-items: center;
   display: flex;
-  justify-content: space-between;
   font-size: 14px;
+  justify-content: space-between;
   margin-bottom: $heading-content-gap;
   position: relative;
+
+  .name {
+    align-items: center;
+    display: grid;
+    gap: 5px;
+    grid-template-columns: auto auto;
+  }
+
+  vis-selected-time-clipped {
+    font-size: 1.2em;
+    line-height: 0;
+  }
 }
 
 .tag {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -51,6 +51,8 @@ type ScalarTooltipDatum = TooltipDatum<
   }
 >;
 
+export type LinkedTimeWithClipped = LinkedTime & {clipped: boolean};
+
 @Component({
   selector: 'scalar-card-component',
   templateUrl: 'scalar_card_component.ng.html',
@@ -80,7 +82,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() xAxisType!: XAxisType;
   @Input() xScaleType!: ScaleType;
   @Input() useDarkMode!: boolean;
-  @Input() selectedTime!: LinkedTime | null;
+  @Input() selectedTime!: LinkedTimeWithClipped | null;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -369,6 +369,12 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
           return {...selectedTime, clipped: false};
         }
 
+        // When selectedTime and data extent (in step axis) do not overlap,
+        // default single select min or max data extent depending on which side
+        // the selectedTime is at.
+
+        // Case when selectedTime is on the right of the maximum of the
+        // time series.
         if (maxStep <= selectedTime.start.step) {
           return {
             start: {step: maxStep},
@@ -376,6 +382,8 @@ export class ScalarCardContainer implements CardRenderer, OnInit {
             clipped: true,
           };
         }
+        // Case when selectedtime is on the left of the minimum of the time
+        // series.
         return {
           start: {step: minStep},
           end: null,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -25,6 +25,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {DataDownloadModule} from './data_download_module';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
+import {VisSelectedTimeClippedModule} from './vis_selected_time_clipped_module';
 
 @NgModule({
   declarations: [ScalarCardContainer, ScalarCardComponent],
@@ -39,6 +40,7 @@ import {ScalarCardContainer} from './scalar_card_container';
     MatProgressSpinnerModule,
     ResizeDetectorModule,
     TruncatedPathModule,
+    VisSelectedTimeClippedModule,
   ],
 })
 export class ScalarCardModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_component.scss
@@ -1,0 +1,29 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+@import 'tensorboard/webapp/theme/tb_theme';
+
+:host {
+  color: mat-color(map-get($tb-theme, warn), 700);
+
+  @include tb-dark-theme {
+    color: mat-color(map-get($tb-dark-theme, warn), 700);
+  }
+
+  mat-icon {
+    height: 1em;
+    line-height: 0;
+    width: 1em;
+  }
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_component.ts
@@ -1,0 +1,34 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+
+import {LinkedTime} from '../../types';
+
+export type LinkedTimeWithClipped = LinkedTime & {clipped: boolean};
+
+@Component({
+  selector: 'vis-selected-time-clipped',
+  template: `
+    <mat-icon
+      svgIcon="info_outline_24px"
+      title="Linked step is not found in this visualization. We highlighted the closest step for you."
+    ></mat-icon>
+  `,
+  styleUrls: ['vis_selected_time_clipped_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VisSelectedTimeClippedComponent {
+  @Input() selectedTime!: LinkedTimeWithClipped | null;
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_module.ts
@@ -1,0 +1,26 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatIconModule} from '@angular/material/icon';
+
+import {VisSelectedTimeClippedComponent} from './vis_selected_time_clipped_component';
+
+@NgModule({
+  declarations: [VisSelectedTimeClippedComponent],
+  exports: [VisSelectedTimeClippedComponent],
+  imports: [CommonModule, MatIconModule],
+})
+export class VisSelectedTimeClippedModule {}


### PR DESCRIPTION
We now show a small read "i" when an x-axis extent (extremums) of the
line chart is not intersecting with the selected time. This "i"
informs user that the data presented below is not within the linked
time. In that situation, we will clip the selectedTime to the minimum or
maximum of the dataset so something is visible on the screen.

![image](https://user-images.githubusercontent.com/2547313/129145944-b5cfebb2-be53-4ea9-84e1-5365511ac3d0.png)

Do note that the "i" treatment will be there for other kinds of visualizations
thus is pulled out as a separate component.