### PR TITLE
infra: upgrade `@angular/material`

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@angular/core": "^12.2.0",
     "@angular/forms": "^12.2.0",
     "@angular/localize": "^12.2.0",
-    "@angular/material": "^11.2.8",
+    "@angular/material": "^12.2.3",
     "@angular/platform-browser": "^12.2.0",
     "@angular/platform-browser-dynamic": "^12.2.0",
     "@angular/router": "^12.2.0",

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -16,7 +16,7 @@
 load("@npm//@bazel/rollup:index.bzl", "rollup_bundle")
 load("@npm//@bazel/concatjs:index.bzl", "karma_web_test_suite")
 load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_library")
-load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
+load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library", "sass_binary", "sass_library")
 load("@npm//@bazel/terser:index.bzl", "terser_minified")
 load("//tensorboard/defs/internal:js.bzl", _tf_dev_js_binary = "tf_dev_js_binary")
 
@@ -191,6 +191,17 @@ def tf_sass_library(**kwargs):
         **kwargs
     )
 
+def tf_external_sass_libray(**kwargs):
+    """TensorBoard wrapper for declaring external SASS dependency.
+
+    When an external (NPM) package have SASS files that has `import` statements,
+    TensorBoard has to depdend on them very specifically. This rule allows SASS
+    modules in NPM packages to be built properly.
+    """
+    npm_sass_library(
+        **kwargs
+    )
+
 def tf_ng_module(assets = [], **kwargs):
     """TensorBoard wrapper for Angular modules."""
     ts_library(
@@ -232,9 +243,9 @@ def tf_inline_pngs(name, html_template, images, out):
      out: Name of the output (inlined) .html file.
     """
     native.genrule(
-        name=name,
-        srcs=[html_template] + images,
-        outs=[out],
-        cmd="$(execpath //tensorboard/defs:inline_images) $(SRCS) >'$@'",
-        exec_tools=["//tensorboard/defs:inline_images"],
+        name = name,
+        srcs = [html_template] + images,
+        outs = [out],
+        cmd = "$(execpath //tensorboard/defs:inline_images) $(SRCS) >'$@'",
+        exec_tools = ["//tensorboard/defs:inline_images"],
     )

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_sass_library", "tf_svg_bundle", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_external_sass_libray", "tf_js_binary", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_sass_library", "tf_svg_bundle", "tf_ts_library")
 load("//tensorboard/defs:js.bzl", "tf_resource_digest_suffixer")
 load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
 
@@ -399,11 +399,18 @@ tf_svg_bundle(
     out = "icon_bundle.svg",
 )
 
+tf_external_sass_libray(
+    name = "angular_material_sass_deps",
+    deps = ["@npm//@angular/material"],
+)
+
 tf_sass_library(
     name = "angular_material_theming",
     srcs = [
         "_angular_material_theming.scss",
-        "@npm//:node_modules/@angular/material/_theming.scss",
+    ],
+    deps = [
+        ":angular_material_sass_deps",
     ],
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,12 +139,12 @@
     glob "7.1.7"
     yargs "^17.0.0"
 
-"@angular/material@^11.2.8":
-  version "11.2.13"
-  resolved "https://registry.yarnpkg.com/@angular/material/-/material-11.2.13.tgz#99960316d3ce58aac7497d7bb8b0c05468f502b9"
-  integrity sha512-FqFdGSkOtqsmeLyTSousodDGUy2NqbtxCIKv2rwbsIRwHNKB0KpR/UQhA2gMRuGa5hxhMJ0DW0Tf9neMRuLCTg==
+"@angular/material@^12.2.3":
+  version "12.2.3"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-12.2.3.tgz#9551ee0caed02532e240ebc14c410f251d764c83"
+  integrity sha512-kwCTYPckOsrLU9ukM9c3E4EnJJu6PMEymn/Xb6QKAo+0qwaV527QrWl6EW1IgcDpUvEB5UNbxXTU32wa+LhtVA==
   dependencies:
-    tslib "^2.0.0"
+    tslib "^2.2.0"
 
 "@angular/platform-browser-dynamic@^12.2.0":
   version "12.2.1"


### PR DESCRIPTION
This change introduces new rule for external SASS dependencies and use
it to add `@angular/material` dependency.
