### PR TITLE
(time-namespaced state) Only rehydrate state from url for namespaces not seen since page load.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -395,9 +395,9 @@ export class AppRoutingEffects {
         // have in-memory state for the namespace being navigated to.
 
         const isKnownNamespace =
-          options.namespaceUpdateOption ===
+          options.namespaceUpdate.option ===
             NamespaceUpdateOption.FROM_HISTORY &&
-          knownNamespaceIds.has(options.namespaceId);
+          knownNamespaceIds.has(options.namespaceUpdate.namespaceId);
 
         if (
           !options.browserInitiated ||

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -52,6 +52,7 @@ import {RouteRegistryModule} from '../route_registry_module';
 import {
   getActiveNamespaceId,
   getActiveRoute,
+  getKnownNamespaceIds,
 } from '../store/app_routing_selectors';
 import {Route, RouteKind, RouteParams} from '../types';
 
@@ -363,30 +364,48 @@ export class AppRoutingEffects {
           })
         );
       }),
-      tap(({routeMatch, options}) => {
-        if (options.browserInitiated && routeMatch.deepLinkProvider) {
-          // Query paramter formed by the redirector is passed to the
-          // deserializer instead of one from Location.getSearch(). This
-          // behavior emulates redirected URL to be on the URL bar such as
-          // "/compare?foo=bar" based on information provided by redirector (do
-          // note that location.getSearch() will return current query parameter
-          // which is pre-redirection URL).
-          const queryParams =
-            routeMatch.originateFromRedirection &&
-            routeMatch.redirectionOnlyQueryParams
-              ? routeMatch.redirectionOnlyQueryParams
-              : this.location.getSearch();
-          const rehydratingState =
-            routeMatch.deepLinkProvider.deserializeQueryParams(queryParams);
-          this.store.dispatch(
-            stateRehydratedFromUrl({
-              routeKind: routeMatch.routeKind,
-              partialState: rehydratingState,
-            })
-          );
+      withLatestFrom(this.store.select(getKnownNamespaceIds)),
+      tap(([{routeMatch, options}, knownNamespaceIds]) => {
+        // Possibly rehydrate state from the URL.
+        //
+        // We do this on "browser initiated" events (like a page load or
+        // navigation in browser history) but we only do this when we don't yet
+        // have in-memory state for the namespace being navigated to.
+
+        const isKnownNamespace =
+          options.namespaceUpdateOption ===
+            NamespaceUpdateOption.FROM_HISTORY &&
+          knownNamespaceIds.has(options.namespaceId);
+
+        if (
+          !options.browserInitiated ||
+          isKnownNamespace ||
+          !routeMatch.deepLinkProvider
+        ) {
+          return;
         }
+
+        // Query parameter formed by the redirector is passed to the
+        // deserializer instead of one from Location.getSearch(). This
+        // behavior emulates redirected URL to be on the URL bar such as
+        // "/compare?foo=bar" based on information provided by redirector (do
+        // note that location.getSearch() will return current query parameter
+        // which is pre-redirection URL).
+        const queryParams =
+          routeMatch.originateFromRedirection &&
+          routeMatch.redirectionOnlyQueryParams
+            ? routeMatch.redirectionOnlyQueryParams
+            : this.location.getSearch();
+        const rehydratingState =
+          routeMatch.deepLinkProvider.deserializeQueryParams(queryParams);
+        this.store.dispatch(
+          stateRehydratedFromUrl({
+            routeKind: routeMatch.routeKind,
+            partialState: rehydratingState,
+          })
+        );
       }),
-      switchMap(({routeMatch, options}): Observable<InternalRoute> => {
+      switchMap(([{routeMatch, options}]): Observable<InternalRoute> => {
         if (routeMatch.deepLinkProvider === null) {
           // Without a DeepLinkProvider emit a single result without query
           // params.

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -803,7 +803,7 @@ describe('app_routing_effects', () => {
         }));
       });
 
-      it('dispatches stateRehydratedFromUrl when known namespace id', fakeAsync(() => {
+      it('dispatches stateRehydratedFromUrl when unknown namespace id', fakeAsync(() => {
         deserializeQueryParamsSpy.and.returnValue({a: 'A', b: 'B'});
         getPathSpy.and.returnValue('/compare/a:b');
 
@@ -836,7 +836,7 @@ describe('app_routing_effects', () => {
         ]);
       }));
 
-      it('does not dispatch stateRehydratedFromUrl when unknown namespace id', fakeAsync(() => {
+      it('does not dispatch stateRehydratedFromUrl when known namespace id', fakeAsync(() => {
         deserializeQueryParamsSpy.and.returnValue({a: 'A', b: 'B'});
         getPathSpy.and.returnValue('/compare/a:b');
 

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
@@ -20,6 +20,7 @@ const initialState: AppRoutingState = {
   activeRoute: null,
   nextRoute: null,
   activeNamespaceId: null,
+  knownNamespaceIds: new Set(),
   registeredRouteKeys: new Set(),
 };
 
@@ -29,11 +30,17 @@ const reducer = createReducer(
     return {...state, nextRoute: after};
   }),
   on(actions.navigated, (state, {after, afterNamespaceId}) => {
+    let knownNamespaceIds = state.knownNamespaceIds;
+    if (!state.knownNamespaceIds.has(afterNamespaceId)) {
+      knownNamespaceIds = new Set(state.knownNamespaceIds);
+      knownNamespaceIds.add(afterNamespaceId);
+    }
     return {
       ...state,
       activeRoute: after,
       nextRoute: null,
       activeNamespaceId: afterNamespaceId,
+      knownNamespaceIds,
     };
   }),
   on(actions.routeConfigLoaded, (state, {routeKinds}) => {

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
@@ -90,6 +90,50 @@ describe('app_routing_reducers', () => {
       );
       expect(nextState.activeNamespaceId).toEqual('namespace1');
     });
+
+    it('adds to knownNamespaceIds', () => {
+      const originalKnownNamespaceIds = new Set<string>(['n1', 'n2']);
+      const state = buildAppRoutingState({
+        knownNamespaceIds: originalKnownNamespaceIds,
+      });
+
+      const nextState = appRoutingReducers.reducers(
+        state,
+        actions.navigated({
+          before: null,
+          after: buildRoute(),
+          beforeNamespaceId: null,
+          afterNamespaceId: 'n3',
+        })
+      );
+
+      expect(nextState.knownNamespaceIds).toEqual(
+        new Set<string>(['n1', 'n2', 'n3'])
+      );
+      expect(nextState.knownNamespaceIds).not.toBe(originalKnownNamespaceIds);
+    });
+
+    it('does not create new knownNamespaceIds when no changes necessary', () => {
+      const originalKnownNamespaceIds = new Set<string>(['n1', 'n2']);
+      const state = buildAppRoutingState({
+        knownNamespaceIds: originalKnownNamespaceIds,
+      });
+
+      const nextState = appRoutingReducers.reducers(
+        state,
+        actions.navigated({
+          before: null,
+          after: buildRoute(),
+          beforeNamespaceId: null,
+          afterNamespaceId: 'n2',
+        })
+      );
+
+      expect(nextState.knownNamespaceIds).toEqual(
+        new Set<string>(['n1', 'n2'])
+      );
+      expect(nextState.knownNamespaceIds).toBe(originalKnownNamespaceIds);
+    });
   });
 
   describe('routeConfigLoaded', () => {

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -54,6 +54,13 @@ export const getActiveNamespaceId = createSelector(
   }
 );
 
+export const getKnownNamespaceIds = createSelector(
+  getAppRoutingState,
+  (state): Set<string> => {
+    return state.knownNamespaceIds;
+  }
+);
+
 export const getRegisteredRouteKinds = createSelector<
   State,
   AppRoutingState,

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -65,6 +65,24 @@ describe('app_routing_selectors', () => {
     });
   });
 
+  describe('getKnownNamespaceIds', () => {
+    beforeEach(() => {
+      selectors.getKnownNamespaceIds.release();
+    });
+
+    it('returns knownNamespaceIds', () => {
+      const state = buildStateFromAppRoutingState(
+        buildAppRoutingState({
+          knownNamespaceIds: new Set<string>(['n1', 'n2', 'n3']),
+        })
+      );
+
+      expect(selectors.getKnownNamespaceIds(state)).toEqual(
+        new Set<string>(['n1', 'n2', 'n3'])
+      );
+    });
+  });
+
   describe('getRouteKind', () => {
     beforeEach(() => {
       selectors.getRouteKind.release();

--- a/tensorboard/webapp/app_routing/store/app_routing_types.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_types.ts
@@ -19,10 +19,14 @@ export const APP_ROUTING_FEATURE_KEY = 'app_routing';
 export interface AppRoutingState {
   activeRoute: Route | null;
   // Transient state that tells certain components like the router-outlet to
-  // make changes before a route change. `ntextRoute` is non-null only while
+  // make changes before a route change. `nextRoute` is non-null only while
   // we are navigating.
   nextRoute: Route | null;
+  // The id of the namespace that is currently active.
   activeNamespaceId: string | null;
+  // All namespaces that currently have a representation in state. This includes
+  // the active namespace but also any cached namespaces.
+  knownNamespaceIds: Set<string>;
   registeredRouteKeys: Set<RouteKind>;
 }
 

--- a/tensorboard/webapp/app_routing/store/testing.ts
+++ b/tensorboard/webapp/app_routing/store/testing.ts
@@ -25,6 +25,7 @@ export function buildAppRoutingState(
     activeRoute: null,
     nextRoute: null,
     activeNamespaceId: null,
+    knownNamespaceIds: new Set(),
     registeredRouteKeys: new Set(),
     ...override,
   };


### PR DESCRIPTION
As desribed in detail in b/211018035 (sorry, Googlers only), there is tension between ngrx-managed state and state as described in the URL.

We can get in situations where user navigates back and forward in browser history and the state rehydrated from the URL overwrites ngrx-managed state. In the case of namespaced state it can often overwrite the WRONG state since the rehydration happens before namespace resolution is completed.

The solution we propose is to rehydrate state from the URL less frequently. We skip rehydration from URL if navigating to a namespace that we already have tracked in ngrx-managed state.

This approach will solve a bunch of navigation bugs in route-namespaced state but will also avoid some weird potential navigation bugs in the new time-namespaced state.

It does have some certain idiosyncracies of its own that we will have to accept as intended behavior. Consider if user has generated the following browser history and namespaces since loading the app:

* (1) {http://urlA?tagFilter=A, namespaceId: A}
* (2) {http://urlAprime?tagFilter=Aprime, namespaceId: A}
* (3) {http://urlB?tagFilter=B, namespaceId: B}

Then two behaviors we'd have to accept as 'Working as Intended':

1. If user jumps from state (3) to state (1) then 'tagFilter=A' will be ignored and the tag filter will be 'Aprime'. This seems to be justifiable since it fits into our mental model about how namespaces are supposed to behave according to go/tb-timespaced-state.

2. If user reloads the page (thus clearing in-memory state) and then jumps from state (3) to state (1) then 'tagFilter=A' will be honored and the tag filter will be 'A'. If they then navigate forward to state (2) then 'tagFilter=Aprime' will be ignored and the tag filter will remain 'A'. This might be a little harder to justify but I think it is a compromise that makes sense given how the system works.
