### PR TITLE
[time-namespaced state] Add feature flag for time-namespaced state.

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -123,3 +123,10 @@ export const getEnabledCardWidthSetting = createSelector(
     return flags.enabledCardWidthSetting;
   }
 );
+
+export const getEnabledTimeNamespacedState = createSelector(
+  getFeatureFlags,
+  (flags: FeatureFlags): boolean => {
+    return flags.enabledTimeNamespacedState;
+  }
+);

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -340,4 +340,29 @@ describe('feature_flag_selectors', () => {
       expect(selectors.getEnabledCardWidthSetting(state)).toEqual(true);
     });
   });
+
+  describe('#getEnabledTimeNamespacedState', () => {
+    it('returns the proper value', () => {
+      let state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            enabledTimeNamespacedState: false,
+          }),
+        })
+      );
+      expect(selectors.getEnabledTimeNamespacedState(state)).toEqual(false);
+
+      state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            enabledTimeNamespacedState: false,
+          }),
+          flagOverrides: {
+            enabledTimeNamespacedState: true,
+          },
+        })
+      );
+      expect(selectors.getEnabledTimeNamespacedState(state)).toEqual(true);
+    });
+  });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -32,6 +32,7 @@ export const initialState: FeatureFlagState = {
     enabledLinkedTime: false,
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: false,
+    enabledTimeNamespacedState: false,
   },
   flagOverrides: {},
 };

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -31,6 +31,7 @@ export function buildFeatureFlag(
     enabledLinkedTime: false,
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: false,
+    enabledTimeNamespacedState: false,
     ...override,
   };
 }

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -47,4 +47,7 @@ export interface FeatureFlags {
   enableTimeSeriesPromotion: boolean;
   // Whether to enable card width adjustment on the right panle.
   enabledCardWidthSetting: boolean;
+  // Whether to enable time-namespaced state and how it impacts how user
+  // settings are kept during navigation.
+  enabledTimeNamespacedState: boolean;
 }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -21,6 +21,7 @@ import {
   ENABLE_COLOR_GROUP_QUERY_PARAM_KEY,
   ENABLE_DARK_MODE_QUERY_PARAM_KEY,
   ENABLE_LINK_TIME_PARAM_KEY,
+  ENABLE_TIME_NAMESPACED_STATE,
   EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
   SCALARS_BATCH_SIZE_PARAM_KEY,
   TBFeatureFlagDataSource,
@@ -83,6 +84,11 @@ export class QueryParamsFeatureFlagDataSource
     if (params.has(ENABLE_CARD_WIDTH_SETTING_PARAM_KEY)) {
       featureFlags.enabledCardWidthSetting =
         params.get(ENABLE_CARD_WIDTH_SETTING_PARAM_KEY) !== 'false';
+    }
+
+    if (params.has(ENABLE_TIME_NAMESPACED_STATE)) {
+      featureFlags.enabledTimeNamespacedState =
+        params.get(ENABLE_TIME_NAMESPACED_STATE) !== 'false';
     }
 
     return featureFlags;

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -162,6 +162,28 @@ describe('tb_feature_flag_data_source', () => {
         });
       });
 
+      it('returns enabledTimeNamespacedState from the query params', () => {
+        getParamsSpy.and.returnValues(
+          new URLSearchParams('enableTimespace=false'),
+          new URLSearchParams('enableTimespace='),
+          new URLSearchParams('enableTimespace=true'),
+          new URLSearchParams('enableTimespace=foo')
+        );
+
+        expect(dataSource.getFeatures()).toEqual({
+          enabledTimeNamespacedState: false,
+        });
+        expect(dataSource.getFeatures()).toEqual({
+          enabledTimeNamespacedState: true,
+        });
+        expect(dataSource.getFeatures()).toEqual({
+          enabledTimeNamespacedState: true,
+        });
+        expect(dataSource.getFeatures()).toEqual({
+          enabledTimeNamespacedState: true,
+        });
+      });
+
       it('returns all flag values when they are all set', () => {
         getParamsSpy.and.returnValue(
           new URLSearchParams(

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -45,3 +45,5 @@ export const ENABLE_COLOR_GROUP_BY_REGEX_QUERY_PARAM_KEY =
 export const ENABLE_DARK_MODE_QUERY_PARAM_KEY = 'darkMode';
 
 export const ENABLE_LINK_TIME_PARAM_KEY = 'enableLinkTime';
+
+export const ENABLE_TIME_NAMESPACED_STATE = 'enableTimespace';


### PR DESCRIPTION
Add a feature flag for the new behavior to namespace state sequentially by time rather than by id.

Googlers, see http://go/tb-timespaced-state.