### PR TITLE
cleanup: alphabetize argument order for FakeFlags

### DIFF
--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -33,31 +33,31 @@ from tensorboard.plugins import base_plugin
 class FakeFlags(object):
     def __init__(
         self,
-        logdir,
+        generic_data="auto",
+        logdir="",
         logdir_spec="",
+        max_reload_threads=1,
+        path_prefix="",
         purge_orphaned_data=True,
         reload_interval=60,
-        samples_per_plugin=None,
-        max_reload_threads=1,
-        reload_task="auto",
-        window_title="",
-        path_prefix="",
         reload_multifile=False,
         reload_multifile_inactive_secs=4000,
-        generic_data="auto",
+        reload_task="auto",
+        samples_per_plugin=None,
+        window_title="",
     ):
+        self.generic_data = generic_data
         self.logdir = logdir
         self.logdir_spec = logdir_spec
+        self.max_reload_threads = max_reload_threads
+        self.path_prefix = path_prefix
         self.purge_orphaned_data = purge_orphaned_data
         self.reload_interval = reload_interval
-        self.samples_per_plugin = samples_per_plugin or {}
-        self.max_reload_threads = max_reload_threads
-        self.reload_task = reload_task
-        self.window_title = window_title
-        self.path_prefix = path_prefix
         self.reload_multifile = reload_multifile
         self.reload_multifile_inactive_secs = reload_multifile_inactive_secs
-        self.generic_data = generic_data
+        self.reload_task = reload_task
+        self.samples_per_plugin = samples_per_plugin or {}
+        self.window_title = window_title
 
 
 class FakePlugin(base_plugin.TBPlugin):

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -32,47 +32,51 @@ _TENSORFLOW_IO_MODULE = "tensorflow_io"
 class FakeFlags(object):
     def __init__(
         self,
-        logdir,
+        generic_data="auto",
+        logdir="",
         logdir_spec="",
+        max_reload_threads=1,
+        path_prefix="",
         purge_orphaned_data=True,
         reload_interval=60,
-        samples_per_plugin=None,
-        max_reload_threads=1,
-        reload_task="auto",
-        window_title="",
-        path_prefix="",
         reload_multifile=False,
         reload_multifile_inactive_secs=4000,
-        generic_data="auto",
+        reload_task="auto",
+        samples_per_plugin=None,
+        window_title="",
     ):
+        self.generic_data = generic_data
         self.logdir = logdir
         self.logdir_spec = logdir_spec
+        self.max_reload_threads = max_reload_threads
+        self.path_prefix = path_prefix
         self.purge_orphaned_data = purge_orphaned_data
         self.reload_interval = reload_interval
-        self.samples_per_plugin = samples_per_plugin or {}
-        self.max_reload_threads = max_reload_threads
-        self.reload_task = reload_task
-        self.window_title = window_title
-        self.path_prefix = path_prefix
         self.reload_multifile = reload_multifile
         self.reload_multifile_inactive_secs = reload_multifile_inactive_secs
-        self.generic_data = generic_data
+        self.reload_task = reload_task
+        self.samples_per_plugin = samples_per_plugin or {}
+        self.window_title = window_title
 
 
 class GetEventFileActiveFilterTest(tb_test.TestCase):
     def testDisabled(self):
-        flags = FakeFlags("logdir", reload_multifile=False)
+        flags = FakeFlags(logdir="logdir", reload_multifile=False)
         self.assertIsNone(data_ingester._get_event_file_active_filter(flags))
 
     def testInactiveSecsZero(self):
         flags = FakeFlags(
-            "logdir", reload_multifile=True, reload_multifile_inactive_secs=0
+            logdir="logdir",
+            reload_multifile=True,
+            reload_multifile_inactive_secs=0,
         )
         self.assertIsNone(data_ingester._get_event_file_active_filter(flags))
 
     def testInactiveSecsNegative(self):
         flags = FakeFlags(
-            "logdir", reload_multifile=True, reload_multifile_inactive_secs=-1
+            logdir="logdir",
+            reload_multifile=True,
+            reload_multifile_inactive_secs=-1,
         )
         filter_fn = data_ingester._get_event_file_active_filter(flags)
         self.assertTrue(filter_fn(0))
@@ -81,7 +85,9 @@ class GetEventFileActiveFilterTest(tb_test.TestCase):
 
     def testInactiveSecs(self):
         flags = FakeFlags(
-            "logdir", reload_multifile=True, reload_multifile_inactive_secs=10
+            logdir="logdir",
+            reload_multifile=True,
+            reload_multifile_inactive_secs=10,
         )
         filter_fn = data_ingester._get_event_file_active_filter(flags)
         with mock.patch.object(time, "time") as mock_time:
@@ -378,7 +384,9 @@ class FileSystemSupportTest(tb_test.TestCase):
             with mock.patch.object(
                 data_ingester, "_check_filesystem_support", autospec=True
             ) as mock_check_filesystem_support:
-                data_ingester.LocalDataIngester(flags=FakeFlags("logdir"))
+                data_ingester.LocalDataIngester(
+                    flags=FakeFlags(logdir="logdir")
+                )
         mock_check_filesystem_support.assert_called_once_with({"logdir"})
 
     def testCheckFilesystemSupport_notCalled(self):
@@ -386,7 +394,9 @@ class FileSystemSupportTest(tb_test.TestCase):
             with mock.patch.object(
                 data_ingester, "_check_filesystem_support", autospec=True
             ) as mock_check_filesystem_support:
-                data_ingester.LocalDataIngester(flags=FakeFlags("logdir"))
+                data_ingester.LocalDataIngester(
+                    flags=FakeFlags(logdir="logdir")
+                )
         mock_check_filesystem_support.assert_not_called()
 
 

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -47,30 +47,30 @@ class FakeFlags(object):
     def __init__(
         self,
         bind_all=False,
-        host=None,
-        inspect=False,
-        version_tb=False,
-        logdir="",
-        logdir_spec="",
-        event_file="",
         db="",
-        path_prefix="",
+        event_file="",
         generic_data="true",
         grpc_data_provider="",
+        host=None,
+        inspect=False,
+        logdir="",
+        logdir_spec="",
+        path_prefix="",
         reuse_port=False,
+        version_tb=False,
     ):
         self.bind_all = bind_all
-        self.host = host
-        self.inspect = inspect
-        self.version_tb = version_tb
-        self.logdir = logdir
-        self.logdir_spec = logdir_spec
-        self.event_file = event_file
         self.db = db
-        self.path_prefix = path_prefix
+        self.event_file = event_file
         self.generic_data = generic_data
         self.grpc_data_provider = grpc_data_provider
+        self.host = host
+        self.inspect = inspect
+        self.logdir = logdir
+        self.logdir_spec = logdir_spec
+        self.path_prefix = path_prefix
         self.reuse_port = reuse_port
+        self.version_tb = version_tb
 
 
 class CorePluginFlagsTest(tf.test.TestCase):


### PR DESCRIPTION
We have a few FakeFlag instances in our tests.  We periodically have to add flags to these (for new flags that we're introducing or existing flags we're using in new places), but since the flags aren't in any particular order, it's kind of messy and hard to tell where to put the flag / whether a flag is already present.

This resolves this by just alphabetizing the flags.  We also make them all keyword args (rather than special-casing `logdir` to be a positional argument).

This is pre-work for #5530.

