### PR TITLE
chore: remove typehack

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
@@ -32,10 +32,6 @@ import {
   SourceFileResponse,
 } from '../data_source/tfdbg2_data_source';
 
-// HACK: Below import is for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-
 /**
  * Actions for Debugger V2.
  */

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
@@ -29,7 +29,6 @@ import {
 } from '../store/debugger_types';
 import {TBHttpClient} from '../../../../webapp/webapp_data_source/tb_http_client';
 
-
 // The backend route for source-file list responds with an array
 // of 2-tuples: <host_name, file_path>.
 export type SourceFileListResponse = Array<[string, string]>;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
@@ -29,7 +29,6 @@ import {
 } from '../store/debugger_types';
 import {TBHttpClient} from '../../../../webapp/webapp_data_source/tb_http_client';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 // The backend route for source-file list responds with an array
 // of 2-tuples: <host_name, file_path>.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
@@ -19,7 +19,6 @@ import {State} from './store/debugger_types';
 import {debuggerLoaded, debuggerUnloaded} from './actions';
 import {getActiveRunId, getDebuggerRunListing} from './store';
 
-
 @Component({
   selector: 'tf-debugger-v2',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
@@ -19,7 +19,6 @@ import {State} from './store/debugger_types';
 import {debuggerLoaded, debuggerUnloaded} from './actions';
 import {getActiveRunId, getDebuggerRunListing} from './store';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'tf-debugger-v2',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -118,8 +118,6 @@ import {
 } from '../store/debugger_types';
 import {PLUGIN_ID} from '../types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
 
 type State = AppState & DebuggerState;
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -118,7 +118,6 @@ import {
 } from '../store/debugger_types';
 import {PLUGIN_ID} from '../types';
 
-
 type State = AppState & DebuggerState;
 
 // Minimum polling interval in milliseconds.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -43,10 +43,6 @@ import {
   StackFrame,
 } from './debugger_types';
 
-// HACK: These imports are for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
-
 const DEFAULT_EXECUTION_PAGE_SIZE = 100;
 const DEFAULT_GRAPH_EXECUTION_PAGE_SIZE = 200;
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -47,10 +47,6 @@ import {
   State,
 } from './debugger_types';
 
-// HACK: These imports are for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
-
 const selectDebuggerState = createFeatureSelector<State, DebuggerState>(
   DEBUGGER_FEATURE_KEY
 );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
@@ -25,7 +25,6 @@ import {
 import {AlertType} from '../../store/debugger_types';
 import {AlertTypeDisplay} from './alerts_component';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL: {
   [alertType: string]: {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
@@ -25,7 +25,6 @@ import {
 import {AlertType} from '../../store/debugger_types';
 import {AlertTypeDisplay} from './alerts_component';
 
-
 const ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL: {
   [alertType: string]: {
     displayName: string;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
@@ -40,7 +40,6 @@ import {SourceFilesModule} from '../source_files/source_files_module';
 import {StackTraceModule} from '../stack_trace/stack_trace_module';
 import {TimelineModule} from '../timeline/timeline_module';
 
-
 describe('Alerts Container', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
@@ -40,7 +40,6 @@ import {SourceFilesModule} from '../source_files/source_files_module';
 import {StackTraceModule} from '../stack_trace/stack_trace_module';
 import {TimelineModule} from '../timeline/timeline_module';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Alerts Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
@@ -20,7 +20,6 @@ import {Execution, State, TensorDebugMode} from '../../store/debugger_types';
 import {getFocusedExecutionData} from '../../store';
 import {DTYPE_ENUM_TO_NAME} from '../../tf_dtypes';
 
-
 const UNKNOWN_DTYPE_NAME = 'Unknown dtype';
 
 @Component({

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
@@ -20,7 +20,6 @@ import {Execution, State, TensorDebugMode} from '../../store/debugger_types';
 import {getFocusedExecutionData} from '../../store';
 import {DTYPE_ENUM_TO_NAME} from '../../tf_dtypes';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const UNKNOWN_DTYPE_NAME = 'Unknown dtype';
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
@@ -37,7 +37,6 @@ import {
 import {ExecutionDataContainer} from './execution_data_container';
 import {ExecutionDataModule} from './execution_data_module';
 
-
 describe('Execution Data Container', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
@@ -37,7 +37,6 @@ import {
 import {ExecutionDataContainer} from './execution_data_container';
 import {ExecutionDataModule} from './execution_data_module';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Execution Data Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container.ts
@@ -23,7 +23,6 @@ import {
 } from '../../store';
 import {State} from '../../store/debugger_types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'tf-debugger-v2-graph',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container.ts
@@ -23,7 +23,6 @@ import {
 } from '../../store';
 import {State} from '../../store/debugger_types';
 
-
 @Component({
   selector: 'tf-debugger-v2-graph',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
@@ -39,7 +39,6 @@ import {
 import {GraphContainer} from './graph_container';
 import {GraphModule} from './graph_module';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Graph Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
@@ -39,7 +39,6 @@ import {
 import {GraphContainer} from './graph_container';
 import {GraphModule} from './graph_module';
 
-
 describe('Graph Container', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -27,7 +27,6 @@ import {
 } from '../../store';
 import {State} from '../../store/debugger_types';
 
-
 @Component({
   selector: 'tf-debugger-v2-graph-executions',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -27,7 +27,6 @@ import {
 } from '../../store';
 import {State} from '../../store/debugger_types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'tf-debugger-v2-graph-executions',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -51,7 +51,6 @@ import {TimelineModule} from '../timeline/timeline_module';
 import {GraphExecutionsContainer} from './graph_executions_container';
 import {GraphExecutionsModule} from './graph_executions_module';
 
-
 describe('Graph Executions Container', () => {
   let store: MockStore<State>;
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -51,7 +51,6 @@ import {TimelineModule} from '../timeline/timeline_module';
 import {GraphExecutionsContainer} from './graph_executions_container';
 import {GraphExecutionsModule} from './graph_executions_module';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Graph Executions Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_container.ts
@@ -15,7 +15,6 @@ limitations under the License.
 import {Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 
-
 // TODO(cais): Move to a separate file.
 export interface InactiveState {}
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_container.ts
@@ -15,7 +15,6 @@ limitations under the License.
 import {Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 // TODO(cais): Move to a separate file.
 export interface InactiveState {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
@@ -48,7 +48,6 @@ import {TimelineModule} from '../timeline/timeline_module';
 import {SourceFilesContainer} from './source_files_container';
 import {SourceFilesModule} from './source_files_module';
 
-
 type AppState = DebuggerState & OtherAppState;
 
 describe('Source Files Container', () => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
@@ -48,7 +48,6 @@ import {TimelineModule} from '../timeline/timeline_module';
 import {SourceFilesContainer} from './source_files_container';
 import {SourceFilesModule} from './source_files_module';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 type AppState = DebuggerState & OtherAppState;
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
@@ -25,7 +25,6 @@ import {
 } from '../../store';
 import {StackFrameForDisplay} from './stack_trace_component';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'tf-debugger-v2-stack-trace',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
@@ -25,7 +25,6 @@ import {
 } from '../../store';
 import {StackFrameForDisplay} from './stack_trace_component';
 
-
 @Component({
   selector: 'tf-debugger-v2-stack-trace',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container_test.ts
@@ -41,7 +41,6 @@ import {StackTraceComponent} from './stack_trace_component';
 import {StackTraceContainer} from './stack_trace_container';
 import {StackTraceModule} from './stack_trace_module';
 
-
 describe('Stack Trace container', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container_test.ts
@@ -41,7 +41,6 @@ import {StackTraceComponent} from './stack_trace_component';
 import {StackTraceContainer} from './stack_trace_container';
 import {StackTraceModule} from './stack_trace_module';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Stack Trace container', () => {
   let store: MockStore<State>;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container.ts
@@ -37,7 +37,6 @@ import {
 import {DataLoadState, ExecutionDigest} from '../../store/debugger_types';
 import {ExecutionDigestForDisplay} from './timeline_component';
 
-
 const FUNCTION_OP_TYPE_PREFIXES: string[] = [
   '__forward_',
   '__backward_',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container.ts
@@ -37,7 +37,6 @@ import {
 import {DataLoadState, ExecutionDigest} from '../../store/debugger_types';
 import {ExecutionDigestForDisplay} from './timeline_component';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const FUNCTION_OP_TYPE_PREFIXES: string[] = [
   '__forward_',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
@@ -40,7 +40,6 @@ import {
 import {TEST_ONLY, TimelineContainer} from './timeline_container';
 import {TimelineModule} from './timeline_module';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('getExecutionDigestForDisplay', () => {
   for (const [opType, strLen, expectedShortOpType, isGraph] of [

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
@@ -40,7 +40,6 @@ import {
 import {TEST_ONLY, TimelineContainer} from './timeline_container';
 import {TimelineModule} from './timeline_module';
 
-
 describe('getExecutionDigestForDisplay', () => {
   for (const [opType, strLen, expectedShortOpType, isGraph] of [
     ['MatMul', 1, 'M', false],

--- a/tensorboard/webapp/alert/actions/index.ts
+++ b/tensorboard/webapp/alert/actions/index.ts
@@ -16,7 +16,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {AlertReport} from '../types';
 
-
 /**
  * Fires when an alert is to be reported.
  */

--- a/tensorboard/webapp/alert/actions/index.ts
+++ b/tensorboard/webapp/alert/actions/index.ts
@@ -16,8 +16,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {AlertReport} from '../types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 /**
  * Fires when an alert is to be reported.

--- a/tensorboard/webapp/alert/effects/index.ts
+++ b/tensorboard/webapp/alert/effects/index.ts
@@ -20,7 +20,6 @@ import {State} from '../../app_state';
 import {alertReported} from '../actions';
 import {AlertActionModule} from '../alert_action_module';
 
-
 @Injectable()
 export class AlertEffects {
   constructor(

--- a/tensorboard/webapp/alert/effects/index.ts
+++ b/tensorboard/webapp/alert/effects/index.ts
@@ -20,9 +20,6 @@ import {State} from '../../app_state';
 import {alertReported} from '../actions';
 import {AlertActionModule} from '../alert_action_module';
 
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Injectable()
 export class AlertEffects {

--- a/tensorboard/webapp/alert/store/alert_reducers.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers.ts
@@ -16,7 +16,6 @@ import {Action, createReducer, on} from '@ngrx/store';
 import * as actions from '../actions';
 import {AlertState} from './alert_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const initialState: AlertState = {
   latestAlert: null,

--- a/tensorboard/webapp/alert/store/alert_reducers.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers.ts
@@ -16,7 +16,6 @@ import {Action, createReducer, on} from '@ngrx/store';
 import * as actions from '../actions';
 import {AlertState} from './alert_types';
 
-
 const initialState: AlertState = {
   latestAlert: null,
 };

--- a/tensorboard/webapp/alert/store/alert_selectors.ts
+++ b/tensorboard/webapp/alert/store/alert_selectors.ts
@@ -16,7 +16,6 @@ import {createSelector, createFeatureSelector} from '@ngrx/store';
 import {AlertInfo} from '../types';
 import {AlertState, State, ALERT_FEATURE_KEY} from './alert_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const selectAlertState = createFeatureSelector<State, AlertState>(
   ALERT_FEATURE_KEY

--- a/tensorboard/webapp/alert/store/alert_selectors.ts
+++ b/tensorboard/webapp/alert/store/alert_selectors.ts
@@ -16,7 +16,6 @@ import {createSelector, createFeatureSelector} from '@ngrx/store';
 import {AlertInfo} from '../types';
 import {AlertState, State, ALERT_FEATURE_KEY} from './alert_types';
 
-
 const selectAlertState = createFeatureSelector<State, AlertState>(
   ALERT_FEATURE_KEY
 );

--- a/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
+++ b/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
@@ -16,7 +16,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {Navigation, Route, RouteKind} from '../types';
 
-
 /**
  * Created when user wants to discard unsaved edits and navigate away.
  */

--- a/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
+++ b/tensorboard/webapp/app_routing/actions/app_routing_actions.ts
@@ -16,8 +16,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {Navigation, Route, RouteKind} from '../types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 /**
  * Created when user wants to discard unsaved edits and navigate away.

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -55,7 +55,6 @@ import {
 } from '../store/app_routing_selectors';
 import {Navigation, Route, RouteKind, RouteParams} from '../types';
 
-
 const initAction = createAction('[App Routing] Effects Init');
 
 interface InternalNavigation extends Navigation {

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -55,9 +55,6 @@ import {
 } from '../store/app_routing_selectors';
 import {Navigation, Route, RouteKind, RouteParams} from '../types';
 
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const initAction = createAction('[App Routing] Effects Init');
 

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -31,7 +31,6 @@ import {
 } from '../store_only_utils';
 import {ExperimentAlias} from '../../experiments/types';
 
-
 const getAppRoutingState = createFeatureSelector<State, AppRoutingState>(
   APP_ROUTING_FEATURE_KEY
 );

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -31,7 +31,6 @@ import {
 } from '../store_only_utils';
 import {ExperimentAlias} from '../../experiments/types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const getAppRoutingState = createFeatureSelector<State, AppRoutingState>(
   APP_ROUTING_FEATURE_KEY

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -20,8 +20,6 @@ import {navigated, NavigatedPayload} from './actions';
 import {Location} from './location';
 import {Route, RouteKind} from './types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 import {getRouteId} from './internal_utils';
 
 export function buildRoute(routeOverride: Partial<Route> = {}): Route {

--- a/tensorboard/webapp/app_routing/views/router_outlet_container.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_container.ts
@@ -25,7 +25,6 @@ import {
   getNextRouteForRouterOutletOnly,
 } from '../store/app_routing_selectors';
 
-
 @Component({
   selector: 'router-outlet',
   template: `

--- a/tensorboard/webapp/app_routing/views/router_outlet_container.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_container.ts
@@ -25,8 +25,6 @@ import {
   getNextRouteForRouterOutletOnly,
 } from '../store/app_routing_selectors';
 
-/** @typehack */ import * as _typeHackAngularCore from '@angular/core/core';
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'router-outlet',

--- a/tensorboard/webapp/core/actions/core_actions.ts
+++ b/tensorboard/webapp/core/actions/core_actions.ts
@@ -17,10 +17,6 @@ import {Environment, PluginId, PluginsListing} from '../../types/api';
 
 import {PluginsListFailureCode, Run, RunId} from '../types';
 
-// HACK: Below import is for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-
 /**
  * User has clicked on a button in the header to change the plugin.
  */

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -66,7 +66,6 @@ import {
 } from '../store';
 import {PluginsListFailureCode} from '../types';
 
-
 // throttle + 1ms are somewhat random but it does following:
 // - when an app uses both router and manually fires coreLoaded, we prevent
 //   double requests.

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -66,8 +66,6 @@ import {
 } from '../store';
 import {PluginsListFailureCode} from '../types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
 
 // throttle + 1ms are somewhat random but it does following:
 // - when an app uses both router and manually fires coreLoaded, we prevent

--- a/tensorboard/webapp/core/store/core_initial_state_provider.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider.ts
@@ -19,7 +19,6 @@ import {CoreState} from './core_types';
 import {DeepLinkerInterface} from '../../deeplink';
 import {initialState} from './core_types';
 
-
 export const CORE_STORE_CONFIG_TOKEN = new InjectionToken<
   StoreConfig<CoreState>
 >('Core Feature Config');

--- a/tensorboard/webapp/core/store/core_initial_state_provider.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider.ts
@@ -19,7 +19,6 @@ import {CoreState} from './core_types';
 import {DeepLinkerInterface} from '../../deeplink';
 import {initialState} from './core_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 export const CORE_STORE_CONFIG_TOKEN = new InjectionToken<
   StoreConfig<CoreState>

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -23,10 +23,6 @@ import {
   State,
 } from './core_types';
 
-// HACK: These imports are for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackSelector from '@ngrx/store/src/selector';
-
 const selectCoreState = createFeatureSelector<State, CoreState>(
   CORE_FEATURE_KEY
 );

--- a/tensorboard/webapp/core/views/hash_storage_container.ts
+++ b/tensorboard/webapp/core/views/hash_storage_container.ts
@@ -21,7 +21,6 @@ import {pluginUrlHashChanged} from '../actions';
 
 import {ChangedProp} from './hash_storage_component';
 
-
 @Component({
   selector: 'hash-storage',
   template: `

--- a/tensorboard/webapp/core/views/hash_storage_container.ts
+++ b/tensorboard/webapp/core/views/hash_storage_container.ts
@@ -21,7 +21,6 @@ import {pluginUrlHashChanged} from '../actions';
 
 import {ChangedProp} from './hash_storage_component';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'hash-storage',

--- a/tensorboard/webapp/core/views/page_title_container.ts
+++ b/tensorboard/webapp/core/views/page_title_container.ts
@@ -39,7 +39,6 @@ import {getEnvironment} from '../store';
 import {State} from '../state';
 import {TB_BRAND_NAME} from '../types';
 
-
 const DEFAULT_BRAND_NAME = 'TensorBoard';
 
 /**

--- a/tensorboard/webapp/core/views/page_title_container.ts
+++ b/tensorboard/webapp/core/views/page_title_container.ts
@@ -39,7 +39,6 @@ import {getEnvironment} from '../store';
 import {State} from '../state';
 import {TB_BRAND_NAME} from '../types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const DEFAULT_BRAND_NAME = 'TensorBoard';
 

--- a/tensorboard/webapp/deeplink/hash_test.ts
+++ b/tensorboard/webapp/deeplink/hash_test.ts
@@ -16,7 +16,6 @@ import {TestBed} from '@angular/core/testing';
 
 import {HashStorageComponent} from './hash';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('hash storage test', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/deeplink/hash_test.ts
+++ b/tensorboard/webapp/deeplink/hash_test.ts
@@ -16,7 +16,6 @@ import {TestBed} from '@angular/core/testing';
 
 import {HashStorageComponent} from './hash';
 
-
 describe('hash storage test', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;

--- a/tensorboard/webapp/experiments/store/experiments_selectors.ts
+++ b/tensorboard/webapp/experiments/store/experiments_selectors.ts
@@ -23,7 +23,6 @@ import {
   State,
 } from './experiments_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const getExperimentsState = createFeatureSelector<State, ExperimentsState>(
   EXPERIMENTS_FEATURE_KEY

--- a/tensorboard/webapp/experiments/store/experiments_selectors.ts
+++ b/tensorboard/webapp/experiments/store/experiments_selectors.ts
@@ -23,7 +23,6 @@ import {
   State,
 } from './experiments_types';
 
-
 const getExperimentsState = createFeatureSelector<State, ExperimentsState>(
   EXPERIMENTS_FEATURE_KEY
 );

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -17,7 +17,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {FeatureFlags} from '../types';
 
-
 /**
  * Signals that a data source has loaded feature flag values.
  *

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -17,8 +17,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {FeatureFlags} from '../types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
-/** @typehack */ import * as _typeHackStoreModel from '@ngrx/store/src/models';
 
 /**
  * Signals that a data source has loaded feature flag values.

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
@@ -23,9 +23,6 @@ import {partialFeatureFlagsLoaded} from '../actions/feature_flag_actions';
 import {getIsAutoDarkModeAllowed} from '../store/feature_flag_selectors';
 import {State} from '../store/feature_flag_types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
-/** @typehack */ import * as _typeHackNgrx from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
 
 const effectsInitialized = createAction('[FEATURE FLAG] Effects Init');
 

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
@@ -23,7 +23,6 @@ import {partialFeatureFlagsLoaded} from '../actions/feature_flag_actions';
 import {getIsAutoDarkModeAllowed} from '../store/feature_flag_selectors';
 import {State} from '../store/feature_flag_types';
 
-
 const effectsInitialized = createAction('[FEATURE FLAG] Effects Init');
 
 @Injectable()

--- a/tensorboard/webapp/feature_flag/feature_flag_module.ts
+++ b/tensorboard/webapp/feature_flag/feature_flag_module.ts
@@ -32,7 +32,6 @@ import {
 } from './store/feature_flag_store_config_provider';
 import {FEATURE_FLAG_FEATURE_KEY, State} from './store/feature_flag_types';
 
-
 export function getThemeSettingSelector() {
   return createSelector(getEnableDarkModeOverride, (darkModeOverride) => {
     if (darkModeOverride === null) {

--- a/tensorboard/webapp/feature_flag/feature_flag_module.ts
+++ b/tensorboard/webapp/feature_flag/feature_flag_module.ts
@@ -32,7 +32,6 @@ import {
 } from './store/feature_flag_store_config_provider';
 import {FEATURE_FLAG_FEATURE_KEY, State} from './store/feature_flag_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 export function getThemeSettingSelector() {
   return createSelector(getEnableDarkModeOverride, (darkModeOverride) => {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -19,7 +19,6 @@ import * as actions from '../actions/feature_flag_actions';
 import {initialState} from './feature_flag_store_config_provider';
 import {FeatureFlagState} from './feature_flag_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const reducer = createReducer<FeatureFlagState>(
   initialState,

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -19,7 +19,6 @@ import * as actions from '../actions/feature_flag_actions';
 import {initialState} from './feature_flag_store_config_provider';
 import {FeatureFlagState} from './feature_flag_types';
 
-
 const reducer = createReducer<FeatureFlagState>(
   initialState,
   on(actions.partialFeatureFlagsLoaded, (state, {features}) => {

--- a/tensorboard/webapp/header/plugin_selector_container.ts
+++ b/tensorboard/webapp/header/plugin_selector_container.ts
@@ -21,7 +21,6 @@ import {changePlugin} from '../core/actions';
 import {PluginId} from '../types/api';
 import {UiPluginMetadata} from './types';
 
-
 const getUiPlugins = createSelector(getPlugins, (listing): UiPluginMetadata[] =>
   Object.keys(listing).map((key) => Object.assign({}, {id: key}, listing[key]))
 );

--- a/tensorboard/webapp/header/plugin_selector_container.ts
+++ b/tensorboard/webapp/header/plugin_selector_container.ts
@@ -21,7 +21,6 @@ import {changePlugin} from '../core/actions';
 import {PluginId} from '../types/api';
 import {UiPluginMetadata} from './types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const getUiPlugins = createSelector(getPlugins, (listing): UiPluginMetadata[] =>
   Object.keys(listing).map((key) => Object.assign({}, {id: key}, listing[key]))

--- a/tensorboard/webapp/hparams/_redux/hparams_actions.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_actions.ts
@@ -20,7 +20,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {DiscreteHparamValues} from '../types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 
 export const hparamsDiscreteHparamFilterChanged = createAction(
   '[Hparams] Hparams Discrete Hparam Filter Changed',

--- a/tensorboard/webapp/hparams/_redux/hparams_actions.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_actions.ts
@@ -20,7 +20,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {DiscreteHparamValues} from '../types';
 
-
 export const hparamsDiscreteHparamFilterChanged = createAction(
   '[Hparams] Hparams Discrete Hparam Filter Changed',
   props<{

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -28,8 +28,6 @@ import {
   XAxisType,
 } from '../internal_types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 export const metricsSettingsPaneClosed = createAction(
   '[Metrics] Metrics Settings Pane Closed'

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -28,7 +28,6 @@ import {
   XAxisType,
 } from '../internal_types';
 
-
 export const metricsSettingsPaneClosed = createAction(
   '[Metrics] Metrics Settings Pane Closed'
 );

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -50,7 +50,6 @@ import {
 } from '../store';
 import {CardId, CardMetadata} from '../types';
 
-
 export type CardFetchInfo = CardMetadata & {
   id: CardId;
   loadState: DataLoadState;

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -50,9 +50,6 @@ import {
 } from '../store';
 import {CardId, CardMetadata} from '../types';
 
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 export type CardFetchInfo = CardMetadata & {
   id: CardId;

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -44,7 +44,6 @@ import {
 import {MetricsDashboardContainer} from './views/metrics_container';
 import {MetricsViewsModule} from './views/metrics_views_module';
 
-
 const CREATE_PIN_MAX_EXCEEDED_TEXT =
   `Max pin limit exceeded. Remove existing` +
   ` pins before adding more. See ` +

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -44,8 +44,6 @@ import {
 import {MetricsDashboardContainer} from './views/metrics_container';
 import {MetricsViewsModule} from './views/metrics_views_module';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const CREATE_PIN_MAX_EXCEEDED_TEXT =
   `Max pin limit exceeded. Remove existing` +

--- a/tensorboard/webapp/metrics/store/metrics_initial_state_provider.ts
+++ b/tensorboard/webapp/metrics/store/metrics_initial_state_provider.ts
@@ -19,7 +19,6 @@ import {StoreConfig} from '@ngrx/store';
 import {INITIAL_STATE} from './metrics_reducers';
 import {MetricsSettings, MetricsState} from './metrics_types';
 
-
 export const METRICS_STORE_CONFIG_TOKEN = new InjectionToken<
   StoreConfig<MetricsState>
 >('Metrics Store Config');

--- a/tensorboard/webapp/metrics/store/metrics_initial_state_provider.ts
+++ b/tensorboard/webapp/metrics/store/metrics_initial_state_provider.ts
@@ -19,7 +19,6 @@ import {StoreConfig} from '@ngrx/store';
 import {INITIAL_STATE} from './metrics_reducers';
 import {MetricsSettings, MetricsState} from './metrics_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 export const METRICS_STORE_CONFIG_TOKEN = new InjectionToken<
   StoreConfig<MetricsState>

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -41,7 +41,6 @@ import {
   TagMetadata,
 } from './metrics_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const selectMetricsState = createFeatureSelector<State, MetricsState>(
   METRICS_FEATURE_KEY

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -41,7 +41,6 @@ import {
   TagMetadata,
 } from './metrics_types';
 
-
 const selectMetricsState = createFeatureSelector<State, MetricsState>(
   METRICS_FEATURE_KEY
 );

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -33,7 +33,6 @@ import {
   XAxisType,
 } from '../../types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const SLIDER_AUDIT_TIME_MS = 250;
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -33,7 +33,6 @@ import {
   XAxisType,
 } from '../../types';
 
-
 const SLIDER_AUDIT_TIME_MS = 250;
 
 /**

--- a/tensorboard/webapp/notification_center/_data_source/testing.ts
+++ b/tensorboard/webapp/notification_center/_data_source/testing.ts
@@ -21,7 +21,6 @@ import {
   BackendNotification,
 } from './backend_types';
 
-
 @Injectable()
 export class TestingNotificationCenterDataSource
   implements NotificationCenterDataSource

--- a/tensorboard/webapp/notification_center/_data_source/testing.ts
+++ b/tensorboard/webapp/notification_center/_data_source/testing.ts
@@ -21,7 +21,6 @@ import {
   BackendNotification,
 } from './backend_types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Injectable()
 export class TestingNotificationCenterDataSource

--- a/tensorboard/webapp/notification_center/_notification_center_module.ts
+++ b/tensorboard/webapp/notification_center/_notification_center_module.ts
@@ -30,7 +30,6 @@ import {
 } from './_redux/notification_center_types';
 import {NotificationCenterViewModule} from './_views/views_module';
 
-
 export function getNotificationLastReadTimeSettingSelector() {
   return createSelector(getLastReadTime, (lastReadTime) => {
     return {notificationLastReadTimeInMs: lastReadTime};

--- a/tensorboard/webapp/notification_center/_notification_center_module.ts
+++ b/tensorboard/webapp/notification_center/_notification_center_module.ts
@@ -30,7 +30,6 @@ import {
 } from './_redux/notification_center_types';
 import {NotificationCenterViewModule} from './_views/views_module';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 export function getNotificationLastReadTimeSettingSelector() {
   return createSelector(getLastReadTime, (lastReadTime) => {

--- a/tensorboard/webapp/notification_center/_redux/notification_center_actions.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_actions.ts
@@ -16,7 +16,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {Notification} from './notification_center_types';
 
-
 /**
  * Fires when the bell icon is clicked.
  */

--- a/tensorboard/webapp/notification_center/_redux/notification_center_actions.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_actions.ts
@@ -16,8 +16,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {Notification} from './notification_center_types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 /**
  * Fires when the bell icon is clicked.

--- a/tensorboard/webapp/notification_center/_redux/notification_center_effects.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_effects.ts
@@ -23,7 +23,6 @@ import {NotificationCenterDataSource} from '../_data_source/index';
 import * as actions from './notification_center_actions';
 import {CategoryEnum} from './notification_center_types';
 
-
 export const initAction = createAction('[NotificationCenter Effects] Init');
 
 @Injectable()

--- a/tensorboard/webapp/notification_center/_redux/notification_center_effects.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_effects.ts
@@ -23,9 +23,6 @@ import {NotificationCenterDataSource} from '../_data_source/index';
 import * as actions from './notification_center_actions';
 import {CategoryEnum} from './notification_center_types';
 
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 export const initAction = createAction('[NotificationCenter Effects] Init');
 

--- a/tensorboard/webapp/notification_center/_redux/notification_center_selectors.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_selectors.ts
@@ -20,7 +20,6 @@ import {
   State,
 } from './notification_center_types';
 
-
 const selectNotifications = createFeatureSelector<State, NotificationState>(
   NOTIFICATION_FEATURE_KEY
 );

--- a/tensorboard/webapp/notification_center/_redux/notification_center_selectors.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_selectors.ts
@@ -20,7 +20,6 @@ import {
   State,
 } from './notification_center_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const selectNotifications = createFeatureSelector<State, NotificationState>(
   NOTIFICATION_FEATURE_KEY

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
@@ -16,7 +16,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {PersistableSettings} from '../_data_source/types';
 
-
 /**
  * Describes settings loaded from a global settings storage. Dispatched once
  * when the application bootstraps.

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
@@ -16,7 +16,6 @@ import {createAction, props} from '@ngrx/store';
 
 import {PersistableSettings} from '../_data_source/types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 
 /**
  * Describes settings loaded from a global settings storage. Dispatched once

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
@@ -32,7 +32,6 @@ import {PersistentSettingsDataSource} from '../_data_source/persistent_settings_
 import {globalSettingsLoaded} from './persistent_settings_actions';
 import {PersistableSettings} from '../_data_source/types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 
 const initAction = createAction('[Persistent Settings] Effects Init');
 const DEBOUNCE_PERIOD_IN_MS = 500;

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
@@ -32,7 +32,6 @@ import {PersistentSettingsDataSource} from '../_data_source/persistent_settings_
 import {globalSettingsLoaded} from './persistent_settings_actions';
 import {PersistableSettings} from '../_data_source/types';
 
-
 const initAction = createAction('[Persistent Settings] Effects Init');
 const DEBOUNCE_PERIOD_IN_MS = 500;
 

--- a/tensorboard/webapp/plugins/npmi/actions/npmi_actions.ts
+++ b/tensorboard/webapp/plugins/npmi/actions/npmi_actions.ts
@@ -19,10 +19,6 @@ import {
   EmbeddingDataSet,
 } from '../store/npmi_types';
 
-// HACK: Below import is for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-
 /**
  * Actions for the NPMI Component.
  */

--- a/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source.ts
+++ b/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source.ts
@@ -30,7 +30,6 @@ import {
 } from './../store/npmi_types';
 import {EmbeddingDataSet, buildEmbeddingDataSet} from '../util/umap';
 
-
 export abstract class NpmiDataSource {
   abstract fetchData(experimentIds: string[]): Observable<{
     annotationData: AnnotationDataListing;

--- a/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source.ts
+++ b/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source.ts
@@ -30,7 +30,6 @@ import {
 } from './../store/npmi_types';
 import {EmbeddingDataSet, buildEmbeddingDataSet} from '../util/umap';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 export abstract class NpmiDataSource {
   abstract fetchData(experimentIds: string[]): Observable<{

--- a/tensorboard/webapp/plugins/npmi/effects/npmi_effects.ts
+++ b/tensorboard/webapp/plugins/npmi/effects/npmi_effects.ts
@@ -38,8 +38,6 @@ import {
 } from './../actions';
 import * as selectors from '../../../selectors';
 
-
-
 @Injectable()
 export class NpmiEffects {
   /**

--- a/tensorboard/webapp/plugins/npmi/effects/npmi_effects.ts
+++ b/tensorboard/webapp/plugins/npmi/effects/npmi_effects.ts
@@ -38,9 +38,7 @@ import {
 } from './../actions';
 import * as selectors from '../../../selectors';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
 
 @Injectable()
 export class NpmiEffects {

--- a/tensorboard/webapp/plugins/npmi/npmi_container.ts
+++ b/tensorboard/webapp/plugins/npmi/npmi_container.ts
@@ -20,7 +20,6 @@ import {State} from '../../app_state';
 import {getViewActive} from './store/npmi_selectors';
 import {getCurrentRouteRunSelection} from '../../selectors';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi',

--- a/tensorboard/webapp/plugins/npmi/npmi_container.ts
+++ b/tensorboard/webapp/plugins/npmi/npmi_container.ts
@@ -20,7 +20,6 @@ import {State} from '../../app_state';
 import {getViewActive} from './store/npmi_selectors';
 import {getCurrentRouteRunSelection} from '../../selectors';
 
-
 @Component({
   selector: 'npmi',
   template: `

--- a/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
@@ -31,7 +31,6 @@ import {NpmiComponent} from './npmi_component';
 import {NpmiContainer} from './npmi_container';
 import {ViewActive} from './store/npmi_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
@@ -31,7 +31,6 @@ import {NpmiComponent} from './npmi_component';
 import {NpmiContainer} from './npmi_container';
 import {ViewActive} from './store/npmi_types';
 
-
 describe('Npmi Container', () => {
   let store: MockStore<State>;
   const css = {

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
@@ -28,10 +28,6 @@ import {
 import * as metricType from '../util/metric_type';
 import {buildEmbeddingDataSet} from '../util/umap';
 
-// HACK: These imports are for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
-
 const initialState: NpmiState = {
   pluginDataLoaded: {
     state: DataLoadState.NOT_LOADED,

--- a/tensorboard/webapp/plugins/npmi/store/npmi_selectors.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_selectors.ts
@@ -27,11 +27,6 @@ import {
   EmbeddingDataSet,
 } from './npmi_types';
 
-// HACK: These imports are for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
-
 const selectNpmiState = createFeatureSelector<State, NpmiState>(
   NPMI_FEATURE_KEY
 );

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_container.ts
@@ -31,7 +31,6 @@ import {ValueData} from '../../../store/npmi_types';
 import * as npmiActions from '../../../actions';
 import {RunColorScale} from '../../../../../types/ui';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-annotation',

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_container.ts
@@ -31,7 +31,6 @@ import {ValueData} from '../../../store/npmi_types';
 import * as npmiActions from '../../../actions';
 import {RunColorScale} from '../../../../../types/ui';
 
-
 @Component({
   selector: 'npmi-annotation',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_test.ts
@@ -34,7 +34,6 @@ import {
 import * as selectors from '../../../../../selectors';
 import {buildRun} from '../../../../../runs/store/testing';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 import {getExperimentIdsFromRoute} from '../../../../../app_routing/store/app_routing_selectors';
 
 describe('Npmi Annotations List Row', () => {

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_container.ts
@@ -41,7 +41,6 @@ import {metricIsNpmiAndNotDiff} from '../../util/metric_type';
 import * as npmiActions from '../../actions';
 import {sortAnnotations} from '../../util/sort_annotations';
 
-
 @Component({
   selector: 'npmi-annotations-list',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_container.ts
@@ -41,7 +41,6 @@ import {metricIsNpmiAndNotDiff} from '../../util/metric_type';
 import * as npmiActions from '../../actions';
 import {sortAnnotations} from '../../util/sort_annotations';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-annotations-list',

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
@@ -27,7 +27,6 @@ import {createState, createCoreState} from '../../../../core/testing';
 import {AnnotationsListComponent} from './annotations_list_component';
 import {AnnotationsListContainer} from './annotations_list_container';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Annotations List Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
@@ -27,7 +27,6 @@ import {createState, createCoreState} from '../../../../core/testing';
 import {AnnotationsListComponent} from './annotations_list_component';
 import {AnnotationsListContainer} from './annotations_list_container';
 
-
 describe('Npmi Annotations List Container', () => {
   let store: MockStore<State>;
   const css = {

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_container.ts
@@ -26,7 +26,6 @@ import {
   getShowHiddenAnnotations,
 } from '../../../store';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-annotations-list-toolbar',

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_container.ts
@@ -26,7 +26,6 @@ import {
   getShowHiddenAnnotations,
 } from '../../../store';
 
-
 @Component({
   selector: 'npmi-annotations-list-toolbar',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_test.ts
@@ -26,7 +26,6 @@ import {appStateFromNpmiState, createNpmiState} from '../../../testing';
 import * as npmiActions from '../../../actions';
 import {getSelectedAnnotations} from '../../../store';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Annotations List Toolbar Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_test.ts
@@ -26,7 +26,6 @@ import {appStateFromNpmiState, createNpmiState} from '../../../testing';
 import * as npmiActions from '../../../actions';
 import {getSelectedAnnotations} from '../../../store';
 
-
 describe('Npmi Annotations List Toolbar Container', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[];

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_container.ts
@@ -20,7 +20,6 @@ import * as npmiActions from '../../../../actions';
 
 import {getAnnotationsRegex} from '../../../../store';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-annotations-search',

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_container.ts
@@ -20,7 +20,6 @@ import * as npmiActions from '../../../../actions';
 
 import {getAnnotationsRegex} from '../../../../store';
 
-
 @Component({
   selector: 'npmi-annotations-search',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_test.ts
@@ -33,7 +33,6 @@ import {AnnotationsSearchContainer} from './annotations_search_container';
 import {AnnotationsSearchComponent} from './annotations_search_component';
 import {getAnnotationsRegex} from '../../../../store';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Annotations Search Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_test.ts
@@ -33,7 +33,6 @@ import {AnnotationsSearchContainer} from './annotations_search_container';
 import {AnnotationsSearchComponent} from './annotations_search_component';
 import {getAnnotationsRegex} from '../../../../store';
 
-
 describe('Npmi Annotations Search Container', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[];

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_container.ts
@@ -20,7 +20,6 @@ import {getSelectedAnnotations, getAnnotationSort} from '../../../store';
 import {AnnotationDataListing} from './../../../store/npmi_types';
 import * as npmiActions from '../../../actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-annotations-list-header',

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_container.ts
@@ -20,7 +20,6 @@ import {getSelectedAnnotations, getAnnotationSort} from '../../../store';
 import {AnnotationDataListing} from './../../../store/npmi_types';
 import * as npmiActions from '../../../actions';
 
-
 @Component({
   selector: 'npmi-annotations-list-header',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_test.ts
@@ -27,7 +27,6 @@ import {SortOrder} from '../../../store/npmi_types';
 import {appStateFromNpmiState, createNpmiState} from '../../../testing';
 import {getAnnotationSort} from '../../../store';
 
-
 describe('Npmi Annotations List Header Container', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[];

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_test.ts
@@ -27,7 +27,6 @@ import {SortOrder} from '../../../store/npmi_types';
 import {appStateFromNpmiState, createNpmiState} from '../../../testing';
 import {getAnnotationSort} from '../../../store';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Annotations List Header Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/data_selection_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/data_selection_test.ts
@@ -27,7 +27,6 @@ import {DataSelectionComponent} from './data_selection_component';
 import {appStateFromNpmiState, createNpmiState} from '../../testing';
 import {createState, createCoreState} from '../../../../core/testing';
 
-
 describe('Npmi Data Selection Container', () => {
   let store: MockStore<State>;
 

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/data_selection_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/data_selection_test.ts
@@ -27,7 +27,6 @@ import {DataSelectionComponent} from './data_selection_component';
 import {appStateFromNpmiState, createNpmiState} from '../../testing';
 import {createState, createCoreState} from '../../../../core/testing';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Data Selection Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_container.ts
@@ -17,7 +17,6 @@ import {select, Store} from '@ngrx/store';
 import {State} from '../../../store/npmi_types';
 import {getMetricArithmetic} from '../../../store';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-metric-arithmetic',

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_container.ts
@@ -17,7 +17,6 @@ import {select, Store} from '@ngrx/store';
 import {State} from '../../../store/npmi_types';
 import {getMetricArithmetic} from '../../../store';
 
-
 @Component({
   selector: 'npmi-metric-arithmetic',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_container.ts
@@ -25,7 +25,6 @@ import {
 } from '../../../../store';
 import * as npmiActions from '../../../../actions';
 
-
 @Component({
   selector: 'npmi-metric-arithmetic-element',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_container.ts
@@ -25,7 +25,6 @@ import {
 } from '../../../../store';
 import * as npmiActions from '../../../../actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-metric-arithmetic-element',

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_test.ts
@@ -40,7 +40,6 @@ import {
 import {MetricArithmeticElementContainer} from './metric_arithmetic_element_container';
 import {MetricArithmeticElementComponent} from './metric_arithmetic_element_component';
 
-
 describe('Npmi Metric Arithmetic Element Container', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[];

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_test.ts
@@ -40,7 +40,6 @@ import {
 import {MetricArithmeticElementContainer} from './metric_arithmetic_element_container';
 import {MetricArithmeticElementComponent} from './metric_arithmetic_element_component';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Metric Arithmetic Element Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/metric_arithmetic_operator_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/metric_arithmetic_operator_test.ts
@@ -21,7 +21,6 @@ import {TestBed} from '@angular/core/testing';
 import {MetricArithmeticOperatorComponent} from './metric_arithmetic_operator_component';
 import {Operator} from '../../../../store/npmi_types';
 
-
 describe('Npmi Metric Arithmetic Operator Component', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/metric_arithmetic_operator_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/metric_arithmetic_operator_test.ts
@@ -21,7 +21,6 @@ import {TestBed} from '@angular/core/testing';
 import {MetricArithmeticOperatorComponent} from './metric_arithmetic_operator_component';
 import {Operator} from '../../../../store/npmi_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Metric Arithmetic Operator Component', () => {
   beforeEach(async () => {

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_test.ts
@@ -32,7 +32,6 @@ import {
 } from './../../../store/npmi_selectors';
 import {ArithmeticKind, Operator} from '../../../store/npmi_types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Metric Arithmetic Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_test.ts
@@ -32,7 +32,6 @@ import {
 } from './../../../store/npmi_selectors';
 import {ArithmeticKind, Operator} from '../../../store/npmi_types';
 
-
 describe('Npmi Metric Arithmetic Container', () => {
   let store: MockStore<State>;
 

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_container.ts
@@ -27,7 +27,6 @@ import {
 import {getCurrentRouteRunSelection} from '../../../../../selectors';
 import * as npmiActions from '../../../actions';
 
-
 @Component({
   selector: 'npmi-metric-search',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_container.ts
@@ -27,7 +27,6 @@ import {
 import {getCurrentRouteRunSelection} from '../../../../../selectors';
 import * as npmiActions from '../../../actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-metric-search',

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
@@ -40,7 +40,6 @@ import {appStateFromNpmiState, createNpmiState} from '../../../testing';
 import {MetricSearchComponent} from './metric_search_component';
 import {MetricSearchContainer} from './metric_search_container';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Metric Search Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
@@ -40,7 +40,6 @@ import {appStateFromNpmiState, createNpmiState} from '../../../testing';
 import {MetricSearchComponent} from './metric_search_component';
 import {MetricSearchContainer} from './metric_search_container';
 
-
 describe('Npmi Metric Search Container', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[];

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_container.ts
@@ -28,7 +28,6 @@ import {
 import {getCurrentRouteRunSelection} from '../../../../../selectors';
 import {metricIsNpmiAndNotDiff} from '../../../util/metric_type';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-results-download',

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_container.ts
@@ -28,7 +28,6 @@ import {
 import {getCurrentRouteRunSelection} from '../../../../../selectors';
 import {metricIsNpmiAndNotDiff} from '../../../util/metric_type';
 
-
 @Component({
   selector: 'npmi-results-download',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
@@ -31,7 +31,6 @@ import {ResultsDownloadComponent} from './results_download_component';
 
 import {getFlaggedAnnotations} from '../../../store';
 
-
 describe('Npmi Results Download', () => {
   let store: MockStore<State>;
   const css = {

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
@@ -31,7 +31,6 @@ import {ResultsDownloadComponent} from './results_download_component';
 
 import {getFlaggedAnnotations} from '../../../store';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Results Download', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_container.ts
@@ -25,7 +25,6 @@ import {
 } from './../../store/npmi_selectors';
 import * as npmiActions from '../../actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-embeddings',

--- a/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_container.ts
@@ -25,7 +25,6 @@ import {
 } from './../../store/npmi_selectors';
 import * as npmiActions from '../../actions';
 
-
 @Component({
   selector: 'npmi-embeddings',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_test.ts
@@ -30,7 +30,6 @@ import {EmbeddingsComponent} from './embeddings_component';
 import {EmbeddingsContainer} from './embeddings_container';
 import * as npmiActions from '../../actions';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 
 describe('Npmi Embeddings Container', () => {

--- a/tensorboard/webapp/plugins/npmi/views/main/main_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_container.ts
@@ -25,7 +25,6 @@ import {
 } from './../../store/npmi_selectors';
 import * as npmiActions from '../../actions';
 
-
 @Component({
   selector: 'npmi-main',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/main/main_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_container.ts
@@ -25,7 +25,6 @@ import {
 } from './../../store/npmi_selectors';
 import * as npmiActions from '../../actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-main',

--- a/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
@@ -30,7 +30,6 @@ import {MainComponent} from './main_component';
 import {MainContainer} from './main_container';
 import * as npmiActions from '../../actions';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 
 describe('Npmi Main Container', () => {

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_container.ts
@@ -33,7 +33,6 @@ import {stripMetricString} from '../../../util/metric_type';
 import * as selectors from '../../../../../selectors';
 import {RunColorScale} from '../../../../../types/ui';
 
-
 @Component({
   selector: 'npmi-parallel-coordinates',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_container.ts
@@ -33,7 +33,6 @@ import {stripMetricString} from '../../../util/metric_type';
 import * as selectors from '../../../../../selectors';
 import {RunColorScale} from '../../../../../types/ui';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-parallel-coordinates',

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_test.ts
@@ -34,7 +34,6 @@ import {
   getRunColorMap,
 } from '../../../../../selectors';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Parallel Coordinates Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_test.ts
@@ -34,7 +34,6 @@ import {
   getRunColorMap,
 } from '../../../../../selectors';
 
-
 describe('Npmi Parallel Coordinates Container', () => {
   let store: MockStore<State>;
   const css = {

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_container.ts
@@ -19,7 +19,6 @@ import {State} from '../../../../app_state';
 import {getPCExpanded, getSelectedAnnotations} from '../../store';
 import * as npmiActions from '../../actions';
 
-
 @Component({
   selector: 'npmi-selected-annotations',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_container.ts
@@ -19,7 +19,6 @@ import {State} from '../../../../app_state';
 import {getPCExpanded, getSelectedAnnotations} from '../../store';
 import * as npmiActions from '../../actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-selected-annotations',

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_test.ts
@@ -29,7 +29,6 @@ import {SelectedAnnotationsComponent} from './selected_annotations_component';
 import * as npmiActions from '../../actions';
 import {getPCExpanded, getSelectedAnnotations} from '../../store';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Selected Annotations', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_test.ts
@@ -29,7 +29,6 @@ import {SelectedAnnotationsComponent} from './selected_annotations_component';
 import * as npmiActions from '../../actions';
 import {getPCExpanded, getSelectedAnnotations} from '../../store';
 
-
 describe('Npmi Selected Annotations', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[];

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_container.ts
@@ -33,7 +33,6 @@ import {violinData, ViolinChartData} from '../../../util/violin_data';
 import * as selectors from '../../../../../selectors';
 import {RunColorScale} from '../../../../../types/ui';
 
-
 @Component({
   selector: 'npmi-violin-filter',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_container.ts
@@ -33,7 +33,6 @@ import {violinData, ViolinChartData} from '../../../util/violin_data';
 import * as selectors from '../../../../../selectors';
 import {RunColorScale} from '../../../../../types/ui';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-violin-filter',

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
@@ -32,7 +32,6 @@ import {getAnnotationData} from '../../../store';
 import {getCurrentRouteRunSelection} from '../../../../../selectors';
 import * as selectors from '../../../../../selectors';
 
-
 describe('Npmi Violin Filter Container', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[];

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
@@ -32,7 +32,6 @@ import {getAnnotationData} from '../../../store';
 import {getCurrentRouteRunSelection} from '../../../../../selectors';
 import * as selectors from '../../../../../selectors';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Violin Filter Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_container.ts
@@ -21,7 +21,6 @@ import {map} from 'rxjs/operators';
 import {getSidebarExpanded, getMetricFilters} from '../../store';
 import * as npmiActions from '../../actions';
 
-
 @Component({
   selector: 'npmi-violin-filters',
   template: `

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_container.ts
@@ -21,7 +21,6 @@ import {map} from 'rxjs/operators';
 import {getSidebarExpanded, getMetricFilters} from '../../store';
 import * as npmiActions from '../../actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'npmi-violin-filters',

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_test.ts
@@ -30,7 +30,6 @@ import {createState, createCoreState} from '../../../../core/testing';
 import * as npmiActions from '../../actions';
 import {getSidebarExpanded, getMetricFilters} from '../../store';
 
-
 describe('Npmi Violin Filters Container', () => {
   let store: MockStore<State>;
   let dispatchedActions: Action[];

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_test.ts
@@ -30,7 +30,6 @@ import {createState, createCoreState} from '../../../../core/testing';
 import * as npmiActions from '../../actions';
 import {getSidebarExpanded, getMetricFilters} from '../../store';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('Npmi Violin Filters Container', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -41,7 +41,6 @@ import {selectors as settingsSelectors} from '../settings';
 
 import {PluginLoadState} from './plugins_component';
 
-
 export interface UiPluginMetadata extends PluginMetadata {
   id: string;
 }

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -41,7 +41,6 @@ import {selectors as settingsSelectors} from '../settings';
 
 import {PluginLoadState} from './plugins_component';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 export interface UiPluginMetadata extends PluginMetadata {
   id: string;

--- a/tensorboard/webapp/plugins/text_v2/actions/text_actions.ts
+++ b/tensorboard/webapp/plugins/text_v2/actions/text_actions.ts
@@ -18,10 +18,6 @@ import {createAction, props} from '@ngrx/store';
 import {StepDatum} from '../data_source';
 import {TagGroup} from '../types';
 
-// HACK: Below import is for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-
 export const textPluginLoaded = createAction('[Text] Text Plugin Loaded');
 
 export const textRunToTagsLoaded = createAction(

--- a/tensorboard/webapp/plugins/text_v2/data_source/text_v2_server_data_source.ts
+++ b/tensorboard/webapp/plugins/text_v2/data_source/text_v2_server_data_source.ts
@@ -19,7 +19,6 @@ import {TBHttpClient} from '../../../webapp_data_source/tb_http_client';
 
 import {TextV2DataSource} from './text_v2_data_source';
 
-
 interface BackendRunToTagsMap {
   [runName: string]: string[];
 }

--- a/tensorboard/webapp/plugins/text_v2/data_source/text_v2_server_data_source.ts
+++ b/tensorboard/webapp/plugins/text_v2/data_source/text_v2_server_data_source.ts
@@ -19,7 +19,6 @@ import {TBHttpClient} from '../../../webapp_data_source/tb_http_client';
 
 import {TextV2DataSource} from './text_v2_data_source';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 interface BackendRunToTagsMap {
   [runName: string]: string[];

--- a/tensorboard/webapp/plugins/text_v2/effects/text_effects.ts
+++ b/tensorboard/webapp/plugins/text_v2/effects/text_effects.ts
@@ -39,8 +39,6 @@ import {
 } from '../store/text_v2_selectors';
 import {manualReload, reload} from '../../../core/actions';
 
-
-
 @Injectable()
 export class TextEffects {
   /** @export */

--- a/tensorboard/webapp/plugins/text_v2/effects/text_effects.ts
+++ b/tensorboard/webapp/plugins/text_v2/effects/text_effects.ts
@@ -39,9 +39,7 @@ import {
 } from '../store/text_v2_selectors';
 import {manualReload, reload} from '../../../core/actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
 
 @Injectable()
 export class TextEffects {

--- a/tensorboard/webapp/plugins/text_v2/store/text_v2_reducers.ts
+++ b/tensorboard/webapp/plugins/text_v2/store/text_v2_reducers.ts
@@ -16,10 +16,6 @@ import {Action, createReducer, on} from '@ngrx/store';
 
 import {TextState} from './text_types';
 
-// HACK: These imports are for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
-
 const DATA_A_B_RUN1 = [
   {
     originalShape: [3],

--- a/tensorboard/webapp/plugins/text_v2/store/text_v2_selectors.ts
+++ b/tensorboard/webapp/plugins/text_v2/store/text_v2_selectors.ts
@@ -18,11 +18,6 @@ import {TextState, State, TEXT_FEATURE_KEY} from './text_types';
 import {StepDatum} from '../data_source';
 import {RunTag} from '../types';
 
-// HACK: These imports are for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
-
 const selectTextState = createFeatureSelector<State, TextState>(
   TEXT_FEATURE_KEY
 );

--- a/tensorboard/webapp/reloader/reloader_component.ts
+++ b/tensorboard/webapp/reloader/reloader_component.ts
@@ -21,7 +21,6 @@ import {distinctUntilChanged} from 'rxjs/operators';
 import {selectors as settingsSelectors, State} from '../settings';
 import {reload} from '../core/actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'reloader',

--- a/tensorboard/webapp/reloader/reloader_component.ts
+++ b/tensorboard/webapp/reloader/reloader_component.ts
@@ -21,7 +21,6 @@ import {distinctUntilChanged} from 'rxjs/operators';
 import {selectors as settingsSelectors, State} from '../settings';
 import {reload} from '../core/actions';
 
-
 @Component({
   selector: 'reloader',
   template: '',

--- a/tensorboard/webapp/reloader/reloader_component_test.ts
+++ b/tensorboard/webapp/reloader/reloader_component_test.ts
@@ -26,7 +26,6 @@ import {
   createSettings,
 } from '../settings/testing';
 
-
 describe('reloader_component', () => {
   let store: MockStore;
   let dispatchSpy: jasmine.Spy;

--- a/tensorboard/webapp/reloader/reloader_component_test.ts
+++ b/tensorboard/webapp/reloader/reloader_component_test.ts
@@ -26,7 +26,6 @@ import {
   createSettings,
 } from '../settings/testing';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('reloader_component', () => {
   let store: MockStore;

--- a/tensorboard/webapp/runs/actions/runs_actions.ts
+++ b/tensorboard/webapp/runs/actions/runs_actions.ts
@@ -22,8 +22,6 @@ import {SortDirection} from '../../types/ui';
 import {Run} from '../data_source/runs_data_source_types';
 import {ExperimentIdToRunsAndMetadata, GroupBy, SortKey} from '../types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 /**
  * The action can fire when no requests are actually made (i.e., an empty

--- a/tensorboard/webapp/runs/actions/runs_actions.ts
+++ b/tensorboard/webapp/runs/actions/runs_actions.ts
@@ -22,7 +22,6 @@ import {SortDirection} from '../../types/ui';
 import {Run} from '../data_source/runs_data_source_types';
 import {ExperimentIdToRunsAndMetadata, GroupBy, SortKey} from '../types';
 
-
 /**
  * The action can fire when no requests are actually made (i.e., an empty
  * requestedExperimentIds).

--- a/tensorboard/webapp/runs/data_source/runs_data_source.ts
+++ b/tensorboard/webapp/runs/data_source/runs_data_source.ts
@@ -24,7 +24,6 @@ import {
   RunsDataSource,
 } from './runs_data_source_types';
 
-
 type BackendGetRunsResponse = string[];
 
 function runToRunId(run: string, experimentId: string) {

--- a/tensorboard/webapp/runs/data_source/runs_data_source.ts
+++ b/tensorboard/webapp/runs/data_source/runs_data_source.ts
@@ -24,7 +24,6 @@ import {
   RunsDataSource,
 } from './runs_data_source_types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 type BackendGetRunsResponse = string[];
 

--- a/tensorboard/webapp/runs/data_source/testing.ts
+++ b/tensorboard/webapp/runs/data_source/testing.ts
@@ -23,7 +23,6 @@ import {
   RunsDataSource,
 } from './runs_data_source_types';
 
-
 export function buildHparamsAndMetadata(
   override: Partial<HparamsAndMetadata>
 ): HparamsAndMetadata {

--- a/tensorboard/webapp/runs/data_source/testing.ts
+++ b/tensorboard/webapp/runs/data_source/testing.ts
@@ -23,7 +23,6 @@ import {
   RunsDataSource,
 } from './runs_data_source_types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 export function buildHparamsAndMetadata(
   override: Partial<HparamsAndMetadata>

--- a/tensorboard/webapp/runs/effects/runs_effects.ts
+++ b/tensorboard/webapp/runs/effects/runs_effects.ts
@@ -43,7 +43,6 @@ import {RunsDataSource} from '../data_source/runs_data_source_types';
 import {HparamsAndMetadata} from '../data_source/runs_data_source_types';
 import {ExperimentIdToRunsAndMetadata} from '../types';
 
-
 /**
  * Runs effect for fetching data from the backend.
  */

--- a/tensorboard/webapp/runs/effects/runs_effects.ts
+++ b/tensorboard/webapp/runs/effects/runs_effects.ts
@@ -43,7 +43,6 @@ import {RunsDataSource} from '../data_source/runs_data_source_types';
 import {HparamsAndMetadata} from '../data_source/runs_data_source_types';
 import {ExperimentIdToRunsAndMetadata} from '../types';
 
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
 
 /**
  * Runs effect for fetching data from the backend.

--- a/tensorboard/webapp/runs/runs_module.ts
+++ b/tensorboard/webapp/runs/runs_module.ts
@@ -27,7 +27,6 @@ import {RunsEffects} from './effects';
 import {reducers} from './store';
 import {RUNS_FEATURE_KEY} from './store/runs_types';
 
-
 export function alertActionProvider() {
   return [
     {

--- a/tensorboard/webapp/runs/runs_module.ts
+++ b/tensorboard/webapp/runs/runs_module.ts
@@ -27,8 +27,6 @@ import {RunsEffects} from './effects';
 import {reducers} from './store';
 import {RUNS_FEATURE_KEY} from './store/runs_types';
 
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 export function alertActionProvider() {
   return [

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -27,7 +27,6 @@ import {
 } from './runs_types';
 import {createGroupBy, serializeExperimentIds} from './utils';
 
-
 const getRunsState = createFeatureSelector<State, RunsState>(RUNS_FEATURE_KEY);
 
 const getDataState = createSelector(

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -27,7 +27,6 @@ import {
 } from './runs_types';
 import {createGroupBy, serializeExperimentIds} from './utils';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const getRunsState = createFeatureSelector<State, RunsState>(RUNS_FEATURE_KEY);
 

--- a/tensorboard/webapp/runs/views/runs_selector/runs_selector_container.ts
+++ b/tensorboard/webapp/runs/views/runs_selector/runs_selector_container.ts
@@ -20,7 +20,6 @@ import {State} from '../../../app_state';
 import {getExperimentIdsFromRoute} from '../../../selectors';
 import {RunsTableColumn} from '../runs_table/types';
 
-
 @Component({
   selector: 'runs-selector',
   template: `

--- a/tensorboard/webapp/runs/views/runs_selector/runs_selector_container.ts
+++ b/tensorboard/webapp/runs/views/runs_selector/runs_selector_container.ts
@@ -20,7 +20,6 @@ import {State} from '../../../app_state';
 import {getExperimentIdsFromRoute} from '../../../selectors';
 import {RunsTableColumn} from '../runs_table/types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'runs-selector',

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -79,7 +79,6 @@ import {
 } from './runs_table_component';
 import {RunsTableColumn, RunTableItem} from './types';
 
-
 const getRunsLoading = createSelector<
   State,
   {experimentId: string},

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -79,7 +79,6 @@ import {
 } from './runs_table_component';
 import {RunsTableColumn, RunTableItem} from './types';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 const getRunsLoading = createSelector<
   State,

--- a/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_test.ts
+++ b/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_test.ts
@@ -26,7 +26,6 @@ import {polymerInteropRunSelectionChanged} from '../../../core/actions';
 import {LegacyRunsSelectorContainer} from './legacy_runs_selector_container';
 import {LegacyRunsSelectorComponent} from './legacy_runs_selector_component';
 
-
 describe('legacy_runs_selector test', () => {
   let store: MockStore<State>;
   let recordedActions: Action[];

--- a/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_test.ts
+++ b/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_test.ts
@@ -26,7 +26,6 @@ import {polymerInteropRunSelectionChanged} from '../../../core/actions';
 import {LegacyRunsSelectorContainer} from './legacy_runs_selector_container';
 import {LegacyRunsSelectorComponent} from './legacy_runs_selector_component';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('legacy_runs_selector test', () => {
   let store: MockStore<State>;

--- a/tensorboard/webapp/settings/_redux/settings_actions.ts
+++ b/tensorboard/webapp/settings/_redux/settings_actions.ts
@@ -14,10 +14,6 @@ limitations under the License.
 ==============================================================================*/
 import {createAction, props} from '@ngrx/store';
 
-// HACK: Below import is for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
-
 /**
  * Action for when user wants to enable/disable reload.
  */

--- a/tensorboard/webapp/settings/_redux/settings_selectors.ts
+++ b/tensorboard/webapp/settings/_redux/settings_selectors.ts
@@ -18,10 +18,6 @@ import {DataLoadState} from '../../types/data';
 import {ColorPalette} from '../../util/colors';
 import {SettingsState, SETTINGS_FEATURE_KEY, State} from './settings_types';
 
-// HACK: These imports are for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-/** @typehack */ import * as _typeHackSelector from '@ngrx/store/src/selector';
-
 const selectSettingsState = createFeatureSelector<State, SettingsState>(
   SETTINGS_FEATURE_KEY
 );

--- a/tensorboard/webapp/settings/_views/polymer_interop_container.ts
+++ b/tensorboard/webapp/settings/_views/polymer_interop_container.ts
@@ -22,7 +22,6 @@ import {takeUntil, distinctUntilChanged} from 'rxjs/operators';
 import {getPageSize} from '../_redux/settings_selectors';
 import {State} from '../_redux/settings_types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 /**
  * SettingsPolymerInterop is a temporary interop module that writes settings in

--- a/tensorboard/webapp/settings/_views/polymer_interop_container.ts
+++ b/tensorboard/webapp/settings/_views/polymer_interop_container.ts
@@ -22,7 +22,6 @@ import {takeUntil, distinctUntilChanged} from 'rxjs/operators';
 import {getPageSize} from '../_redux/settings_selectors';
 import {State} from '../_redux/settings_types';
 
-
 /**
  * SettingsPolymerInterop is a temporary interop module that writes settings in
  * Ngrx store to Polymer-based TensorBoard components. As long as TensorBoard

--- a/tensorboard/webapp/settings/_views/polymer_interop_test.ts
+++ b/tensorboard/webapp/settings/_views/polymer_interop_test.ts
@@ -22,7 +22,6 @@ import {SettingsPolymerInteropContainer} from './polymer_interop_container';
 
 import {getPageSize} from '../_redux/settings_selectors';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('settings polymer_interop', () => {
   let store: MockStore;

--- a/tensorboard/webapp/settings/_views/polymer_interop_test.ts
+++ b/tensorboard/webapp/settings/_views/polymer_interop_test.ts
@@ -22,7 +22,6 @@ import {SettingsPolymerInteropContainer} from './polymer_interop_container';
 
 import {getPageSize} from '../_redux/settings_selectors';
 
-
 describe('settings polymer_interop', () => {
   let store: MockStore;
   let setLimitCalls: number[];

--- a/tensorboard/webapp/settings/_views/settings_button_container.ts
+++ b/tensorboard/webapp/settings/_views/settings_button_container.ts
@@ -18,7 +18,6 @@ import {Store} from '@ngrx/store';
 import {getSettingsLoadState} from '../_redux/settings_selectors';
 import {State} from '../_redux/settings_types';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'settings-button',

--- a/tensorboard/webapp/settings/_views/settings_button_container.ts
+++ b/tensorboard/webapp/settings/_views/settings_button_container.ts
@@ -18,7 +18,6 @@ import {Store} from '@ngrx/store';
 import {getSettingsLoadState} from '../_redux/settings_selectors';
 import {State} from '../_redux/settings_types';
 
-
 @Component({
   selector: 'settings-button',
   template: `

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.ts
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.ts
@@ -33,7 +33,6 @@ import {takeUntil, debounceTime, filter} from 'rxjs/operators';
 
 import {MIN_RELOAD_PERIOD_IN_MS} from '../_redux/settings_reducers';
 
-
 export function createIntegerValidator(): ValidatorFn {
   return (control: AbstractControl): {[key: string]: any} | null => {
     const numValue = Number(control.value);

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.ts
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.ts
@@ -33,7 +33,6 @@ import {takeUntil, debounceTime, filter} from 'rxjs/operators';
 
 import {MIN_RELOAD_PERIOD_IN_MS} from '../_redux/settings_reducers';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 export function createIntegerValidator(): ValidatorFn {
   return (control: AbstractControl): {[key: string]: any} | null => {

--- a/tensorboard/webapp/settings/_views/settings_dialog_container.ts
+++ b/tensorboard/webapp/settings/_views/settings_dialog_container.ts
@@ -27,7 +27,6 @@ import {
   changePageSize,
 } from '../_redux/settings_actions';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'settings-dialog',

--- a/tensorboard/webapp/settings/_views/settings_dialog_container.ts
+++ b/tensorboard/webapp/settings/_views/settings_dialog_container.ts
@@ -27,7 +27,6 @@ import {
   changePageSize,
 } from '../_redux/settings_actions';
 
-
 @Component({
   selector: 'settings-dialog',
   template: `

--- a/tensorboard/webapp/settings/_views/settings_test.ts
+++ b/tensorboard/webapp/settings/_views/settings_test.ts
@@ -37,7 +37,6 @@ import {
 } from '../_redux/settings_actions';
 import {createSettings, createSettingsState, createState} from '../testing';
 
-/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 import {getSettingsLoadState} from '../_redux/settings_selectors';
 import {DataLoadState} from '../../types/data';
 

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_container.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_container.ts
@@ -17,7 +17,6 @@ import {Store, select, createSelector} from '@ngrx/store';
 
 import {getEnvironment, State} from '../core/store';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const getLogdir = createSelector(
   getEnvironment,

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_container.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_container.ts
@@ -17,7 +17,6 @@ import {Store, select, createSelector} from '@ngrx/store';
 
 import {getEnvironment, State} from '../core/store';
 
-
 const getLogdir = createSelector(
   getEnvironment,
   (environment): string => environment.data_location

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
@@ -23,7 +23,6 @@ import {PluginsListFailureCode} from '../core/types';
 
 import {HttpErrorResponse, TBHttpClient} from './tb_http_client';
 
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 function getPluginsListingQueryParams(enabledExperimentPluginIds: string[]) {
   if (!enabledExperimentPluginIds.length) {

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
@@ -23,7 +23,6 @@ import {PluginsListFailureCode} from '../core/types';
 
 import {HttpErrorResponse, TBHttpClient} from './tb_http_client';
 
-
 function getPluginsListingQueryParams(enabledExperimentPluginIds: string[]) {
   if (!enabledExperimentPluginIds.length) {
     return null;


### PR DESCRIPTION
typehack was introduced to workaround build issues when using certain
build rules with Bazel. The problem no longer seems to be present so we
are removing now vestigial statements.

Commands executed: `git grep -l '@typehack.*;$' | xargs sed -i -z 's/\/\*\* @typehack[^\n]*;\n//g'`
Tested sync: cl/415396536
