### PR TITLE
timeseries: reset PluginType filter when selected all

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -890,12 +890,20 @@ const reducer = createReducer(
     };
   }),
   on(actions.metricsToggleVisiblePlugin, (state, {plugin}) => {
-    const nextFilteredPluginTypes = new Set(state.filteredPluginTypes);
+    let nextFilteredPluginTypes = new Set(state.filteredPluginTypes);
     if (nextFilteredPluginTypes.has(plugin)) {
       nextFilteredPluginTypes.delete(plugin);
     } else {
       nextFilteredPluginTypes.add(plugin);
     }
+    if (
+      Object.values(PluginType).every((pluginType) =>
+        nextFilteredPluginTypes.has(pluginType)
+      )
+    ) {
+      nextFilteredPluginTypes = new Set();
+    }
+
     return {...state, filteredPluginTypes: nextFilteredPluginTypes};
   }),
   on(

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2138,6 +2138,23 @@ describe('metrics reducers', () => {
           new Set([PluginType.SCALARS])
         );
       });
+
+      it('empties the plugin filter set when filteredPluginTypes contains all plugins', () => {
+        const before = buildMetricsState({
+          filteredPluginTypes: new Set([
+            PluginType.IMAGES,
+            PluginType.HISTOGRAMS,
+          ]),
+        });
+
+        const after = reducers(
+          before,
+          actions.metricsToggleVisiblePlugin({
+            plugin: PluginType.SCALARS,
+          })
+        );
+        expect(after.filteredPluginTypes).toEqual(new Set([]));
+      });
     });
 
     describe('#metricsShowAllPlugins', () => {

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -161,6 +161,8 @@ export interface MetricsRoutefulState {
   selectedTime: StoreInternalLinkedTime | null;
   selectTimeEnabled: boolean;
   useRangeSelectTime: boolean;
+  // Empty Set would signify "show all". `filteredPluginTypes` will never have
+  // all pluginTypes in the Set.
   filteredPluginTypes: Set<PluginType>;
   // Minimum and maximum step number across all TimeSeries data.
   stepMinMax: {


### PR DESCRIPTION
filteredPluginType previously had a contract where an empty Set would
be equivalent to "show all types". Of course, when user manually toggles
on every plugins, the Set can contain all entries and now we have two
states that both means "show all types". Instead of having this
confusing states, we are now making everything consistent by only
allowing empty Set to signify "show all".