### PR TITLE
timeseries: adjust wording of empty match warning

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/empty_tag_match_message_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/empty_tag_match_message_component.ts
@@ -32,13 +32,12 @@ declare namespace Intl {
 
 @Component({
   selector: 'metrics-empty-tag-match-component',
-  template: `No cards matches tag filter
-    <code>/{{ tagFilterRegex }}/</code> among {{ tagCounts | number }} tags<span
-      *ngIf="pluginTypes.size"
-    >
+  template: `No matches for tag filter <code>/{{ tagFilterRegex }}/</code
+    ><span *ngIf="pluginTypes.size">
       and {{ getPluginTypeFilterString(pluginTypes) }} visualization
       filter</span
-    >.`,
+    >
+    out of {{ tagCounts | number }} tags.`,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EmptyTagMatchMessageComponent {

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1252,7 +1252,7 @@ describe('metrics main view', () => {
           .query(By.css('metrics-filtered-view'))
           .nativeElement.textContent.trim()
       ).toContain(
-        'No cards matches tag filter /^no_match_please$/ among 100 tags.'
+        'No matches for tag filter /^no_match_please$/ out of 100 tags.'
       );
     }));
 
@@ -1273,8 +1273,8 @@ describe('metrics main view', () => {
           .query(By.css('metrics-filtered-view'))
           .nativeElement.textContent.trim()
       ).toContain(
-        'No cards matches tag filter /./ among 100 tags and image ' +
-          'or histogram visualization filter.'
+        'No matches for tag filter /./ and image or histogram ' +
+          'visualization filter out of 100 tags.'
       );
     }));
 


### PR DESCRIPTION
Minor tweak since the existing wording for the empty match warning was a bit confusing to me.  In particular it felt hard to scan with the tag count in between the two different filters.  I'm assuming the idea was to distinguish that the tag filter filters "tags" and the plugin type filter instead filters "cards", but practically speaking I think we can treat them as equivalent here, and "tag filtering" is the term used in the section header and in the search field placeholder.

Here's the proposed wording:
 
![Screen Shot 2021-09-02 at 5 46 35 PM](https://user-images.githubusercontent.com/710113/131933739-a80d5900-9e12-4fd4-9984-376bbebf8f0d.png)
