### PR TITLE
histogram: add back the test for large counts

### DIFF
--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -112,6 +112,7 @@ py_library(
 
 py_test(
     name = "summary_test",
+    # Ensure enough RAM for test_with_large_counts.
     size = "medium",
     srcs = ["summary_test.py"],
     main = "summary_test.py",

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -112,7 +112,7 @@ py_library(
 
 py_test(
     name = "summary_test",
-    size = "small",
+    size = "medium",
     srcs = ["summary_test.py"],
     main = "summary_test.py",
     srcs_version = "PY3",

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -122,10 +122,12 @@ class SummaryBaseTest(object):
     def test_with_large_counts(self):
         # Check for accumulating floating point errors with large counts (> 2^24).
         # See https://github.com/tensorflow/tensorflow/issues/51419 for details.
-        # TODO(ytjing): add a test for counts > 2^24.
-        self.skipTest(
-            "TODO(#36128): figure out how to test without segmentation fault in sync"
-        )
+        large_count = 20_000_000
+        data = [0] + [1] * large_count
+        pb = self.histogram("large_count", data=data, buckets=2)
+        buckets = tensor_util.make_ndarray(pb.value[0].tensor)
+        self.assertEqual(buckets[0][2], 1)
+        self.assertEqual(buckets[1][2], large_count)
 
 
 class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):


### PR DESCRIPTION
This reverts commit 9529cf7dce77c5928ee1f80e841e3703ba3fe70d.

Also increase the summary_test size from `small` to `medium` to get more RAM. 

Tested the sync locally.

#histogram #tpu