### PR TITLE
time series: force use SVG renderer

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -102,7 +102,7 @@ limitations under the License.
   ></mat-spinner>
   <line-chart
     [disableUpdate]="!isCardVisible"
-    [preferredRendererType]="RendererType.WEBGL"
+    [preferredRendererType]="RendererType.SVG"
     [seriesData]="dataSeries"
     [seriesMetadataMap]="chartMetadataMap"
     [xScaleType]="xScaleType"


### PR DESCRIPTION
WebGL render for the line chart can be problematic if user's system has
limited memory or browser is configured to limit number of WebGL
context. This can manifest, to user, as empty charts or randomly
disappearing lines.

Without an ability to induce the problem and as an emergency mitigation,
we are default using SVG renderer instead of the WebGL one.

In the future, we may want to make this configurable so a user can
change the configuration more robustly.
