### PR TITLE
dark mode: Style link colors in both dark and light modes in polymer plugins.

### DIFF
--- a/tensorboard/components/tf_dashboard_common/dashboard-style.ts
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.ts
@@ -113,5 +113,13 @@ registerStyleDomModule({
         font-size: 15px;
         margin-top: 5px;
       }
+
+      a {
+        color: var(--tb-link);
+      }
+
+      a:visited {
+        color: var(--tb-link-visited);
+      }
   `,
 });

--- a/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
+++ b/tensorboard/components/tf_dashboard_common/tensorboard-color.ts
@@ -31,6 +31,8 @@ style.textContent = `
     --primary-background-color: #fff;
     --secondary-background-color: #e9e9e9;
     --tb-layout-background-color: #f5f5f5;
+    --tb-link: #1976d2; /* material blue 700. */
+    --tb-link-visited: #7b1fa2; /* material purple 700. */
   }
 
   :root .dark-mode {
@@ -44,6 +46,8 @@ style.textContent = `
     --primary-background-color: #303030;  /* material grey A400. */
     --secondary-background-color: #3a3a3a;
     --tb-layout-background-color: #3a3a3a;
+    --tb-link: #42a5f5; /* material blue 400. */
+    --tb-link-visited: #ba68c8; /* material purple 300. */
     /* Overrides paper-material */
     --shadow-elevation-2dp_-_box-shadow: 0 2px 2px 0 rgba(255, 255, 255, 0.14),
       0 1px 5px 0 rgba(255, 255, 255, 0.12),

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -202,6 +202,14 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
       .center:not(.no-graph) .no-data-message {
         display: none;
       }
+
+      a {
+        color: var(--tb-link);
+      }
+
+      a:visited {
+        color: var(--tb-link-visited);
+      }
     </style>
   `;
   /**

--- a/tensorboard/plugins/hparams/tf_hparams_main/tf-hparams-main.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_main/tf-hparams-main.ts
@@ -138,6 +138,14 @@ class TfHparamsMain extends LegacyElementMixin(PolymerElement) {
         max-width: 540px;
         margin: 80px auto 0 auto;
       }
+
+      a {
+        color: var(--tb-link);
+      }
+
+      a:visited {
+        color: var(--tb-link-visited);
+      }
     </style>
   `;
   // An object for making HParams API requests to the backend.


### PR DESCRIPTION
* Motivation for features / changes

  As reported in #5309, links in some error messages in dark mode are difficult to see. It turns out this is potentially a more general problem: there is no attempt to style any links for dark or light mode in the polymer part of the code base.

* Technical description of changes

1. Mirroring definitions for the Angular part of the code base we add --tb-link and --tb-link-visited definitions in tensorboard-color.ts.

    The corresponding Angular definitions can be found in: 
    https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/webapp/theme/_tb_theme.template.scss

2. We use --tb-link and --tb-link-visited in dashboard-style.ts, applying the styling for most dashboards.

3. We use --tb-link and --tb-link-visited in the graphs and hparams dashboards, since they do not import styles from dashboard-style.ts.

* Screenshots of UI changes
  Dark Mode Sample:
  ![image](https://user-images.githubusercontent.com/17152369/133850211-3b7edc4f-183f-4b55-9d70-d02b355abaa4.png)
  Light Mode Sample:
  ![image](https://user-images.githubusercontent.com/17152369/133850238-f8e4d65e-00ff-4a3e-a1e6-4c4b6aebe9a6.png)
