### PR TITLE
infra: Upgrade pinned version of black to 21.10b0.

### DIFF
--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -25,7 +25,7 @@ moto==1.3.7
 fsspec==0.7.4
 
 # For linting
-black==20.8b1
+black==21.10b0
 flake8==3.7.8
 yamllint==1.17.0
 


### PR DESCRIPTION
Upgrade pinned version of black to fix error when running on local desktop. The upgrade doesn't have any side effects. No formatting has changed.

When running `black` in tensorboard, I have been getting following error:

```
Traceback (most recent call last):
  File "/usr/local/google/home/bdubois/virtualenv/tensorboard/bin/black", line 5, in <module>
    from black import patched_main
  File "/usr/local/google/home/bdubois/virtualenv/tensorboard/lib/python3.9/site-packages/black/__init__.py", line 52, in <module>
    from typed_ast import ast3, ast27
  File "/usr/local/google/home/bdubois/virtualenv/tensorboard/lib/python3.9/site-packages/typed_ast/ast3.py", line 40, in <module>
    from typed_ast import _ast3
ImportError: /usr/local/google/home/bdubois/virtualenv/tensorboard/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape
```

A quick internet search convinced me to upgrade to 21.10b0.

See:
* https://stackoverflow.com/questions/69912264/python-3-9-8-fails-using-black-and-importing-typed-ast-ast3
* https://github.com/psf/black/releases/tag/21.10b0

To test:
* Run `pip install --upgrade pip; pip install tf-nightly -r tensorboard/pip_package/requirements.txt -r tensorboard/pip_package/requirements_dev.txt;`
* Run black and observe it runs successfully.
