### PR TITLE
(time-namespaced state) Complete removal of routeId.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -42,7 +42,7 @@ import {DirtyUpdatesRegistryModule} from '../dirty_updates_registry_module';
 import {
   areRoutesEqual,
   areSameRouteKindAndExperiments,
-  getRouteId,
+  getRouteNamespaceId,
   serializeCompareExperimentParams,
 } from '../internal_utils';
 import {Location} from '../location';
@@ -563,7 +563,7 @@ function getAfterNamespaceId(
   beforeNamespaceId: string | null
 ): string {
   if (!enabledTimeNamespacedState) {
-    return getRouteId(route.routeKind, route.params);
+    return getRouteNamespaceId(route.routeKind, route.params);
   } else {
     // Time-namespaced state is enabled.
     if (options.namespaceUpdate.option === NamespaceUpdateOption.FROM_HISTORY) {

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -24,7 +24,7 @@ import {getEnabledTimeNamespacedState} from '../../feature_flag/store/feature_fl
 import * as actions from '../actions';
 import {AppRootProvider, TestableAppRootProvider} from '../app_root';
 import {DirtyUpdatesRegistryModule} from '../dirty_updates_registry_module';
-import {getRouteId} from '../internal_utils';
+import {getRouteNamespaceId} from '../internal_utils';
 import {Location} from '../location';
 import {
   NavigateToCompare,
@@ -291,7 +291,7 @@ describe('app_routing_effects', () => {
               queryParams: [],
             }),
             beforeNamespaceId: null,
-            afterNamespaceId: getRouteId(RouteKind.EXPERIMENTS, {}),
+            afterNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
           }),
         ]);
       })
@@ -322,13 +322,13 @@ describe('app_routing_effects', () => {
           pathname: '/experiments',
           queryParams: [],
         });
-        const activeRouteId = getRouteId(RouteKind.EXPERIMENTS, {});
+        const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENTS, {});
         const dirtyExperimentsFactory = () => {
           return {experimentIds: ['otter']};
         };
 
         store.overrideSelector(getActiveRoute, activeRoute);
-        store.overrideSelector(getActiveNamespaceId, activeRouteId);
+        store.overrideSelector(getActiveNamespaceId, namespaceId);
         store.overrideSelector(
           testDirtyExperimentsSelector,
           dirtyExperimentsFactory()
@@ -371,7 +371,7 @@ describe('app_routing_effects', () => {
         );
       });
 
-      it('does not warn user when changing tab (same routeId)', fakeAsync(() => {
+      it('does not warn user when changing experiment tab', fakeAsync(() => {
         spyOn(window, 'confirm');
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENT,
@@ -379,11 +379,11 @@ describe('app_routing_effects', () => {
           pathname: '/experiment/meow',
           queryParams: [],
         });
-        const activeRouteId = getRouteId(RouteKind.EXPERIMENT, {
+        const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENT, {
           experimentId: 'meow',
         });
         store.overrideSelector(getActiveRoute, activeRoute);
-        store.overrideSelector(getActiveNamespaceId, activeRouteId);
+        store.overrideSelector(getActiveNamespaceId, namespaceId);
         store.refreshState();
         getPathSpy.and.returnValue('/experiment/meow');
         // Changing tab.
@@ -399,8 +399,8 @@ describe('app_routing_effects', () => {
           actions.navigated({
             before: activeRoute,
             after: activeRoute,
-            beforeNamespaceId: activeRouteId,
-            afterNamespaceId: activeRouteId,
+            beforeNamespaceId: namespaceId,
+            afterNamespaceId: namespaceId,
           }),
         ]);
       }));
@@ -466,8 +466,8 @@ describe('app_routing_effects', () => {
                 pathname: '/experiment/meow',
                 queryParams: [],
               }),
-              beforeNamespaceId: getRouteId(RouteKind.EXPERIMENTS, {}),
-              afterNamespaceId: getRouteId(RouteKind.EXPERIMENT, {
+              beforeNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
+              afterNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENT, {
                 experimentId: 'meow',
               }),
             }),
@@ -518,7 +518,7 @@ describe('app_routing_effects', () => {
                 queryParams: [],
               }),
               beforeNamespaceId: null,
-              afterNamespaceId: getRouteId(RouteKind.EXPERIMENTS, {}),
+              afterNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
             }),
           ]);
         })
