### PR TITLE
Time Series: fix dark mode color

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/card_group_toolbar_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_group_toolbar_component.scss
@@ -34,11 +34,16 @@ limitations under the License.
       cursor: pointer;
     }
   }
+
+  @include tb-dark-theme {
+    .group-toolbar {
+      color: map-get($tb-dark-foreground, text);
+    }
+  }
 }
 
 .expand-group-icon {
   @include tb-theme-foreground-prop(color, secondary-text);
-  background-color: $metrics-button-background-color-on-gray;
 
   &:disabled {
     @include tb-theme-foreground-prop(color, disabled-text);

--- a/tensorboard/webapp/metrics/views/main_view/card_group_toolbar_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_group_toolbar_component.scss
@@ -21,6 +21,7 @@ limitations under the License.
   .group-toolbar {
     border: 0;
     @include tb-theme-foreground-prop(border-top, border, 1px solid);
+    @include tb-theme-foreground-prop(color, text);
     // border-top on group-toolbar needs to be offset on sticky header for the
     // flawless UI.
     top: -1px;
@@ -32,12 +33,6 @@ limitations under the License.
     }
     &:hover {
       cursor: pointer;
-    }
-  }
-
-  @include tb-dark-theme {
-    .group-toolbar {
-      color: map-get($tb-dark-foreground, text);
     }
   }
 }


### PR DESCRIPTION
Fix dark mode color for collapsible groups

before 
![Screen Shot 2021-11-16 at 11 22 33 PM](https://user-images.githubusercontent.com/1131010/142250090-44b888db-4122-4c06-be8f-849876751c1e.png)

after 
![Screen Shot 2021-11-16 at 11 49 26 PM](https://user-images.githubusercontent.com/1131010/142250129-e317b5f3-3937-4109-a91c-89e07f7537bd.png)
light mode
![Screen Shot 2021-11-17 at 9 22 08 AM](https://user-images.githubusercontent.com/1131010/142250196-1ce9a2e5-a7ab-479e-9a93-4380ad1dd68b.png)


