### PR TITLE
Remove references to expect_futures_installed.

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -398,11 +398,6 @@ tensorboard_zip_file(
 # `pip install numpy`
 py_library(name = "expect_numpy_installed")
 
-# This is a dummy rule used as a futures dependency in open-source.
-# We expect futures to already be installed on the system, e.g. via
-# `pip install futures`
-py_library(name = "expect_futures_installed")
-
 # This is a dummy rule used as a grpc dependency in open-source.
 # We expect grpc to already be installed on the system, e.g. via
 # `pip install grpcio`

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -280,7 +280,6 @@ py_test(
     srcs = ["server_info_test.py"],
     deps = [
         ":server_info",
-        "//tensorboard:expect_futures_installed",
         "//tensorboard:test",
         "//tensorboard:version",
         "//tensorboard/plugins/scalar:metadata",

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -48,7 +48,6 @@ py_test(
         ":grpc_util_test_proto_py_pb2",
         ":grpc_util_test_proto_py_pb2_grpc",
         ":test_util",
-        "//tensorboard:expect_futures_installed",
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:test",
         "//tensorboard:version",


### PR DESCRIPTION
The internal library this references is obsolete with upgrade to
python3. Googlers please see b/191919903 and cl/404841625.