### PR TITLE
Time Series: fix color group preserve bug

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -102,8 +102,8 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
     if (!groupBy && !regexFilter) {
       return state;
     }
-    let {colorGroupRegexString, userSetGroupByKey} = state;
 
+    let {colorGroupRegexString, userSetGroupByKey} = state;
     if (groupBy) {
       const regexString =
         groupBy.key === GroupByKey.REGEX

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -116,8 +116,8 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
     return {
       ...state,
       colorGroupRegexString,
-      userSetGroupByKey,
       regexFilter,
+      userSetGroupByKey,
     };
   }),
   on(runsActions.fetchRunsRequested, (state, action) => {

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -102,18 +102,21 @@ const dataReducer: ActionReducer<RunsDataState, Action> = createReducer(
     if (!groupBy && !regexFilter) {
       return state;
     }
+    let {colorGroupRegexString, userSetGroupByKey} = state;
 
     if (groupBy) {
       const regexString =
         groupBy.key === GroupByKey.REGEX
           ? groupBy.regexString
           : state.colorGroupRegexString;
-      state.colorGroupRegexString = regexString;
-      state.userSetGroupByKey = groupBy.key ?? null;
+      colorGroupRegexString = regexString;
+      userSetGroupByKey = groupBy.key ?? null;
     }
 
     return {
       ...state,
+      colorGroupRegexString,
+      userSetGroupByKey,
       regexFilter,
     };
   }),

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -1205,6 +1205,34 @@ describe('runs_reducers', () => {
       expect(nextState.data.regexFilter).toBe('world');
       expect(nextState.data.userSetGroupByKey).toBe(GroupByKey.EXPERIMENT);
     });
+
+    it('set regexFilter and userSetGroupBy to be group by regex', () => {
+      const state = buildRunsState({
+        colorGroupRegexString: '',
+        initialGroupBy: {key: GroupByKey.RUN},
+        userSetGroupByKey: GroupByKey.EXPERIMENT,
+        regexFilter: 'hello',
+      });
+
+      const partialState: URLDeserializedState = {
+        runs: {
+          groupBy: {key: GroupByKey.REGEX, regexString: 'train'},
+          regexFilter: 'world',
+        },
+      };
+
+      const nextState = runsReducers.reducers(
+        state,
+        stateRehydratedFromUrl({
+          routeKind: RouteKind.EXPERIMENT,
+          partialState,
+        })
+      );
+
+      expect(nextState.data.regexFilter).toBe('world');
+      expect(nextState.data.userSetGroupByKey).toBe(GroupByKey.REGEX);
+      expect(nextState.data.colorGroupRegexString).toBe('train');
+    });
   });
 
   describe('when freshly navigating', () => {


### PR DESCRIPTION
When rehydrate state from url, I shouldn't directly set value to `colorGroupRegexString` and `userSetGroupByKey` of state. This bug only happens for color group by regex. Add one more test to check changes on both regexFilter and color group by regex.
However, It's not caught by the unit test (specifically `'sets regexString on groupBy REGEX'` )is because the state we built up for unit tests allow attribute overwrite.