### PR TITLE
(time-namespaced state) Reuse namespace id on page reload if it exists.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -86,21 +86,20 @@ enum NamespaceUpdateOption {
   FROM_HISTORY,
 }
 
-type NavigationOptions =
+type NamespaceUpdate =
   | {
-      browserInitiated: boolean;
-      replaceState: boolean;
-      namespaceUpdateOption:
-        | NamespaceUpdateOption.NEW
-        | NamespaceUpdateOption.UNCHANGED;
+      option: NamespaceUpdateOption.NEW | NamespaceUpdateOption.UNCHANGED;
     }
   | {
-      browserInitiated: boolean;
-      replaceState: boolean;
-      // When namespace is FROM_HISTORY, a namespaceId must also be provided.
-      namespaceUpdateOption: NamespaceUpdateOption.FROM_HISTORY;
+      option: NamespaceUpdateOption.FROM_HISTORY;
       namespaceId: string;
     };
+
+type NavigationOptions = {
+  browserInitiated: boolean;
+  replaceState: boolean;
+  namespaceUpdate: NamespaceUpdate;
+};
 
 /**
  * Effects to translate attempted app navigations into Route navigation actions.
@@ -151,9 +150,11 @@ export class AppRoutingEffects {
           options: {
             browserInitiated: false,
             replaceState: navigation.replaceState ?? false,
-            namespaceUpdateOption: navigation.resetNamespacedState
-              ? NamespaceUpdateOption.NEW
-              : NamespaceUpdateOption.UNCHANGED,
+            namespaceUpdate: {
+              option: navigation.resetNamespacedState
+                ? NamespaceUpdateOption.NEW
+                : NamespaceUpdateOption.UNCHANGED,
+            },
           },
         };
       })
@@ -181,12 +182,31 @@ export class AppRoutingEffects {
     .pipe(
       delay(0),
       map(() => {
+        const namespaceId: string | undefined =
+          this.location.getHistoryState()?.namespaceId;
+
+        const namespaceUpdate: NamespaceUpdate =
+          namespaceId === undefined
+            ? // There is no namespace id in the browser history entry. This is,
+              // therefore, some sort of new navigation to the app. Set options
+              // so that a new namespace id is set downstream.
+              {
+                option: NamespaceUpdateOption.NEW,
+              }
+            : // There is a namespace id in the browser history entry. This is,
+              // therefore, a page reload. Set options so that the namespace id
+              // is reused downstream.
+              {
+                option: NamespaceUpdateOption.FROM_HISTORY,
+                namespaceId: namespaceId,
+              };
+
         return {
           pathname: this.location.getPath(),
           options: {
             browserInitiated: true,
             replaceState: true,
-            namespaceUpdateOption: NamespaceUpdateOption.UNCHANGED,
+            namespaceUpdate,
           },
         };
       })
@@ -204,8 +224,10 @@ export class AppRoutingEffects {
           options: {
             browserInitiated: true,
             replaceState: true,
-            namespaceUpdateOption: NamespaceUpdateOption.FROM_HISTORY,
-            namespaceId: navigation.state?.namespaceId,
+            namespaceUpdate: {
+              option: NamespaceUpdateOption.FROM_HISTORY,
+              namespaceId: navigation.state?.namespaceId,
+            },
           },
         };
       })
@@ -291,7 +313,7 @@ export class AppRoutingEffects {
         options: {
           replaceState: false,
           browserInitiated: false,
-          namespaceUpdateOption: NamespaceUpdateOption.UNCHANGED,
+          namespaceUpdate: {option: NamespaceUpdateOption.UNCHANGED},
         } as NavigationOptions,
       };
     })
@@ -544,11 +566,11 @@ function getAfterNamespaceId(
     return getRouteId(route.routeKind, route.params);
   } else {
     // Time-namespaced state is enabled.
-    if (options.namespaceUpdateOption === NamespaceUpdateOption.FROM_HISTORY) {
-      return options.namespaceId;
+    if (options.namespaceUpdate.option === NamespaceUpdateOption.FROM_HISTORY) {
+      return options.namespaceUpdate.namespaceId;
     } else if (
       beforeNamespaceId == null ||
-      options.namespaceUpdateOption === NamespaceUpdateOption.NEW
+      options.namespaceUpdate.option === NamespaceUpdateOption.NEW
     ) {
       return Date.now().toString();
     } else {

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -526,7 +526,7 @@ describe('app_routing_effects', () => {
     });
 
     describe('time-namespaced ids', () => {
-      it('are generated on bootstrap (when none exists)', fakeAsync(() => {
+      it('are generated on bootstrap when none in history', fakeAsync(() => {
         store.overrideSelector(getActiveRoute, null);
         store.overrideSelector(getActiveNamespaceId, null);
         store.overrideSelector(getEnabledTimeNamespacedState, true);
@@ -534,7 +534,6 @@ describe('app_routing_effects', () => {
 
         getPathSpy.and.returnValue('/experiments');
         getSearchSpy.and.returnValue([]);
-
         action.next(effects.ngrxOnInitEffects());
 
         tick();
@@ -551,6 +550,35 @@ describe('app_routing_effects', () => {
             beforeNamespaceId: null,
             // Newly-generated Id based on mock clock time.
             afterNamespaceId: Date.now().toString(),
+          }),
+        ]);
+      }));
+
+      it('are reused from history on bootstrap', fakeAsync(() => {
+        store.overrideSelector(getActiveRoute, null);
+        store.overrideSelector(getActiveNamespaceId, null);
+        store.overrideSelector(getEnabledTimeNamespacedState, true);
+        store.refreshState();
+
+        getPathSpy.and.returnValue('/experiments');
+        getHistoryStateSpy.and.returnValue({namespaceId: 'id_from_history'});
+        getSearchSpy.and.returnValue([]);
+        action.next(effects.ngrxOnInitEffects());
+
+        tick();
+
+        expect(actualActions).toEqual([
+          jasmine.any(Object),
+          actions.navigated({
+            before: null,
+            after: buildRoute({
+              routeKind: RouteKind.EXPERIMENTS,
+              pathname: '/experiments',
+            }),
+            // From getActiveNamespaceId().
+            beforeNamespaceId: null,
+            // From history.
+            afterNamespaceId: 'id_from_history',
           }),
         ]);
       }));


### PR DESCRIPTION
This change ensures that we read and reuse namespace id from browser history if a page is reloaded.

Consider the situation where user:

1. Selects to view an experiment and sets tag filter to 'A'.
2. Adds an experiment to the comparison and then sets the tag filter to 'B'.
3. Refreshes the page.

All these actions are supposed to take place in the same namespace. But currently the page refresh breaks this - a page load always generates a new namespace and new namespace id. So if user navigates back to the single view they will see tag filter set to 'A' instead of to 'B'.