### PR TITLE
time-namespaced state: generalize navigated callback function on createNamespaceContextedState

### DIFF
--- a/tensorboard/webapp/app_routing/namespaced_state_reducer_helper.ts
+++ b/tensorboard/webapp/app_routing/namespaced_state_reducer_helper.ts
@@ -53,7 +53,6 @@ limitations under the License.
 
 import {ActionReducer, createReducer, on} from '@ngrx/store';
 import {navigated} from './actions';
-import {areSameRouteKindAndExperiments} from './internal_utils';
 import {Route} from './types';
 
 // `privateNamespacedState` loosely typed only for ease of writing tests.
@@ -85,10 +84,12 @@ export type NamespaceContextedState<
  * Utility for managing namespaced state. It returns namespace-contexted
  * `initialState` and `reducers` that help manage the namespaced state.
  *
- * An optional `onRouteKindOrExperimentsChanged` function allows more
- * fine-grained changes on state after a key change in Route - that is, after
- * navigating to a Route with either a change in route kind or in the set of
- * experiments. It guarantees that the change happens after namespaced state has
+ * An optional `onNavigated` function allows more fine-grained changes to state
+ * based on the routes information. This function gurantees in app navigation
+ * happens and has finished. Instead of listening to navigated action on feature
+ * reducers, we should implement this `OnNavigated` function, which guarantees
+ * that the implmentation runs after route completely navigated.
+ * It guarantees that the change happens after namespaced state has
  * been properly cached or reset, if appropriate. Note that this callback may be
  * called even when namespace is not changed -- not all navigations to Routes
  * lead to namespaces changes.
@@ -99,10 +100,13 @@ export type NamespaceContextedState<
  *    createNamespaceContextedState(
  *        {myNamespacedState: 0},
  *        {nonNamespacedState: 'one'},
- *        (state) => {
+ *        (state, oldRoute, newRoute) => {
  *          // Perform more complex state transformations based on route kind
  *          // or the set of experiments.
- *          return {nonNamespacedState: 'one'};
+ *          if (!areSameRouteKindAndExperiments(oldRoute, newRoute)) {
+ *            return {nonNamespacedState: 'one'};
+ *          }
+ *          return state;
  *        }
  *    );
  *
@@ -114,8 +118,9 @@ export function createNamespaceContextedState<
 >(
   namespacedInitialState: NamespacedState,
   nonNamespacedInitialState: NonNamespacedState,
-  onRouteKindOrExperimentsChanged?: (
+  onNavigated?: (
     state: NamespaceContextedState<NamespacedState, NonNamespacedState>,
+    oldRoute: Route | null,
     newRoute: Route
   ) => NamespaceContextedState<NamespacedState, NonNamespacedState>
 ): {
@@ -205,13 +210,8 @@ export function createNamespaceContextedState<
           );
         }
 
-        if (
-          !areSameRouteKindAndExperiments(before, after) &&
-          onRouteKindOrExperimentsChanged
-        ) {
-          // RouteKind or Experiments have changed. Delegate additional changes
-          // to the caller.
-          nextFullState = onRouteKindOrExperimentsChanged(nextFullState, after);
+        if (onNavigated) {
+          nextFullState = onNavigated(nextFullState, before, after);
         }
 
         return nextFullState;

--- a/tensorboard/webapp/app_routing/namespaced_state_reducer_helper.ts
+++ b/tensorboard/webapp/app_routing/namespaced_state_reducer_helper.ts
@@ -85,10 +85,9 @@ export type NamespaceContextedState<
  * `initialState` and `reducers` that help manage the namespaced state.
  *
  * An optional `onNavigated` function allows more fine-grained changes to state
- * based on the routes information. This function gurantees in app navigation
- * happens and has finished. Instead of listening to navigated action on feature
- * reducers, we should implement this `OnNavigated` function, which guarantees
- * that the implmentation runs after route completely navigated.
+ * based on the routes information. Instead of listening to `navigated` action
+ * on feature reducers, we should implement this `onNavigated` function, which
+ * guarantees that the implementation runs after route completely navigated.
  * It guarantees that the change happens after namespaced state has
  * been properly cached or reset, if appropriate. Note that this callback may be
  * called even when namespace is not changed -- not all navigations to Routes
@@ -104,7 +103,7 @@ export type NamespaceContextedState<
  *          // Perform more complex state transformations based on route kind
  *          // or the set of experiments.
  *          if (!areSameRouteKindAndExperiments(oldRoute, newRoute)) {
- *            return {nonNamespacedState: 'one'};
+ *            return {myState: 'one'};
  *          }
  *          return state;
  *        }

--- a/tensorboard/webapp/app_routing/namespaced_state_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/namespaced_state_reducer_helper_test.ts
@@ -23,9 +23,9 @@ import {
   StoreModule,
 } from '@ngrx/store';
 import {firstValueFrom} from 'rxjs';
-import {areSameRouteKindAndExperiments} from './internal_utils';
 import {composeReducers} from '../util/ngrx';
 import {navigated} from './actions';
+import {areSameRouteKindAndExperiments} from './internal_utils';
 import {
   createNamespaceContextedState,
   NamespaceContextedState,
@@ -362,7 +362,8 @@ describe('route_contexted_reducer_helper', () => {
           (state, oldRoute, newRoute) => {
             return {
               ...state,
-              namespaced: newRoute.routeKind === RouteKind.EXPERIMENTS ? 7 : 999,
+              namespaced:
+                newRoute.routeKind === RouteKind.EXPERIMENTS ? 7 : 999,
             };
           }
         );
@@ -415,7 +416,7 @@ describe('route_contexted_reducer_helper', () => {
               return {
                 ...state,
                 namespaced: 1000,
-              }
+              };
             }
             return {
               ...state,
@@ -458,9 +459,7 @@ describe('route_contexted_reducer_helper', () => {
         })
       );
       expect(state3.namespaced).toEqual(1000);
-
     });
-
   });
 });
 

