### PR TITLE
timeseries: hide pinned section while filtering

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
@@ -65,19 +65,17 @@ limitations under the License.
       *ngIf="showFilteredView"
       [cardObserver]="cardObserver"
     ></metrics-filtered-view>
-    <!-- We cannot use 'display: none' until the small charts issue is fixed.
-    Otherwise, adding a pinned card when the section is hidden reliably creates
-    a 'squished chart'. We can switch to 'display: none' when this issue is
-    fixed: https://github.com/tensorflow/tensorboard/issues/2595. -->
+    <!-- Always render the metrics-pinned-view as a performance optimization--it makes view transition
+    from filtered view to card view quicker. -->
     <metrics-pinned-view
       [style.display]="showFilteredView ? 'none' : ''"
       [cardObserver]="cardObserver"
     ></metrics-pinned-view>
-    <!-- Always show the metrics-card-groups as a performance optimization--it makes view transition
-    from filtered view to card view quicker. -->
     <div *ngIf="initialTagsLoading" class="loading-container">
       <mat-spinner diameter="36"></mat-spinner>
     </div>
+    <!-- Always render the metrics-card-groups as a performance optimization--it makes view transition
+    from filtered view to card view quicker. -->
     <metrics-card-groups
       [style.display]="showFilteredView ? 'none' : ''"
       [cardObserver]="cardObserver"

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
@@ -69,7 +69,10 @@ limitations under the License.
     Otherwise, adding a pinned card when the section is hidden reliably creates
     a 'squished chart'. We can switch to 'display: none' when this issue is
     fixed: https://github.com/tensorflow/tensorboard/issues/2595. -->
-    <metrics-pinned-view [cardObserver]="cardObserver"></metrics-pinned-view>
+    <metrics-pinned-view
+      [style.display]="showFilteredView ? 'none' : ''"
+      [cardObserver]="cardObserver"
+    ></metrics-pinned-view>
     <!-- Always show the metrics-card-groups as a performance optimization--it makes view transition
     from filtered view to card view quicker. -->
     <div *ngIf="initialTagsLoading" class="loading-container">

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -89,20 +89,10 @@ limitations under the License.
   &.filter-view {
     overflow: hidden;
 
-    metrics-filtered-view,
-    metrics-pinned-view {
+    metrics-filtered-view {
       contain: content;
       overflow: auto;
       will-change: transform, scroll-position;
-    }
-
-    metrics-filtered-view {
-      flex: 0 1 auto;
-    }
-
-    metrics-pinned-view {
-      flex: 1 1;
-      min-height: 300px;
     }
   }
 }

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1173,7 +1173,7 @@ describe('metrics main view', () => {
       expect(getFilterviewCardContents(fixture)).toEqual(['images: card2']);
     }));
 
-    it('hides the main but shows pinned views while the filter view is active', fakeAsync(() => {
+    it('hides the main and pinned views while the filter view is active', fakeAsync(() => {
       store.overrideSelector(selectors.getPinnedCardsWithMetadata, [
         {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         {cardId: 'card2', ...createCardMetadata(PluginType.IMAGES)},
@@ -1187,6 +1187,7 @@ describe('metrics main view', () => {
       const pinnedViewDebugEl = fixture.debugElement.query(
         By.css('.main metrics-pinned-view')
       );
+      expect(pinnedViewDebugEl.styles['display']).toBe('none');
       const cardContents = getCardContents(getCards(pinnedViewDebugEl));
       expect(cardContents).toEqual(['scalars: card1', 'images: card2']);
     }));


### PR DESCRIPTION
This change hides pinned section from the main view when you are
filtering. It takes up too much space and is bad for UX when a screen
size is small.
