### PR TITLE
Fix 2.7 branch ci to use tensorflow 2.7.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  TENSORFLOW_VERSION: 'tf-nightly'
+  TENSORFLOW_VERSION: 'tensorflow==2.7.0'
 
 jobs:
   build:
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tf_version_id: ['tensorflow==2.7.0rc0', 'notf']
+        tf_version_id: ['tf', 'notf']
         python_version: ['3.7']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e


### PR DESCRIPTION
The 2.7 branch ci.yml does not correctly specify which tensorflow to use for testing - it uses tf-nightly. Update to use tensorflow 2.7.0.