### PR TITLE
histogram: make timeseries histogram visualization compatible with v3 data format

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_util.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util.ts
@@ -149,8 +149,14 @@ function rebuildBins(bins: Bin[], range: Range, binCount: number): Bin[] {
 
 /**
  * Computes how much of the input bin's 'y' counts should be allocated to a new
- * range. For 0 width input bins, the allocation may be split in half across 2
- * bins.
+ * range. For 0 width input bins, the allocation will be distributed to the last
+ * close-close bin ([resultLeft, resultRight]).
+ *
+ * For example, assuming the middle bin has width 0 and count 20:
+ * bins:       [ 0 ][20][   0   ]
+ * range:      [                ]
+ * binsCount:  2
+ * results:    [   0   ][   20  ]
  */
 function getBinContribution(
   bin: Bin,
@@ -165,8 +171,8 @@ function getBinContribution(
   }
 
   if (bin.dx === 0) {
-    if (resultHasRightNeighbor && binRight === resultRight) {
-      return {curr: 0.5 * bin.y, next: 0.5 * bin.y};
+    if (resultHasRightNeighbor && binRight >= resultRight) {
+      return {curr: 0, next: bin.y};
     }
     return {curr: bin.y, next: 0};
   }

--- a/tensorboard/webapp/widgets/histogram/histogram_util.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util.ts
@@ -150,7 +150,7 @@ function rebuildBins(bins: Bin[], range: Range, binCount: number): Bin[] {
 /**
  * Computes how much of the input bin's 'y' counts should be allocated to this output bin.
  *
- * Where both bins have non-zero width, this computed by multiplying the input y value by
+ * Where both bins have non-zero width, this is computed by multiplying the input y value by
  * the ratio of the width-wise overlap in the bins to the total width of the output bin.
  * (This can be thought of redistributing the overlapping "area" of the bar in the input
  * histogram across the full width of the output bin.)
@@ -163,12 +163,6 @@ function rebuildBins(bins: Bin[], range: Range, binCount: number): Bin[] {
  * if the output bin's interval contains x. This interval is the closed-open interval
  * [resultLeft, resultRight), except if resultHasRightNeighbor is false, in which case it's
  * the closed interval [resultLeft, resultRight].
- *
- * For example, assuming the middle bin has width 0 and count 20:
- * bins:       [ 0 ][20][   0   ]
- * range:      [                ]
- * binsCount:  2
- * results:    [   0   ][   20  ]
  */
 function getBinContribution(
   bin: Bin,

--- a/tensorboard/webapp/widgets/histogram/histogram_util.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util.ts
@@ -148,9 +148,21 @@ function rebuildBins(bins: Bin[], range: Range, binCount: number): Bin[] {
 }
 
 /**
- * Computes how much of the input bin's 'y' counts should be allocated to a new
- * range. For 0 width input bins, the allocation will be distributed to the last
- * close-close bin ([resultLeft, resultRight]).
+ * Computes how much of the input bin's 'y' counts should be allocated to this output bin.
+ *
+ * Where both bins have non-zero width, this computed by multiplying the input y value by
+ * the ratio of the width-wise overlap in the bins to the total width of the output bin.
+ * (This can be thought of redistributing the overlapping "area" of the bar in the input
+ * histogram across the full width of the output bin.)
+ *
+ * When the input bin has zero width (the output bin cannot have zero width by construction),
+ * we instead have to consider several cases depending on the open/closed-ness of the
+ * underlying intervals. If the zero width input bin has y value 0, the contribution is
+ * always 0. Otherwise, if zero width input bin has y value greater than 0, it must represent
+ * the closed interval [x, x]. In this case, it contributes the full value of y if and only
+ * if the output bin's interval contains x. This interval is the closed-open interval
+ * [resultLeft, resultRight), except if resultHasRightNeighbor is false, in which case it's
+ * the closed interval [resultLeft, resultRight].
  *
  * For example, assuming the middle bin has width 0 and count 20:
  * bins:       [ 0 ][20][   0   ]

--- a/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
@@ -347,17 +347,16 @@ describe('histogram util', () => {
       });
 
       it(
-        'produces result bins with full contributions from ' +
-          'multiple 0 width bins',
+        'produces result bins from multiple 0 width bins in different ' +
+          'steps',
         () => {
           expect(
             histogramsToBins(
               buildNormalizedHistograms(
                 [
                   binsToHistogram([
-                    {x: 0, dx: 1, y: 0},
-                    {x: 5, dx: 0, y: 200},
-                    {x: 10, dx: 0, y: 100},
+                    {x: 0, dx: 0, y: 200},
+                    {x: 1.0, dx: 0, y: 100},
                   ]),
                 ],
                 2
@@ -365,8 +364,8 @@ describe('histogram util', () => {
             )
           ).toEqual([
             [
-              {x: 0, dx: 5, y: 0},
-              {x: 5, dx: 5, y: 300},
+              {x: 0, dx: 0.5, y: 200},
+              {x: 0.5, dx: 0.5, y: 100},
             ],
           ]);
         }

--- a/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
@@ -282,27 +282,6 @@ describe('histogram util', () => {
         ]);
       });
 
-      it('redistributes 0 width bins at the edges', () => {
-        expect(
-          histogramsToBins(
-            buildNormalizedHistograms(
-              [
-                binsToHistogram([
-                  {x: 0, dx: 0, y: 100},
-                  {x: 10, dx: 0, y: 200},
-                ]),
-              ],
-              2
-            )
-          )
-        ).toEqual([
-          [
-            {x: 0, dx: 5, y: 100},
-            {x: 5, dx: 5, y: 200},
-          ],
-        ]);
-      });
-
       it(
         'preserves 0 width bin counts in a result bin that has no other ' +
           'contributions',

--- a/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
@@ -276,8 +276,8 @@ describe('histogram util', () => {
           )
         ).toEqual([
           [
-            {x: 0, dx: 5, y: 100},
-            {x: 5, dx: 5, y: 100},
+            {x: 0, dx: 5, y: 0},
+            {x: 5, dx: 5, y: 200},
           ],
         ]);
       });
@@ -347,7 +347,7 @@ describe('histogram util', () => {
       });
 
       it(
-        'produces result bins with full and partial contributions from ' +
+        'produces result bins with full contributions from ' +
           'multiple 0 width bins',
         () => {
           expect(
@@ -365,8 +365,8 @@ describe('histogram util', () => {
             )
           ).toEqual([
             [
-              {x: 0, dx: 5, y: 100},
-              {x: 5, dx: 5, y: 200},
+              {x: 0, dx: 5, y: 0},
+              {x: 5, dx: 5, y: 300},
             ],
           ]);
         }

--- a/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
@@ -260,15 +260,15 @@ describe('histogram util', () => {
         ]);
       });
 
-      it('redistributes 0 width bin evenly over edges of result bins', () => {
+      it('redistributes bin counts where the last bin has zero width', () => {
         expect(
           histogramsToBins(
             buildNormalizedHistograms(
               [
                 binsToHistogram([
-                  {x: 0, dx: 1, y: 0},
-                  {x: 5, dx: 0, y: 200},
-                  {x: 9, dx: 1, y: 0},
+                  {x: 0, dx: 1, y: 10},
+                  {x: 1, dx: 1, y: 10},
+                  {x: 2, dx: 0, y: 10},
                 ]),
               ],
               2
@@ -276,8 +276,8 @@ describe('histogram util', () => {
           )
         ).toEqual([
           [
-            {x: 0, dx: 5, y: 0},
-            {x: 5, dx: 5, y: 200},
+            {x: 0, dx: 1, y: 10},
+            {x: 1, dx: 1, y: 20},
           ],
         ]);
       });
@@ -324,31 +324,6 @@ describe('histogram util', () => {
           )
         ).toEqual([[{x: 0, dx: 10, y: 300}]]);
       });
-
-      it(
-        'produces result bins from multiple 0 width bins in different ' +
-          'steps',
-        () => {
-          expect(
-            histogramsToBins(
-              buildNormalizedHistograms(
-                [
-                  binsToHistogram([
-                    {x: 0, dx: 0, y: 200},
-                    {x: 1.0, dx: 0, y: 100},
-                  ]),
-                ],
-                2
-              )
-            )
-          ).toEqual([
-            [
-              {x: 0, dx: 0.5, y: 200},
-              {x: 0.5, dx: 0.5, y: 100},
-            ],
-          ]);
-        }
-      );
     });
 
     describe('multiple histograms', () => {
@@ -404,6 +379,33 @@ describe('histogram util', () => {
           ],
         ]);
       });
+
+      it(
+        'produces result bins from multiple 0 width bins in different ' +
+          'steps',
+        () => {
+          expect(
+            histogramsToBins(
+              buildNormalizedHistograms(
+                [
+                  binsToHistogram([{x: 0, dx: 0, y: 200}]),
+                  binsToHistogram([{x: 1.0, dx: 0, y: 100}]),
+                ],
+                2
+              )
+            )
+          ).toEqual([
+            [
+              {x: 0, dx: 0.5, y: 200},
+              {x: 0.5, dx: 0.5, y: 0},
+            ],
+            [
+              {x: 0, dx: 0.5, y: 0},
+              {x: 0.5, dx: 0.5, y: 100},
+            ],
+          ]);
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
Change the timeseries histogram visualization logics, before the count of a 0-width bin is split into two halves, now each zero-width bin count will be full allocated to one bin, with the restriction that all redistributed bins (or ranges) are closed-open except the last one.

- Current visualization implementation with **v3** histogram data input:
![image](https://user-images.githubusercontent.com/15273931/139505882-f696b390-cbfd-4bd3-9d62-1dd560add2a7.png)

- Current visualization implementation with **v2** histogram data input:
![image](https://user-images.githubusercontent.com/15273931/139505891-c06c176c-b5ab-443c-847d-c28163f241f7.png)


#histogram #tpu
