### PR TITLE
timeseries: fix memory leaks involving CardObserver and shareReplay

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader.ts
@@ -33,7 +33,7 @@ type CardObserverCallback = (
 export class CardObserver {
   private intersectionObserver?: IntersectionObserver;
   private intersectionCallback?: CardObserverCallback;
-  private readonly destroyedTargets = new Set<Element>();
+  private readonly destroyedTargets = new WeakSet<Element>();
 
   /**
    * Buffer determines how far a card can be, beyond the root's bounding rect,

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -160,6 +160,7 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
 
     const selectCardMetadata$ = this.store.select(getCardMetadata, this.cardId);
     const cardMetadata$ = selectCardMetadata$.pipe(
+      takeUntil(this.ngUnsubscribe),
       filter((cardMetadata) => {
         return !!cardMetadata && this.isImageCardMetadata(cardMetadata);
       }),
@@ -174,6 +175,7 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       this.store.select(getCardTimeSeries, this.cardId),
     ]);
     const timeSeries$ = metadataAndSeries$.pipe(
+      takeUntil(this.ngUnsubscribe),
       map(([cardMetadata, runToSeries]) => {
         const runId = cardMetadata.runId;
         if (!runToSeries || !runToSeries.hasOwnProperty(runId)) {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -297,6 +297,7 @@ export class RunsTableContainer implements OnInit, OnDestroy {
       })
     );
     this.allUnsortedRunTableItems$ = rawAllUnsortedRunTableItems$.pipe(
+      takeUntil(this.ngUnsubscribe),
       shareReplay(1)
     );
     this.allItemsLength$ = this.allUnsortedRunTableItems$.pipe(
@@ -305,7 +306,7 @@ export class RunsTableContainer implements OnInit, OnDestroy {
 
     const getFilteredItems$ = this.getFilteredItems$(
       this.allUnsortedRunTableItems$
-    ).pipe(shareReplay(1));
+    ).pipe(takeUntil(this.ngUnsubscribe), shareReplay(1));
 
     this.filteredItemsLength$ = getFilteredItems$.pipe(
       map((items) => items.length)


### PR DESCRIPTION
This addresses 2 non-trivial sources of memory leaks observed when
filtering tags in the Time Series dashboard.

a) CardObserver used to track Elements that were destroyed via
ngOnDestroy and stored them in a `Set<Element>`. Now with a WeakSet
instead, we cover cases when the browser's IntersectionObserverEntry
is not handled for some reason.

b) The rxjs operator "shareReplay" has some known gotchas [1], [2].
When more observables subscribe to a source containing
`shareReplay(1)` in its operator chain, the source remains subscribed
even after the other observables unsubscribe. This change uses the
`takeUntil(ngUnsubscribe$)` pattern to ensure any component using a
`shareReplay` will not keep it subscribed after the component is gone.
Alternatively we could use `refCount`, but this opts for the `takeUntil`
pattern already used widely in the codebase.

Manually checked that the dashboard still operates properly, and in
Angular's dev mode, using a specific demo logdir, adding and clearing a
"." tag filter has these characteristics:

Before this change: 5.8 MB, 5.5K DOM nodes added each cycle
After this change: 0.05 MB, <10 DOM nodes added each cycle

Googlers, see b/196996936

[1] https://github.com/ReactiveX/rxjs/issues/5034
[2] https://github.com/ReactiveX/rxjs/issues/5931