### PR TITLE
chore: Upgrade html5lib to version 1.1.

### DIFF
--- a/third_party/html5lib.BUILD
+++ b/third_party/html5lib.BUILD
@@ -16,7 +16,6 @@ py_library(
         "html5lib/_tokenizer.py",
         "html5lib/_trie/__init__.py",
         "html5lib/_trie/_base.py",
-        "html5lib/_trie/datrie.py",
         "html5lib/_trie/py.py",
         "html5lib/_utils.py",
         "html5lib/constants.py",

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -47,10 +47,11 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_html5lib",
         urls = [
-            "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz",
+            "http://mirror.tensorflow.org/github.com/html5lib/html5lib-python/archive/1.1.tar.gz",
+            "https://github.com/html5lib/html5lib-python/archive/1.1.tar.gz",
         ],
-        sha256 = "b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f",
-        strip_prefix = "html5lib-1.1",
+        sha256 = "66e9e24a53c10c27abb6be8a3cf2cf55824c6ea1cef8570a633cb223ec46e894",
+        strip_prefix = "html5lib-python-1.1",
         build_file = str(Label("//third_party:html5lib.BUILD")),
     )
 

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -47,11 +47,10 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_html5lib",
         urls = [
-            "http://mirror.tensorflow.org/github.com/html5lib/html5lib-python/archive/1.0.1.tar.gz",
-            "https://github.com/html5lib/html5lib-python/archive/1.0.1.tar.gz",
+            "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz",
         ],
-        sha256 = "fabbebd6a55d07842087f13849076eeed350aa8bb6c9ec840f6a6aba9388db06",
-        strip_prefix = "html5lib-python-1.0.1",
+        sha256 = "b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f",
+        strip_prefix = "html5lib-1.1",
         build_file = str(Label("//third_party:html5lib.BUILD")),
     )
 


### PR DESCRIPTION
As noted by https://github.com/tensorflow/tensorboard/issues/5478 , tensorboard fails when run in a python 3.10 environment. The reporter fortunately discovered that the problems would be fixed with an upgrade of our html5lib dependency.

I tested by building a python3.10 virtualenv on my machine (this required building python 3.10 from source as we don't have it natively).

```
$ virtualenv -p /usr/local/bin/python3.10 ~/virtualenv/tensorboard-python-3.10
$ source ~/virtualenv/tensorboard-python-3.10/bin/activate
$ python3.10 -m ensurepip --upgrade
$ python3.10 -m pip install tensorboard
$ tensorboard --version
Traceback (most recent call last):
  File "/usr/local/google/home/bdubois/virtualenv/tensorboard-python-3.10/bin/tensorboard", line 5, in <module>
    from tensorboard.main import run_main
<snip>
    from collections import Mapping
ImportError: cannot import name 'Mapping' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
$ python3.10 -m pip install --upgrade /tmp/tb-with-html5lib-1.1/tensorboard*.whl
$ tensorboard --version
TensorFlow installation not found - running with reduced feature set.
2.8.0a0
```

I also ran the tensorboard with some logdirs and did some basic sanity. I specifically checked that markdown rendering seemed to be working for a couple text plugin logs that I have.
