### PR TITLE
histogram: make legacy histogram visualization compatible with v3 data format

### DIFF
--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library", "tf_ng_web_test_suite")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -29,5 +29,30 @@ tf_ts_library(
         "@npm//@types/lodash",
         "@npm//d3",
         "@npm//lodash",
+    ],
+)
+
+tf_ts_library(
+    name = "histogram_core_test_lib",
+    testonly = True,
+    srcs = [
+        "histogram_core_test.ts",
+    ],
+    deps = [
+        ":tf_histogram_dashboard",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",
+        "//tensorboard/webapp/widgets/linked_time_fob",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@types/jasmine",
+    ],
+)
+
+tf_ng_web_test_suite(
+    name = "karma_test",
+    deps= [
+        ":histogram_core_test_lib",
     ],
 )

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library", "tf_ng_web_test_suite")
+load("//tensorboard/defs:defs.bzl", "tf_ng_web_test_suite", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -52,7 +52,7 @@ tf_ts_library(
 
 tf_ng_web_test_suite(
     name = "karma_test",
-    deps= [
+    deps = [
         ":histogram_core_test_lib",
     ],
 )

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
@@ -90,6 +90,12 @@ export function intermediateToD3(
     min = 0;
     max = 0;
   }
+  if (max === min) {
+    // If the output range is 0 width, use a default non 0 range for
+    // visualization purpose.
+    max = min * 1.1 + 1;
+    min = min / 1.1 - 1;
+  }
   // Terminology note: _buckets_ are the input to this function,
   // while _bins_ are our output.
   const binWidth = (max - min) / numBins;
@@ -140,12 +146,6 @@ export function backendToVz(histograms: BackendHistogram[]): VzHistogram[] {
   const intermediateHistograms = histograms.map(backendToIntermediate);
   let minmin = d3.min(intermediateHistograms, (h) => h.min);
   let maxmax = d3.max(intermediateHistograms, (h) => h.max);
-  // If the output range is 0 width, use a default non 0 range for
-  // visualization purpose.
-  if (minmin !== undefined && maxmax !== undefined && minmin === maxmax) {
-    maxmax = maxmax * 1.1 + 1;
-    minmin = minmin / 1.1 - 1;
-  }
   return intermediateHistograms.map((h) => ({
     wall_time: h.wall_time,
     step: h.step,

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
@@ -100,7 +100,7 @@ export function intermediateToD3(
   // while _bins_ are our output.
   const binWidth = (max - min) / numBins;
   let bucketIndex = 0;
-  let d3HistogramBins: D3HistogramBin[] = [];
+  const d3HistogramBins: D3HistogramBin[] = [];
   for (let i = 0; i < numBins; i++) {
     const binLeft = min + i * binWidth;
     const binRight = binLeft + binWidth;

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
@@ -28,8 +28,8 @@ export type BackendHistogram = [
 export type IntermediateHistogram = {
   wall_time: number; // in seconds
   step: number;
-  min: number;
-  max: number;
+  min: number | undefined;
+  max: number | undefined;
   buckets: {
     left: number;
     right: number;
@@ -86,10 +86,22 @@ export function intermediateToD3(
   max: number,
   numBins = 30
 ): D3HistogramBin[] {
+  // Empty case.
+  if (!histogram.buckets || histogram.buckets.length === 0) {
+    return [];
+  }
+  // Single value case.
   if (max === min) {
-    // Create bins even if all the data has a single value.
-    max = min * 1.1 + 1;
-    min = min / 1.1 - 1;
+    let count = 0;
+    for (let bucket of histogram.buckets) {
+      count += bucket.count;
+    }
+    let bins: D3HistogramBin[] = [];
+    for (let i = 0; i < numBins - 1; i++) {
+      bins.push({x: min, dx: 0, y: 0});
+    }
+    bins.push({x: min, dx: 0, y: count});
+    return bins;
   }
   // Terminology note: _buckets_ are the input to this function,
   // while _bins_ are our output.

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
@@ -144,8 +144,8 @@ export function intermediateToD3(
 
 export function backendToVz(histograms: BackendHistogram[]): VzHistogram[] {
   const intermediateHistograms = histograms.map(backendToIntermediate);
-  let minmin = d3.min(intermediateHistograms, (h) => h.min);
-  let maxmax = d3.max(intermediateHistograms, (h) => h.max);
+  const minmin = d3.min(intermediateHistograms, (h) => h.min);
+  const maxmax = d3.max(intermediateHistograms, (h) => h.max);
   return intermediateHistograms.map((h) => ({
     wall_time: h.wall_time,
     step: h.step,

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
@@ -75,12 +75,19 @@ describe('histogram core', () => {
       const newMin = 1 / 1.1 - 1;
       const newMax = 1 * 1.1 + 1;
       const binWidth = (newMax - newMin) / 2;
-      expect(
-        intermediateToD3(backendToIntermediate([0, 0, bins]), 1, 1, 2)
-      ).toEqual([
-        {x: newMin, dx: binWidth, y: 10},
-        {x: newMin + binWidth, dx: binWidth, y: 0},
-      ]);
+      const results = intermediateToD3(
+        backendToIntermediate([0, 0, bins]),
+        1,
+        1,
+        2
+      );
+      expect(results.length).toEqual(2);
+      expect(results[0].x).toBeCloseTo(newMin);
+      expect(results[0].dx).toBeCloseTo(binWidth);
+      expect(results[0].y).toEqual(10);
+      expect(results[1].x).toBeCloseTo(newMin + binWidth);
+      expect(results[1].dx).toBeCloseTo(binWidth);
+      expect(results[1].y).toEqual(0);
     });
 
     it('converts intermediate histogram data to D3 format', () => {

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
@@ -1,0 +1,141 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {
+  BackendHistogramBin,
+  backendToIntermediate,
+  backendToVz,
+  intermediateToD3,
+} from './histogramCore';
+
+describe('histogram core', () => {
+  describe('backendToIntermediate', () => {
+    it('handles empty case', () => {
+      expect(backendToIntermediate([0, 0, []])).toEqual({
+        wall_time: 0,
+        step: 0,
+        min: undefined,
+        max: undefined,
+        buckets: [],
+      });
+    });
+
+    it('converts backend histogram to intermediate', () => {
+      const bins: BackendHistogramBin[] = [
+        [2, 3, 1],
+        [1, 2, 2],
+        [3, 4, 1],
+      ];
+      expect(backendToIntermediate([1000, 2, bins])).toEqual({
+        wall_time: 1000,
+        step: 2,
+        min: 1,
+        max: 4,
+        buckets: [
+          {left: 2, right: 3, count: 1},
+          {left: 1, right: 2, count: 2},
+          {left: 3, right: 4, count: 1},
+        ],
+      });
+    });
+  });
+
+  describe('intermediateToD3', () => {
+    it('handles empty case', () => {
+      expect(
+        intermediateToD3(backendToIntermediate([0, 0, []]), 0, 10)
+      ).toEqual([]);
+    });
+
+    it('handles data consisting of one single value', () => {
+      const bins: BackendHistogramBin[] = [
+        [1, 1, 0],
+        [1, 1, 0],
+        [1, 1, 10],
+      ];
+      expect(
+        intermediateToD3(backendToIntermediate([0, 0, bins]), 1, 1, 2)
+      ).toEqual([
+        {x: 1, dx: 0, y: 0},
+        {x: 1, dx: 0, y: 10},
+      ]);
+    });
+
+    it('converts intermediate histogram data to D3 format', () => {
+      const bins: BackendHistogramBin[] = [
+        [1, 5, 2],
+        [5, 10, 4],
+      ];
+      expect(
+        intermediateToD3(backendToIntermediate([0, 0, bins]), 1, 10, 2)
+      ).toEqual([
+        {x: 1, dx: 4.5, y: 2.4},
+        {x: 5.5, dx: 4.5, y: 3.6},
+      ]);
+    });
+  });
+
+  describe('backendToVz', () => {
+    it('handles empty case', () => {
+      expect(backendToVz([])).toEqual([]);
+    });
+
+    it('converts backend histogram data to VzHistogram', () => {
+      const bins: BackendHistogramBin[] = [
+        [10, 20, 100],
+        [20, 30, 300],
+        [30, 40, 600],
+      ];
+      expect(backendToVz([[1000, 1, bins]])).toEqual([
+        {
+          wall_time: 1000,
+          step: 1,
+          bins: [
+            {x: 10, dx: 1, y: 10},
+            {x: 11, dx: 1, y: 10},
+            {x: 12, dx: 1, y: 10},
+            {x: 13, dx: 1, y: 10},
+            {x: 14, dx: 1, y: 10},
+            {x: 15, dx: 1, y: 10},
+            {x: 16, dx: 1, y: 10},
+            {x: 17, dx: 1, y: 10},
+            {x: 18, dx: 1, y: 10},
+            {x: 19, dx: 1, y: 10},
+            {x: 20, dx: 1, y: 30},
+            {x: 21, dx: 1, y: 30},
+            {x: 22, dx: 1, y: 30},
+            {x: 23, dx: 1, y: 30},
+            {x: 24, dx: 1, y: 30},
+            {x: 25, dx: 1, y: 30},
+            {x: 26, dx: 1, y: 30},
+            {x: 27, dx: 1, y: 30},
+            {x: 28, dx: 1, y: 30},
+            {x: 29, dx: 1, y: 30},
+            {x: 30, dx: 1, y: 60},
+            {x: 31, dx: 1, y: 60},
+            {x: 32, dx: 1, y: 60},
+            {x: 33, dx: 1, y: 60},
+            {x: 34, dx: 1, y: 60},
+            {x: 35, dx: 1, y: 60},
+            {x: 36, dx: 1, y: 60},
+            {x: 37, dx: 1, y: 60},
+            {x: 38, dx: 1, y: 60},
+            {x: 39, dx: 1, y: 60},
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
@@ -72,11 +72,14 @@ describe('histogram core', () => {
         [1, 1, 0],
         [1, 1, 10],
       ];
+      const newMin = 1 / 1.1 - 1;
+      const newMax = 1 * 1.1 + 1;
+      const binWidth = (newMax - newMin) / 2;
       expect(
         intermediateToD3(backendToIntermediate([0, 0, bins]), 1, 1, 2)
       ).toEqual([
-        {x: 1, dx: 0, y: 10},
-        {x: 1, dx: 0, y: 0},
+        {x: newMin, dx: binWidth, y: 10},
+        {x: newMin + binWidth, dx: binWidth, y: 0},
       ]);
     });
 


### PR DESCRIPTION
Changes:
- Add special handling for single value data case in legacy histogram visualization logic to support v3 format.
- Also add tests for `histogramCore.ts`.

Visualization with **v3** histogram data input:
- overlay mode: 
![image](https://user-images.githubusercontent.com/15273931/139775425-fe593949-0ef5-41b6-86e6-6dd9e3f2f685.png)
- offset mode: 
![image](https://user-images.githubusercontent.com/15273931/139775471-dfe32dfb-3703-47aa-949a-f7842340f6d4.png)

Visualization with **v2** histogram data input:
![image](https://user-images.githubusercontent.com/15273931/139343510-91994bd9-56ce-4b7b-9f67-1e8484f6600c.png)

#histogram #tpu