### PR TITLE
[time-namespaced state] Fix tags and pinned cards on experiments adding/removal

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -53,7 +53,7 @@ import {
   getCardId,
   getRunIds,
   getTimeSeriesLoadable,
-  updateCardMap,
+  updateCardMaps,
 } from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
@@ -486,8 +486,6 @@ const reducer = createReducer(
         images: tagMetadata[PluginType.IMAGES],
       };
 
-      // Reset cardMetadataMap because metadata loaded action fired after
-      // complete tag metadata is received.
       const newCardMetadataMap = {} as CardMetadataMap;
       const nextCardMetadataList = buildCardMetadataList(nextTagMetadata);
       const nextCardList = [];
@@ -514,13 +512,16 @@ const reducer = createReducer(
         }
       }
 
-      const {nextCardToPinnedCopy,
-             nextPinnedCardToOriginal,
-             nextCardMetadataMap}
-          = updateCardMap(state.cardToPinnedCopy,
-                          state.pinnedCardToOriginal,
-                          newCardMetadataMap,
-                          nextCardList);
+      const {
+        nextCardToPinnedCopy,
+        nextPinnedCardToOriginal,
+        nextCardMetadataMap,
+      } = updateCardMaps(
+        state.cardToPinnedCopy,
+        state.pinnedCardToOriginal,
+        newCardMetadataMap,
+        nextCardList
+      );
 
       const resolvedResult = buildOrReturnStateWithUnresolvedImportedPins(
         state.unresolvedImportedPinnedCards,

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -50,10 +50,10 @@ import {
   canCreateNewPins,
   createPluginDataWithLoadable,
   createRunToLoadState,
+  generateNextPinnedCardMappings,
   getCardId,
   getRunIds,
   getTimeSeriesLoadable,
-  updatePinnedCardMappingsUnderNamespaceUnchanged,
 } from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
@@ -280,8 +280,8 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState<
     return {
       ...state,
       // We want to trigger tag metadata to reload every time route id changed, which is
-      // needed wthin the same namespace.
-      // TODO(japie1235813):moves the reload trigging to a proper place.
+      // needed within the same namespace.
+      // TODO(japie1235813):moves the reload triggering to a proper place.
       tagMetadataLoadState: {
         state: DataLoadState.NOT_LOADED,
         lastLoadedTimeInMs: null,
@@ -513,20 +513,22 @@ const reducer = createReducer(
         }
       }
 
-      // Updates pinned/original card id mapping and cardmetadatamap because
-      // they are routeful state and remain unchanged under the same namespace.
-      // The mappings are outdated under experiments removal.
-      // The outputs remain the same on the namespace changed.
+      // Generates next pinned/original card id mapping because they are routeful
+      // state and remain unchanged under the same namespace.
       const {
         nextCardToPinnedCopy,
         nextPinnedCardToOriginal,
-        nextCardMetadataMap,
-      } = updatePinnedCardMappingsUnderNamespaceUnchanged(
+        pinnedCardMetadataMap,
+      } = generateNextPinnedCardMappings(
         state.cardToPinnedCopy,
         state.pinnedCardToOriginal,
         newCardMetadataMap,
         nextCardList
       );
+      const nextCardMetadataMap = {
+        ...newCardMetadataMap,
+        ...pinnedCardMetadataMap,
+      };
 
       const resolvedResult = buildOrReturnStateWithUnresolvedImportedPins(
         state.unresolvedImportedPinnedCards,

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -50,6 +50,7 @@ import {
   canCreateNewPins,
   createPluginDataWithLoadable,
   createRunToLoadState,
+  generateNextCardStepIndex,
   generateNextPinnedCardMappings,
   getCardId,
   getRunIds,
@@ -530,13 +531,18 @@ const reducer = createReducer(
         ...pinnedCardMetadataMap,
       };
 
+      const nextCardStepIndex = generateNextCardStepIndex(
+        state.cardStepIndex,
+        nextCardMetadataMap
+      );
+
       const resolvedResult = buildOrReturnStateWithUnresolvedImportedPins(
         state.unresolvedImportedPinnedCards,
         nextCardList,
         nextCardMetadataMap,
         nextCardToPinnedCopy,
         nextPinnedCardToOriginal,
-        state.cardStepIndex
+        nextCardStepIndex
       );
 
       return {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -53,7 +53,7 @@ import {
   getCardId,
   getRunIds,
   getTimeSeriesLoadable,
-  updateCardMaps,
+  updatePinnedCardMappingsUnderNamespaceUnchanged,
 } from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
@@ -279,8 +279,9 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState<
   (state) => {
     return {
       ...state,
-      // Forces tag metadata to reload every time route id changed. This is
+      // We want to trigger tag metadata to reload every time route id changed, which is
       // needed wthin the same namespace.
+      // TODO(japie1235813):moves the reload trigging to a proper place.
       tagMetadataLoadState: {
         state: DataLoadState.NOT_LOADED,
         lastLoadedTimeInMs: null,
@@ -512,11 +513,15 @@ const reducer = createReducer(
         }
       }
 
+      // Updates pinned/original card id mapping and cardmetadatamap because
+      // they are routeful state and remain unchanged under the same namespace.
+      // The mappings are outdated under experiments removal.
+      // The outputs remain the same on the namespace changed.
       const {
         nextCardToPinnedCopy,
         nextPinnedCardToOriginal,
         nextCardMetadataMap,
-      } = updateCardMaps(
+      } = updatePinnedCardMappingsUnderNamespaceUnchanged(
         state.cardToPinnedCopy,
         state.pinnedCardToOriginal,
         newCardMetadataMap,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -365,7 +365,7 @@ describe('metrics reducers', () => {
       );
     });
 
-    it('updates cardMetadataMap and remains pinned/original cards mapping unchanged on non-pinned cards removal', () => {
+    it('updates cardMetadataMap and keeps pinned/original cards mapping unchanged on non-pinned cards removal', () => {
       const cardMetadata1 = {
         plugin: PluginType.HISTOGRAMS,
         tag: 'tagA',
@@ -379,13 +379,11 @@ describe('metrics reducers', () => {
       const cardId1 = getCardId(cardMetadata1);
       const cardId2 = getCardId(cardMetadata2);
       const pinnedCopyId1 = getPinnedCardId(cardId1);
-      const pinnedCopyId2 = getPinnedCardId(cardId2);
       const beforeState = buildMetricsState({
         cardMetadataMap: {
           [cardId1]: cardMetadata1,
           [cardId2]: cardMetadata2,
           [pinnedCopyId1]: cardMetadata1,
-          [pinnedCopyId2]: cardMetadata2,
         },
         cardList: [cardId1, cardId2],
         cardToPinnedCopy: new Map([[cardId1, pinnedCopyId1]]),
@@ -421,7 +419,7 @@ describe('metrics reducers', () => {
       );
     });
 
-    it('updates cardMetadataMap and remains pinned/original cards mapping unchanged on adding new cards', () => {
+    it('updates cardMetadataMap and keeps pinned/original cards mapping unchanged on adding new cards', () => {
       const cardMetadata1 = {
         plugin: PluginType.HISTOGRAMS,
         tag: 'tagA',
@@ -435,7 +433,6 @@ describe('metrics reducers', () => {
       const cardId1 = getCardId(cardMetadata1);
       const cardId2 = getCardId(cardMetadata2);
       const pinnedCopyId1 = getPinnedCardId(cardId1);
-      const pinnedCopyId2 = getPinnedCardId(cardId2);
       const beforeState = buildMetricsState({
         cardMetadataMap: {
           [cardId1]: cardMetadata1,
@@ -610,7 +607,7 @@ describe('metrics reducers', () => {
       const expectedCardMetadataMap: CardMetadataMap = {};
       expectedCardMetadataMap[cardId] = cardMetadata;
 
-      expect(nextState.cardMetadataMap['<cardId>']).not.toBe(origCardMetadata);
+      expect(nextState.cardMetadataMap.hasOwnProperty('<cardId>')).toBe(false);
       expect(nextState.cardMetadataMap[cardId]).toEqual(
         expectedCardMetadataMap[cardId]
       );

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -303,6 +303,179 @@ describe('metrics reducers', () => {
       );
     });
 
+    it('updates pinned/original cards mapping on pinned cards removal', () => {
+      const cardMetadata1 = {
+        plugin: PluginType.HISTOGRAMS,
+        tag: 'tagA',
+        runId: 'run1',
+      };
+      const cardMetadata2 = {
+        plugin: PluginType.SCALARS,
+        tag: 'tagB',
+        runId: null,
+      };
+      const cardId1 = getCardId(cardMetadata1);
+      const cardId2 = getCardId(cardMetadata2);
+      const pinnedCopyId1 = getPinnedCardId(cardId1);
+      const pinnedCopyId2 = getPinnedCardId(cardId2);
+      const beforeState = buildMetricsState({
+        cardMetadataMap: {
+          [cardId1]: cardMetadata1,
+          [cardId2]: cardMetadata2,
+          [pinnedCopyId1]: cardMetadata1,
+          [pinnedCopyId2]: cardMetadata2,
+        },
+        cardList: [cardId1, cardId2],
+        cardToPinnedCopy: new Map([
+          [cardId1, pinnedCopyId1],
+          [cardId2, pinnedCopyId2],
+        ]),
+        pinnedCardToOriginal: new Map([
+          [pinnedCopyId1, cardId1],
+          [pinnedCopyId2, cardId2],
+        ]),
+      });
+      const action = actions.metricsTagMetadataLoaded({
+        tagMetadata: {
+          ...buildDataSourceTagMetadata(),
+          [PluginType.HISTOGRAMS]: {
+            tagDescriptions: {},
+            runTagInfo: {run1: ['tagA']},
+          },
+        },
+      });
+      const nextState = reducers(beforeState, action);
+
+      const expectedState = buildMetricsState({
+        cardMetadataMap: {
+          [cardId1]: cardMetadata1,
+          [pinnedCopyId1]: cardMetadata1,
+        },
+        cardList: [cardId1],
+        cardToPinnedCopy: new Map([[cardId1, pinnedCopyId1]]),
+        pinnedCardToOriginal: new Map([[pinnedCopyId1, cardId1]]),
+      });
+      expect(nextState.cardMetadataMap).toEqual(expectedState.cardMetadataMap);
+      expect(nextState.cardList).toEqual(expectedState.cardList);
+      expect(nextState.cardToPinnedCopy).toEqual(
+        expectedState.cardToPinnedCopy
+      );
+      expect(nextState.pinnedCardToOriginal).toEqual(
+        expectedState.pinnedCardToOriginal
+      );
+    });
+
+    it('updates cardMetadataMap and remains pinned/original cards mapping unchanged on non-pinned cards removal', () => {
+      const cardMetadata1 = {
+        plugin: PluginType.HISTOGRAMS,
+        tag: 'tagA',
+        runId: 'run1',
+      };
+      const cardMetadata2 = {
+        plugin: PluginType.SCALARS,
+        tag: 'tagB',
+        runId: null,
+      };
+      const cardId1 = getCardId(cardMetadata1);
+      const cardId2 = getCardId(cardMetadata2);
+      const pinnedCopyId1 = getPinnedCardId(cardId1);
+      const pinnedCopyId2 = getPinnedCardId(cardId2);
+      const beforeState = buildMetricsState({
+        cardMetadataMap: {
+          [cardId1]: cardMetadata1,
+          [cardId2]: cardMetadata2,
+          [pinnedCopyId1]: cardMetadata1,
+          [pinnedCopyId2]: cardMetadata2,
+        },
+        cardList: [cardId1, cardId2],
+        cardToPinnedCopy: new Map([[cardId1, pinnedCopyId1]]),
+        pinnedCardToOriginal: new Map([[pinnedCopyId1, cardId1]]),
+      });
+      const action = actions.metricsTagMetadataLoaded({
+        tagMetadata: {
+          ...buildDataSourceTagMetadata(),
+          [PluginType.HISTOGRAMS]: {
+            tagDescriptions: {},
+            runTagInfo: {run1: ['tagA']},
+          },
+        },
+      });
+      const nextState = reducers(beforeState, action);
+
+      const expectedState = buildMetricsState({
+        cardMetadataMap: {
+          [cardId1]: cardMetadata1,
+          [pinnedCopyId1]: cardMetadata1,
+        },
+        cardList: [cardId1],
+        cardToPinnedCopy: new Map([[cardId1, pinnedCopyId1]]),
+        pinnedCardToOriginal: new Map([[pinnedCopyId1, cardId1]]),
+      });
+      expect(nextState.cardMetadataMap).toEqual(expectedState.cardMetadataMap);
+      expect(nextState.cardList).toEqual(expectedState.cardList);
+      expect(nextState.cardToPinnedCopy).toEqual(
+        expectedState.cardToPinnedCopy
+      );
+      expect(nextState.pinnedCardToOriginal).toEqual(
+        expectedState.pinnedCardToOriginal
+      );
+    });
+
+    it('updates cardMetadataMap and remains pinned/original cards mapping unchanged on adding new cards', () => {
+      const cardMetadata1 = {
+        plugin: PluginType.HISTOGRAMS,
+        tag: 'tagA',
+        runId: 'run1',
+      };
+      const cardMetadata2 = {
+        plugin: PluginType.HISTOGRAMS,
+        tag: 'tagB',
+        runId: 'run1',
+      };
+      const cardId1 = getCardId(cardMetadata1);
+      const cardId2 = getCardId(cardMetadata2);
+      const pinnedCopyId1 = getPinnedCardId(cardId1);
+      const pinnedCopyId2 = getPinnedCardId(cardId2);
+      const beforeState = buildMetricsState({
+        cardMetadataMap: {
+          [cardId1]: cardMetadata1,
+          [pinnedCopyId1]: cardMetadata1,
+        },
+        cardList: [cardId1],
+        cardToPinnedCopy: new Map([[cardId1, pinnedCopyId1]]),
+        pinnedCardToOriginal: new Map([[pinnedCopyId1, cardId1]]),
+      });
+      const action = actions.metricsTagMetadataLoaded({
+        tagMetadata: {
+          ...buildDataSourceTagMetadata(),
+          [PluginType.HISTOGRAMS]: {
+            tagDescriptions: {},
+            runTagInfo: {run1: ['tagA', 'tagB']},
+          },
+        },
+      });
+      const nextState = reducers(beforeState, action);
+
+      const expectedState = buildMetricsState({
+        cardMetadataMap: {
+          [cardId1]: cardMetadata1,
+          [cardId2]: cardMetadata2,
+          [pinnedCopyId1]: cardMetadata1,
+        },
+        cardList: [cardId1, cardId2],
+        cardToPinnedCopy: new Map([[cardId1, pinnedCopyId1]]),
+        pinnedCardToOriginal: new Map([[pinnedCopyId1, cardId1]]),
+      });
+      expect(nextState.cardMetadataMap).toEqual(expectedState.cardMetadataMap);
+      expect(nextState.cardList).toEqual(expectedState.cardList);
+      expect(nextState.cardToPinnedCopy).toEqual(
+        expectedState.cardToPinnedCopy
+      );
+      expect(nextState.pinnedCardToOriginal).toEqual(
+        expectedState.pinnedCardToOriginal
+      );
+    });
+
     it('resolves imported pins by automatically creating pinned copies', () => {
       const fakeCardMetadata = {
         plugin: PluginType.SCALARS,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -498,6 +498,7 @@ describe('metrics reducers', () => {
         cardStepIndex: {
           [pinnedCopyId1]: 1,
           [pinnedCopyId2]: 2,
+          [cardId1]: 1,
           [cardId2]: 2,
         },
         cardToPinnedCopy: new Map([
@@ -527,6 +528,7 @@ describe('metrics reducers', () => {
         },
         cardStepIndex: {
           [pinnedCopyId1]: 1,
+          [cardId1]: 1,
         },
       });
       expect(nextState.cardMetadataMap).toEqual(expectedState.cardMetadataMap);

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -275,6 +275,7 @@ describe('metrics reducers', () => {
         },
         cardList: [cardId],
         cardToPinnedCopy: new Map([[cardId, pinnedCopyId]]),
+        pinnedCardToOriginal: new Map([[pinnedCopyId, cardId]]),
       });
       const action = actions.metricsTagMetadataLoaded({
         tagMetadata: {
@@ -409,7 +410,7 @@ describe('metrics reducers', () => {
       ]);
     });
 
-    it('does not drop existing data', () => {
+    it('resets existing data and replaces with new card set', () => {
       const beforeState = {
         ...buildMetricsState(),
         cardMetadataMap: {'<cardId>': createScalarCardMetadata()},
@@ -423,13 +424,23 @@ describe('metrics reducers', () => {
         },
       };
 
+      const cardMetadata = {
+        plugin: PluginType.SCALARS,
+        tag: 'tagA',
+        runId: null,
+      };
+      const cardId = getCardId(cardMetadata);
+
       const action = actions.metricsTagMetadataLoaded({tagMetadata});
       const nextState = reducers(beforeState, action);
 
-      expect(nextState.cardMetadataMap['<cardId>']).toEqual(
-        createScalarCardMetadata()
+      const expectedCardMetadataMap: CardMetadataMap = {};
+      expectedCardMetadataMap[cardId] = cardMetadata;
+
+      expect(nextState.cardMetadataMap['<cardId>']).not.toBe(origCardMetadata);
+      expect(nextState.cardMetadataMap[cardId]).toEqual(
+        expectedCardMetadataMap[cardId]
       );
-      expect(nextState.cardMetadataMap['<cardId>']).toBe(origCardMetadata);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -305,7 +305,7 @@ export function buildOrReturnStateWithPinnedCopy(
  * the same reason. To preserve the pinned card mapping we need to adding the
  * pinned card mappng to cardmetadatamap.
  */
-export function updatePinnedCardMappingsUnderNamespaceUnchanged(
+export function generateNextPinnedCardMappings(
   cardToPinnedCopy: CardToPinnedCard,
   pinnedCardToOriginal: PinnedCardToCard,
   nextCardMetadataMap: CardMetadataMap,
@@ -327,20 +327,21 @@ export function updatePinnedCardMappingsUnderNamespaceUnchanged(
     }
   }
 
-  // Updates cardMetadataMap to preserve the mapping of pinned cards.
+  // Creates pinnedCardMetadataMap to preserve the mapping of pinned cards .
+  const pinnedCardMetadataMap = {} as CardMetadataMap;
   for (const [
     pinnedCardId,
     originalCardId,
   ] of nextPinnedCardToOriginal.entries()) {
     if (nextCardToPinnedCopy.has(originalCardId)) {
-      nextCardMetadataMap[pinnedCardId] = nextCardMetadataMap[originalCardId];
+      pinnedCardMetadataMap[pinnedCardId] = nextCardMetadataMap[originalCardId];
     }
   }
 
   return {
     nextCardToPinnedCopy,
     nextPinnedCardToOriginal,
-    nextCardMetadataMap,
+    pinnedCardMetadataMap,
   };
 }
 

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -301,8 +301,7 @@ export function updateCardMaps(
   nextCardMetadataMap: CardMetadataMap,
   nextCardList: CardId[]
 ) {
-  const nextCardToPinnedCopy = new Map(cardToPinnedCopy);
-  nextCardToPinnedCopy.clear();
+  const nextCardToPinnedCopy = new Map() as CardToPinnedCard;
   for (const cardId of nextCardList) {
     if (cardToPinnedCopy.has(cardId)) {
       nextCardToPinnedCopy.set(cardId, cardToPinnedCopy.get(cardId)!);

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -296,7 +296,7 @@ export function buildOrReturnStateWithPinnedCopy(
 }
 
 /**
- * Returns updated cardToPinnedCopy, pinnedCardToOriginal, and cardmetadatamap.
+ * Returns updated cardToPinnedCopy, pinnedCardToOriginal, and cardMetadataMap.
  * Under the same namespace, cardToPinnedCopy and pinnedCardToOriginal are
  * routeful state and remained still, which might stil include the outdated
  * mapping of removed experiments. This function handles the mappings.

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -295,16 +295,16 @@ export function buildOrReturnStateWithPinnedCopy(
   };
 }
 
-export function updateCardMap(
+export function updateCardMaps(
   cardToPinnedCopy: CardToPinnedCard,
   pinnedCardToOriginal: PinnedCardToCard,
   nextCardMetadataMap: CardMetadataMap,
-  nextCardList: CardId[]) {
-
+  nextCardList: CardId[]
+) {
   const nextCardToPinnedCopy = new Map(cardToPinnedCopy);
   nextCardToPinnedCopy.clear();
   for (const cardId of nextCardList) {
-    if (cardToPinnedCopy.has(cardId)){
+    if (cardToPinnedCopy.has(cardId)) {
       nextCardToPinnedCopy.set(cardId, cardToPinnedCopy.get(cardId)!);
     }
   }
@@ -319,8 +319,11 @@ export function updateCardMap(
   }
 
   // Updates cardMetadataMap to preserve the mapping of pinned cards.
-  for (const [pinnedCardId, originalCardId] of nextPinnedCardToOriginal.entries()) {
-    if(nextCardToPinnedCopy.has(originalCardId)) {
+  for (const [
+    pinnedCardId,
+    originalCardId,
+  ] of nextPinnedCardToOriginal.entries()) {
+    if (nextCardToPinnedCopy.has(originalCardId)) {
       nextCardMetadataMap[pinnedCardId] = nextCardMetadataMap[originalCardId];
     }
   }

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -346,6 +346,22 @@ export function generateNextPinnedCardMappings(
 }
 
 /**
+ * Removes cards not in cardMetadataMap from cardStepIndex mapping.
+ */
+export function generateNextCardStepIndex(
+  cardStepIndex: CardStepIndexMap,
+  cardMetadataMap: CardMetadataMap
+): CardStepIndexMap {
+  const nextCardStepIndexMap = {} as CardStepIndexMap;
+  Object.entries(cardStepIndex).forEach(([cardId, step]) => {
+    if (cardMetadataMap[cardId]) {
+      nextCardStepIndexMap[cardId] = step;
+    }
+  });
+  return nextCardStepIndexMap;
+}
+
+/**
  * The maximum number of pins we allow the user to create. This is intentionally
  * finite at the moment to mitigate super long URL lengths, until there is more
  * durable value storage for pins.

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -295,6 +295,43 @@ export function buildOrReturnStateWithPinnedCopy(
   };
 }
 
+export function updateCardMap(
+  cardToPinnedCopy: CardToPinnedCard,
+  pinnedCardToOriginal: PinnedCardToCard,
+  nextCardMetadataMap: CardMetadataMap,
+  nextCardList: CardId[]) {
+
+  const nextCardToPinnedCopy = new Map(cardToPinnedCopy);
+  nextCardToPinnedCopy.clear();
+  for (const cardId of nextCardList) {
+    if (cardToPinnedCopy.has(cardId)){
+      nextCardToPinnedCopy.set(cardId, cardToPinnedCopy.get(cardId)!);
+    }
+  }
+
+  const nextPinnedCardToOriginal = new Map(pinnedCardToOriginal);
+  // Removes previous pinned cards which are not in nextCardList; updated when
+  // experiments are removed
+  for (const [pinnedCardId, originalCardId] of pinnedCardToOriginal.entries()) {
+    if (!nextCardList.includes(originalCardId)) {
+      nextPinnedCardToOriginal.delete(pinnedCardId);
+    }
+  }
+
+  // Updates cardMetadataMap to preserve the mapping of pinned cards.
+  for (const [pinnedCardId, originalCardId] of nextPinnedCardToOriginal.entries()) {
+    if(nextCardToPinnedCopy.has(originalCardId)) {
+      nextCardMetadataMap[pinnedCardId] = nextCardMetadataMap[originalCardId];
+    }
+  }
+
+  return {
+    nextCardToPinnedCopy,
+    nextPinnedCardToOriginal,
+    nextCardMetadataMap,
+  };
+}
+
 /**
  * The maximum number of pins we allow the user to create. This is intentionally
  * finite at the moment to mitigate super long URL lengths, until there is more

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -295,7 +295,17 @@ export function buildOrReturnStateWithPinnedCopy(
   };
 }
 
-export function updateCardMaps(
+/**
+ * Returns updated cardToPinnedCopy, pinnedCardToOriginal, and cardmetadatamap.
+ * Under the same namespace, cardToPinnedCopy and pinnedCardToOriginal are
+ * routeful state and remained still, which might stil include the outdated
+ * mapping of removed experiments. This function handles the mappings.
+ * In the reducer nextCardmetadatamap is created from empty instead of
+ * preserving the previous map, which might also contain outdated mapping due to
+ * the same reason. To preserve the pinned card mapping we need to adding the
+ * pinned card mappng to cardmetadatamap.
+ */
+export function updatePinnedCardMappingsUnderNamespaceUnchanged(
   cardToPinnedCopy: CardToPinnedCard,
   pinnedCardToOriginal: PinnedCardToCard,
   nextCardMetadataMap: CardMetadataMap,

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -25,6 +25,7 @@ import {
   canCreateNewPins,
   createPluginDataWithLoadable,
   createRunToLoadState,
+  generateNextCardStepIndex,
   generateNextPinnedCardMappings,
   getCardId,
   getPinnedCardId,
@@ -502,7 +503,7 @@ describe('metrics store utils', () => {
     });
   });
 
-  describe('updatePinnedCardMappings', () => {
+  describe('generateNextPinnedCardMappings', () => {
     it(`keeps cardToPinnedCopy and pinnedCardToOriginal unchanged on all pinned cards included in cardlist`, () => {
       const cardToPinnedCopy = new Map([
         ['card1', 'card-pin1'],
@@ -589,6 +590,53 @@ describe('metrics store utils', () => {
         'card-pin1': createCardMetadata(),
       };
       expect(pinnedCardMetadataMap).toEqual(expectedCardMetadataMap);
+    });
+  });
+
+  describe('generateNextCardStepIndex', () => {
+    it(`keeps nextCardStepIndexMap unchanged on cards included in cardMetadataMap`, () => {
+      const cardStepIndex = {card1: 1, card2: 2};
+      const cardMetadataMap = {
+        card1: createCardMetadata(),
+        card2: createCardMetadata(),
+      };
+
+      const nextCardStepIndexMap = generateNextCardStepIndex(
+        cardStepIndex,
+        cardMetadataMap
+      );
+
+      expect(nextCardStepIndexMap).toEqual({card1: 1, card2: 2});
+    });
+
+    it(`removes card mapping from nextCardStepIndexMap on cards not in cardMetadataMap`, () => {
+      const cardStepIndex = {card1: 1, card4: 2};
+      const cardMetadataMap = {
+        card1: createCardMetadata(),
+        card2: createCardMetadata(),
+      };
+
+      const nextCardStepIndexMap = generateNextCardStepIndex(
+        cardStepIndex,
+        cardMetadataMap
+      );
+
+      expect(nextCardStepIndexMap).toEqual({card1: 1});
+    });
+
+    it(`keeps nextCardStepIndexMap unchanged on cards not in nextCardStepIndexMap but in cardMetadataMap`, () => {
+      const cardStepIndex = {card1: 1};
+      const cardMetadataMap = {
+        card1: createCardMetadata(),
+        card2: createCardMetadata(),
+      };
+
+      const nextCardStepIndexMap = generateNextCardStepIndex(
+        cardStepIndex,
+        cardMetadataMap
+      );
+
+      expect(nextCardStepIndexMap).toEqual({card1: 1});
     });
   });
 });

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -504,8 +504,7 @@ describe('metrics store utils', () => {
 
   describe('updatePinnedCardMappingsUnderNamespaceUnchanged', () => {
     it(
-      'remains cardToPinnedCopy and pinnedCardToOriginal unchanged on all ' +
-        'pinned cards included in cardlist ',
+      `remains cardToPinnedCopy and pinnedCardToOriginal unchanged on all pinned cards included in cardlist `,
       () => {
         const cardToPinnedCopy = new Map([
           ['card1', 'card-pin1'],
@@ -545,8 +544,7 @@ describe('metrics store utils', () => {
     );
 
     it(
-      'removes pinned cards from the maps on pinned cards not included in' +
-        'cardList',
+      `removes pinned cards from the maps on pinned cards not included in cardList`,
       () => {
         const cardToPinnedCopy = new Map([
           ['card1', 'card-pin1'],

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -30,8 +30,10 @@ import {
   getRunIds,
   getTimeSeriesLoadable,
   TEST_ONLY,
+  updateCardMaps,
 } from './metrics_store_internal_utils';
 import {ImageTimeSeriesData} from './metrics_types';
+import {CardId} from '../internal_types';
 
 describe('metrics store utils', () => {
   it('getTimeSeriesLoadable properly gets loadables', () => {
@@ -498,6 +500,106 @@ describe('metrics store utils', () => {
       });
 
       expect(canCreateNewPins(state)).toBe(false);
+    });
+  });
+
+  describe('updateCardMaps', () => {
+    it('keeps cardToPinnedCopy and pinnedCardToOriginal as status quo on all pinned cards are in cardlist ', () => {
+      const cardToPinnedCopy = new Map([
+        ['card1', 'card-pin1'],
+        ['card2', 'card-pin2'],
+      ]);
+      const pinnedCardToOriginal = new Map([
+        ['card-pin1', 'card1'],
+        ['card-pin2', 'card2'],
+      ]);
+      const cardList = ['card1', 'card2'];
+      const cardMetadataMap = {
+        card1: createCardMetadata(),
+        card2: createCardMetadata(),
+      };
+
+      const {
+        nextCardToPinnedCopy,
+        nextPinnedCardToOriginal,
+        nextCardMetadataMap,
+      } = updateCardMaps(
+        cardToPinnedCopy,
+        pinnedCardToOriginal,
+        cardMetadataMap,
+        cardList
+      );
+
+      expect(nextCardToPinnedCopy).toEqual(
+        new Map([
+          ['card1', 'card-pin1'],
+          ['card2', 'card-pin2'],
+        ])
+      );
+      expect(nextPinnedCardToOriginal).toEqual(
+        new Map([
+          ['card-pin1', 'card1'],
+          ['card-pin2', 'card2'],
+        ])
+      );
+    });
+
+    it('removes pinned cards from the maps when the cards are not in cardList ', () => {
+      const cardToPinnedCopy = new Map([
+        ['card1', 'card-pin1'],
+        ['card2', 'card-pin2'],
+      ]);
+      const pinnedCardToOriginal = new Map([
+        ['card-pin1', 'card1'],
+        ['card-pin2', 'card2'],
+      ]);
+      const cardList = ['card1', 'card3'];
+      const cardMetadataMap = {
+        card1: createCardMetadata(),
+        card3: createCardMetadata(),
+      };
+
+      const {
+        nextCardToPinnedCopy,
+        nextPinnedCardToOriginal,
+        nextCardMetadataMap,
+      } = updateCardMaps(
+        cardToPinnedCopy,
+        pinnedCardToOriginal,
+        cardMetadataMap,
+        cardList
+      );
+
+      const expectedCardMetadataMap = {
+        card1: createCardMetadata(),
+        card3: createCardMetadata(),
+        'card-pin1': createCardMetadata(),
+      };
+      expect(nextCardMetadataMap).toEqual(expectedCardMetadataMap);
+      expect(nextCardToPinnedCopy).toEqual(new Map([['card1', 'card-pin1']]));
+      expect(nextPinnedCardToOriginal).toEqual(
+        new Map([['card-pin1', 'card1']])
+      );
+    });
+
+    it('preserves pinned cards in cardMetadataMap', () => {
+      const cardToPinnedCopy = new Map([['card1', 'card-pin1']]);
+      const pinnedCardToOriginal = new Map([['card-pin1', 'card1']]);
+      const cardMetadataMap = {card1: createCardMetadata()};
+      const cardList = ['card1'];
+
+      const {nextCardMetadataMap} = updateCardMaps(
+        cardToPinnedCopy,
+        pinnedCardToOriginal,
+        cardMetadataMap,
+        cardList
+      );
+
+      const expectedCardMetadataMap = {
+        card1: createCardMetadata(),
+        'card-pin1': createCardMetadata(),
+      };
+      expect(nextCardMetadataMap).toEqual(expectedCardMetadataMap);
     });
   });
 });

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -29,8 +29,8 @@ import {
   getPinnedCardId,
   getRunIds,
   getTimeSeriesLoadable,
-  updatePinnedCardMappingsUnderNamespaceUnchanged,
   TEST_ONLY,
+  updatePinnedCardMappingsUnderNamespaceUnchanged,
 } from './metrics_store_internal_utils';
 import {ImageTimeSeriesData} from './metrics_types';
 
@@ -503,86 +503,80 @@ describe('metrics store utils', () => {
   });
 
   describe('updatePinnedCardMappingsUnderNamespaceUnchanged', () => {
-    it(
-      `remains cardToPinnedCopy and pinnedCardToOriginal unchanged on all pinned cards included in cardlist `,
-      () => {
-        const cardToPinnedCopy = new Map([
-          ['card1', 'card-pin1'],
-          ['card2', 'card-pin2'],
-        ]);
-        const pinnedCardToOriginal = new Map([
-          ['card-pin1', 'card1'],
-          ['card-pin2', 'card2'],
-        ]);
-        const cardList = ['card1', 'card2'];
-        const cardMetadataMap = {
-          card1: createCardMetadata(),
-          card2: createCardMetadata(),
-        };
+    it(`remains cardToPinnedCopy and pinnedCardToOriginal unchanged on all pinned cards included in cardlist `, () => {
+      const cardToPinnedCopy = new Map([
+        ['card1', 'card-pin1'],
+        ['card2', 'card-pin2'],
+      ]);
+      const pinnedCardToOriginal = new Map([
+        ['card-pin1', 'card1'],
+        ['card-pin2', 'card2'],
+      ]);
+      const cardList = ['card1', 'card2'];
+      const cardMetadataMap = {
+        card1: createCardMetadata(),
+        card2: createCardMetadata(),
+      };
 
-        const {nextCardToPinnedCopy, nextPinnedCardToOriginal} =
-          updatePinnedCardMappingsUnderNamespaceUnchanged(
-            cardToPinnedCopy,
-            pinnedCardToOriginal,
-            cardMetadataMap,
-            cardList
-          );
-
-        expect(nextCardToPinnedCopy).toEqual(
-          new Map([
-            ['card1', 'card-pin1'],
-            ['card2', 'card-pin2'],
-          ])
-        );
-        expect(nextPinnedCardToOriginal).toEqual(
-          new Map([
-            ['card-pin1', 'card1'],
-            ['card-pin2', 'card2'],
-          ])
-        );
-      }
-    );
-
-    it(
-      `removes pinned cards from the maps on pinned cards not included in cardList`,
-      () => {
-        const cardToPinnedCopy = new Map([
-          ['card1', 'card-pin1'],
-          ['card2', 'card-pin2'],
-        ]);
-        const pinnedCardToOriginal = new Map([
-          ['card-pin1', 'card1'],
-          ['card-pin2', 'card2'],
-        ]);
-        const cardList = ['card1', 'card3'];
-        const cardMetadataMap = {
-          card1: createCardMetadata(),
-          card3: createCardMetadata(),
-        };
-
-        const {
-          nextCardToPinnedCopy,
-          nextPinnedCardToOriginal,
-          nextCardMetadataMap,
-        } = updatePinnedCardMappingsUnderNamespaceUnchanged(
+      const {nextCardToPinnedCopy, nextPinnedCardToOriginal} =
+        updatePinnedCardMappingsUnderNamespaceUnchanged(
           cardToPinnedCopy,
           pinnedCardToOriginal,
           cardMetadataMap,
           cardList
         );
 
-        const expectedCardMetadataMap = {
-          card1: createCardMetadata(),
-          card3: createCardMetadata(),
-          'card-pin1': createCardMetadata(),
-        };
-        expect(nextCardMetadataMap).toEqual(expectedCardMetadataMap);
-        expect(nextCardToPinnedCopy).toEqual(new Map([['card1', 'card-pin1']]));
-        expect(nextPinnedCardToOriginal).toEqual(
-          new Map([['card-pin1', 'card1']])
-        );
-      }
-    );
+      expect(nextCardToPinnedCopy).toEqual(
+        new Map([
+          ['card1', 'card-pin1'],
+          ['card2', 'card-pin2'],
+        ])
+      );
+      expect(nextPinnedCardToOriginal).toEqual(
+        new Map([
+          ['card-pin1', 'card1'],
+          ['card-pin2', 'card2'],
+        ])
+      );
+    });
+
+    it(`removes pinned cards from the maps on pinned cards not included in cardList`, () => {
+      const cardToPinnedCopy = new Map([
+        ['card1', 'card-pin1'],
+        ['card2', 'card-pin2'],
+      ]);
+      const pinnedCardToOriginal = new Map([
+        ['card-pin1', 'card1'],
+        ['card-pin2', 'card2'],
+      ]);
+      const cardList = ['card1', 'card3'];
+      const cardMetadataMap = {
+        card1: createCardMetadata(),
+        card3: createCardMetadata(),
+      };
+
+      const {
+        nextCardToPinnedCopy,
+        nextPinnedCardToOriginal,
+        nextCardMetadataMap,
+      } = updatePinnedCardMappingsUnderNamespaceUnchanged(
+        cardToPinnedCopy,
+        pinnedCardToOriginal,
+        cardMetadataMap,
+        cardList
+      );
+
+      const expectedCardMetadataMap = {
+        card1: createCardMetadata(),
+        card3: createCardMetadata(),
+        'card-pin1': createCardMetadata(),
+      };
+      expect(nextCardMetadataMap).toEqual(expectedCardMetadataMap);
+      expect(nextCardToPinnedCopy).toEqual(new Map([['card1', 'card-pin1']]));
+      expect(nextPinnedCardToOriginal).toEqual(
+        new Map([['card-pin1', 'card1']])
+      );
+    });
 
     it('preserves pinned cards mapping in cardMetadataMap', () => {
       const cardToPinnedCopy = new Map([['card1', 'card-pin1']]);

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -25,12 +25,12 @@ import {
   canCreateNewPins,
   createPluginDataWithLoadable,
   createRunToLoadState,
+  generateNextPinnedCardMappings,
   getCardId,
   getPinnedCardId,
   getRunIds,
   getTimeSeriesLoadable,
   TEST_ONLY,
-  updatePinnedCardMappingsUnderNamespaceUnchanged,
 } from './metrics_store_internal_utils';
 import {ImageTimeSeriesData} from './metrics_types';
 
@@ -502,8 +502,8 @@ describe('metrics store utils', () => {
     });
   });
 
-  describe('updatePinnedCardMappingsUnderNamespaceUnchanged', () => {
-    it(`remains cardToPinnedCopy and pinnedCardToOriginal unchanged on all pinned cards included in cardlist `, () => {
+  describe('updatePinnedCardMappings', () => {
+    it(`keeps cardToPinnedCopy and pinnedCardToOriginal unchanged on all pinned cards included in cardlist`, () => {
       const cardToPinnedCopy = new Map([
         ['card1', 'card-pin1'],
         ['card2', 'card-pin2'],
@@ -519,7 +519,7 @@ describe('metrics store utils', () => {
       };
 
       const {nextCardToPinnedCopy, nextPinnedCardToOriginal} =
-        updatePinnedCardMappingsUnderNamespaceUnchanged(
+        generateNextPinnedCardMappings(
           cardToPinnedCopy,
           pinnedCardToOriginal,
           cardMetadataMap,
@@ -558,20 +558,14 @@ describe('metrics store utils', () => {
       const {
         nextCardToPinnedCopy,
         nextPinnedCardToOriginal,
-        nextCardMetadataMap,
-      } = updatePinnedCardMappingsUnderNamespaceUnchanged(
+        pinnedCardMetadataMap,
+      } = generateNextPinnedCardMappings(
         cardToPinnedCopy,
         pinnedCardToOriginal,
         cardMetadataMap,
         cardList
       );
 
-      const expectedCardMetadataMap = {
-        card1: createCardMetadata(),
-        card3: createCardMetadata(),
-        'card-pin1': createCardMetadata(),
-      };
-      expect(nextCardMetadataMap).toEqual(expectedCardMetadataMap);
       expect(nextCardToPinnedCopy).toEqual(new Map([['card1', 'card-pin1']]));
       expect(nextPinnedCardToOriginal).toEqual(
         new Map([['card-pin1', 'card1']])
@@ -584,19 +578,17 @@ describe('metrics store utils', () => {
       const cardMetadataMap = {card1: createCardMetadata()};
       const cardList = ['card1'];
 
-      const {nextCardMetadataMap} =
-        updatePinnedCardMappingsUnderNamespaceUnchanged(
-          cardToPinnedCopy,
-          pinnedCardToOriginal,
-          cardMetadataMap,
-          cardList
-        );
+      const {pinnedCardMetadataMap} = generateNextPinnedCardMappings(
+        cardToPinnedCopy,
+        pinnedCardToOriginal,
+        cardMetadataMap,
+        cardList
+      );
 
       const expectedCardMetadataMap = {
-        card1: createCardMetadata(),
         'card-pin1': createCardMetadata(),
       };
-      expect(nextCardMetadataMap).toEqual(expectedCardMetadataMap);
+      expect(pinnedCardMetadataMap).toEqual(expectedCardMetadataMap);
     });
   });
 });

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -30,7 +30,7 @@ import {
   getRunIds,
   getTimeSeriesLoadable,
   TEST_ONLY,
-  updateCardMaps,
+  updatePinnedCardMappingsUnderNamespaceUnchanged,
 } from './metrics_store_internal_utils';
 import {ImageTimeSeriesData} from './metrics_types';
 import {CardId} from '../internal_types';
@@ -503,8 +503,8 @@ describe('metrics store utils', () => {
     });
   });
 
-  describe('updateCardMaps', () => {
-    it('keeps cardToPinnedCopy and pinnedCardToOriginal as status quo on all pinned cards are in cardlist ', () => {
+  describe('updatePinnedCardMappingsUnderNamespaceUnchanged', () => {
+    it('remains cardToPinnedCopy and pinnedCardToOriginal unchanged on all pinned cards included in cardlist ', () => {
       const cardToPinnedCopy = new Map([
         ['card1', 'card-pin1'],
         ['card2', 'card-pin2'],
@@ -523,7 +523,7 @@ describe('metrics store utils', () => {
         nextCardToPinnedCopy,
         nextPinnedCardToOriginal,
         nextCardMetadataMap,
-      } = updateCardMaps(
+      } = updatePinnedCardMappingsUnderNamespaceUnchanged(
         cardToPinnedCopy,
         pinnedCardToOriginal,
         cardMetadataMap,
@@ -544,7 +544,7 @@ describe('metrics store utils', () => {
       );
     });
 
-    it('removes pinned cards from the maps when the cards are not in cardList ', () => {
+    it('removes pinned cards from the maps on pinned cards not included in cardList ', () => {
       const cardToPinnedCopy = new Map([
         ['card1', 'card-pin1'],
         ['card2', 'card-pin2'],
@@ -563,7 +563,7 @@ describe('metrics store utils', () => {
         nextCardToPinnedCopy,
         nextPinnedCardToOriginal,
         nextCardMetadataMap,
-      } = updateCardMaps(
+      } = updatePinnedCardMappingsUnderNamespaceUnchanged(
         cardToPinnedCopy,
         pinnedCardToOriginal,
         cardMetadataMap,
@@ -582,18 +582,19 @@ describe('metrics store utils', () => {
       );
     });
 
-    it('preserves pinned cards in cardMetadataMap', () => {
+    it('preserves pinned cards mapping in cardMetadataMap', () => {
       const cardToPinnedCopy = new Map([['card1', 'card-pin1']]);
       const pinnedCardToOriginal = new Map([['card-pin1', 'card1']]);
       const cardMetadataMap = {card1: createCardMetadata()};
       const cardList = ['card1'];
 
-      const {nextCardMetadataMap} = updateCardMaps(
-        cardToPinnedCopy,
-        pinnedCardToOriginal,
-        cardMetadataMap,
-        cardList
-      );
+      const {nextCardMetadataMap} =
+        updatePinnedCardMappingsUnderNamespaceUnchanged(
+          cardToPinnedCopy,
+          pinnedCardToOriginal,
+          cardMetadataMap,
+          cardList
+        );
 
       const expectedCardMetadataMap = {
         card1: createCardMetadata(),

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -29,11 +29,10 @@ import {
   getPinnedCardId,
   getRunIds,
   getTimeSeriesLoadable,
-  TEST_ONLY,
   updatePinnedCardMappingsUnderNamespaceUnchanged,
+  TEST_ONLY,
 } from './metrics_store_internal_utils';
 import {ImageTimeSeriesData} from './metrics_types';
-import {CardId} from '../internal_types';
 
 describe('metrics store utils', () => {
   it('getTimeSeriesLoadable properly gets loadables', () => {
@@ -504,83 +503,88 @@ describe('metrics store utils', () => {
   });
 
   describe('updatePinnedCardMappingsUnderNamespaceUnchanged', () => {
-    it('remains cardToPinnedCopy and pinnedCardToOriginal unchanged on all pinned cards included in cardlist ', () => {
-      const cardToPinnedCopy = new Map([
-        ['card1', 'card-pin1'],
-        ['card2', 'card-pin2'],
-      ]);
-      const pinnedCardToOriginal = new Map([
-        ['card-pin1', 'card1'],
-        ['card-pin2', 'card2'],
-      ]);
-      const cardList = ['card1', 'card2'];
-      const cardMetadataMap = {
-        card1: createCardMetadata(),
-        card2: createCardMetadata(),
-      };
-
-      const {
-        nextCardToPinnedCopy,
-        nextPinnedCardToOriginal,
-        nextCardMetadataMap,
-      } = updatePinnedCardMappingsUnderNamespaceUnchanged(
-        cardToPinnedCopy,
-        pinnedCardToOriginal,
-        cardMetadataMap,
-        cardList
-      );
-
-      expect(nextCardToPinnedCopy).toEqual(
-        new Map([
+    it(
+      'remains cardToPinnedCopy and pinnedCardToOriginal unchanged on all ' +
+        'pinned cards included in cardlist ',
+      () => {
+        const cardToPinnedCopy = new Map([
           ['card1', 'card-pin1'],
           ['card2', 'card-pin2'],
-        ])
-      );
-      expect(nextPinnedCardToOriginal).toEqual(
-        new Map([
+        ]);
+        const pinnedCardToOriginal = new Map([
           ['card-pin1', 'card1'],
           ['card-pin2', 'card2'],
-        ])
-      );
-    });
+        ]);
+        const cardList = ['card1', 'card2'];
+        const cardMetadataMap = {
+          card1: createCardMetadata(),
+          card2: createCardMetadata(),
+        };
 
-    it('removes pinned cards from the maps on pinned cards not included in cardList ', () => {
-      const cardToPinnedCopy = new Map([
-        ['card1', 'card-pin1'],
-        ['card2', 'card-pin2'],
-      ]);
-      const pinnedCardToOriginal = new Map([
-        ['card-pin1', 'card1'],
-        ['card-pin2', 'card2'],
-      ]);
-      const cardList = ['card1', 'card3'];
-      const cardMetadataMap = {
-        card1: createCardMetadata(),
-        card3: createCardMetadata(),
-      };
+        const {nextCardToPinnedCopy, nextPinnedCardToOriginal} =
+          updatePinnedCardMappingsUnderNamespaceUnchanged(
+            cardToPinnedCopy,
+            pinnedCardToOriginal,
+            cardMetadataMap,
+            cardList
+          );
 
-      const {
-        nextCardToPinnedCopy,
-        nextPinnedCardToOriginal,
-        nextCardMetadataMap,
-      } = updatePinnedCardMappingsUnderNamespaceUnchanged(
-        cardToPinnedCopy,
-        pinnedCardToOriginal,
-        cardMetadataMap,
-        cardList
-      );
+        expect(nextCardToPinnedCopy).toEqual(
+          new Map([
+            ['card1', 'card-pin1'],
+            ['card2', 'card-pin2'],
+          ])
+        );
+        expect(nextPinnedCardToOriginal).toEqual(
+          new Map([
+            ['card-pin1', 'card1'],
+            ['card-pin2', 'card2'],
+          ])
+        );
+      }
+    );
 
-      const expectedCardMetadataMap = {
-        card1: createCardMetadata(),
-        card3: createCardMetadata(),
-        'card-pin1': createCardMetadata(),
-      };
-      expect(nextCardMetadataMap).toEqual(expectedCardMetadataMap);
-      expect(nextCardToPinnedCopy).toEqual(new Map([['card1', 'card-pin1']]));
-      expect(nextPinnedCardToOriginal).toEqual(
-        new Map([['card-pin1', 'card1']])
-      );
-    });
+    it(
+      'removes pinned cards from the maps on pinned cards not included in' +
+        'cardList',
+      () => {
+        const cardToPinnedCopy = new Map([
+          ['card1', 'card-pin1'],
+          ['card2', 'card-pin2'],
+        ]);
+        const pinnedCardToOriginal = new Map([
+          ['card-pin1', 'card1'],
+          ['card-pin2', 'card2'],
+        ]);
+        const cardList = ['card1', 'card3'];
+        const cardMetadataMap = {
+          card1: createCardMetadata(),
+          card3: createCardMetadata(),
+        };
+
+        const {
+          nextCardToPinnedCopy,
+          nextPinnedCardToOriginal,
+          nextCardMetadataMap,
+        } = updatePinnedCardMappingsUnderNamespaceUnchanged(
+          cardToPinnedCopy,
+          pinnedCardToOriginal,
+          cardMetadataMap,
+          cardList
+        );
+
+        const expectedCardMetadataMap = {
+          card1: createCardMetadata(),
+          card3: createCardMetadata(),
+          'card-pin1': createCardMetadata(),
+        };
+        expect(nextCardMetadataMap).toEqual(expectedCardMetadataMap);
+        expect(nextCardToPinnedCopy).toEqual(new Map([['card1', 'card-pin1']]));
+        expect(nextPinnedCardToOriginal).toEqual(
+          new Map([['card-pin1', 'card1']])
+        );
+      }
+    );
 
     it('preserves pinned cards mapping in cardMetadataMap', () => {
       const cardToPinnedCopy = new Map([['card1', 'card-pin1']]);


### PR DESCRIPTION
Previously within a namespace, when experiments are added or removed the load tag metadata is not fired. Now we fire the loading on changes of route id. The key change for this pr is cardMetadataMap is reset. The map contains data from previous route and, because the namespace does not change, the map is outdated (includes card id of removed experiments). It is safe to reset the map because the metadata loaded action is fired after receiving complete tag metadata.

Other corresponding state updated include nextCardToPinnedCopy nextPinnedCardToOriginal.