### PR TITLE
notification: clip the date to today

### DIFF
--- a/tensorboard/webapp/notification_center/_data_source/notification_center_data_source.ts
+++ b/tensorboard/webapp/notification_center/_data_source/notification_center_data_source.ts
@@ -41,6 +41,7 @@ export class TBNotificationCenterDataSource
           return {
             ...response,
             notifications: response.notifications.map((notification) => {
+              if (!notification.hasOwnProperty('dateInMs')) return notification;
               return {
                 ...notification,
                 // `dateInMs` can never exceed local machine's today at 12:00 AM.

--- a/tensorboard/webapp/notification_center/_data_source/notification_center_data_source.ts
+++ b/tensorboard/webapp/notification_center/_data_source/notification_center_data_source.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
 
 import {TBHttpClient} from '../../webapp_data_source/tb_http_client';
 import {
@@ -30,6 +31,24 @@ export class TBNotificationCenterDataSource
   constructor(private readonly http: TBHttpClient) {}
 
   fetchNotifications(): Observable<NotificationCenterResponse> {
-    return this.http.get<NotificationCenterResponse>(`/data/notifications`);
+    return this.http
+      .get<NotificationCenterResponse>(`/data/notifications`)
+      .pipe(
+        map((response) => {
+          const todayInMs: number = new Date(
+            new Date().toDateString()
+          ).getTime();
+          return {
+            ...response,
+            notifications: response.notifications.map((notification) => {
+              return {
+                ...notification,
+                // `dateInMs` can never exceed local machine's today at 12:00 AM.
+                dateInMs: Math.min(notification.dateInMs, todayInMs),
+              };
+            }),
+          };
+        })
+      );
   }
 }

--- a/tensorboard/webapp/notification_center/_data_source/notification_center_data_source_test.ts
+++ b/tensorboard/webapp/notification_center/_data_source/notification_center_data_source_test.ts
@@ -85,7 +85,7 @@ describe('TBNotificationCenterDataSource test', () => {
     expect(errorSpy).toHaveBeenCalledWith(httpErrorResponse);
   });
 
-  fit(
+  it(
     'clips dateInMs to max today to prevent issue where notification never ' +
       'gets dismissed',
     () => {

--- a/tensorboard/webapp/notification_center/_data_source/testing.ts
+++ b/tensorboard/webapp/notification_center/_data_source/testing.ts
@@ -51,16 +51,21 @@ export function provideTestingNotificationCenterDataSource() {
   ];
 }
 
+export function buildNotification(
+  override: Partial<BackendNotification> = {}
+): BackendNotification {
+  return {
+    dateInMs: 123,
+    title: 'test title',
+    content: 'random content',
+    ...override,
+  };
+}
+
 export function buildNotificationResponse(
   notifications?: BackendNotification[]
 ): NotificationCenterResponse {
   return {
-    notifications: notifications ?? [
-      {
-        dateInMs: 123,
-        title: 'test title',
-        content: 'random content',
-      },
-    ],
+    notifications: notifications ?? [buildNotification()],
   };
 }


### PR DESCRIPTION
There were cases when the notification payload we handcrafted is in the
future and since we only dismiss the notification by recording the last
read time (NOW), there were cases when new notifications in the future
are never dismissable. To prevent developer mistakes, we can clip the
date to start of the day so a notification can never been in the future.
