### PR TITLE
[time-namespaced state] Generate namespace ids in app_routing_effects.

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -191,6 +191,7 @@ tf_ng_module(
         "testing.ts",
     ],
     deps = [
+        ":internal_utils",
         ":location",
         ":types",
         "//tensorboard/webapp/app_routing/actions",

--- a/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
+++ b/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
@@ -70,8 +70,10 @@ export const navigating = createAction(
 export interface NavigatedPayload {
   before: Route | null;
   after: Route;
-  beforeNamespaceId: string | null;
-  afterNamespaceId: string;
+  // TODO(bdubois): Remove optionality of these properties when all internal
+  // code is migrated to specify them.
+  beforeNamespaceId?: string | null;
+  afterNamespaceId?: string;
 }
 
 /**

--- a/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
+++ b/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
@@ -70,6 +70,8 @@ export const navigating = createAction(
 export interface NavigatedPayload {
   before: Route | null;
   after: Route;
+  beforeNamespaceId: string | null;
+  afterNamespaceId: string;
 }
 
 /**

--- a/tensorboard/webapp/app_routing/effects/BUILD
+++ b/tensorboard/webapp/app_routing/effects/BUILD
@@ -40,6 +40,7 @@ tf_ng_module(
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/app_routing:app_root",
         "//tensorboard/webapp/app_routing:dirty_updates_registry",
+        "//tensorboard/webapp/app_routing:internal_utils",
         "//tensorboard/webapp/app_routing:location",
         "//tensorboard/webapp/app_routing:programmatical_navigation_module",
         "//tensorboard/webapp/app_routing:route_registry",

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -48,7 +48,10 @@ import {Location} from '../location';
 import {ProgrammaticalNavigationModule} from '../programmatical_navigation_module';
 import {RouteConfigs} from '../route_config';
 import {RouteRegistryModule} from '../route_registry_module';
-import {getActiveRoute} from '../store/app_routing_selectors';
+import {
+  getActiveRoute,
+  getActiveNamespaceId,
+} from '../store/app_routing_selectors';
 import {Navigation, Route, RouteKind, RouteParams} from '../types';
 
 /** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
@@ -384,9 +387,17 @@ export class AppRoutingEffects {
     );
 
     return changeUrl$.pipe(
-      withLatestFrom(this.store.select(getActiveRoute)),
-      map(([{route}, oldRoute]) => {
-        return navigated({before: oldRoute, after: route});
+      withLatestFrom(
+        this.store.select(getActiveRoute),
+        this.store.select(getActiveNamespaceId)
+      ),
+      map(([{route}, oldRoute, oldNamespaceId]) => {
+        return navigated({
+          before: oldRoute,
+          after: route,
+          beforeNamespaceId: oldNamespaceId,
+          afterNamespaceId: getRouteId(route.routeKind, route.params),
+        });
       })
     );
   });

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
@@ -118,7 +118,9 @@ export function createRouteContextedState<
     state: FullState,
     beforeRouteId: string | null,
     beforeNamespaceId: string | null,
-    afterNamespaceId: string
+    // TODO(bdubois): afterNamespaceId should not allow null when it is no
+    // longer optional.
+    afterNamespaceId: string | null
   ) {
     let nextContextedStateCache: {
       [routeId: string]: RoutefulState;
@@ -140,7 +142,10 @@ export function createRouteContextedState<
     let nextRoutefulState = {};
     // Note: state.privateRouteContextedState always exists in practice except
     // for in tests.
-    if (state.privateRouteContextedState?.[afterNamespaceId]) {
+    if (
+      afterNamespaceId &&
+      state.privateRouteContextedState?.[afterNamespaceId]
+    ) {
       // Swap in existing state since it already exists in the cache.
       nextRoutefulState = state.privateRouteContextedState[afterNamespaceId];
     } else if (beforeRouteId) {
@@ -182,8 +187,10 @@ export function createRouteContextedState<
           nextFullState = updateRoutefulState(
             state,
             beforeRouteId,
-            beforeNamespaceId,
-            afterNamespaceId
+            // TODO(bdubois): Remove null fallbacks when beforeNamespaceId and
+            // afterNamespaceId are no longer optional.
+            beforeNamespaceId || null,
+            afterNamespaceId || null
           );
         }
         if (beforeRouteId !== afterRouteId && onRouteIdChanged) {

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
@@ -69,7 +69,7 @@ describe('route_contexted_reducer_helper', () => {
       const state1 = {
         routeful: 1,
         notRouteful: 2,
-        privateRouteContextedState: {
+        privateNamespacedState: {
           namespace2: {
             routeful: 10,
           },
@@ -121,7 +121,7 @@ describe('route_contexted_reducer_helper', () => {
       const state = {
         routeful: 2000,
         notRouteful: 2,
-        privateRouteContextedState: {},
+        privateNamespacedState: {},
       };
 
       const nextState = routeReducers(
@@ -152,7 +152,7 @@ describe('route_contexted_reducer_helper', () => {
         const state = {
           routeful: 1337,
           notRouteful: 2,
-          privateRouteContextedState: {},
+          privateNamespacedState: {},
         };
 
         const nextState = routeReducers(
@@ -177,7 +177,7 @@ describe('route_contexted_reducer_helper', () => {
       const state1 = {
         routeful: 2000,
         notRouteful: 2,
-        privateRouteContextedState: {
+        privateNamespacedState: {
           namespace1: {
             routeful: 10,
           },
@@ -205,7 +205,7 @@ describe('route_contexted_reducer_helper', () => {
       const state = {
         routeful: 2000,
         notRouteful: 2,
-        privateRouteContextedState: {
+        privateNamespacedState: {
           namespace2: {
             routeful: 3,
           },
@@ -240,7 +240,7 @@ describe('route_contexted_reducer_helper', () => {
       const state = {
         routeful: 1,
         notRouteful: 10,
-        privateRouteContextedState: {},
+        privateNamespacedState: {},
       };
       const routefulNextState = reducers(state, incrementRouteful());
       expect(routefulNextState.routeful).toBe(2);
@@ -253,7 +253,7 @@ describe('route_contexted_reducer_helper', () => {
       const state1 = {
         routeful: 1,
         notRouteful: 2,
-        privateRouteContextedState: {
+        privateNamespacedState: {
           namespace2: {
             routeful: 10,
           },
@@ -419,7 +419,7 @@ describe('route_contexted_reducer_helper ngrx integration test', () => {
     expect(initialState).toEqual({
       routeful: 0,
       notRouteful: 1,
-      privateRouteContextedState: {},
+      privateNamespacedState: {},
     });
   });
 });

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
@@ -19,6 +19,7 @@ import {AppRoutingState} from './app_routing_types';
 const initialState: AppRoutingState = {
   activeRoute: null,
   nextRoute: null,
+  activeNamespaceId: null,
   registeredRouteKeys: new Set(),
 };
 
@@ -27,8 +28,13 @@ const reducer = createReducer(
   on(actions.navigating, (state, {after}) => {
     return {...state, nextRoute: after};
   }),
-  on(actions.navigated, (state, {after}) => {
-    return {...state, activeRoute: after, nextRoute: null};
+  on(actions.navigated, (state, {after, afterNamespaceId}) => {
+    return {
+      ...state,
+      activeRoute: after,
+      nextRoute: null,
+      activeNamespaceId: afterNamespaceId,
+    };
   }),
   on(actions.routeConfigLoaded, (state, {routeKinds}) => {
     return {

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
@@ -35,7 +35,7 @@ const reducer = createReducer(
       nextRoute: null,
       // TODO(bdubois): Remove the null fallback when afterNamespaceId is no
       // longer optional.
-      activeNamespaceId: afterNamespaceId || null,
+      activeNamespaceId: afterNamespaceId ?? null,
     };
   }),
   on(actions.routeConfigLoaded, (state, {routeKinds}) => {

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
@@ -33,7 +33,9 @@ const reducer = createReducer(
       ...state,
       activeRoute: after,
       nextRoute: null,
-      activeNamespaceId: afterNamespaceId,
+      // TODO(bdubois): Remove the null fallback when afterNamespaceId is no
+      // longer optional.
+      activeNamespaceId: afterNamespaceId || null,
     };
   }),
   on(actions.routeConfigLoaded, (state, {routeKinds}) => {

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
@@ -22,7 +22,7 @@ import {buildAppRoutingState} from './testing';
 
 describe('app_routing_reducers', () => {
   describe('navigating', () => {
-    it('sets the new route onto activeRoute', () => {
+    it('sets nextRoute', () => {
       const state = buildAppRoutingState({
         activeRoute: null,
         nextRoute: null,
@@ -62,9 +62,10 @@ describe('app_routing_reducers', () => {
   });
 
   describe('navigated', () => {
-    it('sets the new route onto activeRoute', () => {
+    it('sets activeRoute and activeNamespaceId', () => {
       const state = buildAppRoutingState({
         activeRoute: null,
+        activeNamespaceId: null,
       });
 
       const nextState = appRoutingReducers.reducers(
@@ -82,6 +83,8 @@ describe('app_routing_reducers', () => {
               replaceState: true,
             },
           }),
+          beforeNamespaceId: null,
+          afterNamespaceId: 'namespace1',
         })
       );
 
@@ -98,11 +101,12 @@ describe('app_routing_reducers', () => {
           },
         })
       );
+      expect(nextState.activeNamespaceId).toEqual('namespace1');
     });
   });
 
   describe('routeConfigLoaded', () => {
-    it('sets registered route kinds in the state', () => {
+    it('sets registeredRouteKeys', () => {
       const state = buildAppRoutingState({
         registeredRouteKeys: new Set(),
       });
@@ -122,7 +126,7 @@ describe('app_routing_reducers', () => {
       );
     });
 
-    it('replaces existing registered route kinds', () => {
+    it('replaces existing registeredRouteKeys', () => {
       const state = buildAppRoutingState({
         registeredRouteKeys: new Set([RouteKind.EXPERIMENTS]),
       });

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -53,7 +53,7 @@ export const getNextRouteForRouterOutletOnly = createSelector(
 
 export const getActiveNamespaceId = createSelector(
   getAppRoutingState,
-  (state) => {
+  (state) : string | null => {
     return state.activeNamespaceId;
   }
 );

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -51,6 +51,13 @@ export const getNextRouteForRouterOutletOnly = createSelector(
   }
 );
 
+export const getActiveNamespaceId = createSelector(
+  getAppRoutingState,
+  (state) => {
+    return state.activeNamespaceId;
+  }
+);
+
 export const getRegisteredRouteKinds = createSelector<
   State,
   AppRoutingState,

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -53,7 +53,7 @@ export const getNextRouteForRouterOutletOnly = createSelector(
 
 export const getActiveNamespaceId = createSelector(
   getAppRoutingState,
-  (state) : string | null => {
+  (state): string | null => {
     return state.activeNamespaceId;
   }
 );

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -56,6 +56,22 @@ describe('app_routing_selectors', () => {
     });
   });
 
+  describe('getActiveNamespaceId', () => {
+    beforeEach(() => {
+      selectors.getActiveNamespaceId.release();
+    });
+
+    it('returns activeNamespaceId', () => {
+      const state = buildStateFromAppRoutingState(
+        buildAppRoutingState({
+          activeNamespaceId: 'namespace1',
+        })
+      );
+
+      expect(selectors.getActiveNamespaceId(state)).toEqual('namespace1');
+    });
+  });
+
   describe('getRouteKind', () => {
     beforeEach(() => {
       selectors.getRouteKind.release();

--- a/tensorboard/webapp/app_routing/store/app_routing_types.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_types.ts
@@ -22,6 +22,7 @@ export interface AppRoutingState {
   // make changes before a route change. `ntextRoute` is non-null only while
   // we are navigating.
   nextRoute: Route | null;
+  activeNamespaceId: string | null;
   registeredRouteKeys: Set<RouteKind>;
 }
 

--- a/tensorboard/webapp/app_routing/store/testing.ts
+++ b/tensorboard/webapp/app_routing/store/testing.ts
@@ -24,6 +24,7 @@ export function buildAppRoutingState(
   return {
     activeRoute: null,
     nextRoute: null,
+    activeNamespaceId: null,
     registeredRouteKeys: new Set(),
     ...override,
   };

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -63,6 +63,8 @@ export function buildNavigatedActionFull(overrides: Partial<NavigatedPayload>) {
   });
 }
 
+// TODO(bdubois): Remove once all internal callers have been migrated to
+// buildNavigatedActionFull.
 /**
  * @deprecated Use buildNavigateActionFull instead.
  */

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -53,11 +53,13 @@ export function buildCompareRoute(
   };
 }
 
-export function buildNavigatedActionFull(overrides: Partial<NavigatedPayload>) {
+export function buildNavigatedActionFull(
+  overrides?: Partial<NavigatedPayload>
+) {
   return navigated({
     before: null,
     after: buildRoute(),
-    beforeNamespaceId: overrides.before ? 'namespace' : null,
+    beforeNamespaceId: overrides?.before ? 'namespace' : null,
     afterNamespaceId: 'namespace',
     ...overrides,
   });

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -16,12 +16,13 @@ import {Injectable, Provider} from '@angular/core';
 
 import {of} from 'rxjs';
 
-import {navigated} from './actions';
+import {navigated, NavigatedPayload} from './actions';
 import {Location} from './location';
 import {Route, RouteKind} from './types';
 
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
+import {getRouteId} from './internal_utils';
 
 export function buildRoute(routeOverride: Partial<Route> = {}): Route {
   return {
@@ -52,10 +53,25 @@ export function buildCompareRoute(
   };
 }
 
+export function buildNavigatedActionFull(overrides: Partial<NavigatedPayload>) {
+  return navigated({
+    before: null,
+    after: buildRoute(),
+    beforeNamespaceId: overrides.before ? 'namespace' : null,
+    afterNamespaceId: 'namespace',
+    ...overrides,
+  });
+}
+
+/**
+ * @deprecated Use buildNavigateActionFull instead.
+ */
 export function buildNavigatedAction(routeOverride: Partial<Route> = {}) {
   return navigated({
     before: null,
     after: buildRoute(routeOverride),
+    beforeNamespaceId: null,
+    afterNamespaceId: 'namespace',
   });
 }
 
@@ -64,15 +80,19 @@ export function buildNavigatedAction(routeOverride: Partial<Route> = {}) {
  * will be created.
  */
 export function buildNavigatedToNewRouteIdAction() {
+  const beforeRoute = buildRoute({
+    routeKind: RouteKind.EXPERIMENT,
+    params: {experimentId: 'abc'},
+  });
+  const afterRoute = buildRoute({
+    routeKind: RouteKind.EXPERIMENT,
+    params: {experimentId: 'xyz'},
+  });
   return navigated({
-    before: buildRoute({
-      routeKind: RouteKind.EXPERIMENT,
-      params: {experimentId: 'abc'},
-    }),
-    after: buildRoute({
-      routeKind: RouteKind.EXPERIMENT,
-      params: {experimentId: 'xyz'},
-    }),
+    before: beforeRoute,
+    after: afterRoute,
+    beforeNamespaceId: getRouteId(beforeRoute.routeKind, beforeRoute.params),
+    afterNamespaceId: getRouteId(afterRoute.routeKind, afterRoute.params),
   });
 }
 

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -23,13 +23,12 @@ import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {of, ReplaySubject, Subject} from 'rxjs';
 
-import {navigated} from '../../app_routing/actions';
 import {
   getExperimentIdToExperimentAliasMap,
   getRouteId,
   getRouteKind,
 } from '../../app_routing/store/app_routing_selectors';
-import {buildRoute} from '../../app_routing/testing';
+import {buildNavigatedActionFull, buildRoute} from '../../app_routing/testing';
 import {RouteKind} from '../../app_routing/types';
 import {State} from '../../app_state';
 import {getEnabledExperimentalPlugins} from '../../feature_flag/store/feature_flag_selectors';
@@ -135,11 +134,8 @@ describe('core_effects', () => {
   [
     {
       specSetName: '#navigated',
-      onAction: navigated({
-        before: null,
-        after: buildRoute({
-          routeKind: RouteKind.EXPERIMENT,
-        }),
+      onAction: buildNavigatedActionFull({
+        after: buildRoute({routeKind: RouteKind.EXPERIMENT}),
       }),
     },
     {specSetName: '#coreLoaded (legacy)', onAction: coreActions.coreLoaded()},
@@ -328,11 +324,8 @@ describe('core_effects', () => {
       store.refreshState();
 
       action.next(
-        navigated({
-          before: null,
-          after: buildRoute({
-            routeKind: RouteKind.EXPERIMENT,
-          }),
+        buildNavigatedActionFull({
+          after: buildRoute({routeKind: RouteKind.EXPERIMENT}),
         })
       );
 
@@ -342,11 +335,8 @@ describe('core_effects', () => {
       tick(TEST_ONLY.DATA_LOAD_CONDITIONAL_THROTTLE_IN_MS);
 
       action.next(
-        navigated({
-          before: null,
-          after: buildRoute({
-            routeKind: RouteKind.EXPERIMENT,
-          }),
+        buildNavigatedActionFull({
+          after: buildRoute({routeKind: RouteKind.EXPERIMENT}),
         })
       );
       httpMock.expectNone('data/plugins_listing');
@@ -355,11 +345,8 @@ describe('core_effects', () => {
       store.overrideSelector(getRouteId, 'bar');
       store.refreshState();
       action.next(
-        navigated({
-          before: null,
-          after: buildRoute({
-            routeKind: RouteKind.EXPERIMENT,
-          }),
+        buildNavigatedActionFull({
+          after: buildRoute({routeKind: RouteKind.EXPERIMENT}),
         })
       );
       httpMock.expectOne('data/plugins_listing');
@@ -388,11 +375,8 @@ describe('core_effects', () => {
       };
 
       action.next(
-        navigated({
-          before: null,
-          after: buildRoute({
-            routeKind: RouteKind.COMPARE_EXPERIMENT,
-          }),
+        buildNavigatedActionFull({
+          after: buildRoute({routeKind: RouteKind.COMPARE_EXPERIMENT}),
         })
       );
       tick();
@@ -408,11 +392,8 @@ describe('core_effects', () => {
       store.refreshState();
       tick(TEST_ONLY.DATA_LOAD_CONDITIONAL_THROTTLE_IN_MS);
       action.next(
-        navigated({
-          before: null,
-          after: buildRoute({
-            routeKind: RouteKind.COMPARE_EXPERIMENT,
-          }),
+        buildNavigatedActionFull({
+          after: buildRoute({routeKind: RouteKind.COMPARE_EXPERIMENT}),
         })
       );
       tick(TEST_ONLY.ALIAS_CHANGE_RUNS_RELOAD_THROTTLE_IN_MS * 2);
@@ -477,11 +458,8 @@ describe('core_effects', () => {
       };
 
       action.next(
-        navigated({
-          before: null,
-          after: buildRoute({
-            routeKind: RouteKind.COMPARE_EXPERIMENT,
-          }),
+        buildNavigatedActionFull({
+          after: buildRoute({routeKind: RouteKind.COMPARE_EXPERIMENT}),
         })
       );
       tick();
@@ -527,11 +505,8 @@ describe('core_effects', () => {
         };
 
         action.next(
-          navigated({
-            before: null,
-            after: buildRoute({
-              routeKind: RouteKind.COMPARE_EXPERIMENT,
-            }),
+          buildNavigatedActionFull({
+            after: buildRoute({routeKind: RouteKind.COMPARE_EXPERIMENT}),
           })
         );
         tick();
@@ -549,11 +524,8 @@ describe('core_effects', () => {
 
         tick(TEST_ONLY.DATA_LOAD_CONDITIONAL_THROTTLE_IN_MS);
         action.next(
-          navigated({
-            before: null,
-            after: buildRoute({
-              routeKind: RouteKind.EXPERIMENT,
-            }),
+          buildNavigatedActionFull({
+            after: buildRoute({routeKind: RouteKind.EXPERIMENT}),
           })
         );
 
@@ -617,11 +589,8 @@ describe('core_effects', () => {
         };
 
         action.next(
-          navigated({
-            before: null,
-            after: buildRoute({
-              routeKind: RouteKind.COMPARE_EXPERIMENT,
-            }),
+          buildNavigatedActionFull({
+            after: buildRoute({routeKind: RouteKind.COMPARE_EXPERIMENT}),
           })
         );
         tick();
@@ -641,11 +610,8 @@ describe('core_effects', () => {
         store.refreshState();
 
         action.next(
-          navigated({
-            before: null,
-            after: buildRoute({
-              routeKind: RouteKind.EXPERIMENTS,
-            }),
+          buildNavigatedActionFull({
+            after: buildRoute({routeKind: RouteKind.EXPERIMENTS}),
           })
         );
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import * as routingActions from '../../app_routing/actions';
-import {buildRoute} from '../../app_routing/testing';
+import {buildNavigatedActionFull, buildRoute} from '../../app_routing/testing';
 import {RouteKind} from '../../app_routing/types';
 import * as coreActions from '../../core/actions';
 import {globalSettingsLoaded} from '../../persistent_settings';
@@ -561,7 +561,7 @@ describe('metrics reducers', () => {
         ]),
       });
 
-      const navigateFrom1to2 = routingActions.navigated({
+      const navigateFrom1to2 = buildNavigatedActionFull({
         before: buildRoute({
           routeKind: RouteKind.EXPERIMENT,
           params: {experimentId: 'exp1'},
@@ -571,7 +571,7 @@ describe('metrics reducers', () => {
           params: {experimentId: 'exp2'},
         }),
       });
-      const navigateFrom2to1 = routingActions.navigated({
+      const navigateFrom2to1 = buildNavigatedActionFull({
         before: buildRoute({
           routeKind: RouteKind.EXPERIMENT,
           params: {experimentId: 'exp2'},

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -12,8 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {navigated, stateRehydratedFromUrl} from '../../app_routing/actions';
-import {buildCompareRoute, buildRoute} from '../../app_routing/testing';
+import {stateRehydratedFromUrl} from '../../app_routing/actions';
+import {
+  buildCompareRoute,
+  buildNavigatedActionFull,
+  buildRoute,
+} from '../../app_routing/testing';
 import {RouteKind} from '../../app_routing/types';
 import {deepFreeze} from '../../testing/lang';
 import {DataLoadState} from '../../types/data';
@@ -1243,7 +1247,7 @@ describe('runs_reducers', () => {
 
       const nextState = runsReducers.reducers(
         state,
-        navigated({
+        buildNavigatedActionFull({
           before: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
           }),
@@ -1254,32 +1258,6 @@ describe('runs_reducers', () => {
       expect(nextState.data.initialGroupBy.key).toBe(GroupByKey.EXPERIMENT);
     });
 
-    it('preserves userSetGroupByKey set on prior navigation to the same route', () => {
-      const state = buildRunsState({
-        initialGroupBy: {key: GroupByKey.EXPERIMENT},
-        userSetGroupByKey: GroupByKey.RUN,
-      });
-
-      const state2 = runsReducers.reducers(
-        state,
-        navigated({
-          before: buildCompareRoute(['eid1:run1', 'eid2:run2']),
-          after: buildCompareRoute(['eid3:run3', 'eid4:run4']),
-        })
-      );
-
-      const state3 = runsReducers.reducers(
-        state2,
-        navigated({
-          before: buildCompareRoute(['eid3:run3', 'eid4:run4']),
-          after: buildCompareRoute(['eid1:run1', 'eid2:run2']),
-        })
-      );
-
-      expect(state3.data.initialGroupBy.key).toBe(GroupByKey.EXPERIMENT);
-      expect(state3.data.userSetGroupByKey).toBe(GroupByKey.RUN);
-    });
-
     it('sets groupby to RUN on single experiment', () => {
       const state = buildRunsState({
         initialGroupBy: {key: GroupByKey.REGEX, regexString: 'test'},
@@ -1287,7 +1265,7 @@ describe('runs_reducers', () => {
 
       const nextState = runsReducers.reducers(
         state,
-        navigated({
+        buildNavigatedActionFull({
           before: buildCompareRoute(['eid1:run1', 'eid2:run2']),
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,


### PR DESCRIPTION
As part of the work to migrate to "time-namespaced state" (Googlers, see http://go/tb-timenamespaced-state) we need to refactor namespace id generation from route_contexted_reducer_helper.ts to app_routing_effects.ts.

This requires changing the navigated() action to include the namespace information - beforeNamespaceId and afterNamespaceId. So there is a somewhat high blast radius. I've tried to ensure that the changes will not break the build. I'll also comment on the PR to try to make sense of the changes.

There is also a new property in app_routing state: activeNamespaceId. We use this to populate the beforeNamespaceId value.