### PR TITLE
timeseries: fix button toggle state issue

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
@@ -17,30 +17,38 @@ limitations under the License.
 <div class="toolbar">
   <metrics-tag-filter></metrics-tag-filter>
   <mat-button-toggle-group class="filter-view" multiple appearance="standard">
-    <mat-button-toggle
-      [checked]="filteredPluginTypes.size === 0"
+    <button
+      mat-button
+      role="checkbox"
+      [attr.aria-checked]="filteredPluginTypes.size === 0"
       (click)="onPluginTypeAllToggled.emit()"
     >
       All
-    </mat-button-toggle>
-    <mat-button-toggle
-      [checked]="filteredPluginTypes.has(PluginType.SCALARS)"
+    </button>
+    <button
+      mat-button
+      role="checkbox"
+      [attr.aria-checked]="filteredPluginTypes.has(PluginType.SCALARS)"
       (click)="onPluginTypeToggled.emit(PluginType.SCALARS)"
     >
       Scalars
-    </mat-button-toggle>
-    <mat-button-toggle
-      [checked]="filteredPluginTypes.has(PluginType.IMAGES)"
+    </button>
+    <button
+      mat-button
+      role="checkbox"
+      [attr.aria-checked]="filteredPluginTypes.has(PluginType.IMAGES)"
       (click)="onPluginTypeToggled.emit(PluginType.IMAGES)"
     >
       Image
-    </mat-button-toggle>
-    <mat-button-toggle
-      [checked]="filteredPluginTypes.has(PluginType.HISTOGRAMS)"
+    </button>
+    <button
+      mat-button
+      role="checkbox"
+      [attr.aria-checked]="filteredPluginTypes.has(PluginType.HISTOGRAMS)"
       (click)="onPluginTypeToggled.emit(PluginType.HISTOGRAMS)"
     >
       Histogram
-    </mat-button-toggle>
+    </button>
   </mat-button-toggle-group>
   <div class="right-items">
     <button

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -42,16 +42,27 @@ limitations under the License.
 }
 
 .filter-view {
+  border-radius: 4px;
   flex: none;
   margin-right: 5px;
 
-  mat-button-toggle {
+  button {
     $_height: 25px;
-    height: $_height;
-    font-size: 12px;
 
-    ::ng-deep .mat-button-toggle-label-content {
-      line-height: $_height;
+    border-radius: 0;
+    font-size: 12px;
+    font-weight: normal;
+    height: $_height;
+    line-height: $_height;
+    min-width: unset;
+    padding: 0 12px;
+
+    & + button {
+      @include tb-theme-foreground-prop(border-left, border, 1px solid);
+    }
+
+    &[aria-checked='true'] {
+      @include tb-theme-background-prop(background-color, selected-button);
     }
   }
 }


### PR DESCRIPTION
Angular material components are not truly "controlled input" that even
if the parent sets `checked` state to false, if user clicked on the
button from false to true to cause a redux state change that makes
parent put that state, it will have a value `checked`. This is directly
observable by printing out value of `checked` vs. value set by parent.

We work around this issue by simply using button that acts like a
checkbox instead of using an Angular material component. Also, styled
carefully to make it look about the same.
