### PR TITLE
time series: move settings pane opened state to store

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -31,6 +31,14 @@ import {
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
+export const metricsSettingsPaneClosed = createAction(
+  '[Metrics] Metrics Settings Pane Closed'
+);
+
+export const metricsSettingsPaneToggled = createAction(
+  '[Metrics] Metrics Settings Pane Toggled'
+);
+
 export const metricsTagMetadataRequested = createAction(
   '[Metrics] Metrics Tag Metadata Requested'
 );

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -262,6 +262,7 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState<
     },
   },
   {
+    isSettingsPaneOpen: true,
     promoteTimeSeries: true,
     timeSeriesData: {
       scalars: {},
@@ -915,6 +916,12 @@ const reducer = createReducer(
   }),
   on(actions.metricsPromoDismissed, (state) => {
     return {...state, promoteTimeSeries: false};
+  }),
+  on(actions.metricsSettingsPaneToggled, (state) => {
+    return {...state, isSettingsPaneOpen: !state.isSettingsPaneOpen};
+  }),
+  on(actions.metricsSettingsPaneClosed, (state) => {
+    return {...state, isSettingsPaneOpen: false};
   })
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2179,4 +2179,32 @@ describe('metrics reducers', () => {
       expect(after.promoteTimeSeries).toBe(false);
     });
   });
