### PR TITLE
ui: fix wrapping of dropdown items

### DIFF
--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
@@ -32,8 +32,9 @@ mat-select:focus {
   max-width: 70vw;
 }
 
-.tb-mat-option {
-  // Overrides Angular Material's fixed height.
+// This selector needs relatively more specificity than Angular Material's
+// to override the fixed height.
+::ng-deep mat-option.mat-option {
   height: auto;
 }
 

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -35,7 +35,6 @@ export interface DropdownOption {
     >
       <mat-option
         *ngFor="let option of options"
-        class="tb-mat-option"
         [value]="option.value"
         [disabled]="option.disabled"
       >


### PR DESCRIPTION
Long items within tb-dropdown are supposed to wrap onto multiple
lines. Our CSS was incorrectly using a selector without enough
specificity, and Angular was overriding our classname.

Before
![image](https://user-images.githubusercontent.com/2322480/129420969-1dd37bb4-9def-40df-a175-3281d80d2312.png)

After
![image](https://user-images.githubusercontent.com/2322480/129420912-3308a67b-e00b-4f03-84bd-cfff0561fdf8.png)