### PR TITLE
histogram: remove `backwards` buckets in v1 histogram migration

### DIFF
--- a/tensorboard/data_compat.py
+++ b/tensorboard/data_compat.py
@@ -83,33 +83,42 @@ def make_summary(tag, metadata, data):
 def _migrate_histogram_value(value):
     """Convert `old-style` histogram value to `new-style`.
 
-    Since by default min value is DBL_MAX and max value is -DBL_MAX, empty
-    buckets on the left and right ends are removed to prevent the case of
-    `backwards` (left edge > right edge) buckets.
+    The "old-style" format can have outermost bucket limits of -DBL_MAX and
+    DBL_MAX, which are problematic for visualization. We replace those here
+    with the actual min and max values seen in the input data, but then in
+    order to avoid introducing "backwards" buckets (where left edge > right
+    edge), we first must drop all empty buckets on the left and right ends.
     """
+    summary_metadata = histogram_metadata.create_summary_metadata(
+        display_name=value.metadata.display_name or value.tag,
+        description=value.metadata.summary_description,
+    )
+
     histogram_value = value.histo
     bucket_counts = histogram_value.bucket
     # Find the indices of the leftmost and rightmost non-empty buckets.
     n = len(bucket_counts)
     start = next((i for i in range(n) if bucket_counts[i] > 0), n)
-    end = next((i for i in range(n - 1, -1, -1) if bucket_counts[i] > 0), -1)
-    # Discard empty buckets on both ends.
-    bucket_lefts = histogram_value.bucket_limit[start:end]
-    bucket_rights = histogram_value.bucket_limit[start:end]
+    end = next((i for i in reversed(range(n)) if bucket_counts[i] > 0), -1)
+    if start > end:
+        # If all input buckets were empty, treat it as a zero-bucket
+        # new-style histogram.
+        return make_summary(
+            value.tag, summary_metadata, np.zeros([0, 3], dtype=np.float32)
+        )
+    # Discard empty buckets on both ends, and keep only the "inner" edges
+    # from the remaining buckets. Note that bucket indices range from `start`
+    # to `end` inclusive, but bucket_limit indices are exclusive of `end` -
+    # this is because bucket_limit[i] is the right-hand edge for bucket[i].
     bucket_counts = bucket_counts[start : end + 1]
-    if start <= end:
-        # Use min as the left-hand limit for the first non-empty bucket.
-        bucket_lefts = [histogram_value.min] + bucket_lefts
-        # Use max as the right-hand limit for the last non-empty bucket.
-        bucket_rights = bucket_rights + [histogram_value.max]
+    inner_edges = histogram_value.bucket_limit[start:end]
+    # Use min as the left-hand limit for the first non-empty bucket.
+    bucket_lefts = [histogram_value.min] + inner_edges
+    # Use max as the right-hand limit for the last non-empty bucket.
+    bucket_rights = inner_edges + [histogram_value.max]
     buckets = np.array(
         [bucket_lefts, bucket_rights, bucket_counts], dtype=np.float32
     ).transpose()
-
-    summary_metadata = histogram_metadata.create_summary_metadata(
-        display_name=value.metadata.display_name or value.tag,
-        description=value.metadata.summary_description,
-    )
 
     return make_summary(value.tag, summary_metadata, buckets)
 

--- a/tensorboard/data_compat.py
+++ b/tensorboard/data_compat.py
@@ -81,7 +81,7 @@ def make_summary(tag, metadata, data):
 
 
 def _migrate_histogram_value(value):
-    """Convert `old-stype` histogram to `new-style`.
+    """Convert `old-style` histogram value to `new-style`.
 
     Since by default min value is DBL_MAX and max value is -DBL_MAX, empty
     buckets on the left and right ends are removed to prevent the case of

