### PR TITLE
Time Series: adjust card width (UI)

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -280,9 +280,9 @@ export const getMetricsSettingOverrides = createSelector(
   }
 );
 
-export const getMetricCardMaxWidthMultiplier = createSelector(
+export const getMetricCardMaxWidth = createSelector(
   selectSettings,
-  (settings): number => settings.cardMaxWidthMultiplier
+  (settings): number => settings.cardMaxWidthInVW
 );
 
 export const getMetricsTooltipSort = createSelector(

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -280,6 +280,11 @@ export const getMetricsSettingOverrides = createSelector(
   }
 );
 
+export const getMetricCardMaxWidthMultiplier = createSelector(
+  selectSettings,
+  (settings): number => settings.cardMaxWidthMultiplier
+);
+
 export const getMetricsTooltipSort = createSelector(
   selectSettings,
   (settings): TooltipSort => settings.tooltipSort

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -282,7 +282,7 @@ export const getMetricsSettingOverrides = createSelector(
 
 export const getMetricsCardMaxWidth = createSelector(
   selectSettings,
-  (settings): number => settings.cardMaxWidthInVW
+  (settings): number | null => settings.cardMaxWidthInVW
 );
 
 export const getMetricsTooltipSort = createSelector(

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -280,7 +280,7 @@ export const getMetricsSettingOverrides = createSelector(
   }
 );
 
-export const getMetricCardMaxWidth = createSelector(
+export const getMetricsCardMaxWidth = createSelector(
   selectSettings,
   (settings): number => settings.cardMaxWidthInVW
 );

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -663,6 +663,18 @@ describe('metrics selectors', () => {
         HistogramMode.OVERLAY
       );
     });
+
+    it('returns cardMaxWidthInVW when called getMetricCardMaxWidth', () => {
+      selectors.getMetricCardMaxWidth.release();
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          settings: buildMetricsSettingsState({
+            cardMaxWidthInVW: 40,
+          }),
+        })
+      );
+      expect(selectors.getMetricCardMaxWidth(state)).toBe(40);
+    });
   });
 
   describe('getMetricsTagFilter', () => {

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -665,7 +665,7 @@ describe('metrics selectors', () => {
     });
 
     it('returns cardMaxWidthInVW when called getMetricCardMaxWidth', () => {
-      selectors.getMetricCardMaxWidth.release();
+      selectors.getMetricsCardMaxWidth.release();
       const state = appStateFromMetricsState(
         buildMetricsState({
           settings: buildMetricsSettingsState({
@@ -673,7 +673,7 @@ describe('metrics selectors', () => {
           }),
         })
       );
-      expect(selectors.getMetricCardMaxWidth(state)).toBe(40);
+      expect(selectors.getMetricsCardMaxWidth(state)).toBe(40);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -169,6 +169,7 @@ export interface MetricsRoutefulState {
 }
 
 export interface MetricsSettings {
+  cardMaxWidthMultiplier: number;
   tooltipSort: TooltipSort;
   ignoreOutliers: boolean;
   xAxisType: XAxisType;
@@ -221,6 +222,7 @@ export interface State {
 }
 
 export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
+  cardMaxWidthMultiplier: 1,
   tooltipSort: TooltipSort.DEFAULT,
   ignoreOutliers: true,
   xAxisType: XAxisType.STEP,

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -169,7 +169,7 @@ export interface MetricsRoutefulState {
 }
 
 export interface MetricsSettings {
-  cardMaxWidthInVW: number;
+  cardMaxWidthInVW: number | null;
   tooltipSort: TooltipSort;
   ignoreOutliers: boolean;
   xAxisType: XAxisType;
@@ -222,7 +222,7 @@ export interface State {
 }
 
 export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
-  cardMaxWidthInVW: 30,
+  cardMaxWidthInVW: null,
   tooltipSort: TooltipSort.DEFAULT,
   ignoreOutliers: true,
   xAxisType: XAxisType.STEP,

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -169,7 +169,7 @@ export interface MetricsRoutefulState {
 }
 
 export interface MetricsSettings {
-  cardMaxWidthMultiplier: number;
+  cardMaxWidthInVW: number;
   tooltipSort: TooltipSort;
   ignoreOutliers: boolean;
   xAxisType: XAxisType;
@@ -222,7 +222,7 @@ export interface State {
 }
 
 export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
-  cardMaxWidthMultiplier: 1,
+  cardMaxWidthInVW: 30,
   tooltipSort: TooltipSort.DEFAULT,
   ignoreOutliers: true,
   xAxisType: XAxisType.STEP,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -43,6 +43,7 @@ export function buildMetricsSettingsState(
   overrides?: Partial<MetricsSettings>
 ): MetricsSettings {
   return {
+    cardMaxWidthMultiplier: 1,
     tooltipSort: TooltipSort.NEAREST,
     ignoreOutliers: false,
     xAxisType: XAxisType.WALL_TIME,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -43,7 +43,7 @@ export function buildMetricsSettingsState(
   overrides?: Partial<MetricsSettings>
 ): MetricsSettings {
   return {
-    cardMaxWidthInVW: 30,
+    cardMaxWidthInVW: null,
     tooltipSort: TooltipSort.NEAREST,
     ignoreOutliers: false,
     xAxisType: XAxisType.WALL_TIME,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -43,7 +43,7 @@ export function buildMetricsSettingsState(
   overrides?: Partial<MetricsSettings>
 ): MetricsSettings {
   return {
-    cardMaxWidthMultiplier: 1,
+    cardMaxWidthInVW: 30,
     tooltipSort: TooltipSort.NEAREST,
     ignoreOutliers: false,
     xAxisType: XAxisType.WALL_TIME,

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -20,7 +20,9 @@ limitations under the License.
     *ngTemplateOutlet="groupControls; context: {isBottomControl: false}"
   ></ng-container>
 
-  <div class="card-grid">
+  <div class="card-grid"
+    [style.grid-template-columns]="gridTemplateColumn">
+  >
     <card-view
       *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
       [cardId]="item.cardId"

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -20,9 +20,7 @@ limitations under the License.
     *ngTemplateOutlet="groupControls; context: {isBottomControl: false}"
   ></ng-container>
 
-  <div class="card-grid"
-    [style.grid-template-columns]="gridTemplateColumn">
-  >
+  <div class="card-grid" [style.grid-template-columns]="gridTemplateColumn">
     <card-view
       *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
       [cardId]="item.cardId"

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -28,6 +28,8 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 
 const MIN_CARD_WIDTH = 335;
+const MIN_CARD_MAX_WIDTH_IN_VW = 30;
+const MAX_CARD_MAX_WIDTH_IN_VW = 100;
 
 @Component({
   selector: 'metrics-card-grid-component',
@@ -37,7 +39,7 @@ const MIN_CARD_WIDTH = 335;
 })
 export class CardGridComponent {
   readonly PluginType = PluginType;
-  gridTemplateColumn = "";
+  gridTemplateColumn = '';
 
   @Input() isGroupExpanded!: boolean;
   @Input() pageIndex!: number;
@@ -54,8 +56,12 @@ export class CardGridComponent {
   ) {}
 
   ngOnInit() {
-    if (this.cardMaxWidthInVW && this.cardMaxWidthInVW >= 30 && this.cardMaxWidthInVW <= 100) {
-      this.gridTemplateColumn = `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, ${this.cardMaxWidthInVW}vw))`
+    if (
+      this.cardMaxWidthInVW &&
+      this.cardMaxWidthInVW >= MIN_CARD_MAX_WIDTH_IN_VW &&
+      this.cardMaxWidthInVW <= MAX_CARD_MAX_WIDTH_IN_VW
+    ) {
+      this.gridTemplateColumn = `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, ${this.cardMaxWidthInVW}vw))`;
     }
   }
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -28,7 +28,6 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 
 const MIN_CARD_WIDTH = 335;
-const MAX_CARD_WIDTH = 600;
 
 @Component({
   selector: 'metrics-card-grid-component',
@@ -44,7 +43,7 @@ export class CardGridComponent {
   @Input() pageIndex!: number;
   @Input() numPages!: number;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
-  @Input() cardMaxWidthMultiplier!: number;
+  @Input() cardMaxWidthInVW!: number;
   @Input() cardObserver!: CardObserver;
   @Input() showPaginationControls!: boolean;
 
@@ -55,10 +54,9 @@ export class CardGridComponent {
   ) {}
 
   ngOnInit() {
-    const maxCardWidth = this.cardMaxWidthMultiplier * MAX_CARD_WIDTH;
-
-    // TODO check if maxCardWidth is less than auto
-    this.gridTemplateColumn = `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, ${maxCardWidth}px))`
+    if (this.cardMaxWidthInVW >= 30 && this.cardMaxWidthInVW <= 100) {
+      this.gridTemplateColumn = `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, ${this.cardMaxWidthInVW}vw))`
+    }
   }
 
   showPaginationInput(isBottomControl: boolean) {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -43,7 +43,7 @@ export class CardGridComponent {
   @Input() pageIndex!: number;
   @Input() numPages!: number;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
-  @Input() cardMaxWidthInVW!: number;
+  @Input() cardMaxWidthInVW!: number | null;
   @Input() cardObserver!: CardObserver;
   @Input() showPaginationControls!: boolean;
 
@@ -54,7 +54,7 @@ export class CardGridComponent {
   ) {}
 
   ngOnInit() {
-    if (this.cardMaxWidthInVW >= 30 && this.cardMaxWidthInVW <= 100) {
+    if (this.cardMaxWidthInVW && this.cardMaxWidthInVW >= 30 && this.cardMaxWidthInVW <= 100) {
       this.gridTemplateColumn = `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, ${this.cardMaxWidthInVW}vw))`
     }
   }

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -27,6 +27,9 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
 
 import {CardIdWithMetadata} from '../metrics_view_types';
 
+const MIN_CARD_WIDTH = 335;
+const MAX_CARD_WIDTH = 600;
+
 @Component({
   selector: 'metrics-card-grid-component',
   templateUrl: './card_grid_component.ng.html',
@@ -35,11 +38,13 @@ import {CardIdWithMetadata} from '../metrics_view_types';
 })
 export class CardGridComponent {
   readonly PluginType = PluginType;
+  gridTemplateColumn = "";
 
   @Input() isGroupExpanded!: boolean;
   @Input() pageIndex!: number;
   @Input() numPages!: number;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
+  @Input() cardMaxWidthMultiplier!: number;
   @Input() cardObserver!: CardObserver;
   @Input() showPaginationControls!: boolean;
 
@@ -48,6 +53,13 @@ export class CardGridComponent {
   constructor(
     @Optional() private readonly cdkScrollable: CdkScrollable | null
   ) {}
+
+  ngOnInit() {
+    const maxCardWidth = this.cardMaxWidthMultiplier * MAX_CARD_WIDTH;
+
+    // TODO check if maxCardWidth is less than auto
+    this.gridTemplateColumn = `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, ${maxCardWidth}px))`
+  }
 
   showPaginationInput(isBottomControl: boolean) {
     return isBottomControl;

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -26,7 +26,11 @@ import {BehaviorSubject, combineLatest, Observable, of, Subject} from 'rxjs';
 import {map, shareReplay, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {State} from '../../../app_state';
-import {getMetricCardMaxWidth, getMetricsTagGroupExpansionState} from '../../../selectors';
+import {
+  getMetricCardMaxWidth,
+  getMetricsTagGroupExpansionState,
+  getEnabledCardWidthSetting,
+} from '../../../selectors';
 import {metricsTagGroupExpansionChanged} from '../../actions';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
@@ -116,7 +120,14 @@ export class CardGridContainer implements OnChanges, OnDestroy {
     })
   );
 
-  readonly cardMaxWidthInVW$ = this.store.select(getMetricCardMaxWidth);
+  readonly cardMaxWidthInVW$ = combineLatest([
+    this.store.select(getMetricCardMaxWidth),
+    this.store.select(getEnabledCardWidthSetting),
+  ]).pipe(
+    map(([cardMaxWidth, isCardWithSettingEnabled]) =>
+      isCardWithSettingEnabled ? cardMaxWidth : null
+    )
+  );
 
   constructor(private readonly store: Store<State>) {}
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -26,7 +26,7 @@ import {BehaviorSubject, combineLatest, Observable, of, Subject} from 'rxjs';
 import {map, shareReplay, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {State} from '../../../app_state';
-import {getMetricCardMaxWidthMultiplier, getMetricsTagGroupExpansionState} from '../../../selectors';
+import {getMetricCardMaxWidth, getMetricsTagGroupExpansionState} from '../../../selectors';
 import {metricsTagGroupExpansionChanged} from '../../actions';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
@@ -40,7 +40,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
       [numPages]="numPages$ | async"
       [showPaginationControls]="showPaginationControls$ | async"
       [cardIdsWithMetadata]="pagedItems$ | async"
-      [cardMaxWidthMultiplier]="cardMaxWidthMultiplier$ | async"
+      [cardMaxWidthInVW]="cardMaxWidthInVW$ | async"
       [cardObserver]="cardObserver"
       (pageIndexChanged)="onPageIndexChanged($event)"
     >
@@ -116,7 +116,7 @@ export class CardGridContainer implements OnChanges, OnDestroy {
     })
   );
 
-  readonly cardMaxWidthMultiplier$ = this.store.select(getMetricCardMaxWidthMultiplier);
+  readonly cardMaxWidthInVW$ = this.store.select(getMetricCardMaxWidth);
 
   constructor(private readonly store: Store<State>) {}
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -27,7 +27,7 @@ import {map, shareReplay, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {State} from '../../../app_state';
 import {
-  getMetricCardMaxWidth,
+  getMetricsCardMaxWidth,
   getMetricsTagGroupExpansionState,
   getEnabledCardWidthSetting,
 } from '../../../selectors';
@@ -121,7 +121,7 @@ export class CardGridContainer implements OnChanges, OnDestroy {
   );
 
   readonly cardMaxWidthInVW$ = combineLatest([
-    this.store.select(getMetricCardMaxWidth),
+    this.store.select(getMetricsCardMaxWidth),
     this.store.select(getEnabledCardWidthSetting),
   ]).pipe(
     map(([cardMaxWidth, isCardWidthSettingEnabled]) =>

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -124,8 +124,8 @@ export class CardGridContainer implements OnChanges, OnDestroy {
     this.store.select(getMetricCardMaxWidth),
     this.store.select(getEnabledCardWidthSetting),
   ]).pipe(
-    map(([cardMaxWidth, isCardWithSettingEnabled]) =>
-      isCardWithSettingEnabled ? cardMaxWidth : null
+    map(([cardMaxWidth, isCardWidthSettingEnabled]) =>
+      isCardWidthSettingEnabled ? cardMaxWidth : null
     )
   );
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -26,7 +26,7 @@ import {BehaviorSubject, combineLatest, Observable, of, Subject} from 'rxjs';
 import {map, shareReplay, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {State} from '../../../app_state';
-import {getMetricsTagGroupExpansionState} from '../../../selectors';
+import {getMetricCardMaxWidthMultiplier, getMetricsTagGroupExpansionState} from '../../../selectors';
 import {metricsTagGroupExpansionChanged} from '../../actions';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
@@ -40,6 +40,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
       [numPages]="numPages$ | async"
       [showPaginationControls]="showPaginationControls$ | async"
       [cardIdsWithMetadata]="pagedItems$ | async"
+      [cardMaxWidthMultiplier]="cardMaxWidthMultiplier$ | async"
       [cardObserver]="cardObserver"
       (pageIndexChanged)="onPageIndexChanged($event)"
     >
@@ -114,6 +115,8 @@ export class CardGridContainer implements OnChanges, OnDestroy {
       return items.slice(startIndex, endIndex);
     })
   );
+
+  readonly cardMaxWidthMultiplier$ = this.store.select(getMetricCardMaxWidthMultiplier);
 
   constructor(private readonly store: Store<State>) {}
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -34,7 +34,7 @@ import {selectors as settingsSelectors} from '../../../settings';
 import * as selectors from '../../../selectors';
 import {
   getEnabledCardWidthSetting,
-  getMetricCardMaxWidth,
+  getMetricsCardMaxWidth,
   getMetricsTagGroupExpansionState,
 } from '../../../selectors';
 
@@ -89,7 +89,7 @@ describe('card grid', () => {
     store.overrideSelector(selectors.getRunColorMap, {});
     store.overrideSelector(getMetricsTagGroupExpansionState, true);
     store.overrideSelector(getEnabledCardWidthSetting, false);
-    store.overrideSelector(getMetricCardMaxWidth, 30);
+    store.overrideSelector(getMetricsCardMaxWidth, 30);
   });
 
   it('keeps pagination button position when page size changes', fakeAsync(() => {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -32,7 +32,11 @@ import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {State} from '../../../app_state';
 import {selectors as settingsSelectors} from '../../../settings';
 import * as selectors from '../../../selectors';
-import {getMetricsTagGroupExpansionState} from '../../../selectors';
+import {
+  getEnabledCardWidthSetting,
+  getMetricCardMaxWidth,
+  getMetricsTagGroupExpansionState,
+} from '../../../selectors';
 
 const scrollElementHeight = 100;
 
@@ -84,6 +88,8 @@ describe('card grid', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(selectors.getRunColorMap, {});
     store.overrideSelector(getMetricsTagGroupExpansionState, true);
+    store.overrideSelector(getEnabledCardWidthSetting, false);
+    store.overrideSelector(getMetricCardMaxWidth, 30);
   });
 
   it('keeps pagination button position when page size changes', fakeAsync(() => {

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -921,7 +921,7 @@ describe('metrics main view', () => {
 
       it('sets the max width to be cardMaxWidth', () => {
         store.overrideSelector(selectors.getEnabledCardWidthSetting, true);
-        store.overrideSelector(selectors.getMetricCardMaxWidth, 50);
+        store.overrideSelector(selectors.getMetricsCardMaxWidth, 50);
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -934,7 +934,7 @@ describe('metrics main view', () => {
 
       it('does not set the max width with invalid width value', () => {
         store.overrideSelector(selectors.getEnabledCardWidthSetting, true);
-        store.overrideSelector(selectors.getMetricCardMaxWidth, -50);
+        store.overrideSelector(selectors.getMetricsCardMaxWidth, -50);
         let fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
         expect(
@@ -943,7 +943,7 @@ describe('metrics main view', () => {
           ]
         ).toBe('');
 
-        store.overrideSelector(selectors.getMetricCardMaxWidth, 20);
+        store.overrideSelector(selectors.getMetricsCardMaxWidth, 20);
         fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -953,7 +953,7 @@ describe('metrics main view', () => {
           ]
         ).toBe('');
 
-        store.overrideSelector(selectors.getMetricCardMaxWidth, 110);
+        store.overrideSelector(selectors.getMetricsCardMaxWidth, 110);
         fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -934,8 +934,19 @@ describe('metrics main view', () => {
 
       it('does not set the max width with invalid width value', () => {
         store.overrideSelector(selectors.getEnabledCardWidthSetting, true);
-        store.overrideSelector(selectors.getMetricsCardMaxWidth, -50);
+
+        store.overrideSelector(selectors.getMetricsCardMaxWidth, null);
         let fixture = TestBed.createComponent(MainViewContainer);
+        fixture.detectChanges();
+
+        expect(
+          fixture.debugElement.query(By.css('.card-grid')).styles[
+            'grid-template-columns'
+          ]
+        ).toBe('');
+
+        store.overrideSelector(selectors.getMetricsCardMaxWidth, -50);
+        fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
         expect(
           fixture.debugElement.query(By.css('.card-grid')).styles[

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -202,6 +202,7 @@ describe('metrics main view', () => {
       lastLoadedTimeInMs: null,
     });
     store.overrideSelector(selectors.isMetricsSettingsPaneOpen, false);
+    store.overrideSelector(selectors.getEnabledCardWidthSetting, false);
   });
 
   describe('toolbar', () => {
@@ -892,6 +893,75 @@ describe('metrics main view', () => {
         expect(
           fixture.debugElement.queryAll(By.css('.card-group')).length
         ).toBe(0);
+      });
+    });
+
+    describe('card width setting', () => {
+      beforeEach(() => {
+        store.overrideSelector(selectors.getNonEmptyCardIdsWithMetadata, [
+          {
+            cardId: 'card1',
+            plugin: PluginType.SCALARS,
+            tag: 'tagA',
+            runId: null,
+          },
+        ]);
+      });
+
+      it('does not set the max width without feature flag enabled', () => {
+        const fixture = TestBed.createComponent(MainViewContainer);
+        fixture.detectChanges();
+
+        expect(
+          fixture.debugElement.query(By.css('.card-grid')).styles[
+            'grid-template-columns'
+          ]
+        ).toBe('');
+      });
+
+      it('sets the max width to be cardMaxWidth', () => {
+        store.overrideSelector(selectors.getEnabledCardWidthSetting, true);
+        store.overrideSelector(selectors.getMetricCardMaxWidth, 50);
+        const fixture = TestBed.createComponent(MainViewContainer);
+        fixture.detectChanges();
+
+        expect(
+          fixture.debugElement.query(By.css('.card-grid')).styles[
+            'grid-template-columns'
+          ]
+        ).toBe('repeat(auto-fill, minmax(335px, 50vw))');
+      });
+
+      it('does not set the max width with invalid width value', () => {
+        store.overrideSelector(selectors.getEnabledCardWidthSetting, true);
+        store.overrideSelector(selectors.getMetricCardMaxWidth, -50);
+        let fixture = TestBed.createComponent(MainViewContainer);
+        fixture.detectChanges();
+        expect(
+          fixture.debugElement.query(By.css('.card-grid')).styles[
+            'grid-template-columns'
+          ]
+        ).toBe('');
+
+        store.overrideSelector(selectors.getMetricCardMaxWidth, 20);
+        fixture = TestBed.createComponent(MainViewContainer);
+        fixture.detectChanges();
+
+        expect(
+          fixture.debugElement.query(By.css('.card-grid')).styles[
+            'grid-template-columns'
+          ]
+        ).toBe('');
+
+        store.overrideSelector(selectors.getMetricCardMaxWidth, 110);
+        fixture = TestBed.createComponent(MainViewContainer);
+        fixture.detectChanges();
+
+        expect(
+          fixture.debugElement.query(By.css('.card-grid')).styles[
+            'grid-template-columns'
+          ]
+        ).toBe('');
       });
     });
   });


### PR DESCRIPTION
* Motivation for features / changes
Some tag name on cards might be too long and be truncated. We want to provide users a setting to adjust the card width. This pr only includes the part of metrics/ and the card with would be set based on the state value.

* Technical description of changes
Only update the max width of the card in css. The range of the max width is 30-100vw. 