### PR TITLE
app_routing: expose registered route kinds

### DIFF
--- a/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
+++ b/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
@@ -40,6 +40,14 @@ export const stateRehydratedFromUrl = createAction(
 );
 
 /**
+ * Created when the route configurations are loaded on the initial load.
+ */
+export const routeConfigLoaded = createAction(
+  '[App Routing] Route Config Loaded',
+  props<{routeKinds: Set<RouteKind>}>()
+);
+
+/**
  * Created when user intends to navigate in the application
  */
 export const navigationRequested = createAction(

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -34,6 +34,7 @@ import {
   navigated,
   navigating,
   navigationRequested,
+  routeConfigLoaded,
   stateRehydratedFromUrl,
 } from '../actions';
 import {AppRootProvider} from '../app_root';
@@ -69,7 +70,7 @@ export class AppRoutingEffects {
     private readonly store: Store<State>,
     private readonly location: Location,
     private readonly dirtyUpdatesRegistry: DirtyUpdatesRegistryModule<State>,
-    registry: RouteRegistryModule,
+    private readonly registry: RouteRegistryModule,
     private readonly programmaticalNavModule: ProgrammaticalNavigationModule,
     private readonly appRootProvider: AppRootProvider
   ) {
@@ -85,6 +86,20 @@ export class AppRoutingEffects {
       return {...navigation, pathname: resolvedPathname};
     })
   );
