### PR TITLE
chore: Update Angular Material style imports to @use

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/BUILD
@@ -6,5 +6,8 @@ licenses(["notice"])
 
 tf_sass_library(
     name = "style_lib",
-    srcs = ["_lib.scss"],
+    srcs = [
+        "_lib.scss",
+        "//tensorboard/webapp:angular_material_theming",
+    ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/_lib.scss
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/_lib.scss
@@ -12,9 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 
 @mixin debugger-op-type {
-  background-color: mat-color($mat-blue-grey, 50);
+  background-color: mat.get-color-from-palette(mat.$blue-palette-grey, 50);
   @include tb-theme-foreground-prop(border, border, 1px solid);
   border-radius: 4px;
   font-family: 'Roboto Mono', monospace;
@@ -25,13 +26,13 @@ limitations under the License.
   width: max-content;
 
   @include tb-dark-theme {
-    background-color: mat-color($mat-blue-grey, 700);
+    background-color: mat.get-color-from-palette(mat.$blue-palette-grey, 700);
   }
 }
 
 @mixin debugger-highlight-background {
   background-color: #fff099;
   @include tb-dark-theme {
-    background-color: mat-color($mat-orange, 900);
+    background-color: mat.get-color-from-palette(mat.$orange-palette, 900);
   }
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/_lib.scss
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/_lib.scss
@@ -15,7 +15,7 @@ limitations under the License.
 @use '@angular/material' as mat;
 
 @mixin debugger-op-type {
-  background-color: mat.get-color-from-palette(mat.$blue-palette-grey, 50);
+  background-color: mat.get-color-from-palette(mat.$blue-grey-palette, 50);
   @include tb-theme-foreground-prop(border, border, 1px solid);
   border-radius: 4px;
   font-family: 'Roboto Mono', monospace;
@@ -26,7 +26,7 @@ limitations under the License.
   width: max-content;
 
   @include tb-dark-theme {
-    background-color: mat.get-color-from-palette(mat.$blue-palette-grey, 700);
+    background-color: mat.get-color-from-palette(mat.$blue-grey-palette, 700);
   }
 }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "execution_data_styles",
     src = "execution_data_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_component.scss
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .debug-tensor-values-table {
@@ -44,7 +45,7 @@ limitations under the License.
 }
 
 .focus-execution-container {
-  background-color: mat-color($mat-orange, 200);
+  background-color: mat.get-color-from-palette(mat.$orange-palette, 200);
   border-radius: 4px;
   font-size: 12px;
   height: 120px;
@@ -52,7 +53,7 @@ limitations under the License.
   width: 360px;
 
   @include tb-dark-theme {
-    background-color: mat-color($mat-orange, 900);
+    background-color: mat.get-color-from-palette(mat.$orange-palette, 900);
   }
 }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_op_component.scss
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_op_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common/lib';
 
@@ -31,7 +32,7 @@ limitations under the License.
   text-align: right;
   width: 200px;
   @include tb-dark-theme {
-    box-shadow: 1px 3px mat-color($mat-gray, 600);
+    box-shadow: 1px 3px mat.get-color-from-palette(mat.$gray-palette, 600);
   }
 }
 

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -175,11 +175,11 @@ tf_js_binary(
     entry_point = "main_prod.ts",
     deps = [
         ":ng_main",
+        "//tensorboard/webapp:angular_material_theming",
         "//tensorboard/webapp/angular:expect_angular_material_tabs",
         "//tensorboard/webapp/angular:expect_angular_material_toolbar",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@angular/material",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//rxjs",

--- a/tensorboard/webapp/metrics/views/BUILD
+++ b/tensorboard/webapp/metrics/views/BUILD
@@ -12,6 +12,7 @@ tf_sass_library(
 tf_sass_binary(
     name = "metrics_container_styles",
     src = "metrics_container.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_sass_binary(

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -121,6 +121,7 @@ tf_sass_binary(
     name = "image_card_styles",
     src = "image_card_component.scss",
     deps = [
+        "//tensorboard/webapp:angular_material_theming",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
     ],
 )
@@ -190,6 +191,7 @@ tf_ng_module(
 tf_sass_binary(
     name = "vis_selected_time_clipped_styles",
     src = "vis_selected_time_clipped_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common';
 
@@ -142,7 +143,7 @@ $_title-to-heading-gap: 12px;
 }
 
 :host ::ng-deep .mat-slider-min-value .mat-slider-thumb {
-  background-color: mat-color($tb-primary);
+  background-color: mat.get-color-from-palette($tb-primary);
 }
 
 .empty-message {

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_clipped_component.scss
@@ -12,16 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
-  color: mat-color(map-get($tb-theme, warn), 700);
+  color: mat.get-color-from-palette(map-get($tb-theme, warn), 700);
   height: 1em;
   line-height: 0;
   width: 1em;
 
   @include tb-dark-theme {
-    color: mat-color(map-get($tb-dark-theme, warn), 700);
+    color: mat.get-color-from-palette(map-get($tb-dark-theme, warn), 700);
   }
 
   mat-icon {

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -6,6 +6,7 @@ tf_sass_binary(
     name = "main_view_styles",
     src = "main_view_component.scss",
     deps = [
+        "//tensorboard/webapp:angular_material_theming",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
     ],
 )
@@ -13,12 +14,14 @@ tf_sass_binary(
 tf_sass_binary(
     name = "filter_input_component_styles",
     src = "filter_input_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_sass_binary(
     name = "filtered_view_component_styles",
     src = "filtered_view_component.scss",
     deps = [
+        "//tensorboard/webapp:angular_material_theming",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
     ],
 )
@@ -27,6 +30,7 @@ tf_sass_binary(
     name = "pinned_view_component_styles",
     src = "pinned_view_component.scss",
     deps = [
+        "//tensorboard/webapp:angular_material_theming",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
     ],
 )

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .tag-filter {
@@ -27,7 +28,7 @@ tb-filter-input {
   @include tb-theme-foreground-prop(color, text);
 
   &:not(.valid) {
-    $_error-color: mat-color($tb-warn, 800);
+    $_error-color: mat.get-color-from-palette($tb-warn, 800);
 
     color: $_error-color;
 

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common';
 
@@ -82,7 +83,7 @@ limitations under the License.
 }
 
 .main {
-  background-color: mat-color($tf-slate, 200);
+  background-color: mat.get-color-from-palette($tf-slate, 200);
   flex: 1 1;
   display: flex;
   flex-direction: column;
@@ -138,16 +139,16 @@ limitations under the License.
 
 /** TODO(psybuzz): consider making a tb-button instead. */
 :host .settings-button {
-  color: mat-color($tb-foreground, secondary-text);
+  color: mat.get-color-from-palette($tb-foreground, secondary-text);
   display: inline-flex;
 
   @include tb-dark-theme {
-    color: mat-color($tb-dark-foreground, secondary-text);
+    color: mat.get-color-from-palette($tb-dark-foreground, secondary-text);
   }
 
   &.checked {
     @include tb-theme-background-prop(background-color, selected-button);
-    border-color: mat-color($mat-gray, 300);
+    border-color: mat.get-color-from-palette(mat.$gray-palette, 300);
   }
 
   ::ng-deep .mat-button-wrapper {

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common';
 
@@ -45,7 +46,7 @@ mat-icon {
 
 .new-card-pinned {
   animation: pinned-view-fade-out 3s linear;
-  background: mat-color($mat-red, 500);
+  background: mat.get-color-from-palette(mat.$red-palette, 500);
   border-radius: 5px;
   color: #fff;
   display: inline-block;

--- a/tensorboard/webapp/metrics/views/metrics_container.scss
+++ b/tensorboard/webapp/metrics/views/metrics_container.scss
@@ -24,7 +24,10 @@ limitations under the License.
 }
 
 .notice {
-  background-color: rgba(mat.get-color-from-palette(mat.$yellow-palette, 200), 0.85);
+  background-color: rgba(
+    mat.get-color-from-palette(mat.$yellow-palette, 200),
+    0.85
+  );
   border-bottom: 1px solid mat.get-color-from-palette(mat.$yellow-palette, 500);
   color: map-get($tb-foreground, text);
   display: block;

--- a/tensorboard/webapp/metrics/views/metrics_container.scss
+++ b/tensorboard/webapp/metrics/views/metrics_container.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -23,8 +24,8 @@ limitations under the License.
 }
 
 .notice {
-  background-color: rgba(mat-color($mat-yellow, 200), 0.85);
-  border-bottom: 1px solid mat-color($mat-yellow, 500);
+  background-color: rgba(mat.get-color-from-palette(mat.$yellow-palette, 200), 0.85);
+  border-bottom: 1px solid mat.get-color-from-palette(mat.$yellow-palette, 500);
   color: map-get($tb-foreground, text);
   display: block;
   flex: 0 0;
@@ -36,14 +37,14 @@ tb-dashboard-layout {
 }
 
 nav {
-  background-color: mat-color($tb-background, background);
-  border-right: 1px solid mat-color($tb-foreground, border);
+  background-color: mat.get-color-from-palette($tb-background, background);
+  border-right: 1px solid mat.get-color-from-palette($tb-foreground, border);
   flex: none;
   width: 340px;
 
   @include tb-dark-theme {
     background-color: map-get($tb-dark-background, background);
-    border-right-color: mat-color($tb-dark-foreground, border);
+    border-right-color: mat.get-color-from-palette($tb-dark-foreground, border);
   }
 }
 

--- a/tensorboard/webapp/metrics/views/right_pane/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "settings_view_styles",
     src = "settings_view_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -54,7 +55,7 @@ section .control-row:not(:last-child) {
 
   .slider-input {
     background-color: inherit;
-    border: 1px solid mat-color($tf-slate, 500);
+    border: 1px solid mat.get-color-from-palette($tf-slate, 500);
     border-radius: 2px;
     box-sizing: border-box;
     color: inherit;
@@ -63,7 +64,7 @@ section .control-row:not(:last-child) {
     padding: 0 4px;
 
     @include tb-dark-theme {
-      border-color: mat-color($tf-slate, 700);
+      border-color: mat.get-color-from-palette($tf-slate, 700);
     }
   }
 }

--- a/tensorboard/webapp/notification_center/_views/BUILD
+++ b/tensorboard/webapp/notification_center/_views/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "notification_center_styles",
     src = "notification_center_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .notification-icon-button {
@@ -20,7 +21,7 @@ limitations under the License.
 
 .red-dot {
   $_dim: 10px;
-  background-color: mat-color($mat-red, 700);
+  background-color: mat.get-color-from-palette(mat.$red-palette, 700);
   border-radius: $_dim * 0.5;
   height: $_dim;
   position: absolute;
@@ -49,7 +50,7 @@ limitations under the License.
 }
 
 .category-icon {
-  color: mat-color($mat-blue, 700);
+  color: mat.get-color-from-palette(mat.$blue-palette, 700);
   height: 15px;
   margin-right: 6px;
   vertical-align: middle;

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "annotations_list_component_styles",
     src = "annotations_list_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "annotation_component_styles",
     src = "annotation_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -28,16 +29,16 @@ limitations under the License.
 }
 
 .selected-row {
-  background-color: mat-color($tb-background, selected-button);
+  background-color: mat.get-color-from-palette($tb-background, selected-button);
   display: block;
 }
 
 .flagged-annotation {
-  color: mat-color($tb-primary);
+  color: mat.get-color-from-palette($tb-primary);
 }
 
 .hidden-annotation {
-  color: mat-color($tb-foreground, disabled-text);
+  color: mat.get-color-from-palette($tb-foreground, disabled-text);
 }
 
 .annotation-checkbox {
@@ -57,7 +58,7 @@ limitations under the License.
 }
 
 .chart-div {
-  border-bottom: 1px solid mat-color($tb-foreground, border);
+  border-bottom: 1px solid mat.get-color-from-palette($tb-foreground, border);
 }
 
 .chart-svg {
@@ -66,15 +67,15 @@ limitations under the License.
 }
 
 .default-text {
-  fill: mat-color($tb-foreground, base);
+  fill: mat.get-color-from-palette($tb-foreground, base);
 }
 
 .flag-text {
-  fill: mat-color($tb-primary);
+  fill: mat.get-color-from-palette($tb-primary);
 }
 
 .hidden-text {
-  fill: mat-color($tb-foreground, disabled-text);
+  fill: mat.get-color-from-palette($tb-foreground, disabled-text);
 }
 
 .clickable-annotation {

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_component.scss
@@ -12,11 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
-  background-color: mat-color($tb-background, card);
-  border: 1px solid mat-color($tb-foreground, border);
+  background-color: mat.get-color-from-palette($tb-background, card);
+  border: 1px solid mat.get-color-from-palette($tb-foreground, border);
   display: flex;
   flex-direction: column;
   height: calc(100% - 2px); // Because of Border

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "annotations_search_component_styles",
     src = "annotations_search_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -19,7 +20,7 @@ limitations under the License.
   position: relative;
 
   &:not(.valid) {
-    $_error-color: mat-color($tb-warn, 800);
+    $_error-color: mat.get-color-from-palette($tb-warn, 800);
     color: $_error-color;
 
     input {

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "header_component_styles",
     src = "header_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_component.scss
@@ -12,10 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
-  border-bottom: 2px solid mat-color($tb-foreground, border);
+  border-bottom: 2px solid mat.get-color-from-palette($tb-foreground, border);
   display: flex;
   height: 28px;
   align-items: flex-end;

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "data_selection_component_styles",
     src = "data_selection_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/data_selection_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/data_selection_component.scss
@@ -12,13 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
   display: flex;
   flex-direction: column;
   background-color: #fff;
-  border: 1px solid mat-color($tb-foreground, border);
+  border: 1px solid mat.get-color-from-palette($tb-foreground, border);
   padding: 10px 20px;
 }
 

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "metric_arithmetic_element_component_styles",
     src = "metric_arithmetic_element_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .filter-chip {
@@ -22,7 +23,7 @@ limitations under the License.
 
 .metric-arithmetic-element-range {
   align-items: center;
-  background-color: mat-color($tb-background, card);
+  background-color: mat.get-color-from-palette($tb-background, card);
   font-size: 0.8em;
   height: 30px;
   justify-content: center;
@@ -39,18 +40,18 @@ limitations under the License.
   transition: width 1s;
 
   &:focus {
-    background-color: mat-color($tb-background, focused-button);
+    background-color: mat.get-color-from-palette($tb-background, focused-button);
     border: none;
     outline: none;
   }
 }
 
 .value-invalid {
-  color: mat-color($tb-warn);
+  color: mat.get-color-from-palette($tb-warn);
 }
 
 .embedding-selected {
-  color: mat-color($tb-primary);
+  color: mat.get-color-from-palette($tb-primary);
   opacity: 1;
 }
 

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_component.scss
@@ -40,7 +40,10 @@ limitations under the License.
   transition: width 1s;
 
   &:focus {
-    background-color: mat.get-color-from-palette($tb-background, focused-button);
+    background-color: mat.get-color-from-palette(
+      $tb-background,
+      focused-button
+    );
     border: none;
     outline: none;
   }

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "metric_search_component_styles",
     src = "metric_search_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 mat-icon {
@@ -26,7 +27,7 @@ mat-icon {
   font-size: 0.9em;
 
   &:not(.valid) {
-    color: mat-color($tb-warn, 800);
+    color: mat.get-color-from-palette($tb-warn, 800);
 
     input {
       caret-color: currentColor;

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "results_download_component_styles",
     src = "results_download_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_component.scss
@@ -12,10 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .active-button {
-  background-color: mat-color($tb-primary, 500);
+  background-color: mat.get-color-from-palette($tb-primary, 500);
   border: 1px solid map-get($tb-foreground, border);
   color: map-get($tb-background, raised-button);
 }

--- a/tensorboard/webapp/plugins/npmi/views/embeddings/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/embeddings/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "embeddings_component_styles",
     src = "embeddings_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -57,7 +58,7 @@ limitations under the License.
   position: absolute;
   left: 10px;
   bottom: 10px;
-  border: 1px solid mat-color($tb-foreground, border);
+  border: 1px solid mat.get-color-from-palette($tb-foreground, border);
   border-radius: 3px;
   display: flex;
   align-items: center;
@@ -70,7 +71,7 @@ limitations under the License.
   height: 100%;
   width: 3px;
   overflow: hidden;
-  background-color: mat-color($tb-foreground, divider);
+  background-color: mat.get-color-from-palette($tb-foreground, divider);
 }
 
 .annotations-list {

--- a/tensorboard/webapp/plugins/npmi/views/main/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/main/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "main_component_styles",
     src = "main_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/main/main_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -62,7 +63,7 @@ limitations under the License.
   position: absolute;
   left: 10px;
   bottom: 10px;
-  border: 1px solid mat-color($tb-foreground, border);
+  border: 1px solid mat.get-color-from-palette($tb-foreground, border);
   border-radius: 3px;
   display: flex;
   align-items: center;
@@ -75,7 +76,7 @@ limitations under the License.
   height: 100%;
   width: 3px;
   overflow: hidden;
-  background-color: mat-color($tb-foreground, divider);
+  background-color: mat.get-color-from-palette($tb-foreground, divider);
 }
 
 .annotations-list {

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "selected_annotations_component_styles",
     src = "selected_annotations_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_component.scss
@@ -12,16 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .pc-container {
-  background-color: mat-color($tb-background, card);
-  border: 1px solid mat-color($tb-foreground, border);
+  background-color: mat.get-color-from-palette($tb-background, card);
+  border: 1px solid mat.get-color-from-palette($tb-foreground, border);
 }
 
 .pc-toolbar {
   align-items: center;
-  border-bottom: 1px solid mat-color($tb-foreground, border);
+  border-bottom: 1px solid mat.get-color-from-palette($tb-foreground, border);
   display: flex;
   height: 42px;
   padding: 0 16px;

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "violin_filters_component_styles",
     src = "violin_filters_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "violin_filter_component_styles",
     src = "violin_filter_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.scss
@@ -12,11 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .chart-container {
-  background-color: mat-color($tb-background, card);
-  border-bottom: 1px solid mat-color($tb-foreground, border);
+  background-color: mat.get-color-from-palette($tb-background, card);
+  border-bottom: 1px solid mat.get-color-from-palette($tb-foreground, border);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -45,6 +46,6 @@ limitations under the License.
 }
 
 .stroked-line {
-  stroke: mat-color($tb-foreground, divider);
+  stroke: mat.get-color-from-palette($tb-foreground, divider);
   stroke-dasharray: 3 3;
 }

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -22,7 +23,7 @@ limitations under the License.
 
 .filters-toolbar {
   align-items: center;
-  border-bottom: 1px solid mat-color($tb-foreground, border);
+  border-bottom: 1px solid mat.get-color-from-palette($tb-foreground, border);
   display: flex;
   height: 42px;
   justify-content: space-between;
@@ -37,9 +38,9 @@ limitations under the License.
 
 .side-toggle {
   align-items: center;
-  background-color: mat-color($tb-background, raised-button);
+  background-color: mat.get-color-from-palette($tb-background, raised-button);
   border-radius: 3px;
-  border: 1px solid mat-color($tb-foreground, border);
+  border: 1px solid mat.get-color-from-palette($tb-foreground, border);
   display: flex;
   height: 30px;
   justify-content: center;
@@ -58,5 +59,5 @@ limitations under the License.
 }
 
 .filters-hint-text {
-  color: mat-color($tb-foreground, hint-text);
+  color: mat.get-color-from-palette($tb-foreground, hint-text);
 }

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -7,11 +7,13 @@ licenses(["notice"])
 tf_sass_binary(
     name = "runs_table_styles",
     src = "runs_table_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_sass_binary(
     name = "runs_group_menu_button_styles",
     src = "runs_group_menu_button_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_sass_binary(

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 ::ng-deep .run-table-color-group-by {
@@ -19,7 +20,7 @@ limitations under the License.
   font-size: 16px;
 
   .label {
-    color: mat-color($tb-foreground, secondary-text);
+    color: mat.get-color-from-palette($tb-foreground, secondary-text);
     font-size: 0.9em;
     margin: 10px 0;
     padding: 0 16px;

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 // 42px + 1px for border.
@@ -157,13 +158,13 @@ $_font-size: 13px;
   $_swatch-size: 20px;
 
   border-radius: 100%;
-  border: 1px solid mat-color($tb-foreground, border);
+  border: 1px solid mat.get-color-from-palette($tb-foreground, border);
   height: $_swatch-size;
   width: $_swatch-size;
   outline: none;
 
   &.no-color {
-    border-color: mat-color($tf-slate, 300);
+    border-color: mat.get-color-from-palette($tf-slate, 300);
     border-width: 2px;
   }
 }

--- a/tensorboard/webapp/tbdev_upload/BUILD
+++ b/tensorboard/webapp/tbdev_upload/BUILD
@@ -33,11 +33,13 @@ tf_ng_module(
 tf_sass_binary(
     name = "tbdev_upload_button_component_css",
     src = "tbdev_upload_button_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_sass_binary(
     name = "tbdev_upload_dialog_component_css",
     src = "tbdev_upload_dialog_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ts_library(

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_button_component.scss
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_button_component.scss
@@ -12,15 +12,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 /* Override material styling with more precise selector. */
 :host button.mat-stroked-button {
-  background-color: mat-color($tb-primary, 500);
+  background-color: mat.get-color-from-palette($tb-primary, 500);
   border: 1px solid map-get($tb-foreground, border);
 
   @include tb-dark-theme {
-    background-color: mat-color($tb-primary, 800);
+    background-color: mat.get-color-from-palette($tb-primary, 800);
   }
 }
 

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 div,
@@ -52,7 +53,7 @@ p {
   padding: 2px 12px;
 
   @include tb-dark-theme {
-    background-color: mat-color($mat-grey, 700);
+    background-color: mat.get-color-from-palette($mat-grey, 700);
   }
 }
 

--- a/tensorboard/webapp/theme/_tb_palette.scss
+++ b/tensorboard/webapp/theme/_tb_palette.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 
 @import 'tensorboard/webapp/angular_material_theming';
 
@@ -44,15 +45,15 @@ $tf-slate: (
    several orange values, but only one of them (--tb-orange-strong) is used
    widely. */
 $tf-orange: (
-  100: mat-color($mat-orange, 100),
-  200: mat-color($mat-orange, 200),
-  300: mat-color($mat-orange, 300),
-  400: mat-color($mat-orange, 400),
-  500: mat-color($mat-orange, 500),
-  600: mat-color($mat-orange, 600),
-  700: mat-color($mat-orange, 700),
-  800: mat-color($mat-orange, 800),
-  900: mat-color($mat-orange, 900),
+  100: mat.get-color-from-palette(mat.$orange-palette, 100),
+  200: mat.get-color-from-palette(mat.$orange-palette, 200),
+  300: mat.get-color-from-palette(mat.$orange-palette, 300),
+  400: mat.get-color-from-palette(mat.$orange-palette, 400),
+  500: mat.get-color-from-palette(mat.$orange-palette, 500),
+  600: mat.get-color-from-palette(mat.$orange-palette, 600),
+  700: mat.get-color-from-palette(mat.$orange-palette, 700),
+  800: mat.get-color-from-palette(mat.$orange-palette, 800),
+  900: mat.get-color-from-palette(mat.$orange-palette, 900),
   contrast: (
     100: $dark-primary-text,
     200: $dark-primary-text,

--- a/tensorboard/webapp/theme/_tb_palette.scss
+++ b/tensorboard/webapp/theme/_tb_palette.scss
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 @use '@angular/material' as mat;
-
 @import 'tensorboard/webapp/angular_material_theming';
 
 $tf-slate: (

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-@use '@angular/material' as mat;
 @import 'tensorboard/webapp/angular_material_theming';
 
 /***********************************************************
@@ -36,7 +35,10 @@ $tb-dark-accent: $tb-accent !default;
 $tb-dark-warn: $tb-warn !default;
 // Value for `app-bar` property in $tb-dark-background. Can specify an override
 // in _variable.scss to specifically customize this value.
-$tb-dark-app-bar-color: mat.get-color-from-palette($tb-dark-primary, default) !default;
+$tb-dark-app-bar-color: mat.get-color-from-palette(
+  $tb-dark-primary,
+  default
+) !default;
 
 $tb-theme: mat.define-light-theme($tb-primary, $tb-accent, $tb-warn);
 

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/angular_material_theming';
 
 /***********************************************************
@@ -28,32 +29,32 @@ limitations under the License.
 
 // Value for `app-bar` property in $tb-background. Can specify an override in
 // _variable.scss to specifically customize this value.
-$tb-app-bar-color: mat-color($tb-primary, default) !default;
+$tb-app-bar-color: mat.get-color-from-palette($tb-primary, default) !default;
 
 $tb-dark-primary: $tb-primary !default;
 $tb-dark-accent: $tb-accent !default;
 $tb-dark-warn: $tb-warn !default;
 // Value for `app-bar` property in $tb-dark-background. Can specify an override
 // in _variable.scss to specifically customize this value.
-$tb-dark-app-bar-color: mat-color($tb-dark-primary, default) !default;
+$tb-dark-app-bar-color: mat.get-color-from-palette($tb-dark-primary, default) !default;
 
-$tb-theme: mat-light-theme($tb-primary, $tb-accent, $tb-warn);
+$tb-theme: mat.define-light-theme($tb-primary, $tb-accent, $tb-warn);
 
 // Overriding mat-light-theme-foreground variables.
 $tb-foreground: map_merge(
-  $mat-light-theme-foreground,
+  mat.$light-theme-foreground-palette,
   (
-    text: mat-color($mat-gray, 900),
-    secondary-text: mat-color($mat-gray, 700),
-    disabled-text: mat-color($mat-gray, 600),
+    text: mat.get-color-from-palette(mat.$gray-palette, 900),
+    secondary-text: mat.get-color-from-palette(mat.$gray-palette, 700),
+    disabled-text: mat.get-color-from-palette(mat.$gray-palette, 600),
     // TB specific variable.
     border: #ebebeb,
-    link: mat-color($mat-blue, 700),
-    link-visited: mat-color($mat-purple, 700),
+    link: mat.get-color-from-palette(mat.$blue-palette, 700),
+    link-visited: mat.get-color-from-palette(mat.$purple-palette, 700),
   )
 );
 $tb-background: map_merge(
-  $mat-light-theme-background,
+  mat.$light-theme-background-palette,
   (
     app-bar: $tb-app-bar-color,
     // Default is `map.get($grey-palette, 50)`.
@@ -69,7 +70,7 @@ $tb-theme: map_merge(
   )
 );
 
-$tb-dark-theme: mat-dark-theme(
+$tb-dark-theme: mat.define-dark-theme(
   $tb-dark-primary,
   $tb-dark-accent,
   $tb-dark-warn
@@ -78,9 +79,9 @@ $tb-dark-foreground: map_merge(
   map-get($tb-dark-theme, foreground),
   (
     border: #555,
-    disabled-text: mat-color($mat-gray, 700),
-    link: mat-color($mat-blue, 400),
-    link-visited: mat-color($mat-purple, 300),
+    disabled-text: mat.get-color-from-palette(mat.$gray-palette, 700),
+    link: mat.get-color-from-palette(mat.$blue-palette, 400),
+    link-visited: mat.get-color-from-palette(mat.$purple-palette, 300),
   )
 );
 $tb-dark-background: map_merge(

--- a/tensorboard/webapp/theme/_variable.scss
+++ b/tensorboard/webapp/theme/_variable.scss
@@ -12,12 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/angular_material_theming';
 @import 'tensorboard/webapp/theme/tb_palette';
 
-$tb-primary: mat-palette($tf-orange, 700, 400, 800);
-$tb-accent: mat-palette($tf-orange);
-$tb-warn: mat-palette($mat-red);
+$tb-primary: mat.define-palette($tf-orange, 700, 400, 800);
+$tb-accent: mat.define-palette($tf-orange);
+$tb-warn: mat.define-palette(mat.$red-palette);
 
-$tb-dark-primary: mat-palette($tf-orange, 800, 600, 900);
+$tb-dark-primary: mat.define-palette($tf-orange, 800, 600, 900);
 $tb-dark-accent: $tb-dark-primary;

--- a/tensorboard/webapp/widgets/content_wrapping_input/BUILD
+++ b/tensorboard/webapp/widgets/content_wrapping_input/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "content_wrapping_input_component_styles",
     src = "content_wrapping_input_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_component.scss
+++ b/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_component.scss
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -20,7 +21,7 @@ limitations under the License.
   width: max-content;
 
   &:focus-within .container {
-    border-color: mat-color($tb-primary, 700);
+    border-color: mat.get-color-from-palette($tb-primary, 700);
   }
 
   &.default {
@@ -31,7 +32,7 @@ limitations under the License.
 
   &.error .container,
   .container:not(.is-valid) {
-    $_error-color: mat-color($tb-warn, 200);
+    $_error-color: mat.get-color-from-palette($tb-warn, 200);
     border-color: $_error-color;
 
     &:hover,
@@ -41,10 +42,10 @@ limitations under the License.
   }
 
   &.high-contrast .container {
-    border-color: mat-color($mat-gray, 400);
+    border-color: mat.get-color-from-palette(mat.$gray-palette, 400);
 
     &:hover {
-      border-color: mat-color($mat-gray, 600);
+      border-color: mat.get-color-from-palette(mat.$gray-palette, 600);
     }
   }
 }

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "dropdown_styles",
     src = "dropdown_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
@@ -12,10 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 mat-select {
-  border: 1px solid mat-color($tf-slate, 500);
+  border: 1px solid mat.get-color-from-palette($tf-slate, 500);
   border-radius: 3px;
   box-sizing: border-box;
   padding: 6px;

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "line_chart_axis_view_styles",
     src = "line_chart_axis_view.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_sass_binary(

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -112,7 +113,7 @@ text {
 }
 
 .extent-edit-button {
-  background-color: mat-color($mat-gray, 200);
+  background-color: mat.get-color-from-palette(mat.$gray-palette, 200);
   display: none;
   font-size: 0;
   height: 24px;
@@ -187,7 +188,7 @@ text {
   }
 }
 
-$_border-style: 1px solid mat-color($mat-gray, 500);
+$_border-style: 1px solid mat.get-color-from-palette(mat.$gray-palette, 500);
 
 .x-axis .major-label {
   border-left: $_border-style;

--- a/tensorboard/webapp/widgets/linked_time_fob/BUILD
+++ b/tensorboard/webapp/widgets/linked_time_fob/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "linked_time_fob_styles",
     src = "linked_time_fob_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
@@ -19,7 +20,7 @@ limitations under the License.
 }
 
 span {
-  background-color: mat-color($mat-gray, 300);
+  background-color: mat.get-color-from-palette(mat.$gray-palette, 300);
   border-radius: 25px;
   color: inherit;
   display: inline-block;
@@ -28,16 +29,16 @@ span {
 
   &:hover,
   &:active {
-    border-color: mat-color($mat-gray, 700);
+    border-color: mat.get-color-from-palette(mat.$gray-palette, 700);
   }
 
   @include tb-dark-theme {
-    background-color: mat-color($mat-gray, 700);
-    border-color: mat-color($tf-slate, 500);
+    background-color: mat.get-color-from-palette(mat.$gray-palette, 700);
+    border-color: mat.get-color-from-palette($tf-slate, 500);
 
     &:hover,
     &:active {
-      border-color: mat-color($mat-gray, 200);
+      border-color: mat.get-color-from-palette(mat.$gray-palette, 200);
     }
   }
 }

--- a/tensorboard/webapp/widgets/range_input/BUILD
+++ b/tensorboard/webapp/widgets/range_input/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "range_input_styles",
     src = "range_input_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/widgets/range_input/range_input_component.scss
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.scss
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 
 // Keep this in sync with range_input_component.ts's `THUMB_SIZE_PX`.
@@ -89,9 +90,9 @@ input {
 
 .slider-track-fill,
 .thumb {
-  background: mat-color($tb-primary);
+  background: mat.get-color-from-palette($tb-primary);
 
   @include tb-dark-theme {
-    background: mat-color($tb-dark-primary);
+    background: mat.get-color-from-palette($tb-dark-primary);
   }
 }


### PR DESCRIPTION
Updates the stylesheet imports of Angular Material to use the non-deprecated import paths