### PR TITLE
[time-namespaced state] Remove Navigation support for getFullPathFromRouteOrNav().

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -373,13 +373,13 @@ export class AppRoutingEffects {
         if (route.navigationOptions.replaceState) {
           this.location.replaceState(
             this.appRootProvider.getAbsPathnameWithAppRoot(
-              this.location.getFullPathFromRouteOrNav(route, preserveHash)
+              this.location.getFullPathFromRoute(route, preserveHash)
             )
           );
         } else {
           this.location.pushState(
             this.appRootProvider.getAbsPathnameWithAppRoot(
-              this.location.getFullPathFromRouteOrNav(route, preserveHash)
+              this.location.getFullPathFromRoute(route, preserveHash)
             )
           );
         }

--- a/tensorboard/webapp/app_routing/location.ts
+++ b/tensorboard/webapp/app_routing/location.ts
@@ -36,7 +36,7 @@ export interface LocationInterface {
 
   getResolvedPath(relativePath: string): string;
 
-  getFullPathFromRouteOrNav(routeLike: Route | Navigation): string;
+  getFullPathFromRoute(route: Route): string;
 }
 
 const utils = {
@@ -44,15 +44,6 @@ const utils = {
     return window.location.href;
   },
 };
-
-function isNavigation(
-  navOrRoute: Navigation | Route
-): navOrRoute is Navigation {
-  return (
-    navOrRoute.hasOwnProperty('pathname') &&
-    !navOrRoute.hasOwnProperty('queryParams')
-  );
-}
 
 @Injectable()
 export class Location implements LocationInterface {
@@ -98,23 +89,26 @@ export class Location implements LocationInterface {
     );
   }
 
+  /**
+   * Converts a relative path to an absolute path.
+   */
   getResolvedPath(relativePath: string): string {
     const url = new URL(relativePath, utils.getHref());
     return url.pathname;
   }
 
-  getFullPathFromRouteOrNav(
-    routeLike: Route | Navigation,
+  getFullPathFromRoute(
+    route: Route,
     shouldPreserveHash?: boolean
   ): string {
-    // TODO(stephanwlee): support hashes in the routeLike.
-    const pathname = this.getResolvedPath(routeLike.pathname);
+    // TODO(stephanwlee): support hashes in the route.
+    const pathname = this.getResolvedPath(route.pathname);
     let search = '';
-    if (!isNavigation(routeLike) && routeLike.queryParams.length) {
+    if (route.queryParams.length) {
       search =
         '?' +
         createURLSearchParamsFromSerializableQueryParams(
-          routeLike.queryParams
+          route.queryParams
         ).toString();
     }
     const hash = shouldPreserveHash ? this.getHash() : '';

--- a/tensorboard/webapp/app_routing/location.ts
+++ b/tensorboard/webapp/app_routing/location.ts
@@ -97,10 +97,7 @@ export class Location implements LocationInterface {
     return url.pathname;
   }
 
-  getFullPathFromRoute(
-    route: Route,
-    shouldPreserveHash?: boolean
-  ): string {
+  getFullPathFromRoute(route: Route, shouldPreserveHash?: boolean): string {
     // TODO(stephanwlee): support hashes in the route.
     const pathname = this.getResolvedPath(route.pathname);
     let search = '';

--- a/tensorboard/webapp/app_routing/location_test.ts
+++ b/tensorboard/webapp/app_routing/location_test.ts
@@ -65,19 +65,23 @@ describe('location', () => {
   describe('#getFullPathFromRouteOrNav', () => {
     it('forms the full path', () => {
       expect(
-        location.getFullPathFromRoute(buildRoute({
-          pathname: '/foo/bar/baz',
-          queryParams: [{key: 'a', value: '1'}],
-        }))
+        location.getFullPathFromRoute(
+          buildRoute({
+            pathname: '/foo/bar/baz',
+            queryParams: [{key: 'a', value: '1'}],
+          })
+        )
       ).toBe('/foo/bar/baz?a=1');
     });
 
     it('does not add "?" when queryParams is empty', () => {
       expect(
-        location.getFullPathFromRoute(buildRoute({
-          pathname: '/foo',
-          queryParams: [],
-        }))
+        location.getFullPathFromRoute(
+          buildRoute({
+            pathname: '/foo',
+            queryParams: [],
+          })
+        )
       ).toBe('/foo');
     });
   });

--- a/tensorboard/webapp/app_routing/location_test.ts
+++ b/tensorboard/webapp/app_routing/location_test.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {Location, TEST_ONLY} from './location';
+import {buildRoute} from './testing';
 
 describe('location', () => {
   let location: Location;
@@ -64,19 +65,19 @@ describe('location', () => {
   describe('#getFullPathFromRouteOrNav', () => {
     it('forms the full path', () => {
       expect(
-        location.getFullPathFromRouteOrNav({
+        location.getFullPathFromRoute(buildRoute({
           pathname: '/foo/bar/baz',
           queryParams: [{key: 'a', value: '1'}],
-        })
+        }))
       ).toBe('/foo/bar/baz?a=1');
     });
 
     it('does not add "?" when queryParams is empty', () => {
       expect(
-        location.getFullPathFromRouteOrNav({
+        location.getFullPathFromRoute(buildRoute({
           pathname: '/foo',
           queryParams: [],
-        })
+        }))
       ).toBe('/foo');
     });
   });

--- a/tensorboard/webapp/app_routing/views/router_link_directive_container.ts
+++ b/tensorboard/webapp/app_routing/views/router_link_directive_container.ts
@@ -55,9 +55,7 @@ export class RouterLinkDirectiveContainer {
   get href() {
     if (!this.pathname) return null;
     return this.appRootProvider.getAbsPathnameWithAppRoot(
-      this.location.getFullPathFromRouteOrNav({
-        pathname: this.pathname,
-      })
+      this.location.getResolvedPath(this.pathname)
     );
   }
 


### PR DESCRIPTION
So it becomes getFullPathFromRoute().

Migrate the one call to getFullPathFromRouteOrNav() that used a Navigation
to instead call getResolvedPath() directly since this is effectively all
it wanted anyways.

This simplifies the code by allowing us to get rid of the isNavigation()
check.