### PR TITLE
chore: remove instance of `/` in SASS

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -135,7 +135,7 @@ $_title-to-heading-gap: 12px;
 
   &.start {
     border-right-width: $_border-width;
-    margin-left: -$_border-width / 2;
+    margin-left: -0.5 * $_border-width;
 
     &.range {
       left: 0;
@@ -144,7 +144,7 @@ $_title-to-heading-gap: 12px;
 
   &.end {
     border-left-width: $_border-width;
-    margin-right: -$_border-width / 2;
+    margin-right: -0.5 * $_border-width;
     right: 0;
   }
 


### PR DESCRIPTION
In SASS, they have deprecated use of slash for division
<https://sass-lang.com/documentation/breaking-changes/slash-div>. This
change replaces division with multiplication instead.
