### PR TITLE
infra: add strict_templates checking for Angular

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,8 @@
     // Instead we'll be explicit about declaring ambient type dependencies
     // using the ///<reference types=""/> syntax.
     "types": []
+  },
+  "angularCompilerOptions": {
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
This change adds a line to tsconfig that allows Angular to check types
more strictly in the template. This is relatively new option so it
remains to be seen how capable and power this feature is.

For more information, refer to
<https://angular.io/guide/angular-compiler-options#stricttemplates>

