### PR TITLE
line chart: x-axis extent editable

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -17,6 +17,13 @@ limitations under the License.
 :host {
   contain: strict;
   display: inline-block;
+
+  .custom-vis {
+    // custom-vis shows on top of interactive-view but we still need to give
+    // mouse interactions to the interactive-view. Currently, the contract is
+    // that you can only supply purely visual UI on top of the line chart.
+    pointer-events: none;
+  }
 }
 
 .container {
@@ -60,13 +67,6 @@ limitations under the License.
     position: absolute;
     top: 0;
     width: 100%;
-  }
-
-  .custom-vis {
-    // custom-vis shows on top of interactive-view but we still need to give
-    // mouse interactions to the interactive-view. Currently, the contract is
-    // that you can only supply purely visual UI on top of the line chart.
-    pointer-events: none;
   }
 }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
@@ -114,13 +114,13 @@ text {
 
 .extent-edit-button {
   background-color: mat.get-color-from-palette(mat.$gray-palette, 200);
-  display: none;
   font-size: 0;
   height: 24px;
   line-height: 24px;
   position: absolute;
   right: 5px;
   top: 5px;
+  visibility: hidden;
   width: 24px;
 
   mat-icon {
@@ -164,8 +164,9 @@ text {
 }
 
 .axis:hover .extent-edit-button,
+.axis:focus-within .extent-edit-button,
 .extent-edit-menu-opened {
-  display: initial;
+  visibility: visible;
 }
 
 .major {


### PR DESCRIPTION
After DOM structure refactor, manual extent setting feature was broken
on the x-axis only. This is due to it having `customVis` specified for
it and the customVis was taking all the pointer events, causing :hover
not to function.

This change puts `pointer-events: none` on `.custom-vis` in all cases
and also improved the CSS a little bit.

This will be tested via screenshot tests internally.
