### PR TITLE
time-namespaced state: Support resetNamespacedState in programmatical navigation.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -288,6 +288,7 @@ export class AppRoutingEffects {
     map((programmaticalNavigation) => {
       const nav = programmaticalNavigation!;
       const routeKind = nav.routeKind;
+      const resetNamespacedState = nav.resetNamespacedState;
 
       // TODO(stephanwlee): currently, the RouteParams is ill-typed and you can
       // currently add any property without any type error. Better type it.
@@ -303,9 +304,9 @@ export class AppRoutingEffects {
         default:
           routeParams = nav.routeParams;
       }
-      return {routeKind, routeParams};
+      return {routeKind, routeParams, resetNamespacedState};
     }),
-    map(({routeKind, routeParams}) => {
+    map(({routeKind, routeParams, resetNamespacedState}) => {
       const routeMatch = this.routeConfigs
         ? this.routeConfigs.matchByRouteKind(routeKind, routeParams)
         : null;
@@ -314,7 +315,11 @@ export class AppRoutingEffects {
         options: {
           replaceState: false,
           browserInitiated: false,
-          namespaceUpdate: {option: NamespaceUpdateOption.UNCHANGED},
+          namespaceUpdate: {
+            option: resetNamespacedState
+              ? NamespaceUpdateOption.NEW
+              : NamespaceUpdateOption.UNCHANGED,
+          },
         } as NavigationOptions,
       };
     })

--- a/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
@@ -23,6 +23,7 @@ export const NAVIGATION_PROVIDER = new InjectionToken<NavigationLambda[]>(
 export interface NavigateToExperiment {
   routeKind: RouteKind.EXPERIMENT;
   routeParams: ExperimentRouteParams;
+  resetNamespacedState?: boolean;
 }
 
 export interface NavigateToCompare {
@@ -30,11 +31,13 @@ export interface NavigateToCompare {
   routeParams: {
     aliasAndExperimentIds: Array<{alias: string; id: string}>;
   };
+  resetNamespacedState?: boolean;
 }
 
 export interface NavigateToExperiments {
   routeKind: RouteKind.EXPERIMENTS;
   routeParams: {};
+  resetNamespacedState?: boolean;
 }
 
 export type ProgrammaticalNavigation =


### PR DESCRIPTION
Adds support to programmatical navigation to allow resetNamespacedState to be set. This is similar to how the routerLink directive supports a resetNamespacedState attribute.

If unspecified then it is treated as false (aka NamespaceUpdateOption.UNCHANGED).

I tested it by importing into the internal repo and modifying one of the programatical navigations to set this to true. I loaded the app with enableTimeNamespacedState and observed that performing the corresponding action reset the namespaced state.