### PR TITLE
linked time: fix fob positioning on scalar

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -209,6 +209,7 @@ limitations under the License.
 >
   <ng-container *ngIf="selectedTime">
     <div
+      class="linked-time-fob-container"
       [style.transform]="'translate(' +
         xScale.forward(
           viewExtent.x,
@@ -224,6 +225,7 @@ limitations under the License.
     </div>
     <div
       *ngIf="selectedTime.endStep"
+      class="linked-time-fob-container"
       [style.transform]="'translate(' +
         xScale.forward(
           viewExtent.x,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -158,6 +158,13 @@ $_title-to-heading-gap: 12px;
   }
 }
 
+.linked-time-fob-container {
+  display: inline-block;
+  left: 0;
+  position: absolute;
+  top: 0;
+}
+
 linked-time-fob {
   transform: translateX(-50%); // Center the fob by its width.
 }


### PR DESCRIPTION
Previously, when using range selection, the fob was incorrectly placed.
This change fixes that.

Before:
![Screenshot from 2021-09-08 17-17-59](https://user-images.githubusercontent.com/2547313/132602300-ae7f5007-1ba8-47a6-be5b-eee5624d3a95.png)

After:
![Screenshot from 2021-09-08 17-18-42](https://user-images.githubusercontent.com/2547313/132602316-1737656a-95ba-43f6-948b-c54a2a2c46d0.png)
