### PR TITLE
runs table: fix color-picker position

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -254,7 +254,6 @@ limitations under the License.
             [style.background]="item.runColor"
             [colorPicker]="item.runColor"
             [cpDialogDisplay]="'popup'"
-            [cpPosition]="'bottom-right'"
             [cpPositionOffset]="-20"
             [cpUseRootViewContainer]="true"
             [cpOutputFormat]="'hex'"

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -223,6 +223,11 @@ $tb-dark-theme: map_merge(
   // Include all theme-styles for the components based on the current theme.
   @include angular-material-theme($tb-theme);
 
+  body {
+    // Prevents ngx-color-picker from creating a scrollbar and misposition.
+    overflow: hidden;
+  }
+
   // Prevent color-picker from briefly showing scrollbar when calculating its
   // position.
   .cdk-overlay-container {


### PR DESCRIPTION
ngx-color-picker is capable of automatically position w.r.t. the view
port. However, because:
1. we hard coded "bottom-right" position, and
2. we had flicker of color-picker positioning incorrectly in the
viewport because of lack of `overflow: hidden`

it miscalculated the dialog's position and free space w.r.t. to the view
port. By putting the `overflow`, it knows to only take available pixels
in the view port (instead of making the page scrollable and think that
there exists more space below the view port) into account.

Previous:
![image](https://user-images.githubusercontent.com/2547313/135171659-7b8843fa-082e-47d4-9c3d-69641c6ec164.png)

New:
![image](https://user-images.githubusercontent.com/2547313/135171693-c1917a66-0446-4dbf-828b-198c9c7dffc4.png)
