### PR TITLE
timeseries: keep all digits for step values in scalar cards

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -29,6 +29,7 @@ import {
   Formatter,
   numberFormatter,
   relativeTimeFormatter,
+  intlNumberFormatter,
   siNumberFormatter,
 } from '../../../widgets/line_chart_v2/lib/formatter';
 import {LineChartComponent} from '../../../widgets/line_chart_v2/line_chart_component';
@@ -110,7 +111,7 @@ export class ScalarCardComponent<Downloader> {
 
   readonly relativeXFormatter = relativeTimeFormatter;
   readonly valueFormatter = numberFormatter;
-  readonly stepFormatter = siNumberFormatter;
+  readonly stepFormatter = intlNumberFormatter;
 
   getCustomXFormatter(): Formatter | undefined {
     switch (this.xAxisType) {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -1384,7 +1384,7 @@ describe('scalar card', () => {
 
       assertTooltipRows(fixture, [
         ['', 'Row 2', '-500', '1,000', anyString, anyString],
-        ['', 'Row 3', '3', '10k', anyString, anyString],
+        ['', 'Row 3', '3', '10,000', anyString, anyString],
         ['', 'Row 1', '1000', '10', anyString, anyString],
       ]);
     }));
@@ -1453,7 +1453,7 @@ describe('scalar card', () => {
 
       assertTooltipRows(fixture, [
         ['', 'Row 1', '1000', '10', anyString, anyString],
-        ['', 'Row 3', '3', '10k', anyString, anyString],
+        ['', 'Row 3', '3', '10,000', anyString, anyString],
         ['', 'Row 2', '-500', '1,000', anyString, anyString],
       ]);
     }));
@@ -1523,7 +1523,7 @@ describe('scalar card', () => {
       assertTooltipRows(fixture, [
         ['', 'Row 2', '-500', '1,000', anyString, anyString],
         ['', 'Row 1', '1000', '0', anyString, anyString],
-        ['', 'Row 3', '3', '10k', anyString, anyString],
+        ['', 'Row 3', '3', '10,000', anyString, anyString],
       ]);
 
       setCursorLocation(fixture, {x: 500, y: 600});
@@ -1531,13 +1531,13 @@ describe('scalar card', () => {
       assertTooltipRows(fixture, [
         ['', 'Row 1', '1000', '0', anyString, anyString],
         ['', 'Row 2', '-500', '1,000', anyString, anyString],
-        ['', 'Row 3', '3', '10k', anyString, anyString],
+        ['', 'Row 3', '3', '10,000', anyString, anyString],
       ]);
 
       setCursorLocation(fixture, {x: 10000, y: -100});
       fixture.detectChanges();
       assertTooltipRows(fixture, [
-        ['', 'Row 3', '3', '10k', anyString, anyString],
+        ['', 'Row 3', '3', '10,000', anyString, anyString],
         ['', 'Row 2', '-500', '1,000', anyString, anyString],
         ['', 'Row 1', '1000', '0', anyString, anyString],
       ]);
@@ -1548,7 +1548,7 @@ describe('scalar card', () => {
       assertTooltipRows(fixture, [
         ['', 'Row 1', '1000', '0', anyString, anyString],
         ['', 'Row 2', '-500', '1,000', anyString, anyString],
-        ['', 'Row 3', '3', '10k', anyString, anyString],
+        ['', 'Row 3', '3', '10,000', anyString, anyString],
       ]);
     }));
   });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/formatter.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/formatter.ts
@@ -88,16 +88,40 @@ export const numberFormatter: Formatter = {
 
 /**
  * ===================
+ * INTL NUMBER FORMATTER
+ * ===================
+ */
+
+const IntlNumberFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 3,
+});
+
+function formatIntlNumber(x: number): string {
+  return IntlNumberFormatter.format(x);
+}
+
+export const intlNumberFormatter: Formatter = {
+  formatTick: formatIntlNumber,
+  formatShort: formatIntlNumber,
+  formatReadable: formatIntlNumber,
+  formatLong: formatIntlNumber,
+};
+
+/**
+ * ===================
  * SI NUMBER FORMATTER
  * ===================
  */
 
-const SiFormatter = new Intl.NumberFormat(undefined, {
-  maximumFractionDigits: 3,
-});
+const d3SiFormatter = format('0.3~s');
+const d3SiSmallNumberFormatter = format(',.3~f');
 
 function formatSiNumber(x: number): string {
-  return SiFormatter.format(x);
+  const absNum = Math.abs(x);
+  if (absNum >= LARGE_NUMBER || absNum < SMALL_NUMBER) {
+    return d3SiFormatter(x);
+  }
+  return d3SiSmallNumberFormatter(x);
 }
 
 export const siNumberFormatter: Formatter = {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/formatter.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/formatter.ts
@@ -92,7 +92,7 @@ export const numberFormatter: Formatter = {
  * ===================
  */
 
-const d3SiFormatter = format('0.3~s');
+const d3SiFormatter = format('0.4~s');
 const d3SiSmallNumberFormatter = format(',.3~f');
 
 function formatSiNumber(x: number): string {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/formatter.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/formatter.ts
@@ -92,15 +92,12 @@ export const numberFormatter: Formatter = {
  * ===================
  */
 
-const d3SiFormatter = format('0.4~s');
-const d3SiSmallNumberFormatter = format(',.3~f');
+const SiFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 3,
+});
 
 function formatSiNumber(x: number): string {
-  const absNum = Math.abs(x);
-  if (absNum >= LARGE_NUMBER || absNum < SMALL_NUMBER) {
-    return d3SiFormatter(x);
-  }
-  return d3SiSmallNumberFormatter(x);
+  return SiFormatter.format(x);
 }
 
 export const siNumberFormatter: Formatter = {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/formatter_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/formatter_test.ts
@@ -175,7 +175,7 @@ describe('line_chart_v2/lib/formatter test', () => {
       {name: 'formatLong', fn: siNumberFormatter.formatLong},
     ]) {
       describe(`#${name}`, () => {
-        it('formats without si-suffix for number less than 10k', () => {
+        it('formats without si-suffix for number less than 10k in absolute value', () => {
           expect(fn(1)).toBe('1');
           expect(fn(5)).toBe('5');
           expect(fn(-100.4)).toBe('-100.4');
@@ -183,12 +183,16 @@ describe('line_chart_v2/lib/formatter test', () => {
           expect(fn(9999)).toBe('9,999');
           expect(fn(9999.9123)).toBe('9,999.912');
           expect(fn(0.09)).toBe('0.09');
+        });
+
+        it('formats with si-suffix for number more than 10k in absolute value', () => {
           expect(fn(10000)).toBe('10k');
           expect(fn(10001)).toBe('10k');
           expect(fn(-10000)).toBe('-10k');
           expect(fn(-10001)).toBe('-10k');
           expect(fn(-10101)).toBe('-10.1k');
-          expect(fn(-1.004e6)).toBe('-1M');
+          expect(fn(-1.004e6)).toBe('-1.004M');
+          expect(fn(1004500)).toBe('1.005M');
           expect(fn(0.00005)).toBe('50µ');
         });
       });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/formatter_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/formatter_test.ts
@@ -175,7 +175,7 @@ describe('line_chart_v2/lib/formatter test', () => {
       {name: 'formatLong', fn: siNumberFormatter.formatLong},
     ]) {
       describe(`#${name}`, () => {
-        it('formats without si-suffix for number less than 10k in absolute value', () => {
+        it('formats numbers and keeps three decimal places', () => {
           expect(fn(1)).toBe('1');
           expect(fn(5)).toBe('5');
           expect(fn(-100.4)).toBe('-100.4');
@@ -183,17 +183,14 @@ describe('line_chart_v2/lib/formatter test', () => {
           expect(fn(9999)).toBe('9,999');
           expect(fn(9999.9123)).toBe('9,999.912');
           expect(fn(0.09)).toBe('0.09');
-        });
-
-        it('formats with si-suffix for number more than 10k in absolute value', () => {
-          expect(fn(10000)).toBe('10k');
-          expect(fn(10001)).toBe('10k');
-          expect(fn(-10000)).toBe('-10k');
-          expect(fn(-10001)).toBe('-10k');
-          expect(fn(-10101)).toBe('-10.1k');
-          expect(fn(-1.004e6)).toBe('-1.004M');
-          expect(fn(1004500)).toBe('1.005M');
-          expect(fn(0.00005)).toBe('50µ');
+          expect(fn(0.0005)).toBe('0.001');
+          expect(fn(0.00005)).toBe('0');
+          expect(fn(10000)).toBe('10,000');
+          expect(fn(10001)).toBe('10,001');
+          expect(fn(-10000)).toBe('-10,000');
+          expect(fn(-10001)).toBe('-10,001');
+          expect(fn(-10101)).toBe('-10,101');
+          expect(fn(-1.004e6)).toBe('-1,004,000');
         });
       });
     }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/formatter_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/formatter_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {
   numberFormatter,
   relativeTimeFormatter,
+  intlNumberFormatter,
   siNumberFormatter,
   TEST_ONLY,
   wallTimeFormatter,
@@ -167,12 +168,12 @@ describe('line_chart_v2/lib/formatter test', () => {
     });
   });
 
-  describe('#siNumberFormatter', () => {
+  describe('#intlNumberFormatter', () => {
     for (const {name, fn} of [
-      {name: 'formatTick', fn: siNumberFormatter.formatTick},
-      {name: 'formatShort', fn: siNumberFormatter.formatShort},
-      {name: 'formatReadable', fn: siNumberFormatter.formatReadable},
-      {name: 'formatLong', fn: siNumberFormatter.formatLong},
+      {name: 'formatTick', fn: intlNumberFormatter.formatTick},
+      {name: 'formatShort', fn: intlNumberFormatter.formatShort},
+      {name: 'formatReadable', fn: intlNumberFormatter.formatReadable},
+      {name: 'formatLong', fn: intlNumberFormatter.formatLong},
     ]) {
       describe(`#${name}`, () => {
         it('formats numbers and keeps three decimal places', () => {
@@ -185,12 +186,40 @@ describe('line_chart_v2/lib/formatter test', () => {
           expect(fn(0.09)).toBe('0.09');
           expect(fn(0.0005)).toBe('0.001');
           expect(fn(0.00005)).toBe('0');
-          expect(fn(10000)).toBe('10,000');
           expect(fn(10001)).toBe('10,001');
           expect(fn(-10000)).toBe('-10,000');
-          expect(fn(-10001)).toBe('-10,001');
-          expect(fn(-10101)).toBe('-10,101');
           expect(fn(-1.004e6)).toBe('-1,004,000');
+        });
+      });
+    }
+  });
+
+  describe('#siNumberFormatter', () => {
+    for (const {name, fn} of [
+      {name: 'formatTick', fn: siNumberFormatter.formatTick},
+      {name: 'formatShort', fn: siNumberFormatter.formatShort},
+      {name: 'formatReadable', fn: siNumberFormatter.formatReadable},
+      {name: 'formatLong', fn: siNumberFormatter.formatLong},
+    ]) {
+      describe(`#${name}`, () => {
+        it('formats without si-suffix', () => {
+          expect(fn(1)).toBe('1');
+          expect(fn(5)).toBe('5');
+          expect(fn(-100.4)).toBe('-100.4');
+          expect(fn(3.01)).toBe('3.01');
+          expect(fn(9999)).toBe('9,999');
+          expect(fn(9999.9123)).toBe('9,999.912');
+          expect(fn(0.09)).toBe('0.09');
+        });
+
+        it('formats with si-suffix', () => {
+          expect(fn(10000)).toBe('10k');
+          expect(fn(10001)).toBe('10k');
+          expect(fn(-10000)).toBe('-10k');
+          expect(fn(-10001)).toBe('-10k');
+          expect(fn(-10101)).toBe('-10.1k');
+          expect(fn(-1.004e6)).toBe('-1M');
+          expect(fn(0.00005)).toBe('50µ');
         });
       });
     }


### PR DESCRIPTION
To make the step values more meaningful, e.g. display `1,001,001` instead of just `1M`.

Visualization:

<img width="541" alt="Screen Shot 2021-09-22 at 2 12 29 PM" src="https://user-images.githubusercontent.com/15273931/134401836-1fe63a14-3ae1-454e-a9e3-c9c549236071.png">

Googlers, see [issue](https://b.corp.google.com/issues/200663497).


