### PR TITLE
sync: add missing cdk scrolling dep

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -138,6 +138,7 @@ tf_ts_library(
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
+        "//tensorboard/webapp/angular:expect_angular_cdk_scrolling",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_material_autocomplete",
         "//tensorboard/webapp/angular:expect_angular_material_button",


### PR DESCRIPTION
Our test was depending on cdk/scrolling without explicitly specifying
the dependency. This change adds the missing `deps`.
