### PR TITLE
chore: guard against mat-color and $mat-*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,8 @@ jobs:
           ! git grep -E '"@npm//d3"|"@npm//@types/d3"' 'tensorboard/webapp/**/*BUILD' ':!tensorboard/webapp/third_party/**'
       - run: |
           ! git grep -E '"@npm_angular_bazel//:index.bzl"' 'tensorboard/**/BUILD'
+       - run: |
+          ! git grep -E 'mat-color|$mat-' 'tensorboard/**/*.scss'
 
   lint-misc: # build, protos, etc.
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
           ! git grep -E '"@npm//d3"|"@npm//@types/d3"' 'tensorboard/webapp/**/*BUILD' ':!tensorboard/webapp/third_party/**'
       - run: |
           ! git grep -E '"@npm_angular_bazel//:index.bzl"' 'tensorboard/**/BUILD'
-       - run: |
+      - run: |
           ! git grep -E 'mat-color|$mat-' 'tensorboard/**/*.scss'
 
   lint-misc: # build, protos, etc.


### PR DESCRIPTION
Newer `@angular/material` disallows using these ambient mixins and color
definitions. This change enforces that via lint.

