### PR TITLE
timeseries: show pinned view while filtering

### DIFF
--- a/tensorboard/webapp/metrics/views/_common.scss
+++ b/tensorboard/webapp/metrics/views/_common.scss
@@ -21,12 +21,21 @@ $metrics-button-background-color-on-gray: #fff;
 $metrics-min-card-width: 335px;
 $metrics-min-card-height: 320px;
 
-@mixin metrics-card-group-toolbar {
-  @include tb-theme-background-prop(background-color, background);
-  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
-  background-color: #fff;
-  height: 42px;
-  padding: 0 16px;
+@mixin metrics-sub-view {
+  .group-toolbar {
+    @include tb-theme-background-prop(background-color, background);
+    @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
+
+    align-items: center;
+    background-color: #fff;
+    display: flex;
+    flex: none;
+    height: 42px;
+    padding: 0 16px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
 }
 
 @mixin metrics-card-group-title {

--- a/tensorboard/webapp/metrics/views/main_view/card_groups_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_groups_component.scss
@@ -15,11 +15,15 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common';
 
-.group-toolbar {
-  @include metrics-card-group-toolbar;
-  @include tb-theme-foreground-prop(border-top, border, 1px solid);
-  display: flex;
-  align-items: center;
+:host {
+  @include metrics-sub-view;
+
+  .group-toolbar {
+    @include tb-theme-foreground-prop(border-top, border, 1px solid);
+    // border-top on group-toolbar needs to be offset on sticky header for the
+    // flawless UI.
+    top: -1px;
+  }
 }
 
 .card-group:first-of-type .group-toolbar {

--- a/tensorboard/webapp/metrics/views/main_view/filtered_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/filtered_view_component.scss
@@ -15,11 +15,8 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common';
 
-.group-toolbar {
-  @include metrics-card-group-toolbar;
-  display: flex;
-  align-items: center;
-  border-bottom: 1px solid mat-color($tb-foreground, border);
+:host {
+  @include metrics-sub-view;
 }
 
 .group-text {

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
@@ -60,7 +60,7 @@ limitations under the License.
   </div>
 </div>
 <div class="split-content">
-  <div cdkScrollable class="main">
+  <div cdkScrollable [class.main]="true" [class.filter-view]="showFilteredView">
     <metrics-filtered-view
       *ngIf="showFilteredView"
       [cardObserver]="cardObserver"
@@ -69,10 +69,7 @@ limitations under the License.
     Otherwise, adding a pinned card when the section is hidden reliably creates
     a 'squished chart'. We can switch to 'display: none' when this issue is
     fixed: https://github.com/tensorflow/tensorboard/issues/2595. -->
-    <metrics-pinned-view
-      *ngIf="!showFilteredView"
-      [cardObserver]="cardObserver"
-    ></metrics-pinned-view>
+    <metrics-pinned-view [cardObserver]="cardObserver"></metrics-pinned-view>
     <!-- Always show the metrics-card-groups as a performance optimization--it makes view transition
     from filtered view to card view quicker. -->
     <metrics-card-groups

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -85,6 +85,21 @@ limitations under the License.
   metrics-pinned-view {
     @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   }
+
+  &.filter-view {
+    overflow: hidden;
+
+    metrics-filtered-view {
+      flex: 0 1 auto;
+      overflow: auto;
+    }
+
+    metrics-pinned-view {
+      flex: 1 1;
+      min-height: 300px;
+      overflow: auto;
+    }
+  }
 }
 
 .sidebar {

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -64,10 +64,10 @@ limitations under the License.
 
 .main,
 .sidebar {
+  contain: strict;
   overflow-x: hidden;
   overflow-y: auto;
-  will-change: transform;
-  contain: strict;
+  will-change: transform, scroll-position;
 }
 
 .main {
@@ -89,15 +89,20 @@ limitations under the License.
   &.filter-view {
     overflow: hidden;
 
+    metrics-filtered-view,
+    metrics-pinned-view {
+      contain: content size;
+      overflow: auto;
+      will-change: transform, scroll-position;
+    }
+
     metrics-filtered-view {
       flex: 0 1 auto;
-      overflow: auto;
     }
 
     metrics-pinned-view {
       flex: 1 1;
       min-height: 300px;
-      overflow: auto;
     }
   }
 }

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1090,19 +1090,24 @@ describe('metrics main view', () => {
       expect(getFilterviewCardContents(fixture)).toEqual(['images: card2']);
     });
 
-    it('hides the main, pinned views while the filter view is active', () => {
+    it('hides the main but shows pinned views while the filter view is active', () => {
       store.overrideSelector(selectors.getMetricsTagFilter, 'tagA');
+      store.overrideSelector(selectors.getPinnedCardsWithMetadata, [
+        {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
+        {cardId: 'card2', ...createCardMetadata(PluginType.IMAGES)},
+      ]);
       const fixture = TestBed.createComponent(MainViewContainer);
       fixture.detectChanges();
 
       const mainView = fixture.debugElement.query(
         By.css('.main metrics-card-groups')
       );
-      const pinnedView = fixture.debugElement.query(
+      expect(mainView.styles['display']).toBe('none');
+      const pinnedViewDebugEl = fixture.debugElement.query(
         By.css('.main metrics-pinned-view')
       );
-      expect(mainView.styles['display']).toBe('none');
-      expect(pinnedView).not.toBeTruthy();
+      const cardContents = getCardContents(getCards(pinnedViewDebugEl));
+      expect(cardContents).toEqual(['scalars: card1', 'images: card2']);
     });
 
     it('updates the list on tagFilter change', () => {
@@ -1347,21 +1352,6 @@ describe('metrics main view', () => {
     ): DebugElement {
       return fixture.debugElement.query(By.directive(directive));
     }
-
-    it('appears only when not filtering', () => {
-      const fixture = TestBed.createComponent(MainViewContainer);
-      fixture.detectChanges();
-
-      expect(queryDirective(fixture, PinnedViewContainer)).toBeTruthy();
-      expect(queryDirective(fixture, FilteredViewContainer)).not.toBeTruthy();
-
-      store.overrideSelector(selectors.getMetricsTagFilter, 'tagA');
-      store.refreshState();
-      fixture.detectChanges();
-
-      expect(queryDirective(fixture, PinnedViewContainer)).not.toBeTruthy();
-      expect(queryDirective(fixture, FilteredViewContainer)).toBeTruthy();
-    });
 
     it('shows an empty message only when there are no pinned cards', () => {
       store.overrideSelector(selectors.getPinnedCardsWithMetadata, []);

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
@@ -15,10 +15,8 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common';
 
-.group-toolbar {
-  @include metrics-card-group-toolbar;
-  display: flex;
-  align-items: center;
+:host {
+  @include metrics-sub-view;
 }
 
 mat-icon {


### PR DESCRIPTION
You may want to treat the pinned UI as the shopping cart and want to add
cards to the "cart" while filtering. In the past, the shopping cart did
not show up when filtering so it was difficult to understand all the
items in the shopping cart. To fix that, we now show pinned cards below
the filter view each with their own scrollable container.

![image](https://user-images.githubusercontent.com/2547313/129944552-47e0d726-1d51-4d9d-9649-2afb0863d243.png)