+
+  /**
+   * @exports
+   */
+  readonly bootstrapReducers$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(initAction),
+      map(() => {
+        return routeConfigLoaded({
+          routeKinds: new Set(this.registry.getRegisteredRouteKinds()),
+        });
+      })
+    );
+  });
 
   private readonly onInit$: Observable<Navigation> = this.actions$
     .pipe(ofType(initAction))

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -1145,13 +1145,7 @@ describe('app_routing_effects', () => {
       provider.setAppRoot(appRoot);
 
       effects = TestBed.inject(AppRoutingEffects);
-      const dispatchSpy = spyOn(store, 'dispatch');
       effects.navigate$.subscribe((action) => {
-        actualActions.push(action);
-      });
-
-      actualActions = [];
-      dispatchSpy.and.callFake((action: Action) => {
         actualActions.push(action);
       });
     }

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -195,18 +195,43 @@ describe('app_routing_effects', () => {
     getSearchSpy = spyOn(location, 'getSearch').and.returnValue([]);
 
     store.overrideSelector(getActiveRoute, null);
+    actualActions = [];
+
+    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+      actualActions.push(action);
+    });
+  });
+
+  describe('bootstrapReducers$', () => {
+    beforeEach(() => {
+      effects = TestBed.inject(AppRoutingEffects);
+      effects.bootstrapReducers$.subscribe((action) => {
+        actualActions.push(action);
+      });
+    });
+
+    it(
+      'grabs registered route kinds from the registry and dispatches ' +
+        'routeConfigLoaded',
+      () => {
+        const registry = TestBed.inject(RouteRegistryModule);
+        spyOn(registry, 'getRegisteredRouteKinds').and.returnValue(
+          new Set([RouteKind.EXPERIMENT, RouteKind.EXPERIMENTS])
+        );
+        action.next(effects.ngrxOnInitEffects());
+
+        expect(actualActions).toEqual([
+          actions.routeConfigLoaded({
+            routeKinds: new Set([RouteKind.EXPERIMENT, RouteKind.EXPERIMENTS]),
+          }),
+        ]);
+      }
+    );
   });
 
   describe('navigate$', () => {
-    let actualActions: Action[];
-
     beforeEach(() => {
       effects = TestBed.inject(AppRoutingEffects);
-      actualActions = [];
-
-      spyOn(store, 'dispatch').and.callFake((action: Action) => {
-        actualActions.push(action);
-      });
       effects.navigate$.subscribe((action) => {
         actualActions.push(action);
       });

--- a/tensorboard/webapp/app_routing/route_registry_module.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module.ts
@@ -54,6 +54,10 @@ export class RouteRegistryModule {
     });
   }
 
+  getRegisteredRouteKinds(): Iterable<RouteKind> {
+    return this.routeKindToNgComponent.keys();
+  }
+
   /**
    * Returns RouteConfigs of current route configuration. Returnsn null if no
    * routes are registered.

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
@@ -19,6 +19,7 @@ import {AppRoutingState} from './app_routing_types';
 const initialState: AppRoutingState = {
   activeRoute: null,
   nextRoute: null,
+  registeredRouteKeys: new Set(),
 };
 
 const reducer = createReducer(
@@ -28,6 +29,12 @@ const reducer = createReducer(
   }),
   on(actions.navigated, (state, {after}) => {
     return {...state, activeRoute: after, nextRoute: null};
+  }),
+  on(actions.routeConfigLoaded, (state, {routeKinds}) => {
+    return {
+      ...state,
+      registeredRouteKeys: routeKinds,
+    };
   })
 );
 

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
@@ -100,4 +100,43 @@ describe('app_routing_reducers', () => {
       );
     });
   });
+
+  describe('routeConfigLoaded', () => {
+    it('sets registered route kinds in the state', () => {
+      const state = buildAppRoutingState({
+        registeredRouteKeys: new Set(),
+      });
+
+      const nextState = appRoutingReducers.reducers(
+        state,
+        actions.routeConfigLoaded({
+          routeKinds: new Set([
+            RouteKind.COMPARE_EXPERIMENT,
+            RouteKind.UNKNOWN,
+          ]),
+        })
+      );
+
+      expect(nextState.registeredRouteKeys).toEqual(
+        new Set([RouteKind.COMPARE_EXPERIMENT, RouteKind.UNKNOWN])
+      );
+    });
+
+    it('replaces existing registered route kinds', () => {
+      const state = buildAppRoutingState({
+        registeredRouteKeys: new Set([RouteKind.EXPERIMENTS]),
+      });
+
+      const nextState = appRoutingReducers.reducers(
+        state,
+        actions.routeConfigLoaded({
+          routeKinds: new Set([RouteKind.UNKNOWN]),
+        })
+      );
+
+      expect(nextState.registeredRouteKeys).toEqual(
+        new Set([RouteKind.UNKNOWN])
+      );
+    });
+  });
 });

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -47,6 +47,14 @@ export const getNextRouteForRouterOutletOnly = createSelector(
   }
 );
 
+export const getRegisteredRouteKinds = createSelector<
+  State,
+  AppRoutingState,
+  Set<RouteKind>
+>(getAppRoutingState, (state) => {
+  return state.registeredRouteKeys;
+});
+
 /**
  * Returns current RouteKind or returns `null` if route is not set at all
  * (e.g., an application does not define any routes).

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -188,4 +188,22 @@ describe('app_routing_selectors', () => {
       expect(selectors.getRouteId(state)).toBe('__not_set');
     });
   });
+
+  describe('getRegisteredRouteKinds', () => {
+    beforeEach(() => {
+      selectors.getRegisteredRouteKinds.release();
+    });
+
+    it('returns registered routes', () => {
+      const state = buildStateFromAppRoutingState(
+        buildAppRoutingState({
+          registeredRouteKeys: new Set([RouteKind.UNKNOWN]),
+        })
+      );
+
+      expect(selectors.getRegisteredRouteKinds(state)).toEqual(
+        new Set([RouteKind.UNKNOWN])
+      );
+    });
+  });
 });

--- a/tensorboard/webapp/app_routing/store/app_routing_types.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_types.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Route} from '../types';
+import {Route, RouteKind} from '../types';
 
 export const APP_ROUTING_FEATURE_KEY = 'app_routing';
 
@@ -22,6 +22,7 @@ export interface AppRoutingState {
   // make changes before a route change. `ntextRoute` is non-null only while
   // we are navigating.
   nextRoute: Route | null;
+  registeredRouteKeys: Set<RouteKind>;
 }
 
 export interface State {

--- a/tensorboard/webapp/app_routing/store/testing.ts
+++ b/tensorboard/webapp/app_routing/store/testing.ts
@@ -24,6 +24,7 @@ export function buildAppRoutingState(
   return {
     activeRoute: null,
     nextRoute: null,
+    registeredRouteKeys: new Set(),
     ...override,
   };
 }


### PR DESCRIPTION
This change introduces a new state in the AppRouting so we can control
features based on how routes are registered in the application.