+
+  describe('#metricsSettingsPaneToggled', () => {
+    it('toggles the settings pane opened state', () => {
+      const state1 = buildMetricsState({
+        isSettingsPaneOpen: false,
+      });
+
+      const state2 = reducers(state1, actions.metricsSettingsPaneToggled());
+      expect(state2.isSettingsPaneOpen).toBe(true);
+
+      const state3 = reducers(state2, actions.metricsSettingsPaneToggled());
+      expect(state3.isSettingsPaneOpen).toBe(false);
+    });
+  });
+
+  describe('#metricsSettingsPaneClosed', () => {
+    it('sets false to the settings pane opened state', () => {
+      const state1 = buildMetricsState({
+        isSettingsPaneOpen: true,
+      });
+
+      const state2 = reducers(state1, actions.metricsSettingsPaneClosed());
+      expect(state2.isSettingsPaneOpen).toBe(false);
+
+      const state3 = reducers(state2, actions.metricsSettingsPaneClosed());
+      expect(state3.isSettingsPaneOpen).toBe(false);
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -429,3 +429,8 @@ export const getPromoteTimeSeries = createSelector(
     return state.promoteTimeSeries;
   }
 );
+
+export const isMetricsSettingsPaneOpen = createSelector(
+  selectMetricsState,
+  (state): boolean => state.isSettingsPaneOpen
+);

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -200,6 +200,7 @@ export interface MetricsSettings {
 export interface MetricsRoutelessState {
   promoteTimeSeries: boolean;
   timeSeriesData: TimeSeriesData;
+  isSettingsPaneOpen: boolean;
   // Default settings. For the legacy reasons, we cannot change the name of the
   // prop. It either is set by application or a user via settings storage.
   settings: MetricsSettings;

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -98,6 +98,7 @@ function buildBlankState(): MetricsState {
     filteredPluginTypes: new Set(),
     stepMinMax: {min: Infinity, max: -Infinity},
     promoteTimeSeries: false,
+    isSettingsPaneOpen: false,
   };
 }
 

--- a/tensorboard/webapp/metrics/views/main_view/main_view_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_container.ts
@@ -19,11 +19,17 @@ import {map, takeWhile} from 'rxjs/operators';
 
 import {State} from '../../../app_state';
 import {DataLoadState} from '../../../types/data';
-import {metricsShowAllPlugins, metricsToggleVisiblePlugin} from '../../actions';
+import {
+  metricsSettingsPaneToggled,
+  metricsSettingsPaneClosed,
+  metricsShowAllPlugins,
+  metricsToggleVisiblePlugin,
+} from '../../actions';
 import {
   getMetricsFilteredPluginTypes,
   getMetricsTagFilter,
   getMetricsTagMetadataLoadState,
+  isMetricsSettingsPaneOpen,
 } from '../../store';
 import {PluginType} from '../../types';
 
@@ -32,7 +38,7 @@ import {PluginType} from '../../types';
   template: `
     <metrics-main-view-component
       [showFilteredView]="showFilteredView$ | async"
-      [isSidepaneOpen]="isSidepaneOpen"
+      [isSidepaneOpen]="isSidepaneOpen$ | async"
       [initialTagsLoading]="initialTagsLoading$ | async"
       [filteredPluginTypes]="filteredPluginTypes$ | async"
       (onSettingsButtonClicked)="onSettingsButtonClicked()"
@@ -46,7 +52,9 @@ import {PluginType} from '../../types';
 export class MainViewContainer {
   constructor(private readonly store: Store<State>) {}
 
-  isSidepaneOpen = true;
+  readonly isSidepaneOpen$: Observable<boolean> = this.store.select(
+    isMetricsSettingsPaneOpen
+  );
 
   readonly initialTagsLoading$: Observable<boolean> = this.store
     .select(getMetricsTagMetadataLoadState)
@@ -76,11 +84,11 @@ export class MainViewContainer {
   );
 
   onSettingsButtonClicked() {
-    this.isSidepaneOpen = !this.isSidepaneOpen;
+    this.store.dispatch(metricsSettingsPaneToggled());
   }
 
   onCloseSidepaneButtonClicked() {
-    this.isSidepaneOpen = false;
+    this.store.dispatch(metricsSettingsPaneClosed());
   }
 
   onPluginVisibilityToggled(plugin: PluginType) {

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -197,6 +197,7 @@ describe('metrics main view', () => {
       state: DataLoadState.NOT_LOADED,
       lastLoadedTimeInMs: null,
     });
+    store.overrideSelector(selectors.isMetricsSettingsPaneOpen, false);
   });
 
   describe('toolbar', () => {
@@ -1655,27 +1656,33 @@ describe('metrics main view', () => {
   });
 
   describe('sidepane', () => {
-    it('settings button should toggle side pane', () => {
+    it('renders settings pane opened when store says it is opened', () => {
+      store.overrideSelector(selectors.isMetricsSettingsPaneOpen, true);
       const fixture = TestBed.createComponent(MainViewContainer);
       fixture.detectChanges();
 
       expect(fixture.debugElement.query(By.css('.sidebar'))).toBeTruthy();
 
+      store.overrideSelector(selectors.isMetricsSettingsPaneOpen, false);
+      store.refreshState();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.sidebar'))).toBeFalsy();
+    });
+
+    it('fires action when toggling a gear button', () => {
+      const fixture = TestBed.createComponent(MainViewContainer);
+      fixture.detectChanges();
+
       const settingsButton = fixture.debugElement.query(
         By.css('[aria-label="Toggle settings side pane"]')
       );
       settingsButton.nativeElement.click();
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.query(By.css('.sidebar'))).not.toBeTruthy();
-
-      settingsButton.nativeElement.click();
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.query(By.css('.sidebar'))).toBeTruthy();
+      expect(dispatchedActions).toEqual([actions.metricsSettingsPaneToggled()]);
     });
 
-    it('closes upon clicking the sidepane close button', () => {
+    it('dispatches closed action when clicked on sidepane close button', () => {
+      store.overrideSelector(selectors.isMetricsSettingsPaneOpen, true);
       const fixture = TestBed.createComponent(MainViewContainer);
       fixture.detectChanges();
 
@@ -1685,9 +1692,8 @@ describe('metrics main view', () => {
         By.css('[aria-label="Close side pane"]')
       );
       closeButton.nativeElement.click();
-      fixture.detectChanges();
 
-      expect(fixture.debugElement.query(By.css('.sidebar'))).not.toBeTruthy();
+      expect(dispatchedActions).toEqual([actions.metricsSettingsPaneClosed()]);
     });
   });
 });


### PR DESCRIPTION
This change refactors so that the settings pane opened state is moved to
the Redux store instead of Angular container.

Besides the refactor, there are no functional changes.
