### PR TITLE
Revert "Sparkline: add controls to lineChartComponent to be "line only""

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 <div
-  [ngClass]="{'container': true, 'dark-mode': useDarkMode, 'line-only-mode': lineOnly}"
+  [ngClass]="{'container': true, 'dark-mode': useDarkMode}"
   detectResize
   (onResize)="onViewResize()"
   [resizeEventDebouncePeriodInMs]="0"
@@ -25,7 +25,6 @@ limitations under the License.
 >
   <div class="series-view" #seriesView>
     <line-chart-grid-view
-      *ngIf="!lineOnly"
       [viewExtent]="viewBox"
       [xScale]="xScale"
       [yScale]="yScale"
@@ -41,7 +40,6 @@ limitations under the License.
       ></canvas>
     </ng-container>
     <line-chart-interactive-view
-      *ngIf="!lineOnly"
       [seriesData]="seriesData"
       [seriesMetadataMap]="seriesMetadataMap"
       [viewExtent]="viewBox"
@@ -65,21 +63,20 @@ limitations under the License.
       ></ng-container>
     </div>
   </div>
-  <div class="y-axis" #yAxis>
+  <line-chart-axis
+    #yAxis
+    class="y-axis"
+    axis="y"
+    [axisExtent]="viewBox.y"
+    [customFormatter]="customYFormatter"
+    [domDim]="domDimensions.yAxis"
+    [gridCount]="Y_GRID_COUNT"
+    [scale]="yScale"
+    (onViewExtentChange)="onViewBoxChangedFromAxis($event, 'y')"
+  ></line-chart-axis>
+  <div class="x-axis">
     <line-chart-axis
-      *ngIf="!lineOnly"
-      axis="y"
-      [axisExtent]="viewBox.y"
-      [customFormatter]="customYFormatter"
-      [domDim]="domDimensions.yAxis"
-      [gridCount]="Y_GRID_COUNT"
-      [scale]="yScale"
-      (onViewExtentChange)="onViewBoxChangedFromAxis($event, 'y')"
-    ></line-chart-axis>
-  </div>
-  <div class="x-axis" #xAxis>
-    <line-chart-axis
-      *ngIf="!lineOnly"
+      #xAxis
       axis="x"
       [axisExtent]="viewBox.x"
       [customFormatter]="customXFormatter"
@@ -101,5 +98,5 @@ limitations under the License.
       ></ng-container>
     </div>
   </div>
-  <div class="dot" *ngIf="!lineOnly"><span class="rect"></span></div>
+  <div class="dot"><span class="rect"></span></div>
 </div>

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -37,12 +37,6 @@ limitations under the License.
   &.dark-mode {
     color: map-get($tb-dark-foreground, text);
   }
-  // We does not want to render x-axis and y axis in line only mode. Thus
-  // we also removes the spaces the axis take.
-  &.line-only-mode {
-    grid-template-columns: 0 1fr;
-    grid-auto-rows: 1fr 0;
-  }
 }
 
 .series-view {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -134,9 +134,6 @@ export class LineChartComponent
   @Input()
   tooltipTemplate?: TooltipTemplate;
 
-  @Input()
-  lineOnly?: boolean = false;
-
   private onViewBoxOverridden = new ReplaySubject<boolean>(1);
 
   /**

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -49,7 +49,6 @@ class FakeGridComponent {
     <line-chart
       #chart
       [disableUpdate]="disableUpdate"
-      [lineOnly]="lineOnly"
       [preferredRendererType]="preferredRendererType"
       [seriesData]="seriesData"
       [seriesMetadataMap]="seriesMetadataMap"
@@ -89,9 +88,6 @@ class TestableComponent {
 
   @Input()
   useDarkMode: boolean = false;
-
-  @Input()
-  lineOnly: boolean = false;
 
   // WebGL one is harder to test.
   preferredRendererType = RendererType.SVG;
@@ -804,72 +800,6 @@ describe('line_chart_v2/line_chart test', () => {
       expect(didChartRendererRecover(fixture, chartBefore)).toBe(true);
       expect(disposeSpy).toHaveBeenCalledTimes(1);
       expectChartUpdateSpiesToHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('lineOnly', () => {
-    it('shows complete lineChartComponent when lineOnly=false', () => {
-      const fixture = createComponent({
-        seriesData: [
-          buildSeries({
-            id: 'foo',
-            points: [
-              {x: 0, y: 0},
-              {x: 1, y: -1},
-              {x: 2, y: 1},
-            ],
-          }),
-        ],
-        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
-        yScaleType: ScaleType.LINEAR,
-      });
-      fixture.componentInstance.lineOnly = false;
-      fixture.detectChanges();
-
-      expect(
-        fixture.debugElement.query(By.css('line-chart-grid-view'))
-      ).toBeTruthy();
-      expect(
-        fixture.debugElement.query(By.css('line-chart-interactive-view'))
-      ).toBeTruthy();
-      expect(
-        fixture.debugElement.query(By.css('.y-axis line-chart-axis'))
-      ).toBeTruthy();
-      expect(
-        fixture.debugElement.query(By.css('.x-axis line-chart-axis'))
-      ).toBeTruthy();
-    });
-
-    it('shows only line chart when lineOnly=true', () => {
-      const fixture = createComponent({
-        seriesData: [
-          buildSeries({
-            id: 'foo',
-            points: [
-              {x: 0, y: 0},
-              {x: 1, y: -1},
-              {x: 2, y: 1},
-            ],
-          }),
-        ],
-        seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
-        yScaleType: ScaleType.LINEAR,
-      });
-      fixture.componentInstance.lineOnly = true;
-      fixture.detectChanges();
-
-      expect(
-        fixture.debugElement.query(By.css('line-chart-grid-view'))
-      ).toBeNull();
-      expect(
-        fixture.debugElement.query(By.css('line-chart-interactive-view'))
-      ).toBeNull();
-      expect(
-        fixture.debugElement.query(By.css('.y-axis line-chart-axis'))
-      ).toBeNull();
-      expect(
-        fixture.debugElement.query(By.css('.x-axis line-chart-axis'))
-      ).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Reverts tensorflow/tensorboard#5269
The y-axis will not be rendered under the new html structure. Cannot identify the fix in short time. Revert this pr.
<img width="414" alt="Screen Shot 2021-08-26 at 5 03 23 PM" src="https://user-images.githubusercontent.com/1131010/131051060-89179635-8114-4422-bb46-3a85fd61036d.png">
