### PR TITLE
linked time: clipping indicator on histogram 

### DIFF
--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -161,11 +161,34 @@ export function createScalarStepData(): ScalarStepDatum[] {
   ];
 }
 
+export function buildHistogramStepData(
+  override: Partial<HistogramStepDatum> = {}
+): HistogramStepDatum {
+  return {
+    step: 0,
+    wallTime: 123,
+    bins: [{min: 0, max: 100, count: 42}],
+    ...override,
+  };
+}
+
 export function createHistogramStepData(): HistogramStepDatum[] {
   return [
-    {step: 0, wallTime: 123, bins: [{min: 0, max: 100, count: 42}]},
-    {step: 1, wallTime: 124, bins: [{min: 0, max: 100, count: 42}]},
-    {step: 99, wallTime: 125, bins: [{min: 0, max: 100, count: 42}]},
+    buildHistogramStepData({
+      step: 0,
+      wallTime: 123,
+      bins: [{min: 0, max: 100, count: 42}],
+    }),
+    buildHistogramStepData({
+      step: 1,
+      wallTime: 124,
+      bins: [{min: 0, max: 100, count: 42}],
+    }),
+    buildHistogramStepData({
+      step: 99,
+      wallTime: 125,
+      bins: [{min: 0, max: 100, count: 42}],
+    }),
   ];
 }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -94,6 +94,8 @@ tf_ng_module(
     ],
     deps = [
         ":run_name",
+        ":utils",
+        ":vis_selected_time_clipped",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
@@ -222,6 +224,7 @@ tf_ts_library(
     ],
     deps = [
         ":scalar_card_types",
+        "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/runs/store:types",
     ],
 )
