### PR TITLE
styles: TimeSeries UI improvements

### DIFF
--- a/tensorboard/webapp/metrics/views/_common.scss
+++ b/tensorboard/webapp/metrics/views/_common.scss
@@ -31,10 +31,19 @@ $metrics-min-card-height: 320px;
     display: flex;
     flex: none;
     height: 42px;
+    // toolbar has bottom border and it should not be accounted for when
+    // positioning sticky headers. Without this, you will see two borders when
+    // a toolbar is put against another toolbar.
+    margin-bottom: -1px;
     padding: 0 16px;
     position: sticky;
     top: 0;
     z-index: 1;
+
+    box-shadow: 0px 2px 4px 0px rgba(#000, 15%);
+    @include tb-dark-theme {
+      box-shadow: 0px 2px 4px 0px rgba(#fff, 15%);
+    }
   }
 }
 

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -91,7 +91,7 @@ limitations under the License.
 
     metrics-filtered-view,
     metrics-pinned-view {
-      contain: content size;
+      contain: content;
       overflow: auto;
       will-change: transform, scroll-position;
     }

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -35,7 +35,7 @@ $_font-size: 13px;
   max-width: 100%;
   overflow-x: auto;
   overflow-y: auto;
-  will-change: scroll-position;
+  will-change: transform, scroll-position;
 }
 
 :host.flex-layout {

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -223,6 +223,12 @@ $tb-dark-theme: map_merge(
   // Include all theme-styles for the components based on the current theme.
   @include angular-material-theme($tb-theme);
 
+  body {
+    // Prevent color-picker from briefly showing scrollbar when calculating its
+    // position.
+    contain: strict;
+  }
+
   a:not(.mat-button, .mat-icon-button) {
     color: map-get($tb-foreground, link);
 


### PR DESCRIPTION
This change contains three visual improvements for TimeSeries:
- now, the section headers have shadow to give a sense of height
- color picker no longer causes scrollbar on the app to show up for a
brief moment
- Correct value for `contain` on the grid container for better paint
containment
- Scrolling on left pane no longer causes repaint.

Before
![image](https://user-images.githubusercontent.com/2547313/130276423-872f5966-4085-4ac1-abe2-790f237e003d.png)

New
![image](https://user-images.githubusercontent.com/2547313/130276175-536b812a-84b6-4fcb-baf4-bcad8cead1c2.png)
