### PR TITLE
cleanup: log as a warning instead of an error when HParams-plugin experiment data is not found

### DIFF
--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -15,7 +15,7 @@
 """Classes and functions for handling the GetExperiment API call."""
 
 
-from tensorboard.plugins.hparams import error
+import logging
 
 
 class Handler(object):
@@ -48,7 +48,7 @@ class Handler(object):
             ),
         )
         if experiment is None:
-            raise error.HParamsError(
+            logging.info(
                 "Can't find an HParams-plugin experiment data in"
                 " the log directory. Note that it takes some time to"
                 " scan the log directory; if you just started"

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -95,6 +95,10 @@ class HParamsPlugin(base_plugin.TBPlugin):
             experiment = get_experiment.Handler(
                 ctx, self._context, experiment_id
             ).run()
+            if not experiment:
+                return http_util.Respond(
+                    request, "Experiment not found", "text/plain", 204
+                )
             body, mime_type = download_data.Handler(
                 self._context,
                 experiment,

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
@@ -534,8 +534,13 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
           return;
         }
         this.set('_experiment', experiment);
-        this._computeHParams();
-        this._computeMetrics();
+        if (!this._experiment) {
+          this.set('_hparams', []);
+          this.set('_metrics', []);
+        } else {
+          this._computeHParams();
+          this._computeMetrics();
+        }
         this._queryServer();
         this._resolveGetExperiment();
       })


### PR DESCRIPTION
Reduce non-essential errors in the logs for easier debugging.

Googlers, see [issue](https://b.corp.google.com/issues/199306961) for more context.

#onduty