### PR TITLE
timeseries: improve first paint

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -30,6 +30,7 @@ tf_ng_module(
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/types:ui",
         "//tensorboard/webapp/util:dom",
+        "//tensorboard/webapp/widgets/intersection_observer",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/metrics/views/card_renderer/card_renderer_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_renderer_module.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
+import {IntersectionObserverModule} from '../../../widgets/intersection_observer/intersection_observer_module';
 import {CardLazyLoader} from './card_lazy_loader';
 import {CardViewComponent} from './card_view_component';
 import {CardViewContainer} from './card_view_container';
@@ -30,6 +31,7 @@ import {ScalarCardModule} from './scalar_card_module';
     ImageCardModule,
     ScalarCardModule,
     HistogramCardModule,
+    IntersectionObserverModule,
   ],
 })
 export class CardRendererModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<ng-container [ngSwitch]="pluginType">
+<ng-container *ngIf="isEverVisible" [ngSwitch]="pluginType">
   <!-- TODO(psybuzz): consider plugin renderer configuration outisde of this template. -->
   <image-card
     *ngSwitchCase="PluginType.IMAGES"

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ts
@@ -32,6 +32,7 @@ import {CardId} from '../../types';
 export class CardViewComponent {
   readonly PluginType = PluginType;
 
+  @Input() isEverVisible!: boolean;
   @Input() cardId!: CardId;
   @Input() groupName!: string | null;
   @Input() pluginType!: PluginType;

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
@@ -39,6 +39,7 @@ const RUN_COLOR_UPDATE_THROTTLE_TIME_IN_MS = 350;
   selector: 'card-view',
   template: `
     <card-view-component
+      [isEverVisible]="isEverVisible"
       [cardId]="cardId"
       [groupName]="groupName"
       [pluginType]="pluginType"
@@ -46,6 +47,8 @@ const RUN_COLOR_UPDATE_THROTTLE_TIME_IN_MS = 350;
       (fullWidthChanged)="onFullWidthChanged($event)"
       (fullHeightChanged)="onFullHeightChanged($event)"
       (pinStateChanged)="onPinStateChanged()"
+      observeIntersection
+      (onVisibilityChange)="onVisibilityChange($event)"
     >
     </card-view-component>
   `,
@@ -55,12 +58,18 @@ const RUN_COLOR_UPDATE_THROTTLE_TIME_IN_MS = 350;
 export class CardViewContainer {
   constructor(private readonly store: Store<State>) {}
 
+  isEverVisible = false;
+
   @Input() cardId!: CardId;
   @Input() groupName!: string | null;
   @Input() pluginType!: PluginType;
 
   @HostBinding('class.full-width') showFullWidth: boolean = false;
   @HostBinding('class.full-height') showFullHeight: boolean = false;
+
+  onVisibilityChange({visible}: {visible: boolean}) {
+    this.isEverVisible = this.isEverVisible || visible;
+  }
 
   readonly runColorScale$: Observable<RunColorScale> = this.store
     .select(selectors.getRunColorMap)

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -19,21 +19,21 @@ import {
   NO_ERRORS_SCHEMA,
   Output,
 } from '@angular/core';
-import {fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {Action, Store, StoreModule} from '@ngrx/store';
+import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {State} from '../../../app_state';
 
+import {State} from '../../../app_state';
 import * as selectors from '../../../selectors';
 import {RunColorScale} from '../../../types/ui';
+import {IntersectionObserverTestingModule} from '../../../widgets/intersection_observer/intersection_observer_testing_module';
 import * as actions from '../../actions';
 import {PluginType} from '../../data_source';
 import {appStateFromMetricsState, buildMetricsState} from '../../testing';
-
 import {CardViewComponent} from './card_view_component';
-import {CardViewContainer, TEST_ONLY} from './card_view_container';
+import {CardViewContainer} from './card_view_container';
 
 @Component({
   selector: 'scalar-card',
@@ -49,10 +49,11 @@ class TestableScalarCard {
 describe('card view test', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[] = [];
+  let intersectionObserver: IntersectionObserverTestingModule;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
+      imports: [NoopAnimationsModule, IntersectionObserverTestingModule],
       declarations: [CardViewComponent, CardViewContainer, TestableScalarCard],
       providers: [
         provideMockStore({
@@ -68,6 +69,21 @@ describe('card view test', () => {
       dispatchedActions.push(action);
     });
     store.overrideSelector(selectors.getRunColorMap, {});
+    intersectionObserver = TestBed.inject(IntersectionObserverTestingModule);
+  });
+
+  it('stamps DOM only when it is first visible', () => {
+    const fixture = TestBed.createComponent(CardViewContainer);
+    fixture.componentInstance.cardId = 'cardId';
+    fixture.componentInstance.pluginType = PluginType.SCALARS;
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('scalar-card'))).toBeNull();
+    fixture.detectChanges();
+
+    intersectionObserver.simulateVisibilityChange(fixture, true);
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('scalar-card'))).not.toBeNull();
   });
 
   [
@@ -79,6 +95,7 @@ describe('card view test', () => {
       const fixture = TestBed.createComponent(CardViewContainer);
       fixture.componentInstance.cardId = 'cardId';
       fixture.componentInstance.pluginType = pluginType;
+      intersectionObserver.simulateVisibilityChange(fixture, true);
       fixture.detectChanges();
 
       expect(fixture.debugElement.query(By.css(tagName))).not.toBeNull();
@@ -89,6 +106,7 @@ describe('card view test', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';
     fixture.componentInstance.pluginType = PluginType.SCALARS;
+    intersectionObserver.simulateVisibilityChange(fixture, true);
     fixture.detectChanges();
 
     expect(fixture.debugElement.classes['full-width']).not.toBeTruthy();
@@ -109,6 +127,7 @@ describe('card view test', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';
     fixture.componentInstance.pluginType = PluginType.SCALARS;
+    intersectionObserver.simulateVisibilityChange(fixture, true);
     fixture.detectChanges();
 
     expect(fixture.debugElement.classes['full-height']).not.toBeTruthy();
@@ -129,6 +148,7 @@ describe('card view test', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';
     fixture.componentInstance.pluginType = PluginType.SCALARS;
+    intersectionObserver.simulateVisibilityChange(fixture, true);
     fixture.detectChanges();
 
     const scalarCard = fixture.debugElement.query(By.css('scalar-card'));

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -100,25 +100,21 @@ limitations under the License.
     diameter="18"
     *ngIf="loadState === DataLoadState.LOADING"
   ></mat-spinner>
-
-  <ng-container *ngIf="isEverVisible">
-    <line-chart
-      [disableUpdate]="!isCardVisible"
-      [preferredRendererType]="RendererType.WEBGL"
-      [seriesData]="dataSeries"
-      [seriesMetadataMap]="chartMetadataMap"
-      [xScaleType]="xScaleType"
-      [yScaleType]="yScaleType"
-      [customXFormatter]="getCustomXFormatter()"
-      [ignoreYOutliers]="ignoreOutliers"
-      [tooltipTemplate]="tooltip"
-      [useDarkMode]="useDarkMode"
-      (onViewBoxOverridden)="isViewBoxOverridden = $event"
-      [customVisTemplate]="lineChartCustomVis"
-      [customXAxisTemplate]="lineChartCustomXAxisVis"
-    ></line-chart>
-  </ng-container>
-
+  <line-chart
+    [disableUpdate]="!isCardVisible"
+    [preferredRendererType]="RendererType.WEBGL"
+    [seriesData]="dataSeries"
+    [seriesMetadataMap]="chartMetadataMap"
+    [xScaleType]="xScaleType"
+    [yScaleType]="yScaleType"
+    [customXFormatter]="getCustomXFormatter()"
+    [ignoreYOutliers]="ignoreOutliers"
+    [tooltipTemplate]="tooltip"
+    [useDarkMode]="useDarkMode"
+    (onViewBoxOverridden)="isViewBoxOverridden = $event"
+    [customVisTemplate]="lineChartCustomVis"
+    [customXAxisTemplate]="lineChartCustomXAxisVis"
+  ></line-chart>
   <ng-template
     #tooltip
     let-tooltipData="data"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -71,7 +71,6 @@ export class ScalarCardComponent<Downloader> {
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() ignoreOutliers!: boolean;
   @Input() isCardVisible!: boolean;
-  @Input() isEverVisible!: boolean;
   @Input() isPinned!: boolean;
   @Input() loadState!: DataLoadState;
   @Input() showFullSize!: boolean;
@@ -94,6 +93,7 @@ export class ScalarCardComponent<Downloader> {
   constructor(private readonly ref: ElementRef, private dialog: MatDialog) {}
 
   yScaleType = ScaleType.LINEAR;
+  isViewBoxOverridden: boolean = false;
 
   toggleYScaleType() {
     this.yScaleType =

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -114,7 +114,6 @@ function areSeriesEqual(
       [dataSeries]="dataSeries$ | async"
       [ignoreOutliers]="ignoreOutliers$ | async"
       [isCardVisible]="isVisible"
-      [isEverVisible]="isEverVisible"
       [isPinned]="isPinned$ | async"
       [loadState]="loadState$ | async"
       [showFullSize]="showFullSize"
@@ -158,7 +157,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   @Output() pinStateChanged = new EventEmitter<boolean>();
 
   isVisible: boolean = false;
-  isEverVisible: boolean = false;
   loadState$?: Observable<DataLoadState>;
   title$?: Observable<string>;
   tag$?: Observable<string>;
@@ -169,7 +167,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   onVisibilityChange({visible}: {visible: boolean}) {
     this.isVisible = visible;
-    this.isEverVisible = this.isEverVisible || visible;
   }
 
   readonly useDarkMode$ = this.store.select(getDarkModeEnabled);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -285,48 +285,6 @@ describe('scalar card', () => {
   });
 
   describe('basic renders', () => {
-    it('stamps line chart impl only when card is first visible', fakeAsync(() => {
-      const cardMetadata = {
-        plugin: PluginType.SCALARS,
-        tag: 'tagA',
-        run: null,
-      };
-      provideMockCardRunToSeriesData(
-        selectSpy,
-        PluginType.SCALARS,
-        'card1',
-        cardMetadata,
-        null /* runToSeries */
-      );
-      store.overrideSelector(
-        selectors.getVisibleCardIdSet,
-        new Set(['unknown'])
-      );
-
-      const fixture = createComponent('card1', true /* initiallyHidden */);
-
-      const lineChart1 = fixture.debugElement.query(Selector.LINE_CHART);
-      expect(lineChart1).toBeNull();
-
-      intersectionObserver.simulateVisibilityChange(fixture, true);
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['card1']));
-      store.refreshState();
-      fixture.detectChanges();
-
-      const lineChart2 = fixture.debugElement.query(Selector.LINE_CHART);
-      expect(lineChart2).not.toBeNull();
-      expect(lineChart2.componentInstance.disableUpdate).toBe(false);
-
-      intersectionObserver.simulateVisibilityChange(fixture, false);
-      store.overrideSelector(selectors.getVisibleCardIdSet, new Set(['gone']));
-      store.refreshState();
-      fixture.detectChanges();
-
-      const lineChart3 = fixture.debugElement.query(Selector.LINE_CHART);
-      expect(lineChart3).not.toBeNull();
-      expect(lineChart2.componentInstance.disableUpdate).toBe(true);
-    }));
-
     it('renders empty chart when there is no data', fakeAsync(() => {
       const cardMetadata = {
         plugin: PluginType.SCALARS,

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
@@ -17,6 +17,10 @@ limitations under the License.
 
 $_background: map-get($tb-theme, background);
 
+:host {
+  contain: content;
+}
+
 .card-grid {
   display: grid;
   grid-template-columns: repeat(


### PR DESCRIPTION
This change adopts the "isEverVisible"-ness to all types of
visualization. The premise of this change is following: some users wants
high number of pagination size with many distinct tag groups. For those
users, we optimized line chart render by deferring render until the card
is visible on the screen. With the optimization, we were able to reduce
number of DOM nodes we mount at the start of the page load. This change
expands the optimizations to defer rendering card headers and rendering
other visualization types like image and histograms.
