### PR TITLE
(time-namespaced state) Always set namespace id in browser history state.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -477,14 +477,13 @@ export class AppRoutingEffects {
         if (!shouldUpdateHistory) return;
 
         if (options.replaceState) {
-          this.location.replaceState(
-            this.location.getHistoryState(),
+          this.location.replaceStateUrl(
             this.appRootProvider.getAbsPathnameWithAppRoot(
               this.location.getFullPathFromRoute(route, preserveHash)
             )
           );
         } else {
-          this.location.pushState(
+          this.location.pushStateUrl(
             this.appRootProvider.getAbsPathnameWithAppRoot(
               this.location.getFullPathFromRoute(route, preserveHash)
             )
@@ -513,15 +512,10 @@ export class AppRoutingEffects {
             beforeNamespaceId
           );
 
-          if (enabledTimeNamespacedState) {
-            this.location.replaceState(
-              {
-                ...this.location.getHistoryState(),
-                namespaceId: afterNamespaceId,
-              },
-              /* do not replace path */ null
-            );
-          }
+          this.location.replaceStateData({
+            ...this.location.getHistoryState(),
+            namespaceId: afterNamespaceId,
+          });
 
           return navigated({
             before: oldRoute,

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -71,8 +71,9 @@ describe('app_routing_effects', () => {
   let location: Location;
   let actualActions: Action[];
   let onPopStateSubject: ReplaySubject<NavigationFromHistory>;
-  let pushStateSpy: jasmine.Spy;
-  let replaceStateSpy: jasmine.Spy;
+  let pushStateUrlSpy: jasmine.Spy;
+  let replaceStateUrlSpy: jasmine.Spy;
+  let replaceStateDataSpy: jasmine.Spy;
   let getHistoryStateSpy: jasmine.Spy;
   let getHashSpy: jasmine.Spy;
   let getPathSpy: jasmine.Spy;
@@ -195,8 +196,9 @@ describe('app_routing_effects', () => {
     location = TestBed.inject(TestableLocation) as Location;
     onPopStateSubject = new ReplaySubject<NavigationFromHistory>(1);
     spyOn(location, 'onPopState').and.returnValue(onPopStateSubject);
-    pushStateSpy = spyOn(location, 'pushState');
-    replaceStateSpy = spyOn(location, 'replaceState');
+    pushStateUrlSpy = spyOn(location, 'pushStateUrl');
+    replaceStateUrlSpy = spyOn(location, 'replaceStateUrl');
+    replaceStateDataSpy = spyOn(location, 'replaceStateData');
     getHistoryStateSpy = spyOn(location, 'getHistoryState').and.returnValue({});
     getHashSpy = spyOn(location, 'getHash').and.returnValue('');
     getPathSpy = spyOn(location, 'getPath').and.returnValue('');
@@ -499,11 +501,11 @@ describe('app_routing_effects', () => {
               }),
             }),
           ]);
-          expect(pushStateSpy).not.toHaveBeenCalled();
+          expect(pushStateUrlSpy).not.toHaveBeenCalled();
 
           tick();
 
-          expect(pushStateSpy).toHaveBeenCalledOnceWith('/experiments');
+          expect(pushStateUrlSpy).toHaveBeenCalledOnceWith('/experiments');
 
           expect(actualActions).toEqual([
             jasmine.any(Object),
@@ -568,10 +570,10 @@ describe('app_routing_effects', () => {
         action.next(effects.ngrxOnInitEffects());
         tick();
 
-        expect(replaceStateSpy).toHaveBeenCalledWith(
-          {namespaceId: Date.now().toString(), other: 'data'},
-          null
-        );
+        expect(replaceStateDataSpy).toHaveBeenCalledWith({
+          namespaceId: Date.now().toString(),
+          other: 'data',
+        });
       }));
 
       it('are generated when resetNamespacedState is true', fakeAsync(() => {
@@ -862,7 +864,7 @@ describe('app_routing_effects', () => {
 
       it(
         'replaces state on subsequent query param changes to prevent pushing ' +
-          ' new history entry',
+          'new history entry',
         fakeAsync(() => {
           // Mimic initial navigation.
           action.next(
@@ -876,11 +878,11 @@ describe('app_routing_effects', () => {
 
           // Based on information in the action (replaceState = false), the initial history state is
           // pushed rather than reset.
-          expect(pushStateSpy).toHaveBeenCalled();
-          expect(replaceStateSpy).not.toHaveBeenCalled();
+          expect(pushStateUrlSpy).toHaveBeenCalled();
+          expect(replaceStateUrlSpy).not.toHaveBeenCalled();
 
-          pushStateSpy.calls.reset();
-          replaceStateSpy.calls.reset();
+          pushStateUrlSpy.calls.reset();
+          replaceStateUrlSpy.calls.reset();
 
           // Mimic subsequent change in query parameter.
           serializeStateToQueryParamsSubject.next([
@@ -889,8 +891,8 @@ describe('app_routing_effects', () => {
           tick();
 
           // History state is replaced rather than pushed.
-          expect(pushStateSpy).not.toHaveBeenCalled();
-          expect(replaceStateSpy).toHaveBeenCalled();
+          expect(pushStateUrlSpy).not.toHaveBeenCalled();
+          expect(replaceStateUrlSpy).toHaveBeenCalled();
         })
       );
 
@@ -998,8 +1000,8 @@ describe('app_routing_effects', () => {
 
         tick();
 
-        expect(pushStateSpy).not.toHaveBeenCalled();
-        expect(replaceStateSpy).not.toHaveBeenCalled();
+        expect(pushStateUrlSpy).not.toHaveBeenCalled();
+        expect(replaceStateUrlSpy).not.toHaveBeenCalled();
       }));
 
       describe('programmatical navigation integration', () => {
@@ -1234,16 +1236,15 @@ describe('app_routing_effects', () => {
 
           tick();
           if (expected.pushStateUrl === null) {
-            expect(pushStateSpy).not.toHaveBeenCalled();
+            expect(pushStateUrlSpy).not.toHaveBeenCalled();
           } else {
-            expect(pushStateSpy).toHaveBeenCalledWith(expected.pushStateUrl);
+            expect(pushStateUrlSpy).toHaveBeenCalledWith(expected.pushStateUrl);
           }
 
           if (expected.replaceStateUrl === null) {
-            expect(replaceStateSpy).not.toHaveBeenCalled();
+            expect(replaceStateUrlSpy).not.toHaveBeenCalled();
           } else {
-            expect(replaceStateSpy).toHaveBeenCalledWith(
-              {},
+            expect(replaceStateUrlSpy).toHaveBeenCalledWith(
               expected.replaceStateUrl
             );
           }
@@ -1516,7 +1517,9 @@ describe('app_routing_effects', () => {
 
         tick();
 
-        expect(pushStateSpy).toHaveBeenCalledWith('/foo/bar/baz/experiments');
+        expect(pushStateUrlSpy).toHaveBeenCalledWith(
+          '/foo/bar/baz/experiments'
+        );
       }));
     });
   });

--- a/tensorboard/webapp/app_routing/location.ts
+++ b/tensorboard/webapp/app_routing/location.ts
@@ -27,9 +27,11 @@ export interface LocationInterface {
 
   getPath(): string;
 
-  replaceState(data: any, url: string | null): void;
+  replaceStateUrl(url: string): void;
 
-  pushState(url: string): void;
+  pushStateUrl(url: string): void;
+
+  replaceStateData(data: any): void;
 
   onPopState(): Observable<NavigationFromHistory>;
 
@@ -74,12 +76,16 @@ export class Location implements LocationInterface {
     return window.history.state;
   }
 
-  replaceState(data: any, url: string | null): void {
-    window.history.replaceState(data, '', url);
+  replaceStateUrl(url: string): void {
+    window.history.replaceState(window.history.state, '', url);
   }
 
-  pushState(url: string): void {
+  pushStateUrl(url: string): void {
     window.history.pushState(null, '', url);
+  }
+
+  replaceStateData(data: any) {
+    window.history.replaceState(data, '');
   }
 
   onPopState(): Observable<NavigationFromHistory> {

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -95,9 +95,11 @@ export class TestableLocation extends Location {
     return '/is/cool/';
   }
 
-  override replaceState(path: string) {}
+  override replaceStateUrl(path: string) {}
 
-  override pushState(path: string) {}
+  override pushStateUrl(path: string) {}
+
+  override replaceStateData(data: any) {}
 
   override onPopState() {
     return of({


### PR DESCRIPTION
Set it whether enableTimeNamespacedState is true or false.

It has no practical impact on the behavior of the application (we don't yet read this value in any case where enableTimeNamespacedState is set to false).

This is a prelimary change to fix some of the navigation issues detailed in b/211018035 (sorry, for Googlers only. I promise to be a bit more descriptive in the PR that actually fixes the issues). I made this change separate from the rest to limit the size of the PR.

In order to minimize impact on tests, a lot of which assert on the number of calls to Location.replaceState(),  I refactored Location.replaceState(data, url) into two separate calls: Location.replaceStateUrl(url) and Location.replaceStateData(data). I can additionally rationalize this by pointing out that replaceState(data, url) was never called with both data and url. 