### PR TITLE
backend: implement event file replacement detection

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -186,6 +186,7 @@ py_test(
         ":event_file_loader",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
+        "//tensorboard/compat",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/summary/writer",
     ],
@@ -200,6 +201,7 @@ py_test(
     deps = [
         ":event_file_loader",
         "//tensorboard:test",
+        "//tensorboard/compat",
         "//tensorboard/compat:no_tensorflow",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/summary/writer",

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -117,11 +117,32 @@ class _PyRecordReaderIterator(object):
 class RawEventFileLoader(object):
     """An iterator that yields Event protos as serialized bytestrings."""
 
-    def __init__(self, file_path):
+    def __init__(self, file_path, detect_file_replacement=False):
+        """Constructs a RawEventFileLoader for the given file path.
+
+        Args:
+          file_path: the event file path to read from
+          detect_file_replacement: if True, when Load() is called, the loader
+              will make a stat() call to check the size of the file. If it sees
+              that the file has grown, it will reopen the file entirely (while
+              preserving the current offset) before attempting to read from it.
+              Otherwise, Load() will simply poll at EOF for new data.
+        """
         if file_path is None:
             raise ValueError("A file path is required")
         self._file_path = platform_util.readahead_file_path(file_path)
+        self._detect_file_replacement = detect_file_replacement
+        self._file_size = None
         self._iterator = _make_tf_record_iterator(self._file_path)
+        if self._detect_file_replacement and not hasattr(
+            self._iterator, "reopen"
+        ):
+            logger.warning(
+                "File replacement detection requested, but not enabled because "
+                "TF record iterator impl does not support reopening. This "
+                "functionality requires TensorFlow 2.9+"
+            )
+            self._detect_file_replacement = False
 
     def Load(self):
         """Loads all new events from disk as raw serialized proto bytestrings.
@@ -133,6 +154,25 @@ class RawEventFileLoader(object):
           All event proto bytestrings in the file that have not been yielded yet.
         """
         logger.debug("Loading events from %s", self._file_path)
+        if self._detect_file_replacement:
+            has_increased = self.CheckForIncreasedFileSize()
+            # Only act on the file size information if we got a concrete result.
+            if has_increased is not None:
+                if has_increased:
+                    logger.debug(
+                        "Reopening %s since file size has changed",
+                        self._file_path,
+                    )
+                    self._iterator.close()
+                    self._iterator.reopen()
+                else:
+                    logger.debug(
+                        "Skipping attempt to poll %s since file size has not "
+                        "changed (still %d)",
+                        self._file_path,
+                        self._file_size,
+                    )
+                    return
         while True:
             try:
                 yield next(self._iterator)
@@ -146,6 +186,47 @@ class RawEventFileLoader(object):
                 logger.debug("Truncated record in %s (%s)", self._file_path, e)
                 break
         logger.debug("No more events in %s", self._file_path)
+
+    def CheckForIncreasedFileSize(self):
+        """Stats the file to get its updated size, returning True if it grew.
+
+        If the stat call fails or reports a smaller size than was previously
+        seen, then any previously cached size is left unchanged.
+
+        Returns:
+            boolean or None: True if the file size increased; False if it was
+                the same or decreased; or None if neither case could be detected
+                (either because the previous size had not been recorded yet, or
+                because the stat call for the current size failed).
+        """
+        previous_size = self._file_size
+        try:
+            self._file_size = tf.io.gfile.stat(self._file_path).length
+        except tf.errors.OpError as e:
+            logger.error("Failed to stat %s: %s", self._file_path, e)
+            return None
+        logger.debug(
+            "Stat on %s got size %d, previous size %s",
+            self._file_path,
+            self._file_size,
+            previous_size,
+        )
+        if previous_size is None:
+            return None
+        if self._file_size > previous_size:
+            return True
+        if self._file_size < previous_size:
+            logger.warning(
+                "File %s shrank from previous size %d to size %d",
+                self._file_path,
+                previous_size,
+                self._file_size,
+            )
+            # In case this was transient, preserve the previously cached size,
+            # to avoid reporting a spurious increase next time. If the file was
+            # actually truncated, we can't recover anyway, so just ignore it.
+            self._file_size = previous_size
+        return False
 
 
 class LegacyEventFileLoader(RawEventFileLoader):
@@ -170,8 +251,8 @@ class EventFileLoader(LegacyEventFileLoader):
     Specifically, this includes `data_compat` and `dataclass_compat`.
     """
 
-    def __init__(self, file_path):
-        super(EventFileLoader, self).__init__(file_path)
+    def __init__(self, *args, **kwargs):
+        super(EventFileLoader, self).__init__(*args, **kwargs)
         # Track initial metadata for each tag, for `dataclass_compat`.
         # This is meant to be tracked per run, not per event file, so
         # there is a potential failure case when the second event file

--- a/tensorboard/backend/event_processing/event_file_loader_test.py
+++ b/tensorboard/backend/event_processing/event_file_loader_test.py
@@ -19,23 +19,30 @@
 import abc
 import io
 import os
+import unittest
+from unittest import mock
 
 from tensorboard import test as tb_test
 from tensorboard.backend.event_processing import event_file_loader
+from tensorboard.compat import tf
 from tensorboard.compat.proto import event_pb2
 from tensorboard.summary.writer import record_writer
 
 
 FILENAME = "test.events"
+USING_STUB_TF = tf.__version__ == "stub"
 
 
 class EventFileLoaderTestBase(metaclass=abc.ABCMeta):
+    def _get_filename(self):
+        return os.path.join(self.get_temp_dir(), FILENAME)
+
     def _append_record(self, data):
-        with open(os.path.join(self.get_temp_dir(), FILENAME), "ab") as f:
+        with open(self._get_filename(), "ab") as f:
             record_writer.RecordWriter(f).write(data)
 
-    def _make_loader(self):
-        return self._loader_class(os.path.join(self.get_temp_dir(), FILENAME))
+    def _make_loader(self, **kwargs):
+        return self._loader_class(self._get_filename(), **kwargs)
 
     @abc.abstractproperty
     def _loader_class(self):
@@ -48,7 +55,7 @@ class EventFileLoaderTestBase(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     def testLoad_emptyEventFile(self):
-        with open(os.path.join(self.get_temp_dir(), FILENAME), "ab") as f:
+        with open(self._get_filename(), "ab") as f:
             f.write(b"")
         loader = self._make_loader()
         self.assertEmpty(list(loader.Load()))
@@ -94,6 +101,93 @@ class EventFileLoaderTestBase(metaclass=abc.ABCMeta):
         loader.Load()
         loader.Load()
         self.assertEventWallTimes(loader.Load(), [1.0])
+
+    def testLoad_detectFileReplacement_simple(self):
+        # This test confirms that detect_file_replacement=True doesn't break the
+        # existing basic loading behavior, including for no-TF mode (where it
+        # cannot reopen iterators, so it just falls back to polling).
+        self._append_record(_make_event(wall_time=1.0))
+        loader = self._make_loader(detect_file_replacement=True)
+        self._append_record(_make_event(wall_time=2.0))
+        self.assertEventWallTimes(loader.Load(), [1.0, 2.0])
+        self._append_record(_make_event(wall_time=3.0))
+        self.assertEventWallTimes(loader.Load(), [3.0])
+
+    @unittest.skipIf(USING_STUB_TF, "detect_file_replacement requires real TF")
+    def testLoad_detectFileReplacement_reopensIteratorAfterFileGrows(self):
+        self._append_record(_make_event(wall_time=1.0))
+        loader = self._make_loader(detect_file_replacement=True)
+        self._append_record(_make_event(wall_time=2.0))
+        self.assertEventWallTimes(loader.Load(), [1.0, 2.0])
+        self.assertEventWallTimes(loader.Load(), [])
+        # Remove original file; replace it with a file containing 1 additional
+        # event. Without detect_file_replacement=True, we don't detect the new data.
+        os.remove(self._get_filename())
+        self._append_record(_make_event(wall_time=1.0))
+        self._append_record(_make_event(wall_time=2.0))
+        self._append_record(_make_event(wall_time=3.0))
+        self.assertEventWallTimes(loader.Load(), [3.0])
+
+    @unittest.skipIf(USING_STUB_TF, "detect_file_replacement requires real TF")
+    def testLoad_detectFileReplacement_statFails_shouldPollInstead(self):
+        self._append_record(_make_event(wall_time=1.0))
+        with mock.patch.object(tf.io.gfile, "stat") as mock_stat:
+            mock_stat.side_effect = tf.errors.UnimplementedError(
+                None, None, "stat is unsupported"
+            )
+            loader = self._make_loader(detect_file_replacement=True)
+            self._append_record(_make_event(wall_time=2.0))
+            self.assertEventWallTimes(loader.Load(), [1.0, 2.0])
+            mock_stat.assert_called_once()
+            mock_stat.reset_mock()
+            self._append_record(_make_event(wall_time=3.0))
+            self.assertEventWallTimes(loader.Load(), [3.0])
+            mock_stat.assert_called_once()
+
+    @unittest.skipIf(USING_STUB_TF, "detect_file_replacement requires real TF")
+    def testLoad_detectFileReplacement_statFailsTransiently_shouldRecover(self):
+        self._append_record(_make_event(wall_time=1.0))
+        loader = self._make_loader(detect_file_replacement=True)
+        self._append_record(_make_event(wall_time=2.0))
+        self.assertEventWallTimes(loader.Load(), [1.0, 2.0])
+        with mock.patch.object(tf.io.gfile, "stat") as mock_stat:
+            mock_stat.side_effect = tf.errors.DeadlineExceededError(
+                None, None, "transient failure"
+            )
+            # Stat call fails; we fall back to polling, which shows no new data.
+            self.assertEventWallTimes(loader.Load(), [])
+            mock_stat.assert_called_once()
+            mock_stat.reset_mock()
+            # Simulate file growing via replacement.
+            os.remove(self._get_filename())
+            self._append_record(_make_event(wall_time=1.0))
+            self._append_record(_make_event(wall_time=2.0))
+            self._append_record(_make_event(wall_time=3.0))
+            # Stat call fails again; since we're polling; still no new data.
+            self.assertEventWallTimes(loader.Load(), [])
+            mock_stat.assert_called_once()
+            mock_stat.reset_mock()
+        # Removing the mock and getting a successful stat result triggers
+        # reopening the file, and we see the new data.
+        self.assertEventWallTimes(loader.Load(), [3.0])
+
+    @unittest.skipIf(USING_STUB_TF, "detect_file_replacement requires real TF")
+    def testLoad_detectFileReplacement_statShowsSizeDecrease_shouldIgnore(self):
+        self._append_record(_make_event(wall_time=1.0))
+        loader = self._make_loader(detect_file_replacement=True)
+        self._append_record(_make_event(wall_time=2.0))
+        self.assertEventWallTimes(loader.Load(), [1.0, 2.0])
+        self.assertEventWallTimes(loader.Load(), [])
+        # Remove original file; replace it with a truncated file. Since the
+        # stat call shows a reduced file size, we should ignore it until we
+        # see an increase relative to the previously cached size.
+        os.remove(self._get_filename())
+        self._append_record(_make_event(wall_time=1.0))
+        self.assertEventWallTimes(loader.Load(), [])
+        self._append_record(_make_event(wall_time=2.0))
+        self.assertEventWallTimes(loader.Load(), [])
+        self._append_record(_make_event(wall_time=3.0))
+        self.assertEventWallTimes(loader.Load(), [3.0])
 
 
 class RawEventFileLoaderTest(EventFileLoaderTestBase, tb_test.TestCase):


### PR DESCRIPTION
This implements an optional mode in our Python `EventFileLoader` that will attempt to detect and handle the case when an event file is replaced entirely with a new version of the file containing additional data (rather than the new data being appended to the existing file, the normal behavior we expect).

This situation occurs for example when using `rsync` as described in #349.  When run without the `--inplace` option, `rsync` will transfer data to a temporary file and then swap it in for the final file, but this means that TensorBoard will only ever see the first version of that file and never shows any updates to it until it's restarted.  A similar issue happens for internal users - Googlers, please see b/201113906 for context.

The new logic uses `stat()` to monitor the size of the file, and if it grows, we will re-open the underlying iterator for that filename, resuming at the prior read offset. Care has been taken to try to avoid adding too much filesystem I/O overhead, but it's possible that this new mode is more expensive (since it re-opens the file potentially many times), hence the reason to leave it off by default, at least for now.

This functionality requires that the underlying iterator supports re-opening, which is under development for `tf.compat.v1.summary.tf_record_iterator()` (Googlers, please see cl/423871645).  It is _not_ currently supported for the no-TF mode stub iterator implementation (although I suspect, but have not confirmed, that the stub implementation is not affected by the original issue since it has a simpler albeit likely less efficient implementation that just re-opens files each time it reads).  Also, since this code change is currently only in our Python event loading code, it has no effect on RustBoard (our rust data server).  If there's demand, however, it should be possible to port this logic.

Note that there is currently no way to activate this mode - #5530 is the followup PR with the CLI flag and plumbing.

Tested: ran TensorBoard with these changes enabled (see followup PR) and confirmed that it now picks up new data when replacing an event file entirely rather than appending to it, writes the appropriate log messages, etc.