### PR TITLE
[time-namespaced state] Move navigationOptions out of Route.

### DIFF
--- a/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
@@ -38,9 +38,6 @@ describe('app_routing_reducers', () => {
               experimentId: '234',
             },
             queryParams: [],
-            navigationOptions: {
-              replaceState: true,
-            },
           }),
         })
       );
@@ -53,9 +50,6 @@ describe('app_routing_reducers', () => {
             experimentId: '234',
           },
           queryParams: [],
-          navigationOptions: {
-            replaceState: true,
-          },
         })
       );
     });
@@ -79,9 +73,6 @@ describe('app_routing_reducers', () => {
               experimentId: '234',
             },
             queryParams: [],
-            navigationOptions: {
-              replaceState: true,
-            },
           }),
           beforeNamespaceId: null,
           afterNamespaceId: 'namespace1',
@@ -96,9 +87,6 @@ describe('app_routing_reducers', () => {
             experimentId: '234',
           },
           queryParams: [],
-          navigationOptions: {
-            replaceState: true,
-          },
         })
       );
       expect(nextState.activeNamespaceId).toEqual('namespace1');

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -35,9 +35,6 @@ describe('app_routing_selectors', () => {
               experimentId: '234',
             },
             queryParams: [],
-            navigationOptions: {
-              replaceState: false,
-            },
           }),
         })
       );
@@ -49,9 +46,6 @@ describe('app_routing_selectors', () => {
           experimentId: '234',
         },
         queryParams: [],
-        navigationOptions: {
-          replaceState: false,
-        },
       });
     });
   });

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -30,9 +30,6 @@ export function buildRoute(routeOverride: Partial<Route> = {}): Route {
     pathname: '/experiments',
     params: {},
     queryParams: [],
-    navigationOptions: {
-      replaceState: false,
-    },
     ...routeOverride,
   };
 }
@@ -46,9 +43,6 @@ export function buildCompareRoute(
     pathname: '/campare',
     params: {experimentIds: aliasAndExperimentIds.join(',')},
     queryParams: [],
-    navigationOptions: {
-      replaceState: false,
-    },
     ...routeOverride,
   };
 }

--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -68,9 +68,6 @@ export interface Route {
   params: RouteParams;
   pathname: string;
   queryParams: SerializableQueryParams;
-  navigationOptions: {
-    replaceState: boolean;
-  };
 }
 
 /**


### PR DESCRIPTION
Moves navigationOptions out of the Route. 

navigationOptions currently only has a `replaceState` property, which is an internal detail of app_routing_effects. Nothing else in the code base depends on this value. I will be adding another property `resetNamespace` to navigationOptions in a followup change, which is another navigation-related internal detail of app_routing_effects.

In practice navigationOptions (replaceState and resetNamespace) is a separate concern from Route. It describes properties that we consider between possible Route transitions rather than a property of Routes themselves. 