@@ -794,9 +794,12 @@ describe('app_routing_effects', () => {
                 queryParams: [],
               } as unknown as Route),
               beforeNamespaceId: null,
-              afterNamespaceId: getRouteId(RouteKind.COMPARE_EXPERIMENT, {
-                experimentIds: 'a:b',
-              }),
+              afterNamespaceId: getRouteNamespaceId(
+                RouteKind.COMPARE_EXPERIMENT,
+                {
+                  experimentIds: 'a:b',
+                }
+              ),
             }),
           ]);
         }));
@@ -845,9 +848,12 @@ describe('app_routing_effects', () => {
                 queryParams: [],
               }),
               beforeNamespaceId: null,
-              afterNamespaceId: getRouteId(RouteKind.COMPARE_EXPERIMENT, {
-                experimentIds: 'a:b',
-              }),
+              afterNamespaceId: getRouteNamespaceId(
+                RouteKind.COMPARE_EXPERIMENT,
+                {
+                  experimentIds: 'a:b',
+                }
+              ),
             }),
           ]);
         })
@@ -883,9 +889,12 @@ describe('app_routing_effects', () => {
               queryParams: [{key: 'a', value: 'a_value'}],
             }),
             beforeNamespaceId: null,
-            afterNamespaceId: getRouteId(RouteKind.COMPARE_EXPERIMENT, {
-              experimentIds: 'a:b',
-            }),
+            afterNamespaceId: getRouteNamespaceId(
+              RouteKind.COMPARE_EXPERIMENT,
+              {
+                experimentIds: 'a:b',
+              }
+            ),
           }),
         ]);
       }));
@@ -1169,7 +1178,7 @@ describe('app_routing_effects', () => {
       );
       store.overrideSelector(
         getActiveNamespaceId,
-        getRouteId(RouteKind.EXPERIMENTS, {})
+        getRouteNamespaceId(RouteKind.EXPERIMENTS, {})
       );
       store.refreshState();
 
@@ -1199,8 +1208,8 @@ describe('app_routing_effects', () => {
             pathname: '/experiments',
             queryParams: [],
           }),
-          beforeNamespaceId: getRouteId(RouteKind.EXPERIMENTS, {}),
-          afterNamespaceId: getRouteId(RouteKind.EXPERIMENTS, {}),
+          beforeNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
+          afterNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
         }),
       ]);
     }));
@@ -1285,9 +1294,9 @@ describe('app_routing_effects', () => {
           pathname: '/experiments',
           queryParams: [],
         });
-        const activeRouteId = getRouteId(RouteKind.EXPERIMENTS, {});
+        const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENTS, {});
         store.overrideSelector(getActiveRoute, activeRoute);
-        store.overrideSelector(getActiveNamespaceId, activeRouteId);
+        store.overrideSelector(getActiveNamespaceId, namespaceId);
         store.refreshState();
         getHashSpy.and.returnValue('');
         getPathSpy.and.returnValue('/experiments');
@@ -1305,9 +1314,9 @@ describe('app_routing_effects', () => {
           pathname: '/experiments',
           queryParams: [],
         });
-        const activeRouteId = getRouteId(RouteKind.EXPERIMENTS, {});
+        const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENTS, {});
         store.overrideSelector(getActiveRoute, activeRoute);
-        store.overrideSelector(getActiveNamespaceId, activeRouteId);
+        store.overrideSelector(getActiveNamespaceId, namespaceId);
         store.refreshState();
         getHashSpy.and.returnValue('');
         getPathSpy.and.returnValue('meow');
