### PR TITLE
widget: support margin on IntersectionObserver

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
@@ -48,6 +48,7 @@ const RUN_COLOR_UPDATE_THROTTLE_TIME_IN_MS = 350;
       (fullHeightChanged)="onFullHeightChanged($event)"
       (pinStateChanged)="onPinStateChanged()"
       observeIntersection
+      intersectionObserverMargin="200px 200px 200px 200px"
       (onVisibilityChange)="onVisibilityChange($event)"
     >
     </card-view-component>

--- a/tensorboard/webapp/widgets/intersection_observer/BUILD
+++ b/tensorboard/webapp/widgets/intersection_observer/BUILD
@@ -11,6 +11,7 @@ tf_ng_module(
         "intersection_observer_module.ts",
     ],
     deps = [
+        "//tensorboard/webapp/angular:expect_angular_cdk_scrolling",
         "@npm//@angular/core",
         "@npm//rxjs",
     ],
@@ -24,6 +25,7 @@ tf_ts_library(
     ],
     deps = [
         ":intersection_observer",
+        "//tensorboard/webapp/angular:expect_angular_cdk_scrolling",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "@npm//@angular/core",
         "@npm//@types/jasmine",


### PR DESCRIPTION
This change adds support for optional parameter on the
IntersectionObserver that lets us specify the margin for triggering the
IntersectionObserver.
