### PR TITLE
time series: remember settings pane open state

### DIFF
--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -30,6 +30,7 @@ import {
   getMetricsScalarSmoothing,
   getMetricsTooltipSort,
   getPromoteTimeSeries,
+  isMetricsSettingsPaneOpen,
   METRICS_FEATURE_KEY,
   METRICS_SETTINGS_DEFAULT,
   reducers,
@@ -93,6 +94,12 @@ export function getMetricsTimeSeriesPromotionDismissed() {
   });
 }
 
+export function getMetricsTimeSeriesSettingsPaneOpen() {
+  return createSelector(isMetricsSettingsPaneOpen, (isOpened) => {
+    return {timeSeriesSettingsPaneOpened: isOpened};
+  });
+}
+
 @NgModule({
   imports: [
     CommonModule,
@@ -122,6 +129,9 @@ export function getMetricsTimeSeriesPromotionDismissed() {
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
       getMetricsTimeSeriesPromotionDismissed
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsTimeSeriesSettingsPaneOpen
     ),
   ],
   providers: [

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -400,9 +400,13 @@ const reducer = createReducer(
         ? !partialSettings.timeSeriesPromotionDismissed
         : state.promoteTimeSeries;
 
+    const isSettingsPaneOpen =
+      partialSettings.timeSeriesSettingsPaneOpened ?? state.isSettingsPaneOpen;
+
     return {
       ...state,
       promoteTimeSeries,
+      isSettingsPaneOpen,
       settings: {
         ...state.settings,
         ...metricsSettings,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1928,6 +1928,23 @@ describe('metrics reducers', () => {
         expect(nextState.settings.tooltipSort).toBe(TooltipSort.ASCENDING);
       }
     );
+
+    it('loads settings pane state from the storage', () => {
+      const beforeState = buildMetricsState({
+        isSettingsPaneOpen: true,
+      });
+
+      const nextState = reducers(
+        beforeState,
+        globalSettingsLoaded({
+          partialSettings: {
+            timeSeriesSettingsPaneOpened: false,
+          },
+        })
+      );
+
+      expect(nextState.isSettingsPaneOpen).toBe(false);
+    });
   });
 
   describe('linked time features', () => {

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -860,4 +860,17 @@ describe('metrics selectors', () => {
       expect(selectors.getPromoteTimeSeries(state)).toEqual(false);
     });
   });
+
+  describe('#isMetricsSettingsPaneOpen', () => {
+    beforeEach(() => {
+      selectors.getPromoteTimeSeries.release();
+    });
+
+    it('returns current visualization filters', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({promoteTimeSeries: false})
+      );
+      expect(selectors.getPromoteTimeSeries(state)).toEqual(false);
+    });
+  });
 });

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -58,6 +58,7 @@ export class OSSSettingsConverter extends SettingsConverter<
       notificationLastReadTimeInMs: settings.notificationLastReadTimeInMs,
       sideBarWidthInPercent: settings.sideBarWidthInPercent,
       timeSeriesPromotionDismissed: settings.timeSeriesPromotionDismissed,
+      timeSeriesSettingsPaneOpened: settings.timeSeriesSettingsPaneOpened,
     };
     return serializableSettings;
   }
@@ -135,6 +136,14 @@ export class OSSSettingsConverter extends SettingsConverter<
     ) {
       settings.timeSeriesPromotionDismissed =
         backendSettings.timeSeriesPromotionDismissed;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('timeSeriesSettingsPaneOpened') &&
+      typeof backendSettings.timeSeriesSettingsPaneOpened === 'boolean'
+    ) {
+      settings.timeSeriesSettingsPaneOpened =
+        backendSettings.timeSeriesSettingsPaneOpened;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -37,6 +37,7 @@ export declare interface BackendSettings {
   notificationLastReadTimeInMs?: number;
   sideBarWidthInPercent?: number;
   timeSeriesPromotionDismissed?: boolean;
+  timeSeriesSettingsPaneOpened?: boolean;
 }
 
 /**
@@ -55,4 +56,5 @@ export interface PersistableSettings {
   notificationLastReadTimeInMs?: number;
   sideBarWidthInPercent?: number;
   timeSeriesPromotionDismissed?: boolean;
+  timeSeriesSettingsPaneOpened?: boolean;
 }


### PR DESCRIPTION
This change puts the settings pane opened state in the global settings
storage so the view remain the same as how user has left it.
