### PR TITLE
gfile: conditionally import tensorflow_io

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -36,6 +36,7 @@ py_library(
         ":data_provider",
         ":event_multiplexer",
         ":tag_types",
+        "//tensorboard/compat:tensorflow",
         "//tensorboard/data:ingester",
         "//tensorboard/plugins/audio:metadata",
         "//tensorboard/plugins/histogram:metadata",
@@ -53,7 +54,9 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":data_ingester",
+        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
+        "//tensorboard/compat:tensorflow",
     ],
 )
 

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -204,14 +204,15 @@ def _parse_event_files_spec(logdir_spec):
 
 
 def _get_filesystem_scheme(path):
-    """Extracts filesystem from a given path.
+    """Extracts filesystem scheme from a given path.
+
+    The filesystem scheme is usually separated by `://` from the local filesystem
+    path if given. For example, the scheme of `file://tmp/tf` is `file`.
 
     Args:
         path: A strings representing an input log directory.
     Returns:
-        Filesystem scheme, None if the path doesn't contain one. The filesystem
-        scheme is usually separated by `://` from the local filesystem path if
-        given. For example, the scheme of `file://tmp/tf` is `file`.
+        Filesystem scheme, None if the path doesn't contain one.
     """
     if "://" not in path:
         return None

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -88,7 +88,7 @@ class LocalDataIngester(ingester.DataIngester):
         if not getattr(tf, "__version__", "stub") == "stub":
             if not _cloud_fs_supported():
                 try:
-                    import tensorflow_io as tfio
+                    import tensorflow_io  # pylint: disable=unused-import
                 except:
                     warning_msg = (
                         "`tensorflow_io` is not installed, for additional file "

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -88,7 +88,7 @@ class LocalDataIngester(ingester.DataIngester):
         if not getattr(tf, "__version__", "stub") == "stub":
             if not _cloud_fs_supported():
                 try:
-                    import tensorflow_io
+                    import tensorflow_io as tfio
                 except:
                     warning_msg = (
                         "`tensorflow_io` is not installed, for additional file "

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -82,10 +82,7 @@ class LocalDataIngester(ingester.DataIngester):
 
         # Conditionally import tensorflow_io.
         if not getattr(tf, "__version__", "stub") == "stub":
-            tfio_filesystems = _check_filesystem_support(
-                self._path_to_run.keys()
-            )
-            _try_to_support_tfio(self._path_to_run.keys())
+            _check_filesystem_support(self._path_to_run.keys())
 
     @property
     def data_provider(self):

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -88,7 +88,7 @@ class LocalDataIngester(ingester.DataIngester):
         if not getattr(tf, "__version__", "stub") == "stub":
             if not _cloud_fs_supported():
                 try:
-                    import tensorflow_io  # pylint: disable=unused-import
+                    import tensorflow_io  # noqa: F401
                 except:
                     warning_msg = (
                         "`tensorflow_io` is not installed, for additional file "

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -252,119 +252,87 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
             )
 
 
-class TfioSupport(tb_test.TestCase):
+class FileSystemSupport(tb_test.TestCase):
     def testCheckFilesystemSupport(self):
-        self.assertEqual(
-            ["s3"],
-            data_ingester._check_filesystem_support(
-                ["tmp/demo", "s3://bucket/123", "file://tmp"]
-            ),
-        )
-
-    def testTryToSupportTfio(self):
-        with mock.patch.object(tf.io, "gfile") as gfile_mock:
-            gfile_mock.return_value.get_registered_schemes = mock.MagicMock()
-            with mock.patch(
-                "builtins.__import__", side_effect=mock.MagicMock()
-            ) as mock_import:
-                with mock.patch.object(
-                    gfile_mock,
-                    "get_registered_schemes",
-                    return_value=["gs", "s3"],
-                ) as mock_get_registered_schemes:
-                    data_ingester._try_to_support_tfio(
-                        ["tmp/demo", "s3://bucket/123"]
-                    )
+        with mock.patch.object(
+            tf.io.gfile,
+            "get_registered_schemes",
+            return_value=["gs", "s3"],
+        ) as mock_get_registered_schemes:
+            with mock.patch("builtins.__import__") as mock_import:
+                data_ingester._check_filesystem_support(
+                    ["tmp/demo", "s3://bucket/123"]
+                )
         mock_import.assert_not_called()
         mock_get_registered_schemes.assert_called_once()
 
-    def testTryToSupportTfio_import(self):
-        with mock.patch.object(tf.io, "gfile") as gfile_mock:
-            gfile_mock.return_value.get_registered_schemes = mock.MagicMock()
-            with mock.patch(
-                "builtins.__import__", side_effect=mock.MagicMock()
-            ) as mock_import:
-                with mock.patch.object(
-                    gfile_mock,
-                    "get_registered_schemes",
-                    return_value=["file", ""],
-                ) as mock_get_registered_schemes:
-                    data_ingester._try_to_support_tfio(
-                        ["tmp/demo", "s3://bucket/123"]
-                    )
+    def testCheckFilesystemSupport_importTFIO(self):
+        with mock.patch.object(
+            tf.io.gfile,
+            "get_registered_schemes",
+            return_value=["file", ""],
+        ) as mock_get_registered_schemes:
+            with mock.patch("builtins.__import__") as mock_import:
+                data_ingester._check_filesystem_support(
+                    ["tmp/demo", "s3://bucket/123"]
+                )
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])
         mock_get_registered_schemes.assert_called_once()
 
-    def testTryToSupportTfio_raiseError(self):
-        with mock.patch.object(tf.io, "gfile") as gfile_mock:
-            gfile_mock.return_value.get_registered_schemes = mock.MagicMock()
+    def testCheckFilesystemSupport_raiseError(self):
+        with mock.patch.object(
+            tf.io.gfile,
+            "get_registered_schemes",
+            return_value=["file", "ram"],
+        ) as mock_get_registered_schemes:
             with mock.patch(
                 "builtins.__import__",
                 side_effect=ImportError,
             ) as mock_import:
-                with mock.patch.object(
-                    gfile_mock,
-                    "get_registered_schemes",
-                    return_value=["file", "ram"],
-                ) as mock_get_registered_schemes:
-                    err_msg = (
-                        "Error: Unsupported filename scheme 's3' (supported schemes: ['file', 'ram'])."
-                        + " For additional filesystem support, consider installing TensorFlow I/O"
-                        + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
+                err_msg = (
+                    "Error: Unsupported filename scheme 's3' (supported schemes: ['file', 'ram'])."
+                    + " For additional filesystem support, consider installing TensorFlow I/O"
+                    + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
+                )
+                with self.assertRaisesWithLiteralMatch(
+                    tf.errors.UnimplementedError, err_msg
+                ):
+                    data_ingester._check_filesystem_support(
+                        ["tmp/demo", "s3://bucket/123"]
                     )
-                    with self.assertRaisesWithLiteralMatch(
-                        tf.errors.UnimplementedError, err_msg
-                    ):
-                        data_ingester._try_to_support_tfio(
-                            ["tmp/demo", "s3://bucket/123"]
-                        )
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])
         mock_get_registered_schemes.assert_called_once()
 
-    def testTryToSupportTfio_fallback(self):
-        with mock.patch.object(
-            tf.io.gfile, "get_registered_schemes"
-        ) as mock_get_registered_schemes:
-            mock_get_registered_schemes.return_value = None
-            with mock.patch(
-                "builtins.__import__", side_effect=mock.MagicMock()
-            ) as mock_import:
-                with mock.patch.object(
-                    tf.io.gfile,
-                    "exists",
-                    return_value=True,
-                ) as mock_gfile_exists:
-                    data_ingester._try_to_support_tfio(["gs://bucket/abc"])
+    def testCheckFilesystemSupport_fallback(self):
+        with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:
+            del mock_gfile.get_registered_schemes
+            with mock.patch("builtins.__import__") as mock_import:
+                mock_gfile.exists.return_value = True
+                data_ingester._check_filesystem_support(["gs://bucket/abc"])
         mock_import.assert_not_called()
-        mock_gfile_exists.assert_called_once_with("gs://bucket/abc")
+        mock_gfile.exists.assert_called_once_with("gs://bucket/abc")
 
-    def testTryToSupportTfio_fallback_raiseError(self):
-        with mock.patch.object(
-            tf.io.gfile, "get_registered_schemes"
-        ) as mock_get_registered_schemes:
-            mock_get_registered_schemes.return_value = None
+    def testCheckFilesystemSupport_fallback_raiseError(self):
+        with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:
+            del mock_gfile.get_registered_schemes
             with mock.patch(
                 "builtins.__import__",
                 side_effect=ImportError,
             ) as mock_import:
-                with mock.patch.object(
-                    tf.io.gfile,
-                    "exists",
-                    side_effect=tf.errors.UnimplementedError(
-                        None, None, "oops"
-                    ),
-                ) as mock_gfile_exists:
-                    err_msg = (
-                        "Error: Unsupported filename scheme 'gs'."
-                        + " For additional filesystem support, consider installing TensorFlow I/O"
-                        + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
-                    )
-                    with self.assertRaisesWithLiteralMatch(
-                        tf.errors.UnimplementedError, err_msg
-                    ):
-                        data_ingester._try_to_support_tfio(["gs://bucket/abc"])
+                mock_gfile.exists.side_effect = tf.errors.UnimplementedError(
+                    None, None, "oops"
+                )
+                err_msg = (
+                    "Error: Unsupported filename scheme 'gs'."
+                    + " For additional filesystem support, consider installing TensorFlow I/O"
+                    + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
+                )
+                with self.assertRaisesWithLiteralMatch(
+                    tf.errors.UnimplementedError, err_msg
+                ):
+                    data_ingester._check_filesystem_support(["gs://bucket/abc"])
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])
-        mock_gfile_exists.assert_called_once_with("gs://bucket/abc")
+        mock_gfile.exists.assert_called_once_with("gs://bucket/abc")
 
 
 if __name__ == "__main__":

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -254,37 +254,34 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
 
 class FileSystemSupport(tb_test.TestCase):
     def testCheckFilesystemSupport(self):
-        with mock.patch.object(
-            tf.io.gfile,
-            "get_registered_schemes",
-            return_value=["gs", "s3"],
-        ) as mock_get_registered_schemes:
+        with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:
+            mock_gfile.get_registered_schemes = mock.MagicMock(
+                return_value=["gs", "s3"]
+            )
             with mock.patch("builtins.__import__") as mock_import:
                 data_ingester._check_filesystem_support(
                     ["tmp/demo", "s3://bucket/123"]
                 )
         mock_import.assert_not_called()
-        mock_get_registered_schemes.assert_called_once()
+        mock_gfile.get_registered_schemes.assert_called_once()
 
     def testCheckFilesystemSupport_importTFIO(self):
-        with mock.patch.object(
-            tf.io.gfile,
-            "get_registered_schemes",
-            return_value=["file", ""],
-        ) as mock_get_registered_schemes:
+        with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:
+            mock_gfile.get_registered_schemes = mock.MagicMock(
+                return_value=["file", ""]
+            )
             with mock.patch("builtins.__import__") as mock_import:
                 data_ingester._check_filesystem_support(
                     ["tmp/demo", "s3://bucket/123"]
                 )
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])
-        mock_get_registered_schemes.assert_called_once()
+        mock_gfile.get_registered_schemes.assert_called_once()
 
     def testCheckFilesystemSupport_raiseError(self):
-        with mock.patch.object(
-            tf.io.gfile,
-            "get_registered_schemes",
-            return_value=["file", "ram"],
-        ) as mock_get_registered_schemes:
+        with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:
+            mock_gfile.get_registered_schemes = mock.MagicMock(
+                return_value=["file", "ram"]
+            )
             with mock.patch(
                 "builtins.__import__",
                 side_effect=ImportError,
@@ -301,7 +298,7 @@ class FileSystemSupport(tb_test.TestCase):
                         ["tmp/demo", "s3://bucket/123"]
                     )
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])
-        mock_get_registered_schemes.assert_called_once()
+        mock_gfile.get_registered_schemes.assert_called_once()
 
     def testCheckFilesystemSupport_fallback(self):
         with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -254,34 +254,40 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
 
 class FileSystemSupport(tb_test.TestCase):
     def testCheckFilesystemSupport(self):
-        with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:
-            mock_gfile.get_registered_schemes = mock.MagicMock(
-                return_value=["gs", "s3"]
-            )
+        with mock.patch.object(
+            tf.io.gfile,
+            "get_registered_schemes",
+            autospec=True,
+            return_value=["g3", "s3"],
+        ) as mock_get_registered_schemes:
             with mock.patch("builtins.__import__") as mock_import:
                 data_ingester._check_filesystem_support(
                     ["tmp/demo", "s3://bucket/123"]
                 )
         mock_import.assert_not_called()
-        mock_gfile.get_registered_schemes.assert_called_once()
+        mock_get_registered_schemes.assert_called_once()
 
     def testCheckFilesystemSupport_importTFIO(self):
-        with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:
-            mock_gfile.get_registered_schemes = mock.MagicMock(
-                return_value=["file", ""]
-            )
+        with mock.patch.object(
+            tf.io.gfile,
+            "get_registered_schemes",
+            autospec=True,
+            return_value=["file", ""],
+        ) as mock_get_registered_schemes:
             with mock.patch("builtins.__import__") as mock_import:
                 data_ingester._check_filesystem_support(
                     ["tmp/demo", "s3://bucket/123"]
                 )
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])
-        mock_gfile.get_registered_schemes.assert_called_once()
+        mock_get_registered_schemes.assert_called_once()
 
     def testCheckFilesystemSupport_raiseError(self):
-        with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:
-            mock_gfile.get_registered_schemes = mock.MagicMock(
-                return_value=["file", "ram"]
-            )
+        with mock.patch.object(
+            tf.io.gfile,
+            "get_registered_schemes",
+            autospec=True,
+            return_value=["file", "ram"],
+        ) as mock_get_registered_schemes:
             with mock.patch(
                 "builtins.__import__",
                 side_effect=ImportError,
@@ -298,7 +304,7 @@ class FileSystemSupport(tb_test.TestCase):
                         ["tmp/demo", "s3://bucket/123"]
                     )
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])
-        mock_gfile.get_registered_schemes.assert_called_once()
+        mock_get_registered_schemes.assert_called_once()
 
     def testCheckFilesystemSupport_fallback(self):
         with mock.patch.object(tf.io, "gfile", autospec=True) as mock_gfile:


### PR DESCRIPTION
Conditionally import `tensorflow_io` module for additional cloud file system support (https://www.tensorflow.org/io). If the module is missing, prompt the user to run `pip install tensorflow_io`. 

Relevant issues:
- https://github.com/tensorflow/tensorboard/issues/5359
- https://github.com/tensorflow/tensorboard/issues/5480