### PR TITLE
histogram: pass color instead of scale

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -58,11 +58,10 @@ limitations under the License.
 </div>
 <tb-histogram
   *ngIf="data && data.length; else noData"
-  [name]="runId"
   [data]="data"
   [mode]="mode"
   [timeProperty]="timeProperty(xAxisType)"
-  [colorScale]="runColorScale"
+  [color]="runColorScale(runId)"
 ></tb-histogram>
 <ng-template #noData>
   <div *ngIf="loadState === DataLoadState.FAILED" class="empty-message">

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -29,7 +29,6 @@ import {
 } from '../../../selectors';
 import {MatIconTestingModule} from '../../../testing/mat_icon_module';
 import {
-  ColorScale,
   HistogramData,
   HistogramMode,
   TimeProperty,
@@ -56,7 +55,7 @@ import {RunNameModule} from './run_name_module';
 class TestableHistogramWidget {
   @Input() mode!: HistogramMode;
   @Input() timeProperty!: TimeProperty;
-  @Input() colorScale!: ColorScale;
+  @Input() color!: string;
   @Input() name!: string;
   @Input() data!: HistogramData;
 
@@ -201,7 +200,6 @@ describe('histogram card', () => {
     expect(headingEl.nativeElement.textContent).toContain('tagA');
     expect(emptyEl).not.toBeTruthy();
     expect(histogramEl).toBeTruthy();
-    expect(histogramEl.componentInstance.name).toBe('run1');
     expect(histogramEl.componentInstance.data).toEqual(
       buildNormalizedHistograms([
         {wallTime: 100, step: 333, bins: [{x: 0, dx: 100, y: 42}]},

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_component.ts
@@ -30,7 +30,6 @@ import * as d3 from '../../third_party/d3';
 import {HCLColor} from '../../third_party/d3';
 import {
   Bin,
-  ColorScale,
   HistogramData,
   HistogramDatum,
   HistogramMode,
@@ -93,14 +92,7 @@ export class HistogramV2Component
 
   @Input() timeProperty: TimeProperty = TimeProperty.STEP;
 
-  /**
-   * TODO(tensorboard-team): VzHistogram only needs 'name', 'colorScale'
-   * properties to determine the histogram color. We could replace these with a
-   * single 'color' property to make the interface simpler.
-   */
-  @Input() colorScale?: ColorScale;
-
-  @Input() name!: string;
+  @Input() color?: string;
 
   @Input() data!: HistogramData;
 
@@ -304,9 +296,7 @@ export class HistogramV2Component
     temporalScale.domain(temporalDomain);
     const countScale = d3.scaleLinear();
     countScale.domain([0, countMax]);
-    const d3Color = d3.hcl(
-      this.colorScale ? this.colorScale(this.name) : '#000'
-    );
+    const d3Color = d3.hcl(this.color || '#000');
     const d3ColorScale = d3.scaleLinear<HCLColor, string>();
     d3ColorScale.domain(temporalDomain);
 

--- a/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_v2_test.ts
@@ -26,7 +26,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {IntersectionObserverTestingModule} from '../intersection_observer/intersection_observer_testing_module';
 import {
   Bin,
-  ColorScale,
   HistogramData,
   HistogramDatum,
   HistogramMode,
@@ -63,7 +62,7 @@ function buildHistogramDatum(
       #instance
       [mode]="mode"
       [timeProperty]="timeProperty"
-      [colorScale]="colorScale"
+      [color]="color"
       [name]="name"
       [data]="data"
     >
@@ -84,7 +83,7 @@ class TestableComponent {
 
   @Input() mode!: HistogramMode;
   @Input() timeProperty!: TimeProperty;
-  @Input() colorScale!: ColorScale;
+  @Input() color!: string;
   @Input() name!: string;
   @Input() data!: HistogramData;
 
@@ -127,7 +126,7 @@ describe('histogram test', () => {
     fixture.componentInstance.data = data;
     fixture.componentInstance.mode = HistogramMode.OFFSET;
     fixture.componentInstance.timeProperty = TimeProperty.STEP;
-    fixture.componentInstance.colorScale = (name) => '#fff';
+    fixture.componentInstance.color = '#fff';
     intersectionObserver = TestBed.inject(IntersectionObserverTestingModule);
     return fixture;
   }


### PR DESCRIPTION
This change knocks off one of the TODO on the histograms. Instead of
a function that would return a color, this change pipes color to
histograms component instead.
