### PR TITLE
line chart: fix bug where line does not update

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -97,26 +97,30 @@ describe('line_chart_v2/lib/renderer test', () => {
       expect(path.style.display).toBe('');
     });
 
-    it('skips updating path and color if visibility goes from true to false', () => {
-      const cacheObject = renderer.createOrUpdateLineObject(
-        null,
-        new Float32Array([0, 10, 10, 100]),
-        {visible: true, color: '#f00', width: 6}
-      );
+    it(
+      'updates path and color if visibility goes from true to false so value is ' +
+        'correct when it goes back to true',
+      () => {
+        const cacheObject = renderer.createOrUpdateLineObject(
+          null,
+          new Float32Array([0, 10, 10, 100]),
+          {visible: true, color: '#f00', width: 6}
+        );
 
-      renderer.createOrUpdateLineObject(
-        cacheObject,
-        new Float32Array([0, 5, 5, 50]),
-        {visible: false, color: '#0f0', width: 3}
-      );
+        renderer.createOrUpdateLineObject(
+          cacheObject,
+          new Float32Array([0, 5, 5, 50]),
+          {visible: false, color: '#0f0', width: 3}
+        );
 
-      expect(el.children.length).toBe(1);
-      const path = el.children[0] as SVGPathElement;
-      expect(path.tagName).toBe('path');
-      expect(path.style.display).toBe('none');
-      expect(path.getAttribute('d')).toBe('M0,10L10,100');
-      expect(path.style.stroke).toBe('rgb(255, 0, 0)');
-    });
+        expect(el.children.length).toBe(1);
+        const path = el.children[0] as SVGPathElement;
+        expect(path.tagName).toBe('path');
+        expect(path.style.display).toBe('none');
+        expect(path.getAttribute('d')).toBe('M0,5L5,50');
+        expect(path.style.stroke).toBe('rgb(0, 255, 0)');
+      }
+    );
 
     it('skips rendering DOM when a new cacheId starts with visible=false', () => {
       renderer.createOrUpdateLineObject(

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -44,18 +44,13 @@ function createOrUpdateObject<T extends SVGPathElement | SVGCircleElement>(
   const {color, visible, opacity} = paintOpt;
   let dom: T | undefined = prevDom;
 
-  if (!dom) {
-    // Skip if prevDom does not exist and Object is invisible
-    if (!visible) return null;
-
-    dom = creator();
-  } else if (!visible) {
-    dom.style.display = 'none';
-    return dom;
+  if (!dom && !visible) {
+    return null;
   }
 
+  dom = dom ?? creator();
   dom = updater(dom);
-  dom.style.display = '';
+  dom.style.display = visible ? '' : 'none';
   dom.style.stroke = color;
   dom.style.opacity = String(opacity ?? 1);
   return dom;


### PR DESCRIPTION
For SVG renderer, which is current default, when a line path updates
while invisible, we never update its path leading to very subtle issue.

Repro steps:
1. Find a scalar card with more than two runs (all toggled on here)
2. Toggle all runs off
3. Toggle on run on
4. Zoom in and change viewBox
5. Toggle on another run. Observe that the run line is positioned where
   it was in (1).

Fixes b/206638910.