### PR TITLE
linked time: clip axis UI from leaving bound

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -69,9 +69,24 @@ limitations under the License.
   .custom-vis {
     height: 100%;
     left: 0;
+    overflow: hidden;
     position: absolute;
     top: 0;
     width: 100%;
+    -webkit-mask-image: linear-gradient(
+      to right,
+      #0000 0%,
+      #000 10%,
+      #000 90%,
+      #0000 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      #0000 0%,
+      #000 10%,
+      #000 90%,
+      #0000 100%
+    );
   }
 }
 


### PR DESCRIPTION
With this change, we are now clipping content of the custom axis
visualization so it is contained inside the axis container. Previously,
linked time step scrubber extruded out of the container and left very
awkward UI.

Before:
![image](https://user-images.githubusercontent.com/2547313/129428911-1950b018-531a-4320-a498-d3f7b593c1fd.png)

After:
![image](https://user-images.githubusercontent.com/2547313/129428787-e8bc0428-720a-42c2-ba93-52215011a4e4.png)
