### PR TITLE
bug: prevent scrollbar when angular dialog presents

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -225,7 +225,6 @@ $tb-dark-theme: map_merge(
 
   // Prevent color-picker from briefly showing scrollbar when calculating its
   // position.
-  body,
   .cdk-overlay-container {
     contain: strict;
   }


### PR DESCRIPTION
In Scalars plugin, or any Polymer plugin, when you click on the settings
that bring up the Angular overlay, you see a scrollbar render on the
`body` level. This is because we put `contain: strict` on the body
recently which can be omitted for now.

Buggy TensorBoard (found in screenshot test)
![image](https://user-images.githubusercontent.com/2547313/130537098-d57ff09b-cf1a-41d2-99f3-be5670a185fa.png)