@@ -1328,9 +1337,9 @@ describe('app_routing_effects', () => {
           pathname: '/experiments',
           queryParams: [],
         });
-        const activeRouteId = getRouteId(RouteKind.EXPERIMENTS, {});
+        const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENTS, {});
         store.overrideSelector(getActiveRoute, activeRoute);
-        store.overrideSelector(getActiveNamespaceId, activeRouteId);
+        store.overrideSelector(getActiveNamespaceId, namespaceId);
         store.refreshState();
         getHashSpy.and.returnValue('');
         getPathSpy.and.returnValue('meow');
@@ -1365,16 +1374,16 @@ describe('app_routing_effects', () => {
       // This hash preservation spec may become obsolete. If we enable app_routing
       // to properly set the URL hash, and all TB embedders use app_routing, then
       // this spec can be removed.
-      it('preserves hash upon navigations to the same routeId', () => {
+      it('preserves hash upon navigations to the same experiment', () => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENT,
           pathname: '/experiment',
           params: {experimentId: '123'},
           queryParams: [],
         });
-        const activeRouteId = getRouteId(RouteKind.EXPERIMENT, {});
+        const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENT, {});
         store.overrideSelector(getActiveRoute, activeRoute);
-        store.overrideSelector(getActiveNamespaceId, activeRouteId);
+        store.overrideSelector(getActiveNamespaceId, namespaceId);
         store.refreshState();
         getHashSpy.and.returnValue('#foo');
         getPathSpy.and.returnValue('meow');
@@ -1389,16 +1398,16 @@ describe('app_routing_effects', () => {
         );
       });
 
-      it('discards hash upon navigations to a new routeId', () => {
+      it('discards hash upon navigations to a new experiment', () => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENTS,
           pathname: '/experiments',
           queryParams: [],
         });
-        const activeRouteId = getRouteId(RouteKind.EXPERIMENT, {});
+        const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENT, {});
 
         store.overrideSelector(getActiveRoute, activeRoute);
-        store.overrideSelector(getActiveNamespaceId, activeRouteId);
+        store.overrideSelector(getActiveNamespaceId, namespaceId);
         store.refreshState();
         getHashSpy.and.returnValue('#foo');
         getPathSpy.and.returnValue('meow');

--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -85,9 +85,14 @@ export function getExperimentIdsFromRouteParams(
 }
 
 /**
- * @deprecated Use areSameRouteKindAndExperiments.
+ * Generates a namespace id based on route information.
+ *
+ * To be used only by app_routing_effects.ts (and only temporarily).
  */
-export function getRouteId(routeKind: RouteKind, params: RouteParams): string {
+export function getRouteNamespaceId(
+  routeKind: RouteKind,
+  params: RouteParams
+): string {
   switch (routeKind) {
     case RouteKind.COMPARE_EXPERIMENT:
     case RouteKind.EXPERIMENT: {

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -123,7 +123,7 @@ describe('app_routing/utils', () => {
     });
   });
 
-  describe('getRouteId', () => {
+  describe('getRouteNamespaceId', () => {
     [
       {
         kind: RouteKind.COMPARE_EXPERIMENT,
@@ -147,27 +147,27 @@ describe('app_routing/utils', () => {
       },
     ].forEach(({kind, params, expectedVal}) => {
       it(`returns unique identifier for ${RouteKind[kind]}`, () => {
-        const actual = utils.getRouteId(kind, params);
+        const actual = utils.getRouteNamespaceId(kind, params);
         expect(actual).toBe(expectedVal);
       });
     });
 
     describe('COMPARE route', () => {
       it('returns stable id as long as id sets are the same', () => {
-        const id1 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
+        const id1 = utils.getRouteNamespaceId(RouteKind.COMPARE_EXPERIMENT, {
           experimentIds: 'foo:123,bar:456',
         });
-        const id2 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
+        const id2 = utils.getRouteNamespaceId(RouteKind.COMPARE_EXPERIMENT, {
           experimentIds: 'bar:456,foo:123',
         });
         expect(id1).toBe(id2);
       });
 
       it('does not differentiate compare of same eids with different display names', () => {
-        const id1 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
+        const id1 = utils.getRouteNamespaceId(RouteKind.COMPARE_EXPERIMENT, {
           experimentIds: 'foo:123',
         });
-        const id2 = utils.getRouteId(RouteKind.COMPARE_EXPERIMENT, {
+        const id2 = utils.getRouteNamespaceId(RouteKind.COMPARE_EXPERIMENT, {
           experimentIds: 'bar:123',
         });
         expect(id1).toBe(id2);

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
@@ -187,7 +187,8 @@ export function createRouteContextedState<
           !areSameRouteKindAndExperiments(before, after) &&
           onRouteKindOrExperimentsChanged
         ) {
-          // Experiments have changed. Delegate additional changes to the caller.
+          // RouteKind or Experiments have changed. Delegate additional changes
+          // to the caller.
           nextFullState = onRouteKindOrExperimentsChanged(nextFullState, after);
         }
 

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper.ts
@@ -73,8 +73,8 @@ export type RouteContextedState<
  * Utility for managing routeful states. It returns route contexted
  * `initialState` and `reducers` that help manage the routeful state.
  *
- * An optional `onRouteIdChanged` function will modify the state after it
- * is loaded from the cache.
+ * An optional `onRouteKindOrExperimentsChanged` function will modify the state
+ * after it is loaded from the cache.
  *
  * Example usage:
  *
@@ -96,7 +96,7 @@ export function createRouteContextedState<
 >(
   routefulInitialState: RoutefulState,
   nonRoutefulInitialState: NonRoutefulState,
-  onRouteIdChanged?: (
+  onRouteKindOrExperimentsChanged?: (
     state: RouteContextedState<RoutefulState, NonRoutefulState>,
     newRoute: Route
   ) => RouteContextedState<RoutefulState, NonRoutefulState>
@@ -185,10 +185,10 @@ export function createRouteContextedState<
 
         if (
           !areSameRouteKindAndExperiments(before, after) &&
-          onRouteIdChanged
+          onRouteKindOrExperimentsChanged
         ) {
-          // areSameRouteKindAndExperimentsperiments have changed. Delegate additional changes to the caller.
-          nextFullState = onRouteIdChanged(nextFullState, after);
+          // Experiments have changed. Delegate additional changes to the caller.
+          nextFullState = onRouteKindOrExperimentsChanged(nextFullState, after);
         }
 
         return nextFullState;

--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
@@ -29,7 +29,7 @@ import {
   createRouteContextedState,
   RouteContextedState,
 } from './route_contexted_reducer_helper';
-import {buildNavigatedToNewRouteIdAction, buildRoute} from './testing';
+import {buildNavigatedToNewExperimentAction, buildRoute} from './testing';
 import {RouteKind} from './types';
 
 interface RoutefulState {
@@ -301,7 +301,7 @@ describe('route_contexted_reducer_helper', () => {
     });
   });
 
-  describe('onRouteIdChanged', () => {
+  describe('onRouteKindOrExperimentsChanged', () => {
     it('transforms the state', () => {
       const {reducers: routeReducers} = createRouteContextedState<
         RoutefulState,
@@ -314,7 +314,10 @@ describe('route_contexted_reducer_helper', () => {
         routeful: 0,
         notRouteful: 1,
       };
-      const state2 = routeReducers(state1, buildNavigatedToNewRouteIdAction());
+      const state2 = routeReducers(
+        state1,
+        buildNavigatedToNewExperimentAction()
+      );
 
       expect(state2.routeful).toBe(999);
     });
@@ -339,7 +342,7 @@ describe('route_contexted_reducer_helper', () => {
         routeful: 0,
         notRouteful: 1,
       };
-      const state2 = reducers(state1, buildNavigatedToNewRouteIdAction());
+      const state2 = reducers(state1, buildNavigatedToNewExperimentAction());
 
       expect(state2.routeful).toBe(123);
     });

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -14,10 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {ExperimentAlias} from '../../experiments/types';
-import {
-  getExperimentIdsFromRouteParams,
-  getRouteId as getRouteIdFromKindAndParams,
-} from '../internal_utils';
+import {getExperimentIdsFromRouteParams} from '../internal_utils';
 import {
   getCompareExperimentIdAliasSpec,
   getCompareExperimentIdAliasWithNumberSpec,
@@ -83,17 +80,6 @@ export const getExperimentIdsFromRoute = createSelector(
   getRouteParams,
   (routeKind, routeParams): string[] | null => {
     return getExperimentIdsFromRouteParams(routeKind, routeParams);
-  }
-);
-
-/**
- * @deprecated Use getActiveRoute and, possibly, areSameRouteKindAndExperiments.
- */
-export const getRouteId = createSelector(
-  getRouteKind,
-  getRouteParams,
-  (routeKind, routeParams): string => {
-    return getRouteIdFromKindAndParams(routeKind, routeParams);
   }
 );
 

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -167,37 +167,6 @@ describe('app_routing_selectors', () => {
     });
   });
 
-  describe('getRouteId', () => {
-    beforeEach(() => {
-      selectors.getRouteId.release();
-    });
-
-    it('returns routeId from an activeRoute', () => {
-      const state = buildStateFromAppRoutingState(
-        buildAppRoutingState({
-          activeRoute: buildRoute({
-            routeKind: RouteKind.EXPERIMENT,
-            pathname: '/experiment/234',
-            params: {
-              experimentId: '234',
-            },
-            queryParams: [],
-          }),
-        })
-      );
-
-      expect(selectors.getRouteId(state)).toBe('2/234');
-    });
-
-    it('returns "__not_set" when it does not have an active one', () => {
-      const state = buildStateFromAppRoutingState(
-        buildAppRoutingState({activeRoute: null})
-      );
-
-      expect(selectors.getRouteId(state)).toBe('__not_set');
-    });
-  });
-
   describe('getRegisteredRouteKinds', () => {
     beforeEach(() => {
       selectors.getRegisteredRouteKinds.release();

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -61,10 +61,9 @@ export function buildNavigatedAction(overrides?: Partial<NavigatedPayload>) {
 }
 
 /**
- * A navigation that corresponds to a change in routeId (new route context)
- * will be created.
+ * Builds a navigated() event that corresponds to a change in experiment.
  */
-export function buildNavigatedToNewRouteIdAction() {
+export function buildNavigatedToNewExperimentAction() {
   const beforeRoute = buildRoute({
     routeKind: RouteKind.EXPERIMENT,
     params: {experimentId: 'abc'},

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -274,7 +274,7 @@ const {initialState, reducers: routeContextReducer} = createRouteContextedState<
     visibleCardMap: new Map<ElementId, CardId>(),
   },
 
-  /** onRouteIdChanged */
+  /** onRouteKindOrExperimentsChanged */
   (state) => {
     return {
       ...state,


### PR DESCRIPTION
After removing most of routeId in #5464 and then following up with changes to internal code, we can complete the removal of the term "RouteId". Notable changes:

* `getRouteId` ngrx selector is removed.

* `route_contexted_reducer_helper`'s `onRouteIdChanged` argument is renamed to `onRouteKindOrExperimentsChanged`.

* test helper function `buildNavigatedToNewRouteIdAction` is renamed to `buildNavigatedToNewExperimentAction`.

* The one remaining usage of "RouteId" is for generating namespace ids for App Routing. We therefore rename the internal function `getRouteId()` to `getRouteNamespaceId()` to signal the narrowed purpose of the function. Note that we will remove `getRouteNamespacedId()` with the launch of go/tb-timespaced-state.
