### PR TITLE
TensorBoard.dev : Uploader delete functionality supports more than one experiment_id at a time.

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -92,6 +92,7 @@ py_test(
         ":uploader",
         ":uploader_subcommand",
         "//tensorboard:expect_grpc_testing_installed",
+        "//tensorboard/plugins:base_plugin",
     ],
 )
 

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -182,7 +182,7 @@ def define_flags(parser):
         metavar="EXPERIMENT_ID",
         type=lambda option: option.split(","),
         default=[],
-        help="ID of an experiment to delete permanently.  Comma separated list"
+        help="ID of an experiment to delete permanently. Comma separated list"
         "of experiment ids is also supported.",
     )
 

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -180,9 +180,10 @@ def define_flags(parser):
     delete.add_argument(
         "--experiment_id",
         metavar="EXPERIMENT_ID",
-        type=str,
-        default=None,
-        help="ID of an experiment to delete permanently",
+        type=lambda option: option.split(","),
+        default=[],
+        help="ID of an experiment to delete permanently.  Comma separated list"
+        "of experiment ids is also supported.",
     )
 
     list_parser = subparsers.add_parser(

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -178,8 +178,8 @@ class _DeleteExperimentIntent(_Intent):
 
     _MESSAGE_TEMPLATE = textwrap.dedent(
         """\
-        This will delete the {num} experiments on
-        https://tensorboard.dev with the following experiment ID:
+        This will delete the {num} experiment(s) on
+        https://tensorboard.dev with the following experiment ID(s):
 
         {experiment_id_list}
 
@@ -206,26 +206,50 @@ class _DeleteExperimentIntent(_Intent):
             raise base_plugin.FlagsError(
                 "Must specify at least one experiment ID to delete."
             )
-        for experiment_id in self.experiment_id_list:
+        # Map from eid to (msg, action) pair.
+        results = {}
+        NO_ACTION = "NO_ACTION"
+        DIE_ACTION = "DIE_ACTION"
+        for experiment_id in set(self.experiment_id_list):
             if not experiment_id:
-                raise base_plugin.FlagsError(
-                    "Must specify a non-empty experiment ID to delete."
-                )
+                results[experiment_id] = (
+                    "Must specify a non-empty experiment ID to delete.",
+                    NO_ACTION)
             try:
                 uploader_lib.delete_experiment(api_client, experiment_id)
-                print("Deleted experiment %s." % experiment_id)
+                results[experiment_id] = (
+                    "Deleted experiment %s." % experiment_id,
+                    NO_ACTION)
             except uploader_lib.ExperimentNotFoundError:
-                _die(
+                results[experiment_id] = (
                     "No such experiment %s. Either it never existed or it has "
-                    "already been deleted." % experiment_id
+                    "already been deleted." % experiment_id,
+                    DIE_ACTION
                 )
             except uploader_lib.PermissionDeniedError:
-                _die(
+                results[experiment_id] = (
                     "Cannot delete experiment %s because it is owned by a "
-                    "different user." % experiment_id
+                    "different user." % experiment_id,
+                    DIE_ACTION
                 )
             except grpc.RpcError as e:
-                _die("Internal error deleting experiment: %s" % e)
+                results[experiment_id] = (
+                    "Internal error deleting experiment: %s." % e,
+                    DIE_ACTION
+                )
+        # business logic on the receipt
+        any_die_action = False
+        err_msg = ""
+        for (msg, action) in results.values():
+            if action == NO_ACTION:
+                print(msg)
+            if action == DIE_ACTION:
+                err_msg += msg + "\n"
+                any_die_action = True
+        if any_die_action:
+            _die(err_msg)
+
+
 
 
 class _UpdateMetadataIntent(_Intent):

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -195,7 +195,8 @@ class _DeleteExperimentIntent(_Intent):
     def get_ack_message_body(self):
         return self._MESSAGE_TEMPLATE.format(
             num=len(self.experiment_id_list),
-            experiment_id_list=self.experiment_id_list)
+            experiment_id_list=self.experiment_id_list,
+        )
 
     def execute(self, server_info, channel):
         api_client = write_service_pb2_grpc.TensorBoardWriterServiceStub(
@@ -203,8 +204,8 @@ class _DeleteExperimentIntent(_Intent):
         )
         if not self.experiment_id_list:
             raise base_plugin.FlagsError(
-                    "Must specify at least one experiment ID to delete."
-                )
+                "Must specify at least one experiment ID to delete."
+            )
         for experiment_id in self.experiment_id_list:
             if not experiment_id:
                 raise base_plugin.FlagsError(

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -213,8 +213,9 @@ class _DeleteExperimentIntent(_Intent):
         for experiment_id in set(self.experiment_id_list):
             if not experiment_id:
                 results[experiment_id] = (
-                    "Must specify a non-empty experiment ID to delete.",
+                    "Skipping empty experiment_id.",
                     NO_ACTION)
+                continue
             try:
                 uploader_lib.delete_experiment(api_client, experiment_id)
                 results[experiment_id] = (
@@ -234,7 +235,10 @@ class _DeleteExperimentIntent(_Intent):
                 )
             except grpc.RpcError as e:
                 results[experiment_id] = (
-                    "Internal error deleting experiment: %s." % e,
+                    (
+                        "Internal error deleting experiment %s: %s." %
+                        (experiment_id, e)
+                    ),
                     DIE_ACTION
                 )
         # business logic on the receipt

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -214,32 +214,34 @@ class _DeleteExperimentIntent(_Intent):
             if not experiment_id:
                 results[experiment_id] = (
                     "Skipping empty experiment_id.",
-                    NO_ACTION)
+                    NO_ACTION,
+                )
                 continue
             try:
                 uploader_lib.delete_experiment(api_client, experiment_id)
                 results[experiment_id] = (
                     "Deleted experiment %s." % experiment_id,
-                    NO_ACTION)
+                    NO_ACTION,
+                )
             except uploader_lib.ExperimentNotFoundError:
                 results[experiment_id] = (
                     "No such experiment %s. Either it never existed or it has "
                     "already been deleted." % experiment_id,
-                    DIE_ACTION
+                    DIE_ACTION,
                 )
             except uploader_lib.PermissionDeniedError:
                 results[experiment_id] = (
                     "Cannot delete experiment %s because it is owned by a "
                     "different user." % experiment_id,
-                    DIE_ACTION
+                    DIE_ACTION,
                 )
             except grpc.RpcError as e:
                 results[experiment_id] = (
                     (
-                        "Internal error deleting experiment %s: %s." %
-                        (experiment_id, e)
+                        "Internal error deleting experiment %s: %s."
+                        % (experiment_id, e)
                     ),
-                    DIE_ACTION
+                    DIE_ACTION,
                 )
         # business logic on the receipt
         any_die_action = False
@@ -252,8 +254,6 @@ class _DeleteExperimentIntent(_Intent):
                 any_die_action = True
         if any_die_action:
             _die(err_msg)
-
-
 
 
 class _UpdateMetadataIntent(_Intent):

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -317,8 +317,8 @@ class UploadIntentTest(tf.test.TestCase):
         self.assertRegex(out_msg, f".*Deleted experiment {eid_3}.*")
 
     def testDeleteIntentHandlesUndeletableExperiemtns(self):
-        # Setup: A uploader_lib which will report success (return `None`) on the
-        #   deletion of an experiment.
+        # Setup: A uploader_lib which will emit scripted results for differen
+        # eids.  See mock_delete_func for script.
         eid_1_ok = "1111"
         eid_2_empty = ""
         eid_3_ok = "3333"
@@ -425,8 +425,6 @@ class UploadIntentTest(tf.test.TestCase):
         self.assertEqual(mock_sys_exit.call_count, 1)
 
     def testDeleteIntentRaisesWhenAskedToDeleteZeroExperiments(self):
-        # Setup: A uploader_lib which will report success (return `None`) on the
-        #   deletion of an experiment.
         mock_delete_experiment = mock.MagicMock(return_value=None)
         mock_stdout_write = mock.MagicMock()
 

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -18,6 +18,7 @@
 import sys
 from unittest import mock
 
+import grpc
 import tensorflow as tf
 
 from tensorboard.uploader.proto import experiment_pb2
@@ -229,7 +230,6 @@ class UploadIntentTest(tf.test.TestCase):
             self.assertEqual(actual_mask, expected_mask)
 
     def testDeleteIntentDeletesExistingExperiment(self):
-        """Test the delete intent under the one-shot mode."""
         # Setup: A uploader_lib which will report success (return `None`) on the
         #   deletion of an experiment.
         eid_1 = "1111"
@@ -270,8 +270,147 @@ class UploadIntentTest(tf.test.TestCase):
             ",".join(stdout_writes), f".*Deleted experiment {eid_1}.*",
         )
 
+    def testDeleteIntentDeletesMultipleExperiments(self):
+        # Setup: A uploader_lib which will report success (return `None`) on the
+        #   deletion of an experiment.
+        eid_1 = "1111"
+        eid_2 = "22222"
+        eid_3 = "333333"
+        mock_delete_experiment = mock.MagicMock(return_value=None)
+        mock_stdout_write = mock.MagicMock()
+
+        # Execute: A _DeleteExperimentIntent on the list containing exactly
+        #  three experiment_ids
+        #
+        # Mock three places:
+        # 1. Writing to stdout, so we can inspect messages to the user.
+        # 2. uploader_lib.delete_experiment itself, we will inspect invocations
+        #    this method but do not want to actually delete anything.
+        # 3. The creation of the grpc TensorBoardWriterServiceStub, which
+        #    happens in intent, but we don't want to actually open a network
+        #    communication.
+        with mock.patch.object(
+            sys.stdout, "write", mock_stdout_write
+        ), mock.patch.object(
+            uploader_lib, "delete_experiment", mock_delete_experiment
+        ), mock.patch.object(
+            write_service_pb2_grpc, "TensorBoardWriterServiceStub"
+        ):
+            # Set up an UploadIntent configured with one_shot and an empty temp
+            # directory.
+            intent = uploader_subcommand._DeleteExperimentIntent(
+                experiment_id_list=[eid_1, eid_2, eid_3]
+            )
+            # Execute the intent.execute method.
+            intent.execute(server_info_pb2.ServerInfoResponse(), None)
+
+        # Expect that there are three calls to delete_experiment.
+        self.assertEqual(mock_delete_experiment.call_count, 3)
+        # Expect that ".*Deleted experiment.*" and the eid are among the things
+        #    printed.
+        out_msg = ",".join([x[0][0] for x in mock_stdout_write.call_args_list])
+        self.assertRegex(out_msg, f".*Deleted experiment {eid_1}.*")
+        self.assertRegex(out_msg, f".*Deleted experiment {eid_2}.*")
+        self.assertRegex(out_msg, f".*Deleted experiment {eid_3}.*")
+
+    def testDeleteIntentHandlesUndeletableExperiemtns(self):
+        # Setup: A uploader_lib which will report success (return `None`) on the
+        #   deletion of an experiment.
+        eid_1_ok = "1111"
+        eid_2_empty = ""
+        eid_3_ok = "3333"
+        eid_4_missing = "4444"
+        eid_5_ok = "5555"
+        eid_6_permission_denied = "6666"
+        eid_7_ok = "7777"
+        eid_8_rate_limited = "8888"
+        eid_9_ok = "9999"
+
+        def mock_delete_func(_, eid):
+            if eid == eid_4_missing:
+                raise uploader_lib.ExperimentNotFoundError()
+            if eid == eid_6_permission_denied:
+                raise uploader_lib.PermissionDeniedError()
+            if eid == eid_8_rate_limited:
+                raise grpc.RpcError("Rate limited")
+            return None
+
+        mock_delete_experiment = mock.MagicMock(side_effect=mock_delete_func)
+        mock_stdout_write = mock.MagicMock()
+        mock_stderr_write = mock.MagicMock()
+        mock_sys_exit = mock.MagicMock()
+
+        # Execute: A _DeleteExperimentIntent on the motley list of
+        #    experiments.
+        #
+        # Mock five places:
+        # 1. Writing to stdout, so we can inspect messages to the user.
+        # 2. Writing to stderr.
+        # 3. uploader_lib.delete_experiment itself, we will inspect invocations
+        #    this method but do not want to actually delete anything.
+        # 4. The creation of the grpc TensorBoardWriterServiceStub, which
+        #    happens in intent, but we don't want to actually open a network
+        #    communication.
+        # 5. Replace uploader_subcommand._die with something that wont
+        #    actually kill the test.
+        with mock.patch.object(
+            sys.stdout, "write", mock_stdout_write
+        ), mock.patch.object(
+            sys.stderr, "write", mock_stderr_write
+        ), mock.patch.object(
+            uploader_lib, "delete_experiment", mock_delete_experiment
+        ), mock.patch.object(
+            write_service_pb2_grpc, "TensorBoardWriterServiceStub"
+        ), mock.patch.object(sys, "exit", mock_sys_exit):
+            # Set up an UploadIntent configured with one_shot and an empty temp
+            # directory.
+            intent = uploader_subcommand._DeleteExperimentIntent(
+                experiment_id_list=[
+                    eid_1_ok,
+                    eid_2_empty,
+                    eid_3_ok,
+                    eid_4_missing,
+                    eid_5_ok,
+                    eid_6_permission_denied,
+                    eid_7_ok,
+                    eid_8_rate_limited,
+                    eid_9_ok]
+            )
+            # Execute the intent.execute method.
+            intent.execute(server_info_pb2.ServerInfoResponse(), None)
+
+        # Expect that there are eight calls to delete_experiment, one for each
+        # experiment *except* the empty one.
+        self.assertEqual(mock_delete_experiment.call_count, 8)
+        # Expect that ".*Deleted experiment.*" and the eid are among the things
+        #    printed to stdout
+        stdout_msg = ",".join([x[0][0] for x in mock_stdout_write.call_args_list])
+        self.assertRegex(stdout_msg, f".*Deleted experiment {eid_1_ok}.*")
+        self.assertRegex(stdout_msg, f".*Deleted experiment {eid_3_ok}.*")
+        self.assertRegex(stdout_msg, f".*Deleted experiment {eid_5_ok}.*")
+        self.assertRegex(stdout_msg, f".*Deleted experiment {eid_7_ok}.*")
+        self.assertRegex(stdout_msg, f".*Deleted experiment {eid_9_ok}.*")
+        self.assertRegex(stdout_msg, ".*Skipping empty experiment_id.*")
+        self.assertNotRegex(stdout_msg, f".*Deleted experiment {eid_4_missing}.*")
+        self.assertNotRegex(
+            stdout_msg, f".*Deleted experiment {eid_6_permission_denied}.*")
+        self.assertNotRegex(
+            stdout_msg, f".*Deleted experiment {eid_8_rate_limited}.*")
+        # Expect appropriate error messages sent to stderr
+        stderr_msg = ",".join([x[0][0] for x in mock_stderr_write.call_args_list])
+        self.assertRegex(
+            stderr_msg,
+            f".*No such experiment {eid_4_missing}.*")
+        self.assertRegex(
+            stderr_msg,
+            f".*Cannot delete experiment {eid_6_permission_denied}.*")
+        self.assertRegex(
+            stderr_msg,
+            f".*Internal error deleting experiment {eid_8_rate_limited}.*")
+        # Expect a call to kill the process.
+        self.assertEqual(mock_sys_exit.call_count, 1)
+
     def testDeleteIntentRaisesWhenAskedToDeleteZeroExperiments(self):
-        """Test the delete intent under the one-shot mode."""
         # Setup: A uploader_lib which will report success (return `None`) on the
         #   deletion of an experiment.
         mock_delete_experiment = mock.MagicMock(return_value=None)

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -63,7 +63,9 @@ class UploadIntentTest(tf.test.TestCase):
         mock_uploader = mock.MagicMock()
         mock_stdout_write = mock.MagicMock()
         with mock.patch.object(
-            uploader_lib, "TensorBoardUploader", return_value=mock_uploader,
+            uploader_lib,
+            "TensorBoardUploader",
+            return_value=mock_uploader,
         ), mock.patch.object(
             sys.stdout, "write", mock_stdout_write
         ), mock.patch.object(
@@ -267,7 +269,8 @@ class UploadIntentTest(tf.test.TestCase):
         #    printed.
         stdout_writes = [x[0][0] for x in mock_stdout_write.call_args_list]
         self.assertRegex(
-            ",".join(stdout_writes), f".*Deleted experiment {eid_1}.*",
+            ",".join(stdout_writes),
+            f".*Deleted experiment {eid_1}.*",
         )
 
     def testDeleteIntentDeletesMultipleExperiments(self):
@@ -361,7 +364,9 @@ class UploadIntentTest(tf.test.TestCase):
             uploader_lib, "delete_experiment", mock_delete_experiment
         ), mock.patch.object(
             write_service_pb2_grpc, "TensorBoardWriterServiceStub"
-        ), mock.patch.object(sys, "exit", mock_sys_exit):
+        ), mock.patch.object(
+            sys, "exit", mock_sys_exit
+        ):
             # Set up an UploadIntent configured with one_shot and an empty temp
             # directory.
             intent = uploader_subcommand._DeleteExperimentIntent(
@@ -374,7 +379,8 @@ class UploadIntentTest(tf.test.TestCase):
                     eid_6_permission_denied,
                     eid_7_ok,
                     eid_8_rate_limited,
-                    eid_9_ok]
+                    eid_9_ok,
+                ]
             )
             # Execute the intent.execute method.
             intent.execute(server_info_pb2.ServerInfoResponse(), None)
@@ -384,29 +390,37 @@ class UploadIntentTest(tf.test.TestCase):
         self.assertEqual(mock_delete_experiment.call_count, 8)
         # Expect that ".*Deleted experiment.*" and the eid are among the things
         #    printed to stdout
-        stdout_msg = ",".join([x[0][0] for x in mock_stdout_write.call_args_list])
+        stdout_msg = ",".join(
+            [x[0][0] for x in mock_stdout_write.call_args_list]
+        )
         self.assertRegex(stdout_msg, f".*Deleted experiment {eid_1_ok}.*")
         self.assertRegex(stdout_msg, f".*Deleted experiment {eid_3_ok}.*")
         self.assertRegex(stdout_msg, f".*Deleted experiment {eid_5_ok}.*")
         self.assertRegex(stdout_msg, f".*Deleted experiment {eid_7_ok}.*")
         self.assertRegex(stdout_msg, f".*Deleted experiment {eid_9_ok}.*")
         self.assertRegex(stdout_msg, ".*Skipping empty experiment_id.*")
-        self.assertNotRegex(stdout_msg, f".*Deleted experiment {eid_4_missing}.*")
         self.assertNotRegex(
-            stdout_msg, f".*Deleted experiment {eid_6_permission_denied}.*")
+            stdout_msg, f".*Deleted experiment {eid_4_missing}.*"
+        )
         self.assertNotRegex(
-            stdout_msg, f".*Deleted experiment {eid_8_rate_limited}.*")
+            stdout_msg, f".*Deleted experiment {eid_6_permission_denied}.*"
+        )
+        self.assertNotRegex(
+            stdout_msg, f".*Deleted experiment {eid_8_rate_limited}.*"
+        )
         # Expect appropriate error messages sent to stderr
-        stderr_msg = ",".join([x[0][0] for x in mock_stderr_write.call_args_list])
+        stderr_msg = ",".join(
+            [x[0][0] for x in mock_stderr_write.call_args_list]
+        )
+        self.assertRegex(stderr_msg, f".*No such experiment {eid_4_missing}.*")
         self.assertRegex(
             stderr_msg,
-            f".*No such experiment {eid_4_missing}.*")
+            f".*Cannot delete experiment {eid_6_permission_denied}.*",
+        )
         self.assertRegex(
             stderr_msg,
-            f".*Cannot delete experiment {eid_6_permission_denied}.*")
-        self.assertRegex(
-            stderr_msg,
-            f".*Internal error deleting experiment {eid_8_rate_limited}.*")
+            f".*Internal error deleting experiment {eid_8_rate_limited}.*",
+        )
         # Expect a call to kill the process.
         self.assertEqual(mock_sys_exit.call_count, 1)
 


### PR DESCRIPTION
## Motivation for features / changes

https://github.com/tensorflow/tensorboard/issues/4765

##  Technical description of changes

Modifies flag to support a comma-separated list of experiment ids (while retaining functionality of just one id)

##  Screenshots of UI changes

Expected use case:
```
$ ./bazel-bin/tensorboard/tensorboard dev delete --experiment_id=S0kpfaQeTvaSjCA2nTMQFw,K8vwol4qSoi8UqViDj7q0Q
Deleted experiment S0kpfaQeTvaSjCA2nTMQFw.
Deleted experiment K8vwol4qSoi8UqViDj7q0Q.
```

No auth:
```
$ ./bazel-bin/tensorboard/tensorboard dev delete --experiment_id=S0kpfaQeTvaSjCA2nTMQFw,K8vwol4qSoi8UqViDj7q0Q

***** TensorBoard Uploader *****

This will delete the 2 experiments on
https://tensorboard.dev with the following experiment ID:

['S0kpfaQeTvaSjCA2nTMQFw', 'K8vwol4qSoi8UqViDj7q0Q']

You have chosen to delete an experiment. All experiments uploaded
to TensorBoard.dev are publicly visible. Do not upload sensitive
data.

Your use of this service is subject to Google's Terms of Service
<https://policies.google.com/terms> and Privacy Policy
<https://policies.google.com/privacy>, and TensorBoard.dev's Terms of Service
<https://tensorboard.dev/policy/terms/>.

This notice will not be shown again while you are logged into the uploader.
To log out, run `tensorboard dev auth revoke`.

Continue? (yes/NO) no
```

At least one experiment does not exist
```
$ ./bazel-bin/tensorboard/tensorboard dev delete --experiment_id=S0kpfaQeTvaSjCA2nTMQFw,K8vwol4qSoi8UqViDj7q0Q
No such experiment S0kpfaQeTvaSjCA2nTMQFw. Either it never existed or it has already been deleted.
```

##  Detailed steps to verify changes work correctly (as executed by you)

*  Upload new experiment(s) to tb.dev and then try deleting it, from command line.
* Delete an existing experiment
* Delete in a no-auth state
* Delete multiple experimetns
* Delete multiple experiments where one is invalid

##  Alternate designs / implementations considered

Considered changing the flag name to `experiment_id_list` or adding a second flag name.  This seemed strictly worse than extending the behavior of the existing flag.
