### PR TITLE
fix: timeseries rendering issue on Firefox

### DIFF
--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_directive.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_directive.ts
@@ -43,17 +43,19 @@ export class IntersectionObserverDirective implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    const intersectionObserver = new IntersectionObserver(
-      (entries) => {
-        this.onEvent$.next(entries);
-      },
-      {
-        root: this.cdkScrollable
-          ? this.cdkScrollable.getElementRef().nativeElement
-          : null,
-        rootMargin: this.intersectionObserverMargin ?? '',
-      }
-    );
+    const init: IntersectionObserverInit = {
+      root: this.cdkScrollable
+        ? this.cdkScrollable.getElementRef().nativeElement
+        : null,
+    };
+    if (this.intersectionObserverMargin) {
+      // Firefox does not like `rootMargin` without unit so it must be a string
+      // with unit.
+      init.rootMargin = this.intersectionObserverMargin;
+    }
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      this.onEvent$.next(entries);
+    }, init);
     intersectionObserver.observe(this.ref.nativeElement);
     this.ngUnsubscribe$.subscribe(() => {
       intersectionObserver.unobserve(this.ref.nativeElement);

--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_test.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_test.ts
@@ -163,7 +163,7 @@ describe('widgets/intersection_observer test', () => {
     ]);
   });
 
-  it('does not set rootMargin at all if it is not specified', async () => {
+  it('does not set rootMargin at all if it is not specified', () => {
     const intersectionObserverSpy = spyOn(
       globalThis,
       'IntersectionObserver'

--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_test.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_test.ts
@@ -162,4 +162,23 @@ describe('widgets/intersection_observer test', () => {
       [{visible: true}],
     ]);
   });
+
+  it('does not set rootMargin at all if it is not specified', async () => {
+    const intersectionObserverSpy = spyOn(
+      globalThis,
+      'IntersectionObserver'
+    ).and.callThrough();
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.componentInstance.onVisibilityChange = jasmine.createSpy();
+    // intersectionObserverMargin is not set on purpose.
+    fixture.detectChanges();
+
+    expect(intersectionObserverSpy).toHaveBeenCalledOnceWith(
+      jasmine.any(Function),
+      {
+        root: jasmine.any(HTMLElement),
+        // rootMargin property is omitted as expected.
+      }
+    );
+  });
 });


### PR DESCRIPTION
On Firefox, IntersectionObserverInit's rootMargin property must have a
unit value and thus cannot be an empty string. As such, our recent
refactor which populated its default value as `""` threw in Firefox
(while Chrome was lenient) causing cards to not appear in TimeSeries
dashboard. This change optionally populates the `rootMargin` property in
`IntersectionObserverInit` instead of default setting values.

The bug was caught in an integration test. Added unit test to fail faster in
the future.