### PR TITLE
chore: Update 2.8 branch CI to use tensorflow 2.8.0rc0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tf_version_id: ['tf', 'notf']
+        tf_version_id: ['tensorflow==2.8.0rc0', 'notf']
         python_version: ['3.7']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e


### PR DESCRIPTION
Follow release instructions to update CI configuration for 2.8 branch to refer to tensorflow 2.8 release candidate.