### PR TITLE
timeseries: make promo dismissable

### DIFF
--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -29,6 +29,7 @@ import {
   getMetricsIgnoreOutliers,
   getMetricsScalarSmoothing,
   getMetricsTooltipSort,
+  getPromoteTimeSeries,
   METRICS_FEATURE_KEY,
   METRICS_SETTINGS_DEFAULT,
   reducers,
@@ -86,6 +87,12 @@ export function getMetricsTooltipSortSettingFactory() {
   });
 }
 
+export function getMetricsTimeSeriesPromotionDismissed() {
+  return createSelector(getPromoteTimeSeries, (promoteTimeSeries) => {
+    return {timeSeriesPromotionDismissed: !promoteTimeSeries};
+  });
+}
+
 @NgModule({
   imports: [
     CommonModule,
@@ -112,6 +119,9 @@ export function getMetricsTooltipSortSettingFactory() {
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
       getMetricsTooltipSortSettingFactory
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsTimeSeriesPromotionDismissed
     ),
   ],
   providers: [

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -262,6 +262,7 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState<
     },
   },
   {
+    promoteTimeSeries: true,
     timeSeriesData: {
       scalars: {},
       histograms: {},
@@ -393,8 +394,14 @@ const reducer = createReducer(
       metricsSettings.scalarSmoothing = partialSettings.scalarSmoothing;
     }
 
+    const promoteTimeSeries =
+      typeof partialSettings.timeSeriesPromotionDismissed === 'boolean'
+        ? !partialSettings.timeSeriesPromotionDismissed
+        : state.promoteTimeSeries;
+
     return {
       ...state,
+      promoteTimeSeries,
       settings: {
         ...state.settings,
         ...metricsSettings,
@@ -911,7 +918,10 @@ const reducer = createReducer(
     (state): MetricsState => {
       return {...state, filteredPluginTypes: new Set()};
     }
-  )
+  ),
+  on(actions.metricsPromoDismissed, (state) => {
+    return {...state, promoteTimeSeries: false};
+  })
 );
 
 export function reducers(state: MetricsState | undefined, action: Action) {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2168,4 +2168,15 @@ describe('metrics reducers', () => {
       });
     });
   });
+
+  describe('#metricsPromoDismissed', () => {
+    it('flips off `promotTimeSeries`', () => {
+      const before = buildMetricsState({
+        promoteTimeSeries: true,
+      });
+
+      const after = reducers(before, actions.metricsPromoDismissed());
+      expect(after.promoteTimeSeries).toBe(false);
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -422,3 +422,10 @@ export const getMetricsFilteredPluginTypes = createSelector(
     return state.filteredPluginTypes;
   }
 );
+
+export const getPromoteTimeSeries = createSelector(
+  selectMetricsState,
+  (state: MetricsState): boolean => {
+    return state.promoteTimeSeries;
+  }
+);

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -847,4 +847,17 @@ describe('metrics selectors', () => {
       );
     });
   });
