### PR TITLE
fix npmi plugin run table css overlapping

### DIFF
--- a/tensorboard/webapp/plugins/npmi/views/main/main_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_component.scss
@@ -53,7 +53,6 @@ limitations under the License.
 }
 
 .violin-filters {
-  min-height: 0px;
   width: 100%;
 }
 


### PR DESCRIPTION
before 
<img width="345" alt="Screen Shot 2021-12-20 at 1 54 37 PM" src="https://user-images.githubusercontent.com/1131010/146722830-4cf02dfc-f1c8-4212-8fcc-9645e360aeb9.png">

after
<img width="371" alt="Screen Shot 2021-12-20 at 1 54 47 PM" src="https://user-images.githubusercontent.com/1131010/146722842-ee0bed20-844b-44a6-bb07-48c401983684.png">

