### PR TITLE
chore: remove now defunct webapp:angular_material_theming

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -406,12 +406,6 @@ tf_external_sass_libray(
     deps = ["@npm//@angular/material"],
 )
 
-# //tensorboard/webapp:theme are removed.
-alias(
-    name = "theme",
-    actual = "//tensorboard/webapp/theme",
-)
-
 tf_sass_binary(
     name = "styles",
     src = "styles.scss",

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -406,11 +406,6 @@ tf_external_sass_libray(
     deps = ["@npm//@angular/material"],
 )
 
-alias(
-    name = "angular_material_theming",
-    actual = ":angular_material_sass_deps",
-)
-
 # //tensorboard/webapp:theme are removed.
 alias(
     name = "theme",


### PR DESCRIPTION
The alias was introduced to facilitate better migration. Now it serves
no purposes and thus removed.
