### PR TITLE
Add tf.stop_gradient in tf.summary.histogram

### DIFF
--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -234,6 +234,23 @@ class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
         with writer.as_default():
             graph_fn()
         writer.close()
+        
+    def test_no_gradient_error_xla(self):
+        @tf2.function(jit_compile=True)
+        def graph_fn():
+            x = tf.constant(1.)
+            with tf2.GradientTape() as tape1:
+                with tf2.GradientTape() as tape2:
+                    tape1.watch(x)
+                    tape2.watch(x)
+                    summary.histogram(name="loss", step=0, data=x, buckets=10)
+        # Note that XLA CPU/GPU has no outside compilation support, so summaries
+        # won't actually run in a jit_compiled function. TPUs do, and follow
+        # some similar codepaths, so this test stops at graph building to
+        # exercise those paths without a TPU available.
+        writer = tf2.summary.create_file_writer(self.get_temp_dir())
+        with writer.as_default():
+            graph_fn.get_concrete_function()
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -234,16 +234,17 @@ class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
         with writer.as_default():
             graph_fn()
         writer.close()
-        
+
     def test_no_gradient_error_xla(self):
         @tf2.function(jit_compile=True)
         def graph_fn():
-            x = tf.constant(1.)
+            x = tf.constant(1.0)
             with tf2.GradientTape() as tape1:
                 with tf2.GradientTape() as tape2:
                     tape1.watch(x)
                     tape2.watch(x)
                     summary.histogram(name="loss", step=0, data=x, buckets=10)
+
         # Note that XLA CPU/GPU has no outside compilation support, so summaries
         # won't actually run in a jit_compiled function. TPUs do, and follow
         # some similar codepaths, so this test stops at graph building to

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -105,6 +105,10 @@ def histogram(name, data, step=None, buckets=None, description=None):
       ValueError: if a default writer exists, but no step was provided and
         `tf.summary.experimental.get_step()` is None.
     """
+    # Avoid building unused gradient graphs for conds below. This works around
+    # an error building second-order gradient graphs when XlaDynamicUpdateSlice
+    # is used, and will generally speed up graph building slightly.
+    data = tf.stop_gradient(data)
     summary_metadata = metadata.create_summary_metadata(
         display_name=None, description=description
     )


### PR DESCRIPTION

* Motivation for features / changes

Working around a user issue. It's intended as a temporary fix, but keeping it long-term doesn't have any downsides that I know of.

* Technical description of changes

Adds tf.stop_gradient in tf.summary.histogram. The function is not differentiable, and building gradient graphs for its conds have been causing some issues. This should be a no-op with a tiny positive performance impact for most users, and will work around an error for those using XLA with multiple/persistent tf.GradientTapes (due to XlaDynamicUpdateSlice not having a gradient defined; there is a separate TensorFlow bug about the op with no gradient, which is the more satisfying medium-term solution here).

* Screenshots of UI changes

N/A; this just changes the implementation of a summary API.

* Detailed steps to verify changes work correctly (as executed by you)

Two folks (at Alphabet) have confirmed that this works around an issue they reported for now. It's a bit tricky to reproduce; we might be able to do a unit test with XLA+CPU in the TensorBoard repo, although the original report relates to TPU usage.

* Alternate designs / implementations considered

The op should have a gradient defined, and will eventually.