### PR TITLE
blame: ignore Prettier 2.4.1 reformatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -88,8 +88,11 @@ ea4e9bbc885784a283b8b79974132df7c6cdcc50  # Reformat all `*BUILD` files with `bu
 # third_party/js.bzl reformat (<https://github.com/tensorflow/tensorboard/pull/3332>)
 3e17c44d5bc3c7af72f14059e39d4b872e95d573  # Buildifier format js.bzl for future edits (#3332)
 
-# Prettier 1.18.2 to 2.1.1 upgrade (<https://github.com/tensorflow/tensorboard/pull/4122>)
+# Prettier code-formatting upgrades:
+#  1.18.2 to 2.1.1 (<https://github.com/tensorflow/tensorboard/pull/4122>)
 e42a7f18b33c7a85b51db28d465ec01915a8e725  # prettier: reformat code for 2.1.1
+#  2.1.1 to 2.4.1 upgrade (<https://github.com/tensorflow/tensorboard/pull/5326>)
+2858accc0ec80e8d6a9e02f4dfa12cf47de648dc  # prettier: reformat code for 2.4.1
 
 # Black Python 2.7/3.5 drop and v20.8b1 upgrade (<https://github.com/tensorflow/tensorboard/pull/4409>)
 6d741a8c7afabd1137af2b63b93680d178199aa6  # black: reformat after dropping Python 2.7 and 3.5


### PR DESCRIPTION
Summary:
Merged in #5326 

Test Plan:
The output of `git blame  --ignore-revs-file .git-blame-ignore-revs tensorboard/components/polymer/dark_mode_mixin.ts`
no longer has any lines blaming to the commit in question