### PR TITLE
time-namespaced state: Update symbols in route_contexted_reducer_helper.

### DIFF
--- a/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/route_contexted_reducer_helper_test.ts
@@ -26,56 +26,60 @@ import {firstValueFrom} from 'rxjs';
 import {composeReducers} from '../util/ngrx';
 import {navigated} from './actions';
 import {
-  createRouteContextedState,
-  RouteContextedState,
+  createNamespaceContextedState,
+  NamespaceContextedState,
 } from './route_contexted_reducer_helper';
 import {buildNavigatedToNewExperimentAction, buildRoute} from './testing';
 import {RouteKind} from './types';
 
-interface RoutefulState {
-  routeful: number;
+interface NamespacedState {
+  namespaced: number;
 }
 
-interface NonRoutefulState {
-  notRouteful: number;
+interface NonNamespacedState {
+  nonNamespaced: number;
 }
 
-type ContextedState = RouteContextedState<RoutefulState, NonRoutefulState>;
+type ContextedState = NamespaceContextedState<
+  NamespacedState,
+  NonNamespacedState
+>;
 
-const incrementRouteful = createAction('[TEST] Toggle Routeful');
-const incrementNotRouteful = createAction('[TEST] Toggle Not Routeful');
+const incrementNamespaced = createAction('[TEST] Toggle Namespaced');
+const incrementNonNamespaced = createAction('[TEST] Toggle Not Namespaced');
 
-const {initialState, reducers: routeReducers} = createRouteContextedState<
-  RoutefulState,
-  NonRoutefulState
->({routeful: 0}, {notRouteful: 1});
+const {initialState, reducers: namespacedReducers} =
+  createNamespaceContextedState<NamespacedState, NonNamespacedState>(
+    {namespaced: 0},
+    {nonNamespaced: 1}
+  );
 
 const reducer = createReducer<ContextedState>(
   initialState,
-  on(incrementRouteful, (state) => {
-    return {...state, routeful: state.routeful + 1};
+  on(incrementNamespaced, (state) => {
+    return {...state, namespaced: state.namespaced + 1};
   }),
-  on(incrementNotRouteful, (state) => {
-    return {...state, notRouteful: state.notRouteful + 1};
+  on(incrementNonNamespaced, (state) => {
+    return {...state, nonNamespaced: state.nonNamespaced + 1};
   })
 );
 
-const reducers = composeReducers(routeReducers, reducer);
+const reducers = composeReducers(namespacedReducers, reducer);
 
 describe('route_contexted_reducer_helper', () => {
   describe('helper reducers', () => {
-    it('swaps routeful state in and out of cache', () => {
+    it('swaps namespaced state in and out of cache', () => {
       const state1 = {
-        routeful: 1,
-        notRouteful: 2,
+        namespaced: 1,
+        nonNamespaced: 2,
         privateNamespacedState: {
           namespace2: {
-            routeful: 10,
+            namespaced: 10,
           },
         },
       };
 
-      const state2 = routeReducers(
+      const state2 = namespacedReducers(
         state1,
         navigated({
           before: buildRoute({
@@ -93,9 +97,9 @@ describe('route_contexted_reducer_helper', () => {
         })
       );
 
-      expect(state2.routeful).toBe(10);
+      expect(state2.namespaced).toBe(10);
 
-      const state3 = routeReducers(
+      const state3 = namespacedReducers(
         state2,
         navigated({
           before: buildRoute({
@@ -113,17 +117,17 @@ describe('route_contexted_reducer_helper', () => {
         })
       );
 
-      expect(state3.routeful).toBe(1);
+      expect(state3.namespaced).toBe(1);
     });
 
-    it('sets routeful state to initialValue on cache miss', () => {
+    it('sets namespaced state to initialValue on cache miss', () => {
       const state = {
-        routeful: 2000,
-        notRouteful: 2,
+        namespaced: 2000,
+        nonNamespaced: 2,
         privateNamespacedState: {},
       };
 
-      const nextState = routeReducers(
+      const nextState = namespacedReducers(
         state,
         navigated({
           before: buildRoute({
@@ -141,20 +145,20 @@ describe('route_contexted_reducer_helper', () => {
         })
       );
 
-      expect(nextState.routeful).toBe(initialState.routeful);
+      expect(nextState.namespaced).toBe(initialState.namespaced);
     });
 
     it(
-      'does not modify routeful state on cache miss when `before` is empty ' +
+      'does not modify namespaced state on cache miss when `before` is empty ' +
         'since it can have value from deeplinks',
       () => {
         const state = {
-          routeful: 1337,
-          notRouteful: 2,
+          namespaced: 1337,
+          nonNamespaced: 2,
           privateNamespacedState: {},
         };
 
-        const nextState = routeReducers(
+        const nextState = namespacedReducers(
           state,
           navigated({
             before: null,
@@ -168,22 +172,22 @@ describe('route_contexted_reducer_helper', () => {
           })
         );
 
-        expect(nextState.routeful).toBe(1337);
+        expect(nextState.namespaced).toBe(1337);
       }
     );
 
-    it('modifies routeful state on cache hit even when `before` is null', () => {
+    it('modifies namespaced state on cache hit even when `before` is null', () => {
       const state1 = {
-        routeful: 2000,
-        notRouteful: 2,
+        namespaced: 2000,
+        nonNamespaced: 2,
         privateNamespacedState: {
           namespace1: {
-            routeful: 10,
+            namespaced: 10,
           },
         },
       };
 
-      const state2 = routeReducers(
+      const state2 = namespacedReducers(
         state1,
         navigated({
           before: null,
@@ -197,21 +201,21 @@ describe('route_contexted_reducer_helper', () => {
         })
       );
 
-      expect(state2.routeful).toBe(10);
+      expect(state2.namespaced).toBe(10);
     });
 
-    it('does not modify routeful state when navigating to same namespace', () => {
+    it('does not modify namespaced state when navigating to same namespace', () => {
       const state = {
-        routeful: 2000,
-        notRouteful: 2,
+        namespaced: 2000,
+        nonNamespaced: 2,
         privateNamespacedState: {
           namespace2: {
-            routeful: 3,
+            namespaced: 3,
           },
         },
       };
 
-      const nextState = routeReducers(
+      const nextState = namespacedReducers(
         state,
         navigated({
           before: buildRoute({
@@ -229,32 +233,32 @@ describe('route_contexted_reducer_helper', () => {
         })
       );
 
-      expect(nextState.routeful).toBe(2000);
-      expect(nextState.notRouteful).toBe(2);
+      expect(nextState.namespaced).toBe(2000);
+      expect(nextState.nonNamespaced).toBe(2);
     });
   });
 
   describe('integration', () => {
     it('does not change behavior of reducers', () => {
       const state = {
-        routeful: 1,
-        notRouteful: 10,
+        namespaced: 1,
+        nonNamespaced: 10,
         privateNamespacedState: {},
       };
-      const routefulNextState = reducers(state, incrementRouteful());
-      expect(routefulNextState.routeful).toBe(2);
+      const namespacedNextState = reducers(state, incrementNamespaced());
+      expect(namespacedNextState.namespaced).toBe(2);
 
-      const notRoutefulNextState = reducers(state, incrementNotRouteful());
-      expect(notRoutefulNextState.notRouteful).toBe(11);
+      const nonNamespacedNextState = reducers(state, incrementNonNamespaced());
+      expect(nonNamespacedNextState.nonNamespaced).toBe(11);
     });
 
     it('keeps helper reducers still functional', () => {
       const state1 = {
-        routeful: 1,
-        notRouteful: 2,
+        namespaced: 1,
+        nonNamespaced: 2,
         privateNamespacedState: {
           namespace2: {
-            routeful: 10,
+            namespaced: 10,
           },
         },
       };
@@ -277,7 +281,7 @@ describe('route_contexted_reducer_helper', () => {
         })
       );
 
-      expect(state2.routeful).toBe(10);
+      expect(state2.namespaced).toBe(10);
 
       const state3 = reducers(
         state2,
@@ -297,74 +301,78 @@ describe('route_contexted_reducer_helper', () => {
         })
       );
 
-      expect(state3.routeful).toBe(1);
+      expect(state3.namespaced).toBe(1);
     });
   });
 
   describe('onRouteKindOrExperimentsChanged', () => {
     it('transforms the state', () => {
-      const {reducers: routeReducers} = createRouteContextedState<
-        RoutefulState,
-        NonRoutefulState
-      >({routeful: 0}, {notRouteful: 1}, (state) => {
-        return {...state, routeful: 999};
+      const {reducers: namespacedReducers} = createNamespaceContextedState<
+        NamespacedState,
+        NonNamespacedState
+      >({namespaced: 0}, {nonNamespaced: 1}, (state) => {
+        return {...state, namespaced: 999};
       });
 
       const state1 = {
-        routeful: 0,
-        notRouteful: 1,
+        namespaced: 0,
+        nonNamespaced: 1,
       };
-      const state2 = routeReducers(
+      const state2 = namespacedReducers(
         state1,
         buildNavigatedToNewExperimentAction()
       );
 
-      expect(state2.routeful).toBe(999);
+      expect(state2.namespaced).toBe(999);
     });
 
     it('transforms state before reducers', () => {
-      const {initialState, reducers: routeReducers} = createRouteContextedState<
-        RoutefulState,
-        NonRoutefulState
-      >({routeful: 0}, {notRouteful: 1}, (state, route) => {
-        return {...state, routeful: 999};
-      });
+      const {initialState, reducers: namespacedReducers} =
+        createNamespaceContextedState<NamespacedState, NonNamespacedState>(
+          {namespaced: 0},
+          {nonNamespaced: 1},
+          (state, route) => {
+            return {...state, namespaced: 999};
+          }
+        );
 
       const reducer = createReducer<ContextedState>(
         initialState,
         on(navigated, (state) => {
-          return {...state, routeful: 123};
+          return {...state, namespaced: 123};
         })
       );
-      const reducers = composeReducers(routeReducers, reducer);
+      const reducers = composeReducers(namespacedReducers, reducer);
 
       const state1 = {
-        routeful: 0,
-        notRouteful: 1,
+        namespaced: 0,
+        nonNamespaced: 1,
       };
       const state2 = reducers(state1, buildNavigatedToNewExperimentAction());
 
-      expect(state2.routeful).toBe(123);
+      expect(state2.namespaced).toBe(123);
     });
 
     it('allows transformation with route information', () => {
-      const {initialState, reducers: routeReducers} = createRouteContextedState<
-        RoutefulState,
-        NonRoutefulState
-      >({routeful: 0}, {notRouteful: 1}, (state, route) => {
-        return {
-          ...state,
-          routeful: route.routeKind === RouteKind.EXPERIMENTS ? 7 : 999,
-        };
-      });
+      const {initialState, reducers: namespacedReducers} =
+        createNamespaceContextedState<NamespacedState, NonNamespacedState>(
+          {namespaced: 0},
+          {nonNamespaced: 1},
+          (state, route) => {
+            return {
+              ...state,
+              namespaced: route.routeKind === RouteKind.EXPERIMENTS ? 7 : 999,
+            };
+          }
+        );
 
       const noopReducer = createReducer<ContextedState>(initialState);
 
-      const reducers = composeReducers(routeReducers, noopReducer);
+      const reducers = composeReducers(namespacedReducers, noopReducer);
 
       const state1 = {
-        routeful: 0,
-        notRouteful: 1,
+        namespaced: 0,
+        nonNamespaced: 1,
       };
       const state2 = reducers(
         state1,
@@ -377,7 +385,7 @@ describe('route_contexted_reducer_helper', () => {
           afterNamespaceId: 'namespace1',
         })
       );
-      expect(state2.routeful).toBe(7);
+      expect(state2.namespaced).toBe(7);
 
       const state3 = reducers(
         state1,
@@ -393,7 +401,7 @@ describe('route_contexted_reducer_helper', () => {
           afterNamespaceId: 'namespace2',
         })
       );
-      expect(state3.routeful).toBe(999);
+      expect(state3.namespaced).toBe(999);
     });
   });
 });
@@ -419,8 +427,8 @@ describe('route_contexted_reducer_helper ngrx integration test', () => {
   it('contains correct initial value', async () => {
     const initialState = await firstValueFrom(store.select(selectAll));
     expect(initialState).toEqual({
-      routeful: 0,
-      notRouteful: 1,
+      namespaced: 0,
+      nonNamespaced: 1,
       privateNamespacedState: {},
     });
   });

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
-import {createRouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
+import {createNamespaceContextedState} from '../../app_routing/route_contexted_reducer_helper';
 import {metricsPromoGoToScalars} from '../../metrics/actions';
 import {globalSettingsLoaded} from '../../persistent_settings';
 import {DataLoadState} from '../../types/data';
@@ -174,12 +174,12 @@ const reducer = createReducer(
   })
 );
 
-// Core state is all routeful. None of it is routeless.
-const {reducers: routeContextReducer} = createRouteContextedState<
+// Core state is all namespaced. None of it is non-namespaced.
+const {reducers: namespaceContextedReducer} = createNamespaceContextedState<
   CoreState,
   {}
 >(initialState, {});
 
 export function reducers(state: CoreState | undefined, action: Action) {
-  return composeReducers(reducer, routeContextReducer)(state, action);
+  return composeReducers(reducer, namespaceContextedReducer)(state, action);
 }

--- a/tensorboard/webapp/hparams/_redux/types.ts
+++ b/tensorboard/webapp/hparams/_redux/types.ts
@@ -44,7 +44,7 @@ export const HPARAMS_FEATURE_KEY = 'hparams';
 export interface HparamsState {
   specs: ExperimentToHparams;
   /**
-   * RATIONALE: we do not use the RouteContextedState because of the following reasons.
+   * RATIONALE: we do not use the NamespaceContextedState because of the following reasons.
    * - RunsTable which uses the state renders both on the dashboard view and the
    *     experiments list view.
    * - For the RunsTable on the list view, we have to key the state by an experimentId
@@ -53,7 +53,7 @@ export interface HparamsState {
    * - For the dashboard view that supports comparison, we need to remember filter state
    *    when viewing multiple experiments separate from a single version one; while we can
    *    technically have a reasonable UX, it makes things more complex.
-   * - We can use RouteContextedState to separate single experiment filter selection to be
+   * - We can use NamespaceContextedState to separate single experiment filter selection to be
    *    separate for the list and the dashboard views, but them shared is not too bad.
    */
   filters: {

--- a/tensorboard/webapp/metrics/store/metrics_initial_state_provider.ts
+++ b/tensorboard/webapp/metrics/store/metrics_initial_state_provider.ts
@@ -37,8 +37,9 @@ export function getConfig(
 
   return {
     initialState: {
-      // For other states, please make sure you only provide the routeless state. Routeful
-      // initial state cannot be dependency injected as of right now.
+      // For other states, please make sure you only provide the non-namespaced
+      // state. Namespaced initial state cannot be dependency injected as of
+      // right now.
       ...INITIAL_STATE,
       settings,
     },

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {RouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
+import {NamespaceContextedState} from '../../app_routing/route_contexted_reducer_helper';
 import {DataLoadState, LoadState} from '../../types/data';
 import {ElementId} from '../../util/dom';
 import {
@@ -132,7 +132,7 @@ export interface StoreInternalLinkedTime {
   end: {step: number};
 }
 
-export interface MetricsRoutefulState {
+export interface MetricsNamespacedState {
   tagMetadataLoadState: LoadState;
   tagMetadata: TagMetadata;
   // A list of card ids in the main content area, excluding pinned copies.
@@ -196,7 +196,7 @@ export interface MetricsSettings {
   histogramMode: HistogramMode;
 }
 
-export interface MetricsRoutelessState {
+export interface MetricsNonNamespacedState {
   promoteTimeSeries: boolean;
   timeSeriesData: TimeSeriesData;
   isSettingsPaneOpen: boolean;
@@ -210,9 +210,9 @@ export interface MetricsRoutelessState {
   visibleCardMap: Map<ElementId, CardId>;
 }
 
-export type MetricsState = RouteContextedState<
-  MetricsRoutefulState,
-  MetricsRoutelessState
+export type MetricsState = NamespaceContextedState<
+  MetricsNamespacedState,
+  MetricsNonNamespacedState
 >;
 
 export interface State {

--- a/tensorboard/webapp/runs/store/runs_types.ts
+++ b/tensorboard/webapp/runs/store/runs_types.ts
@@ -16,7 +16,7 @@ limitations under the License.
  * @fileoverview Types of experiments that come from the backend.
  */
 
-import {RouteContextedState} from '../../app_routing/route_contexted_reducer_helper';
+import {NamespaceContextedState} from '../../app_routing/route_contexted_reducer_helper';
 import {LoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
 import {HparamValue} from '../data_source/runs_data_source_types';
@@ -46,7 +46,7 @@ export type RunId = string;
 // 'RouteKey' is a serialization of multiple experiment IDs.
 export type RouteKey = string;
 
-export interface RunsDataRoutefulState {
+export interface RunsDataNamespacedState {
   defaultRunColorIdForGroupBy: Map<RunId, number>;
   // Monotonically increasing opaque id that uniquely identifies color that can
   // be used as an index, starting from 0. -1 is a reversed to denote no matches
@@ -60,7 +60,7 @@ export interface RunsDataRoutefulState {
   regexFilter: string;
 }
 
-export interface RunsDataRoutelessState {
+export interface RunsDataNonNamespacedState {
   runIds: Record<ExperimentId, RunId[]>;
   runIdToExpId: Record<RunId, ExperimentId>;
   runMetadata: Record<RunId, Run>;
@@ -81,24 +81,24 @@ export interface RunsDataRoutelessState {
 /**
  * Interface that describes shape of the `data` state in the runs feature.
  */
-export type RunsDataState = RouteContextedState<
-  RunsDataRoutefulState,
-  RunsDataRoutelessState
+export type RunsDataState = NamespaceContextedState<
+  RunsDataNamespacedState,
+  RunsDataNonNamespacedState
 >;
 
-export interface RunsUiRoutefulState {
+export interface RunsUiNamespacedState {
   paginationOption: {pageIndex: number; pageSize: number};
   sort: {key: SortKey | null; direction: SortDirection};
 }
 
-export interface RunsUiRoutelessState {}
+export interface RunsUiNonNamespacedState {}
 
 /**
  * Interface that describes shape of the `ui` state in the runs feature.
  */
-export type RunsUiState = RouteContextedState<
-  RunsUiRoutefulState,
-  RunsUiRoutelessState
+export type RunsUiState = NamespaceContextedState<
+  RunsUiNamespacedState,
+  RunsUiNonNamespacedState
 >;
 
 /**


### PR DESCRIPTION
Update route_contexted_reducer_helper to use "Namespace" instead of "Route" for symbols. Try to update the remainder of the code base to match. At a high level, make the following replacements in the code:

RouteContexted => NamespaceContexted
Routeful => Namespaced
Routeless => NonNamespaced

Also update the documentation in route_contexted_reducer_helper to reflect the "Namespace" concept and be less route-centric.

We do not update the file names (route_contexted_reducer_helper(_test).ts) at the moment but will in a subsequent change.

Note that this change should be safe to import into the Google-internal repo after cl/417855741 is submitted.