--- a/tensorboard/webapp/app_routing/namespaced_state_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/namespaced_state_reducer_helper_test.ts
@@ -23,6 +23,7 @@ import {
   StoreModule,
 } from '@ngrx/store';
 import {firstValueFrom} from 'rxjs';
+import {areSameRouteKindAndExperiments} from './internal_utils';
 import {composeReducers} from '../util/ngrx';
 import {navigated} from './actions';
 import {
@@ -305,7 +306,7 @@ describe('route_contexted_reducer_helper', () => {
     });
   });
 
-  describe('onRouteKindOrExperimentsChanged', () => {
+  describe('onNavigated', () => {
     it('transforms the state', () => {
       const {reducers: namespacedReducers} = createNamespaceContextedState<
         NamespacedState,
@@ -331,7 +332,7 @@ describe('route_contexted_reducer_helper', () => {
         createNamespaceContextedState<NamespacedState, NonNamespacedState>(
           {namespaced: 0},
           {nonNamespaced: 1},
-          (state, route) => {
+          (state, oldRoute, newRoute) => {
             return {...state, namespaced: 999};
           }
         );
@@ -358,10 +359,10 @@ describe('route_contexted_reducer_helper', () => {
         createNamespaceContextedState<NamespacedState, NonNamespacedState>(
           {namespaced: 0},
           {nonNamespaced: 1},
-          (state, route) => {
+          (state, oldRoute, newRoute) => {
             return {
               ...state,
-              namespaced: route.routeKind === RouteKind.EXPERIMENTS ? 7 : 999,
+              namespaced: newRoute.routeKind === RouteKind.EXPERIMENTS ? 7 : 999,
             };
           }
         );
@@ -403,6 +404,63 @@ describe('route_contexted_reducer_helper', () => {
       );
       expect(state3.namespaced).toBe(999);
     });
+
+    it('allows transformation based on route changes', () => {
+      const {initialState, reducers: namespacedReducers} =
+        createNamespaceContextedState<NamespacedState, NonNamespacedState>(
+          {namespaced: 0},
+          {nonNamespaced: 1},
+          (state, oldRoute, newRoute) => {
+            if (areSameRouteKindAndExperiments(oldRoute, newRoute)) {
+              return {
+                ...state,
+                namespaced: 1000,
+              }
+            }
+            return {
+              ...state,
+              namespaced: -1000,
+            };
+          }
+        );
+
+      const noopReducer = createReducer<ContextedState>(initialState);
+      const reducers = composeReducers(namespacedReducers, noopReducer);
+
+      const state1 = {
+        namespaced: 0,
+        nonNamespaced: 1,
+      };
+      const state2 = reducers(
+        state1,
+        navigated({
+          before: null,
+          after: buildRoute({
+            routeKind: RouteKind.EXPERIMENTS,
+          }),
+          beforeNamespaceId: null,
+          afterNamespaceId: 'namespace1',
+        })
+      );
+      expect(state2.namespaced).toEqual(-1000);
+
+      const state3 = reducers(
+        state1,
+        navigated({
+          before: buildRoute({
+            routeKind: RouteKind.EXPERIMENTS,
+          }),
+          after: buildRoute({
+            routeKind: RouteKind.EXPERIMENTS,
+          }),
+          beforeNamespaceId: 'namespace1',
+          afterNamespaceId: 'namespace2',
+        })
+      );
+      expect(state3.namespaced).toEqual(1000);
+
+    });
+
   });
 });
 

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -13,6 +13,7 @@ tf_ts_library(
         ":internal_utils",
         ":types",
         "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/app_routing",
         "//tensorboard/webapp/app_routing:namespaced_state_reducer_helper",
         "//tensorboard/webapp/app_routing:types",
         "//tensorboard/webapp/app_routing/actions",

--- a/tensorboard/webapp/runs/store/BUILD
+++ b/tensorboard/webapp/runs/store/BUILD
@@ -13,6 +13,7 @@ tf_ts_library(
     deps = [
         ":types",
         ":utils",
+        "//tensorboard/webapp/app_routing",
         "//tensorboard/webapp/app_routing:namespaced_state_reducer_helper",
         "//tensorboard/webapp/app_routing:types",
         "//tensorboard/webapp/app_routing/actions",

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -19,6 +19,7 @@ import {
   createReducer,
   on,
 } from '@ngrx/store';
+import {areSameRouteKindAndExperiments} from '../../app_routing';
 import {stateRehydratedFromUrl} from '../../app_routing/actions';
 import {createNamespaceContextedState} from '../../app_routing/namespaced_state_reducer_helper';
 import {RouteKind} from '../../app_routing/types';
@@ -61,17 +62,20 @@ const {
     runsLoadState: {},
     selectionState: new Map<string, Map<string, boolean>>(),
   },
-  /* onRouteKindOrExperimentsChanged() */
-  (state, route) => {
-    return {
-      ...state,
-      initialGroupBy: {
-        key:
-          route.routeKind === RouteKind.COMPARE_EXPERIMENT
-            ? GroupByKey.EXPERIMENT
-            : GroupByKey.RUN,
-      },
-    };
+  /* onNavigated() */
+  (state, oldRoute, newRoute) => {
+    if (!areSameRouteKindAndExperiments(oldRoute, newRoute)) {
+      return {
+        ...state,
+        initialGroupBy: {
+          key:
+            newRoute.routeKind === RouteKind.COMPARE_EXPERIMENT
+              ? GroupByKey.EXPERIMENT
+              : GroupByKey.RUN,
+        },
+      };
+    }
+    return state;
   }
 );
 


### PR DESCRIPTION
Instead of listening on navigated action in feature reducer, we should implement `onRouteKindOrExperimentsChanged` and pass into `createNamespaceContextedState` which then runs on route (rout kind or experiments) changed. 

However it might be unclear for reducers that the state it returns only takes place when route changed (if there is no route change, the new state is not effective)
We tgeb move this logic out of app_routing and let feature reducers decide what they want to do on `navigated` action.

For the current metrics/ and runs/, the states are updated on route changed.