### PR TITLE
Add owner field to experiment proto.

### DIFF
--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -33,9 +33,9 @@ message Experiment {
   // experiment, across all time series, including estimated overhead.
   // Output-only.
   int64 total_blob_bytes = 10;
-  // The owner of this experiment.  This field is ignored on upload, with owner
-  // information coming from the authentication information passed alongside
-  // the proto.
+  // The owner of this experiment, as an opaque user_id string.  This field is
+  // ignored on upload, with owner information coming from the authentication
+  // information passed alongside the proto.
   string owner = 11;
 }
 

--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -33,6 +33,10 @@ message Experiment {
   // experiment, across all time series, including estimated overhead.
   // Output-only.
   int64 total_blob_bytes = 10;
+  // The owner of this experiment.  This field is ignored on upload, with owner
+  // information coming from the authentication information passed alongside
+  // the proto.
+  string owner = 11;
 }
 
 // Field mask for `Experiment` used in get and update RPCs. The `experiment_id`
@@ -49,4 +53,5 @@ message ExperimentMask {
   bool description = 8;
   bool total_tensor_bytes = 9;
   bool total_blob_bytes = 10;
+  bool owner = 11;
 }

--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 export declare interface Experiment {
   id: string;
-  repository_id?: string;
   name: string;
   start_time: number;
   owner?: string;

--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -14,9 +14,9 @@ limitations under the License.
 ==============================================================================*/
 export declare interface Experiment {
   id: string;
+  repository_id?: string;
   name: string;
   start_time: number;
-  repository_id?: string;
   owner?: string;
   description?: string;
   hparams?: string;

--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -16,6 +16,7 @@ export declare interface Experiment {
   id: string;
   name: string;
   start_time: number;
+  repository_id?: string;
   owner?: string;
   description?: string;
   hparams?: string;


### PR DESCRIPTION
* Motivation for features / changes
Features under development for TensorBoard.dev require access to the owner of an experiment.   The cleanest way to return this information is to plumb it through the call stack using the Experiment proto.  This is more future proof and correct against various other features compared to re-injecting the current user into an owner field at a higher level of the stack.

* Technical description of changes
Addition of the owner field (string) to the Experiment proto and the corresponding bool to the mask.
Note: this changes nothing on the write path, during upload we still only use the authentication credentials on the rpc call and this new field would be ignored -- we don't populate it ourselves and if someone else did, we'd still ignore it.
