### PR TITLE
widget: content wrapping input

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -332,6 +332,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/webapp_data_source:webapp_data_source_test_lib",
         "//tensorboard/webapp/widgets:resize_detector_test",
         "//tensorboard/webapp/widgets:resize_detector_testing",
+        "//tensorboard/webapp/widgets/content_wrapping_input:content_wrapping_input_tests",
         "//tensorboard/webapp/widgets/experiment_alias:experiment_alias_test",
         "//tensorboard/webapp/widgets/filter_input:filter_input_test",
         "//tensorboard/webapp/widgets/histogram:histogram_test",

--- a/tensorboard/webapp/widgets/content_wrapping_input/BUILD
+++ b/tensorboard/webapp/widgets/content_wrapping_input/BUILD
@@ -1,0 +1,36 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_sass_binary(
+    name = "content_wrapping_input_component_styles",
+    src = "content_wrapping_input_component.scss",
+)
+
+tf_ng_module(
+    name = "content_wrapping_input",
+    srcs = [
+        "content_wrapping_input_component.ts",
+        "content_wrapping_input_module.ts",
+    ],
+    assets = [
+        ":content_wrapping_input_component_styles",
+    ],
+    deps = [
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ts_library(
+    name = "content_wrapping_input_tests",
+    testonly = True,
+    srcs = ["content_wrapping_input_test.ts"],
+    deps = [
+        ":content_wrapping_input",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/testing:dom",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_component.scss
+++ b/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_component.scss
@@ -1,0 +1,90 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+@import 'tensorboard/webapp/theme/tb_theme';
+
+:host {
+  display: inline-flex;
+  width: max-content;
+
+  &:focus-within .container {
+    border-color: mat-color($tb-primary, 700);
+  }
+
+  &.default {
+    &:hover .container {
+      border-color: map-get($tb-foreground, border);
+    }
+  }
+
+  &.error .container,
+  .container:not(.is-valid) {
+    $_error-color: mat-color($tb-warn, 200);
+    border-color: $_error-color;
+
+    &:hover,
+    &:focus-within {
+      border-color: $_error-color;
+    }
+  }
+
+  &.high-contrast .container {
+    border-color: mat-color($mat-gray, 400);
+
+    &:hover {
+      border-color: mat-color($mat-gray, 600);
+    }
+  }
+}
+
+.container {
+  border-radius: 4px;
+  border: 2px solid transparent;
+  padding: 1px 2px;
+  position: relative;
+}
+
+.measurer {
+  pointer-events: none;
+  position: absolute;
+  visibility: hidden;
+}
+
+.measurer,
+input {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1.4;
+  padding: 0;
+  white-space: pre;
+
+  &:empty {
+    width: 2ch;
+  }
+}
+
+input {
+  appearance: none;
+  background-color: inherit;
+  border: 0;
+  color: inherit;
+  display: inline-block;
+  font-family: inherit;
+  outline: 0;
+
+  &:focus {
+    padding-right: 1ch;
+  }
+}

--- a/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_component.ts
+++ b/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_component.ts
@@ -1,0 +1,181 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {
+  AfterViewChecked,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+
+interface FontFaceSet {
+  addEventListener(event: string, calback: (event: Event) => void): void;
+  removeEventListener(event: string, calback: (event: Event) => void): void;
+}
+
+// See https://developer.mozilla.org/en-US/docs/Web/API/Document/fonts
+declare global {
+  interface Document {
+    fonts?: FontFaceSet;
+  }
+}
+
+/**
+ * An input that tightly wraps a value.
+ *
+ * Native HTML `<input>` has a fixed width and lets the content scroll within
+ * the element. Instead of that, this component resizes the element dynamically
+ * to match that of the `value`.
+ *
+ * Conditions in which we set the width are: (1) value change, (2) input event,
+ * (3) font load changes. Even if font-family or CSS values change, this module
+ * will not respond to those.
+ */
+@Component({
+  selector: 'content-wrapping-input',
+  template: `
+    <span [class.container]="true" [class.is-valid]="isValid">
+      <span #measurer class="measurer" aria-hidden="true">{{
+        internalValue || placeholder
+      }}</span>
+      <input
+        #input
+        autocomplete="off"
+        spellcheck="false"
+        type="text"
+        (blur)="blur.emit($event)"
+        (focus)="focus.emit($event)"
+        (input)="onInput($event)"
+        (keydown)="keydown.emit($event)"
+        (keyup)="keyup.emit($event)"
+        [value]="value"
+        [placeholder]="placeholder"
+      />
+    </span>
+  `,
+  styleUrls: ['./content_wrapping_input_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ContentWrappingInputComponent
+  implements OnInit, OnDestroy, AfterViewChecked, OnChanges
+{
+  @ViewChild('measurer', {static: true, read: ElementRef})
+  private readonly measurerElRef!: ElementRef<HTMLSpanElement>;
+
+  @ViewChild('input', {static: true, read: ElementRef})
+  private readonly inputElRef!: ElementRef<HTMLInputElement>;
+
+  @Input() value!: string;
+  @Input() placeholder: string = '';
+
+  @HostBinding('class')
+  @Input()
+  style: 'error' | 'high-contrast' | 'default' = 'default';
+
+  /**
+   * `value` validation regex pattern; similar to that of `input#pattern`. When
+   * present and if invalid, it will visually put red border around the input.
+   */
+  @Input() pattern?: string;
+
+  private patternRegex = new RegExp('.*');
+
+  isValid: boolean = true;
+
+  @Output() onValueChange = new EventEmitter<{value: string}>();
+  @Output() blur = new EventEmitter<FocusEvent>();
+  @Output() focus = new EventEmitter<FocusEvent>();
+  @Output() keydown = new EventEmitter<KeyboardEvent>();
+  @Output() keyup = new EventEmitter<KeyboardEvent>();
+
+  // Use internal state so we can update the DOM right away without waiting for
+  // `value` to change by the owner of the component.
+  internalValue: string = '';
+
+  constructor(private readonly changeDetector: ChangeDetectorRef) {}
+
+  private readonly fontChangeListener = this.updateInputWidth.bind(this);
+
+  ngOnInit() {
+    if (document.fonts) {
+      // When font changes, we need to re-calculate the width of the `value`
+      // rendered onto the measurer and re-set the width.
+      // Without this, our screenshot tests become super flaky as Roboto fonts
+      // are never cached under integration test environment and there could be
+      // a timing issue where Roboto font gets loaded quite late.
+      document.fonts.addEventListener('loadingdone', this.fontChangeListener);
+    }
+  }
+
+  ngOnDestroy() {
+    if (document.fonts) {
+      document.fonts.removeEventListener(
+        'loadingdone',
+        this.fontChangeListener
+      );
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['pattern']) {
+      this.patternRegex = new RegExp(this.pattern ?? '');
+    }
+
+    if (changes['value']) {
+      this.internalValue = this.value;
+    }
+
+    this.isValid = this.patternRegex.test(this.internalValue);
+  }
+
+  /**
+   * Gets triggered when `@Input` changes or when event such as keydown happens
+   * inside the component.
+   */
+  ngAfterViewChecked() {
+    this.updateInputWidth();
+  }
+
+  onInput(event: InputEvent) {
+    const prevValue = this.internalValue;
+    this.internalValue = this.inputElRef.nativeElement.value;
+    if (this.internalValue !== prevValue) {
+      // In unit test, we can omit this but for reasons we do not yet
+      // understand, below `changeDetector.markForCheck` does not trigge
+      // `ngOnChanges` in real usage.
+      this.isValid = this.patternRegex.test(this.internalValue);
+      this.changeDetector.markForCheck();
+    }
+
+    this.onValueChange.emit({value: this.internalValue});
+  }
+
+  private updateInputWidth() {
+    // WARN: this flow may cause forced reflow: write (by angular) -> read ->
+    // write. Optimize if it causes performance issues.
+    const {width} = this.measurerElRef.nativeElement.getBoundingClientRect();
+    this.inputElRef.nativeElement.style.width = `${width}px`;
+  }
+}

--- a/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_module.ts
+++ b/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_module.ts
@@ -1,0 +1,31 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {NgModule} from '@angular/core';
+
+import {ContentWrappingInputComponent} from './content_wrapping_input_component';
+
+/**
+ * Provides <content-wrapping-input> that behaves like an <input> but with
+ * different UX. Its width changes based on value typed, or placeholder when
+ * value is empty. When not focused, it looks like a simple span with a text.
+ *
+ * UX was largely inpsired by the title editor in Google Docs.
+ */
+@NgModule({
+  exports: [ContentWrappingInputComponent],
+  declarations: [ContentWrappingInputComponent],
+})
+export class ContentWrappingInputModule {}

--- a/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_test.ts
+++ b/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_test.ts
@@ -1,0 +1,218 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, Input} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {KeyType, sendKey} from '../../testing/dom';
+import {ContentWrappingInputComponent} from './content_wrapping_input_component';
+
+@Component({
+  selector: 'testing-component',
+  template: `
+    <content-wrapping-input
+      [style]="style"
+      [value]="value"
+      [pattern]="pattern"
+      (blur)="onBlur($event)"
+      (focus)="onFocus($event)"
+      (keydown)="onKeydown($event)"
+      (keyup)="onKeyup($event)"
+      (onValueChange)="onValueChange($event)"
+    ></content-wrapping-input>
+  `,
+})
+class TestableComponent {
+  @Input() style?: string;
+  @Input() value!: string;
+  @Input() pattern?: string;
+  @Input() onBlur: (e: FocusEvent) => void = () => {};
+  @Input() onFocus: (e: FocusEvent) => void = () => {};
+  @Input() onKeydown: (e: KeyboardEvent) => void = () => {};
+  @Input() onKeyup: (e: KeyboardEvent) => void = () => {};
+  @Input() onValueChange: (val: {value: string}) => void = () => {};
+}
+
+describe('widgets/content_wrapping_input', () => {
+  const byCss = {
+    input: By.css('content-wrapping-input input'),
+    component: By.directive(ContentWrappingInputComponent),
+    container: By.css('.container'),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ContentWrappingInputComponent, TestableComponent],
+    }).compileComponents();
+  });
+
+  function getInputValue(fixture: ComponentFixture<TestableComponent>): string {
+    const inputEl = fixture.debugElement.query(byCss.input)
+      .nativeElement as HTMLInputElement;
+    return inputEl.value;
+  }
+
+  function getInputWidth(fixture: ComponentFixture<TestableComponent>): number {
+    const inputEl = fixture.debugElement.query(byCss.input)
+      .nativeElement as HTMLInputElement;
+    return Number(window.getComputedStyle(inputEl).width.slice(0, -2));
+  }
+
+  it('renders value and their changes', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.componentInstance.value = 'foo';
+    fixture.detectChanges();
+
+    expect(getInputValue(fixture)).toBe('foo');
+
+    fixture.componentInstance.value = 'bar';
+    fixture.detectChanges();
+    expect(getInputValue(fixture)).toBe('bar');
+  });
+
+  it('resizes the input field on value change', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.componentInstance.value = 'foo';
+    fixture.detectChanges();
+
+    const fooWidth = getInputWidth(fixture);
+
+    fixture.componentInstance.value = 'foobar';
+    fixture.detectChanges();
+
+    expect(getInputWidth(fixture)).toBeGreaterThan(fooWidth);
+
+    fixture.componentInstance.value = 'fo';
+    fixture.detectChanges();
+
+    expect(getInputWidth(fixture)).toBeLessThan(fooWidth);
+  });
+
+  it('propagates events', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    const onKeydown = jasmine.createSpy();
+    fixture.componentInstance.value = 'foo';
+    fixture.componentInstance.onKeydown = onKeydown;
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.query(byCss.input)
+      .nativeElement as HTMLInputElement;
+    inputEl.dispatchEvent(new KeyboardEvent('keydown', {key: 'd'}));
+
+    expect(onKeydown).toHaveBeenCalledWith(
+      new KeyboardEvent('keydown', {key: 'd'})
+    );
+  });
+
+  it('emits onValueChange when value changes with current input value', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    const onValueChange = jasmine.createSpy();
+    fixture.componentInstance.value = 'foo';
+    fixture.componentInstance.onValueChange = onValueChange;
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.query(byCss.input)
+      .nativeElement as HTMLInputElement;
+    inputEl.value = 'food';
+    inputEl.dispatchEvent(new InputEvent('input', {data: 'd'}));
+
+    expect(onValueChange).toHaveBeenCalledWith({value: 'food'});
+  });
+
+  describe('pattern validation-less', () => {
+    it('puts class "is-valid" for all kinds of input', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.value = 'foo';
+      fixture.detectChanges();
+
+      const container = fixture.debugElement.query(byCss.container);
+      expect(container.nativeElement.classList.contains('is-valid')).toBe(true);
+
+      fixture.componentInstance.value = 'bar';
+      fixture.detectChanges();
+
+      expect(container.nativeElement.classList.contains('is-valid')).toBe(true);
+    });
+
+    it('puts class "is-valid" even when style is specified', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.style = 'error';
+      fixture.componentInstance.value = 'foo';
+      fixture.detectChanges();
+
+      const component = fixture.debugElement.query(byCss.component);
+      const container = fixture.debugElement.query(byCss.container);
+      expect(component.nativeElement.classList.contains('error')).toBe(true);
+      expect(container.nativeElement.classList.contains('is-valid')).toBe(true);
+
+      fixture.componentInstance.style = 'high-contrast';
+      fixture.detectChanges();
+
+      expect(component.nativeElement.classList.contains('high-contrast')).toBe(
+        true
+      );
+      expect(container.nativeElement.classList.contains('is-valid')).toBe(true);
+    });
+  });
+
+  describe('pattern validation', () => {
+    it('validates input when `pattern` is present', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.value = 'foo';
+      fixture.componentInstance.pattern = '^[o]+$';
+      fixture.detectChanges();
+
+      const container = fixture.debugElement.query(byCss.container);
+      expect(container.nativeElement.classList.contains('is-valid')).toBe(
+        false
+      );
+
+      fixture.componentInstance.pattern = '^[fo]+$';
+      fixture.detectChanges();
+
+      expect(container.nativeElement.classList.contains('is-valid')).toBe(true);
+    });
+
+    it('sets everything as valid when pattern is not present', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.value = 'foo';
+      fixture.detectChanges();
+
+      const container = fixture.debugElement.query(byCss.container);
+      expect(container.nativeElement.classList.contains('is-valid')).toBe(true);
+    });
+
+    it('validates when user inputs', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.value = 'foo';
+      fixture.componentInstance.pattern = '^hello$';
+      fixture.detectChanges();
+
+      const inputDebugEl = fixture.debugElement.query(byCss.input);
+      sendKey(fixture, inputDebugEl, {
+        type: KeyType.CHARACTER,
+        key: '^',
+        prevString: 'hello',
+        startingCursorIndex: 5,
+      });
+
+      const container = fixture.debugElement.query(byCss.container);
+      expect(container.nativeElement.classList.contains('is-valid')).toBe(
+        false
+      );
+    });
+  });
+});


### PR DESCRIPTION
This change open sources content_wrapping_input, a component that
behaves a lot like content-editable element that tightly wraps content.

A conventional `<input>` element has a fixed width invariable to size of
the content. If content is too long, there exists mechanisms to scroll
within the input. This behavior is not something that we do not want in
some UI elements and this widget helps with that.
