### PR TITLE
Prefer the WebGL Renderer

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -102,7 +102,7 @@ limitations under the License.
   ></mat-spinner>
   <line-chart
     [disableUpdate]="!isCardVisible"
-    [preferredRendererType]="RendererType.SVG"
+    [preferredRendererType]="RendererType.WEBGL"
     [seriesData]="dataSeries"
     [seriesMetadataMap]="chartMetadataMap"
     [xScaleType]="xScaleType"


### PR DESCRIPTION
Changing the preferred renderer back to WebGL after crash mitigations.
