### PR TITLE
timeseries: show indication when there is a new pin

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
@@ -28,6 +28,7 @@ mat-icon {
 .group-text {
   display: flex;
   align-items: baseline;
+  gap: 6px;
 }
 
 .group-title {
@@ -36,9 +37,33 @@ mat-icon {
 
 .group-card-count {
   @include metrics-card-group-count-text;
-  margin-left: 6px;
 }
 
 .empty-message {
   @include metrics-empty-message;
+}
+
+.new-card-pinned {
+  animation: pinned-view-fade-out 3s linear;
+  background: mat-color($mat-red, 500);
+  border-radius: 5px;
+  color: #fff;
+  display: inline-block;
+  font-size: 13px;
+  opacity: 0;
+  padding: 3px 5px;
+}
+
+@keyframes pinned-view-fade-out {
+  from {
+    opacity: 1;
+  }
+
+  66% {
+    opacity: 0.99;
+  }
+
+  to {
+    opacity: 0;
+  }
 }

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
@@ -28,6 +28,12 @@ import {CardIdWithMetadata} from '../metrics_view_types';
         <span *ngIf="cardIdsWithMetadata.length > 1" class="group-card-count"
           >{{ cardIdsWithMetadata.length }} cards</span
         >
+        <span
+          *ngFor="let id of newCardPinnedIds"
+          class="new-card-pinned"
+          [data-id]="id"
+          >New card pinned</span
+        >
       </span>
     </div>
     <metrics-card-grid
@@ -45,4 +51,5 @@ import {CardIdWithMetadata} from '../metrics_view_types';
 export class PinnedViewComponent {
   @Input() cardObserver!: CardObserver;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
+  @Input() newCardPinnedIds!: number[];
 }

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
@@ -28,10 +28,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
         <span *ngIf="cardIdsWithMetadata.length > 1" class="group-card-count"
           >{{ cardIdsWithMetadata.length }} cards</span
         >
-        <span
-          *ngFor="let id of newCardPinnedIds"
-          class="new-card-pinned"
-          [data-id]="id"
+        <span *ngFor="let id of newCardPinnedIds" class="new-card-pinned"
           >New card pinned</span
         >
       </span>
@@ -51,5 +48,5 @@ import {CardIdWithMetadata} from '../metrics_view_types';
 export class PinnedViewComponent {
   @Input() cardObserver!: CardObserver;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
-  @Input() newCardPinnedIds!: number[];
+  @Input() newCardPinnedIds!: [number];
 }

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
@@ -28,7 +28,10 @@ import {CardIdWithMetadata} from '../metrics_view_types';
         <span *ngIf="cardIdsWithMetadata.length > 1" class="group-card-count"
           >{{ cardIdsWithMetadata.length }} cards</span
         >
-        <span *ngFor="let id of newCardPinnedIds" class="new-card-pinned"
+        <span
+          *ngFor="let id of newCardPinnedIds"
+          [data-id]="id"
+          class="new-card-pinned"
           >New card pinned</span
         >
       </span>

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_container.ts
@@ -43,7 +43,8 @@ export class PinnedViewContainer {
     DeepReadonly<CardIdWithMetadata[]>
   > = this.store.select(getPinnedCardsWithMetadata).pipe(startWith([]));
 
-  readonly newCardPinnedIds$: Observable<number[]> = this.store
+  // An opaque id that changes in value when new cards are pinned.
+  readonly newCardPinnedIds$: Observable<[number]> = this.store
     .select(getPinnedCardsWithMetadata)
     .pipe(
       // Ignore the first pinned card values which is empty, `[]`, in the store.
@@ -69,6 +70,6 @@ export class PinnedViewContainer {
         return [after];
       }),
       filter((value) => value !== null),
-      map((val) => val as number[])
+      map((val) => [val![0]] as [number])
     );
 }


### PR DESCRIPTION
The reason why we decided to show pinned section during search is
because we wanted to make pinning more intuitive while you are filter
searching (previously, when you pinned a card, there was no visual
indication of an action besides a small fill on the pin icon which is
occluded by the cursor). This change makes the section a bit smaller but
compensate for the small UI with an indicator for new pinned card.

![Screenshot from 2021-09-15 19-31-43](https://user-images.githubusercontent.com/2547313/133539801-37ee0a1e-581d-4ffd-b178-58a11677e53d.png)
