### PR TITLE
linked time: render end range fob in histogram

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -55,8 +55,20 @@ limitations under the License.
         class="linked-time"
         [style.transform]="getCssTranslatePx(0, scales.temporalScale(linkedTime.startStep))"
       >
-        <linked-time-fob class="linked-time-fob" [step]="linkedTime.startStep">
-        </linked-time-fob>
+        <linked-time-fob
+          class="linked-time-fob"
+          [step]="linkedTime.startStep"
+        ></linked-time-fob>
+      </div>
+      <div
+        *ngIf="linkedTime.endStep"
+        class="linked-time"
+        [style.transform]="getCssTranslatePx(0, scales.temporalScale(linkedTime.endStep))"
+      >
+        <linked-time-fob
+          class="linked-time-fob"
+          [step]="linkedTime.endStep"
+        ></linked-time-fob>
       </div>
     </ng-container>
   </div>

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -949,6 +949,25 @@ describe('histogram test', () => {
     });
 
     describe('multi step', () => {
+      it('shows a fob when a range time selection is present', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: -200}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.componentInstance.linkedTime = {startStep: 5, endStep: 10};
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const controls = fixture.debugElement.queryAll(byCss.LINKED_TIME_FOB);
+        expect(controls.map((el) => el.nativeElement.textContent)).toEqual([
+          '5',
+          '10',
+        ]);
+      });
+
       it('puts color on histogram that is in the range (inclusive)', () => {
         const fixture = createComponent('foo', [
           buildHistogramDatum({step: 0, wallTime: 100}),


### PR DESCRIPTION
This change adds the axis indicator for the end of the selected time
range. This change only adds visual elements.
