### PR TITLE
histogram: change histogram format for singular data case

### DIFF
--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -94,6 +94,23 @@ def run(k, step):
         step=step,
     )
 
+    # Empty data
+    empty = tf.constant([])
+    tf.summary.histogram(
+        "empty",
+        empty,
+        description="An empty distribution.",
+        step=step,
+    )
+
+    # Single value
+    singular = tf.constant([1.0] * 10)
+    tf.summary.histogram(
+        "singular",
+        singular,
+        description="A distribution containing a singular value.",
+        step=step,
+    )
     # Finally, combine everything together!
     all_distributions = [
         mean_moving_normal,
@@ -101,6 +118,8 @@ def run(k, step):
         gamma,
         poisson,
         uniform,
+        empty,
+        singular,
     ]
     all_combined = tf.concat(all_distributions, 0)
     tf.summary.histogram(
@@ -109,7 +128,8 @@ def run(k, step):
         description="An amalgamation of five distributions: a "
         "uniform distribution, a gamma "
         "distribution, a Poisson distribution, and "
-        "two normal distributions.",
+        "two normal distributions, an empty distribution and "
+        "a distribution containing a singular value",
         step=step,
     )
 

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -70,16 +70,6 @@ class SummaryBaseTest(object):
         buckets = tensor_util.make_ndarray(pb.value[0].tensor)
         np.testing.assert_allclose(buckets, np.array([]).reshape((0, 3)))
 
-    def test_singleton_input(self):
-        pb = self.histogram("twelve", [12])
-        buckets = tensor_util.make_ndarray(pb.value[0].tensor)
-        np.testing.assert_allclose(buckets, np.array([[11.5, 12.5, 1]]))
-
-    def test_input_with_all_same_values(self):
-        pb = self.histogram("twelven", [12, 12, 12])
-        buckets = tensor_util.make_ndarray(pb.value[0].tensor)
-        np.testing.assert_allclose(buckets, np.array([[11.5, 12.5, 3]]))
-
     def test_fixed_input(self):
         pass  # TODO: test a small fixed input
 
@@ -135,6 +125,16 @@ class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
             "a/b/histogram_summary", self.histogram("a/b", []).value[0].tag
         )
 
+    def test_singleton_input(self):
+        pb = self.histogram("twelve", [12])
+        buckets = tensor_util.make_ndarray(pb.value[0].tensor)
+        np.testing.assert_allclose(buckets, np.array([[11.5, 12.5, 1]]))
+
+    def test_input_with_all_same_values(self):
+        pb = self.histogram("twelven", [12, 12, 12])
+        buckets = tensor_util.make_ndarray(pb.value[0].tensor)
+        np.testing.assert_allclose(buckets, np.array([[11.5, 12.5, 3]]))
+
 
 class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
     def histogram(self, *args, **kwargs):
@@ -164,6 +164,21 @@ class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
 class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
     def histogram(self, *args, **kwargs):
         return summary.histogram_pb(*args, **kwargs)
+
+    def test_singleton_input(self):
+        pb = self.histogram("twelve", [12])
+        buckets = tensor_util.make_ndarray(pb.value[0].tensor)
+        # By default there will be 30 buckets.
+        expected_buckets = np.array(
+            [[12, 12, 0] for _ in range(29)] + [[12, 12, 1]]
+        )
+        np.testing.assert_allclose(buckets, expected_buckets)
+
+    def test_input_with_all_same_values(self):
+        pb = self.histogram("twelven", [12, 12, 12], buckets=2)
+        buckets = tensor_util.make_ndarray(pb.value[0].tensor)
+        expected_buckets = np.array([[12, 12, 0], [12, 12, 3]])
+        np.testing.assert_allclose(buckets, expected_buckets)
 
 
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -220,7 +220,11 @@ def _buckets(data, bucket_count=None):
             else non_singular_bucket_indices
         )
         clamped_indices = tf.minimum(bucket_indices, bucket_count - 1)
-        one_hots = tf.one_hot(clamped_indices, depth=bucket_count)
+        # Cast to float64 to prevent overflow beyond limt 2^24 in reduce_sum below.
+        one_hots = tf.cast(
+            tf.one_hot(clamped_indices, depth=bucket_count),
+            dtype=tf.float64,
+        )
         bucket_counts = tf.cast(
             tf.reduce_sum(input_tensor=one_hots, axis=0),
             dtype=tf.float64,

--- a/tensorboard/plugins/metrics/metrics_plugin_test.py
+++ b/tensorboard/plugins/metrics/metrics_plugin_test.py
@@ -93,13 +93,14 @@ class MetricsPluginTest(tf.test.TestCase):
             writer.flush()
         self._multiplexer.AddRunsFromDirectory(self._logdir)
 
-    def _write_histogram_data(self, run, tag, data=[]):
+    def _write_histogram_data(self, run, tag, data=[], buckets=None):
         """Writes histogram data, starting at step 0.
 
         Args:
           run: string run name.
           tag: string tag name.
           data: list of histogram values to write at each step.
+          buckets: number of buckets.
         """
         subdir = os.path.join(self._logdir, run)
         writer = tf.summary.create_file_writer(subdir)
@@ -107,7 +108,7 @@ class MetricsPluginTest(tf.test.TestCase):
         with writer.as_default():
             step = 0
             for datum in data:
-                tf.summary.histogram(tag, datum, step=step)
+                tf.summary.histogram(tag, datum, step=step, buckets=buckets)
                 step += 1
             writer.flush()
         self._multiplexer.AddRunsFromDirectory(self._logdir)
@@ -409,7 +410,7 @@ class MetricsPluginTest(tf.test.TestCase):
         )
 
     def test_time_series_histogram(self):
-        self._write_histogram_data("run1", "histograms/tagA", [0, 10])
+        self._write_histogram_data("run1", "histograms/tagA", [0, 10], 1)
         self._multiplexer.Reload()
 
         requests = [
@@ -432,14 +433,14 @@ class MetricsPluginTest(tf.test.TestCase):
                                 "wallTime": "<wall_time>",
                                 "step": 0,
                                 "bins": [
-                                    {"min": -0.5, "max": 0.5, "count": 1.0}
+                                    {"min": 0.0, "max": 0.0, "count": 1.0}
                                 ],
                             },
                             {
                                 "wallTime": "<wall_time>",
                                 "step": 1,
                                 "bins": [
-                                    {"min": 9.5, "max": 10.5, "count": 1.0}
+                                    {"min": 10.0, "max": 10.0, "count": 1.0}
                                 ],
                             },
                         ]


### PR DESCRIPTION
When input data contains only one unique value, generate user specified number of buckets (let `N` denote this number), where the first `N-1` buckets are closed-open (`[v, v)`) with zero counts, and the last bucket is closed (`[v, v]`) with a nonzero count.

This is a POC.

Below are the visualization of the histograms for an empty distribution and a distribution of a singular value:
- Before: ![image](https://user-images.githubusercontent.com/15273931/133657689-a4e69a3c-1b7f-43f3-9e6d-8f693eccd318.png)
- After: 
![image](https://user-images.githubusercontent.com/15273931/133657739-e87f37e8-ee29-4549-9075-e5044c444b0f.png)

#histogram #tpu