### PR TITLE
timeseries: persist tag filter in the URL

### DIFF
--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -89,6 +89,7 @@ export interface URLDeserializedState {
   metrics: {
     pinnedCards: CardUniqueInfo[];
     smoothing: number | null;
+    tagFilter: string | null;
   };
 }
 

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -92,6 +92,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/persistent_settings",
+        "//tensorboard/webapp/routes:testing",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/util:dom",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -347,11 +347,16 @@ const reducer = createReducer(
       };
     }
 
-    return {
+    const newState = {
       ...state,
       ...resolvedResult,
       settingOverrides: newSettings,
     };
+
+    if (hydratedState.metrics.tagFilter !== null) {
+      newState.tagFilter = hydratedState.metrics.tagFilter;
+    }
+    return newState;
   }),
   on(globalSettingsLoaded, (state, {partialSettings}) => {
     const metricsSettings: Partial<MetricsSettings> = {};

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -17,6 +17,7 @@ import {buildRoute} from '../../app_routing/testing';
 import {RouteKind} from '../../app_routing/types';
 import * as coreActions from '../../core/actions';
 import {globalSettingsLoaded} from '../../persistent_settings';
+import {buildDeserializedState} from '../../routes/testing';
 import {DataLoadState} from '../../types/data';
 import {nextElementId} from '../../util/dom';
 import * as actions from '../actions';
@@ -1775,6 +1776,47 @@ describe('metrics reducers', () => {
       const nextState = reducers(beforeState, action);
 
       expect(nextState.settingOverrides.scalarSmoothing).toBe(0.232);
+    });
+  });
+
+  describe('tag filter hydration', () => {
+    it('rehydrates the value', () => {
+      const beforeState = buildMetricsState({tagFilter: 'foo'});
+      const action = routingActions.stateRehydratedFromUrl({
+        routeKind: RouteKind.EXPERIMENT,
+        partialState: {
+          metrics: {...buildDeserializedState().metrics, tagFilter: 'bar'},
+        },
+      });
+      const nextState = reducers(beforeState, action);
+
+      expect(nextState.tagFilter).toBe('bar');
+    });
+
+    it('rehydrates an empty string value', () => {
+      const beforeState = buildMetricsState({tagFilter: 'foo'});
+      const action = routingActions.stateRehydratedFromUrl({
+        routeKind: RouteKind.EXPERIMENT,
+        partialState: {
+          metrics: {...buildDeserializedState().metrics, tagFilter: ''},
+        },
+      });
+      const nextState = reducers(beforeState, action);
+
+      expect(nextState.tagFilter).toBe('');
+    });
+
+    it('does not hydrate when the value is null', () => {
+      const beforeState = buildMetricsState({tagFilter: 'foo'});
+      const action = routingActions.stateRehydratedFromUrl({
+        routeKind: RouteKind.EXPERIMENT,
+        partialState: {
+          metrics: {...buildDeserializedState().metrics, tagFilter: null},
+        },
+      });
+      const nextState = reducers(beforeState, action);
+
+      expect(nextState.tagFilter).toBe('foo');
     });
   });
 

--- a/tensorboard/webapp/routes/BUILD
+++ b/tensorboard/webapp/routes/BUILD
@@ -53,6 +53,17 @@ tf_ts_library(
 )
 
 tf_ts_library(
+    name = "testing",
+    testonly = True,
+    srcs = [
+        "testing.ts",
+    ],
+    deps = [
+        ":dashboard_deeplink_provider_types",
+    ],
+)
+
+tf_ts_library(
     name = "routes_test_lib",
     testonly = True,
     srcs = [
@@ -60,6 +71,7 @@ tf_ts_library(
     ],
     deps = [
         ":dashboard_deeplink_provider",
+        ":testing",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_core_testing",

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
@@ -38,6 +38,7 @@ import {
   DeserializedState,
   PINNED_CARDS_KEY,
   SMOOTHING_KEY,
+  TAG_FILTER_KEY,
 } from './dashboard_deeplink_provider_types';
 
 const COLOR_GROUP_REGEX_VALUE_PREFIX = 'regex:';
@@ -117,6 +118,14 @@ export class DashboardDeepLinkProvider extends DeepLinkProvider {
   ): Observable<SerializableQueryParams> {
     return combineLatest([
       this.getMetricsPinnedCards(store),
+      store.select(selectors.getMetricsTagFilter).pipe(
+        map((filterText) => {
+          if (!filterText) {
+            return [];
+          }
+          return [{key: TAG_FILTER_KEY, value: filterText}];
+        })
+      ),
       this.getFeatureFlagStates(store),
       store.select(selectors.getMetricsSettingOverrides).pipe(
         map((settingOverrides) => {
@@ -165,6 +174,7 @@ export class DashboardDeepLinkProvider extends DeepLinkProvider {
   ): DeserializedState {
     let pinnedCards = null;
     let smoothing = null;
+    let tagFilter = null;
     let groupBy: GroupBy | null = null;
 
     for (const {key, value} of queryParams) {
@@ -193,6 +203,9 @@ export class DashboardDeepLinkProvider extends DeepLinkProvider {
           }
           break;
         }
+        case TAG_FILTER_KEY:
+          tagFilter = value;
+          break;
       }
     }
 
@@ -200,6 +213,7 @@ export class DashboardDeepLinkProvider extends DeepLinkProvider {
       metrics: {
         pinnedCards: pinnedCards || [],
         smoothing,
+        tagFilter,
       },
       runs: {
         groupBy,

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider_types.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider_types.ts
@@ -25,3 +25,5 @@ export const SMOOTHING_KEY = 'smoothing';
 export const PINNED_CARDS_KEY = 'pinnedCards';
 
 export const RUN_COLOR_GROUP_KEY = 'runColorGroup';
+
+export const TAG_FILTER_KEY = 'tagFilter';

--- a/tensorboard/webapp/routes/testing.ts
+++ b/tensorboard/webapp/routes/testing.ts
@@ -1,0 +1,31 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {DeserializedState} from './dashboard_deeplink_provider_types';
+
+export function buildDeserializedState(
+  override: Partial<DeserializedState> = {}
+) {
+  return {
+    runs: {
+      groupBy: null,
+    },
+    metrics: {
+      pinnedCards: [],
+      smoothing: null,
+      tagFilter: null,
+    },
+    ...override,
+  };
+}


### PR DESCRIPTION
The Time Series dashboard tag filter is now synced with the URL's
"?tagFilter" query param.

Manually tested that typing in the tag filter updates the URL, and
that crafting a URL with "?tagFilter=batch" and navigating to it
makes the dashboard show the appropriately matching cards.

Googlers, see b/182797564.

Blocked on: https://github.com/tensorflow/tensorboard/pull/5239