### PR TITLE
test: drop stray debugger statement

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -479,7 +479,6 @@ describe('regex_edit_dialog', () => {
       sendKey(fixture, input, keyArgs);
       tick(TEST_ONLY.INPUT_CHANGE_DEBOUNCE_INTERVAL_MS);
       fixture.detectChanges();
-      debugger;
 
       const groupingResult = fixture.debugElement.query(
         By.css('.group-container')


### PR DESCRIPTION
Removes a stray 'debugger' statement from a web test.