### PR TITLE
Use window.location.replaceState when unsetting plugin hash.

### DIFF
--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -135,7 +135,7 @@ export function makeBindings<T>(
       fireStorageChanged();
     } else if (!_.isEqual(value, get(key, {useLocalStorage}))) {
       if (_.isEqual(value, defaultValue)) {
-        unsetFromURI(key);
+        unsetFromURI(key, useLocationReplace);
       } else {
         const items = componentToDict(readComponent());
         items[key] = stringValue;

--- a/tensorboard/components/tf_storage/storage_utils.ts
+++ b/tensorboard/components/tf_storage/storage_utils.ts
@@ -114,8 +114,8 @@ export function dictToComponent(items: StringDict): string {
 /**
  * Delete a key from the URI.
  */
-export function unsetFromURI(key) {
+export function unsetFromURI(key, useLocationReplace = false) {
   const items = componentToDict(readComponent());
   delete items[key];
-  writeComponent(dictToComponent(items));
+  writeComponent(dictToComponent(items), useLocationReplace);
 }


### PR DESCRIPTION
We discovered an odd navigation-related bug in internal TensorBoards, described in detail in http://b/216307695. TensorBoard, in certain circumstances, will create extra entries on the browser history by modifying `window.location.hash` unnecessarily.

In short, the most relevant causes of this problem:
1. Sometimes `HashStorageComponent` will (unnecessarily) clear the plugin id. (Fortunately, by the time the page finishes loading the plugin id will be restored.) 
2. Further down the call stack, `storage_utils.unsetFromURI()` will clear the plugin id from the url hash. Unfortunately it will do this by directly modifying `window.location.hash`, creating an unnecessary entry in the history state.

This change address cause 2, allowing unsetFromURI() to modify the url hash using `window.history.replaceState()`, thus avoiding the unnecessary entry in the history state.

This mitigates the navigation problem even if it doesn't necessarily address the root cause (whatever triggers the odd behavior by `HashStorageComponent`).

Tested: Tested using internal TensorBoards with more complex navigation scenarios. I wrote a webtest as well.
