### PR TITLE
timeseries: enable card width setting in OSS

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -30,7 +30,7 @@ export const initialState: FeatureFlagState = {
     metricsImageSupportEnabled: true,
     enabledLinkedTime: false,
     enableTimeSeriesPromotion: false,
-    enabledCardWidthSetting: false,
+    enabledCardWidthSetting: true,
     enabledTimeNamespacedState: false,
   },
   flagOverrides: {},


### PR DESCRIPTION
This pr turns on feature flag of card width setting in OSS.