### PR TITLE
Change tag_types visibility

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -206,6 +206,7 @@ py_library(
     name = "tag_types",
     srcs = ["tag_types.py"],
     srcs_version = "PY3",
+    visibility = ["//visibility:public"],
 )
 
 py_library(


### PR DESCRIPTION
This allows to have a direct dependency to tag_types, which may be necessary if one needs custom implementations of event_loaders

* Motivation for features / changes
Strict BUILD rules of Bazel forces users to have direct dependency to each of their targets.
Proper parsing of tensorboard events requires importing tag_types. 

* Technical description of changes
Change tag_type visibility to public.

* Screenshots of UI changes
None

* Detailed steps to verify changes work correctly (as executed by you)
No issues running bazel test

* Alternate designs / implementations considered
None