### PR TITLE
Cherry-pick: Update tensorboard compat protos using tensorflow v2.8.0-rc0. (#5484)

### DIFF
--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -63,12 +63,18 @@ tb_proto_library(
     srcs = ["config.proto"],
     deps = [
         ":cluster",
+        ":coordination_config",
         ":cost_graph",
         ":debug",
         ":graph",
         ":rewriter_config",
         ":step_stats",
     ],
+)
+
+tb_proto_library(
+    name = "coordination_config",
+    srcs = ["coordination_config.proto"],
 )
 
 tb_proto_library(
@@ -296,6 +302,7 @@ tb_proto_library(
         ":attr_value",
         ":cluster",
         ":config",
+        ":coordination_config",
         ":cost_graph",
         ":cpp_shape_inference",
         ":debug",

--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -6,6 +6,7 @@ import "tensorboard/compat/proto/cost_graph.proto";
 import "tensorboard/compat/proto/graph.proto";
 import "tensorboard/compat/proto/step_stats.proto";
 import "tensorboard/compat/proto/cluster.proto";
+import "tensorboard/compat/proto/coordination_config.proto";
 import "tensorboard/compat/proto/debug.proto";
 import "tensorboard/compat/proto/rewriter_config.proto";
 
@@ -668,9 +669,9 @@ message ConfigProto {
     // Whether runtime execution uses TFRT.
     bool use_tfrt = 18;
 
-    // Distributed coordination service to be enabled if set.
-    // Currently only effective in multi-client setup.
-    string coordination_service = 19;
+    // The field "coordination_service was previously specified as a string;
+    // this has been replaced with a message below.
+    reserved 19;
 
     // We removed the flag fetch_remote_devices_in_multi_client. Marking the tag
     // number as reserved.
@@ -681,7 +682,14 @@ message ConfigProto {
     // kernels may not be loaded due to selective registration.
     bool disable_functional_ops_lowering = 21;
 
-    // Next: 22
+    // Provides a hint to XLA auto clustering to prefer forming a single large
+    // cluster that encompases most of the graph.
+    bool xla_prefer_single_graph_cluster = 22;
+
+    // Distributed coordination service configurations.
+    CoordinationServiceConfig coordination_config = 23;
+
+    // Next: 24
   }
 
   Experimental experimental = 16;

--- a/tensorboard/compat/proto/coordination_config.proto
+++ b/tensorboard/compat/proto/coordination_config.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package tensorboard;
+
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
+
+// Coordination service configuration parameters.
+// The system picks appropriate values for fields that are not set.
+message CoordinationServiceConfig {
+  // Type of coordination service implementation to enable.
+  // For example, setting the service type as "standalone" starts a service
+  // instance on the leader task to provide the coordination services such as
+  // heartbeats and consistent key-value store.
+  string service_type = 1;
+
+  // Address where the coordination service instance is hosted.
+  string service_leader = 2;
+
+  // Whether to enable the health check mechanism.
+  bool enable_health_check = 3;
+
+  // Maximum wait time for all members in the cluster to be registered.
+  int64 cluster_register_timeout_in_ms = 4;
+
+  // Heartbeat timeout, if a worker does not record heartbeat in this time
+  // window, it will be considered disconnected.
+  int64 heartbeat_timeout_in_ms = 5;
+
+  // The list of jobs that partipate in the coordination service. If empty, all
+  // jobs will be included in the coordination service by default.
+  repeated string coordinated_jobs = 6;
+}

--- a/tensorboard/compat/proto/full_type.proto
+++ b/tensorboard/compat/proto/full_type.proto
@@ -25,7 +25,7 @@ enum FullTypeId {
   //   TFT_TENSOR[TFT_VAR["T"]], TFT_TENSOR[TFT_VAR["T"]] are two tensors of
   //     identical element types.
   //   TFT_TENSOR[TFT_VAR["P"]], TFT_TENSOR[TFT_VAR["Q"]] are two tensors of
-  //     potentially different element types.
+  //     independent element types.
   //
   TFT_VAR = 1;
 
@@ -61,6 +61,28 @@ enum FullTypeId {
   //     is a structure with two fields, an int tensor "foo" and a float tensor
   //     "bar".
   TFT_NAMED = 4;
+
+  // Template definition. Expands the variables by repeating a template as
+  // arguments of container.
+  //
+  // Parametrization:
+  //   TFT_FOR_EACH[<container_type>, <template>, <expansions>]
+  //   * <container_type> is the type of the container that the template will be
+  //     expanded into
+  //   * <template> is any type definition that potentially contains type
+  //     variables
+  //   * <expansions> is a TFT_VAR and may include more types in the future
+  //
+  // Example:
+  //   TFT_FOR_EACH[
+  //         TFT_PRODUCT,
+  //         TFT_TENSOR[TFT_VAR["t"]],
+  //         TFT_VAR["t"]
+  //     ]
+  //     will substitute a T = TFT_INT32 to TFT_PRODUCT[TFT_TENSOR[TFT_INT32]]
+  //     and a T = (TFT_INT32, TFT_INT64) to
+  //     TFT_PRODUCT[TFT_TENSOR[TFT_INT32], TFT_TENSOR[TFT_INT64]].
+  TFT_FOR_EACH = 20;
 
   // Callable types describe functions and ops.
   //
@@ -151,39 +173,6 @@ enum FullTypeId {
   //   TFT_LITERAL[TFT_INT32]{1} is the compile-time constant 1.
   TFT_LITERAL = 1003;
 
-  // Datasets created by tf.data ops and APIs. Datasets have generator/iterable
-  // semantics, that is, one can construct an iterator from them. Like
-  // Array, they are considered to return elements that can be described
-  // by a single type. Unlike Array, they do not support random access or
-  // mutation, and can potentially produce an infinite number of elements.
-  // A datasets can produce logical structures (e.g. multiple elements). This
-  // is expressed using TFT_PRODUCT.
-  //
-  //
-  // Parametrization: TFT_ARRAY[<element type>].
-  //   * <element type> may be a concrete type or a type symbol. It represents
-  //     the data type of the elements produced by the dataset.
-  //
-  // Examples:
-  //   TFT_DATSET[TFT_TENSOR[TFT_INT32]] is a Dataset producing single int32
-  //     Tensors of unknown shape.
-  //   TFT_DATSET[TFT_PRODUCT[TFT_TENSOR[TFT_INT32], TFT_TENSOR[TFT_FLOAT32]] is
-  //     a Dataset producing pairs of Tensors, one integer and one float.
-  // Note: The high ID number is to prepare for the eventuality that Datasets
-  // will be supported by user types in the future.
-  TFT_DATASET = 10102;
-
-  // A mutex lock tensor, produced by tf.raw_ops.MutexLock.
-  // Unlike strict execution models, where ownership of a lock is denoted by
-  // "running after the lock has been acquired", in non-strict mode, lock
-  // ownership is in the true sense: "the op argument representing the lock is
-  // available".
-  // Mutex locks are the dynamic counterpart of control dependencies.
-  // TODO(mdan): Properly document this thing.
-  //
-  // Parametrization: TFT_MUTEX_LOCK[].
-  TFT_MUTEX_LOCK = 10202;
-
   // Type attributes. These always appear in the parametrization of a type,
   // never alone. For example, there is no such thing as a "bool" TensorFlow
   // object (for now).
@@ -211,6 +200,56 @@ enum FullTypeId {
   TFT_COMPLEX128 = 213;
   // The string element type.
   TFT_STRING = 214;
+
+  // Other types that we don't know yet whether they will become part of the
+  // core type system or be consisdered third-party (and consequently moved to
+  // user-defined type mechanisms). Presently, they are effectively in the core
+  // type system, because key compilation passes like Placer account for their
+  // existence.
+
+  // Datasets created by tf.data ops and APIs. Datasets have generator/iterable
+  // semantics, that is, one can construct an iterator from them. Like
+  // Array, they are considered to return elements that can be described
+  // by a single type. Unlike Array, they do not support random access or
+  // mutation, and can potentially produce an infinite number of elements.
+  // A datasets can produce logical structures (e.g. multiple elements). This
+  // is expressed using TFT_PRODUCT.
+  //
+  //
+  // Parametrization: TFT_ARRAY[<element type>].
+  //   * <element type> may be a concrete type or a type symbol. It represents
+  //     the data type of the elements produced by the dataset.
+  //
+  // Examples:
+  //   TFT_DATSET[TFT_TENSOR[TFT_INT32]] is a Dataset producing single int32
+  //     Tensors of unknown shape.
+  //   TFT_DATSET[TFT_PRODUCT[TFT_TENSOR[TFT_INT32], TFT_TENSOR[TFT_FLOAT32]] is
+  //     a Dataset producing pairs of Tensors, one integer and one float.
+  // Note: The high ID number is to prepare for the eventuality that Datasets
+  // will be supported by user types in the future.
+  TFT_DATASET = 10102;
+
+  // A ragged tensor created by tf.ragged ops and APIs.
+  //
+  // Parametrization: TFT_RAGGED[<element_type>].
+  TFT_RAGGED = 10103;
+
+  // A mutex lock tensor, produced by tf.raw_ops.MutexLock.
+  // Unlike strict execution models, where ownership of a lock is denoted by
+  // "running after the lock has been acquired", in non-strict mode, lock
+  // ownership is in the true sense: "the op argument representing the lock is
+  // available".
+  // Mutex locks are the dynamic counterpart of control dependencies.
+  // TODO(mdan): Properly document this thing.
+  //
+  // Parametrization: TFT_MUTEX_LOCK[].
+  TFT_MUTEX_LOCK = 10202;
+
+  // The equivalent of a Tensor with DT_VARIANT dtype, kept here to simplify
+  // translation. This type should not normally appear after type inference.
+  // Note that LEGACY_VARIANT != ANY: TENSOR[INT32] is a subtype of ANY, but is
+  // not a subtype of LEGACY_VARIANT.
+  TFT_LEGACY_VARIANT = 10203;
 }
 
 // Highly experimental and very likely to change.

--- a/tensorboard/compat/proto/rewriter_config.proto
+++ b/tensorboard/compat/proto/rewriter_config.proto
@@ -104,6 +104,12 @@ message RewriterConfig {
   // This will try to use bfloat16 on CPUs, which is faster.
   // Note that this can change the numerical stability of the graph.
   Toggle auto_mixed_precision_mkl = 25;
+  // Emulate a model using data type float16 on CPU (default is OFF).
+  // This will try to emulate the float16 inputs and outputs of an operator
+  // on CPU to have better correlation with float16 on GPU; however the
+  // computation in the operator is based on float32.
+  // Note that this can change the numerical stability of the graph.
+  Toggle auto_mixed_precision_cpu = 29;
   // Disable the entire meta optimizer (off by default).
   bool disable_meta_optimizer = 19;
   // Optimizers registered by plugin (default is ON)

--- a/tensorboard/compat/proto/saved_object_graph.proto
+++ b/tensorboard/compat/proto/saved_object_graph.proto
@@ -41,6 +41,12 @@ message SavedObject {
   // Note: currently only valid if kind == "user_object" or "resource".
   repeated TrackableObjectGraph.TrackableObject.ObjectReference children = 1;
 
+  // Ordered list of dependencies that must be loaded before this object.
+  // SavedModel loads with the bottom-up approach, by first creating all objects
+  // (in the order defined by the dependencies), then connecting the edges.
+  repeated TrackableObjectGraph.TrackableObject.ObjectReference dependencies =
+      15;
+
   // Removed when forking SavedObject from TrackableObjectGraph.
   reserved "attributes";
   reserved 2;
@@ -64,12 +70,26 @@ message SavedObject {
     CapturedTensor captured_tensor = 12;
   }
 
+  // Stores the functions used to save and restore this object. At most one of
+  // `saveable_objects` or `registered_saver` is defined for each SavedObject.
+  // See the comment below for the difference between SaveableObject and
+  // registered savers.
   map<string, SaveableObject> saveable_objects = 11;
 
   // The fields below are filled when the user serializes a registered Trackable
-  // class. Registered classes may save additional metadata and supersede the
-  // default loading process where nodes are recreated from the proto.
+  // class or an object with a registered saver function.
   //
+  // Registered classes may save additional metadata and supersede the
+  // default loading process where nodes are recreated from the proto.
+  // If the registered class cannot be found, then the object will load as one
+  // one of the default trackable objects: Autotrackable (a class similar to
+  // tf.Module), tf.function, or tf.Variable.
+  //
+  // Unlike SaveableObjects, which store the functions for saving and restoring
+  // from tensors, registered savers allow Trackables to write checkpoint shards
+  // directly (e.g. for performance or coordination reasons).
+  // *All registered savers must be available when loading the SavedModel.*
+
   // The name of the registered class of the form "{package}.{class_name}".
   // This field is used to search for the registered class at loading time.
   string registered_name = 13;
@@ -77,6 +97,10 @@ message SavedObject {
   // the registered classes's _deserialize_from_proto method when this object is
   // loaded from the SavedModel.
   google.protobuf.Any serialized_user_proto = 14;
+
+  // String name of the registered saver. At most one of `saveable_objects` or
+  // `registered_saver` is defined for each SavedObject.
+  string registered_saver = 16;
 }
 
 // A SavedUserObject is an object (in the object-oriented language of the
@@ -220,6 +244,7 @@ message SavedResource {
 
 message SaveableObject {
   // Node ids of concrete functions for saving and loading from a checkpoint.
+  // These functions save and restore directly from tensors.
   int32 save_function = 2;
   int32 restore_function = 3;
 }

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -149,7 +149,7 @@ message TypeSpecProto {
   //  * If type_spec_class == REGISTERED_TYPE_SPEC, the TypeSpec class is
   //    the one registered under this name. For types registered outside
   //    core TensorFlow by an add-on library, that library must be loaded
-  //    before this value can be deserialized by StructureCoder.
+  //    before this value can be deserialized by nested_structure_coder.
   //  * If type_spec_class specifies a particular TypeSpec class, this field is
   //    redundant with the type_spec_class enum, and is only used for error
   //    reporting in older binaries that do not know the tupe_spec_class enum.

--- a/tensorboard/compat/proto/trackable_object_graph.proto
+++ b/tensorboard/compat/proto/trackable_object_graph.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package tensorboard;
 
+import "google/protobuf/wrappers.proto";
+
 option cc_enable_arenas = true;
 option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
@@ -54,7 +56,25 @@ message TrackableObjectGraph {
     repeated SerializedTensor attributes = 2;
     // Slot variables owned by this object.
     repeated SlotVariableReference slot_variables = 3;
+
+    // The registered saver used to save this object. If this saver is not
+    // present when loading the checkpoint, then loading will fail.
+    RegisteredSaver registered_saver = 4;
+
+    // Whether this object has checkpoint values or descendants with checkpoint
+    // values. This is computed at save time to avoid traversing the entire
+    // object graph proto when restoring (which also has to traverse the live
+    // object graph).
+    google.protobuf.BoolValue has_checkpoint_values = 5;
   }
 
   repeated TrackableObject nodes = 1;
+}
+
+message RegisteredSaver {
+  // The name of the registered saver/restore function.
+  string name = 1;
+
+  // Unique auto-generated name of the object.
+  string object_name = 2;
 }


### PR DESCRIPTION
Cherry-picked from master.

In preparation for TensorBoard 2.8.0 release we update our compat protos to match tensorflow v2.8.0-rc0.