--- a/tensorboard/data_compat.py
+++ b/tensorboard/data_compat.py
@@ -89,8 +89,7 @@ def _migrate_histogram_value(value):
     """
     histogram_value = value.histo
     bucket_counts = histogram_value.bucket
-    # Find the indices of the first leftmost and rightmost buckets with
-    # nonzero counts.
+    # Find the indices of the leftmost and rightmost non-empty buckets.
     n = len(bucket_counts)
     start = next((i for i in range(n) if bucket_counts[i] > 0), n)
     end = next((i for i in range(n - 1, -1, -1) if bucket_counts[i] > 0), -1)

--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -201,9 +201,73 @@ class MigrateValueTest(tf.test.TestCase):
         self.assertEqual(expected_metadata, new_value.metadata)
         self.assertTrue(new_value.HasField("tensor"))
         buckets = tensor_util.make_ndarray(new_value.tensor)
-        self.assertEqual(old_value.histo.min, buckets[0][0])
-        self.assertEqual(old_value.histo.max, buckets[-1][1])
+        for bucket in buckets:
+            # No `backwards` buckets.
+            self.assertLess(bucket[0], bucket[1])
         self.assertEqual(23 * 45, buckets[:, 2].astype(int).sum())
+
+    def test_empty_histogram(self):
+        with tf.compat.v1.Graph().as_default():
+            old_op = tf.compat.v1.summary.histogram(
+                "empty_yet_important", tf.constant([])
+            )
+            old_value = self._value_from_op(old_op)
+        assert old_value.HasField("histo"), old_value
+        new_value = data_compat.migrate_value(old_value)
+
+        self.assertEqual("empty_yet_important", new_value.tag)
+        expected_metadata = histogram_metadata.create_summary_metadata(
+            display_name="empty_yet_important", description=""
+        )
+        self.assertEqual(expected_metadata, new_value.metadata)
+        self.assertTrue(new_value.HasField("tensor"))
+        buckets = tensor_util.make_ndarray(new_value.tensor)
+        self.assertEmpty(buckets)
+
+    def test_single_value_histogram(self):
+        with tf.compat.v1.Graph().as_default():
+            old_op = tf.compat.v1.summary.histogram(
+                "single_value_data", tf.constant([1] * 1024)
+            )
+            old_value = self._value_from_op(old_op)
+        assert old_value.HasField("histo"), old_value
+        new_value = data_compat.migrate_value(old_value)
+
+        self.assertEqual("single_value_data", new_value.tag)
+        expected_metadata = histogram_metadata.create_summary_metadata(
+            display_name="single_value_data", description=""
+        )
+        self.assertEqual(expected_metadata, new_value.metadata)
+        self.assertTrue(new_value.HasField("tensor"))
+        buckets = tensor_util.make_ndarray(new_value.tensor)
+        # Only one bucket is kept.
+        self.assertEqual((1, 3), buckets.shape)
+        # Default bucket boundaries exponentially distribute around, starting
+        # at 1e-12 and increasing by a factor of 1.1 up to 1e20.
+        self.assertAlmostEqual(0.9172464, buckets[0][0])
+        self.assertAlmostEqual(1.008971, buckets[0][1])
+        self.assertEqual(1024, buckets[0][2])
+
+    def test_histogram_with_empty_buckets_on_both_ends(self):
+        with tf.compat.v1.Graph().as_default():
+            old_op = tf.compat.v1.summary.histogram(
+                "single_value_data", tf.constant([1, 1, 1, 2, 2, 3, 3, 3, 3])
+            )
+            old_value = self._value_from_op(old_op)
+        assert old_value.HasField("histo"), old_value
+        new_value = data_compat.migrate_value(old_value)
+
+        self.assertEqual("single_value_data", new_value.tag)
+        expected_metadata = histogram_metadata.create_summary_metadata(
+            display_name="single_value_data", description=""
+        )
+        self.assertEqual(expected_metadata, new_value.metadata)
+        self.assertTrue(new_value.HasField("tensor"))
+        buckets = tensor_util.make_ndarray(new_value.tensor)
+        for bucket in buckets:
+            # No `backwards` buckets.
+            self.assertLess(bucket[0], bucket[1])
+        self.assertEqual(9, buckets[:, 2].astype(int).sum())
 
     def test_new_style_histogram(self):
         with tf.compat.v1.Graph().as_default():

--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -203,7 +203,9 @@ class MigrateValueTest(tf.test.TestCase):
         buckets = tensor_util.make_ndarray(new_value.tensor)
         for bucket in buckets:
             # No `backwards` buckets.
-            self.assertLess(bucket[0], bucket[1])
+            self.assertLessEqual(bucket[0], bucket[1])
+        self.assertEqual(old_value.histo.min, buckets[0][0])
+        self.assertEqual(old_value.histo.max, buckets[-1][1])
         self.assertEqual(23 * 45, buckets[:, 2].astype(int).sum())
 
     def test_empty_histogram(self):
@@ -242,10 +244,8 @@ class MigrateValueTest(tf.test.TestCase):
         buckets = tensor_util.make_ndarray(new_value.tensor)
         # Only one bucket is kept.
         self.assertEqual((1, 3), buckets.shape)
-        # Default bucket boundaries exponentially distribute around, starting
-        # at 1e-12 and increasing by a factor of 1.1 up to 1e20.
-        self.assertAlmostEqual(0.9172464, buckets[0][0])
-        self.assertAlmostEqual(1.008971, buckets[0][1])
+        self.assertEqual(1, buckets[0][0])
+        self.assertEqual(1, buckets[-1][1])
         self.assertEqual(1024, buckets[0][2])
 
     def test_histogram_with_empty_buckets_on_both_ends(self):
@@ -266,7 +266,9 @@ class MigrateValueTest(tf.test.TestCase):
         buckets = tensor_util.make_ndarray(new_value.tensor)
         for bucket in buckets:
             # No `backwards` buckets.
-            self.assertLess(bucket[0], bucket[1])
+            self.assertLessEqual(bucket[0], bucket[1])
+        self.assertEqual(1, buckets[0][0])
+        self.assertEqual(3, buckets[-1][1])
         self.assertEqual(9, buckets[:, 2].astype(int).sum())
 
     def test_new_style_histogram(self):


### PR DESCRIPTION
Remove empty buckets on both ends to avoid having `backwards` (left edge > right edge) buckets.

Ran the change internally: cl/407885499

Visualization change:
- before: 
![image](https://user-images.githubusercontent.com/15273931/140778999-7e2f5fd8-caed-496c-8799-d5d1d071deb1.png)
- after: 
![image](https://user-images.githubusercontent.com/15273931/140779068-3050a573-15f4-421b-8338-a3f84a49b4a7.png)


#histogram #tpu