### PR TITLE
line chart: better WebGL edge case handle

### DIFF
--- a/tensorboard/webapp/app_routing/location.ts
+++ b/tensorboard/webapp/app_routing/location.ts
@@ -16,12 +16,7 @@ import {Injectable} from '@angular/core';
 import {fromEvent, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {createURLSearchParamsFromSerializableQueryParams} from './internal_utils';
-import {
-  Navigation,
-  NavigationFromHistory,
-  Route,
-  SerializableQueryParams,
-} from './types';
+import {NavigationFromHistory, Route, SerializableQueryParams} from './types';
 
 export interface LocationInterface {
   getHref(): string;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
@@ -84,6 +84,11 @@ export interface ObjectRenderer<CacheValue = {}> {
   destroyObject(cachedValue: CacheValue): void;
 
   setUseDarkMode(useDarkMode: boolean): void;
+
+  /**
+   * Disposes rendering context. After invocation, renderer will never be used.
+   */
+  dispose(): void;
 }
 
 interface PaintOption {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_types.ts
@@ -86,7 +86,8 @@ export interface ObjectRenderer<CacheValue = {}> {
   setUseDarkMode(useDarkMode: boolean): void;
 
   /**
-   * Disposes rendering context. After invocation, renderer will never be used.
+   * Disposes rendering context. After invocation, renderer should never be
+   * used.
    */
   dispose(): void;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -270,4 +270,8 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
       data: vertices,
     };
   }
+
+  dispose() {
+    // noop.
+  }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -495,4 +495,8 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
   flush() {
     this.renderer.render(this.scene, this.coordinator.getCamera());
   }
+
+  dispose() {
+    this.renderer.dispose();
+  }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/utils.ts
@@ -22,10 +22,22 @@ export function convertRectToExtent(rect: Rect): Extent {
   };
 }
 
-const cachedIsWebGl2Supported = Boolean(
-  self.hasOwnProperty('document') &&
-    document.createElement('canvas').getContext('webgl2')
-);
+let cachedIsWebGl2Supported = false;
+
+{
+  if (
+    self.hasOwnProperty('WebGL2RenderingContext') &&
+    self.hasOwnProperty('document')
+  ) {
+    const canvas = document.createElement('canvas');
+
+    canvas.addEventListener('webglcontextcreationerror', () => {
+      cachedIsWebGl2Supported = false;
+    });
+    const context = canvas.getContext('webgl2');
+    cachedIsWebGl2Supported = Boolean(context);
+  }
+}
 
 export function isWebGl2Supported(): boolean {
   return cachedIsWebGl2Supported;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/message_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/message_types.ts
@@ -28,6 +28,7 @@ export enum HostToGuestEvent {
   INIT,
   DOM_RESIZED,
   DARK_MODE_UPDATED,
+  DISPOSED,
 }
 
 export interface InitMessage {
@@ -73,8 +74,13 @@ export interface DarkModeUpdatedMessage {
   useDarkMode: boolean;
 }
 
+export interface DisposeMessage {
+  type: HostToGuestEvent.DISPOSED;
+}
+
 export type HostToGuestMessage =
   | DarkModeUpdatedMessage
+  | DisposeMessage
   | ResizeMessage
   | ScaleUpdateMessage
   | SeriesMetadataChangedMessage

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart.ts
@@ -80,6 +80,7 @@ export class WorkerChart implements Chart {
   }
 
   dispose() {
+    this.sendMessage({type: HostToGuestEvent.DISPOSED});
     this.workerInstance.free();
     this.txMessagePort.close();
   }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_bridge.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/worker_chart_bridge.ts
@@ -104,6 +104,10 @@ function createPortHandler(port: MessagePort, initMessage: InitMessage) {
         }
         break;
       }
+      case HostToGuestEvent.DISPOSED: {
+        lineChart.dispose();
+        break;
+      }
     }
   };
 }


### PR DESCRIPTION
This change makes two improvements to WebGL support for the line chart.

1. Better feature detection. We now also listen to
   `webglcontextcreationerror` which gets emitted when browser fails to
   create webgl context from a canvas. This can be a good indication
   that user's system may not be able to handle WebGL renderer.
2. Better removal of JavaScript object. When an Angular components get
   scrapped, we get a chance to clean more stuff up. With the signal, we
   now instruct Three.js renderer to dispose all the objects more
   explicitly for better freeing of WebGL context + Three.js objects.

There is no great way to unit test to guarantee correctness of the
utility and the operation. Thus, we will leave such test to an
integration test that would exercise browser capabilities.  For now, we
are happy with a manual functional test.
