### PR TITLE
histogram: use `transform` to prevent repaint

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -28,7 +28,7 @@ limitations under the License.
       <!-- d3 places axis label at 9px below from the top edge. -->
       <g
         *ngIf="tooltipData"
-        [attr.transform]="getCssTranslate(tooltipData.xAxis.position, 9)"
+        [style.transform]="getCssTranslatePx(tooltipData.xAxis.position, 9)"
       >
         <text>{{tooltipData.xAxis.label}}</text>
       </g>
@@ -37,10 +37,10 @@ limitations under the License.
   <svg class="axis y-axis">
     <g #yAxis></g>
     <!-- d3 places axis label at 9px right from the left edge. -->
-    <g class="tooltip" [attr.transform]="getCssTranslate(9, 0)">
+    <g class="tooltip" [style.transform]="getCssTranslatePx(9, 0)">
       <g
         *ngIf="tooltipData"
-        [attr.transform]="getGroupTransform(tooltipData.closestDatum)"
+        [style.transform]="getGroupTransform(tooltipData.closestDatum)"
       >
         <text [attr.y]="tooltipData.yAxis.position">
           {{tooltipData.yAxis.label}}
@@ -52,7 +52,7 @@ limitations under the License.
     <g class="grid">
       <g
         *ngFor="let tick of getGridTickYLocs()"
-        [attr.transform]="getCssTranslate(0, tick)"
+        [style.transform]="getCssTranslatePx(0, tick)"
       >
         <line class="tick" x2="100%"></line>
       </g>
@@ -61,7 +61,7 @@ limitations under the License.
     <g #histograms class="histograms">
       <g
         *ngFor="let datum of data; trackBy: trackByWallTime;"
-        [attr.transform]="getGroupTransform(datum)"
+        [style.transform]="getGroupTransform(datum)"
         class="histogram"
         [style.color]="getHistogramFill(datum)"
       >
@@ -74,24 +74,26 @@ limitations under the License.
         <circle
           *ngIf="tooltipData"
           r="2"
-          [attr.cx]="getUiCoordFromBinForContent(
-            getClosestBinFromBinCoordinate(
-              datum,
-              tooltipData.xPositionInBinCoord
-            )
-          ).x"
-          [attr.cy]="getUiCoordFromBinForContent(
-            getClosestBinFromBinCoordinate(
-              datum,
-              tooltipData.xPositionInBinCoord
-            )
-          ).y"
+          [style.transform]="getCssTranslatePx(
+            getUiCoordFromBinForContent(
+              getClosestBinFromBinCoordinate(
+                datum,
+                tooltipData.xPositionInBinCoord
+              )
+            ).x,
+            getUiCoordFromBinForContent(
+              getClosestBinFromBinCoordinate(
+                datum,
+                tooltipData.xPositionInBinCoord
+              )
+            ).y
+          )"
         ></circle>
       </g>
     </g>
 
     <g class="tooltip" *ngIf="tooltipData">
-      <g [attr.transform]="getGroupTransform(tooltipData.closestDatum)">
+      <g [style.transform]="getGroupTransform(tooltipData.closestDatum)">
         <path [attr.d]="getHistogramPath(tooltipData.closestDatum)"></path>
         <circle
           *ngIf="tooltipData.closestBin"
@@ -102,8 +104,8 @@ limitations under the License.
       </g>
       <g
         class="value-label"
-        [attr.transform]="
-          getCssTranslate(
+        [style.transform]="
+          getCssTranslatePx(
             tooltipData.value.position.x,
             tooltipData.value.position.y
           )

--- a/tensorboard/webapp/widgets/histogram/histogram_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.scss
@@ -88,6 +88,10 @@ svg {
   .tooltip {
     pointer-events: none;
   }
+
+  g {
+    will-change: transform;
+  }
 }
 
 .x-axis {
@@ -125,15 +129,19 @@ svg {
     stroke-dasharray: 2;
   }
 
+  $_path-circle-opacity: 0.6;
+
   circle,
   path {
     fill: currentColor;
-    stroke-opacity: 0.5;
+    stroke-opacity: $_path-circle-opacity;
     stroke-width: 1px;
   }
 
   circle {
+    filter: drop-shadow(0 0 1px rgba(#000, $_path-circle-opacity));
     stroke: #fff;
+    will-change: transform;
   }
 
   .baseline {

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -146,8 +146,8 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
       .subscribe((event) => this.onMouseMove(event));
   }
 
-  getCssTranslate(x: number, y: number): string {
-    return `translate(${x}, ${y})`;
+  getCssTranslatePx(x: number, y: number): string {
+    return `translate(${x}px, ${y}px)`;
   }
 
   getClosestBinFromBinCoordinate(
@@ -211,9 +211,10 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
     if (!this.scales || this.mode === HistogramMode.OVERLAY) {
       return '';
     }
-    return `translate(0, ${this.scales.temporalScale(
-      this.getTimeValue(datum)
-    )})`;
+    return this.getCssTranslatePx(
+      0,
+      this.scales.temporalScale(this.getTimeValue(datum))
+    );
   }
 
   getHistogramFill(datum: HistogramDatum): string {

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -360,7 +360,7 @@ describe('histogram test', () => {
     function getGroupTransforms(element: DebugElement): string[] {
       const transforms: string[] = [];
       for (const debugEl of element.queryAll(By.css('.histogram'))) {
-        transforms.push(debugEl.attributes['transform']!);
+        transforms.push(debugEl.styles['transform']!);
       }
       return transforms;
     }
@@ -392,9 +392,9 @@ describe('histogram test', () => {
           // on 2D screen, we give height / 2.5 space for histogram slices to
           // render. 50 / 2.5 = 20 so effectively, step=0 is rendered at 20px
           // from the top.
-          'translate(0, 20)',
-          'translate(0, 35)',
-          'translate(0, 50)',
+          'translate(0px, 20px)',
+          'translate(0px, 35px)',
+          'translate(0px, 50px)',
         ]);
       });
 
@@ -413,7 +413,11 @@ describe('histogram test', () => {
         fixture.detectChanges();
         expect(
           getGroupTransforms(fixture.debugElement.query(byCss.HISTOGRAMS))
-        ).toEqual(['translate(0, 35)', 'translate(0, 20)', 'translate(0, 50)']);
+        ).toEqual([
+          'translate(0px, 35px)',
+          'translate(0px, 20px)',
+          'translate(0px, 50px)',
+        ]);
 
         fixture.componentInstance.timeProperty = TimeProperty.RELATIVE;
         fixture.detectChanges();
@@ -421,7 +425,11 @@ describe('histogram test', () => {
         // max (-300, 300) which has the same spacing as the WALL_TIME.
         expect(
           getGroupTransforms(fixture.debugElement.query(byCss.HISTOGRAMS))
-        ).toEqual(['translate(0, 35)', 'translate(0, 20)', 'translate(0, 50)']);
+        ).toEqual([
+          'translate(0px, 35px)',
+          'translate(0px, 20px)',
+          'translate(0px, 50px)',
+        ]);
       });
 
       it('renders histogram in the "count" coordinate system', () => {


### PR DESCRIPTION
Paint is one of the most expensive operations when you have too many
items painting at the same time. One technique to prevent that is to use
`transform` and `will-change` which often put the DOM in the GPU context
instead. All in all, using `attr.transform` still causes repaint while
`style.transform` does not so we chose to use latter instead.