### PR TITLE
Update scalars_and_keras.ipynb

### DIFF
--- a/docs/scalars_and_keras.ipynb
+++ b/docs/scalars_and_keras.ipynb
@@ -204,7 +204,7 @@
         "\n",
         "model.compile(\n",
         "    loss='mse', # keras.losses.mean_squared_error\n",
-        "    optimizer=keras.optimizers.SGD(lr=0.2),\n",
+        "    optimizer=keras.optimizers.SGD(learning_rate=0.2),\n",
         ")\n",
         "\n",
         "print(\"Training ... With default parameters, this takes less than 10 seconds.\")\n",


### PR DESCRIPTION
Removed deprecated `lr` and replaced with `learning_rate`. Tested the updated .ipynb file. [Here](https://colab.research.google.com/gist/jvishnuvardhan/25da1f6a06ddde2a7902e71c4aa404d4/scalars_and_keras.ipynb) is a gist for reference.