### PR TITLE
webapp: fix tab breakage

### DIFF
--- a/tensorboard/webapp/header/plugin_selector_component.scss
+++ b/tensorboard/webapp/header/plugin_selector_component.scss
@@ -85,6 +85,7 @@ mat-option {
     display: none;
   }
 
+  mat-tab-list,
   .mat-tab-header,
   .mat-tab-labels,
   .mat-tab-label {


### PR DESCRIPTION
Forward compatible change to preemptively fix breakage that will occur
when https://github.com/angular/components/pull/23672 is submitted.
Because `mat-tab-header` will no longer be a direct child of
`mat-tab-group`, the `mat-tab-list` element must be given a height of
100% to ensure the tab group height does not collapse.

* Motivation for features / changes
https://github.com/angular/components/pull/23672 will break Tensorboard's use of `mat-tab-group`. This is a preemptive fix.

* Technical description of changes
The new `mat-tab-list `will be a direct child of `mat-tab-group`. Because the height of `mat-tab-label` is set to `100%`, the `mat-tab-group` will collapse unless `mat-tab-list` also has a height of 100%. When an element has height 100%, it inherits the height of its containing block. If `mat-tab-list` does not have a set height, its computed height will be 0, and thus its descendants will have computed height 0.

* Screenshots of UI changes
Should be no UI changes

* Detailed steps to verify changes work correctly (as executed by you)
Tested Tensorboard with https://github.com/angular/components/pull/23672 checked out. Confirmed breakage first, and confirmed fix.

* Alternate designs / implementations considered
N/A
