### PR TITLE
backend: remove unnecessary TF dep from event_file_loader_test.py

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -185,6 +185,7 @@ py_test(
     deps = [
         ":event_file_loader",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:test",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/summary/writer",
     ],
@@ -198,7 +199,7 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":event_file_loader",
-        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:test",
         "//tensorboard/compat:no_tensorflow",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/summary/writer",

--- a/tensorboard/backend/event_processing/event_file_loader_test.py
+++ b/tensorboard/backend/event_processing/event_file_loader_test.py
@@ -20,9 +20,7 @@ import abc
 import io
 import os
 
-import tensorflow as tf
-
-
+from tensorboard import test as tb_test
 from tensorboard.backend.event_processing import event_file_loader
 from tensorboard.compat.proto import event_pb2
 from tensorboard.summary.writer import record_writer
@@ -98,7 +96,7 @@ class EventFileLoaderTestBase(metaclass=abc.ABCMeta):
         self.assertEventWallTimes(loader.Load(), [1.0])
 
 
-class RawEventFileLoaderTest(EventFileLoaderTestBase, tf.test.TestCase):
+class RawEventFileLoaderTest(EventFileLoaderTestBase, tb_test.TestCase):
     @property
     def _loader_class(self):
         return event_file_loader.RawEventFileLoader
@@ -113,7 +111,7 @@ class RawEventFileLoaderTest(EventFileLoaderTestBase, tf.test.TestCase):
         )
 
 
-class EventFileLoaderTest(EventFileLoaderTestBase, tf.test.TestCase):
+class EventFileLoaderTest(EventFileLoaderTestBase, tb_test.TestCase):
     @property
     def _loader_class(self):
         return event_file_loader.EventFileLoader
@@ -125,7 +123,7 @@ class EventFileLoaderTest(EventFileLoaderTestBase, tf.test.TestCase):
         )
 
 
-class TimestampedEventFileLoaderTest(EventFileLoaderTestBase, tf.test.TestCase):
+class TimestampedEventFileLoaderTest(EventFileLoaderTestBase, tb_test.TestCase):
     @property
     def _loader_class(self):
         return event_file_loader.TimestampedEventFileLoader
@@ -148,4 +146,4 @@ def _make_event(**kwargs):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    tb_test.main()


### PR DESCRIPTION
Small cleanup (tracking issue: #2007) before making some additions to this test. We don't actually need real TF for this test, so it's better to avoid the dependency.