### PR TITLE
timeseries: make the slider control min card width

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -72,7 +72,7 @@ export const metricsChangeXAxisType = createAction(
 
 export const metricsChangeCardWidth = createAction(
   '[Metrics] Metrics Setting Change Card Width',
-  props<{cardMaxWidthInVW: number}>()
+  props<{cardMinWidth: number}>()
 );
 
 export const metricsResetCardWidth = createAction(

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -26,7 +26,7 @@ import * as actions from './actions';
 import {MetricsDataSourceModule, METRICS_PLUGIN_ID} from './data_source';
 import {MetricsEffects} from './effects';
 import {
-  getMetricsCardMaxWidth,
+  getMetricsCardMinWidth,
   getMetricsIgnoreOutliers,
   getMetricsScalarSmoothing,
   getMetricsTooltipSort,
@@ -101,9 +101,9 @@ export function getMetricsTimeSeriesSettingsPaneOpen() {
   });
 }
 
-export function getMetricsTimeSeriesCardMaxWidthInVW() {
-  return createSelector(getMetricsCardMaxWidth, (cardMaxWidthInVW) => {
-    return {timeSeriesCardMaxWidthInVW: cardMaxWidthInVW};
+export function getMetricsTimeSeriesCardMinWidth() {
+  return createSelector(getMetricsCardMinWidth, (cardMinWidth) => {
+    return {timeSeriesCardMinWidth: cardMinWidth};
   });
 }
 
@@ -141,7 +141,7 @@ export function getMetricsTimeSeriesCardMaxWidthInVW() {
       getMetricsTimeSeriesSettingsPaneOpen
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
-      getMetricsTimeSeriesCardMaxWidthInVW
+      getMetricsTimeSeriesCardMinWidth
     ),
   ],
   providers: [

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -389,9 +389,8 @@ const reducer = createReducer(
         default:
       }
     }
-    if (typeof partialSettings.timeSeriesCardMaxWidthInVW === 'number') {
-      metricsSettings.cardMaxWidthInVW =
-        partialSettings.timeSeriesCardMaxWidthInVW;
+    if (typeof partialSettings.timeSeriesCardMinWidth === 'number') {
+      metricsSettings.cardMinWidth = partialSettings.timeSeriesCardMinWidth;
     }
     if (typeof partialSettings.ignoreOutliers === 'boolean') {
       metricsSettings.ignoreOutliers = partialSettings.ignoreOutliers;
@@ -650,12 +649,12 @@ const reducer = createReducer(
       },
     };
   }),
-  on(actions.metricsChangeCardWidth, (state, {cardMaxWidthInVW}) => {
+  on(actions.metricsChangeCardWidth, (state, {cardMinWidth}) => {
     return {
       ...state,
       settingOverrides: {
         ...state.settingOverrides,
-        cardMaxWidthInVW,
+        cardMinWidth,
       },
     };
   }),
@@ -664,7 +663,7 @@ const reducer = createReducer(
       ...state,
       settingOverrides: {
         ...state.settingOverrides,
-        cardMaxWidthInVW: null,
+        cardMinWidth: null,
       },
     };
   }),

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -774,32 +774,32 @@ describe('metrics reducers', () => {
       );
     });
 
-    it('changes cardMaxWidthInVW on metricsChangeCardWidth', () => {
+    it('changes cardMinWidth on metricsChangeCardWidth', () => {
       const prevState = buildMetricsState({
         settings: buildMetricsSettingsState({
-          cardMaxWidthInVW: 40,
+          cardMinWidth: 400,
         }),
         settingOverrides: {},
       });
       const nextState = reducers(
         prevState,
-        actions.metricsChangeCardWidth({cardMaxWidthInVW: 50})
+        actions.metricsChangeCardWidth({cardMinWidth: 500})
       );
-      expect(nextState.settingOverrides.cardMaxWidthInVW).toBe(50);
+      expect(nextState.settingOverrides.cardMinWidth).toBe(500);
     });
 
-    it('resets cardMaxWidthInVW', () => {
+    it('resets cardMinWidth', () => {
       const prevState = buildMetricsState({
         settings: buildMetricsSettingsState({
-          cardMaxWidthInVW: 40,
+          cardMinWidth: 400,
         }),
         settingOverrides: {
-          cardMaxWidthInVW: 50,
+          cardMinWidth: 500,
         },
       });
       const nextState = reducers(prevState, actions.metricsResetCardWidth());
-      expect(nextState.settings.cardMaxWidthInVW).toBe(40);
-      expect(nextState.settingOverrides.cardMaxWidthInVW).toBe(null);
+      expect(nextState.settings.cardMinWidth).toBe(400);
+      expect(nextState.settingOverrides.cardMinWidth).toBe(null);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -280,9 +280,9 @@ export const getMetricsSettingOverrides = createSelector(
   }
 );
 
-export const getMetricsCardMaxWidth = createSelector(
+export const getMetricsCardMinWidth = createSelector(
   selectSettings,
-  (settings): number | null => settings.cardMaxWidthInVW
+  (settings): number | null => settings.cardMinWidth
 );
 
 export const getMetricsTooltipSort = createSelector(

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -664,16 +664,16 @@ describe('metrics selectors', () => {
       );
     });
 
-    it('returns cardMaxWidthInVW when called getMetricCardMaxWidth', () => {
-      selectors.getMetricsCardMaxWidth.release();
+    it('returns cardMinWidth when called getMetricCardMinWidth', () => {
+      selectors.getMetricsCardMinWidth.release();
       const state = appStateFromMetricsState(
         buildMetricsState({
           settings: buildMetricsSettingsState({
-            cardMaxWidthInVW: 40,
+            cardMinWidth: 400,
           }),
         })
       );
-      expect(selectors.getMetricsCardMaxWidth(state)).toBe(40);
+      expect(selectors.getMetricsCardMinWidth(state)).toBe(400);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -169,7 +169,7 @@ export interface MetricsRoutefulState {
 }
 
 export interface MetricsSettings {
-  cardMaxWidthInVW: number | null;
+  cardMinWidth: number | null;
   tooltipSort: TooltipSort;
   ignoreOutliers: boolean;
   xAxisType: XAxisType;
@@ -222,7 +222,7 @@ export interface State {
 }
 
 export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
-  cardMaxWidthInVW: null,
+  cardMinWidth: null,
   tooltipSort: TooltipSort.DEFAULT,
   ignoreOutliers: true,
   xAxisType: XAxisType.STEP,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -43,7 +43,7 @@ export function buildMetricsSettingsState(
   overrides?: Partial<MetricsSettings>
 ): MetricsSettings {
   return {
-    cardMaxWidthInVW: null,
+    cardMinWidth: null,
     tooltipSort: TooltipSort.NEAREST,
     ignoreOutliers: false,
     xAxisType: XAxisType.WALL_TIME,

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -29,7 +29,7 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 
 const MIN_CARD_WIDTH_IN_PX = 335;
-const MAX_CARD_WIDTH_IN_PX = 805;
+const MAX_CARD_WIDTH_IN_PX = 1005;
 
 @Component({
   selector: 'metrics-card-grid-component',
@@ -66,7 +66,7 @@ export class CardGridComponent {
       const newCardWidth = changes['cardMinWidth'].currentValue;
       if (this.isCardWidthValid(newCardWidth)) {
         this.cardMinWidth = newCardWidth;
-        this.gridTemplateColumn = `repeat(auto-fill, minmax(min(${this.cardMinWidth}px, auto), auto))`;
+        this.gridTemplateColumn = `repeat(auto-fill, minmax(${this.cardMinWidth}px, auto))`;
       } else {
         this.gridTemplateColumn = '';
       }

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -28,9 +28,8 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
 
 import {CardIdWithMetadata} from '../metrics_view_types';
 
-const MIN_CARD_WIDTH = 335;
-const MIN_CARD_MAX_WIDTH_IN_VW = 30;
-const MAX_CARD_MAX_WIDTH_IN_VW = 100;
+const MIN_CARD_WIDTH_IN_PX = 335;
+const MAX_CARD_WIDTH_IN_PX = 805;
 
 @Component({
   selector: 'metrics-card-grid-component',
@@ -46,7 +45,7 @@ export class CardGridComponent {
   @Input() pageIndex!: number;
   @Input() numPages!: number;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
-  @Input() cardMaxWidthInVW!: number | null;
+  @Input() cardMinWidth!: number | null;
   @Input() cardObserver!: CardObserver;
   @Input() showPaginationControls!: boolean;
 
@@ -57,28 +56,28 @@ export class CardGridComponent {
   ) {}
 
   ngOnInit() {
-    if (this.isCardWidthValid(this.cardMaxWidthInVW)) {
-      this.gridTemplateColumn = `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, ${this.cardMaxWidthInVW}vw))`;
+    if (this.isCardWidthValid(this.cardMinWidth)) {
+      this.gridTemplateColumn = `repeat(auto-fill, minmax(${this.cardMinWidth}px, auto))`;
     }
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['cardMaxWidthInVW']) {
-      const newCardWidth = changes['cardMaxWidthInVW'].currentValue;
+    if (changes['cardMinWidth']) {
+      const newCardWidth = changes['cardMinWidth'].currentValue;
       if (this.isCardWidthValid(newCardWidth)) {
-        this.cardMaxWidthInVW = newCardWidth;
-        this.gridTemplateColumn = `repeat(auto-fill, minmax(${MIN_CARD_WIDTH}px, ${this.cardMaxWidthInVW}vw))`;
+        this.cardMinWidth = newCardWidth;
+        this.gridTemplateColumn = `repeat(auto-fill, minmax(min(${this.cardMinWidth}px, auto), auto))`;
       } else {
         this.gridTemplateColumn = '';
       }
     }
   }
 
-  isCardWidthValid(cardMaxWidthInVW: number | null) {
+  isCardWidthValid(cardMinWidth: number | null) {
     return (
-      cardMaxWidthInVW &&
-      cardMaxWidthInVW >= MIN_CARD_MAX_WIDTH_IN_VW &&
-      cardMaxWidthInVW <= MAX_CARD_MAX_WIDTH_IN_VW
+      cardMinWidth &&
+      cardMinWidth >= MIN_CARD_WIDTH_IN_PX &&
+      cardMinWidth <= MAX_CARD_WIDTH_IN_PX
     );
   }
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -28,8 +28,8 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
 
 import {CardIdWithMetadata} from '../metrics_view_types';
 
-const MIN_CARD_WIDTH_IN_PX = 335;
-const MAX_CARD_WIDTH_IN_PX = 700;
+const MIN_CARD_MIN_WIDTH_IN_PX = 335;
+const MAX_CARD_MIN_WIDTH_IN_PX = 735;
 
 @Component({
   selector: 'metrics-card-grid-component',
@@ -76,8 +76,8 @@ export class CardGridComponent {
   isCardWidthValid(cardMinWidth: number | null) {
     return (
       cardMinWidth &&
-      cardMinWidth >= MIN_CARD_WIDTH_IN_PX &&
-      cardMinWidth <= MAX_CARD_WIDTH_IN_PX
+      cardMinWidth >= MIN_CARD_MIN_WIDTH_IN_PX &&
+      cardMinWidth <= MAX_CARD_MIN_WIDTH_IN_PX
     );
   }
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -29,7 +29,7 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 
 const MIN_CARD_WIDTH_IN_PX = 335;
-const MAX_CARD_WIDTH_IN_PX = 1005;
+const MAX_CARD_WIDTH_IN_PX = 700;
 
 @Component({
   selector: 'metrics-card-grid-component',

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -27,11 +27,10 @@ import {map, shareReplay, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {State} from '../../../app_state';
 import {
-  getMetricsCardMaxWidth,
+  getMetricsCardMinWidth,
   getMetricsTagGroupExpansionState,
   getEnabledCardWidthSetting,
 } from '../../../selectors';
-import {metricsTagGroupExpansionChanged} from '../../actions';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 
@@ -44,7 +43,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
       [numPages]="numPages$ | async"
       [showPaginationControls]="showPaginationControls$ | async"
       [cardIdsWithMetadata]="pagedItems$ | async"
-      [cardMaxWidthInVW]="cardMaxWidthInVW$ | async"
+      [cardMinWidth]="cardMinWidth$ | async"
       [cardObserver]="cardObserver"
       (pageIndexChanged)="onPageIndexChanged($event)"
     >
@@ -120,12 +119,12 @@ export class CardGridContainer implements OnChanges, OnDestroy {
     })
   );
 
-  readonly cardMaxWidthInVW$ = combineLatest([
-    this.store.select(getMetricsCardMaxWidth),
+  readonly cardMinWidth$ = combineLatest([
+    this.store.select(getMetricsCardMinWidth),
     this.store.select(getEnabledCardWidthSetting),
   ]).pipe(
-    map(([cardMaxWidth, isCardWidthSettingEnabled]) =>
-      isCardWidthSettingEnabled ? cardMaxWidth : null
+    map(([cardMinWidth, isCardWidthSettingEnabled]) =>
+      isCardWidthSettingEnabled ? cardMinWidth : null
     )
   );
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -34,7 +34,7 @@ import {selectors as settingsSelectors} from '../../../settings';
 import * as selectors from '../../../selectors';
 import {
   getEnabledCardWidthSetting,
-  getMetricsCardMaxWidth,
+  getMetricsCardMinWidth,
   getMetricsTagGroupExpansionState,
 } from '../../../selectors';
 
@@ -89,7 +89,7 @@ describe('card grid', () => {
     store.overrideSelector(selectors.getRunColorMap, {});
     store.overrideSelector(getMetricsTagGroupExpansionState, true);
     store.overrideSelector(getEnabledCardWidthSetting, false);
-    store.overrideSelector(getMetricsCardMaxWidth, 30);
+    store.overrideSelector(getMetricsCardMinWidth, 30);
   });
 
   it('keeps pagination button position when page size changes', fakeAsync(() => {

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -35,7 +35,7 @@ import {of, ReplaySubject} from 'rxjs';
 
 import * as selectors from '../../../selectors';
 import {
-  getMetricsCardMaxWidth,
+  getMetricsCardMinWidth,
   getMetricsTagGroupExpansionState,
 } from '../../../selectors';
 import {KeyType, sendKey, sendKeys} from '../../../testing/dom';
@@ -911,7 +911,7 @@ describe('metrics main view', () => {
         ]);
       });
 
-      it('does not set the max width without feature flag enabled', () => {
+      it('does not set the min width without feature flag enabled', () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -922,9 +922,9 @@ describe('metrics main view', () => {
         ).toBe('');
       });
 
-      it('sets the max width to be cardMaxWidth', () => {
+      it('sets the min width to be cardMinWidth', () => {
         store.overrideSelector(selectors.getEnabledCardWidthSetting, true);
-        store.overrideSelector(selectors.getMetricsCardMaxWidth, 50);
+        store.overrideSelector(selectors.getMetricsCardMinWidth, 500);
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -932,13 +932,13 @@ describe('metrics main view', () => {
           fixture.debugElement.query(By.css('.card-grid')).styles[
             'grid-template-columns'
           ]
-        ).toBe('repeat(auto-fill, minmax(335px, 50vw))');
+        ).toBe('repeat(auto-fill, minmax(500px, auto))');
       });
 
       it('does not set the max width with invalid width value', () => {
         store.overrideSelector(selectors.getEnabledCardWidthSetting, true);
 
-        store.overrideSelector(selectors.getMetricsCardMaxWidth, null);
+        store.overrideSelector(selectors.getMetricsCardMinWidth, null);
         let fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -948,7 +948,7 @@ describe('metrics main view', () => {
           ]
         ).toBe('');
 
-        store.overrideSelector(selectors.getMetricsCardMaxWidth, -50);
+        store.overrideSelector(selectors.getMetricsCardMinWidth, -50);
         fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
         expect(
@@ -957,7 +957,7 @@ describe('metrics main view', () => {
           ]
         ).toBe('');
 
-        store.overrideSelector(selectors.getMetricsCardMaxWidth, 20);
+        store.overrideSelector(selectors.getMetricsCardMinWidth, 20);
         fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -967,7 +967,7 @@ describe('metrics main view', () => {
           ]
         ).toBe('');
 
-        store.overrideSelector(selectors.getMetricsCardMaxWidth, 110);
+        store.overrideSelector(selectors.getMetricsCardMinWidth, 10000);
         fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -978,15 +978,15 @@ describe('metrics main view', () => {
         ).toBe('');
       });
 
-      it('resets the card max width', () => {
+      it('resets the card min width', () => {
         store.overrideSelector(selectors.getEnabledCardWidthSetting, true);
-        const getMetricsCardMaxWidthSubject = new ReplaySubject<number | null>(
+        const getMetricsCardMinWidthSubject = new ReplaySubject<number | null>(
           1
         );
-        getMetricsCardMaxWidthSubject.next(50);
+        getMetricsCardMinWidthSubject.next(500);
         selectSpy
-          .withArgs(getMetricsCardMaxWidth)
-          .and.returnValue(getMetricsCardMaxWidthSubject);
+          .withArgs(getMetricsCardMinWidth)
+          .and.returnValue(getMetricsCardMinWidthSubject);
         let fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -994,9 +994,9 @@ describe('metrics main view', () => {
           fixture.debugElement.query(By.css('.card-grid')).styles[
             'grid-template-columns'
           ]
-        ).toBe('repeat(auto-fill, minmax(335px, 50vw))');
+        ).toBe('repeat(auto-fill, minmax(500px, auto))');
 
-        getMetricsCardMaxWidthSubject.next(null);
+        getMetricsCardMinWidthSubject.next(null);
         fixture.detectChanges();
 
         expect(

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -91,7 +91,7 @@ describe('metrics right_pane', () => {
       store.overrideSelector(selectors.getIsMetricsImageSupportEnabled, true);
       store.overrideSelector(selectors.getIsLinkedTimeEnabled, false);
       store.overrideSelector(selectors.getEnabledCardWidthSetting, false);
-      store.overrideSelector(selectors.getMetricsCardMaxWidth, null);
+      store.overrideSelector(selectors.getMetricsCardMinWidth, null);
       store.overrideSelector(selectors.getMetricsSelectTimeEnabled, false);
       store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
       store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
@@ -337,11 +337,11 @@ describe('metrics right_pane', () => {
         fixture.detectChanges();
         const slider = select(fixture, CARD_WIDTH_SLIDER);
 
-        slider.triggerEventHandler('input', {value: 90});
+        slider.triggerEventHandler('input', {value: 350});
         tick(TEST_ONLY.SLIDER_AUDIT_TIME_MS);
 
         expect(dispatchSpy).toHaveBeenCalledOnceWith(
-          actions.metricsChangeCardWidth({cardMaxWidthInVW: 90})
+          actions.metricsChangeCardWidth({cardMinWidth: 350})
         );
       }));
 
@@ -358,21 +358,20 @@ describe('metrics right_pane', () => {
       });
 
       it('sets the card width to the value provided', () => {
-        store.overrideSelector(selectors.getMetricsCardMaxWidth, 40);
+        store.overrideSelector(selectors.getMetricsCardMinWidth, 400);
         const fixture = TestBed.createComponent(SettingsViewContainer);
         fixture.detectChanges();
-        const slider = select(fixture, CARD_WIDTH_SLIDER);
 
         expect(getMatSliderValue(select(fixture, CARD_WIDTH_SLIDER))).toBe(
-          '40'
+          '400'
         );
       });
 
       it('do not set invalid value', () => {
-        store.overrideSelector(selectors.getMetricsCardMaxWidth, null);
+        store.overrideSelector(selectors.getMetricsCardMinWidth, null);
         let fixture = TestBed.createComponent(SettingsViewContainer);
         fixture.detectChanges();
-        let slider = select(fixture, CARD_WIDTH_SLIDER);
+
         expect(getMatSliderValue(select(fixture, CARD_WIDTH_SLIDER))).toBe(
           TEST_ONLY.MIN_CARD_WIDTH_SLIDER_VALUE.toString()
         );

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -34,7 +34,7 @@ limitations under the License.
         color="primary"
         [max]="MAX_CARD_WIDTH_SLIDER_VALUE"
         [min]="MIN_CARD_WIDTH_SLIDER_VALUE"
-        [step]="5"
+        [step]="50"
         [value]="cardMinWidth"
         [thumbLabel]="false"
         (input)="cardWidthSliderChanged$.emit($event.value)"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -34,8 +34,8 @@ limitations under the License.
         color="primary"
         [max]="MAX_CARD_WIDTH_SLIDER_VALUE"
         [min]="MIN_CARD_WIDTH_SLIDER_VALUE"
-        [step]="1"
-        [value]="cardMaxWidthInVW"
+        [step]="5"
+        [value]="cardMinWidth"
         [thumbLabel]="false"
         (input)="cardWidthSliderChanged$.emit($event.value)"
       ></mat-slider>

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -38,9 +38,9 @@ import {
 const SLIDER_AUDIT_TIME_MS = 250;
 
 /**
- * Minimum card width ranges from 335 to 700 px.
+ * Minimum card width ranges from 335 to 735 px.
  */
-const MAX_CARD_WIDTH_SLIDER_VALUE = 700;
+const MAX_CARD_WIDTH_SLIDER_VALUE = 735;
 const MIN_CARD_WIDTH_SLIDER_VALUE = 335;
 
 /**

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -38,10 +38,10 @@ import {
 const SLIDER_AUDIT_TIME_MS = 250;
 
 /**
- * Maximum card width ranges from 30 to 100 VW.
+ * Minimum card width ranges from 335 to 805 px.
  */
-const MAX_CARD_WIDTH_SLIDER_VALUE = 100;
-const MIN_CARD_WIDTH_SLIDER_VALUE = 30;
+const MAX_CARD_WIDTH_SLIDER_VALUE = 805;
+const MIN_CARD_WIDTH_SLIDER_VALUE = 335;
 
 /**
  * When smoothing === 1, all lines become flat on the x-axis, which is not
@@ -103,7 +103,7 @@ export class SettingsViewComponent {
   readonly MAX_CARD_WIDTH_SLIDER_VALUE = MAX_CARD_WIDTH_SLIDER_VALUE;
   readonly MIN_CARD_WIDTH_SLIDER_VALUE = MIN_CARD_WIDTH_SLIDER_VALUE;
   readonly cardWidthSliderChanged$ = new EventEmitter<number>();
-  @Input() cardMaxWidthInVW!: number;
+  @Input() cardMinWidth!: number;
   @Output()
   cardWidthChanged = this.cardWidthSliderChanged$.pipe(
     auditTime(SLIDER_AUDIT_TIME_MS)

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -38,9 +38,9 @@ import {
 const SLIDER_AUDIT_TIME_MS = 250;
 
 /**
- * Minimum card width ranges from 335 to 1005 px.
+ * Minimum card width ranges from 335 to 700 px.
  */
-const MAX_CARD_WIDTH_SLIDER_VALUE = 1005;
+const MAX_CARD_WIDTH_SLIDER_VALUE = 700;
 const MIN_CARD_WIDTH_SLIDER_VALUE = 335;
 
 /**

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -38,9 +38,9 @@ import {
 const SLIDER_AUDIT_TIME_MS = 250;
 
 /**
- * Minimum card width ranges from 335 to 805 px.
+ * Minimum card width ranges from 335 to 1005 px.
  */
-const MAX_CARD_WIDTH_SLIDER_VALUE = 805;
+const MAX_CARD_WIDTH_SLIDER_VALUE = 1005;
 const MIN_CARD_WIDTH_SLIDER_VALUE = 335;
 
 /**

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -51,7 +51,7 @@ import {HistogramMode, LinkedTime, TooltipSort, XAxisType} from '../../types';
       [xAxisType]="xAxisType$ | async"
       (xAxisTypeChanged)="onXAxisTypeChanged($event)"
       [isCardWidthSettingEnabled]="isCardWidthSettingEnabled$ | async"
-      [cardMaxWidthInVW]="cardMaxWidthInVW$ | async"
+      [cardMinWidth]="cardMinWidth$ | async"
       (cardWidthChanged)="onCardWidthChanged($event)"
       (cardWidthReset)="onCardWidthReset()"
       [histogramMode]="histogramMode$ | async"
@@ -119,9 +119,7 @@ export class SettingsViewContainer {
     selectors.getMetricsIgnoreOutliers
   );
   readonly xAxisType$ = this.store.select(selectors.getMetricsXAxisType);
-  readonly cardMaxWidthInVW$ = this.store.select(
-    selectors.getMetricsCardMaxWidth
-  );
+  readonly cardMinWidth$ = this.store.select(selectors.getMetricsCardMinWidth);
   readonly histogramMode$ = this.store.select(
     selectors.getMetricsHistogramMode
   );
@@ -153,8 +151,8 @@ export class SettingsViewContainer {
     this.store.dispatch(metricsChangeXAxisType({xAxisType}));
   }
 
-  onCardWidthChanged(cardMaxWidthInVW: number) {
-    this.store.dispatch(metricsChangeCardWidth({cardMaxWidthInVW}));
+  onCardWidthChanged(cardMinWidth: number) {
+    this.store.dispatch(metricsChangeCardWidth({cardMinWidth}));
   }
 
   onCardWidthReset() {

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -59,7 +59,7 @@ export class OSSSettingsConverter extends SettingsConverter<
       sideBarWidthInPercent: settings.sideBarWidthInPercent,
       timeSeriesPromotionDismissed: settings.timeSeriesPromotionDismissed,
       timeSeriesSettingsPaneOpened: settings.timeSeriesSettingsPaneOpened,
-      timeSeriesCardMaxWidthInVW: settings.timeSeriesCardMaxWidthInVW,
+      timeSeriesCardMinWidth: settings.timeSeriesCardMinWidth,
     };
     return serializableSettings;
   }
@@ -148,11 +148,10 @@ export class OSSSettingsConverter extends SettingsConverter<
     }
 
     if (
-      backendSettings.hasOwnProperty('timeSeriesCardMaxWidthInVW') &&
-      typeof backendSettings.timeSeriesCardMaxWidthInVW === 'number'
+      backendSettings.hasOwnProperty('timeSeriesCardMinWidth') &&
+      typeof backendSettings.timeSeriesCardMinWidth === 'number'
     ) {
-      settings.timeSeriesCardMaxWidthInVW =
-        backendSettings.timeSeriesCardMaxWidthInVW;
+      settings.timeSeriesCardMinWidth = backendSettings.timeSeriesCardMinWidth;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -93,14 +93,14 @@ describe('persistent_settings data_source test', () => {
         getItemSpy
           .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
           .and.returnValue(
-            '{"foo": "bar", "scalarSmoothing": 0.3, "timeSeriesCardMaxWidthInVW": 50}'
+            '{"foo": "bar", "scalarSmoothing": 0.3, "timeSeriesCardMinWidth": 500}'
           );
 
         const actual = await firstValueFrom(dataSource.getSettings());
 
         expect(actual).toEqual({
           scalarSmoothing: 0.3,
-          timeSeriesCardMaxWidthInVW: 50,
+          timeSeriesCardMinWidth: 500,
         });
       });
 
@@ -156,13 +156,13 @@ describe('persistent_settings data_source test', () => {
         getItemSpy
           .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
           .and.returnValue(
-            '{"scalarSmoothing": 0.3, "ignoreOutliers": false, "timeSeriesCardMaxWidthInVW": 60}'
+            '{"scalarSmoothing": 0.3, "ignoreOutliers": false, "timeSeriesCardMinWidth": 360}'
           );
 
         await firstValueFrom(
           dataSource.setSettings({
             scalarSmoothing: 0.5,
-            timeSeriesCardMaxWidthInVW: 60,
+            timeSeriesCardMinWidth: 360,
           })
         );
 
@@ -171,7 +171,7 @@ describe('persistent_settings data_source test', () => {
           JSON.stringify({
             ignoreOutliers: false,
             scalarSmoothing: 0.5,
-            timeSeriesCardMaxWidthInVW: 60,
+            timeSeriesCardMinWidth: 360,
           })
         );
       });

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -38,7 +38,7 @@ export declare interface BackendSettings {
   sideBarWidthInPercent?: number;
   timeSeriesPromotionDismissed?: boolean;
   timeSeriesSettingsPaneOpened?: boolean;
-  timeSeriesCardMaxWidthInVW?: number;
+  timeSeriesCardMinWidth?: number;
 }
 
 /**
@@ -58,5 +58,5 @@ export interface PersistableSettings {
   sideBarWidthInPercent?: number;
   timeSeriesPromotionDismissed?: boolean;
   timeSeriesSettingsPaneOpened?: boolean;
-  timeSeriesCardMaxWidthInVW?: number;
+  timeSeriesCardMinWidth?: number;
 }


### PR DESCRIPTION
Motivation: Googlers, see user's latest feedback at b/202013641.

Preview: 
![tb_card_width_slider](https://user-images.githubusercontent.com/15273931/143925019-47739daa-8e58-4fce-b33f-c79633511464.gif)


#timeseries