### PR TITLE
chore: Update protos to tensorflow/tensorflow@659aa25f4c2

### DIFF
--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -63,12 +63,18 @@ tb_proto_library(
     srcs = ["config.proto"],
     deps = [
         ":cluster",
+        ":coordination_service",
         ":cost_graph",
         ":debug",
         ":graph",
         ":rewriter_config",
         ":step_stats",
     ],
+)
+
+tb_proto_library(
+    name = "coordination_service",
+    srcs = ["coordination_service.proto"],
 )
 
 tb_proto_library(
@@ -147,6 +153,7 @@ tb_proto_library(
     srcs = ["node_def.proto"],
     deps = [
         ":attr_value",
+        ":full_type",
     ],
 )
 
@@ -295,6 +302,7 @@ tb_proto_library(
         ":attr_value",
         ":cluster",
         ":config",
+        ":coordination_service",
         ":cost_graph",
         ":cpp_shape_inference",
         ":debug",

--- a/tensorboard/compat/proto/api_def.proto
+++ b/tensorboard/compat/proto/api_def.proto
@@ -4,12 +4,14 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/attr_value.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "ApiDefProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
 option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/api_def_go_proto";
-import "tensorboard/compat/proto/attr_value.proto";
 
 // Used to specify and override the default API & behavior in the
 // generated code for client languages, from what you would get from
@@ -19,7 +21,7 @@ import "tensorboard/compat/proto/attr_value.proto";
 // common ApiDefs which it can either replace or modify.
 //
 // We separate the API definition from the OpDef so we can evolve the
-// API while remaining backwards compatible when interpretting old
+// API while remaining backwards compatible when interpreting old
 // graphs.  Overrides go in an "api_def.pbtxt" file with a text-format
 // ApiDefs message.
 //

--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -6,6 +6,7 @@ import "tensorboard/compat/proto/cost_graph.proto";
 import "tensorboard/compat/proto/graph.proto";
 import "tensorboard/compat/proto/step_stats.proto";
 import "tensorboard/compat/proto/cluster.proto";
+import "tensorboard/compat/proto/coordination_service.proto";
 import "tensorboard/compat/proto/debug.proto";
 import "tensorboard/compat/proto/rewriter_config.proto";
 
@@ -270,6 +271,11 @@ message OptimizerOptions {
     ON_2 = 2;
   }
   GlobalJitLevel global_jit_level = 5;
+
+  // CPU code will be autoclustered only if global_jit_level >= ON_1 and either:
+  //  - this flag is true, or
+  //  - TF_XLA_FLAGS contains --tf_xla_cpu_global_jit=true.
+  bool cpu_global_jit = 7;
 }
 
 message GraphOptions {
@@ -663,17 +669,19 @@ message ConfigProto {
     // Whether runtime execution uses TFRT.
     bool use_tfrt = 18;
 
-    // Distributed coordination service to be enabled if set.
-    // Currently only effective in multi-client setup.
-    string coordination_service = 19;
+    // Distributed coordination service configurations if set.
+    CoordinationServiceConfigs coordination_service = 19;
 
-    // Whether the remote devices in the cluster should be fetched during setup
-    // of multi-client cluster. If enabled, the workers will run an extra device
-    // information exchange step during startup and the workers' EagerContexts
-    // will become aware of remote devices in the cluster as well.
-    bool fetch_remote_devices_in_multi_client = 20;
+    // We removed the flag fetch_remote_devices_in_multi_client. Marking the tag
+    // number as reserved.
+    reserved 20;
 
-    // Next: 21
+    // Whether functional control flow op lowering should be disabled. This is
+    // useful when executing within a portable runtime where control flow op
+    // kernels may not be loaded due to selective registration.
+    bool disable_functional_ops_lowering = 21;
+
+    // Next: 22
   }
 
   Experimental experimental = 16;

--- a/tensorboard/compat/proto/coordination_service.proto
+++ b/tensorboard/compat/proto/coordination_service.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package tensorboard;
+
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
+
+// Coordination service configuration parameters.
+// The system picks appropriate values for fields that are not set.
+message CoordinationServiceConfigs {
+  // Type of coordination service implementation to enable.
+  // For example, setting the service type as "standalone" starts a service
+  // instance on the leader task to provide the coordination services such as
+  // heartbeats and consistent key-value store.
+  string service_type = 1;
+
+  // Address where the coordination service instance is hosted.
+  string service_leader = 2;
+
+  // Whether to enable the health check mechanism.
+  bool enable_health_check = 3;
+
+  // Maximum wait time for all members in the cluster to be registered.
+  int64 cluster_register_timeout_in_ms = 4;
+
+  // Heartbeat timeout, if a worker does not record heartbeat in this time
+  // window, it will be considered disconnected.
+  int64 heartbeat_timeout_in_ms = 5;
+}

--- a/tensorboard/compat/proto/full_type.proto
+++ b/tensorboard/compat/proto/full_type.proto
@@ -6,7 +6,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "FullTypeProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/types_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/full_type_go_proto";
 
 // Experimental. Represents the complete type information of a TensorFlow value.
 enum FullTypeId {
@@ -45,14 +45,31 @@ enum FullTypeId {
   //
   TFT_PRODUCT = 3;
 
+  // Represents a named field, with the name stored in the attribute.
+  //
+  // Parametrization:
+  //   TFT_NAMED[<type>]{<name>}
+  //   * <type> is the type of the field
+  //   * <name> is the field name, as string (thpugh can theoretically be an int
+  //     as well)
+  //
+  // Example:
+  //   TFT_RECORD[
+  //     TFT_NAMED[TFT_TENSOR[TFT_INT32]]{'foo'},
+  //     TFT_NAMED[TFT_TENSOR[TFT_FLOAT32]]{'bar'},
+  //   ]
+  //     is a structure with two fields, an int tensor "foo" and a float tensor
+  //     "bar".
+  TFT_NAMED = 4;
+
   // Callable types describe functions and ops.
   //
   // Parametrization:
   //   TFT_CALLABLE[<arg type>, <return type>]
-  //   * <arg_type> is the type of the arguments; TFT_PRODUCT represents
+  //   * <arg type> is the type of the arguments; TFT_PRODUCT represents
   //   multiple
   //     arguments.
-  //   * <return_type> is the return type; TFT_PRODUCT represents multiple
+  //   * <return type> is the return type; TFT_PRODUCT represents multiple
   //     return values (that means that callables returning multiple things
   //     don't necessarily return a single tuple).
   //
@@ -73,9 +90,9 @@ enum FullTypeId {
   //
   // Parametrization:
   //   TFT_TENSOR[<element type>, <shape type>]
-  //   * <element_type> is currently limited to one of the element types
+  //   * <element type> is currently limited to one of the element types
   //     defined below.
-  //   * <shape_type> is not yet defined, and may only be TFT_UNKNOWN for now.
+  //   * <shape type> is not yet defined, and may only be TFT_UNKNOWN for now.
   //
   // A TFT_SHAPE type will be defined in the future.
   //
@@ -97,7 +114,7 @@ enum FullTypeId {
   //
   // Parametrization:
   //   TFT_ARRAY[<element type>]
-  //   * <element_type> may be any concrete type.
+  //   * <element type> may be any concrete type.
   //
   // Examples:
   //   TFT_ARRAY[TFT_TENSOR[TFT_INT32]] is a TensorArray holding int32 Tensors
@@ -115,12 +132,24 @@ enum FullTypeId {
   //
   // Parametrization:
   //   TFT_OPTIONAL[<element type>]
-  //   * <element_type> may be any concrete type.
+  //   * <element type> may be any concrete type.
   //
   // Examples:
   //   TFT_OPTIONAL[TFT_TENSOR[TFT_INT32]] is an Optional holding an int32
   //     Tensor of any shape.
   TFT_OPTIONAL = 1002;
+
+  // Literal types describe compile-time constant values.
+  // Literal types may also participate in dependent types.
+  //
+  // Parametrization:
+  //   TFT_LITERAL[<value type>]{<value>}
+  //   * <value type> may be any concrete type compatible that can hold <value>
+  //   * <value> is the type's attribute, and holds the actual literal value
+  //
+  // Examples:
+  //   TFT_LITERAL[TFT_INT32]{1} is the compile-time constant 1.
+  TFT_LITERAL = 1003;
 
   // Datasets created by tf.data ops and APIs. Datasets have generator/iterable
   // semantics, that is, one can construct an iterator from them. Like
@@ -132,18 +161,28 @@ enum FullTypeId {
   //
   //
   // Parametrization: TFT_ARRAY[<element type>].
-  // <element_type> may be a concrete type or a type symbol. It represents the
-  //   data type of the elements produced by the dataset.
+  //   * <element type> may be a concrete type or a type symbol. It represents
+  //     the data type of the elements produced by the dataset.
   //
   // Examples:
   //   TFT_DATSET[TFT_TENSOR[TFT_INT32]] is a Dataset producing single int32
   //     Tensors of unknown shape.
   //   TFT_DATSET[TFT_PRODUCT[TFT_TENSOR[TFT_INT32], TFT_TENSOR[TFT_FLOAT32]] is
-  //   a
-  //     Dataset producing pairs of Tensors, one integer and one float.
+  //     a Dataset producing pairs of Tensors, one integer and one float.
   // Note: The high ID number is to prepare for the eventuality that Datasets
   // will be supported by user types in the future.
   TFT_DATASET = 10102;
+
+  // A mutex lock tensor, produced by tf.raw_ops.MutexLock.
+  // Unlike strict execution models, where ownership of a lock is denoted by
+  // "running after the lock has been acquired", in non-strict mode, lock
+  // ownership is in the true sense: "the op argument representing the lock is
+  // available".
+  // Mutex locks are the dynamic counterpart of control dependencies.
+  // TODO(mdan): Properly document this thing.
+  //
+  // Parametrization: TFT_MUTEX_LOCK[].
+  TFT_MUTEX_LOCK = 10202;
 
   // Type attributes. These always appear in the parametrization of a type,
   // never alone. For example, there is no such thing as a "bool" TensorFlow
@@ -192,5 +231,7 @@ message FullTypeDef {
   // Fields for more data types to be added as needed.
   oneof attr {
     string s = 3;
+    int64 i = 4;
+    // TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc.
   }
 }

--- a/tensorboard/compat/proto/node_def.proto
+++ b/tensorboard/compat/proto/node_def.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package tensorboard;
 
 import "tensorboard/compat/proto/attr_value.proto";
+import "tensorboard/compat/proto/full_type.proto";
 
 option cc_enable_arenas = true;
 option java_outer_classname = "NodeProto";
@@ -85,4 +86,10 @@ message NodeDef {
 
   // This stores debug information associated with the node.
   ExperimentalDebugInfo experimental_debug_info = 6;
+
+  // The complete type of this node. Experimental and subject to change.
+  // Currently, the field only contains the return types of the node. That will
+  // extend in the future to contain the entire signature of the node, as a
+  // function type.
+  FullTypeDef experimental_type = 7;
 }

--- a/tensorboard/compat/proto/saved_object_graph.proto
+++ b/tensorboard/compat/proto/saved_object_graph.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package tensorboard;
 
+import "google/protobuf/any.proto";
 import "tensorboard/compat/proto/tensor_shape.proto";
 import "tensorboard/compat/proto/types.proto";
 import "tensorboard/compat/proto/variable.proto";
@@ -64,6 +65,18 @@ message SavedObject {
   }
 
   map<string, SaveableObject> saveable_objects = 11;
+
+  // The fields below are filled when the user serializes a registered Trackable
+  // class. Registered classes may save additional metadata and supersede the
+  // default loading process where nodes are recreated from the proto.
+  //
+  // The name of the registered class of the form "{package}.{class_name}".
+  // This field is used to search for the registered class at loading time.
+  string registered_name = 13;
+  // The user-generated proto storing metadata for this object, to be passed to
+  // the registered classes's _deserialize_from_proto method when this object is
+  // loaded from the SavedModel.
+  google.protobuf.Any serialized_user_proto = 14;
 }
 
 // A SavedUserObject is an object (in the object-oriented language of the
@@ -166,7 +179,6 @@ message SavedVariable {
   // This is only supported by experimental loaders at the moment.
   repeated SavedVariable experimental_distributed_variable_components = 8;
 }
-
 
 // Represents `FunctionSpec` used in `Function`. This represents a
 // function that has been wrapped as a TensorFlow `Function`.

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -154,4 +154,7 @@ message TypeSpecProto {
   //    redundant with the type_spec_class enum, and is only used for error
   //    reporting in older binaries that do not know the tupe_spec_class enum.
   string type_spec_class_name = 3;
+
+  // The number of flat tensor components required by this TypeSpec.
+  int32 num_flat_components = 4;
 }


### PR DESCRIPTION
* Motivation for features / changes

Update pinned TensorBoard protos for impending 2.7.0 relase

* Technical description of changes

    * Checkout tensorflow at 659aa25f4c2d74c47cff76dcb93a5f15a97c92bf
    *  ./tensorboard/compat/proto/update.sh $TENSORFLOW_DIR

Tested unit test & spot checked a locally running TB on the scalars demo dir.