### PR TITLE
type: enable `exactOptionalPropertyTypes` option 

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -342,7 +342,7 @@ export const getFocusedGraphOpInputs = createSelector(
           ...inputSpec,
         };
         if (graph.has(inputSpec.op_name)) {
-          spec.data = graph.get(inputSpec.op_name);
+          spec.data = graph.get(inputSpec.op_name)!;
         }
         return spec;
       });
@@ -427,7 +427,7 @@ export const getFocusedGraphOpConsumers = createSelector(
         return slotConsumers.map((consumerSpec) => {
           const spec: GraphOpConsumerSpec = {...consumerSpec};
           if (graph.has(consumerSpec.op_name)) {
-            spec.data = graph.get(consumerSpec.op_name);
+            spec.data = graph.get(consumerSpec.op_name)!;
           }
           return spec;
         });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
@@ -129,20 +129,12 @@ describe('Graph Container', () => {
               },
             ];
             store.overrideSelector(getFocusedGraphOpInfo, op2);
-            store.overrideSelector(getFocusedGraphOpInputs, [
-              {
-                ...op2.inputs[0],
-                data: neighborDataAvailable ? op1 : undefined,
-              },
-            ]);
-            store.overrideSelector(getFocusedGraphOpConsumers, [
-              [
-                {
-                  ...op2.consumers[0][0],
-                  data: neighborDataAvailable ? op3 : undefined,
-                },
-              ],
-            ]);
+            const input = {...op2.inputs[0]};
+            if (neighborDataAvailable) input.data = op1;
+            store.overrideSelector(getFocusedGraphOpInputs, [input]);
+            const consumer = {...op2.consumers[0][0]};
+            if (neighborDataAvailable) consumer.data = op3;
+            store.overrideSelector(getFocusedGraphOpConsumers, [[consumer]]);
 
             fixture.detectChanges();
 

--- a/tensorboard/webapp/alert/alert_action_test.ts
+++ b/tensorboard/webapp/alert/alert_action_test.ts
@@ -43,7 +43,9 @@ describe('alert_effects', () => {
             actionCreator: alertActionOccurred,
             alertFromAction: (action: Action) => {
               if (shouldReportAlert) {
-                return {localizedMessage: 'alert details'};
+                return {
+                  localizedMessage: 'alert details',
+                };
               }
               return null;
             },
@@ -67,7 +69,9 @@ describe('alert_effects', () => {
     actions$.next(alertActionOccurred);
 
     expect(recordedActions).toEqual([
-      alertActions.alertReported({localizedMessage: 'alert details'}),
+      alertActions.alertReported({
+        localizedMessage: 'alert details',
+      }),
     ]);
   });
 

--- a/tensorboard/webapp/alert/store/alert_reducers.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
 import * as actions from '../actions';
+import {AlertInfo} from '../types';
 import {AlertState} from './alert_types';
 
 const initialState: AlertState = {
@@ -25,14 +26,14 @@ const reducer = createReducer(
   on(
     actions.alertReported,
     (state: AlertState, {localizedMessage, followupAction}): AlertState => {
-      return {
-        ...state,
-        latestAlert: {
-          localizedMessage,
-          followupAction,
-          created: Date.now(),
-        },
+      const latestAlert: AlertInfo = {
+        localizedMessage,
+        created: Date.now(),
       };
+      if (followupAction) {
+        latestAlert.followupAction = followupAction;
+      }
+      return {...state, latestAlert};
     }
   )
 );

--- a/tensorboard/webapp/alert/store/alert_reducers_test.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers_test.ts
@@ -41,7 +41,6 @@ describe('alert_reducers', () => {
     const state2 = alertReducers.reducers(state1, action1);
     expect(state2.latestAlert!).toEqual({
       localizedMessage: 'Foo1 failed',
-      followupAction: undefined,
       created: 123,
     });
 

--- a/tensorboard/webapp/app_routing/route_config.ts
+++ b/tensorboard/webapp/app_routing/route_config.ts
@@ -31,7 +31,7 @@ interface PositiveMatch {
   params: RouteParams;
   pathParts: string[];
   isRedirection: boolean;
-  redirectionQueryParams?: SerializableQueryParams;
+  redirectionQueryParams?: SerializableQueryParams | undefined;
 }
 
 type Match = NegativeMatch | PositiveMatch;
@@ -285,7 +285,7 @@ export interface NonRedirectionRouteMatch extends BaseRedirectionRouteMatch {
 
 export interface RedirectionRouteMatch extends BaseRedirectionRouteMatch {
   originateFromRedirection: true;
-  redirectionOnlyQueryParams?: Route['queryParams'];
+  redirectionOnlyQueryParams: Route['queryParams'] | undefined;
 }
 
 export type RouteMatch = NonRedirectionRouteMatch | RedirectionRouteMatch;
@@ -441,7 +441,8 @@ export class RouteConfigs {
         deepLinkProvider: definition.deepLinkProvider ?? null,
         pathname: definition.path,
         params: {},
-        originateFromRedirection: wasRedirected,
+        originateFromRedirection: true,
+        redirectionOnlyQueryParams: undefined,
       };
     }
 

--- a/tensorboard/webapp/app_routing/route_config.ts
+++ b/tensorboard/webapp/app_routing/route_config.ts
@@ -31,7 +31,7 @@ interface PositiveMatch {
   params: RouteParams;
   pathParts: string[];
   isRedirection: boolean;
-  redirectionQueryParams?: SerializableQueryParams | undefined;
+  redirectionQueryParams: SerializableQueryParams | undefined;
 }
 
 type Match = NegativeMatch | PositiveMatch;
@@ -172,6 +172,7 @@ abstract class RouteConfigMatcher {
       params: combinedParams,
       pathParts,
       isRedirection: false,
+      redirectionQueryParams: undefined,
     };
   }
 
@@ -186,6 +187,7 @@ abstract class RouteConfigMatcher {
       params,
       pathParts,
       isRedirection: false,
+      redirectionQueryParams: undefined,
     };
   }
 
@@ -243,6 +245,7 @@ class StaticRedirectionRouteConfigMatcher extends RouteConfigMatcher {
       params: match.params,
       pathParts: newPathParts,
       isRedirection: true,
+      redirectionQueryParams: undefined,
     };
   }
 }

--- a/tensorboard/webapp/app_routing/route_config_test.ts
+++ b/tensorboard/webapp/app_routing/route_config_test.ts
@@ -224,6 +224,8 @@ describe('route config', () => {
           routeKind: RouteKind.EXPERIMENT,
           pathname: '/tb/bestest',
           params: {},
+          originateFromRedirection: true,
+          redirectionOnlyQueryParams: undefined,
         })
       );
     });
