### PR TITLE
time series: deduplicate tags in the search

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
@@ -198,6 +198,54 @@ describe('metrics filter input', () => {
       ).toEqual(['tagA', 'tagC/woof']);
     });
 
+    it('filters de-duplicating tags', () => {
+      store.overrideSelector(
+        selectors.getMetricsFilteredPluginTypes,
+        new Set<PluginType>([])
+      );
+      store.overrideSelector(selectors.getNonEmptyCardIdsWithMetadata, [
+        {
+          cardId: 'card1',
+          plugin: PluginType.SCALARS,
+          tag: 'tagA',
+          runId: null,
+        },
+        {
+          cardId: 'card1',
+          plugin: PluginType.IMAGES,
+          tag: 'tagB/Images',
+          runId: 'run1',
+          sample: 0,
+        },
+        {
+          cardId: 'card1',
+          plugin: PluginType.IMAGES,
+          tag: 'tagB/Images',
+          runId: 'run1',
+          sample: 1,
+        },
+        {
+          cardId: 'card1',
+          plugin: PluginType.IMAGES,
+          tag: 'tagB/Images',
+          runId: 'run1',
+          sample: 2,
+        },
+      ]);
+      store.overrideSelector(selectors.getMetricsTagFilter, '');
+      const fixture = TestBed.createComponent(MetricsFilterInputContainer);
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.focus();
+      fixture.detectChanges();
+
+      const optionBefore = getAutocompleteOptions(overlayContainer);
+      expect(
+        optionBefore.map((option) => option.nativeElement.textContent)
+      ).toEqual(['tagA', 'tagB/Images']);
+    });
+
     it('filters by regex', () => {
       store.overrideSelector(selectors.getMetricsTagFilter, '[/I]m');
       const fixture = TestBed.createComponent(MetricsFilterInputContainer);


### PR DESCRIPTION
Image cards are a bit odd; unlike others, the same tuple of run and tag
can appear more than once and that is because it has the third
axis--sample. When there are more than one sample for a run+tag, the tag
filters previously showed the duplicate entry which this can
de-duplicates.
