### PR TITLE
linked time: implement histogram color for linked time

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -50,14 +50,7 @@ limitations under the License.
       </g>
     </svg>
     <!-- Disable the feature when in non-offset and non-step mode. -->
-    <ng-container
-      *ngIf="
-        mode === HistogramMode.OFFSET &&
-        timeProperty === TimeProperty.STEP &&
-        linkedTime &&
-        scales
-      "
-    >
+    <ng-container *ngIf="isLinkedTimeEnabled(linkedTime)">
       <div
         class="linked-time"
         [style.transform]="getCssTranslatePx(0, scales.temporalScale(linkedTime.startStep))"
@@ -77,11 +70,17 @@ limitations under the License.
       </g>
     </g>
 
-    <g #histograms class="histograms">
+    <g
+      #histograms
+      [class.histograms]="true"
+      [class.linked-time-enabled]="linkedTime"
+      [class.linked-time-single-step]="linkedTime && !linkedTime.endStep"
+    >
       <g
         *ngFor="let datum of data; trackBy: trackByWallTime;"
         [style.transform]="getGroupTransform(datum)"
-        class="histogram"
+        [class.histogram]="true"
+        [class.no-color]="!isDatumInLinkedTimeRange(datum)"
         [style.color]="getHistogramFill(datum)"
       >
         <line
@@ -94,19 +93,19 @@ limitations under the License.
           *ngIf="tooltipData"
           r="2"
           [style.transform]="getCssTranslatePx(
-            getUiCoordFromBinForContent(
-              getClosestBinFromBinCoordinate(
-                datum,
-                tooltipData.xPositionInBinCoord
-              )
-            ).x,
-            getUiCoordFromBinForContent(
-              getClosestBinFromBinCoordinate(
-                datum,
-                tooltipData.xPositionInBinCoord
-              )
-            ).y
-          )"
+          getUiCoordFromBinForContent(
+            getClosestBinFromBinCoordinate(
+              datum,
+              tooltipData.xPositionInBinCoord
+            )
+          ).x,
+          getUiCoordFromBinForContent(
+            getClosestBinFromBinCoordinate(
+              datum,
+              tooltipData.xPositionInBinCoord
+            )
+          ).y
+        )"
         ></circle>
       </g>
     </g>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.scss
@@ -186,14 +186,39 @@ svg {
     stroke: currentColor;
     fill: transparent;
   }
+
+  .no-color {
+    // Must override the color on style attribute.
+    color: rgba(#ddd, 0.4) !important;
+
+    path {
+      stroke-opacity: 0.2;
+    }
+
+    @include tb-dark-theme {
+      color: rgba(#333, 0.4) !important;
+    }
+  }
 }
 
 // Offset mode customizations.
-.offset .content .histograms path {
-  stroke: #fff;
+.offset .content .histograms {
+  path {
+    stroke: #fff;
 
-  @include tb-dark-theme {
-    stroke: map-get($tb-dark-foreground, border);
+    @include tb-dark-theme {
+      stroke: map-get($tb-dark-foreground, border);
+    }
+  }
+
+  &.linked-time-single-step :not(.no-color) {
+    path {
+      stroke: #000;
+
+      @include tb-dark-theme {
+        stroke: #fff;
+      }
+    }
   }
 }
 

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -74,6 +74,11 @@ export interface TooltipData {
   };
 }
 
+export interface LinkedTime {
+  startStep: number;
+  endStep: number | null;
+}
+
 @Component({
   selector: 'tb-histogram',
   templateUrl: 'histogram_component.ng.html',
@@ -95,7 +100,7 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   @Input() data!: HistogramData;
 
-  @Input() linkedTime?: {startStep: number; endStep: number | null} | null;
+  @Input() linkedTime: LinkedTime | null = null;
 
   readonly HistogramMode = HistogramMode;
   readonly TimeProperty = TimeProperty;
@@ -218,6 +223,28 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
     return this.getCssTranslatePx(
       0,
       this.scales.temporalScale(this.getTimeValue(datum))
+    );
+  }
+
+  isLinkedTimeEnabled(linkedTime: LinkedTime | null): linkedTime is LinkedTime {
+    return Boolean(
+      this.mode === HistogramMode.OFFSET &&
+        this.timeProperty === TimeProperty.STEP &&
+        this.scales &&
+        linkedTime
+    );
+  }
+
+  isDatumInLinkedTimeRange(datum: HistogramDatum): boolean {
+    if (!this.isLinkedTimeEnabled(this.linkedTime)) {
+      return true;
+    }
+    if (this.linkedTime.endStep === null) {
+      return this.linkedTime.startStep === datum.step;
+    }
+    return (
+      this.linkedTime.startStep <= datum.step &&
+      this.linkedTime.endStep >= datum.step
     );
   }
 


### PR DESCRIPTION
This change implements fill/color for the linked time feature. When in a
single step mode, if there exists a histogram data with the matching
step, we will highlight it by putting subdued color for non-matching
ones while showing a color for the match. For the range selected time
mode, this change does the same for match/non-match creating a range of
colored histograms.

For single:
![Screenshot from 2021-09-08 17-08-05](https://user-images.githubusercontent.com/2547313/132601541-f96f2bea-585f-4cb1-936c-64c4cd027392.png)

For range:
![Screenshot from 2021-09-08 17-06-53](https://user-images.githubusercontent.com/2547313/132601547-410e6258-a35d-42cf-8007-30e7077c2999.png)
