### PR TITLE
timeseries: fix tags not fetching issue when loading

### DIFF
--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -92,10 +92,17 @@ export class MetricsEffects implements OnInitEffects {
    *
    * [Metrics Effects] Init  - the initial `activePlugin` is set.
    * [Core] Plugin Changed   - subsequent `activePlugin` updates.
+   * [Core] PluginListing Fetch Successful - list of plugins fetched and the
+   *   first `activePlugin` set.
    * [App Routing] Navigated - experiment id updates.
    */
   private readonly dashboardShownWithoutData$ = this.actions$.pipe(
-    ofType(initAction, coreActions.changePlugin, routingActions.navigated),
+    ofType(
+      initAction,
+      coreActions.changePlugin,
+      coreActions.pluginsListingLoaded,
+      routingActions.navigated
+    ),
     withLatestFrom(
       this.store.select(getActivePlugin),
       this.store.select(getMetricsTagMetadataLoadState)


### PR DESCRIPTION
Previously, we were only waiting for navigation and plugin change events
none of which is useful when freshly loading dashboard since
`activePlugin` will be null until we can fetch the plugins listing at
least once. This change, to fix the problem, also listens to plugins
listing loaded event to assert and fetch the data.
