### PR TITLE
chore: Enable useUnknownInCatchVariables for polymer code.

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/minimap.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/minimap.ts
@@ -193,7 +193,7 @@ export class Minimap {
           stylesText +=
             cssRules[i].cssText.replace(/ ?tf-[\w-]+ ?/g, '') + '\n';
         }
-      } catch (e) {
+      } catch (e: any) {
         if (e.name !== 'SecurityError') {
           throw e;
         }

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -168,7 +168,7 @@ export function runTask<T>(
     tracker.updateProgress(incProgressValue);
     // Return the result to be used by other tasks.
     return result;
-  } catch (e) {
+  } catch (e: any) {
     // Errors that happen inside asynchronous tasks are
     // reported to the tracker using a user-friendly message.
     tracker.reportError('Failed ' + msg, e);
@@ -196,7 +196,7 @@ export function runAsyncTask<T>(
         tracker.updateProgress(incProgressValue);
         // Return the result to be used by other tasks.
         resolve(result);
-      } catch (e) {
+      } catch (e: any) {
         // Errors that happen inside asynchronous tasks are
         // reported to the tracker using a user-friendly message.
         tracker.reportError('Failed ' + msg, e);

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-loader.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-loader.ts
@@ -242,7 +242,7 @@ class TfMeshLoaderImpl
       );
       currentStep.mesh = meshData[0];
       this.notifyPath('_currentStep.mesh');
-    } catch (error) {
+    } catch (error: any) {
       if (!error || !error.code || error.code != ErrorCodes.CANCELLED) {
         error = error || 'Response processing failed.';
         throw new Error(error);

--- a/tensorboard/plugins/projector/vz_projector/data-provider.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider.ts
@@ -123,7 +123,7 @@ export function retrieveTensorAsBytes(
     let data: Float32Array;
     try {
       data = new Float32Array(xhr.response);
-    } catch (e) {
+    } catch (e: any) {
       logging.setErrorMessage(e, 'parsing tensor bytes');
       return;
     }

--- a/tsconfig-lax.json
+++ b/tsconfig-lax.json
@@ -14,6 +14,7 @@
     "preserveConstEnums": false,
     "skipLibCheck": true,
     "sourceMap": false,
-    "target": "es5"
+    "target": "es5",
+    "useUnknownInCatchVariables": true,
   }
 }


### PR DESCRIPTION
The internal languages team wants to turn on the useUnknownInCatchVariables compiler option and asked us to upstream some changes. Googlers, see: http://b/215141918 and http://cl/420753218.

This impacts the polymer codebase only, which compiles in a non-strict mode (whereas the Angular codebase is compiled in strict mode and, so, was already subject to useUnknownInCatchVariables).

I turned on the useUnknownInCatchVariables and tried to run the app. I fixed each error by typing the caught exception as `: any`. I then cross referenced with http://cl/420753218 to ensure I made the correct changes.
