### PR TITLE
Changing dark mode makes paint dirty

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/chart.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/chart.ts
@@ -145,6 +145,7 @@ export class ChartImpl implements Chart {
 
   setUseDarkMode(useDarkMode: boolean) {
     this.renderer.setUseDarkMode(useDarkMode);
+    this.seriesLineView.markAsPaintDirty();
     this.scheduleRepaint();
   }
 


### PR DESCRIPTION
This is a fix for [issue 5246](https://github.com/tensorflow/tensorboard/issues/5246).

Upon initial change from light to dark mode and dark to light mode the graphs used to look like this:
<img width="594" alt="Screen Shot 2021-09-08 at 9 57 35 PM" src="https://user-images.githubusercontent.com/8672809/132625412-ad98a39d-3d34-4d78-8965-eb3333823dc4.png">
<img width="590" alt="Screen Shot 2021-09-08 at 9 57 53 PM" src="https://user-images.githubusercontent.com/8672809/132625423-8c15fc31-c28c-4213-86f6-5fad8dc6449d.png">

and now they look like this:
<img width="600" alt="Screen Shot 2021-09-08 at 9 54 17 PM" src="https://user-images.githubusercontent.com/8672809/132625441-a11aa57d-ce99-47b5-a3a2-99fcc0de0c1c.png">
<img width="606" alt="Screen Shot 2021-09-08 at 9 54 10 PM" src="https://user-images.githubusercontent.com/8672809/132625452-8d71a23c-6ce8-4d69-84a4-8161e4752a09.png">


The problem was that that change from dark to light mode did lot indicate the the SeriesLineView that the lines were "dirty" so upon update it did not realize they needed to be redrawn.