### PR TITLE
timeseries: theme group control

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
@@ -52,7 +52,7 @@ card-view {
 }
 
 .group-controls {
-  color: mat-color($tb-foreground, secondary-text);
+  @include tb-theme-foreground-prop(color, secondary-text);
   display: grid;
   align-items: center;
   grid-template-columns: 1fr 1fr 1fr;
@@ -82,10 +82,21 @@ card-view {
 
 .pagination-input {
   margin-right: $metrics-preferred-gap;
+
+  input {
+    background: transparent;
+    border: 1px solid currentColor;
+    color: inherit;
+    font: inherit;
+  }
 }
 
 .expand-group-button,
 .pagination-button {
+  @include tb-theme-foreground-prop(color, secondary-text);
   background-color: $metrics-button-background-color-on-gray;
-  color: mat-color($tb-foreground, secondary-text);
+
+  &:disabled {
+    @include tb-theme-foreground-prop(color, disabled-text);
+  }
 }


### PR DESCRIPTION
Pagination controls were improperly themed and this change fixes that.
Now, the secondary-text colors are correctly picked based on current
theme settings and the `<input>` is hard themed (instead of relying on
OS settings and browser's default dark styling). It also styles disabled
button so when the "Previous" or "Next" button is disabled, we have a
visual cue.

## Before
![old](https://user-images.githubusercontent.com/2547313/132411936-08174fb8-2923-4f18-9181-45bf2def1a60.png)


## After
![Screenshot from 2021-09-07 14-15-02](https://user-images.githubusercontent.com/2547313/132411854-d605fe91-1bfd-427d-8d81-6a9cea1af53a.png)
