### PR TITLE
refactor: move settings template in to html

### DIFF
--- a/tensorboard/webapp/settings/_views/BUILD
+++ b/tensorboard/webapp/settings/_views/BUILD
@@ -14,6 +14,7 @@ tf_ng_module(
     ],
     assets = [
         "settings_dialog_component.css",
+        "settings_dialog_component.ng.html",
     ],
     deps = [
         "//tensorboard/webapp:tb_polymer_interop_types",

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.ng.html
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.ng.html
@@ -1,0 +1,57 @@
+<!--
+@license
+Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<h3>Settings</h3>
+<div>
+  <div class="reload-toggle">
+    <mat-checkbox [checked]="reloadEnabled" (change)="onReloadToggle()"
+      >Reload data</mat-checkbox
+    >
+  </div>
+  <div>
+    <mat-form-field>
+      <input
+        class="reload-period"
+        matInput
+        type="number"
+        placeholder="Reload Period"
+        [formControl]="reloadPeriodControl"
+      />
+    </mat-form-field>
+    <mat-error
+      *ngIf="
+            reloadPeriodControl.hasError('min') ||
+            reloadPeriodControl.hasError('required')
+          "
+    >
+      Reload period has to be minimum of {{ MIN_RELOAD_PERIOD_IN_S }} seconds.
+    </mat-error>
+  </div>
+</div>
+<div>
+  <mat-form-field>
+    <input
+      class="page-size"
+      matInput
+      type="number"
+      placeholder="Pagination Limit"
+      [formControl]="paginationControl"
+    />
+  </mat-form-field>
+  <mat-error *ngIf="paginationControl.invalid">
+    Page size has to be a positive integer.
+  </mat-error>
+</div>

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.ts
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.ts
@@ -45,50 +45,7 @@ export function createIntegerValidator(): ValidatorFn {
 
 @Component({
   selector: 'settings-dialog-component',
-  template: `
-    <h3>Settings</h3>
-    <div>
-      <div class="reload-toggle">
-        <mat-checkbox [checked]="reloadEnabled" (change)="onReloadToggle()"
-          >Reload data</mat-checkbox
-        >
-      </div>
-      <div>
-        <mat-form-field>
-          <input
-            class="reload-period"
-            matInput
-            type="number"
-            placeholder="Reload Period"
-            [formControl]="reloadPeriodControl"
-          />
-        </mat-form-field>
-        <mat-error
-          *ngIf="
-            reloadPeriodControl.hasError('min') ||
-            reloadPeriodControl.hasError('required')
-          "
-        >
-          Reload period has to be minimum of
-          {{ MIN_RELOAD_PERIOD_IN_S }} seconds.
-        </mat-error>
-      </div>
-    </div>
-    <div>
-      <mat-form-field>
-        <input
-          class="page-size"
-          matInput
-          type="number"
-          placeholder="Pagination Limit"
-          [formControl]="paginationControl"
-        />
-      </mat-form-field>
-      <mat-error *ngIf="paginationControl.invalid">
-        Page size has to be a positive integer.
-      </mat-error>
-    </div>
-  `,
+  templateUrl: 'settings_dialog_component.ng.html',
   styleUrls: ['./settings_dialog_component.css'],
 })
 export class SettingsDialogComponent implements OnInit, OnDestroy, OnChanges {


### PR DESCRIPTION
We have plans to add more features to the dialog and having the template
in the TypeScript file is hard to read and understand. This change
simply moves the template out into its own file.
