### PR TITLE
copybara: fix mutation testing error 

### DIFF
--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -23,6 +23,7 @@ import time
 from tensorboard.backend.event_processing import data_provider
 from tensorboard.backend.event_processing import plugin_event_multiplexer
 from tensorboard.backend.event_processing import tag_types
+from tensorboard.compat import tf
 from tensorboard.data import ingester
 from tensorboard.plugins.audio import metadata as audio_metadata
 from tensorboard.plugins.histogram import metadata as histogram_metadata
@@ -30,7 +31,6 @@ from tensorboard.plugins.image import metadata as image_metadata
 from tensorboard.plugins.pr_curve import metadata as pr_curve_metadata
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 from tensorboard.util import tb_logging
-from tensorboard.compat import tf
 
 
 DEFAULT_SIZE_GUIDANCE = {
@@ -81,7 +81,7 @@ class LocalDataIngester(ingester.DataIngester):
             self._path_to_run = _parse_event_files_spec(flags.logdir_spec)
 
         # Conditionally import tensorflow_io.
-        if not getattr(tf, "__version__", "stub") == "stub":
+        if getattr(tf, "__version__", "stub") != "stub":
             _check_filesystem_support(self._path_to_run.keys())
 
     @property

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -373,6 +373,22 @@ class FileSystemSupportTest(tb_test.TestCase):
         self.assertEqual("tensorflow_io", mock_import.call_args[0][0])
         mock_gfile.exists.assert_called_once_with("gs://bucket/abc")
 
+    def testCheckFilesystemSupport_Called(self):
+        with mock.patch.object(tf, "__version__", new="2.2.2"):
+            with mock.patch.object(
+                data_ingester, "_check_filesystem_support", autospec=True
+            ) as mock_check_filesystem_support:
+                data_ingester.LocalDataIngester(flags=FakeFlags("logdir"))
+        mock_check_filesystem_support.assert_called_once_with({"logdir"})
+
+    def testCheckFilesystemSupport_notCalled(self):
+        with mock.patch.object(tf, "__version__", new="stub"):
+            with mock.patch.object(
+                data_ingester, "_check_filesystem_support", autospec=True
+            ) as mock_check_filesystem_support:
+                data_ingester.LocalDataIngester(flags=FakeFlags("logdir"))
+        mock_check_filesystem_support.assert_not_called()
+
 
 if __name__ == "__main__":
     tb_test.main()


### PR DESCRIPTION
Add test for `getattr(tf, "__version__", "stub")` condition, to fix the mutation testing error in cl/421703176.

Also sort the imports alphabetically for lint.