### PR TITLE
sync: change data-id binding to attribute

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1614,8 +1614,8 @@ describe('metrics main view', () => {
         expect(card2IndicatorBefore.nativeElement).not.toBe(
           card2IndicatorAfter.nativeElement
         );
-        expect(card2IndicatorBefore.properties['data-id']).not.toBe(
-          card2IndicatorAfter.properties['data-id']
+        expect(card2IndicatorBefore.attributes['data-id']).not.toBe(
+          card2IndicatorAfter.attributes['data-id']
         );
       });
 

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
@@ -30,7 +30,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
         >
         <span
           *ngFor="let id of newCardPinnedIds"
-          [data-id]="id"
+          [attr.data-id]="id"
           class="new-card-pinned"
           >New card pinned</span
         >


### PR DESCRIPTION
We added the `[data-id]` on a span to uniquely identify a DOM newly
stamped when new pin gets pinned. Bucause AOT Angular compiler complains
about binding to a property in `<span>`, we are instead explicitly
binding to `data-id` attribute on the DOM instead.
