### PR TITLE
hparams: treat no data as an empty experiment rather than an error

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -38,7 +38,6 @@ py_library(
         ":error",
         ":metadata",
         ":protos_all_py_pb2",
-        "//tensorboard:errors",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/data:provider",

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -70,7 +70,7 @@ class Context(object):
         Returns:
           The experiment protobuffer. If no tags are found from which an experiment
           protobuffer can be built (possibly, because the event data has not been
-          completely loaded yet), returns None.
+          completely loaded yet), returns an entirely empty experiment.
         """
         experiment = self._find_experiment_tag(hparams_run_to_tag_to_content)
         if experiment:
@@ -177,14 +177,17 @@ class Context(object):
     def _compute_experiment_from_runs(
         self, ctx, experiment_id, hparams_run_to_tag_to_content
     ):
-        """Computes a minimal Experiment protocol buffer by scanning the
-        runs."""
+        """Computes a minimal Experiment protocol buffer by scanning the runs.
+
+        Returns an empty Experiment if there are no hparam infos logged.
+        """
         hparam_infos = self._compute_hparam_infos(hparams_run_to_tag_to_content)
-        if not hparam_infos:
-            return None
-        metric_infos = self._compute_metric_infos(
-            ctx, experiment_id, hparams_run_to_tag_to_content
-        )
+        if hparam_infos:
+            metric_infos = self._compute_metric_infos(
+                ctx, experiment_id, hparams_run_to_tag_to_content
+            )
+        else:
+            metric_infos = []
         return api_pb2.Experiment(
             hparam_infos=hparam_infos, metric_infos=metric_infos
         )

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -360,6 +360,19 @@ class BackendContextTest(tf.test.TestCase):
         _canonicalize_experiment(actual_exp)
         self.assertProtoEquals(expected_exp, actual_exp)
 
+    def test_experiment_without_any_hparams_summaries(self):
+        ctxt = backend_context.Context(
+            self._mock_tb_context, max_domain_discrete_len=1
+        )
+        request_ctx = context.RequestContext()
+        actual_exp = ctxt.experiment_from_metadata(
+            request_ctx,
+            "123",
+            ctxt.hparams_metadata(request_ctx, "123"),
+        )
+        self.assertIsInstance(actual_exp, api_pb2.Experiment)
+        self.assertProtoEquals("", actual_exp)
+
     def _serialized_plugin_data(self, data_oneof_field, text_protobuffer):
         oneof_type_dict = {
             DATA_TYPE_EXPERIMENT: api_pb2.Experiment,

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -15,9 +15,6 @@
 """Classes and functions for handling the GetExperiment API call."""
 
 
-from tensorboard import errors
-
-
 class Handler(object):
     """Handles a GetExperiment request."""
 
@@ -40,20 +37,10 @@ class Handler(object):
           An Experiment object.
         """
         experiment_id = self._experiment_id
-        experiment = self._backend_context.experiment_from_metadata(
+        return self._backend_context.experiment_from_metadata(
             self._request_context,
             experiment_id,
             self._backend_context.hparams_metadata(
                 self._request_context, experiment_id
             ),
         )
-        if experiment is None:
-            raise errors.NotFoundError(
-                "Can't find an HParams-plugin experiment data in"
-                " the log directory. Note that it takes some time to"
-                " scan the log directory; if you just started"
-                " Tensorboard it could be that we haven't finished"
-                " scanning it yet. Consider trying again in a"
-                " few seconds."
-            )
-        return experiment

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -25,7 +25,6 @@ import json
 import werkzeug
 from werkzeug import wrappers
 
-from tensorboard import errors
 from tensorboard import plugin_util
 from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import backend_context
@@ -107,10 +106,6 @@ class HParamsPlugin(base_plugin.TBPlugin):
         except error.HParamsError as e:
             logger.error("HParams error: %s" % e)
             raise werkzeug.exceptions.BadRequest(description=str(e))
-        except errors.NotFoundError as e:
-            logger.info("HParams not found: %s" % e)
-            # TODO(#5347): Return 200 instead of 400 when there's no hparams data.
-            raise werkzeug.exceptions.BadRequest(description=str(e))
 
     # ---- /experiment -----------------------------------------------------------
     @wrappers.Request.application
@@ -134,10 +129,6 @@ class HParamsPlugin(base_plugin.TBPlugin):
             )
         except error.HParamsError as e:
             logger.error("HParams error: %s" % e)
-            raise werkzeug.exceptions.BadRequest(description=str(e))
-        except errors.NotFoundError as e:
-            logger.info("HParams not found: %s" % e)
-            # TODO(#5347): Return 200 instead of 400 when there's no hparams data.
             raise werkzeug.exceptions.BadRequest(description=str(e))
 
     # ---- /session_groups -------------------------------------------------------


### PR DESCRIPTION
Fixes #5347.

This updates the HParams plugin's `Context.experiment_from_metadata()` to always return an `Experiment` proto, regardless of whether there are any HParams summaries.  The experiment computation already has logic that handles the case where no experiment-level HParams summary was logged by synthesizing an experiment from the existing session-level summaries (which results in an experiment with hparam and metric infos, but no name, description, user, or started time).  This PR simply adjusts that logic so that we return the synthetic experiment even when there are no session-level summaries, in which case we return empty hparam and metric info repeated fields as well.

This is done to address #5347 and ensure that the HParams endpoints don't return 400 errors for the common and normal situation in which there are no hparams summaries logged; instead they will now return 200 OK and an appropriately empty response.  Note that the HParams plugin `is_active()` will already have prevented the HParams plugin from showing up as active in this case, but this ensures those errors aren't thrown if the user manually navigates to it in the INACTIVE menu, or if other parts of the app were to invoke those endpoints unconditionally.

Test plan:

- Added a unit test to backend_context_test.py
- Tested internally, see cl/395956617
- Tested running TB with this PR on a logdir with no hparams summaries. UI still shows the expected `No hparams data was found.` message. The only visible difference is that now that it's not an error, we do load session groups, and thus show that 0 session groups were loaded, making this page "1 / 0", and we show the download as CSV/JSON/TEX links (which result in empty files, see below). If we really care, we could update the HParams frontend in `tf-hparams-query-pane.ts` to check for this case, but it doesn't seem all that important to me.
- Confirmed endpoints don't raise errors
    - `/experiment` returns
        ```
        {
          "name": "",
          "description": "",
          "user": "",
          "timeCreatedSecs": 0.0,
          "hparamInfos": [],
          "metricInfos": []
        }
        ```
    - `/session_groups` returns
        ```
        {
          "sessionGroups": [],
          "totalSize": 0
        }
        ```
    - `/download_data` CSV returns `\r\n`
    - `/download_data` JSON returns `{"header": [], "rows": []}`
    - `/download_data` TEX returns
        ```
        \begin{table}[tbp]
        \begin{tabular}{}
         \\ \hline
        \hline
        \end{tabular}
        \end{table}
        ```