### PR TITLE
bug: prevent violent error when Experiment metadata is missing

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -448,7 +448,6 @@ export class RunsTableContainer implements OnInit, OnDestroy {
             {
               runName: item.run.name,
               experimentAlias: item.experimentAlias,
-              experimentName: item.experimentName,
             },
             regexString,
             shouldIncludeExperimentName

--- a/tensorboard/webapp/util/matcher.ts
+++ b/tensorboard/webapp/util/matcher.ts
@@ -19,7 +19,6 @@ import {ExperimentAlias} from '../experiments/types';
 
 export interface RunMatchable {
   runName: string;
-  experimentName: string;
   experimentAlias: ExperimentAlias;
 }
 

--- a/tensorboard/webapp/util/matcher_test.ts
+++ b/tensorboard/webapp/util/matcher_test.ts
@@ -19,7 +19,6 @@ function buildRunWithName(override: Partial<RunMatchable> = {}): RunMatchable {
   return {
     runName: 'run name',
     experimentAlias: {aliasText: 'alias', aliasNumber: 1},
-    experimentName: 'Experiment name',
     ...override,
   };
 }
@@ -74,7 +73,6 @@ describe('matcher test', () => {
             buildRunWithName({
               runName: 'world',
               experimentAlias: {aliasText: 'hello', aliasNumber: 1},
-              experimentName: 'goodbye',
             }),
             '^hello/world$',
             true
@@ -85,7 +83,6 @@ describe('matcher test', () => {
             buildRunWithName({
               runName: 'world',
               experimentAlias: {aliasText: 'hello', aliasNumber: 1},
-              experimentName: 'goodbye',
             }),
             'hello',
             true

--- a/tensorboard/webapp/util/ui_selectors.ts
+++ b/tensorboard/webapp/util/ui_selectors.ts
@@ -26,6 +26,7 @@ limitations under the License.
  */
 
 import {createSelector} from '@ngrx/store';
+
 import {
   getExperimentIdsFromRoute,
   getExperimentIdToExperimentAliasMap,
@@ -33,7 +34,6 @@ import {
 } from '../app_routing/store/app_routing_selectors';
 import {RouteKind} from '../app_routing/types';
 import {State} from '../app_state';
-import {getExperiment} from '../experiments/store/experiments_selectors';
 import {getDarkModeEnabled} from '../feature_flag/store/feature_flag_selectors';
 import {
   getDefaultRunColorIdMap,
@@ -63,13 +63,10 @@ export const getCurrentRouteRunSelection = createSelector(
 
     const runMatchableMap = new Map<string, RunMatchable>();
     for (const experimentId of experimentIds) {
-      const experiment = getExperiment(state, {experimentId});
-      if (!experiment) continue;
       const runs = getRuns(state, {experimentId});
       for (const run of runs) {
         runMatchableMap.set(run.id, {
           runName: run.name,
-          experimentName: experiment.name,
           experimentAlias: aliasMap[experimentId],
         });
       }

--- a/tensorboard/webapp/util/ui_selectors_test.ts
+++ b/tensorboard/webapp/util/ui_selectors_test.ts
@@ -266,7 +266,7 @@ describe('ui_selectors test', () => {
         );
       });
 
-      it('does not violently throw when an experiment metadata DNE', () => {
+      it('does not violently throw when an experiment metadata is null', () => {
         const state = {
           ...buildStateFromAppRoutingState(
             buildAppRoutingState({

--- a/tensorboard/webapp/util/ui_selectors_test.ts
+++ b/tensorboard/webapp/util/ui_selectors_test.ts
@@ -195,7 +195,7 @@ describe('ui_selectors test', () => {
         );
       });
 
-      it('filters run name, experiment name, and alias in compare mode', () => {
+      it('filters run name and alias in compare mode', () => {
         const state = {
           ...buildStateFromAppRoutingState(
             buildAppRoutingState({
@@ -262,6 +262,63 @@ describe('ui_selectors test', () => {
             ['234/run2', false],
             // Inherits false from `selectionState`.
             ['234/run3', false],
+          ])
+        );
+      });
+
+      it('does not violently throw when an experiment metadata DNE', () => {
+        const state = {
+          ...buildStateFromAppRoutingState(
+            buildAppRoutingState({
+              activeRoute: buildRoute({
+                routeKind: RouteKind.COMPARE_EXPERIMENT,
+                pathname: '/compare/apple:123,banana:234/',
+                params: {experimentIds: 'apple:123,banana:234'},
+              }),
+            })
+          ),
+          ...buildStateFromRunsState(
+            buildRunsState({
+              selectionState: new Map([
+                [
+                  '["123","234"]',
+                  new Map([
+                    ['123/run1', true],
+                    ['123/run2', true],
+                    ['234/run1', true],
+                    ['234/run2', true],
+                  ]),
+                ],
+              ]),
+              runIds: {
+                '123': ['123/run1', '123/run2'],
+                '234': ['234/run1', '234/run2'],
+              },
+              runMetadata: {
+                '123/run1': buildRun({id: '123/run1', name: 'run1'}),
+                '123/run2': buildRun({id: '123/run2', name: 'run2'}),
+                '234/run1': buildRun({id: '234/run1', name: 'run1'}),
+                '234/run2': buildRun({id: '234/run2', name: 'run2'}),
+              },
+              regexFilter: 'run1',
+            })
+          ),
+          ...buildStateFromExperimentsState(
+            buildExperimentState({
+              experimentMap: {
+                '123': buildExperiment({id: '123', name: 'Experiment 123'}),
+                // 234 experiment metadata does not exist.
+              },
+            })
+          ),
+        };
+
+        expect(getCurrentRouteRunSelection(state)).toEqual(
+          new Map([
+            ['123/run1', true],
+            ['123/run2', false],
+            ['234/run1', true],
+            ['234/run2', false],
           ])
         );
       });


### PR DESCRIPTION
ui_selector which provides a convenience selector for getting the run
selection was throwing a JavaScript exception violently when experiment
metadata did not load but runs list was loaded.

Above case can happen when the backend implements /data/experiments
incorrectly and inadvertently apply `limit` on the list of experiments
passed. As such, TensorBoard may not fetch an experiment metadata ever
when list of experiment ids go above `N`.

In theory, there should be a fix to the backend, but we also do not want
the web code to violently throw and henceforth break the app completely.
Especially since the web code never makes use of the experiment name
anymore when filtering, we can easily guard against the case, hence the
change.
