### PR TITLE
Use overflow-wrap on location data text.

### DIFF
--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.ts
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.ts
@@ -83,6 +83,9 @@ class TfRunsSelector extends LegacyElementMixin(PolymerElement) {
         padding-right: 16px;
         box-sizing: border-box;
       }
+      tf-wbr-string {
+        overflow-wrap: break-word;
+      }
       tf-multi-checkbox {
         display: flex;
         flex-grow: 1;


### PR DESCRIPTION
When the file path to the logdir has a long title without any delimiting characters([/=_,-]) the path is truncated. This line of css stops that truncation by moving the truncated text to a new line.

Googlers, see b/181583629.