### PR TITLE
Allow `google-auth < 3`

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -17,7 +17,10 @@
 
 absl-py >= 0.4
 grpcio >= 1.24.3
-google-auth >= 1.6.3, < 2
+# NOTE: Maintainers, please do not require google-auth>=2.x.x
+# Until this issue is closed
+# https://github.com/googleapis/google-cloud-python/issues/10566
+google-auth >= 1.6.3, < 3
 google-auth-oauthlib >= 0.4.1, < 0.5
 markdown >= 2.6.8
 numpy >= 1.12.0


### PR DESCRIPTION
`google-auth` recently published a 2.0.0 release which removed support for Python 2.7. `google-auth` now requires Python >=3.6. No other breaking changes were made. You can see the full list of changes [here](https://github.com/googleapis/google-auth-library-python/commit/560cf1ed02a900436c5d9e0a0fb3f94b5fd98c55).

I am opening PRs to expand google-auth version ranges for packages that meet either of the following criteria:
* Package has >10,000 monthly downloads as of June 2021
* Package is owned by a Google team

`google-auth` is a dependency of many different libraries that interact with Google APIs. Increasing the time and number of packages with compatible pins on `google-auth` lowers the chance end developers who use multiple libraries will see dependency conflicts. 

If possible, please do not require `google-auth>2.0.0` until this issue is resolved
https://github.com/googleapis/google-cloud-python/issues/10566, as that will further reduce the likelihood of diamond dependency conflicts.

Googlers, see [this doc](https://docs.google.com/document/d/1euAvUsia_4zf98lNvpwA3K0o2b4y5Xr9xAkyzCnIMzQ/edit) for more information.

