### PR TITLE
Allow camera to have initial position and look-at vectors.

### DIFF
--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
@@ -50,6 +50,8 @@ export class MeshViewer extends THREE.EventDispatcher {
   private _animationFrameIndex?: number;
 
   private _camera?: THREE.PerspectiveCamera;
+  private _init_camera_position?: THREE.Vector3;
+  private _init_camera_look_at?: THREE.Vector3;
   private _cameraControls?: OrbitControls;
   private _renderer: THREE.WebGLRenderer;
 
@@ -156,6 +158,19 @@ export class MeshViewer extends THREE.EventDispatcher {
       config.camera.far
     );
     this._camera = camera;
+
+    this._init_camera_position = null;
+    if (config.camera.position) {
+      this._init_camera_position = new THREE.Vector3().fromArray(
+        config.camera.position);
+    }
+
+    this._init_camera_look_at = null;
+    if (config.camera.look_at) {
+      this._init_camera_look_at = new THREE.Vector3().fromArray(
+        config.camera.look_at);
+    }
+
     var camControls = new OrbitControls(camera, domElement);
     const anyCamControls = camControls as any;
     // TODO(tensorboard-team): check whether these are depreacted; they no longer exist
@@ -411,11 +426,15 @@ export class MeshViewer extends THREE.EventDispatcher {
     // Make sure that even after arbitrary rotation mesh won't be clipped.
     const camera_to_far_edge = min_z < 0 ? -min_z + camera_z : camera_z - min_z;
     // Set camera position and orientation.
-    this.setCameraViewpoint(
-      {x: center.x, y: center.y, z: camera_z},
-      camera_to_far_edge * 3,
-      center
-    );
+    let camera_position = new THREE.Vector3(center.x, center.y, camera_z);
+    if (this._init_camera_position) {
+      camera_position = this._init_camera_position;
+    }
+    let look_at = center;
+    if (this._init_camera_look_at) {
+      look_at = this._init_camera_look_at;
+    }
+    this.setCameraViewpoint(camera_position, camera_to_far_edge * 3, look_at);
   }
   /**
    * Creates mesh geometry for current step data.

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
@@ -50,8 +50,8 @@ export class MeshViewer extends THREE.EventDispatcher {
   private _animationFrameIndex?: number;
 
   private _camera?: THREE.PerspectiveCamera;
-  private _init_camera_position?: THREE.Vector3;
-  private _init_camera_look_at?: THREE.Vector3;
+  private initCameraPosition?: THREE.Vector3;
+  private initCameraLookAt?: THREE.Vector3;
   private _cameraControls?: OrbitControls;
   private _renderer: THREE.WebGLRenderer;
 
@@ -159,17 +159,17 @@ export class MeshViewer extends THREE.EventDispatcher {
     );
     this._camera = camera;
 
-    this._init_camera_position = null;
+    this.initCameraPosition = null;
     if (config.camera.position) {
-      this._init_camera_position = new THREE.Vector3().fromArray(
+      this.initCameraPosition = new THREE.Vector3().fromArray(
         config.camera.position
       );
     }
 
-    this._init_camera_look_at = null;
-    if (config.camera.look_at) {
-      this._init_camera_look_at = new THREE.Vector3().fromArray(
-        config.camera.look_at
+    this.initCameraLookAt = null;
+    if (config.camera.lookAt) {
+      this.initCameraLookAt = new THREE.Vector3().fromArray(
+        config.camera.lookAt
       );
     }
 
@@ -428,15 +428,11 @@ export class MeshViewer extends THREE.EventDispatcher {
     // Make sure that even after arbitrary rotation mesh won't be clipped.
     const camera_to_far_edge = min_z < 0 ? -min_z + camera_z : camera_z - min_z;
     // Set camera position and orientation.
-    let camera_position = new THREE.Vector3(center.x, center.y, camera_z);
-    if (this._init_camera_position) {
-      camera_position = this._init_camera_position;
-    }
-    let look_at = center;
-    if (this._init_camera_look_at) {
-      look_at = this._init_camera_look_at;
-    }
-    this.setCameraViewpoint(camera_position, camera_to_far_edge * 3, look_at);
+    const cameraPosition = this.initCameraPosition ?? new THREE.Vector3(
+      center.x, center.y, camera_z
+    );
+    const lookAt = this.initCameraLookAt ?? center;
+    this.setCameraViewpoint(cameraPosition, camera_to_far_edge * 3, lookAt);
   }
   /**
    * Creates mesh geometry for current step data.

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
@@ -162,13 +162,15 @@ export class MeshViewer extends THREE.EventDispatcher {
     this._init_camera_position = null;
     if (config.camera.position) {
       this._init_camera_position = new THREE.Vector3().fromArray(
-        config.camera.position);
+        config.camera.position
+      );
     }
 
     this._init_camera_look_at = null;
     if (config.camera.look_at) {
       this._init_camera_look_at = new THREE.Vector3().fromArray(
-        config.camera.look_at);
+        config.camera.look_at
+      );
     }
 
     var camControls = new OrbitControls(camera, domElement);


### PR DESCRIPTION
Currently in mesh plugin camera is positioned automatically which may not be convenient for applications where the model predicts both scene mesh/point cloud as well as camera position and orientation. This PR will allow to specify initial camera position and orientation as following:
```
const plugin_config = {
  'camera': {
    'position': [0, 0, 0],
    'look_at': [1, 1, 1]
  }
}
```