@@ -304,6 +307,7 @@ tf_ts_library(
         ":scalar_card",
         ":scalar_card_types",
         ":utils",
+        ":vis_selected_time_clipped",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -15,11 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="heading">
-  <tb-truncated-path
-    class="tag"
-    title="{{ tag }}"
-    value="{{ title }}"
-  ></tb-truncated-path>
+  <div class="tag">
+    <tb-truncated-path [title]="tag" [value]="title"></tb-truncated-path>
+    <vis-selected-time-clipped
+      *ngIf="selectedTime && selectedTime.clipped"
+    ></vis-selected-time-clipped>
+  </div>
   <div class="run">
     <span
       class="dot"
@@ -63,8 +64,8 @@ limitations under the License.
   [timeProperty]="timeProperty(xAxisType)"
   [color]="runColorScale(runId)"
   [linkedTime]="selectedTime ? {
-    startStep: selectedTime.start.step ?? null,
-    endStep: selectedTime.end?.step ?? null
+    startStep: selectedTime.startStep,
+    endStep: selectedTime.endStep
   } : null"
 ></tb-histogram>
 <ng-template #noData>

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
@@ -41,8 +41,15 @@ $_title-to-heading-gap: 12px;
 }
 
 .tag {
+  align-items: center;
+  display: flex;
+  gap: 5px;
   grid-area: tag;
   overflow: hidden;
+
+  vis-selected-time-clipped {
+    line-height: 0;
+  }
 }
 
 .pin-button mat-icon {

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -19,7 +19,6 @@ import {
   Input,
   Output,
 } from '@angular/core';
-
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
 import {
@@ -27,7 +26,8 @@ import {
   HistogramMode,
   TimeProperty,
 } from '../../../widgets/histogram/histogram_types';
-import {LinkedTime, XAxisType} from '../../types';
+import {XAxisType} from '../../types';
+import {ViewSelectedTime} from './utils';
 
 @Component({
   selector: 'histogram-card-component',
@@ -48,7 +48,7 @@ export class HistogramCardComponent {
   @Input() runColorScale!: RunColorScale;
   @Input() showFullSize!: boolean;
   @Input() isPinned!: boolean;
-  @Input() selectedTime!: LinkedTime | null;
+  @Input() selectedTime!: ViewSelectedTime | null;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_module.ts
@@ -24,6 +24,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {HistogramCardComponent} from './histogram_card_component';
 import {HistogramCardContainer} from './histogram_card_container';
 import {RunNameModule} from './run_name_module';
+import {VisSelectedTimeClippedModule} from './vis_selected_time_clipped_module';
 
 @NgModule({
   declarations: [HistogramCardContainer, HistogramCardComponent],
@@ -36,6 +37,7 @@ import {RunNameModule} from './run_name_module';
     MatProgressSpinnerModule,
     RunNameModule,
     TruncatedPathModule,
+    VisSelectedTimeClippedModule,
   ],
 })
 export class HistogramCardModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -172,18 +172,18 @@ limitations under the License.
       [ngClass]="{
         'out-of-selected-time': true,
         start: true,
-        range: !!selectedTime.end
+        range: !!selectedTime.endStep
       }"
       [style.right]="
         xScale.forward(
           viewExtent.x,
           [domDim.width, 0],
-          selectedTime.start.step
+          selectedTime.startStep
         ) + 'px'
       "
     ></div>
     <div
-      *ngIf="selectedTime.end"
+      *ngIf="selectedTime.endStep"
       [ngClass]="{
         'out-of-selected-time': true,
         end: true,
@@ -193,7 +193,7 @@ limitations under the License.
         xScale.forward(
           viewExtent.x,
           [0, domDim.width],
-          selectedTime.end.step
+          selectedTime.endStep
         ) + 'px'
       "
     ></div>
@@ -213,28 +213,28 @@ limitations under the License.
         xScale.forward(
           viewExtent.x,
           [0, domDim.width],
-          selectedTime.start.step
+          selectedTime.startStep
         ) + 'px, 0)'
       "
     >
       <linked-time-fob
         class="selected-time-fob"
-        [step]="selectedTime.start.step"
+        [step]="selectedTime.startStep"
       ></linked-time-fob>
     </div>
     <div
-      *ngIf="selectedTime.end"
+      *ngIf="selectedTime.endStep"
       [style.transform]="'translate(' +
         xScale.forward(
           viewExtent.x,
           [0, domDim.width],
-          selectedTime.end.step
+          selectedTime.endStep
         ) + 'px, 0)'
       "
     >
       <linked-time-fob
         class="selected-time-fob"
-        [step]="selectedTime.end.step"
+        [step]="selectedTime.endStep"
       ></linked-time-fob>
     </div>
   </ng-container>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -37,12 +37,13 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
-import {LinkedTime, TooltipSort, XAxisType} from '../../types';
+import {TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
   ScalarCardSeriesMetadataMap,
 } from './scalar_card_types';
+import {ViewSelectedTime} from './utils';
 
 type ScalarTooltipDatum = TooltipDatum<
   ScalarCardSeriesMetadata & {
@@ -50,8 +51,6 @@ type ScalarTooltipDatum = TooltipDatum<
     closest: boolean;
   }
 >;
-
-export type LinkedTimeWithClipped = LinkedTime & {clipped: boolean};
 
 @Component({
   selector: 'scalar-card-component',
@@ -81,7 +80,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() xAxisType!: XAxisType;
   @Input() xScaleType!: ScaleType;
   @Input() useDarkMode!: boolean;
-  @Input() selectedTime!: LinkedTimeWithClipped | null;
+  @Input() selectedTime!: ViewSelectedTime | null;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_component.scss
@@ -16,14 +16,16 @@ limitations under the License.
 
 :host {
   color: mat-color(map-get($tb-theme, warn), 700);
+  height: 1em;
+  line-height: 0;
+  width: 1em;
 
   @include tb-dark-theme {
     color: mat-color(map-get($tb-dark-theme, warn), 700);
   }
 
   mat-icon {
-    height: 1em;
-    line-height: 0;
-    width: 1em;
+    height: 100%;
+    width: 100%;
   }
 }


### PR DESCRIPTION
When linked time selection is not in the range of the data, we clip the
time selection and show a little indicator warning user of the clipping.
This change applies the indication on the histogram vis.

![Screenshot from 2021-09-09 14-09-56](https://user-images.githubusercontent.com/2547313/132763028-47ae96e1-b6a5-438a-bde4-d2696c4cf947.png)
