### PR TITLE
alias: improve visuals of alias

### DIFF
--- a/tensorboard/webapp/widgets/experiment_alias/experiment_alias_component.scss
+++ b/tensorboard/webapp/widgets/experiment_alias/experiment_alias_component.scss
@@ -15,9 +15,13 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .alias-number {
+  @include tb-theme-background-prop(background-color, unselected-chip);
   @include tb-theme-foreground-prop(border, border, 1px solid);
+  @include tb-theme-foreground-prop(color, text);
+
   border-radius: 2px;
   margin-right: 2px;
+  padding: 0 2px;
 }
 
 :host {


### PR DESCRIPTION
Alias visual component previously put simple faint border around the
text. In order to make it more visually prominent, this change does
following:
- puts chip color
- puts padding so it looks like a chip-esque
- put distinct text color so text is legible under the faint chip color


![image](https://user-images.githubusercontent.com/2547313/140782084-28709639-1ac3-4bd9-a32f-271404cfeeb0.png)
