### PR TITLE
Change RouteRegistryModule.getRouteConfigs() to have non-nullable return type.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -63,7 +63,7 @@ interface InternalNavigation extends Navigation {
 
 @Injectable()
 export class AppRoutingEffects {
-  private readonly routeConfigs: RouteConfigs | null;
+  private readonly routeConfigs: RouteConfigs;
 
   constructor(
     private readonly actions$: Actions,
@@ -147,9 +147,7 @@ export class AppRoutingEffects {
       };
     }),
     map((navigationWithAbsolutePath) => {
-      const routeMatch = this.routeConfigs
-        ? this.routeConfigs.match(navigationWithAbsolutePath)
-        : null;
+      const routeMatch = this.routeConfigs.match(navigationWithAbsolutePath);
       return {
         routeMatch,
         options: {

--- a/tensorboard/webapp/app_routing/route_registry_module.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module.ts
@@ -28,7 +28,7 @@ import {RouteKind} from './types';
 
 @NgModule({})
 export class RouteRegistryModule {
-  private readonly routeConfigs: RouteConfigs | null = null;
+  private readonly routeConfigs: RouteConfigs;
   private readonly routeKindToNgComponent = new Map<
     RouteKind,
     Type<Component>
@@ -38,8 +38,10 @@ export class RouteRegistryModule {
     @Optional() @Inject(ROUTE_CONFIGS_TOKEN) configsList: RouteDef[][]
   ) {
     if (!configsList) {
+      this.routeConfigs = new RouteConfigs([]);
       return;
     }
+
     const configs: RouteDef[] = [];
     for (const routeDefList of configsList) {
       for (const routeDef of routeDefList) {
@@ -62,7 +64,7 @@ export class RouteRegistryModule {
    * Returns RouteConfigs of current route configuration. Returnsn null if no
    * routes are registered.
    */
-  getRouteConfigs(): RouteConfigs | null {
+  getRouteConfigs(): RouteConfigs {
     return this.routeConfigs;
   }
 

--- a/tensorboard/webapp/app_routing/route_registry_module_test.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module_test.ts
@@ -40,37 +40,37 @@ class NotFound {}
 describe('route_registry_module', () => {
   let registry: RouteRegistryModule;
 
-  beforeEach(async () => {
-    function routeFactory() {
-      return [
-        {
-          routeKind: RouteKind.EXPERIMENT,
-          path: '/experiment/:experimentId',
-          ngComponent: Experiment,
-        },
-        {
-          routeKind: RouteKind.EXPERIMENTS,
-          path: '/experiments',
-          ngComponent: Experiments,
-        },
-        {
-          routeKind: RouteKind.UNKNOWN,
-          path: '/crabs',
-          ngComponent: NotFound,
-        },
-      ];
-    }
+  describe('with configs', () => {
+    beforeEach(async () => {
+      function routeFactory() {
+        return [
+          {
+            routeKind: RouteKind.EXPERIMENT,
+            path: '/experiment/:experimentId',
+            ngComponent: Experiment,
+          },
+          {
+            routeKind: RouteKind.EXPERIMENTS,
+            path: '/experiments',
+            ngComponent: Experiments,
+          },
+          {
+            routeKind: RouteKind.UNKNOWN,
+            path: '/crabs',
+            ngComponent: NotFound,
+          },
+        ];
+      }
 
-    await TestBed.configureTestingModule({
-      imports: [RouteRegistryModule.registerRoutes(routeFactory)],
-      declarations: [Experiments, Experiment, NotFound],
-    }).compileComponents();
+      await TestBed.configureTestingModule({
+        imports: [RouteRegistryModule.registerRoutes(routeFactory)],
+        declarations: [Experiments, Experiment, NotFound],
+      }).compileComponents();
 
-    registry = TestBed.inject<RouteRegistryModule>(RouteRegistryModule);
-  });
+      registry = TestBed.inject<RouteRegistryModule>(RouteRegistryModule);
+    });
 
-  describe('getNgComponentByRouteKind', () => {
-    it('finds a component for routeKind', () => {
+    it('getNgComponentByRouteKind finds a component for routeKind', () => {
       expect(registry.getNgComponentByRouteKind(RouteKind.EXPERIMENT)).toBe(
         Experiment
       );
@@ -80,6 +80,24 @@ describe('route_registry_module', () => {
       expect(registry.getNgComponentByRouteKind(RouteKind.UNKNOWN)).toBe(
         NotFound
       );
+    });
+  });
+
+  describe('without configs', () => {
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          // Creates RouteRegistryModule without any registered routes.
+          RouteRegistryModule,
+        ],
+        declarations: [Experiments, Experiment, NotFound],
+      }).compileComponents();
+
+      registry = TestBed.inject<RouteRegistryModule>(RouteRegistryModule);
+    });
+
+    it('getRouteConfigs is not null', () => {
+      expect(registry.getRouteConfigs()).not.toBeNull();
     });
   });
 });

--- a/tensorboard/webapp/app_routing/route_registry_module_test.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module_test.ts
@@ -98,10 +98,6 @@ describe('route_registry_module', () => {
 
     it('getRouteConfigs is not null', () => {
       expect(registry.getRouteConfigs()).not.toBeNull();
-<<<<<<< HEAD
     });
-=======
-    })
->>>>>>> origin/route-configs-nonnull
   });
 });


### PR DESCRIPTION
Change RouteRegistryModule.getRouteConfigs() to have non-nullable return type. Instead of null, we return a RouteConfig with no underlying RouteDefs. This simplifies call sites -- callers can rely on RouteConfig.match() to return null instead of special casing the case where RouteConfig is null.
