### PR TITLE
Fix errors in copybara import.

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -36,7 +36,7 @@ py_library(
         ":data_provider",
         ":event_multiplexer",
         ":tag_types",
-        "//tensorboard/compat:tensorflow",
+        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/data:ingester",
         "//tensorboard/plugins/audio:metadata",
         "//tensorboard/plugins/histogram:metadata",
@@ -56,7 +56,6 @@ py_test(
         ":data_ingester",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
-        "//tensorboard/compat:tensorflow",
     ],
 )
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -37,6 +37,7 @@ py_library(
         ":event_multiplexer",
         ":tag_types",
         "//tensorboard/compat:tensorflow",
+        "//tensorboard/compat/tensorflow_stub",
         "//tensorboard/data:ingester",
         "//tensorboard/plugins/audio:metadata",
         "//tensorboard/plugins/histogram:metadata",
@@ -57,6 +58,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
         "//tensorboard/compat:tensorflow",
+        "//tensorboard/compat/tensorflow_stub",
     ],
 )
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -37,7 +37,6 @@ py_library(
         ":event_multiplexer",
         ":tag_types",
         "//tensorboard/compat:tensorflow",
-        "//tensorboard/compat/tensorflow_stub",
         "//tensorboard/data:ingester",
         "//tensorboard/plugins/audio:metadata",
         "//tensorboard/plugins/histogram:metadata",
@@ -58,7 +57,6 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
         "//tensorboard/compat:tensorflow",
-        "//tensorboard/compat/tensorflow_stub",
     ],
 )
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -36,7 +36,7 @@ py_library(
         ":data_provider",
         ":event_multiplexer",
         ":tag_types",
-        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat:tensorflow",
         "//tensorboard/data:ingester",
         "//tensorboard/plugins/audio:metadata",
         "//tensorboard/plugins/histogram:metadata",
@@ -56,6 +56,7 @@ py_test(
         ":data_ingester",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
+        "//tensorboard/compat:tensorflow",
     ],
 )
 

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -23,6 +23,8 @@ import time
 from tensorboard.backend.event_processing import data_provider
 from tensorboard.backend.event_processing import plugin_event_multiplexer
 from tensorboard.backend.event_processing import tag_types
+from tensorboard.compat import tf
+from tensorboard.compat.tensorflow_stub import errors
 from tensorboard.data import ingester
 from tensorboard.plugins.audio import metadata as audio_metadata
 from tensorboard.plugins.histogram import metadata as histogram_metadata
@@ -30,7 +32,6 @@ from tensorboard.plugins.image import metadata as image_metadata
 from tensorboard.plugins.pr_curve import metadata as pr_curve_metadata
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 from tensorboard.util import tb_logging
-from tensorboard.compat import tf
 
 
 DEFAULT_SIZE_GUIDANCE = {
@@ -249,10 +250,10 @@ def _check_filesystem_support(paths):
             # Fall back to `tf.io.gfile.exists`.
             try:
                 tf.io.gfile.exists(path)
-            except tf.errors.UnimplementedError:
+            except errors.UnimplementedError:
                 missing_scheme = scheme
                 break
-            except tf.errors.OpError:
+            except errors.OpError:
                 # Swallow other errors; we aren't concerned about them at this point.
                 pass
 
@@ -265,7 +266,7 @@ def _check_filesystem_support(paths):
                 if registered_schemes
                 else ""
             )
