### PR TITLE
cleanup: log as info when no hparams experiment data is found

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -38,6 +38,7 @@ py_library(
         ":error",
         ":metadata",
         ":protos_all_py_pb2",
+        "//tensorboard:errors",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/data:provider",

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -15,7 +15,7 @@
 """Classes and functions for handling the GetExperiment API call."""
 
 
-from tensorboard.plugins.hparams import error
+import logging
 
 
 class Handler(object):
@@ -48,7 +48,7 @@ class Handler(object):
             ),
         )
         if experiment is None:
-            raise error.HParamsError(
+            logging.info(
                 "Can't find an HParams-plugin experiment data in"
                 " the log directory. Note that it takes some time to"
                 " scan the log directory; if you just started"

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -15,7 +15,7 @@
 """Classes and functions for handling the GetExperiment API call."""
 
 
-from tensorboard.plugins.hparams import error
+from tensorboard import errors
 
 
 class Handler(object):
@@ -48,7 +48,7 @@ class Handler(object):
             ),
         )
         if experiment is None:
-            raise error.HParamsError(
+            raise errors.NotFoundError(
                 "Can't find an HParams-plugin experiment data in"
                 " the log directory. Note that it takes some time to"
                 " scan the log directory; if you just started"

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -15,7 +15,7 @@
 """Classes and functions for handling the GetExperiment API call."""
 
 
-import logging
+from tensorboard.plugins.hparams import error
 
 
 class Handler(object):
@@ -48,7 +48,7 @@ class Handler(object):
             ),
         )
         if experiment is None:
-            logging.info(
+            raise error.HParamsError(
                 "Can't find an HParams-plugin experiment data in"
                 " the log directory. Note that it takes some time to"
                 " scan the log directory; if you just started"

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -25,6 +25,7 @@ import json
 import werkzeug
 from werkzeug import wrappers
 
+from tensorboard import errors
 from tensorboard import plugin_util
 from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import backend_context
@@ -106,6 +107,9 @@ class HParamsPlugin(base_plugin.TBPlugin):
         except error.HParamsError as e:
             logger.error("HParams error: %s" % e)
             raise werkzeug.exceptions.BadRequest(description=str(e))
+        except errors.NotFoundError as e:
+            logger.info("HParams not found: %s" % e)
+            raise werkzeug.exceptions.BadRequest(description=str(e))
 
     # ---- /experiment -----------------------------------------------------------
     @wrappers.Request.application
@@ -129,6 +133,9 @@ class HParamsPlugin(base_plugin.TBPlugin):
             )
         except error.HParamsError as e:
             logger.error("HParams error: %s" % e)
+            raise werkzeug.exceptions.BadRequest(description=str(e))
+        except errors.NotFoundError as e:
+            logger.info("HParams not found: %s" % e)
             raise werkzeug.exceptions.BadRequest(description=str(e))
 
     # ---- /session_groups -------------------------------------------------------

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -95,6 +95,10 @@ class HParamsPlugin(base_plugin.TBPlugin):
             experiment = get_experiment.Handler(
                 ctx, self._context, experiment_id
             ).run()
+            if not experiment:
+                raise werkzeug.exceptions.BadRequest(
+                    description="Failed to load HParams-plugin experiment data."
+                )
             body, mime_type = download_data.Handler(
                 self._context,
                 experiment,
@@ -117,12 +121,17 @@ class HParamsPlugin(base_plugin.TBPlugin):
             # we must advance the input stream to skip them -- otherwise the next HTTP
             # request will be parsed incorrectly.
             _ = _parse_request_argument(request, api_pb2.GetExperimentRequest)
+            experiment = get_experiment.Handler(
+                ctx, self._context, experiment_id
+            ).run()
+            if not experiment:
+                raise werkzeug.exceptions.BadRequest(
+                    description="Failed to load HParams-plugin experiment data."
+                )
             return http_util.Respond(
                 request,
                 json_format.MessageToJson(
-                    get_experiment.Handler(
-                        ctx, self._context, experiment_id
-                    ).run(),
+                    experiment,
                     including_default_value_fields=True,
                 ),
                 "application/json",

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -95,10 +95,6 @@ class HParamsPlugin(base_plugin.TBPlugin):
             experiment = get_experiment.Handler(
                 ctx, self._context, experiment_id
             ).run()
-            if not experiment:
-                raise werkzeug.exceptions.BadRequest(
-                    description="Failed to load HParams-plugin experiment data."
-                )
             body, mime_type = download_data.Handler(
                 self._context,
                 experiment,
@@ -121,17 +117,12 @@ class HParamsPlugin(base_plugin.TBPlugin):
             # we must advance the input stream to skip them -- otherwise the next HTTP
             # request will be parsed incorrectly.
             _ = _parse_request_argument(request, api_pb2.GetExperimentRequest)
-            experiment = get_experiment.Handler(
-                ctx, self._context, experiment_id
-            ).run()
-            if not experiment:
-                raise werkzeug.exceptions.BadRequest(
-                    description="Failed to load HParams-plugin experiment data."
-                )
             return http_util.Respond(
                 request,
                 json_format.MessageToJson(
-                    experiment,
+                    get_experiment.Handler(
+                        ctx, self._context, experiment_id
+                    ).run(),
                     including_default_value_fields=True,
                 ),
                 "application/json",

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -109,6 +109,7 @@ class HParamsPlugin(base_plugin.TBPlugin):
             raise werkzeug.exceptions.BadRequest(description=str(e))
         except errors.NotFoundError as e:
             logger.info("HParams not found: %s" % e)
+            # TODO(#5347): Return 200 instead of 400 when there's no hparams data.
             raise werkzeug.exceptions.BadRequest(description=str(e))
 
     # ---- /experiment -----------------------------------------------------------
@@ -136,6 +137,7 @@ class HParamsPlugin(base_plugin.TBPlugin):
             raise werkzeug.exceptions.BadRequest(description=str(e))
         except errors.NotFoundError as e:
             logger.info("HParams not found: %s" % e)
+            # TODO(#5347): Return 200 instead of 400 when there's no hparams data.
             raise werkzeug.exceptions.BadRequest(description=str(e))
 
     # ---- /session_groups -------------------------------------------------------


### PR DESCRIPTION
Reduce non-essential errors in the logs for easier debugging. 

`"HParams error: Can't find an HParams-plugin experiment data in the log directory. Note that it takes some time to scan the log directory; if you just started Tensorboard it could be that we haven't finished scanning it yet. Consider trying again in a few seconds."` should be logged at `INFO` level.

Tested sync locally. 

Googlers, see [issue](https://b.corp.google.com/issues/199306961) for more context.

#onduty