### PR TITLE
runs-table: do not match against exp name

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -1525,7 +1525,7 @@ describe('runs_table', () => {
         rowling: 'HPz',
         tolkien: 'LotR',
       });
-      store.overrideSelector(getRunSelectorRegexFilter, 'ings');
+      store.overrideSelector(getRunSelectorRegexFilter, 'ing');
 
       const fixture = createComponent(
         ['rowling', 'tolkien'],
@@ -1535,7 +1535,6 @@ describe('runs_table', () => {
       fixture.detectChanges();
       expect(getTableRowTextContent(fixture)).toEqual([
         ['LotR', 'The Fellowship of the Ring'],
-        ['LotR', 'The Silmarillion'],
       ]);
 
       // Alias for Harry Potter contains "z". Since legacy Polymer-based

--- a/tensorboard/webapp/util/matcher.ts
+++ b/tensorboard/webapp/util/matcher.ts
@@ -27,7 +27,7 @@ export interface RunMatchable {
  *
  * - Regex matches name of a run.
  * - When `shouldMatchExperiment` is specified, it matches regex against one of
- *   experiment name, experiment alias, and legacy run name which is generated
+ *   experiment alias, and legacy run name which is generated
  *   with "<exp alias>/<run name>".
  * - An empty regex string always returns true.
  * - Invalid regex always return false.
@@ -51,7 +51,6 @@ export function matchRunToRegex(
   const matchables = [runMatchable.runName];
   if (shouldMatchExperiment) {
     matchables.push(
-      runMatchable.experimentName,
       runMatchable.experimentAlias,
       `${runMatchable.experimentAlias}/${runMatchable.runName}`
     );

--- a/tensorboard/webapp/util/matcher_test.ts
+++ b/tensorboard/webapp/util/matcher_test.ts
@@ -45,23 +45,6 @@ describe('matcher test', () => {
     });
 
     describe('shouldMatchExperiment flag', () => {
-      it('matches against experimentName when flag is on', () => {
-        expect(
-          matchRunToRegex(
-            buildRunWithName({runName: 'faaaaro', experimentName: 'hello'}),
-            'lo$',
-            true
-          )
-        ).toBe(true);
-        expect(
-          matchRunToRegex(
-            buildRunWithName({runName: 'faaaaro', experimentName: 'hello'}),
-            'lo$',
-            false
-          )
-        ).toBe(false);
-      });
-
       it('matches against experimentAlias when flag is on', () => {
         expect(
           matchRunToRegex(


### PR DESCRIPTION
Runs table, when in comparison mode, is capable of rendering experiment
alias and show the full experiment name in the hover text. However,
because we are matching regex against experiment name that is not
visible without a user interaction, the match is quite surprising and is
surprising users.

This change removes an ability to match against the experiment name.
