### PR TITLE
router: do not warn users about dirty updates on the same page

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -204,14 +204,18 @@ export class AppRoutingEffects {
    */
   navigate$ = createEffect(() => {
     const dispatchNavigating$ = this.validatedRoute$.pipe(
-      mergeMap((routes) => {
-        const samePathname =
-          routes.routeMatch.pathname === this.location.getPath();
+      withLatestFrom(this.store.select(getActiveRoute)),
+      mergeMap(([routes, oldRoute]) => {
+        const sameRouteId =
+          oldRoute !== null &&
+          getRouteId(routes.routeMatch.routeKind, routes.routeMatch.params) ===
+            getRouteId(oldRoute.routeKind, oldRoute.params);
         const dirtySelectors = this.dirtyUpdatesRegistry.getDirtyUpdatesSelectors();
 
-        // Do not warn about dirty updates on the same page (e.g. when changing
-        // tabs in the same experiment page or query params in experiment list).
-        if (samePathname || !dirtySelectors.length) return of(routes);
+        // Do not warn about dirty updates when route ID is the same (e.g. when
+        // changing tabs in the same experiment page or query params in experiment
+        // list).
+        if (sameRouteId || !dirtySelectors.length) return of(routes);
         return forkJoin(
           this.dirtyUpdatesRegistry
             .getDirtyUpdatesSelectors()

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -207,8 +207,7 @@ export class AppRoutingEffects {
       mergeMap((routes) => {
         const samePathname =
           routes.routeMatch.pathname === this.location.getPath();
-        const dirtySelectors =
-          this.dirtyUpdatesRegistry.getDirtyUpdatesSelectors();
+        const dirtySelectors = this.dirtyUpdatesRegistry.getDirtyUpdatesSelectors();
 
         // Do not warn about dirty updates on the same page (e.g. when changing
         // tabs in the same experiment page or query params in experiment list).
@@ -253,8 +252,9 @@ export class AppRoutingEffects {
             routeMatch.redirectionOnlyQueryParams
               ? routeMatch.redirectionOnlyQueryParams
               : this.location.getSearch();
-          const rehydratingState =
-            routeMatch.deepLinkProvider.deserializeQueryParams(queryParams);
+          const rehydratingState = routeMatch.deepLinkProvider.deserializeQueryParams(
+            queryParams
+          );
           this.store.dispatch(
             stateRehydratedFromUrl({
               routeKind: routeMatch.routeKind,

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -205,9 +205,14 @@ export class AppRoutingEffects {
   navigate$ = createEffect(() => {
     const dispatchNavigating$ = this.validatedRoute$.pipe(
       mergeMap((routes) => {
-        const dirtySelectors = this.dirtyUpdatesRegistry.getDirtyUpdatesSelectors();
+        const samePathname =
+          routes.routeMatch.pathname === this.location.getPath();
+        const dirtySelectors =
+          this.dirtyUpdatesRegistry.getDirtyUpdatesSelectors();
 
-        if (!dirtySelectors.length) return of(routes);
+        // Do not warn about dirty updates on the same page (e.g. when changing
+        // tabs in the same experiment page or query params in experiment list).
+        if (samePathname || !dirtySelectors.length) return of(routes);
         return forkJoin(
           this.dirtyUpdatesRegistry
             .getDirtyUpdatesSelectors()
@@ -248,9 +253,8 @@ export class AppRoutingEffects {
             routeMatch.redirectionOnlyQueryParams
               ? routeMatch.redirectionOnlyQueryParams
               : this.location.getSearch();
-          const rehydratingState = routeMatch.deepLinkProvider.deserializeQueryParams(
-            queryParams
-          );
+          const rehydratingState =
+            routeMatch.deepLinkProvider.deserializeQueryParams(queryParams);
           this.store.dispatch(
             stateRehydratedFromUrl({
               routeKind: routeMatch.routeKind,

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -336,39 +336,28 @@ describe('app_routing_effects', () => {
 
       it('does not warn user when changing tab (same routeId)', fakeAsync(() => {
         spyOn(window, 'confirm');
-        getPathSpy.and.returnValue('/experiments');
+        const activeRoute = buildRoute({
+          routeKind: RouteKind.EXPERIMENT,
+          params: {experimentId: 'meow'},
+          pathname: '/experiment/meow',
+          queryParams: [],
+        });
+        store.overrideSelector(getActiveRoute, activeRoute);
+        store.refreshState();
+        getPathSpy.and.returnValue('/experiment/meow');
         // Changing tab.
         getHashSpy.and.returnValue('#foo');
-        action.next(
-          actions.navigationRequested({
-            pathname: '/experiments',
-          })
-        );
+        action.next(actions.navigationRequested(activeRoute));
         tick();
 
         expect(window.confirm).not.toHaveBeenCalled();
         expect(actualActions).toEqual([
           actions.navigating({
-            after: buildRoute({
-              routeKind: RouteKind.EXPERIMENTS,
-              params: {},
-              pathname: '/experiments',
-              queryParams: [],
-            }),
+            after: activeRoute
           }),
           actions.navigated({
-            before: buildRoute({
-              routeKind: RouteKind.EXPERIMENTS,
-              params: {},
-              pathname: '/experiments',
-              queryParams: [],
-            }),
-            after: buildRoute({
-              routeKind: RouteKind.EXPERIMENTS,
-              params: {},
-              pathname: '/experiments',
-              queryParams: [],
-            }),
+            before: activeRoute,
+            after: activeRoute,
           }),
         ]);
       }));

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -334,7 +334,7 @@ describe('app_routing_effects', () => {
         );
       });
 
-      it('does not warn user if the pathnames are the same', fakeAsync(() => {
+      it('does not warn user when changing tab (same routeId)', fakeAsync(() => {
         spyOn(window, 'confirm');
         getPathSpy.and.returnValue('/experiments');
         // Changing tab.

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -519,24 +519,24 @@ describe('app_routing_effects', () => {
               partialState: {a: 'A', b: 'B'},
             }),
             actions.navigating({
-              after: buildRoute({
+              after: buildRoute(({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {},
                 pathname: '/compare',
                 queryParams: [],
                 // Do not care about the replaceState for this spec.
                 navigationOptions: jasmine.any(Object),
-              } as unknown as Route),
+              } as unknown) as Route),
             }),
             actions.navigated({
               before: null,
-              after: buildRoute({
+              after: buildRoute(({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {},
                 pathname: '/compare',
                 queryParams: [],
                 navigationOptions: jasmine.any(Object),
-              } as unknown as Route),
+              } as unknown) as Route),
             }),
           ]);
         }));

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -334,6 +334,45 @@ describe('app_routing_effects', () => {
         );
       });
 
+      it('does not warn user if the pathnames are the same', fakeAsync(() => {
+        spyOn(window, 'confirm');
+        getPathSpy.and.returnValue('/experiments');
+        // Changing tab.
+        getHashSpy.and.returnValue('#foo');
+        action.next(
+          actions.navigationRequested({
+            pathname: '/experiments',
+          })
+        );
+        tick();
+
+        expect(window.confirm).not.toHaveBeenCalled();
+        expect(actualActions).toEqual([
+          actions.navigating({
+            after: buildRoute({
+              routeKind: RouteKind.EXPERIMENTS,
+              params: {},
+              pathname: '/experiments',
+              queryParams: [],
+            }),
+          }),
+          actions.navigated({
+            before: buildRoute({
+              routeKind: RouteKind.EXPERIMENTS,
+              params: {},
+              pathname: '/experiments',
+              queryParams: [],
+            }),
+            after: buildRoute({
+              routeKind: RouteKind.EXPERIMENTS,
+              params: {},
+              pathname: '/experiments',
+              queryParams: [],
+            }),
+          }),
+        ]);
+      }));
+
       it('noops if user cancels navigation', () => {
         spyOn(window, 'confirm').and.returnValue(false);
         action.next(
@@ -480,24 +519,24 @@ describe('app_routing_effects', () => {
               partialState: {a: 'A', b: 'B'},
             }),
             actions.navigating({
-              after: buildRoute(({
+              after: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {},
                 pathname: '/compare',
                 queryParams: [],
                 // Do not care about the replaceState for this spec.
                 navigationOptions: jasmine.any(Object),
-              } as unknown) as Route),
+              } as unknown as Route),
             }),
             actions.navigated({
               before: null,
-              after: buildRoute(({
+              after: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {},
                 pathname: '/compare',
                 queryParams: [],
                 navigationOptions: jasmine.any(Object),
-              } as unknown) as Route),
+              } as unknown as Route),
             }),
           ]);
         }));

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -353,7 +353,7 @@ describe('app_routing_effects', () => {
         expect(window.confirm).not.toHaveBeenCalled();
         expect(actualActions).toEqual([
           actions.navigating({
-            after: activeRoute
+            after: activeRoute,
           }),
           actions.navigated({
             before: activeRoute,


### PR DESCRIPTION
When users change tabs in the same dashboard or edit query parameters in the same list view, unsaved updates should be kept without warnings.

Googlers, see [issue](https://b.corp.google.com/issues/197321281) for more details.

#edit_exp