### PR TITLE
fix build - - with dirty commits

### DIFF
--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library", "tf_ng_web_test_suite")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -29,5 +29,30 @@ tf_ts_library(
         "@npm//@types/lodash",
         "@npm//d3",
         "@npm//lodash",
+    ],
+)
+
+tf_ts_library(
+    name = "histogram_core_test_lib",
+    testonly = True,
+    srcs = [
+        "histogram_core_test.ts",
+    ],
+    deps = [
+        ":tf_histogram_dashboard",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",
+        "//tensorboard/webapp/widgets/linked_time_fob",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@types/jasmine",
+    ],
+)
+
+tf_ng_web_test_suite(
+    name = "karma_test",
+    deps= [
+        ":histogram_core_test_lib",
     ],
 )

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library", "tf_ng_web_test_suite")
+load("//tensorboard/defs:defs.bzl", "tf_ng_web_test_suite", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -52,7 +52,7 @@ tf_ts_library(
 
 tf_ng_web_test_suite(
     name = "karma_test",
-    deps= [
+    deps = [
         ":histogram_core_test_lib",
     ],
 )

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
@@ -90,6 +90,12 @@ export function intermediateToD3(
     min = 0;
     max = 0;
   }
+  if (max === min) {
+    // If the output range is 0 width, use a default non 0 range for
+    // visualization purpose.
+    max = min * 1.1 + 1;
+    min = min / 1.1 - 1;
+  }
   // Terminology note: _buckets_ are the input to this function,
   // while _bins_ are our output.
   const binWidth = (max - min) / numBins;
@@ -140,12 +146,6 @@ export function backendToVz(histograms: BackendHistogram[]): VzHistogram[] {
   const intermediateHistograms = histograms.map(backendToIntermediate);
   let minmin = d3.min(intermediateHistograms, (h) => h.min);
   let maxmax = d3.max(intermediateHistograms, (h) => h.max);
-  // If the output range is 0 width, use a default non 0 range for
-  // visualization purpose.
-  if (minmin !== undefined && maxmax !== undefined && minmin === maxmax) {
-    maxmax = maxmax * 1.1 + 1;
-    minmin = minmin / 1.1 - 1;
-  }
   return intermediateHistograms.map((h) => ({
     wall_time: h.wall_time,
     step: h.step,

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogramCore.ts
@@ -28,8 +28,8 @@ export type BackendHistogram = [
 export type IntermediateHistogram = {
   wall_time: number; // in seconds
   step: number;
-  min: number;
-  max: number;
+  min: number | undefined;
+  max: number | undefined;
   buckets: {
     left: number;
     right: number;
@@ -86,10 +86,22 @@ export function intermediateToD3(
   max: number,
   numBins = 30
 ): D3HistogramBin[] {
+  // Empty case.
+  if (!histogram.buckets || histogram.buckets.length === 0) {
+    return [];
+  }
+  // Single value case.
   if (max === min) {
-    // Create bins even if all the data has a single value.
-    max = min * 1.1 + 1;
-    min = min / 1.1 - 1;
+    let count = 0;
+    for (let bucket of histogram.buckets) {
+      count += bucket.count;
+    }
+    let bins: D3HistogramBin[] = [];
+    for (let i = 0; i < numBins - 1; i++) {
+      bins.push({x: min, dx: 0, y: 0});
+    }
+    bins.push({x: min, dx: 0, y: count});
+    return bins;
   }
   // Terminology note: _buckets_ are the input to this function,
   // while _bins_ are our output.

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
@@ -1,0 +1,141 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {
+  BackendHistogramBin,
+  backendToIntermediate,
+  backendToVz,
+  intermediateToD3,
+} from './histogramCore';
+
+describe('histogram core', () => {
+  describe('backendToIntermediate', () => {
+    it('handles empty case', () => {
+      expect(backendToIntermediate([0, 0, []])).toEqual({
+        wall_time: 0,
+        step: 0,
+        min: undefined,
+        max: undefined,
+        buckets: [],
+      });
+    });
+
+    it('converts backend histogram to intermediate', () => {
+      const bins: BackendHistogramBin[] = [
+        [2, 3, 1],
+        [1, 2, 2],
+        [3, 4, 1],
+      ];
+      expect(backendToIntermediate([1000, 2, bins])).toEqual({
+        wall_time: 1000,
+        step: 2,
+        min: 1,
+        max: 4,
+        buckets: [
+          {left: 2, right: 3, count: 1},
+          {left: 1, right: 2, count: 2},
+          {left: 3, right: 4, count: 1},
+        ],
+      });
+    });
+  });
+
+  describe('intermediateToD3', () => {
+    it('handles empty case', () => {
+      expect(
+        intermediateToD3(backendToIntermediate([0, 0, []]), 0, 10)
+      ).toEqual([]);
+    });
+
+    it('handles data consisting of one single value', () => {
+      const bins: BackendHistogramBin[] = [
+        [1, 1, 0],
+        [1, 1, 0],
+        [1, 1, 10],
+      ];
+      expect(
+        intermediateToD3(backendToIntermediate([0, 0, bins]), 1, 1, 2)
+      ).toEqual([
+        {x: 1, dx: 0, y: 0},
+        {x: 1, dx: 0, y: 10},
+      ]);
+    });
+
+    it('converts intermediate histogram data to D3 format', () => {
+      const bins: BackendHistogramBin[] = [
+        [1, 5, 2],
+        [5, 10, 4],
+      ];
+      expect(
+        intermediateToD3(backendToIntermediate([0, 0, bins]), 1, 10, 2)
+      ).toEqual([
+        {x: 1, dx: 4.5, y: 2.4},
+        {x: 5.5, dx: 4.5, y: 3.6},
+      ]);
+    });
+  });
+
+  describe('backendToVz', () => {
+    it('handles empty case', () => {
+      expect(backendToVz([])).toEqual([]);
+    });
+
+    it('converts backend histogram data to VzHistogram', () => {
+      const bins: BackendHistogramBin[] = [
+        [10, 20, 100],
+        [20, 30, 300],
+        [30, 40, 600],
+      ];
+      expect(backendToVz([[1000, 1, bins]])).toEqual([
+        {
+          wall_time: 1000,
+          step: 1,
+          bins: [
+            {x: 10, dx: 1, y: 10},
+            {x: 11, dx: 1, y: 10},
+            {x: 12, dx: 1, y: 10},
+            {x: 13, dx: 1, y: 10},
+            {x: 14, dx: 1, y: 10},
+            {x: 15, dx: 1, y: 10},
+            {x: 16, dx: 1, y: 10},
+            {x: 17, dx: 1, y: 10},
+            {x: 18, dx: 1, y: 10},
+            {x: 19, dx: 1, y: 10},
+            {x: 20, dx: 1, y: 30},
+            {x: 21, dx: 1, y: 30},
+            {x: 22, dx: 1, y: 30},
+            {x: 23, dx: 1, y: 30},
+            {x: 24, dx: 1, y: 30},
+            {x: 25, dx: 1, y: 30},
+            {x: 26, dx: 1, y: 30},
+            {x: 27, dx: 1, y: 30},
+            {x: 28, dx: 1, y: 30},
+            {x: 29, dx: 1, y: 30},
+            {x: 30, dx: 1, y: 60},
+            {x: 31, dx: 1, y: 60},
+            {x: 32, dx: 1, y: 60},
+            {x: 33, dx: 1, y: 60},
+            {x: 34, dx: 1, y: 60},
+            {x: 35, dx: 1, y: 60},
+            {x: 36, dx: 1, y: 60},
+            {x: 37, dx: 1, y: 60},
+            {x: 38, dx: 1, y: 60},
+            {x: 39, dx: 1, y: 60},
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/histogram_core_test.ts
@@ -72,11 +72,14 @@ describe('histogram core', () => {
         [1, 1, 0],
         [1, 1, 10],
       ];
+      const newMin = 1 / 1.1 - 1;
+      const newMax = 1 * 1.1 + 1;
+      const binWidth = (newMax - newMin) / 2;
       expect(
         intermediateToD3(backendToIntermediate([0, 0, bins]), 1, 1, 2)
       ).toEqual([
-        {x: 1, dx: 0, y: 10},
-        {x: 1, dx: 0, y: 0},
+        {x: newMin, dx: binWidth, y: 10},
+        {x: newMin + binWidth, dx: binWidth, y: 0},
       ]);
     });
 

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1612,10 +1612,10 @@ describe('metrics main view', () => {
         ]);
         const card2IndicatorAfter = fixture.debugElement.query(byCss.INDICATOR);
 
-        expect(card2IndicatorBefore.nativeElement).not.toBe(
+        expect(card2IndicatorBefore.nativeElement).not.toEqual(
           card2IndicatorAfter.nativeElement
         );
-        expect(card2IndicatorBefore.attributes['data-id']).not.toBe(
+        expect(card2IndicatorBefore.attributes['data-id']).not.toEqual(
           card2IndicatorAfter.attributes['data-id']
         );
       });


### PR DESCRIPTION
Check for deep equality in the test.

Failed run: https://github.com/tensorflow/tensorboard/runs/4106578999?check_suite_focus=true
```
Chrome Headless 84.0.4147.0 (Linux x86_64) metrics main view pinned view new pinned indicator shows the indicator when the same card gets pinned toggled FAILED
	Error: Expected <span _ngcontent-a-c320 class="new-card-pinned" data-id="1000">...</span> not to be <span _ngcontent-a-c320 class="new-card-pinned" data-id="1000">...</span>. Tip: To check for deep equality, use .toEqual() instead of .toBe().
	    at <Jasmine>
	    at UserContext.<anonymous> (tensorboard/webapp/metrics/views/main_view/main_view_test.ts:1615:56 <- org_tensorflow_tensorboard/tensorboard/webapp/metrics/views/main_view/main_view_test.js:1199:68)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-testing-bundle.js:407:30)
	    at ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing-bundle.js:3765:43)

	Error: Expected '1000' not to be '1000'.
	    at <Jasmine>
	    at UserContext.<anonymous> (tensorboard/webapp/metrics/views/main_view/main_view_test.ts:1618:64 <- org_tensorflow_tensorboard/tensorboard/webapp/metrics/views/main_view/main_view_test.js:1200:76)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-testing-bundle.js:407:30)
	    at ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing-bundle.js:3765:43)
```

#oncall