### PR TITLE
time-namespaced: adding unique index on generating name space id

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -105,10 +105,15 @@ type NavigationOptions = {
   namespaceUpdate: NamespaceUpdate;
 };
 
-function generate32bitRandomId() {
-  const arr = new Uint8Array(32);
-
+function getRandomValues(arr: Uint8Array) {
   crypto.getRandomValues(arr);
+  return arr;
+}
+
+function generate32bitRandomId() {
+  let arr = new Uint8Array(32);
+
+  arr = getRandomValues(arr);
 
   let ret = '';
   for (const el of arr) {
@@ -643,4 +648,4 @@ function getAfterNamespaceId(
   }
 }
 
-export const TEST_ONLY = {initAction, generate32bitRandomId};
+export const TEST_ONLY = {initAction, generate32bitRandomId, getRandomValues};

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -643,4 +643,4 @@ function getAfterNamespaceId(
   }
 }
 
-export const TEST_ONLY = {initAction};
+export const TEST_ONLY = {initAction, generate32bitRandomId};

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -43,6 +43,7 @@ import {
   arePathsAndQueryParamsEqual,
   areSameRouteKindAndExperiments,
   canRehydrateDeepLink,
+  generateRandomIdForNamespace,
   getRouteNamespaceId,
   serializeCompareExperimentParams,
 } from '../internal_utils';
@@ -103,21 +104,6 @@ type NavigationOptions = {
   browserInitiated: boolean;
   replaceState: boolean;
   namespaceUpdate: NamespaceUpdate;
-};
-
-const generate32bitRandomId = () => {
-  let arr = new Uint8Array(32);
-
-  // The usage of Crypto `getRandomValues` does not require return an array.
-  // This is for the convenience of mock the funciton in testing.
-  arr = crypto.getRandomValues(arr);
-
-  let ret = '';
-  for (const el of arr) {
-    ret += (el >> 4).toString(16);
-  }
-
-  return ret;
 };
 
 /**
@@ -638,11 +624,11 @@ function getAfterNamespaceId(
       beforeNamespaceId == null ||
       options.namespaceUpdate.option === NamespaceUpdateOption.NEW
     ) {
-      return `${generate32bitRandomId()}:${Date.now().toString()}`;
+      return `${Date.now().toString()}:${generateRandomIdForNamespace()}`;
     } else {
       return beforeNamespaceId;
     }
   }
 }
 
-export const TEST_ONLY = {initAction, generate32bitRandomId};
+export const TEST_ONLY = {initAction};

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -105,17 +105,13 @@ type NavigationOptions = {
   namespaceUpdate: NamespaceUpdate;
 };
 
-const getRandomValues = (arr: Uint8Array) => {
-  // The usage of Crypto `getRandomValues` does not require return array.
-  // This is for the convenience of mock the funciton in testing.
-  arr = crypto.getRandomValues(arr);
-  return arr;
-};
 
 const generate32bitRandomId = () => {
   let arr = new Uint8Array(32);
 
-  arr = getRandomValues(arr);
+  // The usage of Crypto `getRandomValues` does not require return an array.
+  // This is for the convenience of mock the funciton in testing.
+  arr = crypto.getRandomValues(arr);
 
   let ret = '';
   for (const el of arr) {

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -105,7 +105,6 @@ type NavigationOptions = {
   namespaceUpdate: NamespaceUpdate;
 };
 
-
 const generate32bitRandomId = () => {
   let arr = new Uint8Array(32);
 
@@ -646,4 +645,4 @@ function getAfterNamespaceId(
   }
 }
 
-export const TEST_ONLY = {initAction};
+export const TEST_ONLY = {initAction, generate32bitRandomId};

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -105,6 +105,19 @@ type NavigationOptions = {
   namespaceUpdate: NamespaceUpdate;
 };
 
+function generate32bitRandomId() {
+  const arr = new Uint8Array(32);
+
+  crypto.getRandomValues(arr);
+
+  let ret = '';
+  for (const el of arr) {
+   ret += (el >> 4).toString(16)
+  }
+
+  return ret;
+}
+
 /**
  * Effects to translate attempted app navigations into Route navigation actions.
  *
@@ -623,7 +636,7 @@ function getAfterNamespaceId(
       beforeNamespaceId == null ||
       options.namespaceUpdate.option === NamespaceUpdateOption.NEW
     ) {
-      return Date.now().toString();
+      return `${generate32bitRandomId()}:${Date.now().toString()}`;
     } else {
       return beforeNamespaceId;
     }

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -123,6 +123,19 @@ function generate32bitRandomId() {
   return ret;
 }
 
+const generate32bitRandomId2 = { call: () => {
+  const arr = new Uint8Array(32);
+
+  getRandomValues(arr);
+
+  let ret = '';
+  for (const el of arr) {
+   ret += (el >> 4).toString(16)
+  }
+
+  return ret;
+}}
+
 /**
  * Effects to translate attempted app navigations into Route navigation actions.
  *
@@ -641,11 +654,11 @@ function getAfterNamespaceId(
       beforeNamespaceId == null ||
       options.namespaceUpdate.option === NamespaceUpdateOption.NEW
     ) {
-      return `${generate32bitRandomId()}:${Date.now().toString()}`;
+      return `${generate32bitRandomId2.call()}:${Date.now().toString()}`;
     } else {
       return beforeNamespaceId;
     }
   }
 }
 
-export const TEST_ONLY = {initAction, generate32bitRandomId, getRandomValues};
+export const TEST_ONLY = {initAction, generate32bitRandomId, getRandomValues, generate32bitRandomId2};

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -105,36 +105,25 @@ type NavigationOptions = {
   namespaceUpdate: NamespaceUpdate;
 };
 
-function getRandomValues(arr: Uint8Array) {
-  crypto.getRandomValues(arr);
+const getRandomValues = (arr: Uint8Array) => {
+  // The usage of Crypto `getRandomValues` does not require return array.
+  // This is for the convenience of mock the funciton in testing.
+  arr = crypto.getRandomValues(arr);
   return arr;
-}
+};
 
-function generate32bitRandomId() {
+const generate32bitRandomId = () => {
   let arr = new Uint8Array(32);
 
   arr = getRandomValues(arr);
 
   let ret = '';
   for (const el of arr) {
-   ret += (el >> 4).toString(16)
+    ret += (el >> 4).toString(16);
   }
 
   return ret;
-}
-
-const generate32bitRandomId2 = { call: () => {
-  const arr = new Uint8Array(32);
-
-  getRandomValues(arr);
-
-  let ret = '';
-  for (const el of arr) {
-   ret += (el >> 4).toString(16)
-  }
-
-  return ret;
-}}
+};
 
 /**
  * Effects to translate attempted app navigations into Route navigation actions.
@@ -654,11 +643,11 @@ function getAfterNamespaceId(
       beforeNamespaceId == null ||
       options.namespaceUpdate.option === NamespaceUpdateOption.NEW
     ) {
-      return `${generate32bitRandomId2.call()}:${Date.now().toString()}`;
+      return `${generate32bitRandomId()}:${Date.now().toString()}`;
     } else {
       return beforeNamespaceId;
     }
   }
 }
 
-export const TEST_ONLY = {initAction, generate32bitRandomId, getRandomValues, generate32bitRandomId2};
+export const TEST_ONLY = {initAction};

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -70,8 +70,8 @@ const testDirtyExperimentsSelector = createSelector(
   }
 );
 const TEST_UINT8ARRAY = new Uint8Array([12, 34, 50, 160, 200]);
-// '023ac' is the string with base 16 convertd from TEST_UNIT8ARRAY
-// leave thr rest of the string to be 0
+// '023ac' is the string with base 16 converted from TEST_UNIT8ARRAY
+// leave the rest of the string to be 0
 const TEST_RANDOMID_STRING = '023ac000000000000000000000000000';
 
 describe('app_routing_effects', () => {
@@ -245,8 +245,11 @@ describe('app_routing_effects', () => {
     ): Uint8Array {
       if (arr instanceof Uint8Array) {
         arr.set(TEST_UINT8ARRAY);
+        return arr;
       }
-      return arr;
+      throw new Error(
+        `Crypto 'getRandomValues' mock function input type invalid: ${arr}`
+      );
     };
     spyOn(window.crypto, 'getRandomValues').and.callFake(
       mockRandomValuesFunction

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -243,6 +243,7 @@ describe('app_routing_effects', () => {
     }
    //spyOn(window.crypto, 'getRandomValues').and.callFake(mockRandomValuesFunction);
    spyOn(TEST_ONLY, 'generate32bitRandomId').and.returnValue('123456');
+   spyOn(TEST_ONLY.generate32bitRandomId2, 'call').and.returnValue('123456');
    spyOn(TEST_ONLY, 'getRandomValues').and.returnValue(new Uint8Array([3,4,5]));
   });
 
@@ -558,7 +559,7 @@ describe('app_routing_effects', () => {
             // From getActiveNamespaceId().
             beforeNamespaceId: null,
             // Newly-generated Id based on mock clock time.
-            // Error: Expected $[1].afterNamespaceId = '8e03a5acad99c47b49bcf57f8376c67f:1643229900995' to equal '123456:1643229900995'
+            // Pass!
             afterNamespaceId: `123456:${Date.now()}`,
           }),
         ]);

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -609,12 +609,12 @@ describe('app_routing_effects', () => {
 
       it('are generated on navigationRequested when resetNamespacedState is true', fakeAsync(() => {
         // Record initial time for use later.
-        const before = Date.now();
+        const beforeDate = Date.now();
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
         store.overrideSelector(getActiveRoute, buildRoute());
-        store.overrideSelector(getActiveNamespaceId, before.toString());
+        store.overrideSelector(getActiveNamespaceId, `1234:${beforeDate}`);
         store.overrideSelector(getEnabledTimeNamespacedState, true);
         store.refreshState();
 
@@ -635,10 +635,9 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
-            beforeNamespaceId: `023c:${before}`,
+            beforeNamespaceId: `1234:${beforeDate}`,
             // Value of before + the 5000 milliseconds from tick(5000).
-            afterNamespaceId: `023c:${before + 5000}`,
+            afterNamespaceId: `023c:${beforeDate + 5000}`,
           }),
         ]);
       }));
@@ -774,12 +773,12 @@ describe('app_routing_effects', () => {
 
       it('are generated on programmatical navigation when resetNamespacedState is true', fakeAsync(() => {
         // Record initial time for use later.
-        const before = Date.now();
+        const beforeDate = Date.now();
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
         store.overrideSelector(getActiveRoute, buildRoute());
-        store.overrideSelector(getActiveNamespaceId, before.toString());
+        store.overrideSelector(getActiveNamespaceId, `1234:${beforeDate}`);
         store.overrideSelector(getEnabledTimeNamespacedState, true);
         store.refreshState();
 
@@ -796,11 +795,10 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
-            beforeNamespaceId: `023c:${before}`,
+            beforeNamespaceId: `1234:${beforeDate}`,
             // Value of before + the 5000 milliseconds from tick(5000).
             // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
-            afterNamespaceId: `023c:${before + 5000}`,
+            afterNamespaceId: `023c:${beforeDate + 5000}`,
           }),
         ]);
       }));

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -235,6 +235,13 @@ describe('app_routing_effects', () => {
     spyOn(store, 'dispatch').and.callFake((action: Action) => {
       actualActions.push(action);
     });
+    const mockRandomValuesFunction = function<Uint8Array>(x: Uint8Array): Uint8Array {
+      // TODO(japie1235813): return testable value for `getRandomValues`.
+      // This causes error:  Property 'set' does not exist on type 'Uint8Array'.
+      // x.set([1,3,4,5]);
+      return x;
+    }
+   spyOn(window.crypto, 'getRandomValues').and.callFake(mockRandomValuesFunction);
   });
 
   describe('bootstrapReducers$', () => {
@@ -549,7 +556,7 @@ describe('app_routing_effects', () => {
             // From getActiveNamespaceId().
             beforeNamespaceId: null,
             // Newly-generated Id based on mock clock time.
-            afterNamespaceId: Date.now().toString(),
+            afterNamespaceId: `00000000000000000000000000000000:${Date.now()}`,
           }),
         ]);
       }));
@@ -598,14 +605,14 @@ describe('app_routing_effects', () => {
         tick();
 
         expect(replaceStateDataSpy).toHaveBeenCalledWith({
-          namespaceId: Date.now().toString(),
+          namespaceId: `00000000000000000000000000000000:${Date.now()}`,
           other: 'data',
         });
       }));
 
       it('are generated on navigationRequested when resetNamespacedState is true', fakeAsync(() => {
         // Record initial time for use later.
-        const before = Date.now();
+        const before = `00000000000000000000000000000000:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -640,7 +647,7 @@ describe('app_routing_effects', () => {
 
       it('are unchanged on navigationRequested when resetNamespacedState is false', fakeAsync(() => {
         // Record initial time for use later.
-        const before = Date.now();
+        const before = `00000000000000000000000000000000:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -675,7 +682,7 @@ describe('app_routing_effects', () => {
 
       it('are unchanged on navigationRequested when resetNamespacedState is unspecified', fakeAsync(() => {
         // Record initial time for use later.
-        const before = Date.now();
+        const before = `00000000000000000000000000000000:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -767,7 +774,7 @@ describe('app_routing_effects', () => {
 
       it('are generated on programmatical navigation when resetNamespacedState is true', fakeAsync(() => {
         // Record initial time for use later.
-        const before = Date.now();
+        const before = `00000000000000000000000000000000:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -798,7 +805,7 @@ describe('app_routing_effects', () => {
 
       it('are unchanged on programmatical navigation when resetNamespacedState is false', fakeAsync(() => {
         // Record initial time for use later.
-        const before = Date.now();
+        const before = `00000000000000000000000000000000:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -829,7 +836,7 @@ describe('app_routing_effects', () => {
 
       it('are unchanged on programmatical navigation when resetNamespacedState is unspecified', fakeAsync(() => {
         // Record initial time for use later.
-        const before = Date.now();
+        const before = `00000000000000000000000000000000:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -1112,7 +1119,7 @@ describe('app_routing_effects', () => {
         store.refreshState();
 
         // Record the current time from the mocked clock.
-        const firstActionTime = Date.now();
+        const firstActionTime = `00000000000000000000000000000000:${Date.now()}`;
         // Mimic initial navigation.
         action.next(
           actions.navigationRequested({

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -245,11 +245,8 @@ describe('app_routing_effects', () => {
     ): Uint8Array {
       if (arr instanceof Uint8Array) {
         arr.set(TEST_UINT8ARRAY);
-        return arr;
       }
-      throw new Error(
-        `Crypto 'getRandomValues' mock function input type invalid: ${arr}`
-      );
+      return arr;
     };
     spyOn(window.crypto, 'getRandomValues').and.callFake(
       mockRandomValuesFunction

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -69,6 +69,7 @@ const testDirtyExperimentsSelector = createSelector(
     } as DirtyUpdates;
   }
 );
+const TEST_UINT8ARRAY = new Uint8Array([12, 34, 50, 200]);
 
 describe('app_routing_effects', () => {
   let effects: AppRoutingEffects;
@@ -235,16 +236,7 @@ describe('app_routing_effects', () => {
     spyOn(store, 'dispatch').and.callFake((action: Action) => {
       actualActions.push(action);
     });
-    const mockRandomValuesFunction = function<Uint8Array>(x: Uint8Array): Uint8Array {
-      // TODO(japie1235813): return testable value for `getRandomValues`.
-      // This causes error:  Property 'set' does not exist on type 'Uint8Array'.
-      // x.set([1,3,4,5]);
-      return x;
-    }
-   //spyOn(window.crypto, 'getRandomValues').and.callFake(mockRandomValuesFunction);
-   spyOn(TEST_ONLY, 'generate32bitRandomId').and.returnValue('123456');
-   spyOn(TEST_ONLY.generate32bitRandomId2, 'call').and.returnValue('123456');
-   spyOn(TEST_ONLY, 'getRandomValues').and.returnValue(new Uint8Array([3,4,5]));
+    spyOn(window.crypto, 'getRandomValues').and.returnValue(TEST_UINT8ARRAY);
   });
 
   describe('bootstrapReducers$', () => {
@@ -537,7 +529,7 @@ describe('app_routing_effects', () => {
     });
 
     describe('time-namespaced ids', () => {
-      fit('are generated on bootstrap when none in history', fakeAsync(() => {
+      it('are generated on bootstrap when none in history', fakeAsync(() => {
         store.overrideSelector(getActiveRoute, null);
         store.overrideSelector(getActiveNamespaceId, null);
         store.overrideSelector(getEnabledTimeNamespacedState, true);
@@ -559,8 +551,8 @@ describe('app_routing_effects', () => {
             // From getActiveNamespaceId().
             beforeNamespaceId: null,
             // Newly-generated Id based on mock clock time.
-            // Pass!
-            afterNamespaceId: `123456:${Date.now()}`,
+            // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+            afterNamespaceId: `023c:${Date.now()}`,
           }),
         ]);
       }));
@@ -609,7 +601,8 @@ describe('app_routing_effects', () => {
         tick();
 
         expect(replaceStateDataSpy).toHaveBeenCalledWith({
-          namespaceId: `00000000000000000000000000000000:${Date.now()}`,
+          // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+          namespaceId: `023c:${Date.now()}`,
           other: 'data',
         });
       }));
@@ -642,16 +635,18 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            beforeNamespaceId: `00000000000000000000000000000000:${before}`,
+            // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+            beforeNamespaceId: `023c:${before}`,
             // Value of before + the 5000 milliseconds from tick(5000).
-            afterNamespaceId: `00000000000000000000000000000000:${before + 5000}`,
+            afterNamespaceId: `023c:${before + 5000}`,
           }),
         ]);
       }));
 
       it('are unchanged on navigationRequested when resetNamespacedState is false', fakeAsync(() => {
         // Record initial time for use later.
-        const before = `00000000000000000000000000000000:${Date.now()}`;
+        // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+        const before = `023c:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -686,7 +681,8 @@ describe('app_routing_effects', () => {
 
       it('are unchanged on navigationRequested when resetNamespacedState is unspecified', fakeAsync(() => {
         // Record initial time for use later.
-        const before = `00000000000000000000000000000000:${Date.now()}`;
+        // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+        const before = `023c:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -800,16 +796,19 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            beforeNamespaceId: `00000000000000000000000000000000:${before}`,
+            // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+            beforeNamespaceId: `023c:${before}`,
             // Value of before + the 5000 milliseconds from tick(5000).
-            afterNamespaceId: `00000000000000000000000000000000:${before + 5000}`,
+            // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+            afterNamespaceId: `023c:${before + 5000}`,
           }),
         ]);
       }));
 
       it('are unchanged on programmatical navigation when resetNamespacedState is false', fakeAsync(() => {
         // Record initial time for use later.
-        const before = `00000000000000000000000000000000:${Date.now()}`;
+        // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+        const before = `023c:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -840,7 +839,8 @@ describe('app_routing_effects', () => {
 
       it('are unchanged on programmatical navigation when resetNamespacedState is unspecified', fakeAsync(() => {
         // Record initial time for use later.
-        const before = `00000000000000000000000000000000:${Date.now()}`;
+        // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+        const before = `023c:${Date.now()}`;
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -1123,7 +1123,8 @@ describe('app_routing_effects', () => {
         store.refreshState();
 
         // Record the current time from the mocked clock.
-        const firstActionTime = `00000000000000000000000000000000:${Date.now()}`;
+        // '023c' is the string with base 16 convertd from TEST_UNIT8ARRAY
+        const firstActionTime = `023c:${Date.now()}`;
         // Mimic initial navigation.
         action.next(
           actions.navigationRequested({

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -243,6 +243,7 @@ describe('app_routing_effects', () => {
     }
    //spyOn(window.crypto, 'getRandomValues').and.callFake(mockRandomValuesFunction);
    spyOn(TEST_ONLY, 'generate32bitRandomId').and.returnValue('123456');
+   spyOn(TEST_ONLY, 'getRandomValues').and.returnValue(new Uint8Array([3,4,5]));
   });
 
   describe('bootstrapReducers$', () => {

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -241,7 +241,8 @@ describe('app_routing_effects', () => {
       // x.set([1,3,4,5]);
       return x;
     }
-   spyOn(window.crypto, 'getRandomValues').and.callFake(mockRandomValuesFunction);
+   //spyOn(window.crypto, 'getRandomValues').and.callFake(mockRandomValuesFunction);
+   spyOn(TEST_ONLY, 'generate32bitRandomId').and.returnValue('123456');
   });
 
   describe('bootstrapReducers$', () => {
@@ -534,7 +535,7 @@ describe('app_routing_effects', () => {
     });
 
     describe('time-namespaced ids', () => {
-      it('are generated on bootstrap when none in history', fakeAsync(() => {
+      fit('are generated on bootstrap when none in history', fakeAsync(() => {
         store.overrideSelector(getActiveRoute, null);
         store.overrideSelector(getActiveNamespaceId, null);
         store.overrideSelector(getEnabledTimeNamespacedState, true);
@@ -556,7 +557,8 @@ describe('app_routing_effects', () => {
             // From getActiveNamespaceId().
             beforeNamespaceId: null,
             // Newly-generated Id based on mock clock time.
-            afterNamespaceId: `00000000000000000000000000000000:${Date.now()}`,
+            // Error: Expected $[1].afterNamespaceId = '8e03a5acad99c47b49bcf57f8376c67f:1643229900995' to equal '123456:1643229900995'
+            afterNamespaceId: `123456:${Date.now()}`,
           }),
         ]);
       }));
@@ -612,7 +614,7 @@ describe('app_routing_effects', () => {
 
       it('are generated on navigationRequested when resetNamespacedState is true', fakeAsync(() => {
         // Record initial time for use later.
-        const before = `00000000000000000000000000000000:${Date.now()}`;
+        const before = Date.now();
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -638,9 +640,9 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            beforeNamespaceId: before.toString(),
+            beforeNamespaceId: `00000000000000000000000000000000:${before}`,
             // Value of before + the 5000 milliseconds from tick(5000).
-            afterNamespaceId: (before + 5000).toString(),
+            afterNamespaceId: `00000000000000000000000000000000:${before + 5000}`,
           }),
         ]);
       }));
@@ -774,7 +776,7 @@ describe('app_routing_effects', () => {
 
       it('are generated on programmatical navigation when resetNamespacedState is true', fakeAsync(() => {
         // Record initial time for use later.
-        const before = `00000000000000000000000000000000:${Date.now()}`;
+        const before = Date.now();
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
@@ -796,9 +798,9 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            beforeNamespaceId: before.toString(),
+            beforeNamespaceId: `00000000000000000000000000000000:${before}`,
             // Value of before + the 5000 milliseconds from tick(5000).
-            afterNamespaceId: (before + 5000).toString(),
+            afterNamespaceId: `00000000000000000000000000000000:${before + 5000}`,
           }),
         ]);
       }));

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -90,7 +90,6 @@ describe('app_routing_effects', () => {
   let getSearchSpy: jasmine.Spy;
   let serializeStateToQueryParamsSpy: jasmine.Spy;
   let deserializeQueryParamsSpy: jasmine.Spy;
-  let cryptoGetRandomValuesSpy: jasmine.Spy;
 
   beforeEach(async () => {
     action = new ReplaySubject<Action>(1);
@@ -242,12 +241,12 @@ describe('app_routing_effects', () => {
     });
 
     const mockRandomValuesFunction = function <Uint8Array>(
-      x: Uint8Array
+      arr: Uint8Array
     ): Uint8Array {
-      if (x instanceof Uint8Array) {
-        x.set(TEST_UINT8ARRAY);
+      if (arr instanceof Uint8Array) {
+        arr.set(TEST_UINT8ARRAY);
       }
-      return x;
+      return arr;
     };
     spyOn(window.crypto, 'getRandomValues').and.callFake(
       mockRandomValuesFunction
@@ -657,12 +656,12 @@ describe('app_routing_effects', () => {
 
       it('are unchanged on navigationRequested when resetNamespacedState is false', fakeAsync(() => {
         // Record initial time for use later.
-        const beforeDate = `${Date.now()}:${TEST_RANDOMID_STRING}`;
+        const beforeDate = Date.now();
         // Move the clock forward a bit to generate somewhat less arbitrary ids.
         tick(5000);
 
         store.overrideSelector(getActiveRoute, buildRoute());
-        store.overrideSelector(getActiveNamespaceId, beforeDate.toString());
+        store.overrideSelector(getActiveNamespaceId, `${beforeDate}:1234`);
         store.overrideSelector(getEnabledTimeNamespacedState, true);
         store.refreshState();
 
@@ -683,9 +682,9 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            beforeNamespaceId: beforeDate.toString(),
+            beforeNamespaceId: `${beforeDate}:1234`,
             // Same as beforeNamespaceId.
-            afterNamespaceId: beforeDate.toString(),
+            afterNamespaceId: `${beforeDate}:1234`,
           }),
         ]);
       }));
@@ -823,10 +822,7 @@ describe('app_routing_effects', () => {
         tick(5000);
 
         store.overrideSelector(getActiveRoute, buildRoute());
-        store.overrideSelector(
-          getActiveNamespaceId,
-          `${beforeDate}:${TEST_RANDOMID_STRING}`
-        );
+        store.overrideSelector(getActiveNamespaceId, `${beforeDate}:1234`);
         store.overrideSelector(getEnabledTimeNamespacedState, true);
         store.refreshState();
 
@@ -843,9 +839,9 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            beforeNamespaceId: `${beforeDate}:${TEST_RANDOMID_STRING}`,
+            beforeNamespaceId: `${beforeDate}:1234`,
             // Same as beforeNamespaceId.
-            afterNamespaceId: `${beforeDate}:${TEST_RANDOMID_STRING}`,
+            afterNamespaceId: `${beforeDate}:1234`,
           }),
         ]);
       }));
@@ -857,10 +853,7 @@ describe('app_routing_effects', () => {
         tick(5000);
 
         store.overrideSelector(getActiveRoute, buildRoute());
-        store.overrideSelector(
-          getActiveNamespaceId,
-          `${beforeDate}:${TEST_RANDOMID_STRING}`
-        );
+        store.overrideSelector(getActiveNamespaceId, `${beforeDate}:1234`);
         store.overrideSelector(getEnabledTimeNamespacedState, true);
         store.refreshState();
 
@@ -875,9 +868,9 @@ describe('app_routing_effects', () => {
               routeKind: RouteKind.EXPERIMENTS,
             }),
             // From getActiveNamespaceId().
-            beforeNamespaceId: `${beforeDate}:${TEST_RANDOMID_STRING}`,
+            beforeNamespaceId: `${beforeDate}:1234`,
             // Same as beforeNamespaceId.
-            afterNamespaceId: `${beforeDate}:${TEST_RANDOMID_STRING}`,
+            afterNamespaceId: `${beforeDate}:1234`,
           }),
         ]);
       }));
@@ -1138,7 +1131,7 @@ describe('app_routing_effects', () => {
         store.refreshState();
 
         // Record the current time from the mocked clock.
-        const firstActionTime = `${Date.now()}:${TEST_RANDOMID_STRING}`;
+        const firstActionTime = Date.now();
         // Mimic initial navigation.
         action.next(
           actions.navigationRequested({
@@ -1158,7 +1151,7 @@ describe('app_routing_effects', () => {
             }),
             beforeNamespaceId: null,
             // Newly generated id based on mock clock time.
-            afterNamespaceId: firstActionTime.toString(),
+            afterNamespaceId: `${firstActionTime}:${TEST_RANDOMID_STRING}`,
           }),
         ]);
 
@@ -1172,7 +1165,7 @@ describe('app_routing_effects', () => {
         );
         store.overrideSelector(
           getActiveNamespaceId,
-          firstActionTime.toString()
+          `${firstActionTime}:${TEST_RANDOMID_STRING}`
         );
         store.refreshState();
         // Mimic subsequent change in query parameter.
@@ -1193,9 +1186,9 @@ describe('app_routing_effects', () => {
               params: {experimentIds: 'a:b'},
             }),
             // From updated getActiveNamespaceId().
-            beforeNamespaceId: firstActionTime.toString(),
+            beforeNamespaceId: `${firstActionTime}:${TEST_RANDOMID_STRING}`,
             // Same as beforeNamespaceId. (no reset took place)
-            afterNamespaceId: firstActionTime.toString(),
+            afterNamespaceId: `${firstActionTime}:${TEST_RANDOMID_STRING}`,
           }),
         ]);
       }));

--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -246,11 +246,10 @@ export function canRehydrateDeepLink(
 }
 
 /**
- * Generates a 32-character long random id for name space suffix to avoid
+ * Generates a 32-character long random id for namespace suffix to avoid
  * collision of timestamp.
  */
 export function generateRandomIdForNamespace() {
-  // Generates id with 32 numbers/charaters.
   const arr = new Uint8Array(32);
 
   crypto.getRandomValues(arr);
@@ -258,9 +257,9 @@ export function generateRandomIdForNamespace() {
   let ret = '';
   for (const el of arr) {
     // We select base 16 which means the character of id is [0-9a-d].
-    // We only need four bit to convert to base 16 string (2^4) from Uint8array.
-    // Thus we get ride of the last 4 bit and then covert the rest of it.
-    // For example, number 162 woudl be 10100010 in binary. After dropping
+    // We only need four bits to convert to base 16 string (2^4) from Uint8array.
+    // Thus we get rid of the last 4 bit and then convert the rest of it.
+    // For example, number 162 is 10100010 in binary. After dropping
     // the rightest 4 bit, it is 1010, which is 10 in decimal number. Converts
     // 10 to base 16 it is 'a'.
     ret += (el >> 4).toString(16);

--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -251,7 +251,7 @@ export function canRehydrateDeepLink(
  */
 export function generateRandomIdForNamespace() {
   // Generates id with 32 numbers/charaters.
-  let arr = new Uint8Array(32);
+  const arr = new Uint8Array(32);
 
   crypto.getRandomValues(arr);
 

--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -249,13 +249,11 @@ export function canRehydrateDeepLink(
  * Generates a 32-character long random id for name space suffix to avoid
  * collision of timestamp.
  */
- export function generateRandomIdForNamespace() {
+export function generateRandomIdForNamespace() {
   // Generates id with 32 numbers/charaters.
   let arr = new Uint8Array(32);
 
-  // The usage of Crypto `getRandomValues` does not require return an array.
-  // This is for the convenience of mock the funciton in testing.
-  arr = crypto.getRandomValues(arr);
+  crypto.getRandomValues(arr);
 
   let ret = '';
   for (const el of arr) {

--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -244,3 +244,29 @@ export function canRehydrateDeepLink(
     )
   );
 }
+
+/**
+ * Generates a 32-character long random id for name space suffix to avoid
+ * collision of timestamp.
+ */
+ export function generateRandomIdForNamespace() {
+  // Generates id with 32 numbers/charaters.
+  let arr = new Uint8Array(32);
+
+  // The usage of Crypto `getRandomValues` does not require return an array.
+  // This is for the convenience of mock the funciton in testing.
+  arr = crypto.getRandomValues(arr);
+
+  let ret = '';
+  for (const el of arr) {
+    // We select base 16 which means the character of id is [0-9a-d].
+    // We only need four bit to convert to base 16 string (2^4) from Uint8array.
+    // Thus we get ride of the last 4 bit and then covert the rest of it.
+    // For example, number 162 woudl be 10100010 in binary. After dropping
+    // the rightest 4 bit, it is 1010, which is 10 in decimal number. Converts
+    // 10 to base 16 it is 'a'.
+    ret += (el >> 4).toString(16);
+  }
+
+  return ret;
+}

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -21,6 +21,15 @@ import {
 } from './testing';
 import {DeepLinkGroup, RouteKind} from './types';
 
+function getMockReturnValuesFuntion(testUint8array: Uint8Array) {
+  return function <Uint8Array>(arr: Uint8Array): Uint8Array {
+    if (arr instanceof Uint8Array) {
+      arr.set(testUint8array);
+    }
+    return arr;
+  };
+}
+
 describe('app_routing/utils', () => {
   describe('#parseCompareExperimentStr', () => {
     it('parses the map correctly', () => {
@@ -496,31 +505,41 @@ describe('app_routing/utils', () => {
 
     it('returns id witd base 16', () => {
       cryptoGetRandomValuesSpy = spyOn(window.crypto, 'getRandomValues');
-      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([1]));
+      cryptoGetRandomValuesSpy.and.callFake(
+        getMockReturnValuesFuntion(new Uint8Array([1]))
+      );
       let result = utils.generateRandomIdForNamespace();
-      expect(result).toEqual('0');
+      expect(result).toEqual('00000000000000000000000000000000');
 
-      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([15]));
-      result = utils.generateRandomIdForNamespace();
-      expect(result).toEqual('0');
-
-      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([17]));
-      result = utils.generateRandomIdForNamespace();
-      expect(result).toEqual('1');
-
-      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([32]));
-      result = utils.generateRandomIdForNamespace();
-      expect(result).toEqual('2');
-
-      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([160]));
-      result = utils.generateRandomIdForNamespace();
-      expect(result).toEqual('a');
-
-      cryptoGetRandomValuesSpy.and.returnValue(
-        new Uint8Array([0, 16, 32, 160, 320])
+      cryptoGetRandomValuesSpy.and.callFake(
+        getMockReturnValuesFuntion(new Uint8Array([15]))
       );
       result = utils.generateRandomIdForNamespace();
-      expect(result).toEqual('012a4');
+      expect(result).toEqual('00000000000000000000000000000000');
+
+      cryptoGetRandomValuesSpy.and.callFake(
+        getMockReturnValuesFuntion(new Uint8Array([17]))
+      );
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('10000000000000000000000000000000');
+
+      cryptoGetRandomValuesSpy.and.callFake(
+        getMockReturnValuesFuntion(new Uint8Array([32]))
+      );
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('20000000000000000000000000000000');
+
+      cryptoGetRandomValuesSpy.and.callFake(
+        getMockReturnValuesFuntion(new Uint8Array([160]))
+      );
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('a0000000000000000000000000000000');
+
+      cryptoGetRandomValuesSpy.and.callFake(
+        getMockReturnValuesFuntion(new Uint8Array([0, 16, 32, 160, 320]))
+      );
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('012a4000000000000000000000000000');
     });
   });
 });

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -27,9 +27,7 @@ function getMockReturnValuesFuntion(testUint8array: Uint8Array) {
       arr.set(testUint8array);
       return arr;
     }
-    throw new Error(
-      `'getMockReturnValuesFuntion' input type invalid: ${arr}`
-    );
+    throw new Error(`'getMockReturnValuesFuntion' input type invalid: ${arr}`);
   };
 }
 

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -25,8 +25,11 @@ function getMockReturnValuesFuntion(testUint8array: Uint8Array) {
   return function <Uint8Array>(arr: Uint8Array): Uint8Array {
     if (arr instanceof Uint8Array) {
       arr.set(testUint8array);
+      return arr;
     }
-    return arr;
+    throw new Error(
+      `'getMockReturnValuesFuntion' input type invalid: ${arr}`
+    );
   };
 }
 

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -484,4 +484,43 @@ describe('app_routing/utils', () => {
       ).toBeFalse();
     });
   });
+
+  describe('#generateRandomIdForNamespace', () => {
+    let cryptoGetRandomValuesSpy: jasmine.Spy;
+
+    it('returns 32-long id', () => {
+      const result = utils.generateRandomIdForNamespace();
+
+      expect(result.length).toEqual(32);
+    });
+
+    it('returns id witd base 16', () => {
+      cryptoGetRandomValuesSpy = spyOn(window.crypto, 'getRandomValues');
+      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([1]));
+      let result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('0');
+
+      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([15]));
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('0');
+
+      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([17]));
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('1');
+
+      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([32]));
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('2');
+
+      cryptoGetRandomValuesSpy.and.returnValue(new Uint8Array([160]));
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('a');
+
+      cryptoGetRandomValuesSpy.and.returnValue(
+        new Uint8Array([0, 16, 32, 160, 320])
+      );
+      result = utils.generateRandomIdForNamespace();
+      expect(result).toEqual('012a4');
+    });
+  });
 });

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -503,7 +503,7 @@ describe('app_routing/utils', () => {
       expect(result.length).toEqual(32);
     });
 
-    it('returns id witd base 16', () => {
+    it('returns id width base 16', () => {
       cryptoGetRandomValuesSpy = spyOn(window.crypto, 'getRandomValues');
       cryptoGetRandomValuesSpy.and.callFake(
         getMockReturnValuesFuntion(new Uint8Array([1]))


### PR DESCRIPTION
To avoid repeated timestamp causing name space id collision, we add a random generated prefix.