### PR TITLE
run selector: subdue violent exception when hparams are invalid

### DIFF
--- a/tensorboard/webapp/hparams/_redux/utils.ts
+++ b/tensorboard/webapp/hparams/_redux/utils.ts
@@ -92,9 +92,17 @@ export function combineDefaultHparamFilters(
     {minValue, maxValue, filterLowerValue, filterUpperValue},
   ] of intervalHparamsBounds) {
     if (combinedHparams.has(name)) {
-      throw new RangeError(
-        `Cannot combine hparam, ${name}, as it is of mixed types.`
-      );
+      const existingHparam = combinedHparams.get(name)!;
+      // Reconcile incompatible filters if discrete one is empty or has
+      // empty values.
+      if (
+        existingHparam.type === DomainType.DISCRETE &&
+        existingHparam.possibleValues.some((value) => value)
+      ) {
+        throw new RangeError(
+          `Cannot combine hparam, ${name}, as it is of mixed types.`
+        );
+      }
     }
 
     combinedHparams.set(name, {

--- a/tensorboard/webapp/hparams/_redux/utils_test.ts
+++ b/tensorboard/webapp/hparams/_redux/utils_test.ts
@@ -232,7 +232,7 @@ describe('hparams/_redux/utils test', () => {
       ).toThrow();
     });
 
-    it('does not throw there exists a conflicting hparam that only has empty values', () => {
+    it('does not throw if there exists a conflicting hparam that only has empty values', () => {
       expect(() =>
         combineDefaultHparamFilters([
           new Map([

--- a/tensorboard/webapp/hparams/_redux/utils_test.ts
+++ b/tensorboard/webapp/hparams/_redux/utils_test.ts
@@ -231,6 +231,55 @@ describe('hparams/_redux/utils test', () => {
         ])
       ).toThrow();
     });
+
+    it('does not throw there exists a conflicting hparam that only has empty values', () => {
+      expect(() =>
+        combineDefaultHparamFilters([
+          new Map([
+            ['foo', buildDiscreteFilter({possibleValues: ['', 'bar']})],
+          ]),
+          new Map([
+            [
+              'foo',
+              buildIntervalFilter({
+                filterLowerValue: -100,
+                filterUpperValue: 100,
+              }),
+            ],
+          ]),
+        ])
+      ).toThrow();
+
+      expect(() =>
+        combineDefaultHparamFilters([
+          new Map([['foo', buildDiscreteFilter({possibleValues: ['']})]]),
+          new Map([
+            [
+              'foo',
+              buildIntervalFilter({
+                filterLowerValue: -100,
+                filterUpperValue: 100,
+              }),
+            ],
+          ]),
+        ])
+      ).not.toThrow();
+
+      expect(() =>
+        combineDefaultHparamFilters([
+          new Map([['foo', buildDiscreteFilter({possibleValues: []})]]),
+          new Map([
+            [
+              'foo',
+              buildIntervalFilter({
+                filterLowerValue: -100,
+                filterUpperValue: 100,
+              }),
+            ],
+          ]),
+        ])
+      ).not.toThrow();
+    });
   });
 
   describe('combineDefaultMetricFilters', () => {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -22,7 +22,6 @@ import {
 import {createSelector, Store} from '@ngrx/store';
 import {combineLatest, Observable, of, Subject} from 'rxjs';
 import {
-  combineLatestWith,
   filter,
   map,
   shareReplay,
@@ -473,36 +472,40 @@ export class RunsTableContainer implements OnInit, OnDestroy {
           );
         });
       }),
-      combineLatestWith(
-        this.store.select(
-          hparamsSelectors.getHparamFilterMap,
-          this.experimentIds
-        ),
-        this.store.select(
-          hparamsSelectors.getMetricFilterMap,
-          this.experimentIds
-        )
-      ),
-      map(([items, hparamFilters, metricFilters]) => {
+      switchMap((items) => {
         if (!this.showHparamsAndMetrics) {
-          return items;
+          return of(items);
         }
-        return items.filter(({hparams, metrics}) => {
-          const hparamMatches = [...hparamFilters.entries()].every(
-            ([hparamName, filter]) => {
-              const value = hparams.get(hparamName);
-              return matchFilter(filter, value);
-            }
-          );
 
-          return (
-            hparamMatches &&
-            [...metricFilters.entries()].every(([metricTag, filter]) => {
-              const value = metrics.get(metricTag);
-              return matchFilter(filter, value);
-            })
-          );
-        });
+        return combineLatest(
+          this.store.select(
+            hparamsSelectors.getHparamFilterMap,
+            this.experimentIds
+          ),
+          this.store.select(
+            hparamsSelectors.getMetricFilterMap,
+            this.experimentIds
+          )
+        ).pipe(
+          map(([hparamFilters, metricFilters]) => {
+            return items.filter(({hparams, metrics}) => {
+              const hparamMatches = [...hparamFilters.entries()].every(
+                ([hparamName, filter]) => {
+                  const value = hparams.get(hparamName);
+                  return matchFilter(filter, value);
+                }
+              );
+
+              return (
+                hparamMatches &&
+                [...metricFilters.entries()].every(([metricTag, filter]) => {
+                  const value = metrics.get(metricTag);
+                  return matchFilter(filter, value);
+                })
+              );
+            });
+          })
+        );
       })
     );
   }

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -2133,6 +2133,65 @@ describe('runs_table', () => {
       ]);
     });
 
+    it('does not load the hparams filter when it is off', () => {
+      const selectSpy = spyOn(store, 'select').and.callThrough();
+      const hparamSpecs = [
+        buildHparamSpec({
+          name: 'batch_size',
+          displayName: 'Batch size',
+          domain: {type: DomainType.INTERVAL, minValue: 16, maxValue: 128},
+        }),
+        buildHparamSpec({
+          name: 'dropout',
+          displayName: '',
+          domain: {type: DomainType.INTERVAL, minValue: 0.3, maxValue: 0.8},
+        }),
+      ];
+      const metricSpecs = [
+        buildMetricSpec({tag: 'acc', displayName: 'Accuracy'}),
+        buildMetricSpec({tag: 'loss', displayName: ''}),
+      ];
+
+      selectSpy
+        .withArgs(hparamsSelectors.getHparamFilterMap, jasmine.any(String))
+        .and.throwError('Should not be read');
+      selectSpy
+        .withArgs(hparamsSelectors.getMetricFilterMap, jasmine.any(String))
+        .and.throwError('Should not be read');
+
+      store.overrideSelector(getRuns, [
+        buildRun({
+          id: 'book1',
+          name: 'Book 1',
+          hparams: [{name: 'batch_size', value: 32}],
+        }),
+        buildRun({
+          id: 'book2',
+          name: 'Book 2',
+          hparams: [
+            {name: 'batch_size', value: 128},
+            {name: 'dropout', value: 0.3},
+          ],
+          metrics: [{tag: 'acc', value: 0.91}],
+        }),
+        buildRun({
+          id: 'book3',
+          name: 'Book 3',
+          metrics: [
+            {tag: 'acc', value: 0.7},
+            {tag: 'loss', value: 0},
+          ],
+        }),
+      ]);
+
+      const fixture = createComponent(hparamSpecs, metricSpecs, false);
+      expect(getTableRowTextContent(fixture)).toEqual([
+        ['Book 1'],
+        ['Book 2'],
+        ['Book 3'],
+      ]);
+    });
+
     describe('filtering', () => {
       let TEST_HPARAM_SPECS: HparamSpec[];
       let TEST_METRIC_SPECS: MetricSpec[];


### PR DESCRIPTION
When hparams specs in comparison mode are not compatible (e.g., an
experiment has Discrete one while for the same name another experiment
has Interval one), we currently throw a RangeError. That error manifests
as very violent error that breaks entire app and make the TimeSeries
plugin not functional. Since TimeSeries does not really render hparams,
it does not make sense for this error to so violently throw error. Now,
with this change, we do not even read the hparams value when in
TimeSeries.

Also, as a bonus, we have relaxed the constraint a bit and try to
reconcile with incompatible filters if any of the compatible ones are
empty.
