### PR TITLE
time-namespaced state: fix experiment data initial loading on timeNamespacedState enabled

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -466,7 +466,6 @@ export class AppRoutingEffects {
                           option: NamespaceUpdateOption.UNCHANGED,
                         },
                         replaceState: true,
-                        resetNamespacedState: false,
                       },
               };
             })

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -462,7 +462,9 @@ export class AppRoutingEffects {
                     ? options
                     : {
                         ...options,
-                        namespaceUpdate: {option: NamespaceUpdateOption.UNCHANGED},
+                        namespaceUpdate: {
+                          option: NamespaceUpdateOption.UNCHANGED,
+                        },
                         replaceState: true,
                         resetNamespacedState: false,
                       },

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -462,9 +462,9 @@ export class AppRoutingEffects {
                     ? options
                     : {
                         ...options,
+                        namespaceUpdate: {option: NamespaceUpdateOption.UNCHANGED},
                         replaceState: true,
                         resetNamespacedState: false,
-                        namespaceUpdate: {option: NamespaceUpdateOption.UNCHANGED},
                       },
               };
             })

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -464,6 +464,7 @@ export class AppRoutingEffects {
                         ...options,
                         replaceState: true,
                         resetNamespacedState: false,
+                        namespaceUpdate: {option: NamespaceUpdateOption.UNCHANGED},
                       },
               };
             })


### PR DESCRIPTION
fix experiment data initial loading on timeNamespacedState enabled.

This only happens when the browser is initiated on experiment view and timeNamespacedState is enabled from the param. `NamespaceUpdateOption` is set to `NEW` initially and gets updated to `UNCHANGED` on any navigation afterwards.
However in loading experiment view initially there is no navigation actions therefore the option remains `NEW`, which generates a new namespaceId. 
In the fix we set the value to `UNCHANGED` after the first run of app navigation flow. However this is tircky to add the unit tests. InitAction perfectly ran only once of the changed part and trigging any follow up actions triggers navigation$.
Add webtests to catch this. (googlers, please see cl/421637297)