@@ -268,6 +270,8 @@ describe('route config', () => {
           routeKind: RouteKind.EXPERIMENT,
           pathname: '/tb',
           params: {},
+          originateFromRedirection: true,
+          redirectionOnlyQueryParams: undefined,
         })
       );
     });
@@ -494,6 +498,8 @@ describe('route config', () => {
           routeKind: RouteKind.EXPERIMENT,
           pathname: '/default',
           params: {},
+          originateFromRedirection: true,
+          redirectionOnlyQueryParams: undefined,
         })
       );
     });
@@ -508,6 +514,7 @@ describe('route config', () => {
         buildRouteMatch({
           pathname: '/c',
           originateFromRedirection: true,
+          redirectionOnlyQueryParams: undefined,
         })
       );
     });

--- a/tensorboard/webapp/app_routing/route_config_test.ts
+++ b/tensorboard/webapp/app_routing/route_config_test.ts
@@ -54,7 +54,7 @@ function buildRouteMatch(override: Partial<RouteMatch> = {}): RouteMatch {
     deepLinkProvider: null,
     originateFromRedirection: false,
     ...override,
-  };
+  } as RouteMatch;
 }
 
 describe('route config', () => {

--- a/tensorboard/webapp/experiments/store/experiments_reducers.ts
+++ b/tensorboard/webapp/experiments/store/experiments_reducers.ts
@@ -19,11 +19,13 @@ import {
   createReducer,
 } from '@ngrx/store';
 import {DEFAULT_EXPERIMENT_ID} from '../../app_routing/types';
+import {Experiment} from '../types';
 import {ExperimentsDataState, ExperimentsState} from './experiments_types';
 
-const defaultExperiment = {
+const defaultExperiment: Experiment = {
   id: DEFAULT_EXPERIMENT_ID,
   name: '',
+  description: undefined,
   start_time: 0,
 };
 

--- a/tensorboard/webapp/experiments/store/experiments_reducers.ts
+++ b/tensorboard/webapp/experiments/store/experiments_reducers.ts
@@ -25,7 +25,6 @@ import {ExperimentsDataState, ExperimentsState} from './experiments_types';
 const defaultExperiment: Experiment = {
   id: DEFAULT_EXPERIMENT_ID,
   name: '',
-  description: undefined,
   start_time: 0,
 };
 

--- a/tensorboard/webapp/experiments/store/testing.ts
+++ b/tensorboard/webapp/experiments/store/testing.ts
@@ -27,7 +27,6 @@ import {
 export function buildExperiment(override?: Partial<Experiment>): Experiment {
   return {
     id: '1',
-    description: undefined,
     name: 'Default Experiment',
     start_time: 1,
     ...override,

--- a/tensorboard/webapp/experiments/store/testing.ts
+++ b/tensorboard/webapp/experiments/store/testing.ts
@@ -24,13 +24,12 @@ import {
  * Builds an experiment from default. Can override fields by providing
  * `override`.
  */
-export function buildExperiment(override?: Partial<Experiment>) {
+export function buildExperiment(override?: Partial<Experiment>): Experiment {
   return {
     id: '1',
     description: undefined,
     name: 'Default Experiment',
     start_time: 1,
-    tags: undefined,
     ...override,
   };
 }

--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -18,7 +18,7 @@ export declare interface Experiment {
   name: string;
   start_time: number;
   owner?: string;
-  description: string | undefined;
+  description?: string;
   hparams?: string;
   tags?: string[];
   related_links?: Array<{name: string; url: string}>;

--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -18,7 +18,7 @@ export declare interface Experiment {
   name: string;
   start_time: number;
   owner?: string;
-  description?: string;
+  description: string | undefined;
   hparams?: string;
   tags?: string[];
   related_links?: Array<{name: string; url: string}>;

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -173,7 +173,7 @@ export const timeSelectionChanged = createAction(
   '[Metrics] Linked Time Selection Changed',
   props<{
     startStep: number;
-    endStep?: number;
+    endStep: number | undefined;
   }>()
 );
 

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -199,9 +199,13 @@ export class MetricsEffects implements OnInitEffects {
      */
     const requests: TimeSeriesRequest[] = fetchInfos.map((fetchInfo) => {
       const {plugin, tag, runId, sample} = fetchInfo;
-      return isSingleRunPlugin(plugin)
-        ? {plugin, tag, sample, runId: runId!}
-        : {plugin, tag, sample, experimentIds};
+      const partialRequest: TimeSeriesRequest = isSingleRunPlugin(plugin)
+        ? {plugin, tag, runId: runId!}
+        : {plugin, tag, experimentIds};
+      if (sample !== undefined) {
+        partialRequest.sample = sample;
+      }
+      return partialRequest;
     });
 
     // Fetch and handle responses.

--- a/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
+++ b/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
@@ -36,6 +36,7 @@ import {
   PluginType,
   SingleRunPluginType,
   TagMetadata,
+  TimeSeriesRequest,
   TimeSeriesResponse,
 } from '../data_source';
 import {getMetricsTagMetadataLoadState} from '../store';
@@ -328,11 +329,10 @@ describe('metrics effects', () => {
         }
       }
 
-      function buildTimeSeriesResponse() {
+      function buildTimeSeriesResponse(): TimeSeriesResponse {
         return {
           plugin: PluginType.SCALARS,
           tag: 'tagA',
-          sample: undefined,
           runToSeries: {
             run1: createScalarStepData(),
           },
@@ -377,13 +377,11 @@ describe('metrics effects', () => {
                   plugin: PluginType.SCALARS as MultiRunPluginType,
                   tag: 'tagA',
                   experimentIds: ['exp1'],
-                  sample: undefined,
                 },
                 {
                   plugin: PluginType.SCALARS as MultiRunPluginType,
                   tag: 'tagA',
                   experimentIds: ['exp1'],
-                  sample: undefined,
                 },
               ],
             }),
@@ -425,7 +423,6 @@ describe('metrics effects', () => {
                   plugin: PluginType.SCALARS as MultiRunPluginType,
                   tag: 'tagA',
                   experimentIds: ['exp1'],
-                  sample: undefined,
                 },
               ],
             }),
@@ -594,11 +591,10 @@ describe('metrics effects', () => {
           })
         );
 
-        const expectedRequest = {
+        const expectedRequest: TimeSeriesRequest = {
           plugin: PluginType.SCALARS as MultiRunPluginType,
           tag: 'tagA',
           experimentIds: ['exp1'],
-          sample: undefined,
         };
         expect(fetchTimeSeriesSpy.calls.count()).toBe(1);
         expect(fetchTimeSeriesSpy).toHaveBeenCalledWith([expectedRequest]);
@@ -693,12 +689,11 @@ describe('metrics effects', () => {
           })
         );
 
-        const expectedRequests = [
+        const expectedRequests: TimeSeriesRequest[] = [
           {
             plugin: PluginType.SCALARS as MultiRunPluginType,
             tag: 'tagA',
             experimentIds: ['exp1'],
-            sample: undefined,
           },
           {
             plugin: PluginType.IMAGES as SingleRunPluginType,

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -610,21 +610,17 @@ const reducer = createReducer(
     };
   }),
   on(actions.metricsResetImageBrightness, (state) => {
+    const {imageBrightnessInMilli, ...nextOverride} = state.settingOverrides;
     return {
       ...state,
-      settingOverrides: {
-        ...state.settingOverrides,
-        imageBrightnessInMilli: undefined,
-      },
+      settingOverrides: nextOverride,
     };
   }),
   on(actions.metricsResetImageContrast, (state) => {
+    const {imageContrastInMilli, ...nextOverride} = state.settingOverrides;
     return {
       ...state,
-      settingOverrides: {
-        ...state.settingOverrides,
-        imageContrastInMilli: undefined,
-      },
+      settingOverrides: nextOverride,
     };
   }),
   on(actions.metricsToggleImageShowActualSize, (state) => {
@@ -659,12 +655,10 @@ const reducer = createReducer(
     };
   }),
   on(actions.metricsResetCardWidth, (state) => {
+    const {cardMinWidth, ...nextOverride} = state.settingOverrides;
     return {
       ...state,
-      settingOverrides: {
-        ...state.settingOverrides,
-        cardMinWidth: null,
-      },
+      settingOverrides: nextOverride,
     };
   }),
   on(

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -722,7 +722,9 @@ describe('metrics reducers', () => {
         actions.metricsResetImageBrightness()
       );
       expect(nextState.settings.imageBrightnessInMilli).toBe(300);
-      expect(nextState.settingOverrides.imageBrightnessInMilli).toBe(undefined);
+      expect(
+        nextState.settingOverrides.hasOwnProperty('imageBrightnessInMilli')
+      ).toBe(false);
     });
 
     it('resets imageContrastInMilli', () => {
@@ -739,7 +741,9 @@ describe('metrics reducers', () => {
         actions.metricsResetImageContrast()
       );
       expect(nextState.settings.imageContrastInMilli).toBe(300);
-      expect(nextState.settingOverrides.imageContrastInMilli).toBe(undefined);
+      expect(
+        nextState.settingOverrides.hasOwnProperty('imageContrastInMilli')
+      ).toBe(false);
     });
 
     it('changes imageShowActualSize on metricsToggleImageShowActualSize', () => {
@@ -799,7 +803,9 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(prevState, actions.metricsResetCardWidth());
       expect(nextState.settings.cardMinWidth).toBe(400);
-      expect(nextState.settingOverrides.cardMinWidth).toBe(null);
+      expect(nextState.settingOverrides.hasOwnProperty('cardMinWidth')).toBe(
+        false
+      );
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2018,7 +2018,7 @@ describe('metrics reducers', () => {
 
         const after = reducers(
           before,
-          actions.timeSelectionChanged({startStep: 2})
+          actions.timeSelectionChanged({startStep: 2, endStep: undefined})
         );
 
         expect(after.selectedTime).toEqual({
@@ -2058,9 +2058,7 @@ describe('metrics reducers', () => {
 
           const after = reducers(
             before,
-            actions.timeSelectionChanged({
-              startStep: 2,
-            })
+            actions.timeSelectionChanged({startStep: 2, endStep: undefined})
           );
 
           expect(after.selectedTime).toEqual({
@@ -2077,9 +2075,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.timeSelectionChanged({
-            startStep: 2,
-          })
+          actions.timeSelectionChanged({startStep: 2, endStep: undefined})
         );
 
         expect(nextState.selectTimeEnabled).toBe(true);
@@ -2116,9 +2112,7 @@ describe('metrics reducers', () => {
 
           const nextState = reducers(
             beforeState,
-            actions.timeSelectionChanged({
-              startStep: 150,
-            })
+            actions.timeSelectionChanged({startStep: 150, endStep: undefined})
           );
 
           expect(nextState.selectedTime).toEqual({

--- a/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader.ts
@@ -57,9 +57,17 @@ export class CardObserver {
       return;
     }
     this.intersectionCallback = intersectionCallback;
+
+    const init: IntersectionObserverInit = {
+      threshold: 0,
+      root: this.root ?? null,
+    };
+    if (this.buffer) {
+      init.rootMargin = this.buffer;
+    }
     this.intersectionObserver = new IntersectionObserver(
       this.onCardIntersection.bind(this),
-      {threshold: 0, root: this.root, rootMargin: this.buffer}
+      init
     );
   }
 

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -44,22 +44,51 @@ export class OSSSettingsConverter extends SettingsConverter<
   BackendSettings
 > {
   uiToBackend(settings: PersistableSettings): BackendSettings {
-    const serializableSettings: BackendSettings = {
-      ignoreOutliers: settings.ignoreOutliers,
-      scalarSmoothing: settings.scalarSmoothing,
+    const serializableSettings: BackendSettings = {};
+
+    if (settings.ignoreOutliers !== undefined) {
+      serializableSettings.ignoreOutliers = settings.ignoreOutliers;
+    }
+    if (settings.scalarSmoothing !== undefined) {
+      serializableSettings.scalarSmoothing = settings.scalarSmoothing;
+    }
+    if (settings.tooltipSortString !== undefined) {
       // TooltipSort is a string enum and has string values; no need to
       // serialize it differently to account for their unintended changes.
-      tooltipSort: settings.tooltipSortString,
-      autoReload: settings.autoReload,
-      autoReloadPeriodInMs: settings.autoReloadPeriodInMs,
-      paginationSize: settings.pageSize,
-      theme: settings.themeOverride,
-      notificationLastReadTimeInMs: settings.notificationLastReadTimeInMs,
-      sideBarWidthInPercent: settings.sideBarWidthInPercent,
-      timeSeriesPromotionDismissed: settings.timeSeriesPromotionDismissed,
-      timeSeriesSettingsPaneOpened: settings.timeSeriesSettingsPaneOpened,
-      timeSeriesCardMinWidth: settings.timeSeriesCardMinWidth,
-    };
+      serializableSettings.tooltipSort = settings.tooltipSortString;
+    }
+    if (settings.autoReload !== undefined) {
+      serializableSettings.autoReload = settings.autoReload;
+    }
+    if (settings.autoReloadPeriodInMs !== undefined) {
+      serializableSettings.autoReloadPeriodInMs = settings.autoReloadPeriodInMs;
+    }
+    if (settings.pageSize !== undefined) {
+      serializableSettings.paginationSize = settings.pageSize;
+    }
+    if (settings.themeOverride !== undefined) {
+      serializableSettings.theme = settings.themeOverride;
+    }
+    if (settings.notificationLastReadTimeInMs !== undefined) {
+      serializableSettings.notificationLastReadTimeInMs =
+        settings.notificationLastReadTimeInMs;
+    }
+    if (settings.sideBarWidthInPercent !== undefined) {
+      serializableSettings.sideBarWidthInPercent =
+        settings.sideBarWidthInPercent;
+    }
+    if (settings.timeSeriesPromotionDismissed !== undefined) {
+      serializableSettings.timeSeriesPromotionDismissed =
+        settings.timeSeriesPromotionDismissed;
+    }
+    if (settings.timeSeriesSettingsPaneOpened !== undefined) {
+      serializableSettings.timeSeriesSettingsPaneOpened =
+        settings.timeSeriesSettingsPaneOpened;
+    }
+    if (settings.timeSeriesCardMinWidth !== undefined) {
+      serializableSettings.timeSeriesCardMinWidth =
+        settings.timeSeriesCardMinWidth;
+    }
     return serializableSettings;
   }
 

--- a/tensorboard/webapp/plugins/npmi/actions/npmi_actions.ts
+++ b/tensorboard/webapp/plugins/npmi/actions/npmi_actions.ts
@@ -33,7 +33,7 @@ export const npmiPluginDataLoaded = createAction(
   props<{
     annotationData: AnnotationDataListing;
     metrics: MetricListing;
-    embeddingDataSet?: EmbeddingDataSet;
+    embeddingDataSet: EmbeddingDataSet | undefined;
   }>()
 );
 

--- a/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source.ts
+++ b/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source.ts
@@ -32,7 +32,7 @@ export abstract class NpmiDataSource {
   abstract fetchData(experimentIds: string[]): Observable<{
     annotationData: AnnotationDataListing;
     metrics: MetricListing;
-    embeddingDataSet?: EmbeddingDataSet;
+    embeddingDataSet: EmbeddingDataSet | undefined;
   }>;
 }
 

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
@@ -32,6 +32,7 @@ const initialState: NpmiState = {
     lastLoadedTimeInMs: null,
   },
   annotationData: {},
+  embeddingDataSet: undefined,
   runToMetrics: {},
   selectedAnnotations: [],
   flaggedAnnotations: [],

--- a/tensorboard/webapp/plugins/npmi/store/npmi_types.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_types.ts
@@ -87,7 +87,7 @@ export interface NpmiState {
   pluginDataLoaded: LoadState;
   annotationData: AnnotationDataListing;
   runToMetrics: MetricListing;
-  embeddingDataSet?: EmbeddingDataSet;
+  embeddingDataSet: EmbeddingDataSet | undefined;
 
   // based on user interaction
   selectedAnnotations: Annotation[];

--- a/tensorboard/webapp/plugins/npmi/testing/index.ts
+++ b/tensorboard/webapp/plugins/npmi/testing/index.ts
@@ -29,6 +29,7 @@ export function createNpmiState(override?: Partial<NpmiState>): NpmiState {
       lastLoadedTimeInMs: null,
     },
     annotationData: {},
+    embeddingDataSet: undefined,
     runToMetrics: {},
     selectedAnnotations: [],
     flaggedAnnotations: [],

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -167,7 +167,9 @@ describe('runs_table', () => {
     if (columns) {
       fixture.componentInstance.columns = columns;
     }
-    fixture.componentInstance.usePagination = usePagination;
+    if (usePagination !== undefined) {
+      fixture.componentInstance.usePagination = usePagination;
+    }
     fixture.detectChanges();
 
     return fixture;

--- a/tensorboard/webapp/settings/_redux/settings_reducers.ts
+++ b/tensorboard/webapp/settings/_redux/settings_reducers.ts
@@ -89,7 +89,7 @@ const reducer = createReducer(
       Number.isFinite(partialSettings.pageSize) &&
       partialSettings.pageSize! > 0
     ) {
-      nextSettings.pageSize = partialSettings.pageSize;
+      nextSettings.pageSize = Number(partialSettings.pageSize);
     }
 
     if (typeof partialSettings.autoReload === 'boolean') {
@@ -100,7 +100,9 @@ const reducer = createReducer(
       Number.isFinite(partialSettings.autoReloadPeriodInMs) &&
       partialSettings.autoReloadPeriodInMs! > MIN_RELOAD_PERIOD_IN_MS
     ) {
-      nextSettings.reloadPeriodInMs = partialSettings.autoReloadPeriodInMs;
+      nextSettings.reloadPeriodInMs = Number(
+        partialSettings.autoReloadPeriodInMs
+      );
     }
 
     return {

--- a/tensorboard/webapp/webapp_data_source/tb_http_client.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client.ts
@@ -84,7 +84,7 @@ export class TBHttpClient implements TBHttpClientInterface {
     path: string,
     // Angular's HttpClient is typed exactly this way.
     body: any | null,
-    options: PostOptions = {}
+    options: PostOptions | undefined = {}
   ): Observable<ResponseType> {
     options = withXsrfHeader(options);
     return this.store.select(getIsFeatureFlagsLoaded).pipe(
@@ -99,7 +99,7 @@ export class TBHttpClient implements TBHttpClientInterface {
         // See b/72932164.
         if (isInColab) {
           return this.http.get<ResponseType>(resolvedPath, {
-            headers: options.headers,
+            headers: options.headers ?? {},
             params: convertFormDataToObject(body),
           });
         } else {

--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_directive.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_directive.ts
@@ -51,7 +51,7 @@ export class IntersectionObserverDirective implements OnInit, OnDestroy {
         root: this.cdkScrollable
           ? this.cdkScrollable.getElementRef().nativeElement
           : null,
-        rootMargin: this.intersectionObserverMargin,
+        rootMargin: this.intersectionObserverMargin ?? '',
       }
     );
     intersectionObserver.observe(this.ref.nativeElement);

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_utils_test.ts
@@ -103,12 +103,17 @@ describe('line_chart_v2/sub_view/interactive_utils test', () => {
       wheelOption: Partial<WheelEventInit> = {},
       mouseOption: Partial<{offsetX: number; offsetY: number}> = {}
     ): WheelEvent {
-      const event = new WheelEvent('wheel', {
+      const wheelEventInit: WheelEventInit = {
         deltaMode: WheelEvent.DOM_DELTA_LINE,
         ...wheelOption,
-        clientX: mouseOption.offsetX,
-        clientY: mouseOption.offsetY,
-      });
+      };
+      if (mouseOption.offsetX !== undefined) {
+        wheelEventInit.clientX = mouseOption.offsetX;
+      }
+      if (mouseOption.offsetY !== undefined) {
+        wheelEventInit.clientY = mouseOption.offsetY;
+      }
+      const event = new WheelEvent('wheel', wheelEventInit);
 
       return event;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "emitDecoratorMetadata": true,
+    "exactOptionalPropertyTypes": true,
     "experimentalDecorators": true,
     "importHelpers": true,
     "inlineSourceMap": true,


### PR DESCRIPTION
Before this change, below held true:
```ts
interface Foo {
  bar?: number;
}

// Legal
const foo1: Foo = {bar: undefined};
// Legal
const foo2: Foo = {};
```

After this change,
```ts
interface Foo {
  bar?: number;
  baz: number|undefined;
}

// Illegal; `bar` cannot be `undefined` and must be number.
const foo1: Foo = {bar: undefined, baz: undefined};
// Illegal; `baz` property must exist. Must be one of `number` of
// `undefined`.
const foo1: Foo = {};
// Legal; `bar` property does not exist while `baz` is specified.
const foo2: Foo = {baz: undefined};
```

When a property is defined as `?:`, it does not mean that the property
can be `undefined` but it means a property can be omitted altogether or
it must exist with the value of the type as defined. As such, when a
property is written with `undefined`, the value type must explicitly
allow `undefined` like `baz` example above.

Note: this change currently includes #5458. Please review the second commit and beyond.