### PR TITLE
chore: Fix Angular Material style naming

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/BUILD
@@ -6,8 +6,6 @@ licenses(["notice"])
 
 tf_sass_library(
     name = "style_lib",
-    srcs = [
-        "_lib.scss",
-        "//tensorboard/webapp:angular_material_theming",
-    ],
+    srcs = ["_lib.scss"],
+    deps = ["//tensorboard/webapp:angular_material_theming"],
 )

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
@@ -53,7 +53,7 @@ p {
   padding: 2px 12px;
 
   @include tb-dark-theme {
-    background-color: mat.get-color-from-palette($mat-grey, 700);
+    background-color: mat.get-color-from-palette(mat.$grey-palette, 700);
   }
 }
 

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -24,7 +24,7 @@ limitations under the License.
 // Angular Material theme definition.
 
 // Include non-theme styles for core.
-@include mat-core();
+@include mat.core();
 
 // Value for `app-bar` property in $tb-background. Can specify an override in
 // _variable.scss to specifically customize this value.


### PR DESCRIPTION
Fixes some missing renaming from #5421 