### PR TITLE
timeseries: fixed UI for select all

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -22,9 +22,9 @@ limitations under the License.
   ></tb-filter-input>
 </div>
 <div class="table-container">
+  <ng-container *ngTemplateOutlet="selectAll"></ng-container>
   <div role="table">
     <ng-container *ngTemplateOutlet="header"></ng-container>
-    <ng-container *ngTemplateOutlet="selectAll"></ng-container>
     <div role="rowgroup" class="rows">
       <ng-container *ngFor="let item of pageItems; trackBy: tableTrackBy">
         <ng-container
@@ -62,14 +62,16 @@ limitations under the License.
   <div
     *ngIf="allPageItemsSelected() && numSelectedItems !== allItemsLength"
     class="select-all"
-    role="row"
   >
-    <span role="columnheader"
-      >All runs in this page are selected but not all runs ({{ numSelectedItems
-      }} of {{ allItemsLength }}) are selected.</span
-    ><button mat-button (click)="onSelectAllPages.emit()">
-      Select all runs
-    </button>
+    <div>
+      All runs in this page are selected but not all runs ({{ numSelectedItems
+      }} of {{ allItemsLength }}) are selected.
+    </div>
+    <div>
+      <button mat-button (click)="onSelectAllPages.emit()">
+        Select all runs
+      </button>
+    </div>
   </div>
 </ng-template>
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -99,6 +99,15 @@ $_font-size: 13px;
   }
 }
 
+.select-all {
+  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
+  padding: 10px;
+
+  button {
+    width: 100%;
+  }
+}
+
 .loading,
 .no-runs {
   align-items: center;
@@ -111,11 +120,6 @@ $_font-size: 13px;
 
 .loading {
   justify-content: center;
-}
-
-.select-all th {
-  padding-bottom: 12px;
-  padding-top: 12px;
 }
 
 .select-all-content,


### PR DESCRIPTION
In runs selector, Select-all which shows up in the pagination mode
looked incorrect due to the relatively recent refactor not to use
`<table>` but instead use the CSS solution. Without a great solution
around the table layout, we instead decided to put the select all UI
affordance above the runs header.

Before
![image](https://user-images.githubusercontent.com/2547313/129820814-c027f7da-d9fa-4d23-bbfd-0df6a225dd41.png)


After
![image](https://user-images.githubusercontent.com/2547313/129820757-cfb1bfc9-97b1-405e-81f5-d2fda7e941bd.png)
