### PR TITLE
[time-namespaced state] Support back and forward browser button for time-namespaced state.

### DIFF
--- a/tensorboard/components/tf_storage/storage_utils.ts
+++ b/tensorboard/components/tf_storage/storage_utils.ts
@@ -77,7 +77,7 @@ export function writeComponent(component: string, useLocationReplace = false) {
     if (useLocationReplace) {
       const url = new URL(window.location.href);
       url.hash = component;
-      window.history.replaceState(null, '', url.toString());
+      window.history.replaceState(window.history.state, '', url.toString());
     } else {
       window.location.hash = component;
     }

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -47,13 +47,13 @@ import {
 } from '../internal_utils';
 import {Location} from '../location';
 import {ProgrammaticalNavigationModule} from '../programmatical_navigation_module';
-import {RouteConfigs} from '../route_config';
+import {RouteConfigs, RouteMatch} from '../route_config';
 import {RouteRegistryModule} from '../route_registry_module';
 import {
   getActiveRoute,
   getActiveNamespaceId,
 } from '../store/app_routing_selectors';
-import {Navigation, Route, RouteKind, RouteParams} from '../types';
+import {Route, RouteKind, RouteParams} from '../types';
 
 /** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
@@ -61,14 +61,47 @@ import {Navigation, Route, RouteKind, RouteParams} from '../types';
 
 const initAction = createAction('[App Routing] Effects Init');
 
-interface InternalNavigation extends Navigation {
-  browserInitiated?: boolean;
+// Note: The progression of transformation of navigation data is:
+// InternalNavigation -> InternalRouteMatch -> InternalRoute
+
+interface InternalNavigation {
+  pathname: string;
+  options: NavigationOptions;
 }
 
-interface NavigationOptions {
-  replaceState: boolean;
-  resetNamespacedState: boolean;
+interface InternalRouteMatch {
+  routeMatch: RouteMatch;
+  options: NavigationOptions;
 }
+
+interface InternalRoute {
+  route: Route;
+  options: NavigationOptions;
+}
+
+enum NamespaceOption {
+  // No change in namespace has been requested.
+  UNCHANGED,
+  // An entirely new namespace has been requested by the "resetNamespacedState"
+  // option.
+  RESET,
+  // A specific namespace has been specified by history. It is possibly the same
+  // as the active namespace but it is also possibly a different one.
+  FROM_HISTORY,
+}
+
+type NavigationOptions =
+  | {
+      browserInitiated: boolean;
+      replaceState: boolean;
+      namespaceOption: NamespaceOption.RESET | NamespaceOption.UNCHANGED;
+    }
+  | {
+      browserInitiated: boolean;
+      replaceState: boolean;
+      namespaceOption: NamespaceOption.FROM_HISTORY;
+      namespaceId: string;
+    };
 
 @Injectable()
 export class AppRoutingEffects {
@@ -86,15 +119,25 @@ export class AppRoutingEffects {
     this.routeConfigs = registry.getRouteConfigs();
   }
 
-  private readonly onNavigationRequested$ = this.actions$.pipe(
-    ofType(navigationRequested),
-    map((navigation) => {
-      const resolvedPathname = navigation.pathname.startsWith('/')
-        ? this.appRootProvider.getAbsPathnameWithAppRoot(navigation.pathname)
-        : this.location.getResolvedPath(navigation.pathname);
-      return {...navigation, pathname: resolvedPathname};
-    })
-  );
+  private readonly onNavigationRequested$: Observable<InternalNavigation> =
+    this.actions$.pipe(
+      ofType(navigationRequested),
+      map((navigation) => {
+        const resolvedPathname = navigation.pathname.startsWith('/')
+          ? this.appRootProvider.getAbsPathnameWithAppRoot(navigation.pathname)
+          : this.location.getResolvedPath(navigation.pathname);
+        return {
+          pathname: resolvedPathname,
+          options: {
+            browserInitiated: false,
+            replaceState: navigation.replaceState ?? false,
+            namespaceOption: navigation.resetNamespacedState
+              ? NamespaceOption.RESET
+              : NamespaceOption.UNCHANGED,
+          },
+        };
+      })
+    );
 
   /**
    * @exports
@@ -110,15 +153,34 @@ export class AppRoutingEffects {
     );
   });
 
-  private readonly onInit$: Observable<Navigation> = this.actions$
+  private readonly onInit$: Observable<InternalNavigation> = this.actions$
     .pipe(ofType(initAction))
     .pipe(
       delay(0),
       map(() => {
         return {
           pathname: this.location.getPath(),
-          replaceState: true,
-          browserInitiated: true,
+          options: {
+            browserInitiated: true,
+            replaceState: true,
+            namespaceOption: NamespaceOption.UNCHANGED,
+          },
+        };
+      })
+    );
+
+  private readonly onPopState$: Observable<InternalNavigation> = this.location
+    .onPopState()
+    .pipe(
+      map((navigation) => {
+        return {
+          pathname: navigation.pathname,
+          options: {
+            browserInitiated: true,
+            replaceState: true,
+            namespaceOption: NamespaceOption.FROM_HISTORY,
+            namespaceId: navigation.state?.namespaceId,
+          },
         };
       })
     );
@@ -130,14 +192,7 @@ export class AppRoutingEffects {
   private readonly userInitNavRoute$ = merge(
     this.onNavigationRequested$,
     this.onInit$,
-    this.location.onPopState().pipe(
-      map((navigation) => {
-        return {
-          ...navigation,
-          browserInitiated: true,
-        };
-      })
-    )
+    this.onPopState$
   ).pipe(
     map<InternalNavigation, InternalNavigation>((navigation) => {
       // Expect to have absolute navigation here.
@@ -157,16 +212,12 @@ export class AppRoutingEffects {
       const routeMatch = this.routeConfigs.match(navigationWithAbsolutePath);
       return {
         routeMatch,
-        options: {
-          replaceState: navigationWithAbsolutePath.replaceState,
-          browserInitiated: navigationWithAbsolutePath.browserInitiated,
-          resetNamespacedState: navigationWithAbsolutePath.resetNamespacedState,
-        },
+        options: navigationWithAbsolutePath.options,
       };
     })
   );
 
-  private readonly programmticalNavRoute$ = this.actions$.pipe(
+  private readonly programmaticalNavRoute$ = this.actions$.pipe(
     map((action) => {
       return this.programmaticalNavModule.getNavigation(action);
     }),
@@ -202,21 +253,21 @@ export class AppRoutingEffects {
         options: {
           replaceState: false,
           browserInitiated: false,
-          resetNamespacedState: false,
-        },
+          namespaceOption: NamespaceOption.RESET,
+        } as NavigationOptions,
       };
     })
   );
 
-  private readonly validatedRoute$ = merge(
+  private readonly validatedRouteMatch$: Observable<InternalRouteMatch> = merge(
     this.userInitNavRoute$,
-    this.programmticalNavRoute$
+    this.programmaticalNavRoute$
   ).pipe(
     filter(({routeMatch}) => Boolean(routeMatch)),
-    map((routeMatchAndOptions) => {
+    map(({routeMatch, options}) => {
       return {
-        routeMatch: routeMatchAndOptions.routeMatch!,
-        options: routeMatchAndOptions.options,
+        routeMatch: routeMatch!,
+        options,
       };
     })
   );
@@ -225,20 +276,23 @@ export class AppRoutingEffects {
    * @export
    */
   navigate$ = createEffect(() => {
-    const dispatchNavigating$ = this.validatedRoute$.pipe(
+    const dispatchNavigating$ = this.validatedRouteMatch$.pipe(
       withLatestFrom(this.store.select(getActiveRoute)),
-      mergeMap(([routes, oldRoute]) => {
+      mergeMap(([internalRouteMatch, oldRoute]) => {
         const sameRouteId =
           oldRoute !== null &&
-          getRouteId(routes.routeMatch.routeKind, routes.routeMatch.params) ===
-            getRouteId(oldRoute.routeKind, oldRoute.params);
+          getRouteId(
+            internalRouteMatch.routeMatch.routeKind,
+            internalRouteMatch.routeMatch.params
+          ) === getRouteId(oldRoute.routeKind, oldRoute.params);
         const dirtySelectors =
           this.dirtyUpdatesRegistry.getDirtyUpdatesSelectors();
 
         // Do not warn about dirty updates when route ID is the same (e.g. when
         // changing tabs in the same experiment page or query params in experiment
         // list).
-        if (sameRouteId || !dirtySelectors.length) return of(routes);
+        if (sameRouteId || !dirtySelectors.length)
+          return of(internalRouteMatch);
         return forkJoin(
           this.dirtyUpdatesRegistry
             .getDirtyUpdatesSelectors()
@@ -262,7 +316,7 @@ export class AppRoutingEffects {
             return true;
           }),
           map(() => {
-            return routes;
+            return internalRouteMatch;
           })
         );
       }),
@@ -289,60 +343,48 @@ export class AppRoutingEffects {
           );
         }
       }),
-      switchMap(
-        ({
-          routeMatch,
-          options,
-        }): Observable<{
-          route: Route;
-          navigationOptions: NavigationOptions;
-        }> => {
-          const navigationOptions = {
-            replaceState: options.replaceState ?? false,
-            resetNamespacedState: options.resetNamespacedState ?? false,
-          };
-
-          if (routeMatch.deepLinkProvider === null) {
-            // Without a DeepLinkProvider emit a single result without query
-            // params.
-            return of({
-              route: {
-                routeKind: routeMatch.routeKind,
-                params: routeMatch.params,
-                pathname: routeMatch.pathname,
-                queryParams: [],
-              },
-              navigationOptions,
-            });
-          }
-
-          // With a DeepLinkProvider emit a new result each time the query
-          // params change.
-          return routeMatch
-            .deepLinkProvider!.serializeStateToQueryParams(this.store)
-            .pipe(
-              map((queryParams, index) => {
-                return {
-                  route: {
-                    routeKind: routeMatch.routeKind,
-                    params: routeMatch.params,
-                    pathname: routeMatch.pathname,
-                    queryParams,
-                  },
-                  // Only honor replaceState value on first emit. On subsequent
-                  // emits we always want to replaceState rather than pushState.
-                  navigationOptions:
-                    index === 0
-                      ? navigationOptions
-                      : {
-                          replaceState: true,
-                          resetNamespacedState: false,
-                        },
-                };
-              })
-            );
+      switchMap(({routeMatch, options}): Observable<InternalRoute> => {
+        if (routeMatch.deepLinkProvider === null) {
+          // Without a DeepLinkProvider emit a single result without query
+          // params.
+          return of({
+            route: {
+              routeKind: routeMatch.routeKind,
+              params: routeMatch.params,
+              pathname: routeMatch.pathname,
+              queryParams: [],
+            },
+            options,
+          });
         }
-      ),
+
+        // With a DeepLinkProvider emit a new result each time the query
+        // params change.
+        return routeMatch
+          .deepLinkProvider!.serializeStateToQueryParams(this.store)
+          .pipe(
+            map((queryParams, index) => {
+              return {
+                route: {
+                  routeKind: routeMatch.routeKind,
+                  params: routeMatch.params,
+                  pathname: routeMatch.pathname,
+                  queryParams,
+                },
+                // Only honor replaceState value on first emit. On subsequent
+                // emits we always want to replaceState rather than pushState.
+                options:
+                  index === 0
+                    ? options
+                    : {
+                        ...options,
+                        replaceState: true,
+                        resetNamespacedState: false,
+                      },
+              };
+            })
+          );
+      }),
       tap(({route}) => {
         // b/160185039: Allows the route store + router outlet to change
         // before the route change so all components do not have to
@@ -361,7 +403,7 @@ export class AppRoutingEffects {
 
     const changeUrl$ = dispatchNavigating$.pipe(
       withLatestFrom(this.store.select(getActiveRoute)),
-      map(([{route, navigationOptions}, oldRoute]) => {
+      map(([{route, options}, oldRoute]) => {
         // The URL hash can be set via HashStorageComponent (which uses
         // Polymer's tf-storage). DeepLinkProviders also modify the URL when
         // a provider's serializeStateToQueryParams() emits. These result in
@@ -383,10 +425,10 @@ export class AppRoutingEffects {
         return {
           preserveHash,
           route,
-          navigationOptions,
+          options,
         };
       }),
-      tap(({preserveHash, route, navigationOptions}) => {
+      tap(({preserveHash, route, options}) => {
         const shouldUpdateHistory = !areRoutesEqual(route, {
           pathname: this.appRootProvider.getAppRootlessPathname(
             this.location.getPath()
@@ -395,8 +437,9 @@ export class AppRoutingEffects {
         });
         if (!shouldUpdateHistory) return;
 
-        if (navigationOptions.replaceState) {
+        if (options.replaceState) {
           this.location.replaceState(
+            this.location.getHistoryState(),
             this.appRootProvider.getAbsPathnameWithAppRoot(
               this.location.getFullPathFromRouteOrNav(route, preserveHash)
             )
@@ -419,21 +462,33 @@ export class AppRoutingEffects {
       ),
       map(
         ([
-          {route, navigationOptions},
+          {route, options},
           oldRoute,
           beforeNamespaceId,
           enabledTimeNamespacedState,
         ]) => {
+          const afterNamespaceId = getAfterNamespaceId(
+            enabledTimeNamespacedState,
+            route,
+            options,
+            beforeNamespaceId
+          );
+
+          if (enabledTimeNamespacedState) {
+            this.location.replaceState(
+              {
+                ...this.location.getHistoryState(),
+                namespaceId: afterNamespaceId,
+              },
+              /* do not replace path */ null
+            );
+          }
+
           return navigated({
             before: oldRoute,
             after: route,
             beforeNamespaceId,
-            afterNamespaceId: getAfterNamespaceId(
-              enabledTimeNamespacedState,
-              route,
-              navigationOptions,
-              beforeNamespaceId
-            ),
+            afterNamespaceId,
           });
         }
       )
@@ -449,14 +504,19 @@ export class AppRoutingEffects {
 function getAfterNamespaceId(
   enabledTimeNamespacedState: boolean,
   route: Route,
-  navigationOptions: NavigationOptions,
+  options: NavigationOptions,
   beforeNamespaceId: string | null
 ): string {
   if (!enabledTimeNamespacedState) {
     return getRouteId(route.routeKind, route.params);
   } else {
     // Time-namespaced state is enabled.
-    if (beforeNamespaceId == null || navigationOptions.resetNamespacedState) {
+    if (options.namespaceOption === NamespaceOption.FROM_HISTORY) {
+      return options.namespaceId;
+    } else if (
+      beforeNamespaceId == null ||
+      options.namespaceOption === NamespaceOption.RESET
+    ) {
       return Date.now().toString();
     } else {
       return beforeNamespaceId;

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -253,7 +253,7 @@ export class AppRoutingEffects {
         options: {
           replaceState: false,
           browserInitiated: false,
-          namespaceOption: NamespaceOption.RESET,
+          namespaceOption: NamespaceOption.UNCHANGED,
         } as NavigationOptions,
       };
     })

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -94,7 +94,9 @@ type NavigationOptions =
   | {
       browserInitiated: boolean;
       replaceState: boolean;
-      namespaceUpdateOption: NamespaceUpdateOption.NEW | NamespaceUpdateOption.UNCHANGED;
+      namespaceUpdateOption:
+        | NamespaceUpdateOption.NEW
+        | NamespaceUpdateOption.UNCHANGED;
     }
   | {
       browserInitiated: boolean;
@@ -103,7 +105,6 @@ type NavigationOptions =
       namespaceUpdateOption: NamespaceUpdateOption.FROM_HISTORY;
       namespaceId: string;
     };
-
 
 /**
  * Effects to translate attempted app navigations into Route navigation actions.

--- a/tensorboard/webapp/app_routing/location.ts
+++ b/tensorboard/webapp/app_routing/location.ts
@@ -17,7 +17,12 @@ import {fromEvent, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 import {createURLSearchParamsFromSerializableQueryParams} from './internal_utils';
-import {Navigation, Route, SerializableQueryParams} from './types';
+import {
+  Navigation,
+  NavigationFromHistory,
+  Route,
+  SerializableQueryParams,
+} from './types';
 
 export interface LocationInterface {
   getHref(): string;
@@ -28,11 +33,11 @@ export interface LocationInterface {
 
   getPath(): string;
 
-  replaceState(path: string): void;
+  replaceState(data: any, url: string | null): void;
 
-  pushState(path: string): void;
+  pushState(url: string): void;
 
-  onPopState(): Observable<Navigation>;
+  onPopState(): Observable<NavigationFromHistory>;
 
   getResolvedPath(relativePath: string): string;
 
@@ -80,19 +85,24 @@ export class Location implements LocationInterface {
     return window.location.pathname;
   }
 
-  replaceState(path: string): void {
-    window.history.replaceState(null, '', path);
+  getHistoryState() {
+    return window.history.state;
   }
 
-  pushState(path: string): void {
-    window.history.pushState(null, '', path);
+  replaceState(data: any, url: string | null): void {
+    window.history.replaceState(data, '', url);
   }
 
-  onPopState(): Observable<Navigation> {
-    return fromEvent(window, 'popstate').pipe(
-      map(() => {
+  pushState(url: string): void {
+    window.history.pushState(null, '', url);
+  }
+
+  onPopState(): Observable<NavigationFromHistory> {
+    return fromEvent<PopStateEvent>(window, 'popstate').pipe(
+      map((e) => {
         return {
           pathname: this.getPath(),
+          state: e.state,
         };
       })
     );

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -99,6 +99,7 @@ export class TestableLocation extends Location {
   override onPopState() {
     return of({
       pathname: '/is/cool/',
+      state: null,
     });
   }
 }

--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -57,11 +57,24 @@ export declare interface ExperimentRouteParams {
   experimentId: string;
 }
 
+/**
+ * A navigation caused by user action in the app.
+ */
 export interface Navigation {
   pathname: string;
   replaceState?: boolean;
   resetNamespacedState?: boolean;
   // Cannot change hash yet.
+}
+
+/**
+ * A navigation from browser history. For example, from the user clicking on
+ * the 'back' or 'forward' buttons.
+ */
+export interface NavigationFromHistory {
+  pathname: string;
+  // The history state. The `state` property from PopStateEvent.
+  state: any;
 }
 
 export interface Route {


### PR DESCRIPTION
Support time-namespaced state for back and forward browser buttons and, really, any navigation to a point in browser history. As user navigates we store the namespace id with the history entry. When user navigates using browser history then we read the namespace id to determine which namespace to use.

Most of the changes in app_routing_effects are actually just improvements to the typing for data. We formalize the progression of data transformation -- from Navigation, to RouteMatch, to Route -- and we attach well-typed "NavigationOptions" to the data.