### PR TITLE
time-namespaced state: Convert run selection state to be namespaced.

### DIFF
--- a/tensorboard/webapp/runs/actions/runs_actions.ts
+++ b/tensorboard/webapp/runs/actions/runs_actions.ts
@@ -50,12 +50,12 @@ export const fetchRunsFailed = createAction(
 
 export const runSelectionToggled = createAction(
   '[Runs] Run Selection Toggled',
-  props<{experimentIds: string[]; runId: string}>()
+  props<{runId: string}>()
 );
 
 export const runPageSelectionToggled = createAction(
   '[Runs] Run Page Selection Toggled',
-  props<{experimentIds: string[]; runIds: string[]}>()
+  props<{runIds: string[]}>()
 );
 
 export const runSelectorPaginationOptionChanged = createAction(

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -371,11 +371,12 @@ describe('runs_reducers', () => {
 
     it('auto-selects new runs if total num <= N', () => {
       const existingRuns = [buildRun({id: 'existingRun1'})];
-      let state = buildRunsState({
-        selectionState: new Map([
-          ['["b"]', new Map([['existingRun1', false]])],
-        ]),
-      });
+      let state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([['existingRun1', false]]),
+        }
+      );
 
       const fewNewRuns = createFakeRuns(MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT - 1);
       state = runsReducers.reducers(
@@ -392,7 +393,7 @@ describe('runs_reducers', () => {
         })
       );
 
-      const selections = [...state.data.selectionState.get('["b"]')!.entries()];
+      const selections = [...state.ui.selectionState.entries()];
       expect(selections.length).toBe(fewNewRuns.length + existingRuns.length);
       // Existing runs that were unselected should remain so.
       const selectedAsExpected = selections.every(([runId, isSelected]) => {
@@ -403,9 +404,12 @@ describe('runs_reducers', () => {
 
     it('does not auto-select new runs if total num > N', () => {
       const existingRuns = [buildRun({id: 'existingRun1'})];
-      let state = buildRunsState({
-        selectionState: new Map([['["b"]', new Map([['existingRun1', true]])]]),
-      });
+      let state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([['existingRun1', true]]),
+        }
+      );
 
       const manyNewRuns = createFakeRuns(MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT);
       state = runsReducers.reducers(
@@ -422,7 +426,7 @@ describe('runs_reducers', () => {
         })
       );
 
-      const selections = [...state.data.selectionState.get('["b"]')!.entries()];
+      const selections = [...state.ui.selectionState.entries()];
       expect(selections.length).toBe(manyNewRuns.length + existingRuns.length);
       // Existing runs that were selected should remain so.
       const selectedAsExpected = selections.every(([runId, isSelected]) => {
@@ -434,47 +438,42 @@ describe('runs_reducers', () => {
 
   describe('runSelectionToggled', () => {
     it('toggles the run selection state for a runId', () => {
-      const state = buildRunsState({
-        runIds: {eid1: ['r1', 'r2']},
-        selectionState: new Map([['["eid1"]', new Map([['foo', true]])]]),
-      });
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([['foo', true]]),
+        }
+      );
 
       const nextState = runsReducers.reducers(
         state,
         actions.runSelectionToggled({
-          experimentIds: ['eid1'],
           runId: 'foo',
         })
       );
 
-      expect(nextState.data.selectionState).toEqual(
-        new Map([['["eid1"]', new Map([['foo', false]])]])
-      );
+      expect(nextState.ui.selectionState).toEqual(new Map([['foo', false]]));
     });
 
     it('sets true for previously un-set runId', () => {
-      const state = buildRunsState({
-        runIds: {eid1: ['r1', 'r2']},
-        selectionState: new Map([['["eid1"]', new Map([['foo', true]])]]),
-      });
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([['foo', true]]),
+        }
+      );
 
       const nextState = runsReducers.reducers(
         state,
         actions.runSelectionToggled({
-          experimentIds: ['eid1'],
           runId: 'bar',
         })
       );
 
-      expect(nextState.data.selectionState).toEqual(
+      expect(nextState.ui.selectionState).toEqual(
         new Map([
-          [
-            '["eid1"]',
-            new Map([
-              ['foo', true],
-              ['bar', true],
-            ]),
-          ],
+          ['foo', true],
+          ['bar', true],
         ])
       );
     });
@@ -482,53 +481,47 @@ describe('runs_reducers', () => {
 
   describe('runPageSelectionToggled', () => {
     it('toggles all items to on when they were all previously off', () => {
-      const state = buildRunsState({
-        selectionState: new Map([['["eid"]', new Map([['foo', false]])]]),
-      });
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([['foo', false]]),
+        }
+      );
 
       const nextState = runsReducers.reducers(
         state,
         actions.runPageSelectionToggled({
-          experimentIds: ['eid'],
           runIds: ['foo', 'bar'],
         })
       );
 
-      expect(nextState.data.selectionState).toEqual(
+      expect(nextState.ui.selectionState).toEqual(
         new Map([
-          [
-            '["eid"]',
-            new Map([
-              ['foo', true],
-              ['bar', true],
-            ]),
-          ],
+          ['foo', true],
+          ['bar', true],
         ])
       );
     });
 
     it('toggles all items to on when they were partially off', () => {
-      const state = buildRunsState({
-        selectionState: new Map([['["eid"]', new Map([['foo', true]])]]),
-      });
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([['foo', true]]),
+        }
+      );
 
       const nextState = runsReducers.reducers(
         state,
         actions.runPageSelectionToggled({
-          experimentIds: ['eid'],
           runIds: ['foo', 'bar'],
         })
       );
 
-      expect(nextState.data.selectionState).toEqual(
+      expect(nextState.ui.selectionState).toEqual(
         new Map([
-          [
-            '["eid"]',
-            new Map([
-              ['foo', true],
-              ['bar', true],
-            ]),
-          ],
+          ['foo', true],
+          ['bar', true],
         ])
       );
     });
@@ -537,70 +530,54 @@ describe('runs_reducers', () => {
       'toggles all items to on when they were partially off (bar explicitly' +
         'off)',
       () => {
-        const state = buildRunsState({
-          selectionState: new Map([
-            [
-              '["eid"]',
-              new Map([
-                ['foo', true],
-                ['bar', false],
-              ]),
-            ],
-          ]),
-        });
+        const state = buildRunsState(
+          {},
+          {
+            selectionState: new Map([
+              ['foo', true],
+              ['bar', false],
+            ]),
+          }
+        );
 
         const nextState = runsReducers.reducers(
           state,
           actions.runPageSelectionToggled({
-            experimentIds: ['eid'],
             runIds: ['foo', 'bar'],
           })
         );
 
-        expect(nextState.data.selectionState).toEqual(
+        expect(nextState.ui.selectionState).toEqual(
           new Map([
-            [
-              '["eid"]',
-              new Map([
-                ['foo', true],
-                ['bar', true],
-              ]),
-            ],
+            ['foo', true],
+            ['bar', true],
           ])
         );
       }
     );
 
     it('deselects all items if they were on', () => {
-      const state = buildRunsState({
-        selectionState: new Map([
-          [
-            '["eid"]',
-            new Map([
-              ['foo', true],
-              ['bar', true],
-            ]),
-          ],
-        ]),
-      });
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([
+            ['foo', true],
+            ['bar', true],
+          ]),
+        }
+      );
 
       const nextState = runsReducers.reducers(
         state,
         actions.runPageSelectionToggled({
-          experimentIds: ['eid'],
           runIds: ['foo', 'bar'],
         })
       );
 
-      expect(nextState.data.selectionState).toEqual(
+      expect(nextState.ui.selectionState).toEqual(
         new Map([
-          [
-            '["eid"]',
-            new Map([
-              ['foo', false],
-              ['bar', false],
-            ]),
-          ],
+          ['foo', false],
+          ['bar', false],
         ])
       );
     });

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -24,7 +24,7 @@ import {
   RUNS_FEATURE_KEY,
   State,
 } from './runs_types';
-import {createGroupBy, serializeExperimentIds} from './utils';
+import {createGroupBy} from './utils';
 
 const getRunsState = createFeatureSelector<State, RunsState>(RUNS_FEATURE_KEY);
 
@@ -105,22 +105,6 @@ export const getRunsLoadState = createSelector(
 );
 
 /**
- * Returns Observable that emits selection state of runs. If the runs for the
- * current route are desired, please see ui_selectors.ts's
- * getCurrentRouteRunSelection instead.
- */
-export const getRunSelectionMap = createSelector(
-  getDataState,
-  (
-    dataState: RunsDataState,
-    props: {experimentIds: string[]}
-  ): Map<string, boolean> => {
-    const stateKey = serializeExperimentIds(props.experimentIds);
-    return dataState.selectionState.get(stateKey) || new Map();
-  }
-);
-
-/**
  * Returns user defined run grouping setting.
  *
  * User can define it by either specifying it in URL or by interacting with the
@@ -187,6 +171,18 @@ export const getRunSelectorSort = createSelector(
   getUiState,
   (state: RunsUiState): {key: SortKey | null; direction: SortDirection} => {
     return state.sort;
+  }
+);
+
+/**
+ * Returns Observable that emits selection state of runs. If the runs for the
+ * current route are desired, please see ui_selectors.ts's
+ * getCurrentRouteRunSelection instead.
+ */
+export const getRunSelectionMap = createSelector(
+  getUiState,
+  (uiState: RunsUiState): Map<string, boolean> => {
+    return uiState.selectionState;
   }
 );
 

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -262,23 +262,18 @@ describe('runs_selectors', () => {
 
     it('returns selection map of runId passed', () => {
       const state = buildStateFromRunsState(
-        buildRunsState({
-          runIds: {eid: ['r1', 'r2']},
-          selectionState: new Map([
-            [
-              '["eid"]',
-              new Map([
-                ['r1', false],
-                ['r2', true],
-              ]),
-            ],
-          ]),
-        })
+        buildRunsState(
+          {},
+          {
+            selectionState: new Map([
+              ['r1', false],
+              ['r2', true],
+            ]),
+          }
+        )
       );
 
-      const actual = selectors.getRunSelectionMap(state, {
-        experimentIds: ['eid'],
-      });
+      const actual = selectors.getRunSelectionMap(state);
       expect(actual).toEqual(
         new Map([
           ['r1', false],

--- a/tensorboard/webapp/runs/store/runs_types.ts
+++ b/tensorboard/webapp/runs/store/runs_types.ts
@@ -43,9 +43,6 @@ export const RUNS_FEATURE_KEY = 'runs';
 export type ExperimentId = string;
 export type RunId = string;
 
-// 'RouteKey' is a serialization of multiple experiment IDs.
-export type RouteKey = string;
-
 export interface RunsDataNamespacedState {
   defaultRunColorIdForGroupBy: Map<RunId, number>;
   // Monotonically increasing opaque id that uniquely identifies color that can
@@ -65,17 +62,6 @@ export interface RunsDataNonNamespacedState {
   runIdToExpId: Record<RunId, ExperimentId>;
   runMetadata: Record<RunId, Run>;
   runsLoadState: Record<ExperimentId, LoadState>;
-  /**
-   * Map from a 'key' to a `RunId` to boolean whether the run is selected.
-   *
-   * Run selection is tied to a list of experimentIds which is somewhat related
-   * to route but not strictly. For instance, if we want to render the
-   * run-selector in both experiment list and dashboard routes sharing the
-   * state, they need to share a key.
-   *
-   * TODO(psybuzz): this belongs in UI state not data state.
-   */
-  selectionState: Map<RouteKey, Map<RunId, boolean>>;
 }
 
 /**
@@ -89,6 +75,10 @@ export type RunsDataState = NamespaceContextedState<
 export interface RunsUiNamespacedState {
   paginationOption: {pageIndex: number; pageSize: number};
   sort: {key: SortKey | null; direction: SortDirection};
+  /**
+   * Indicates whether the run is selected.
+   */
+  selectionState: Map<RunId, boolean>;
 }
 
 export interface RunsUiNonNamespacedState {}

--- a/tensorboard/webapp/runs/store/testing.ts
+++ b/tensorboard/webapp/runs/store/testing.ts
@@ -55,7 +55,6 @@ export function buildRunsState(
       runIdToExpId: {},
       runMetadata: {},
       runsLoadState: {},
-      selectionState: new Map(),
       runColorOverrideForGroupBy: new Map(),
       defaultRunColorIdForGroupBy: new Map(),
       groupKeyToColorId: new Map(),
@@ -68,6 +67,7 @@ export function buildRunsState(
     ui: {
       paginationOption: {pageIndex: 0, pageSize: 0},
       sort: {key: null, direction: SortDirection.UNSET},
+      selectionState: new Map(),
       ...uiOverride,
     },
   };

--- a/tensorboard/webapp/runs/store/utils.ts
+++ b/tensorboard/webapp/runs/store/utils.ts
@@ -15,10 +15,6 @@ limitations under the License.
 import {GroupBy, GroupByKey, Run, RunGroup} from '../types';
 import {ExperimentId, RunId} from './runs_types';
 
-export function serializeExperimentIds(experimentIds: string[]): string {
-  return JSON.stringify(experimentIds.slice().sort());
-}
-
 export function groupRuns(
   groupBy: GroupBy,
   runs: Run[],

--- a/tensorboard/webapp/runs/store/utils_test.ts
+++ b/tensorboard/webapp/runs/store/utils_test.ts
@@ -14,24 +14,9 @@ limitations under the License.
 ==============================================================================*/
 import {GroupByKey} from '../types';
 import {buildRun} from './testing';
-import {createGroupBy, groupRuns, serializeExperimentIds} from './utils';
+import {createGroupBy, groupRuns} from './utils';
 
 describe('run store utils test', () => {
-  describe('#serializeExperimentIds', () => {
-    it('serializes experiment ids into a string', () => {
-      const actual = serializeExperimentIds(['b', 'c', 'd']);
-
-      expect(actual).toBe('["b","c","d"]');
-    });
-
-    it('sorts the experiment ids so order does not matter', () => {
-      const a = serializeExperimentIds(['a', 'c', 'b']);
-      const b = serializeExperimentIds(['b', 'a', 'c']);
-
-      expect(a).toBe(b);
-    });
-  });
-
   describe('#groupRuns', () => {
     describe('by runs', () => {
       it('groups runs by run ids', () => {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -559,7 +559,6 @@ export class RunsTableContainer implements OnInit, OnDestroy {
   onRunSelectionToggle(item: RunTableItem) {
     this.store.dispatch(
       runSelectionToggled({
-        experimentIds: this.experimentIds,
         runId: item.run.id,
       })
     );
@@ -573,7 +572,6 @@ export class RunsTableContainer implements OnInit, OnDestroy {
 
     this.store.dispatch(
       runPageSelectionToggled({
-        experimentIds: this.experimentIds,
         runIds,
       })
     );

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -1818,13 +1818,11 @@ describe('runs_table', () => {
 
       expect(dispatchSpy).toHaveBeenCalledWith(
         runSelectionToggled({
-          experimentIds: ['rowling'],
           runId: 'book2',
         })
       );
       expect(dispatchSpy).toHaveBeenCalledWith(
         runSelectionToggled({
-          experimentIds: ['rowling'],
           runId: 'book1',
         })
       );
@@ -1858,7 +1856,6 @@ describe('runs_table', () => {
 
         expect(dispatchSpy).toHaveBeenCalledWith(
           runPageSelectionToggled({
-            experimentIds: ['rowling'],
             runIds: ['book1', 'book2'],
           })
         );

--- a/tensorboard/webapp/util/ui_selectors.ts
+++ b/tensorboard/webapp/util/ui_selectors.ts
@@ -51,10 +51,11 @@ import {matchRunToRegex, RunMatchable} from './matcher';
  * Note that emits null when current route is not about an experiment.
  */
 export const getCurrentRouteRunSelection = createSelector(
-  (state: State): Map<string, boolean> | null => {
-    const experimentIds = getExperimentIdsFromRoute(state);
-    return experimentIds ? getRunSelectionMap(state, {experimentIds}) : null;
+  (state: State): boolean => {
+    return !!getExperimentIdsFromRoute(state);
   },
+
+  getRunSelectionMap,
   getRunSelectorRegexFilter,
   (state: State): Map<string, RunMatchable> => {
     const experimentIds = getExperimentIdsFromRoute(state) ?? [];
@@ -73,8 +74,11 @@ export const getCurrentRouteRunSelection = createSelector(
     return runMatchableMap;
   },
   getRouteKind,
-  (runSelection, regexFilter, runMatchableMap, routeKind) => {
-    if (!runSelection) return null;
+  (hasExperiments, runSelection, regexFilter, runMatchableMap, routeKind) => {
+    if (!hasExperiments) {
+      // There are no experiments in the route. Return null.
+      return null;
+    }
     const includeExperimentInfo = routeKind === RouteKind.COMPARE_EXPERIMENT;
     const filteredSelection = new Map<string, boolean>();
 

--- a/tensorboard/webapp/util/ui_selectors_test.ts
+++ b/tensorboard/webapp/util/ui_selectors_test.ts
@@ -74,17 +74,15 @@ describe('ui_selectors test', () => {
           })
         ),
         ...buildStateFromRunsState(
-          buildRunsState({
-            selectionState: new Map([
-              [
-                '["123","234"]',
-                new Map([
-                  ['r1', true],
-                  ['r2', false],
-                ]),
-              ],
-            ]),
-          })
+          buildRunsState(
+            {},
+            {
+              selectionState: new Map([
+                ['r1', true],
+                ['r2', false],
+              ]),
+            }
+          )
         ),
         ...buildStateFromExperimentsState(
           buildExperimentState({
@@ -116,17 +114,15 @@ describe('ui_selectors test', () => {
           })
         ),
         ...buildStateFromRunsState(
-          buildRunsState({
-            selectionState: new Map([
-              [
-                '["234"]',
-                new Map([
-                  ['r1', true],
-                  ['r2', false],
-                ]),
-              ],
-            ]),
-          })
+          buildRunsState(
+            {},
+            {
+              selectionState: new Map([
+                ['r1', true],
+                ['r2', false],
+              ]),
+            }
+          )
         ),
         ...buildStateFromExperimentsState(
           buildExperimentState({
@@ -153,27 +149,26 @@ describe('ui_selectors test', () => {
             })
           ),
           ...buildStateFromRunsState(
-            buildRunsState({
-              selectionState: new Map([
-                [
-                  '["234"]',
-                  new Map([
-                    ['234/run1', true],
-                    ['234/run2', true],
-                    ['234/run3', false],
-                  ]),
-                ],
-              ]),
-              runIds: {
-                '234': ['234/run1', '234/run2', '234/run3'],
+            buildRunsState(
+              {
+                runIds: {
+                  '234': ['234/run1', '234/run2', '234/run3'],
+                },
+                runMetadata: {
+                  '234/run1': buildRun({id: '234/run1', name: 'run1'}),
+                  '234/run2': buildRun({id: '234/run2', name: 'run2'}),
+                  '234/run3': buildRun({id: '234/run3', name: 'run3'}),
+                },
+                regexFilter: '^r.n[1]',
               },
-              runMetadata: {
-                '234/run1': buildRun({id: '234/run1', name: 'run1'}),
-                '234/run2': buildRun({id: '234/run2', name: 'run2'}),
-                '234/run3': buildRun({id: '234/run3', name: 'run3'}),
-              },
-              regexFilter: '^r.n[1]',
-            })
+              {
+                selectionState: new Map([
+                  ['234/run1', true],
+                  ['234/run2', true],
+                  ['234/run3', false],
+                ]),
+              }
+            )
           ),
           ...buildStateFromExperimentsState(
             buildExperimentState({
@@ -205,34 +200,33 @@ describe('ui_selectors test', () => {
             })
           ),
           ...buildStateFromRunsState(
-            buildRunsState({
-              selectionState: new Map([
-                [
-                  '["123","234"]',
-                  new Map([
-                    ['123/run1', false],
-                    ['123/run2', true],
-                    ['123/run3', true],
-                    ['234/run1', true],
-                    ['234/run2', true],
-                    ['234/run3', false],
-                  ]),
-                ],
-              ]),
-              runIds: {
-                '123': ['123/run1', '123/run2', '123/run3'],
-                '234': ['234/run1', '234/run2', '234/run3'],
+            buildRunsState(
+              {
+                runIds: {
+                  '123': ['123/run1', '123/run2', '123/run3'],
+                  '234': ['234/run1', '234/run2', '234/run3'],
+                },
+                runMetadata: {
+                  '123/run1': buildRun({id: '123/run1', name: 'run1'}),
+                  '123/run2': buildRun({id: '123/run2', name: 'run2'}),
+                  '123/run3': buildRun({id: '123/run3', name: 'run3'}),
+                  '234/run1': buildRun({id: '234/run1', name: 'run1'}),
+                  '234/run2': buildRun({id: '234/run2', name: 'run2'}),
+                  '234/run3': buildRun({id: '234/run3', name: 'run3'}),
+                },
+                regexFilter: '^(apple/r..3|r.n[1])',
               },
-              runMetadata: {
-                '123/run1': buildRun({id: '123/run1', name: 'run1'}),
-                '123/run2': buildRun({id: '123/run2', name: 'run2'}),
-                '123/run3': buildRun({id: '123/run3', name: 'run3'}),
-                '234/run1': buildRun({id: '234/run1', name: 'run1'}),
-                '234/run2': buildRun({id: '234/run2', name: 'run2'}),
-                '234/run3': buildRun({id: '234/run3', name: 'run3'}),
-              },
-              regexFilter: '^(apple/r..3|r.n[1])',
-            })
+              {
+                selectionState: new Map([
+                  ['123/run1', false],
+                  ['123/run2', true],
+                  ['123/run3', true],
+                  ['234/run1', true],
+                  ['234/run2', true],
+                  ['234/run3', false],
+                ]),
+              }
+            )
           ),
           ...buildStateFromExperimentsState(
             buildExperimentState({
@@ -276,30 +270,29 @@ describe('ui_selectors test', () => {
             })
           ),
           ...buildStateFromRunsState(
-            buildRunsState({
-              selectionState: new Map([
-                [
-                  '["123","234"]',
-                  new Map([
-                    ['123/run1', true],
-                    ['123/run2', true],
-                    ['234/run1', true],
-                    ['234/run2', true],
-                  ]),
-                ],
-              ]),
-              runIds: {
-                '123': ['123/run1', '123/run2'],
-                '234': ['234/run1', '234/run2'],
+            buildRunsState(
+              {
+                runIds: {
+                  '123': ['123/run1', '123/run2'],
+                  '234': ['234/run1', '234/run2'],
+                },
+                runMetadata: {
+                  '123/run1': buildRun({id: '123/run1', name: 'run1'}),
+                  '123/run2': buildRun({id: '123/run2', name: 'run2'}),
+                  '234/run1': buildRun({id: '234/run1', name: 'run1'}),
+                  '234/run2': buildRun({id: '234/run2', name: 'run2'}),
+                },
+                regexFilter: 'run1',
               },
-              runMetadata: {
-                '123/run1': buildRun({id: '123/run1', name: 'run1'}),
-                '123/run2': buildRun({id: '123/run2', name: 'run2'}),
-                '234/run1': buildRun({id: '234/run1', name: 'run1'}),
-                '234/run2': buildRun({id: '234/run2', name: 'run2'}),
-              },
-              regexFilter: 'run1',
-            })
+              {
+                selectionState: new Map([
+                  ['123/run1', true],
+                  ['123/run2', true],
+                  ['234/run1', true],
+                  ['234/run2', true],
+                ]),
+              }
+            )
           ),
           ...buildStateFromExperimentsState(
             buildExperimentState({


### PR DESCRIPTION
Convert run selection state to be namespaced so that run selection is preserved as users navigate within time-namespaced scenario.

It's not clear to me why this wasn't already namespaced. Instead the run selections were keyed by "RouteKey" -- the set of experiments from the route -- effectively making it behave like namespaced state for the route-namespaced scenario. The documentation makes some claims that we'd want to share the state in some special way between experiment list and dashboard but, in practice, you can't do run selections in experiment list. None of the tests give any hint, either.

With the refactoring I'm also able to move run selection state to "UI" state rather than "Data" state, thus satisfying an old TODO.

How I tested: Imported internally and ran all tests. Ran TensorBoard.corp in both time-namespaced mode and route-namespaced mode and confirmed the behavior is as expected.