### PR TITLE
Change terser configuration to workaround threejs/terser incompatibility.

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -77,6 +77,10 @@ def tf_js_binary(
         terser_minified(
             name = internal_result_name,
             src = internal_rollup_name,
+            # Notes about the terser config:
+            # compress.passes - this is set to '1' to workaround issue with
+            #   terser and threejs. In practice it (surprisingly) generates
+            #   smaller results than when it was previously set to '3'.
             config_file = "//tensorboard/defs:terser_config.json",
             visibility = ["//visibility:private"],
             sourcemap = False,

--- a/tensorboard/defs/terser_config.json
+++ b/tensorboard/defs/terser_config.json
@@ -4,7 +4,7 @@
   },
   "compress": {
     "keep_fnames": true,
-    "passes": 3,
+    "passes": 1,
     "pure_getters": true,
     "reduce_funcs": true,
     "reduce_vars": true,


### PR DESCRIPTION
Users have reported problems loading TensorBoard in Safari: https://github.com/tensorflow/tensorboard/issues/5489

Thanks to @severo and @bileschi we were able to identify the problem to an incompatibility between threejs (which we use for WebGL rendering) and terser (which we use for minimizing/optimizing our code). 

Angular encountered this problem last year and worked around it by changing their terser config by reducing number of passes from 3 to 2: 
* https://github.com/angular/angular-cli/issues/21107
* https://github.com/angular/angular-cli/commit/2c2b499193fb319e1c9cb92318610353b7720e2b

In our case I have to reduce the number of terser passes from 3 to 1. For some reason reducing to 2 does not solve the problem.

This change surprisingly appears to reduce binary size. Before this change the size of index.js is 7672844 bytes. After this change the size of index.js is 7670992 bytes -- reducing binary size by 1852 bytes.