-            raise tf.errors.UnimplementedError(
+            raise errors.UnimplementedError(
                 None,
                 None,
                 (

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -259,7 +259,7 @@ def _check_filesystem_support(paths):
     if missing_scheme:
         try:
             import tensorflow_io  # noqa: F401
-        except (ImportError, ModuleNotFoundError):
+        except ImportError:
             supported_schemes_msg = (
                 " (supported schemes: {})".format(registered_schemes)
                 if registered_schemes
@@ -273,4 +273,4 @@ def _check_filesystem_support(paths):
                     + " filesystem support, consider installing TensorFlow I/O"
                     + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
                 ).format(missing_scheme, supported_schemes_msg),
-            )
+            ) from None

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -259,7 +259,7 @@ def _check_filesystem_support(paths):
     if missing_scheme:
         try:
             import tensorflow_io  # noqa: F401
-        except ImportError:
+        except (ImportError, ModuleNotFoundError):
             supported_schemes_msg = (
                 " (supported schemes: {})".format(registered_schemes)
                 if registered_schemes

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -19,7 +19,6 @@ import re
 import threading
 import time
 
-import tensorflow as tf
 
 from tensorboard.backend.event_processing import data_provider
 from tensorboard.backend.event_processing import plugin_event_multiplexer
@@ -31,6 +30,7 @@ from tensorboard.plugins.image import metadata as image_metadata
 from tensorboard.plugins.pr_curve import metadata as pr_curve_metadata
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 from tensorboard.util import tb_logging
+from tensorboard.compat import tf
 
 
 DEFAULT_SIZE_GUIDANCE = {

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -23,8 +23,6 @@ import time
 from tensorboard.backend.event_processing import data_provider
 from tensorboard.backend.event_processing import plugin_event_multiplexer
 from tensorboard.backend.event_processing import tag_types
-from tensorboard.compat import tf
-from tensorboard.compat.tensorflow_stub import errors
 from tensorboard.data import ingester
 from tensorboard.plugins.audio import metadata as audio_metadata
 from tensorboard.plugins.histogram import metadata as histogram_metadata
@@ -32,6 +30,7 @@ from tensorboard.plugins.image import metadata as image_metadata
 from tensorboard.plugins.pr_curve import metadata as pr_curve_metadata
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 from tensorboard.util import tb_logging
+from tensorboard.compat import tf
 
 
 DEFAULT_SIZE_GUIDANCE = {
@@ -250,10 +249,10 @@ def _check_filesystem_support(paths):
             # Fall back to `tf.io.gfile.exists`.
             try:
                 tf.io.gfile.exists(path)
-            except errors.UnimplementedError:
+            except tf.errors.UnimplementedError:
                 missing_scheme = scheme
                 break
-            except errors.OpError:
+            except tf.errors.OpError:
                 # Swallow other errors; we aren't concerned about them at this point.
                 pass
 
@@ -266,7 +265,7 @@ def _check_filesystem_support(paths):
                 if registered_schemes
                 else ""
             )
-            raise errors.UnimplementedError(
+            raise tf.errors.UnimplementedError(
                 None,
                 None,
                 (

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -19,6 +19,7 @@ import re
 import threading
 import time
 
+import tensorflow as tf
 
 from tensorboard.backend.event_processing import data_provider
 from tensorboard.backend.event_processing import plugin_event_multiplexer
@@ -30,7 +31,6 @@ from tensorboard.plugins.image import metadata as image_metadata
 from tensorboard.plugins.pr_curve import metadata as pr_curve_metadata
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 from tensorboard.util import tb_logging
-from tensorboard.compat import tf
 
 
 DEFAULT_SIZE_GUIDANCE = {

--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -259,7 +259,7 @@ def _check_filesystem_support(paths):
     if missing_scheme:
         try:
             import tensorflow_io  # noqa: F401
-        except ImportError:
+        except ImportError as e:
             supported_schemes_msg = (
                 " (supported schemes: {})".format(registered_schemes)
                 if registered_schemes
@@ -273,4 +273,4 @@ def _check_filesystem_support(paths):
                     + " filesystem support, consider installing TensorFlow I/O"
                     + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
                 ).format(missing_scheme, supported_schemes_msg),
-            ) from None
+            ) from e

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -23,7 +23,6 @@ from unittest import mock
 from tensorboard import test as tb_test
 from tensorboard.backend.event_processing import data_ingester
 from tensorboard.compat import tf
-from tensorboard.compat.tensorflow_stub import errors
 
 
 _TENSORFLOW_IO_MODULE = "tensorflow_io"
@@ -316,7 +315,7 @@ class FileSystemSupportTest(tb_test.TestCase):
                     + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
                 )
                 with self.assertRaisesWithLiteralMatch(
-                    errors.UnimplementedError, err_msg
+                    tf.errors.UnimplementedError, err_msg
                 ):
                     data_ingester._check_filesystem_support(
                         ["tmp/demo", "s3://bucket/123"]
@@ -340,7 +339,7 @@ class FileSystemSupportTest(tb_test.TestCase):
                 "builtins.__import__",
                 side_effect=self.import_mock.mock_import_error,
             ) as mock_import:
-                mock_gfile.exists.side_effect = errors.UnimplementedError(
+                mock_gfile.exists.side_effect = tf.errors.UnimplementedError(
                     None, None, "oops"
                 )
                 err_msg = (
@@ -349,7 +348,7 @@ class FileSystemSupportTest(tb_test.TestCase):
                     + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
                 )
                 with self.assertRaisesWithLiteralMatch(
-                    errors.UnimplementedError, err_msg
+                    tf.errors.UnimplementedError, err_msg
                 ):
                     data_ingester._check_filesystem_support(["gs://bucket/abc"])
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -23,6 +23,7 @@ from unittest import mock
 from tensorboard import test as tb_test
 from tensorboard.backend.event_processing import data_ingester
 from tensorboard.compat import tf
+from tensorboard.compat.tensorflow_stub import errors
 
 
 _TENSORFLOW_IO_MODULE = "tensorflow_io"
@@ -315,7 +316,7 @@ class FileSystemSupportTest(tb_test.TestCase):
                     + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
                 )
                 with self.assertRaisesWithLiteralMatch(
-                    tf.errors.UnimplementedError, err_msg
+                    errors.UnimplementedError, err_msg
                 ):
                     data_ingester._check_filesystem_support(
                         ["tmp/demo", "s3://bucket/123"]
@@ -339,7 +340,7 @@ class FileSystemSupportTest(tb_test.TestCase):
                 "builtins.__import__",
                 side_effect=self.import_mock.mock_import_error,
             ) as mock_import:
-                mock_gfile.exists.side_effect = tf.errors.UnimplementedError(
+                mock_gfile.exists.side_effect = errors.UnimplementedError(
                     None, None, "oops"
                 )
                 err_msg = (
@@ -348,7 +349,7 @@ class FileSystemSupportTest(tb_test.TestCase):
                     + " (https://www.tensorflow.org/io) via `pip install tensorflow-io`."
                 )
                 with self.assertRaisesWithLiteralMatch(
-                    tf.errors.UnimplementedError, err_msg
+                    errors.UnimplementedError, err_msg
                 ):
                     data_ingester._check_filesystem_support(["gs://bucket/abc"])
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -286,10 +286,10 @@ class FileSystemSupportTest(tb_test.TestCase):
         mock_get_registered_schemes.assert_called_once()
 
     def testCheckFilesystemSupport_importTFIO(self):
+        # autospec=True doesn't work for this test internally.
         with mock.patch.object(
             tf.io.gfile,
             "get_registered_schemes",
-            autospec=True,
             return_value=["file", ""],
         ) as mock_get_registered_schemes:
             with mock.patch("builtins.__import__") as mock_import:
@@ -300,10 +300,10 @@ class FileSystemSupportTest(tb_test.TestCase):
         mock_get_registered_schemes.assert_called_once()
 
     def testCheckFilesystemSupport_raiseError(self):
+        # autospec=True doesn't work for this test internally.
         with mock.patch.object(
             tf.io.gfile,
             "get_registered_schemes",
-            autospec=True,
             return_value=["file", "ram"],
         ) as mock_get_registered_schemes:
             with mock.patch(

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -20,10 +20,9 @@ import posixpath
 import time
 from unittest import mock
 
-import tensorflow as tf
-
 from tensorboard import test as tb_test
 from tensorboard.backend.event_processing import data_ingester
+from tensorboard.compat import tf
 
 
 _TENSORFLOW_IO_MODULE = "tensorflow_io"

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -20,9 +20,10 @@ import posixpath
 import time
 from unittest import mock
 
+import tensorflow as tf
+
 from tensorboard import test as tb_test
 from tensorboard.backend.event_processing import data_ingester
-from tensorboard.compat import tf
 
 
 class FakeFlags(object):


### PR DESCRIPTION
Current sync failure: cl/421703176

- Use `tensorboard.compat.tensorflow_stub.errors` instead of `tf.errors`
  - To fix: `module 'tensorflow' has no attribute 'errors'`
- Properly mock `import` errors
- Remove `autospec=True` for failed tests:
  -  `testCheckFilesystemSupport_importTFIO` and `testCheckFilesystemSupport_raiseError`

Tested internally:  cl/421719230