### PR TITLE
core: add --detect_file_replacement flag and plumbing

### DIFF
--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -69,6 +69,7 @@ class LocalDataIngester(ingester.DataIngester):
             purge_orphaned_data=flags.purge_orphaned_data,
             max_reload_threads=flags.max_reload_threads,
             event_file_active_filter=_get_event_file_active_filter(flags),
+            detect_file_replacement=flags.detect_file_replacement,
         )
         self._data_provider = data_provider.MultiplexerDataProvider(
             self._multiplexer, flags.logdir or flags.logdir_spec

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -32,6 +32,7 @@ _TENSORFLOW_IO_MODULE = "tensorflow_io"
 class FakeFlags(object):
     def __init__(
         self,
+        detect_file_replacement=None,
         generic_data="auto",
         logdir="",
         logdir_spec="",
@@ -45,6 +46,7 @@ class FakeFlags(object):
         samples_per_plugin=None,
         window_title="",
     ):
+        self.detect_file_replacement = detect_file_replacement
         self.generic_data = generic_data
         self.logdir = logdir
         self.logdir_spec = logdir_spec

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -77,6 +77,7 @@ class EventMultiplexer(object):
         purge_orphaned_data=True,
         max_reload_threads=None,
         event_file_active_filter=None,
+        detect_file_replacement=None,
     ):
         """Constructor for the `EventMultiplexer`.
 
@@ -98,6 +99,9 @@ class EventMultiplexer(object):
           event_file_active_filter: Optional predicate for determining whether an
             event file latest load timestamp should be considered active. If passed,
             this will enable multifile directory loading.
+          detect_file_replacement: Optional boolean; if True, event file loading
+            will try to detect when a file has been replaced with a new version
+            that contains additional data, by monitoring the file size.
         """
         logger.info("Event Multiplexer initializing.")
         self._accumulators_mutex = threading.Lock()
@@ -111,6 +115,7 @@ class EventMultiplexer(object):
         self.purge_orphaned_data = purge_orphaned_data
         self._max_reload_threads = max_reload_threads or 1
         self._event_file_active_filter = event_file_active_filter
+        self._detect_file_replacement = detect_file_replacement
         if run_path_map is not None:
             logger.info(
                 "Event Multplexer doing initialization load for %s",
@@ -159,6 +164,7 @@ class EventMultiplexer(object):
                     tensor_size_guidance=self._tensor_size_guidance,
                     purge_orphaned_data=self.purge_orphaned_data,
                     event_file_active_filter=self._event_file_active_filter,
+                    detect_file_replacement=self._detect_file_replacement,
                 )
                 self._accumulators[name] = accumulator
                 self._paths[name] = path

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
@@ -94,13 +94,9 @@ class _FakeAccumulator(object):
 
 def _GetFakeAccumulator(
     path,
-    size_guidance=None,
-    tensor_size_guidance=None,
-    purge_orphaned_data=None,
-    event_file_active_filter=None,
+    **unused_kwargs,
 ):
-    del size_guidance, tensor_size_guidance, purge_orphaned_data  # Unused.
-    del event_file_active_filter  # unused
+    del unused_kwargs
     return _FakeAccumulator(path)
 
 

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -53,6 +53,7 @@ class FakeFlags(object):
         grpc_data_provider="",
         host=None,
         inspect=False,
+        load_fast="auto",
         logdir="",
         logdir_spec="",
         path_prefix="",
@@ -66,6 +67,7 @@ class FakeFlags(object):
         self.grpc_data_provider = grpc_data_provider
         self.host = host
         self.inspect = inspect
+        self.load_fast = load_fast
         self.logdir = logdir
         self.logdir_spec = logdir_spec
         self.path_prefix = path_prefix

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -491,6 +491,13 @@ def _should_use_data_server(flags):
             "paths; falling back to slower Python-only load path."
         )
         return False
+    if flags.detect_file_replacement is True:
+        logger.info(
+            "Note: --detect_file_replacement=true is not supported with "
+            "--load_fast behavior; falling back to slower Python-only load "
+            "path."
+        )
+        return False
     return True
 
 

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -86,6 +86,7 @@ class TensorBoardTest(tb_test.TestCase):
         def f(**kwargs):
             kwargs.setdefault("logdir", "")
             kwargs.setdefault("logdir_spec", "")
+            kwargs.setdefault("detect_file_replacement", None)
             flags = argparse.Namespace()
             for k, v in kwargs.items():
                 setattr(flags, k, v)
@@ -96,6 +97,7 @@ class TensorBoardTest(tb_test.TestCase):
         self.assertTrue(f(logdir="logs/mnist/"))
         self.assertTrue(f(logdir="gs://logs"))
         self.assertFalse(f(logdir="notgs://logs"))
+        self.assertFalse(f(logdir="foo", detect_file_replacement=True))
 
 
 class WerkzeugServerTest(tb_test.TestCase):


### PR DESCRIPTION
Add the `--detect_file_replacement` flag to control the behavior introduced in #5529, and all the associated plumbing in between.

Note: since this flag would currently be pointless for RustBoard (`--load_fast=true`) we disallow the combination, and in the default automatic selection logic (`--load_fast=auto`), we check for this flag and don't use RustBoard if it was passed.

Tested: ran TensorBoard with these changes enabled (including behavior-introducing PR) and confirmed that it now picks up new data when replacing an event file entirely rather than appending to it, writes the appropriate log messages, disables RustBoard, etc.

Diffbased on top of #5543 and #5544.

Cc: #349.