### PR TITLE
layout: adjust contain style to show the expander

### DIFF
--- a/tensorboard/webapp/core/views/layout_container.scss
+++ b/tensorboard/webapp/core/views/layout_container.scss
@@ -30,7 +30,6 @@ limitations under the License.
 .expand {
   @include tb-theme-foreground-prop(border-color, border);
   box-sizing: border-box;
-  contain: strict;
   flex: 0 0;
   justify-self: stretch;
 }
@@ -44,6 +43,7 @@ limitations under the License.
   border-style: solid;
   border-width: 0 2px;
   cursor: ew-resize;
+  contain: strict;
   display: flex;
   justify-self: stretch;
 
@@ -69,6 +69,7 @@ limitations under the License.
   border-style: solid;
   border-width: 0 1px 0 0;
   color: inherit;
+  contain: content;
   cursor: pointer;
   display: flex;
   justify-self: stretch;


### PR DESCRIPTION
When the sidebar got resized and the width is small enough, we collapsed it. The bug is the expander used to reopen the sidebar disappears and the sidebar can never be expanded again. (What's worse is we remember this setting in local storage)

before 
<img width="334" alt="Screen Shot 2022-01-13 at 4 50 18 PM" src="https://user-images.githubusercontent.com/1131010/149432253-a77688f9-688c-4986-9ec1-5bf77a932086.png">

after
<img width="431" alt="Screen Shot 2022-01-13 at 4 43 25 PM" src="https://user-images.githubusercontent.com/1131010/149431963-79ec80bd-e0dd-47f1-bb99-a080a0037bb0.png">

The contain style is used to optimize the rendering, indicating the element might be independent of the rest of the dom tree. But for the expander, the width can't be sized without its descendants' sizes (the icon). Updates the contain to remove size from the consideration. `contain: content;` is equivalent to `contain: layout paint`