### PR TITLE
timeseries: preserve card width setting in local storage

### DIFF
--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -26,6 +26,7 @@ import * as actions from './actions';
 import {MetricsDataSourceModule, METRICS_PLUGIN_ID} from './data_source';
 import {MetricsEffects} from './effects';
 import {
+  getMetricsCardMaxWidth,
   getMetricsIgnoreOutliers,
   getMetricsScalarSmoothing,
   getMetricsTooltipSort,
@@ -100,6 +101,12 @@ export function getMetricsTimeSeriesSettingsPaneOpen() {
   });
 }
 
+export function getMetricsTimeSeriesCardMaxWidthInVW() {
+  return createSelector(getMetricsCardMaxWidth, (cardMaxWidthInVW) => {
+    return {timeSeriesCardMaxWidthInVW: cardMaxWidthInVW};
+  });
+}
+
 @NgModule({
   imports: [
     CommonModule,
@@ -132,6 +139,9 @@ export function getMetricsTimeSeriesSettingsPaneOpen() {
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
       getMetricsTimeSeriesSettingsPaneOpen
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsTimeSeriesCardMaxWidthInVW
     ),
   ],
   providers: [

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -389,6 +389,10 @@ const reducer = createReducer(
         default:
       }
     }
+    if (typeof partialSettings.timeSeriesCardMaxWidthInVW === 'number') {
+      metricsSettings.cardMaxWidthInVW =
+        partialSettings.timeSeriesCardMaxWidthInVW;
+    }
     if (typeof partialSettings.ignoreOutliers === 'boolean') {
       metricsSettings.ignoreOutliers = partialSettings.ignoreOutliers;
     }

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -155,17 +155,24 @@ describe('persistent_settings data_source test', () => {
       it('sets settings', async () => {
         getItemSpy
           .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
-          .and.returnValue('{"scalarSmoothing": 0.3, "ignoreOutliers": false}');
+          .and.returnValue(
+            '{"scalarSmoothing": 0.3, "ignoreOutliers": false, "timeSeriesCardMaxWidthInVW": 60}'
+          );
 
         await firstValueFrom(
           dataSource.setSettings({
             scalarSmoothing: 0.5,
+            timeSeriesCardMaxWidthInVW: 60,
           })
         );
 
         expect(setItemSpy).toHaveBeenCalledOnceWith(
           TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
-          JSON.stringify({ignoreOutliers: false, scalarSmoothing: 0.5})
+          JSON.stringify({
+            ignoreOutliers: false,
+            scalarSmoothing: 0.5,
+            timeSeriesCardMaxWidthInVW: 60,
+          })
         );
       });
     });


### PR DESCRIPTION
Tested locally:

![Screen Shot 2021-11-19 at 12 06 28 PM](https://user-images.githubusercontent.com/15273931/142669704-8ff6331e-25b2-4790-8317-35462578c324.png)

#timeseries 