### PR TITLE
timeseries: fix setting reset causing weird behavior

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -610,21 +610,17 @@ const reducer = createReducer(
     };
   }),
   on(actions.metricsResetImageBrightness, (state) => {
+    const {imageBrightnessInMilli, ...nextOverride} = state.settingOverrides;
     return {
       ...state,
-      settingOverrides: {
-        ...state.settingOverrides,
-        imageBrightnessInMilli: undefined,
-      },
+      settingOverrides: nextOverride,
     };
   }),
   on(actions.metricsResetImageContrast, (state) => {
+    const {imageContrastInMilli, ...nextOverride} = state.settingOverrides;
     return {
       ...state,
-      settingOverrides: {
-        ...state.settingOverrides,
-        imageContrastInMilli: undefined,
-      },
+      settingOverrides: nextOverride,
     };
   }),
   on(actions.metricsToggleImageShowActualSize, (state) => {
@@ -659,12 +655,10 @@ const reducer = createReducer(
     };
   }),
   on(actions.metricsResetCardWidth, (state) => {
+    const {cardMinWidth, ...nextOverride} = state.settingOverrides;
     return {
       ...state,
-      settingOverrides: {
-        ...state.settingOverrides,
-        cardMinWidth: null,
-      },
+      settingOverrides: nextOverride,
     };
   }),
   on(

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -722,7 +722,9 @@ describe('metrics reducers', () => {
         actions.metricsResetImageBrightness()
       );
       expect(nextState.settings.imageBrightnessInMilli).toBe(300);
-      expect(nextState.settingOverrides.imageBrightnessInMilli).toBe(undefined);
+      expect(
+        nextState.settingOverrides.hasOwnProperty('imageBrightnessInMilli')
+      ).toBe(false);
     });
 
     it('resets imageContrastInMilli', () => {
@@ -739,7 +741,9 @@ describe('metrics reducers', () => {
         actions.metricsResetImageContrast()
       );
       expect(nextState.settings.imageContrastInMilli).toBe(300);
-      expect(nextState.settingOverrides.imageContrastInMilli).toBe(undefined);
+      expect(
+        nextState.settingOverrides.hasOwnProperty('imageContrastInMilli')
+      ).toBe(false);
     });
 
     it('changes imageShowActualSize on metricsToggleImageShowActualSize', () => {
@@ -799,7 +803,9 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(prevState, actions.metricsResetCardWidth());
       expect(nextState.settings.cardMinWidth).toBe(400);
-      expect(nextState.settingOverrides.cardMinWidth).toBe(null);
+      expect(nextState.settingOverrides.hasOwnProperty('cardMinWidth')).toBe(
+        false
+      );
     });
   });
 


### PR DESCRIPTION
PR #5030 divided up the default setting from overrides and, in selector,
we have mixed two values in selectors to make a concrete settings value.

When reset, overriden values were set to `undefined` and caused the
settings to be very wrong.

```ts
// This resolves to {a: undefined}
{...{a: 1}, ...{a: undefined}}
```

Object spread (or `assign`) does not skip a property whose value is
`undefined` and causes settingOverride with undefined value to take
precedence over the default value which, in the end, resolves the image
brightness/contrast values to `undefined` unlike what the types
indicated.

In the end, this is a fault of the type system since the interface is
defined as `Partial<>` and a value should really not have `undefined`
value. To illustrate,

```ts
interface Foo {
  bar: number;
}

// Legal; `bar` property may not exist
const foo2: Partial<Foo> = {
};

// Legal; `bar` is defined as `number` but here, it is `undefined`
// yet it is legal.
const foo3: Partial<Foo> = {
  bar: undefined
};
```

TypeScript 4.4 has a way to property guard against `undefined` value in
a `Partial<>` type, `"exactOptionalPropertyTypes"` but TensorBoard app
currently violates the type definition so we will enable the tsconfig in
a subsequent changes.
