### PR TITLE
fix build

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1612,10 +1612,10 @@ describe('metrics main view', () => {
         ]);
         const card2IndicatorAfter = fixture.debugElement.query(byCss.INDICATOR);
 
-        expect(card2IndicatorBefore.nativeElement).not.toBe(
+        expect(card2IndicatorBefore.nativeElement).not.toEqual(
           card2IndicatorAfter.nativeElement
         );
-        expect(card2IndicatorBefore.attributes['data-id']).not.toBe(
+        expect(card2IndicatorBefore.attributes['data-id']).not.toEqual(
           card2IndicatorAfter.attributes['data-id']
         );
       });


### PR DESCRIPTION
Check for deep equality in the test.

Failed run: https://github.com/tensorflow/tensorboard/runs/4106578999?check_suite_focus=true
```
Chrome Headless 84.0.4147.0 (Linux x86_64) metrics main view pinned view new pinned indicator shows the indicator when the same card gets pinned toggled FAILED
	Error: Expected <span _ngcontent-a-c320 class="new-card-pinned" data-id="1000">...</span> not to be <span _ngcontent-a-c320 class="new-card-pinned" data-id="1000">...</span>. Tip: To check for deep equality, use .toEqual() instead of .toBe().
	    at <Jasmine>
	    at UserContext.<anonymous> (tensorboard/webapp/metrics/views/main_view/main_view_test.ts:1615:56 <- org_tensorflow_tensorboard/tensorboard/webapp/metrics/views/main_view/main_view_test.js:1199:68)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-testing-bundle.js:407:30)
	    at ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing-bundle.js:3765:43)

	Error: Expected '1000' not to be '1000'.
	    at <Jasmine>
	    at UserContext.<anonymous> (tensorboard/webapp/metrics/views/main_view/main_view_test.ts:1618:64 <- org_tensorflow_tensorboard/tensorboard/webapp/metrics/views/main_view/main_view_test.js:1200:76)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-testing-bundle.js:407:30)
	    at ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing-bundle.js:3765:43)
```

#oncall