### PR TITLE
alias: implement edit mode

### DIFF
--- a/tensorboard/webapp/widgets/experiment_alias/BUILD
+++ b/tensorboard/webapp/widgets/experiment_alias/BUILD
@@ -20,6 +20,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/experiments:types",
+        "//tensorboard/webapp/widgets/content_wrapping_input",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],
@@ -35,6 +36,8 @@ tf_ts_library(
         ":experiment_alias",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/experiments:types",
+        "//tensorboard/webapp/testing:dom",
+        "//tensorboard/webapp/widgets/content_wrapping_input",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/widgets/experiment_alias/experiment_alias_component.ts
+++ b/tensorboard/webapp/widgets/experiment_alias/experiment_alias_component.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, EventEmitter, Input, Output} from '@angular/core';
 
 import {ExperimentAlias} from '../../experiments/types';
 
@@ -24,11 +24,29 @@ import {ExperimentAlias} from '../../experiments/types';
   selector: 'tb-experiment-alias',
   template: `
     <span class="alias-number">{{ alias.aliasNumber }}</span>
-    <span>{{ alias.aliasText }}</span>
+    <content-wrapping-input
+      *ngIf="aliasEditable; else noEditAliasName"
+      placeholder="Alias for experiment"
+      [style]="isAliasNameLegal ? 'high-contrast' : 'error'"
+      [value]="alias.aliasText"
+      (onValueChange)="aliasChanged.emit($event)"
+    ></content-wrapping-input>
+    <ng-template #noEditAliasName>
+      <span [class.illegal]="!isAliasNameLegal">{{ alias.aliasText }}</span>
+    </ng-template>
   `,
   styleUrls: [`experiment_alias_component.css`],
 })
 export class ExperimentAliasComponent {
   @Input()
   alias!: ExperimentAlias;
+
+  @Input()
+  aliasEditable!: boolean;
+
+  @Input()
+  isAliasNameLegal: boolean = true;
+
+  @Output()
+  aliasChanged = new EventEmitter<{value: string}>();
 }

--- a/tensorboard/webapp/widgets/experiment_alias/experiment_alias_module.ts
+++ b/tensorboard/webapp/widgets/experiment_alias/experiment_alias_module.ts
@@ -15,10 +15,11 @@ limitations under the License.
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
+import {ContentWrappingInputModule} from '../content_wrapping_input/content_wrapping_input_module';
 import {ExperimentAliasComponent} from './experiment_alias_component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, ContentWrappingInputModule],
   exports: [ExperimentAliasComponent],
   declarations: [ExperimentAliasComponent],
 })

--- a/tensorboard/webapp/widgets/experiment_alias/experiment_alias_test.ts
+++ b/tensorboard/webapp/widgets/experiment_alias/experiment_alias_test.ts
@@ -12,28 +12,115 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {Component, Input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
+import {ExperimentAlias} from '../../experiments/types';
+import {sendKeys} from '../../testing/dom';
+import {ContentWrappingInputModule} from '../content_wrapping_input/content_wrapping_input_module';
 import {ExperimentAliasComponent} from './experiment_alias_component';
+
+@Component({
+  selector: 'testable',
+  template: `<tb-experiment-alias
+    [alias]="alias"
+    [aliasEditable]="aliasEditable"
+    [isAliasNameLegal]="isAliasNameLegal"
+    (aliasChanged)="aliasChanged($event)"
+  ></tb-experiment-alias>`,
+})
+class TestableComponent {
+  @Input()
+  alias!: ExperimentAlias;
+
+  @Input()
+  aliasEditable!: boolean;
+
+  @Input()
+  isAliasNameLegal?: boolean;
+
+  @Input()
+  aliasChanged: () => void = () => {};
+}
 
 describe('experiment alias widget', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [],
-      declarations: [ExperimentAliasComponent],
+      imports: [ContentWrappingInputModule],
+      declarations: [ExperimentAliasComponent, TestableComponent],
     }).compileComponents();
   });
 
-  it('renders the alias', () => {
-    const fixture = TestBed.createComponent(ExperimentAliasComponent);
-    fixture.componentInstance.alias = {aliasText: 'my_alias', aliasNumber: 1};
-    fixture.detectChanges();
+  describe('non-edit mode', () => {
+    it('renders the alias', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.alias = {aliasText: 'my_alias', aliasNumber: 1};
+      fixture.detectChanges();
 
-    const spans = fixture.debugElement.queryAll(By.css('span'));
-    expect(spans[0].nativeElement.textContent).toBe('1');
-    expect(spans[1].nativeElement.textContent).toBe('my_alias');
-    const numberSpan = fixture.debugElement.queryAll(By.css('.alias-number'));
-    expect(numberSpan[0].nativeElement.textContent).toBe('1');
+      const spans = fixture.debugElement.queryAll(By.css('span'));
+      expect(spans[0].nativeElement.textContent).toBe('1');
+      expect(spans[1].nativeElement.textContent).toBe('my_alias');
+      const numberSpan = fixture.debugElement.queryAll(By.css('.alias-number'));
+      expect(numberSpan[0].nativeElement.textContent).toBe('1');
+    });
+
+    it('puts class "illegal" if alias name is not legal', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.alias = {aliasText: '$', aliasNumber: 1};
+      fixture.componentInstance.isAliasNameLegal = false;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.illegal'))).not.toBeNull();
+    });
+  });
+
+  describe('edit mode', () => {
+    it('renders content-wrapping-input', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.alias = {aliasText: 'tb rocks', aliasNumber: 1};
+      fixture.componentInstance.aliasEditable = true;
+      fixture.componentInstance.isAliasNameLegal = true;
+      fixture.detectChanges();
+
+      expect(
+        fixture.debugElement.query(By.css('content-wrapping-input'))
+      ).not.toBeNull();
+      expect(
+        fixture.debugElement.query(By.css('input')).nativeElement.value
+      ).toBe('tb rocks');
+    });
+
+    it('renders input with error ui when alias name is not legal', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.alias = {aliasText: '$', aliasNumber: 1};
+      fixture.componentInstance.aliasEditable = true;
+      fixture.componentInstance.isAliasNameLegal = true;
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(
+        By.css('content-wrapping-input')
+      );
+      expect(input.componentInstance.style).not.toBe('error');
+
+      fixture.componentInstance.isAliasNameLegal = false;
+      fixture.detectChanges();
+      expect(input.componentInstance.style).toBe('error');
+    });
+
+    it('bubbles up alias changes to via aliasChanged emitter', () => {
+      const aliasChangedSpy = jasmine.createSpy();
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.alias = {aliasText: 'tb rocks', aliasNumber: 1};
+      fixture.componentInstance.aliasEditable = true;
+      fixture.componentInstance.aliasChanged = aliasChangedSpy;
+      fixture.detectChanges();
+
+      const debugEl = fixture.debugElement.query(By.css('input'));
+      sendKeys(fixture, debugEl, 'ye');
+
+      expect(aliasChangedSpy).toHaveBeenCalledWith({value: 'y'});
+      expect(aliasChangedSpy).toHaveBeenCalledWith({value: 'ye'});
+    });
   });
 });


### PR DESCRIPTION
Depending on whether the alias component is in an edit mode or not, it
renders a content-wrapping-input.

![image](https://user-images.githubusercontent.com/2547313/140843560-c938811c-a2cc-43f9-8976-a88033b57f9a.png)
