### PR TITLE
(chore) Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/tensorboard/compat/tensorflow_stub/io/gfile_fsspec_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_fsspec_test.py
@@ -464,7 +464,7 @@ class GFileFSSpecTest(tb_test.TestCase):
 
     def testComplexChaining(self):
         path = "simplecache::zip://*::file://banana/bar"
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             errors.InvalidArgumentError,
             "fsspec URL must only have paths in the last chained filesystem",
         ):

--- a/tensorboard/data/experimental/experiment_from_dev_test.py
+++ b/tensorboard/data/experimental/experiment_from_dev_test.py
@@ -199,7 +199,7 @@ class ExperimentFromDevTest(tb_test.TestCase):
             lambda api_endpoint: mock_api_client,
         ):
             experiment = experiment_from_dev.ExperimentFromDev("789")
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 ValueError,
                 r"contains missing value\(s\).*different sets of "
                 r"steps.*pivot=False",

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -64,7 +64,7 @@ class LazyTest(unittest.TestCase):
         def foo():
             self.fail("Should not need to resolve this module.")
 
-        self.assertEquals(
+        self.assertEqual(
             repr(foo), "<module 'foo' via LazyModule (not yet loaded)>"
         )
 
@@ -76,7 +76,7 @@ class LazyTest(unittest.TestCase):
             return collections
 
         foo.namedtuple
-        self.assertEquals(
+        self.assertEqual(
             repr(foo), "<%r via LazyModule (loaded)>" % collections
         )
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -1646,7 +1646,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(
             "application/json", response.headers.get("content-type")
         )
-        self.assertRegexpMatches(
+        self.assertRegex(
             json.loads(response.get_data())["error"],
             "Not found: Cannot find stack frame with ID"
             ".*nonsense-stack-frame-id.*",

--- a/tensorboard/plugins/hparams/list_session_groups_test.py
+++ b/tensorboard/plugins/hparams/list_session_groups_test.py
@@ -583,7 +583,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_type: AGGREGATION_AVG
         """
         response = self._run_handler(request)
-        self.assertEquals(len(response.session_groups), 0)
+        self.assertEqual(len(response.session_groups), 0)
 
     def test_some_allowed_statuses(self):
         request = """
@@ -593,7 +593,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_type: AGGREGATION_AVG
         """
         response = self._run_handler(request)
-        self.assertEquals(
+        self.assertEqual(
             _reduce_to_names(response.session_groups),
             [
                 ("group_1", ["session_1"]),
@@ -610,7 +610,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_type: AGGREGATION_AVG
         """
         response = self._run_handler(request)
-        self.assertEquals(
+        self.assertEqual(
             _reduce_to_names(response.session_groups),
             [("group_2", ["session_3"])],
         )
@@ -629,7 +629,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_metric: { tag: "current_temp" }
         """
         response = self._run_handler(request)
-        self.assertEquals(len(response.session_groups[1].metric_values), 2)
+        self.assertEqual(len(response.session_groups[1].metric_values), 2)
         self.assertProtoEquals(
             """
             name { tag: "current_temp" }
@@ -663,7 +663,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_metric: { tag: "delta_temp" }
         """
         response = self._run_handler(request)
-        self.assertEquals(len(response.session_groups[1].metric_values), 2)
+        self.assertEqual(len(response.session_groups[1].metric_values), 2)
         self.assertProtoEquals(
             """
             name { tag: "current_temp" }
@@ -697,7 +697,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_metric: { tag: "current_temp" }
         """
         response = self._run_handler(request)
-        self.assertEquals(len(response.session_groups[1].metric_values), 2)
+        self.assertEqual(len(response.session_groups[1].metric_values), 2)
         self.assertProtoEquals(
             """
             name { tag: "current_temp" }
@@ -731,7 +731,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_metric: { tag: "delta_temp" }
             """
         response = self._run_handler(request)
-        self.assertEquals(len(response.session_groups[1].metric_values), 2)
+        self.assertEqual(len(response.session_groups[1].metric_values), 2)
         self.assertProtoEquals(
             """
             name { tag: "current_temp" }
@@ -765,7 +765,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_metric: { tag: "current_temp" }
             """
         response = self._run_handler(request)
-        self.assertEquals(len(response.session_groups[1].metric_values), 2)
+        self.assertEqual(len(response.session_groups[1].metric_values), 2)
         self.assertProtoEquals(
             """
             name { tag: "current_temp" }
@@ -799,7 +799,7 @@ class ListSessionGroupsTest(tf.test.TestCase):
             aggregation_metric: { tag: "delta_temp" }
         """
         response = self._run_handler(request)
-        self.assertEquals(len(response.session_groups[1].metric_values), 2)
+        self.assertEqual(len(response.session_groups[1].metric_values), 2)
         self.assertProtoEquals(
             """
             name { tag: "current_temp" }

--- a/tensorboard/plugins/mesh/demo_utils_test.py
+++ b/tensorboard/plugins/mesh/demo_utils_test.py
@@ -35,7 +35,7 @@ class TestPLYReader(tf.test.TestCase):
 
     def test_prase_vertex_expects_colors(self):
         """Tests that method will throw error if color is not poresent."""
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "PLY file must contain vertices with colors"
         ):
             demo_utils._parse_vertex("1 2 3")

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -729,7 +729,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
         #   experiment_id.
         with self.assertRaises(exporter_lib.GrpcTimeoutException) as cm:
             next(generator)
-        self.assertEquals(cm.exception.experiment_id, experiment_id)
+        self.assertEqual(cm.exception.experiment_id, experiment_id)
 
     def test_stream_experiment_data_passes_through_unexpected_exception(self):
         # Setup: Client where:
@@ -758,7 +758,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
         # Expect: The internal error is passed through.
         with self.assertRaises(grpc.RpcError) as cm:
             next(generator)
-        self.assertEquals(cm.exception.details(), "details string")
+        self.assertEqual(cm.exception.details(), "details string")
 
     def test_handles_outdir_with_no_slash(self):
         oldcwd = os.getcwd()

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -227,7 +227,7 @@ class UploadIntentTest(tf.test.TestCase):
             actual_mask = exporter_lib.list_experiments.call_args[1][
                 "fieldmask"
             ]
-            self.assertEquals(actual_mask, expected_mask)
+            self.assertEqual(actual_mask, expected_mask)
 
 
 if __name__ == "__main__":

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -1472,7 +1472,7 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
 
         mock_client = _create_mock_client()
         sender = _create_tensor_request_sender("123", mock_client)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError,
             re.compile(
                 r"failed to upload a tensor.*malformation.*tag.*\'one\'.*step.*42",
@@ -1493,7 +1493,7 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
 
         mock_client = _create_mock_client()
         sender = _create_tensor_request_sender("123", mock_client)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError,
             re.compile(
                 r"failed to upload a tensor.*malformation.*tag.*\'two\'.*step.*1337."


### PR DESCRIPTION
* Motivation for features / changes

The deprecated aliases were removed in Python 3.11 in python/cpython#28268 . This PR uses Python 3 recommended aliases for Python 3.11 support

See also "Deprecated Aliases" here : https://docs.python.org/3/library/unittest.html#deprecated-aliases

* Technical description of changes

Following replacements have been made.

assertEquals -> assertEqual
assertRaisesRegexp -> assertRaisesRegex
assertRegexpMatch -> assertRegex
