### PR TITLE
Remove unnecessary property from some Navigation-related actions.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -108,7 +108,6 @@ export class AppRoutingEffects {
       map(() => {
         return {
           pathname: this.location.getPath(),
-          queryParams: this.location.getSearch(),
           replaceState: true,
           browserInitiated: true,
         };

--- a/tensorboard/webapp/app_routing/location.ts
+++ b/tensorboard/webapp/app_routing/location.ts
@@ -93,7 +93,6 @@ export class Location implements LocationInterface {
       map(() => {
         return {
           pathname: this.getPath(),
-          queryParams: this.getSearch(),
         };
       })
     );

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -97,7 +97,6 @@ export class TestableLocation extends Location {
   override onPopState() {
     return of({
       pathname: '/is/cool/',
-      queryParams: [],
     });
   }
 }


### PR DESCRIPTION
It seems like at some point the `Navigation` type had a queryParams property. It no longer does but some places that create instances of `Navigation` still set the queryParams object. This cleans up those remaining references.
