### PR TITLE
timeseries: Adjust scroll position after pagination

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -131,7 +131,7 @@ tf_ts_library(
     srcs = [
         "filter_input_test.ts",
         "main_view_test.ts",
-        "card_grid_test.ts"
+        "card_grid_test.ts",
     ],
     deps = [
         ":main_view",

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -131,6 +131,7 @@ tf_ts_library(
     srcs = [
         "filter_input_test.ts",
         "main_view_test.ts",
+        "card_grid_test.ts"
     ],
     deps = [
         ":main_view",
@@ -148,6 +149,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/store",
         "//tensorboard/webapp/metrics/views/card_renderer",
+        "//tensorboard/webapp/metrics/views:types",
         "//tensorboard/webapp/settings",
         "//tensorboard/webapp/testing:dom",
         "//tensorboard/webapp/testing:mat_icon",

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -129,9 +129,9 @@ tf_ts_library(
     name = "main_view_tests",
     testonly = True,
     srcs = [
+        "card_grid_test.ts",
         "filter_input_test.ts",
         "main_view_test.ts",
-        "card_grid_test.ts",
     ],
     deps = [
         ":main_view",
@@ -148,8 +148,8 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/store",
-        "//tensorboard/webapp/metrics/views/card_renderer",
         "//tensorboard/webapp/metrics/views:types",
+        "//tensorboard/webapp/metrics/views/card_renderer",
         "//tensorboard/webapp/settings",
         "//tensorboard/webapp/testing:dom",
         "//tensorboard/webapp/testing:mat_icon",

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -18,7 +18,7 @@ limitations under the License.
   *ngTemplateOutlet="groupControls; context: {isBottomControl: false}"
 ></ng-container>
 
-<div class="card-grid" #testName>
+<div class="card-grid">
   <card-view
     *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
     [cardId]="item.cardId"

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -47,7 +47,7 @@ limitations under the License.
         i18n-aria-label="A button that sets a group to the previous page."
         aria-label="Previous page"
         [disabled]="pageIndex === 0"
-        (click)="PaginationCallback(pageIndex - 1, $event.target)"
+        (click)="handlePageChange(pageIndex - 1, $event.target)"
       >
         Previous
       </button>
@@ -92,7 +92,7 @@ limitations under the License.
           aria-label="Next page"
           class="next pagination-button"
           [disabled]="pageIndex + 1 >= numPages"
-          (click)="PaginationCallback(pageIndex + 1, $event.target)"
+          (click)="handlePageChange(pageIndex + 1, $event.target)"
         >
           Next
         </button>

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -18,7 +18,7 @@ limitations under the License.
   *ngTemplateOutlet="groupControls; context: {isBottomControl: false}"
 ></ng-container>
 
-<div class="card-grid">
+<div class="card-grid" #testName>
   <card-view
     *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
     [cardId]="item.cardId"
@@ -47,7 +47,7 @@ limitations under the License.
         i18n-aria-label="A button that sets a group to the previous page."
         aria-label="Previous page"
         [disabled]="pageIndex === 0"
-        (click)="pageIndexChanged.emit(pageIndex - 1)"
+        (click)="testCallback(pageIndex - 1, $event.target)"
       >
         Previous
       </button>
@@ -92,7 +92,7 @@ limitations under the License.
           aria-label="Next page"
           class="next pagination-button"
           [disabled]="pageIndex + 1 >= numPages"
-          (click)="pageIndexChanged.emit(pageIndex + 1)"
+          (click)="testCallback(pageIndex + 1, $event.target)"
         >
           Next
         </button>

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -47,7 +47,7 @@ limitations under the License.
         i18n-aria-label="A button that sets a group to the previous page."
         aria-label="Previous page"
         [disabled]="pageIndex === 0"
-        (click)="testCallback(pageIndex - 1, $event.target)"
+        (click)="PaginationCallback(pageIndex - 1, $event.target)"
       >
         Previous
       </button>
@@ -92,7 +92,7 @@ limitations under the License.
           aria-label="Next page"
           class="next pagination-button"
           [disabled]="pageIndex + 1 >= numPages"
-          (click)="testCallback(pageIndex + 1, $event.target)"
+          (click)="PaginationCallback(pageIndex + 1, $event.target)"
         >
           Next
         </button>

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -60,29 +60,25 @@ export class CardGridComponent {
     return isBottomControl;
   }
 
-  PaginationCallback(pageIndex: number, target: HTMLElement) {
+  handlePageChange(pageIndex: number, target: HTMLElement) {
     // Clear call stack to allow dom update before updating scroll to keep
     // relative position.
-    setTimeout(
-      this.scrollToKeepTargetPosition.bind(
-        this,
-        target,
-        target.getBoundingClientRect().top
-      ),
-      0
-    );
+    const topBeforeChange = target.getBoundingClientRect().top;
+    setTimeout(() => {
+      this.scrollToKeepTargetPosition(target, topBeforeChange);
+    }, 0);
 
     this.pageIndexChanged.emit(pageIndex);
   }
 
   scrollToKeepTargetPosition(target: HTMLElement, previousTop: number) {
-    const ScrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
-    if (ScrollingElement) {
-      ScrollingElement.scrollTo(
+    const scrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
+    if (scrollingElement) {
+      scrollingElement.scrollTo(
         0,
         target.getBoundingClientRect().top -
           previousTop +
-          ScrollingElement.scrollTop
+          scrollingElement.scrollTop
       );
     }
   }
@@ -111,6 +107,6 @@ export class CardGridComponent {
       input.value = String(nextValue + 1);
     }
 
-    this.PaginationCallback(nextValue, input);
+    this.handlePageChange(nextValue, input);
   }
 }

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -16,12 +16,10 @@ import {CdkScrollable} from '@angular/cdk/scrolling';
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   EventEmitter,
   Input,
   Optional,
   Output,
-  ViewChild,
 } from '@angular/core';
 
 import {PluginType} from '../../data_source';
@@ -50,10 +48,6 @@ export class CardGridComponent {
   @Output() pageIndexChanged = new EventEmitter<number>();
   @Output() groupExpansionToggled = new EventEmitter<void>();
 
-  @ViewChild('cardGrid', {static: true}) cardGridElement!: ElementRef<
-    HTMLDivElement
-  >;
-
   constructor(
     @Optional() private readonly cdkScrollable: CdkScrollable | null
   ) {}
@@ -66,19 +60,17 @@ export class CardGridComponent {
     return isBottomControl;
   }
 
-  testCallback(pageIndex: number, target: HTMLElement) {
-    const ScrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
-    if (ScrollingElement) {
-      const distanceToTop =
-        target.getBoundingClientRect().top - ScrollingElement.scrollTop;
-
-      // Clear call stack to allow dom update before updating scroll to keep
-      // relative position.
-      setTimeout(
-        this.scrollToKeepTargetPosition.bind(this, target, distanceToTop),
-        0
-      );
-    }
+  PaginationCallback(pageIndex: number, target: HTMLElement) {
+    // Clear call stack to allow dom update before updating scroll to keep
+    // relative position.
+    setTimeout(
+      this.scrollToKeepTargetPosition.bind(
+        this,
+        target,
+        target.getBoundingClientRect().top
+      ),
+      0
+    );
 
     this.pageIndexChanged.emit(pageIndex);
   }
@@ -88,7 +80,9 @@ export class CardGridComponent {
     if (ScrollingElement) {
       ScrollingElement.scrollTo(
         0,
-        target.getBoundingClientRect().top - previousTop
+        target.getBoundingClientRect().top -
+          previousTop +
+          ScrollingElement.scrollTop
       );
     }
   }
@@ -117,6 +111,6 @@ export class CardGridComponent {
       input.value = String(nextValue + 1);
     }
 
-    this.pageIndexChanged.emit(nextValue);
+    this.PaginationCallback(nextValue, input);
   }
 }

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -12,12 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {CdkScrollable} from '@angular/cdk/scrolling';
 import {
   ChangeDetectionStrategy,
   Component,
   Input,
   OnChanges,
   OnDestroy,
+  Optional,
   SimpleChanges,
 } from '@angular/core';
 import {Store} from '@ngrx/store';
@@ -149,7 +151,9 @@ export class CardGridContainer implements OnChanges, OnDestroy {
     })
   );
 
-  constructor(private readonly store: Store<State>) {}
+  constructor(
+    private readonly store: Store<State>,
+    @Optional() private readonly cdkScrollable: CdkScrollable | null) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['cardIdsWithMetadata']) {
@@ -168,6 +172,20 @@ export class CardGridContainer implements OnChanges, OnDestroy {
 
   onPageIndexChanged(newIndex: number) {
     this.pageIndex$.next(newIndex);
+
+    let ScrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
+    if(ScrollingElement) {
+      let relativePosition = ScrollingElement.scrollHeight - ScrollingElement.scrollTop;
+      // Clear call stack to allow dom update before updating scroll to keep relative position.
+      setTimeout(this.scrollToRelativePosition.bind(this, relativePosition), 0);
+    }
+  }
+
+  scrollToRelativePosition(relativePosition: number) {
+    let ScrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
+    if(ScrollingElement) {
+      ScrollingElement.scrollTo(0, ScrollingElement.scrollHeight - relativePosition);
+    }
   }
 
   onGroupExpansionToggled() {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -153,7 +153,8 @@ export class CardGridContainer implements OnChanges, OnDestroy {
 
   constructor(
     private readonly store: Store<State>,
-    @Optional() private readonly cdkScrollable: CdkScrollable | null) {}
+    @Optional() private readonly cdkScrollable: CdkScrollable | null
+  ) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['cardIdsWithMetadata']) {
@@ -174,17 +175,22 @@ export class CardGridContainer implements OnChanges, OnDestroy {
     this.pageIndex$.next(newIndex);
 
     let ScrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
-    if(ScrollingElement) {
-      let relativePosition = ScrollingElement.scrollHeight - ScrollingElement.scrollTop;
-      // Clear call stack to allow dom update before updating scroll to keep relative position.
+    if (ScrollingElement) {
+      let relativePosition =
+        ScrollingElement.scrollHeight - ScrollingElement.scrollTop;
+      // Clear call stack to allow dom update before updating scroll to keep
+      // relative position.
       setTimeout(this.scrollToRelativePosition.bind(this, relativePosition), 0);
     }
   }
 
   scrollToRelativePosition(relativePosition: number) {
     let ScrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
-    if(ScrollingElement) {
-      ScrollingElement.scrollTo(0, ScrollingElement.scrollHeight - relativePosition);
+    if (ScrollingElement) {
+      ScrollingElement.scrollTo(
+        0,
+        ScrollingElement.scrollHeight - relativePosition
+      );
     }
   }
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {CdkScrollable} from '@angular/cdk/scrolling';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -151,10 +150,7 @@ export class CardGridContainer implements OnChanges, OnDestroy {
     })
   );
 
-  constructor(
-    private readonly store: Store<State>,
-    @Optional() private readonly cdkScrollable: CdkScrollable | null
-  ) {}
+  constructor(private readonly store: Store<State>) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['cardIdsWithMetadata']) {
@@ -173,25 +169,6 @@ export class CardGridContainer implements OnChanges, OnDestroy {
 
   onPageIndexChanged(newIndex: number) {
     this.pageIndex$.next(newIndex);
-
-    let ScrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
-    if (ScrollingElement) {
-      let relativePosition =
-        ScrollingElement.scrollHeight - ScrollingElement.scrollTop;
-      // Clear call stack to allow dom update before updating scroll to keep
-      // relative position.
-      setTimeout(this.scrollToRelativePosition.bind(this, relativePosition), 0);
-    }
-  }
-
-  scrollToRelativePosition(relativePosition: number) {
-    let ScrollingElement = this.cdkScrollable?.getElementRef().nativeElement;
-    if (ScrollingElement) {
-      ScrollingElement.scrollTo(
-        0,
-        ScrollingElement.scrollHeight - relativePosition
-      );
-    }
   }
 
   onGroupExpansionToggled() {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -18,7 +18,6 @@ import {
   Input,
   OnChanges,
   OnDestroy,
-  Optional,
   SimpleChanges,
 } from '@angular/core';
 import {Store} from '@ngrx/store';

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -1,6 +1,6 @@
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import {Component, Input} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed} from '@angular/core/testing';
 import {PluginType} from '../../data_source';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -19,11 +19,6 @@ import {selectors as settingsSelectors} from '../../../settings';
 import * as selectors from '../../../selectors';
 
 const scrollElementHeight = 100;
-
-// Utility funciton to allow use of await.
-function timeout(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 @Component({
   selector: 'testing-component',
@@ -83,8 +78,8 @@ class TestableComponent {
 
 describe('card grid', () => {
   let store: MockStore<State>;
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, ScrollingModule],
       declarations: [
         CardGridComponent,
@@ -103,9 +98,9 @@ describe('card grid', () => {
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(selectors.getRunColorMap, {});
-  });
+  }));
 
-  fit('keeps pagination button position when page size changes', async () => {
+  fit('keeps pagination button position when page size changes', fakeAsync(() => {
     store.overrideSelector(settingsSelectors.getPageSize, 2);
     let scrollOffset = Math.floor(Math.random() * scrollElementHeight);
     const fixture = TestBed.createComponent(TestableComponent);
@@ -131,7 +126,6 @@ describe('card grid', () => {
     nextButtons[1].click();
     fixture.detectChanges();
     // Clear call stack to invoke the scroll adjustement logic.
-    await timeout(0);
     expect(nextButtons[1].offsetTop - scrollingElement.scrollTop).toEqual(
       scrollOffset
     );
@@ -143,7 +137,6 @@ describe('card grid', () => {
     previousButtons[0].click();
     fixture.detectChanges();
     // Clear call stack to invoke the scroll adjustement logic.
-    await timeout(0);
     expect(previousButtons[0].offsetTop - scrollingElement.scrollTop).toEqual(
       scrollOffset
     );
@@ -155,7 +148,6 @@ describe('card grid', () => {
     nextButtons[0].click();
     fixture.detectChanges();
     // Clear call stack to invoke the scroll adjustement logic.
-    await timeout(0);
     expect(nextButtons[0].offsetTop - scrollingElement.scrollTop).toEqual(
       scrollOffset
     );
@@ -167,7 +159,6 @@ describe('card grid', () => {
     previousButtons[1].click();
     fixture.detectChanges();
     // Clear call stack to invoke the scroll adjustement logic.
-    await timeout(0);
     expect(previousButtons[1].offsetTop - scrollingElement.scrollTop).toEqual(
       scrollOffset
     );
@@ -180,9 +171,8 @@ describe('card grid', () => {
     PaginationInput.dispatchEvent(new Event('input'));
     fixture.detectChanges();
     // Clear call stack to invoke the scroll adjustement logic.
-    await timeout(0);
     expect(PaginationInput.offsetTop - scrollingElement.scrollTop).toEqual(
       scrollOffset
     );
-  });
+  }));
 });

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -121,10 +121,7 @@ describe('card grid', () => {
       .map((nextDebugElements) => {
         return nextDebugElements.nativeElement!;
       });
-    const [
-      topPreviousButtons,
-      bottomPreviousButtons,
-    ] = fixture.debugElement
+    const [topPreviousButtons, bottomPreviousButtons] = fixture.debugElement
       .queryAll(By.css('.prev'))
       .map((nextDebugElements) => {
         return nextDebugElements.nativeElement!;

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -16,7 +16,6 @@ import {CardGridContainer} from './card_grid_container';
 import {CardIdWithMetadata} from '../metrics_view_types';
 import {Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {appStateFromMetricsState} from '../../testing';
 import {State} from '../../../app_state';
 import {selectors as settingsSelectors} from '../../../settings';
 import * as selectors from '../../../selectors';
@@ -25,14 +24,14 @@ import {getMetricsTagGroupExpansionState} from '../../../selectors';
 const scrollElementHeight = 100;
 
 @Component({
-  selector: 'testing-component',
+  selector: 'testable-scrolling-container',
   template: `
     <div cdkScrollable>
       <div class="placeholder">placeholder</div>
       <metrics-card-grid
         [cardIdsWithMetadata]="cardIdsWithMetadata"
         [cardObserver]="cardObserver"
-        [groupName]="cardObserver"
+        [groupName]="groupName"
       ></metrics-card-grid>
       <div class="placeholder">placeholder</div>
     </div>
@@ -51,10 +50,8 @@ const scrollElementHeight = 100;
     `,
   ],
 })
-class TestableComponent {
-  @Input() groupName: string = 'test group name';
+class TestableScrollingContainer {
   @Input() cardIdsWithMetadata: CardIdWithMetadata[] = [];
-  @Input() cardObserver: CardObserver = new CardObserver();
 }
 
 describe('card grid', () => {
@@ -62,7 +59,11 @@ describe('card grid', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, ScrollingModule],
-      declarations: [CardGridComponent, CardGridContainer, TestableComponent],
+      declarations: [
+        CardGridComponent,
+        CardGridContainer,
+        TestableScrollingContainer,
+      ],
       providers: [provideMockStore()],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -74,8 +75,11 @@ describe('card grid', () => {
 
   it('keeps pagination button position when page size changes', fakeAsync(() => {
     store.overrideSelector(settingsSelectors.getPageSize, 2);
-    let scrollOffset = Math.floor(Math.random() * scrollElementHeight);
-    const fixture = TestBed.createComponent(TestableComponent);
+    let scrollOffset = 30;
+    const fixture = TestBed.createComponent(TestableScrollingContainer);
+    // With 3 cards and a page size of 2 the number of cards on a page changes
+    // from 2 to 1 when going from the first to second page. This is crucial for
+    // this test.
     fixture.componentInstance.cardIdsWithMetadata = [
       {
         cardId: 'card1',
@@ -119,7 +123,6 @@ describe('card grid', () => {
 
     // Test scrolling adjustments on bottom next button.
     scrollingElement.scrollTo(0, bottomNextButtons.offsetTop - scrollOffset);
-    fixture.detectChanges();
     bottomNextButtons.click();
     fixture.detectChanges();
     // To ensure the click did change the size of the CardGrid ensure make sure
@@ -134,9 +137,7 @@ describe('card grid', () => {
     );
 
     // Test scrolling adjustments on top previous button.
-    scrollOffset = Math.floor(Math.random() * scrollElementHeight);
     scrollingElement.scrollTo(0, topPreviousButtons.offsetTop - scrollOffset);
-    fixture.detectChanges();
     topPreviousButtons.click();
     fixture.detectChanges();
     // Clear call stack to invoke the scroll adjustement logic.
@@ -146,9 +147,7 @@ describe('card grid', () => {
     );
 
     // Test scrolling adjustments on top next button.
-    scrollOffset = Math.floor(Math.random() * scrollElementHeight);
     scrollingElement.scrollTo(0, topNextButtons.offsetTop - scrollOffset);
-    fixture.detectChanges();
     topNextButtons.click();
     fixture.detectChanges();
     // Clear call stack to invoke the scroll adjustement logic.
@@ -158,12 +157,10 @@ describe('card grid', () => {
     );
 
     // Test scrolling adjustments on bottom previous button.
-    scrollOffset = Math.floor(Math.random() * scrollElementHeight);
     scrollingElement.scrollTo(
       0,
       bottomPreviousButtons.offsetTop - scrollOffset
     );
-    fixture.detectChanges();
     bottomPreviousButtons.click();
     fixture.detectChanges();
     // To ensure the click did change the size of the CardGrid ensure make sure
@@ -178,9 +175,7 @@ describe('card grid', () => {
     ).toEqual(scrollOffset);
 
     // Test changes to input.
-    scrollOffset = Math.floor(Math.random() * scrollElementHeight);
     scrollingElement.scrollTo(0, PaginationInput.offsetTop - scrollOffset);
-    fixture.detectChanges();
     PaginationInput.value = '2';
     PaginationInput.dispatchEvent(new Event('input'));
     fixture.detectChanges();

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -23,7 +23,6 @@ import {
 import {PluginType} from '../../data_source';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {CardObserver} from '../card_renderer/card_lazy_loader';
 
 import {CardGridComponent} from './card_grid_component';
 import {CardGridContainer} from './card_grid_container';

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -1,3 +1,17 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import {Component, Input, NO_ERRORS_SCHEMA} from '@angular/core';
 import {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -20,6 +20,7 @@ import {appStateFromMetricsState} from '../../testing';
 import {State} from '../../../app_state';
 import {selectors as settingsSelectors} from '../../../settings';
 import * as selectors from '../../../selectors';
+import {getMetricsTagGroupExpansionState} from '../../../selectors';
 
 const scrollElementHeight = 100;
 
@@ -62,19 +63,16 @@ describe('card grid', () => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, ScrollingModule],
       declarations: [CardGridComponent, CardGridContainer, TestableComponent],
-      providers: [
-        provideMockStore({
-          initialState: appStateFromMetricsState(),
-        }),
-      ],
+      providers: [provideMockStore()],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(selectors.getRunColorMap, {});
+    store.overrideSelector(getMetricsTagGroupExpansionState, true);
   });
 
-  fit('keeps pagination button position when page size changes', fakeAsync(() => {
+  it('keeps pagination button position when page size changes', fakeAsync(() => {
     store.overrideSelector(settingsSelectors.getPageSize, 2);
     let scrollOffset = Math.floor(Math.random() * scrollElementHeight);
     const fixture = TestBed.createComponent(TestableComponent);

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -1,0 +1,188 @@
+import {ScrollingModule} from '@angular/cdk/scrolling';
+import {Component, Input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {PluginType} from '../../data_source';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {CardLazyLoader, CardObserver} from '../card_renderer/card_lazy_loader';
+
+import {CardGridComponent} from './card_grid_component';
+import {CardGridContainer} from './card_grid_container';
+import {CardViewComponent} from '../card_renderer/card_view_component';
+import {CardViewContainer} from '../card_renderer/card_view_container';
+import {CardIdWithMetadata} from '../metrics_view_types';
+import {Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {appStateFromMetricsState} from '../../testing';
+import {State} from '../../../app_state';
+import {selectors as settingsSelectors} from '../../../settings';
+import * as selectors from '../../../selectors';
+
+const scrollElementHeight = 100;
+
+// Utility funciton to allow use of await.
+function timeout(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+@Component({
+  selector: 'testing-component',
+  template: `
+    <div cdkScrollable>
+      <div class="placeholder">placeholder</div>
+      <metrics-card-grid
+        [cardIdsWithMetadata]="cardIdsWithMetadata"
+        [cardObserver]="cardObserver"
+        [groupName]="cardObserver"
+      ></metrics-card-grid>
+      <div class="placeholder">placeholder</div>
+    </div>
+  `,
+  styles: [
+    `
+      div {
+        position: fixed;
+        display: block;
+        height: ${scrollElementHeight}px;
+        overflow-y: scroll;
+      }
+      .placeholder {
+        position: relative;
+        height: 700px;
+        display: block;
+      }
+    `,
+  ],
+})
+class TestableComponent {
+  @Input() groupName: string = 'test group name';
+  @Input() cardIdsWithMetadata: CardIdWithMetadata[] = [
+    {
+      cardId: 'card1',
+      plugin: PluginType.SCALARS,
+      tag: 'tagA',
+      runId: null,
+    },
+    {
+      cardId: 'card2',
+      plugin: PluginType.SCALARS,
+      tag: 'tagA/Images',
+      runId: 'run1',
+      sample: 0,
+    },
+    {
+      cardId: 'card3',
+      plugin: PluginType.SCALARS,
+      tag: 'tagB/meow/cat',
+      runId: 'run1',
+      sample: 0,
+    },
+  ];
+  @Input() cardObserver: CardObserver = new CardObserver();
+}
+
+describe('card grid', () => {
+  let store: MockStore<State>;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, ScrollingModule],
+      declarations: [
+        CardGridComponent,
+        CardGridContainer,
+        TestableComponent,
+        CardViewComponent,
+        CardViewContainer,
+        CardLazyLoader,
+      ],
+      providers: [
+        provideMockStore({
+          initialState: appStateFromMetricsState(),
+        }),
+      ],
+    }).compileComponents();
+
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    store.overrideSelector(selectors.getRunColorMap, {});
+  });
+
+  fit('keeps pagination button position when page size changes', async () => {
+    store.overrideSelector(settingsSelectors.getPageSize, 2);
+    let scrollOffset = Math.floor(Math.random() * scrollElementHeight);
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.detectChanges();
+    const nextButtons = fixture.debugElement
+      .queryAll(By.css('.next'))
+      .map((nextDebugElements) => {
+        return nextDebugElements.nativeElement!;
+      });
+    const previousButtons = fixture.debugElement
+      .queryAll(By.css('.prev'))
+      .map((nextDebugElements) => {
+        return nextDebugElements.nativeElement!;
+      });
+    const PaginationInput: HTMLInputElement = fixture.debugElement.query(
+      By.css('input')
+    ).nativeElement;
+    const scrollingElement = fixture.nativeElement.children[0];
+
+    // Test scrolling adjustements on bottom next button.
+    scrollingElement.scrollTo(0, nextButtons[1].offsetTop - scrollOffset);
+    fixture.detectChanges();
+    nextButtons[1].click();
+    fixture.detectChanges();
+    // Clear call stack to invoke the scroll adjustement logic.
+    await timeout(0);
+    expect(nextButtons[1].offsetTop - scrollingElement.scrollTop).toEqual(
+      scrollOffset
+    );
+
+    // Test scrolling adjustements on top previous button.
+    scrollOffset = Math.floor(Math.random() * scrollElementHeight);
+    scrollingElement.scrollTo(0, previousButtons[0].offsetTop - scrollOffset);
+    fixture.detectChanges();
+    previousButtons[0].click();
+    fixture.detectChanges();
+    // Clear call stack to invoke the scroll adjustement logic.
+    await timeout(0);
+    expect(previousButtons[0].offsetTop - scrollingElement.scrollTop).toEqual(
+      scrollOffset
+    );
+
+    // Test scrolling adjustements on top next button.
+    scrollOffset = Math.floor(Math.random() * scrollElementHeight);
+    scrollingElement.scrollTo(0, nextButtons[0].offsetTop - scrollOffset);
+    fixture.detectChanges();
+    nextButtons[0].click();
+    fixture.detectChanges();
+    // Clear call stack to invoke the scroll adjustement logic.
+    await timeout(0);
+    expect(nextButtons[0].offsetTop - scrollingElement.scrollTop).toEqual(
+      scrollOffset
+    );
+
+    // Test scrolling adjustements on bottom previous button.
+    scrollOffset = Math.floor(Math.random() * scrollElementHeight);
+    scrollingElement.scrollTo(0, previousButtons[1].offsetTop - scrollOffset);
+    fixture.detectChanges();
+    previousButtons[1].click();
+    fixture.detectChanges();
+    // Clear call stack to invoke the scroll adjustement logic.
+    await timeout(0);
+    expect(previousButtons[1].offsetTop - scrollingElement.scrollTop).toEqual(
+      scrollOffset
+    );
+
+    // Test changes to input.
+    scrollOffset = Math.floor(Math.random() * scrollElementHeight);
+    scrollingElement.scrollTo(0, PaginationInput.offsetTop - scrollOffset);
+    fixture.detectChanges();
+    PaginationInput.value = '2';
+    PaginationInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    // Clear call stack to invoke the scroll adjustement logic.
+    await timeout(0);
+    expect(PaginationInput.offsetTop - scrollingElement.scrollTop).toEqual(
+      scrollOffset
+    );
+  });
+});


### PR DESCRIPTION
Previously when you changed pages to grouping that had less cards it could cause a jarring and confusing effect as the size of the grouping changed. Many times this would case the graphs you were looking for to go completely off your screen and you had to scroll to see them. 

Now after the new page appears Tensorboard will automatically scroll to the same position relative to the new size of the grouping.

Googlers see b/160888098.