### PR TITLE
timeseries: improve tag filtering

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/card_groups_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_groups_component.ts
@@ -36,7 +36,7 @@ import {CardGroup} from '../metrics_view_types';
             >{{ group.groupName }}</span
           >
           <span *ngIf="group.items.length > 1" class="group-card-count"
-            >{{ group.items.length }} cards</span
+            >{{ group.items.length | number }} cards</span
           >
         </span>
       </div>

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_component.ng.html
@@ -41,6 +41,6 @@ limitations under the License.
     >{{ completion }}</mat-option
   >
   <div *ngIf="completions?.length > 25" class="and-more">
-    <em>and {{completions.length - 25}} more</em>
+    <em>and {{completions.length - 25 | number}} more tags matched</em>
   </div>
 </mat-autocomplete>

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_component.ng.html
@@ -31,8 +31,16 @@ limitations under the License.
 <mat-autocomplete
   #filterMatches="matAutocomplete"
   (optionSelected)="onCompletionAccepted($event.option.value)"
+  class="tag-options"
 >
-  <mat-option *ngFor="let completion of completions" [value]="completion"
+  <mat-option
+    *ngFor="let completion of completions?.slice(0, 25)"
+    [value]="completion"
+    class="option"
+    [attr.title]="completion"
     >{{ completion }}</mat-option
   >
+  <div *ngIf="completions?.length > 25" class="and-more">
+    <em>and {{completions.length - 25}} more</em>
+  </div>
 </mat-autocomplete>

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_component.scss
@@ -40,3 +40,19 @@ tb-filter-input {
     }
   }
 }
+
+::ng-deep .tag-options {
+  .option,
+  .and-more {
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    display: -webkit-box;
+    font-size: 14px;
+    line-height: 1.4;
+    padding: 8px 16px;
+  }
+
+  .and-more {
+    @include tb-theme-foreground-prop(color, secondary-text);
+  }
+}

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_container.ts
@@ -71,6 +71,7 @@ export class MetricsFilterInputContainer {
       // De-duplicate using Set since Image cards has a notion of Sample and
       // the same `run` and `tag` can appear more than once.
       map((tags) => [...new Set(tags)]),
+      map((tags) => tags.sort(compareTagNames)),
       combineLatestWith(this.store.select(getMetricsTagFilter)),
       map<[string[], string], [string[], RegExp | null]>(
         ([tags, tagFilter]) => {
@@ -84,9 +85,7 @@ export class MetricsFilterInputContainer {
       ),
       filter(([, tagFilterRegex]) => tagFilterRegex !== null),
       map(([tags, tagFilterRegex]) => {
-        return tags
-          .filter((tag: string) => tagFilterRegex!.test(tag))
-          .sort(compareTagNames);
+        return tags.filter((tag: string) => tagFilterRegex!.test(tag));
       })
     );
 

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
@@ -152,7 +152,7 @@ describe('metrics filter input', () => {
       expect(
         overlayContainer.getContainerElement().querySelector('.and-more')!
           .textContent
-      ).toEqual('and 5 more');
+      ).toEqual('and 5 more tags matched');
 
       store.overrideSelector(
         selectors.getNonEmptyCardIdsWithMetadata,

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
@@ -126,6 +126,48 @@ describe('metrics filter input', () => {
       ).toEqual(['tagA', 'tagA/Images', 'tagB/meow/cat']);
     });
 
+    it('truncates to 25 tags when there are more', () => {
+      const cards = [...new Array(30)].map((_, index) => {
+        return {
+          cardId: `card${index}`,
+          plugin: PluginType.SCALARS,
+          tag: `tag${index}`,
+          runId: null,
+        };
+      });
+      const tags = cards.map(({tag}) => tag);
+      store.overrideSelector(selectors.getNonEmptyCardIdsWithMetadata, cards);
+      store.overrideSelector(selectors.getMetricsTagFilter, '');
+      const fixture = TestBed.createComponent(MetricsFilterInputContainer);
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.focus();
+      fixture.detectChanges();
+
+      const options = getAutocompleteOptions(overlayContainer);
+      expect(options.map((option) => option.nativeElement.textContent)).toEqual(
+        tags.slice(0, 25)
+      );
+      expect(
+        overlayContainer.getContainerElement().querySelector('.and-more')!
+          .textContent
+      ).toEqual('and 5 more');
+
+      store.overrideSelector(
+        selectors.getNonEmptyCardIdsWithMetadata,
+        cards.slice(0, 25)
+      );
+      store.refreshState();
+      fixture.detectChanges();
+      expect(options.map((option) => option.nativeElement.textContent)).toEqual(
+        tags.slice(0, 25)
+      );
+      expect(
+        overlayContainer.getContainerElement().querySelector('.and-more')
+      ).toBeNull();
+    });
+
     it('renders empty when no tags match', () => {
       store.overrideSelector(
         selectors.getMetricsTagFilter,

--- a/tensorboard/webapp/metrics/views/main_view/filtered_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filtered_view_component.ts
@@ -26,7 +26,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
           >Tags matching filter</span
         >
         <span *ngIf="cardIdsWithMetadata.length > 1" class="group-card-count"
-          >{{ cardIdsWithMetadata.length }} cards</span
+          >{{ cardIdsWithMetadata.length | number }} cards</span
         >
       </span>
     </div>

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -223,9 +223,10 @@ $tb-dark-theme: map_merge(
   // Include all theme-styles for the components based on the current theme.
   @include angular-material-theme($tb-theme);
 
-  body {
-    // Prevent color-picker from briefly showing scrollbar when calculating its
-    // position.
+  // Prevent color-picker from briefly showing scrollbar when calculating its
+  // position.
+  body,
+  .cdk-overlay-container {
     contain: strict;
   }
 


### PR DESCRIPTION
In performance profiling, there were two medium sized opportunities for
optimization:
1. we were spending significant CPU cycles for rendering all tag matches
in the autocomplete and it was taking non-trivial amount of time
(~100ms) when there were 3000 tags. This definitely contributed to
slowness when every keystroke is expected to be very responsive.
2. `compareTagNames` were taking a significant amount of time. Given
that the list of tags/cards does not change unless the underlying data
from backend changes, we really do not need to sort on every keystroke
that changes tagFilter. We can pre-sort the tag list before we apply the
filter.

These two changes, combined, gave significantly subjectively snappier
experience.
