### PR TITLE
persistent settings: expose OSSSettingsConverter as DI-able

### DIFF
--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_module.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_module.ts
@@ -29,7 +29,8 @@ import {
       provide: PersistentSettingsDataSource,
       useClass: PersistentSettingsDataSourceImpl,
     },
-    {provide: SettingsConverter, useClass: OSSSettingsConverter},
+    OSSSettingsConverter,
+    {provide: SettingsConverter, useExisting: OSSSettingsConverter},
   ],
 })
 export class PersistentSettingsDataSourceModule {}


### PR DESCRIPTION
Currently, OSSSettingsCOnverter is only acquirable by injecting a
symbol, SettingsConverter. If we want to compose the converter in a type
safe manner, we have to convert the converter to be a generic or compose
by injecting an instance of the converter. Here, we have decided to take
the latter approach which tends to keep the base implementation simple
to reason with without generics.
