### PR TITLE
timeseries: add feature flag for butter bar

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -109,3 +109,10 @@ export const getIsLinkedTimeEnabled = createSelector(
     return flags.enabledLinkedTime;
   }
 );
+
+export const getIsTimeSeriesPromotionEnabled = createSelector(
+  getFeatureFlags,
+  (flags: FeatureFlags): boolean => {
+    return flags.enableTimeSeriesPromotion;
+  }
+);

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -290,4 +290,29 @@ describe('feature_flag_selectors', () => {
       expect(selectors.getIsLinkedTimeEnabled(state)).toEqual(true);
     });
   });
+
+  describe('#getIsTimeSeriesPromotionEnabled', () => {
+    it('returns the proper value', () => {
+      let state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            enableTimeSeriesPromotion: false,
+          }),
+        })
+      );
+      expect(selectors.getIsTimeSeriesPromotionEnabled(state)).toEqual(false);
+
+      state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            enableTimeSeriesPromotion: false,
+          }),
+          flagOverrides: {
+            enableTimeSeriesPromotion: true,
+          },
+        })
+      );
+      expect(selectors.getIsTimeSeriesPromotionEnabled(state)).toEqual(true);
+    });
+  });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -30,6 +30,7 @@ export const initialState: FeatureFlagState = {
     scalarsBatchSize: undefined,
     metricsImageSupportEnabled: true,
     enabledLinkedTime: false,
+    enableTimeSeriesPromotion: false,
   },
   flagOverrides: {},
 };

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -29,6 +29,7 @@ export function buildFeatureFlag(
     scalarsBatchSize: undefined,
     metricsImageSupportEnabled: true,
     enabledLinkedTime: false,
+    enableTimeSeriesPromotion: false,
     ...override,
   };
 }

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -43,4 +43,6 @@ export interface FeatureFlags {
   metricsImageSupportEnabled: boolean;
   // Whether TimeSeries linked time feature is enabled or not.
   enabledLinkedTime: boolean;
+  // Whether to enable TimeSeries promotion butter bar.
+  enableTimeSeriesPromotion: boolean;
 }


### PR DESCRIPTION
Soon, we want to promote TimeSeries plugin to the 1st place in the list
of plugins making it the default experience. As it may be jarring for
some users, we want to warn and explain the rationale.
