### PR TITLE
style: optimize paint by putting `contain: strict`

### DIFF
--- a/tensorboard/webapp/core/views/layout_container.scss
+++ b/tensorboard/webapp/core/views/layout_container.scss
@@ -30,6 +30,7 @@ limitations under the License.
 .expand {
   @include tb-theme-foreground-prop(border-color, border);
   box-sizing: border-box;
+  contain: strict;
   flex: 0 0;
   justify-self: stretch;
 }

--- a/tensorboard/webapp/metrics/views/metrics_container.scss
+++ b/tensorboard/webapp/metrics/views/metrics_container.scss
@@ -16,6 +16,7 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
+  contain: strict;
   display: flex;
   flex-direction: column;
   height: 100%;


### PR DESCRIPTION
Notice that mouse move was causing large paints that it should not.
Putting `contain: strict` which informs browser to put a bound to style
calculation helped alleviate the issue.

Repro: in time series dashboard, with "Rendering > Paint Flashing"
option enabled, mouse move in the dashboard.
