### PR TITLE
build: omit SASS target on js_binary

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -175,7 +175,6 @@ tf_js_binary(
     entry_point = "main_prod.ts",
     deps = [
         ":ng_main",
-        "//tensorboard/webapp:angular_material_theming",
         "//tensorboard/webapp/angular:expect_angular_material_tabs",
         "//tensorboard/webapp/angular:expect_angular_material_toolbar",
         "@npm//@angular/common",


### PR DESCRIPTION
js_binary cannot build when it misses JS_INFO in the provider
internally. Since sass library does not provide js_info, we are
omitting the dependency
