### PR TITLE
sync: fix wrong import in rxjs

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
@@ -14,7 +14,9 @@ limitations under the License.
 ==============================================================================*/
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {Store} from '@ngrx/store';
-import {Observable, map} from 'rxjs';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
 import {RouteKind} from '../../../app_routing/types';
 
 import {State} from '../../../app_state';


### PR DESCRIPTION
rxjs externally seems to be lenient and allow `map` to be imported in
base package when it should have been imported as operators. This change
fixes that and unblocks sync.
