### PR TITLE
histogram: cast tf.reduce_sum input to float64

### DIFF
--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -119,6 +119,17 @@ class SummaryBaseTest(object):
         buckets = tensor_util.make_ndarray(pb.value[0].tensor)
         self.assertEqual(buckets.shape, (bucket_count, 3))
 
+    def test_with_large_counts(self):
+        # Check for overflow with large count (2^24) of data in float16.
+        large_count = 2 ** 24
+        data = [0] + [1] * large_count
+
+        pb = self.histogram("large_count", data=data, buckets=2)
+        buckets = tensor_util.make_ndarray(pb.value[0].tensor)
+        np.testing.assert_allclose(
+            buckets, np.array([[0, 0.5, 1], [0.5, 1, large_count]])
+        )
+
 
 class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
     def histogram(self, *args, **kwargs):

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -120,10 +120,9 @@ class SummaryBaseTest(object):
         self.assertEqual(buckets.shape, (bucket_count, 3))
 
     def test_with_large_counts(self):
-        # Check for overflow with large count (2^24) of data in float16.
+        # Check for overflow with large count (2^24) of data.
         large_count = 2 ** 24
         data = [0] + [1] * large_count
-
         pb = self.histogram("large_count", data=data, buckets=2)
         buckets = tensor_util.make_ndarray(pb.value[0].tensor)
         np.testing.assert_allclose(

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -214,10 +214,11 @@ def _buckets(data, bucket_count=None):
                     tf.floor(offsets / bucket_width), dtype=tf.int32
                 )
                 clamped_indices = tf.minimum(bucket_indices, bucket_count - 1)
-                # Cast to float64 to prevent overflow beyond limt 2^24 in reduce_sum below.
-                one_hots = tf.cast(
-                    tf.one_hot(clamped_indices, depth=bucket_count),
-                    dtype=tf.float64,
+                # Use float64 instead of float32 to avoid accumulating floating point error
+                # later in tf.reduce_sum when summing more than 2^24 individual `1.0` values.
+                # See https://github.com/tensorflow/tensorflow/issues/51419 for details.
+                one_hots = tf.one_hot(
+                    clamped_indices, depth=bucket_count, dtype=tf.float64
                 )
                 bucket_counts = tf.cast(
                     tf.reduce_sum(input_tensor=one_hots, axis=0),

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -214,7 +214,11 @@ def _buckets(data, bucket_count=None):
                     tf.floor(offsets / bucket_width), dtype=tf.int32
                 )
                 clamped_indices = tf.minimum(bucket_indices, bucket_count - 1)
-                one_hots = tf.one_hot(clamped_indices, depth=bucket_count)
+                # Cast to float64 to prevent overflow beyond limt 2^24 in reduce_sum below.
+                one_hots = tf.cast(
+                    tf.one_hot(clamped_indices, depth=bucket_count),
+                    dtype=tf.float64,
+                )
                 bucket_counts = tf.cast(
                     tf.reduce_sum(input_tensor=one_hots, axis=0),
                     dtype=tf.float64,


### PR DESCRIPTION
This is to avoid the accumulating floating point errors in `tf.reduce_sum` when using `float32` where large sums are truncated to `2^24` as described in https://github.com/tensorflow/tensorflow/issues/36128.

#histogram #tpu