### PR TITLE
[time-namespaced state] Remove buildNavigatedActionFull.

### DIFF
--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -63,17 +63,6 @@ export function buildNavigatedAction(overrides?: Partial<NavigatedPayload>) {
   });
 }
 
-// TODO(bdubois): Remove once all internal callers have been migrated to
-// buildNavigatedAction.
-/**
- * @deprecated Use buildNavigateAction instead.
- */
-export function buildNavigatedActionFull(
-  overrides?: Partial<NavigatedPayload>
-) {
-  return buildNavigatedAction(overrides);
-}
-
 /**
  * A navigation that corresponds to a change in route id (new route context)
  * will be created.


### PR DESCRIPTION
After https://github.com/tensorflow/tensorboard/pull/5439 we have removed Google-internal usage of buildNavigatedActionFull(). We can now remove the symbol from this repo.