+
+  describe('#getPromoteTimeSeries', () => {
+    beforeEach(() => {
+      selectors.getPromoteTimeSeries.release();
+    });
+
+    it('returns current visualization filters', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({promoteTimeSeries: false})
+      );
+      expect(selectors.getPromoteTimeSeries(state)).toEqual(false);
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -201,6 +201,7 @@ export interface MetricsSettings {
 }
 
 export interface MetricsRoutelessState {
+  promoteTimeSeries: boolean;
   timeSeriesData: TimeSeriesData;
   // Default settings. For the legacy reasons, we cannot change the name of the
   // prop. It either is set by application or a user via settings storage.

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -97,6 +97,7 @@ function buildBlankState(): MetricsState {
     useRangeSelectTime: false,
     filteredPluginTypes: new Set(),
     stepMinMax: {min: Infinity, max: -Infinity},
+    promoteTimeSeries: false,
   };
 }
 

--- a/tensorboard/webapp/metrics/views/metrics_container.ts
+++ b/tensorboard/webapp/metrics/views/metrics_container.ts
@@ -15,9 +15,13 @@ limitations under the License.
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
+import {combineLatestWith, map} from 'rxjs/operators';
 
 import {State} from '../../app_state';
-import {getIsTimeSeriesPromotionEnabled} from '../../selectors';
+import {
+  getIsTimeSeriesPromotionEnabled,
+  getPromoteTimeSeries,
+} from '../../selectors';
 
 @Component({
   selector: 'metrics-dashboard',
@@ -37,7 +41,12 @@ import {getIsTimeSeriesPromotionEnabled} from '../../selectors';
 export class MetricsDashboardContainer {
   constructor(private readonly store: Store<State>) {}
 
-  readonly isButterBarEnabled$: Observable<boolean> = this.store.select(
-    getIsTimeSeriesPromotionEnabled
-  );
+  readonly isButterBarEnabled$: Observable<boolean> = this.store
+    .select(getIsTimeSeriesPromotionEnabled)
+    .pipe(
+      combineLatestWith(this.store.select(getPromoteTimeSeries)),
+      map(([promotionFeatureEnabled, promoteTimeSeries]) => {
+        return promotionFeatureEnabled && promoteTimeSeries;
+      })
+    );
 }

--- a/tensorboard/webapp/metrics/views/metrics_container_test.ts
+++ b/tensorboard/webapp/metrics/views/metrics_container_test.ts
@@ -20,7 +20,10 @@ import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 
 import {State} from '../../app_state';
-import {getIsTimeSeriesPromotionEnabled} from '../../selectors';
+import {
+  getIsTimeSeriesPromotionEnabled,
+  getPromoteTimeSeries,
+} from '../../selectors';
 import {metricsPromoDismissed, metricsPromoGoToScalars} from '../actions';
 import {MetricsDashboardContainer} from './metrics_container';
 import {MetricsPromoNoticeComponent} from './metrics_promo_notice_component';
@@ -45,6 +48,7 @@ describe('metrics view', () => {
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getIsTimeSeriesPromotionEnabled, false);
+    store.overrideSelector(getPromoteTimeSeries, false);
   });
 
   it('renders', () => {
@@ -54,8 +58,9 @@ describe('metrics view', () => {
     expect(fixture.debugElement.query(By.css('runs-selector'))).not.toBeNull();
   });
 
-  it('renders notice when promotion is enabled', () => {
+  it('renders notice when promotion is enabled and feature is not disabled by user', () => {
     store.overrideSelector(getIsTimeSeriesPromotionEnabled, true);
+    store.overrideSelector(getPromoteTimeSeries, true);
     const fixture = TestBed.createComponent(MetricsDashboardContainer);
     fixture.detectChanges();
 
@@ -70,6 +75,7 @@ describe('metrics view', () => {
       spyOn(store, 'dispatch').and.callFake((action) => actions.push(action));
 
       store.overrideSelector(getIsTimeSeriesPromotionEnabled, true);
+      store.overrideSelector(getPromoteTimeSeries, true);
       const fixture = TestBed.createComponent(MetricsDashboardContainer);
       fixture.detectChanges();
 

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -57,6 +57,7 @@ export class OSSSettingsConverter extends SettingsConverter<
       theme: settings.themeOverride,
       notificationLastReadTimeInMs: settings.notificationLastReadTimeInMs,
       sideBarWidthInPercent: settings.sideBarWidthInPercent,
+      timeSeriesPromotionDismissed: settings.timeSeriesPromotionDismissed,
     };
     return serializableSettings;
   }
@@ -126,6 +127,14 @@ export class OSSSettingsConverter extends SettingsConverter<
       typeof backendSettings.sideBarWidthInPercent === 'number'
     ) {
       settings.sideBarWidthInPercent = backendSettings.sideBarWidthInPercent;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('timeSeriesPromotionDismissed') &&
+      typeof backendSettings.timeSeriesPromotionDismissed === 'boolean'
+    ) {
+      settings.timeSeriesPromotionDismissed =
+        backendSettings.timeSeriesPromotionDismissed;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -36,6 +36,7 @@ export declare interface BackendSettings {
   theme?: ThemeValue;
   notificationLastReadTimeInMs?: number;
   sideBarWidthInPercent?: number;
+  timeSeriesPromotionDismissed?: boolean;
 }
 
 /**
@@ -53,4 +54,5 @@ export interface PersistableSettings {
   themeOverride?: ThemeValue;
   notificationLastReadTimeInMs?: number;
   sideBarWidthInPercent?: number;
+  timeSeriesPromotionDismissed?: boolean;
 }


### PR DESCRIPTION
This change makes the promotion butter bar dismissable and the state to
be persisted in the local storage.
