### PR TITLE
line chart: fix fixedViewBox flow

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -449,7 +449,7 @@ export class LineChartComponent
       this.lineChart.setUseDarkMode(this.useDarkMode);
     }
 
-    if (this.isFixedViewBoxUpdated && this.fixedViewBox) {
+    if (!this.isViewBoxOverridden && this.fixedViewBox) {
       this.viewBox = this.fixedViewBox;
     } else if (!this.isViewBoxOverridden && this.isViewBoxChanged) {
       const dataExtent = computeDataSeriesExtent(

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -228,6 +228,78 @@ describe('line_chart_v2/line_chart test', () => {
     });
   });
 
+  it('keeps the fixedViewBox even when data changes', () => {
+    const fixture = createComponent({
+      seriesData: [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+          ],
+        }),
+      ],
+      seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+      yScaleType: ScaleType.LINEAR,
+      fixedViewBox: {
+        x: [-100, 100],
+        y: [0, 1],
+      },
+    });
+    fixture.detectChanges();
+
+    fixture.componentInstance.seriesData = [
+      buildSeries({
+        id: 'foo',
+        points: [
+          {x: 0, y: 0},
+          {x: 2, y: 1},
+          {x: 3, y: 100},
+        ],
+      }),
+    ];
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.chart.viewBox).toEqual({
+      x: [-100, 100],
+      y: [0, 1],
+    });
+  });
+
+  it('allows viewBox to be overridden with fixedViewBox set', () => {
+    const fixture = createComponent({
+      seriesData: [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+          ],
+        }),
+      ],
+      seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+      yScaleType: ScaleType.LINEAR,
+      fixedViewBox: {
+        x: [-100, 100],
+        y: [0, 1],
+      },
+    });
+    fixture.detectChanges();
+
+    fixture.componentInstance.triggerViewBoxChange({
+      x: [-5, 5],
+      y: [0, 10],
+    });
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.chart.viewBox).toEqual({
+      x: [-5, 5],
+      y: [0, 10],
+    });
+  });
+
   it('updates only scaleType when updating scaleType', () => {
     const fixture = createComponent({
       seriesData: [


### PR DESCRIPTION
fixedViewBox is way for parent to set the viewBox so it is not computed
from the data. This is approrpriate for some use cases like PR curve
where the axis should always span [0, 1].

Previously, it was broken when there was a resize on the window or when
data series changed which was not an intended behavior. This change
fixes that.
