### PR TITLE
line chart: introduce onContextLost renderer callback

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/chart.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/chart.ts
@@ -66,7 +66,8 @@ export class ChartImpl implements Chart {
         this.renderer = new ThreeRenderer(
           option.container,
           coordinator,
-          option.devicePixelRatio
+          option.devicePixelRatio,
+          option.callbacks.onContextLost
         );
         break;
       }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/chart_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/chart_types.ts
@@ -42,6 +42,7 @@ export interface Chart {
 
 export interface ChartCallbacks {
   onDrawEnd(): void;
+  onContextLost(): void;
 }
 
 export interface BaseChartOptions {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -268,12 +268,19 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
   constructor(
     canvas: HTMLCanvasElement | OffscreenCanvas,
     private readonly coordinator: ThreeCoordinator,
-    devicePixelRatio: number
+    devicePixelRatio: number,
+    onContextLost?: EventListener
   ) {
     if (isOffscreenCanvasSupported() && canvas instanceof OffscreenCanvas) {
       // THREE.js require the style object which Offscreen canvas lacks.
       (canvas as any).style = (canvas as any).style || {};
     }
+    // WebGL contexts may be abandoned by the browser if too many contexts are
+    // created on the same page.
+    if (onContextLost) {
+      canvas.addEventListener('webglcontextlost', onContextLost);
+    }
+
     this.renderer = new THREE.WebGLRenderer({
       canvas: canvas as HTMLCanvasElement,
       context: canvas.getContext('webgl2', {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/message_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/message_types.ts
@@ -83,10 +83,15 @@ export type HostToGuestMessage =
 
 export enum GuestToMainType {
   ON_REDRAW_END,
+  ON_CONTEXT_LOST,
 }
 
 export interface RedrawEndMessage {
   type: GuestToMainType.ON_REDRAW_END;
 }
 
-export type GuestToMainMessage = RedrawEndMessage;
+export interface ContextLostMessage {
+  type: GuestToMainType.ON_CONTEXT_LOST;
+}
+
+export type GuestToMainMessage = RedrawEndMessage | ContextLostMessage;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart.ts
@@ -146,6 +146,10 @@ export class WorkerChart implements Chart {
         this.callbacks.onDrawEnd();
         break;
       }
+      case GuestToMainType.ON_CONTEXT_LOST: {
+        this.callbacks.onContextLost();
+        break;
+      }
     }
   }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_bridge.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_bridge.ts
@@ -43,6 +43,11 @@ function createPortHandler(port: MessagePort, initMessage: InitMessage) {
         type: GuestToMainType.ON_REDRAW_END,
       });
     },
+    onContextLost: () => {
+      port.postMessage({
+        type: GuestToMainType.ON_CONTEXT_LOST,
+      });
+    },
   };
 
   let chartOptions: ChartOptions;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_test.ts
@@ -23,6 +23,7 @@ describe('line_chart_v2/lib/worker_chart test', () => {
   let workerPostMessageSpy: jasmine.Spy;
   let channelTxSpy: jasmine.Spy;
   let onDrawEndSpy: jasmine.Spy;
+  let onContextLostSpy: jasmine.Spy;
   let chart: WorkerChart;
 
   beforeEach(() => {
@@ -41,10 +42,11 @@ describe('line_chart_v2/lib/worker_chart test', () => {
     });
 
     onDrawEndSpy = jasmine.createSpy();
+    onContextLostSpy = jasmine.createSpy();
     chart = new WorkerChart({
       type: RendererType.WEBGL,
       devicePixelRatio: 1,
-      callbacks: {onDrawEnd: onDrawEndSpy},
+      callbacks: {onDrawEnd: onDrawEndSpy, onContextLost: onContextLostSpy},
       container: document.createElement('canvas'),
       domDimension: {width: 100, height: 200},
       useDarkMode: false,

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -296,7 +296,10 @@ export class LineChartComponent
 
     const rendererType = this.getRendererType();
     // Do not yet need to subscribe to the `onDrawEnd`.
-    const callbacks: ChartCallbacks = {onDrawEnd: () => {}};
+    const callbacks: ChartCallbacks = {
+      onDrawEnd: () => {},
+      onContextLost: () => {},
+    };
     let params: ChartOptions | null = null;
 
     this.readAndUpdateDomDimensions();


### PR DESCRIPTION
Each line chart component in the Time Series dashboard gets its own canvas and
webgl rendering context. After scrolling through too many line charts (for my
device after ~30), the page issues warnings in the console like "Too many active
WebGL contexts. Oldest context will be lost".

When the browser decides there are too many contexts, it disposes old ones
causing blank line charts. This change adds an event dispatched by the line chart's
internal `ChartImpl` to notify clients when the rendering context is lost.

This only applies to the WebGL renderer for now.  A followup change addresses the
remediation of blank scalar cards.

Googlers, see b/196294346.

Diffbase: none.
Followup: https://github.com/tensorflow/tensorboard/pull/5239