### PR TITLE
time-namespaced state: Move pathname and queryParams out of Route.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -295,8 +295,6 @@ describe('app_routing_effects', () => {
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
               params: {},
-              pathname: '/experiments',
-              queryParams: [],
             }),
           }),
         ]);
@@ -309,8 +307,6 @@ describe('app_routing_effects', () => {
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
               params: {},
-              pathname: '/experiments',
-              queryParams: [],
             }),
             beforeNamespaceId: null,
             afterNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
@@ -330,8 +326,6 @@ describe('app_routing_effects', () => {
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENTS,
             params: {},
-            pathname: '/experiments',
-            queryParams: [],
           }),
         }),
       ]);
@@ -341,8 +335,6 @@ describe('app_routing_effects', () => {
       beforeEach(() => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENTS,
-          pathname: '/experiments',
-          queryParams: [],
         });
         const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENTS, {});
         const dirtyExperimentsFactory = () => {
@@ -373,8 +365,6 @@ describe('app_routing_effects', () => {
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENT,
               params: {experimentId: 'meow'},
-              pathname: '/experiment/meow',
-              queryParams: [],
             }),
           }),
         ]);
@@ -398,8 +388,6 @@ describe('app_routing_effects', () => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENT,
           params: {experimentId: 'meow'},
-          pathname: '/experiment/meow',
-          queryParams: [],
         });
         const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENT, {
           experimentId: 'meow',
@@ -410,7 +398,9 @@ describe('app_routing_effects', () => {
         getPathSpy.and.returnValue('/experiment/meow');
         // Changing tab.
         getHashSpy.and.returnValue('#foo');
-        action.next(actions.navigationRequested(activeRoute));
+        action.next(
+          actions.navigationRequested({pathname: '/experiment/meow'})
+        );
         tick();
 
         expect(window.confirm).not.toHaveBeenCalled();
@@ -458,8 +448,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.EXPERIMENT,
                 params: {experimentId: 'meow'},
-                pathname: '/experiment/meow',
-                queryParams: [],
               }),
             }),
           ]);
@@ -471,22 +459,16 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.EXPERIMENT,
                 params: {experimentId: 'meow'},
-                pathname: '/experiment/meow',
-                queryParams: [],
               }),
             }),
             actions.navigated({
               before: buildRoute({
                 routeKind: RouteKind.EXPERIMENTS,
                 params: {},
-                pathname: '/experiments',
-                queryParams: [],
               }),
               after: buildRoute({
                 routeKind: RouteKind.EXPERIMENT,
                 params: {experimentId: 'meow'},
-                pathname: '/experiment/meow',
-                queryParams: [],
               }),
               beforeNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
               afterNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENT, {
@@ -518,8 +500,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.EXPERIMENTS,
                 params: {},
-                pathname: '/experiments',
-                queryParams: [],
               }),
             }),
           ]);
@@ -536,8 +516,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.EXPERIMENTS,
                 params: {},
-                pathname: '/experiments',
-                queryParams: [],
               }),
               beforeNamespaceId: null,
               afterNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
@@ -566,7 +544,6 @@ describe('app_routing_effects', () => {
             before: null,
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: null,
@@ -595,7 +572,6 @@ describe('app_routing_effects', () => {
             before: null,
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: null,
@@ -652,7 +628,6 @@ describe('app_routing_effects', () => {
             before: buildRoute(),
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: before.toString(),
@@ -688,7 +663,6 @@ describe('app_routing_effects', () => {
             before: buildRoute(),
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: before.toString(),
@@ -723,7 +697,6 @@ describe('app_routing_effects', () => {
             before: buildRoute(),
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: before.toString(),
@@ -752,7 +725,6 @@ describe('app_routing_effects', () => {
             before: buildRoute(),
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: 'before',
@@ -783,7 +755,6 @@ describe('app_routing_effects', () => {
             before: buildRoute(),
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: 'before',
@@ -815,7 +786,6 @@ describe('app_routing_effects', () => {
             before: buildRoute(),
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: before.toString(),
@@ -847,7 +817,6 @@ describe('app_routing_effects', () => {
             before: buildRoute(),
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: before.toString(),
@@ -877,7 +846,6 @@ describe('app_routing_effects', () => {
             before: buildRoute(),
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
-              pathname: '/experiments',
             }),
             // From getActiveNamespaceId().
             beforeNamespaceId: before.toString(),
@@ -927,8 +895,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {experimentIds: 'a:b'},
-                pathname: '/compare/a:b',
-                queryParams: [],
               } as unknown as Route),
             }),
             actions.navigated({
@@ -936,8 +902,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {experimentIds: 'a:b'},
-                pathname: '/compare/a:b',
-                queryParams: [],
               } as unknown as Route),
               beforeNamespaceId: null,
               afterNamespaceId: getRouteNamespaceId(
@@ -976,8 +940,6 @@ describe('app_routing_effects', () => {
             after: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
               params: {experimentIds: 'a:b'},
-              pathname: '/compare/a:b',
-              queryParams: [],
             } as unknown as Route),
           }),
           jasmine.any(Object), // actions.navigated
@@ -1006,8 +968,6 @@ describe('app_routing_effects', () => {
             after: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
               params: {experimentIds: 'a:b'},
-              pathname: '/compare/a:b',
-              queryParams: [],
             } as unknown as Route),
           }),
           jasmine.any(Object), // actions.navigated
@@ -1044,8 +1004,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {experimentIds: 'a:b'},
-                pathname: '/compare/a:b',
-                queryParams: [],
               }),
             }),
             actions.navigated({
@@ -1053,8 +1011,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {experimentIds: 'a:b'},
-                pathname: '/compare/a:b',
-                queryParams: [],
               }),
               beforeNamespaceId: null,
               afterNamespaceId: getRouteNamespaceId(
@@ -1085,8 +1041,6 @@ describe('app_routing_effects', () => {
             after: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
               params: {experimentIds: 'a:b'},
-              pathname: '/compare/a:b',
-              queryParams: [{key: 'a', value: 'a_value'}],
             }),
           }),
           actions.navigated({
@@ -1094,8 +1048,6 @@ describe('app_routing_effects', () => {
             after: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
               params: {experimentIds: 'a:b'},
-              pathname: '/compare/a:b',
-              queryParams: [{key: 'a', value: 'a_value'}],
             }),
             beforeNamespaceId: null,
             afterNamespaceId: getRouteNamespaceId(
@@ -1163,7 +1115,6 @@ describe('app_routing_effects', () => {
             before: null,
             after: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
-              pathname: '/compare/a:b',
               params: {experimentIds: 'a:b'},
             }),
             beforeNamespaceId: null,
@@ -1177,7 +1128,6 @@ describe('app_routing_effects', () => {
           getActiveRoute,
           buildRoute({
             routeKind: RouteKind.COMPARE_EXPERIMENT,
-            pathname: '/compare/a:b',
             params: {experimentIds: 'a:b'},
           })
         );
@@ -1197,12 +1147,10 @@ describe('app_routing_effects', () => {
           actions.navigated({
             before: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
-              pathname: '/compare/a:b',
               params: {experimentIds: 'a:b'},
             }),
             after: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
-              pathname: '/compare/a:b',
               params: {experimentIds: 'a:b'},
             }),
             // From updated getActiveNamespaceId().
@@ -1269,8 +1217,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {experimentIds: 'a:b'},
-                pathname: '/compare/a:b',
-                queryParams: [],
               }),
             }),
             // Third action is of type actions.navigated but we ignore it.
@@ -1307,12 +1253,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
                 params: {experimentIds: 'a:b'},
-                pathname: '/compare/a:b',
-                // Query parameter comes from DeepLinkProvider
-                // (serializeStateToQueryParamsSpy) in this case, not
-                // redirector. Query parameter of redirector is fed into
-                // deserializer instead.
-                queryParams: [],
               }),
             }),
             // Third action is of type actions.navigated but we ignore it.
@@ -1337,8 +1277,6 @@ describe('app_routing_effects', () => {
               after: buildRoute({
                 routeKind: RouteKind.UNKNOWN,
                 params: {},
-                pathname: '/no_deeplink_unknown/route',
-                queryParams: [],
               }),
             }),
             // Second action is of type actions.navigated but we ignore it.
@@ -1368,8 +1306,6 @@ describe('app_routing_effects', () => {
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENTS,
             params: {},
-            pathname: '/experiments',
-            queryParams: [],
           }),
         }),
       ]);
@@ -1381,8 +1317,6 @@ describe('app_routing_effects', () => {
         getActiveRoute,
         buildRoute({
           routeKind: RouteKind.EXPERIMENTS,
-          pathname: '/experiments',
-          queryParams: [],
         })
       );
       store.overrideSelector(
@@ -1402,20 +1336,14 @@ describe('app_routing_effects', () => {
         actions.navigating({
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENTS,
-            pathname: '/experiments',
-            queryParams: [],
           }),
         }),
         actions.navigated({
           before: buildRoute({
             routeKind: RouteKind.EXPERIMENTS,
-            pathname: '/experiments',
-            queryParams: [],
           }),
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENTS,
-            pathname: '/experiments',
-            queryParams: [],
           }),
           beforeNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
           afterNamespaceId: getRouteNamespaceId(RouteKind.EXPERIMENTS, {}),
@@ -1436,8 +1364,6 @@ describe('app_routing_effects', () => {
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENTS,
               params: {},
-              pathname: '/experiments',
-              queryParams: [],
             }),
           }),
         ]);
@@ -1464,8 +1390,6 @@ describe('app_routing_effects', () => {
               params: {
                 experimentIds: 'bar:foo,omega:alpha',
               },
-              pathname: '/compare/bar:foo,omega:alpha',
-              queryParams: [],
             }),
           }),
         ]);
@@ -1474,7 +1398,7 @@ describe('app_routing_effects', () => {
 
     describe('url changes', () => {
       function navigateAndExpect(
-        navigation: Navigation | Route,
+        navigation: Navigation,
         expected: {pushStateUrl: null | string; replaceStateUrl: null | string}
       ) {
         fakeAsync(() => {
@@ -1500,8 +1424,6 @@ describe('app_routing_effects', () => {
       it('noops if the new route matches current URL', () => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENTS,
-          pathname: '/experiments',
-          queryParams: [],
         });
         const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENTS, {});
         store.overrideSelector(getActiveRoute, activeRoute);
@@ -1511,17 +1433,18 @@ describe('app_routing_effects', () => {
         getPathSpy.and.returnValue('/experiments');
         getSearchSpy.and.returnValue([]);
 
-        navigateAndExpect(activeRoute, {
-          pushStateUrl: null,
-          replaceStateUrl: null,
-        });
+        navigateAndExpect(
+          {pathname: '/experiments'},
+          {
+            pushStateUrl: null,
+            replaceStateUrl: null,
+          }
+        );
       });
 
       it('pushes state if path and search do not match new route on navigated', () => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENTS,
-          pathname: '/experiments',
-          queryParams: [],
         });
         const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENTS, {});
         store.overrideSelector(getActiveRoute, activeRoute);
@@ -1543,8 +1466,6 @@ describe('app_routing_effects', () => {
       it('replaces state if navigationRequested says so', () => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENTS,
-          pathname: '/experiments',
-          queryParams: [],
         });
         const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENTS, {});
         store.overrideSelector(getActiveRoute, activeRoute);
@@ -1586,9 +1507,7 @@ describe('app_routing_effects', () => {
       it('preserves hash upon navigations to the same experiment', () => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENT,
-          pathname: '/experiment',
           params: {experimentId: '123'},
-          queryParams: [],
         });
         const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENT, {});
         store.overrideSelector(getActiveRoute, activeRoute);
@@ -1610,8 +1529,6 @@ describe('app_routing_effects', () => {
       it('discards hash upon navigations to a new experiment', () => {
         const activeRoute = buildRoute({
           routeKind: RouteKind.EXPERIMENTS,
-          pathname: '/experiments',
-          queryParams: [],
         });
         const namespaceId = getRouteNamespaceId(RouteKind.EXPERIMENT, {});
 
@@ -1669,8 +1586,6 @@ describe('app_routing_effects', () => {
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENTS,
             params: {},
-            pathname: '/experiments',
-            queryParams: [],
           }),
         }),
       ]);
@@ -1691,8 +1606,6 @@ describe('app_routing_effects', () => {
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: '123'},
-            pathname: '/experiment/123',
-            queryParams: [],
           }),
         }),
       ]);
@@ -1711,8 +1624,6 @@ describe('app_routing_effects', () => {
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: '123'},
-            pathname: '/experiment/123',
-            queryParams: [],
           }),
         }),
       ]);
@@ -1735,8 +1646,6 @@ describe('app_routing_effects', () => {
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: '123'},
-            pathname: '/experiment/123',
-            queryParams: [],
           }),
         }),
       ]);

--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -169,17 +169,15 @@ export function createURLSearchParamsFromSerializableQueryParams(
 }
 
 /**
- * Checks whether two RouteOrNavs are equal. RouteOrNav is defined to be Route
- * or Navigation.
+ * Checks whether two sets of URL path and query parameters are equal.
  *
- * Limitations: currently, they only match pathname and query parameter (order
- * of the params have to be equal too; e.g., a=1&b=2 will not equal b=2&a=1).
+ * Limitations: order of the params have to be equal too; e.g., a=1&b=2 will not
+ * equal b=2&a=1).
  */
-export function areRoutesEqual(
-  aRoute: Pick<Route, 'pathname' | 'queryParams'>,
-  bRoute: Pick<Route, 'pathname' | 'queryParams'>
+export function arePathsAndQueryParamsEqual(
+  aRoute: {pathname: string; queryParams: SerializableQueryParams},
+  bRoute: {pathname: string; queryParams: SerializableQueryParams}
 ): boolean {
-  // TODO(stephanwlee): support hashes.
   if (
     aRoute.pathname !== bRoute.pathname ||
     aRoute.queryParams.length !== bRoute.queryParams.length

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -308,10 +308,10 @@ describe('app_routing/utils', () => {
     });
   });
 
-  describe('#areRoutesEqual', () => {
+  describe('#arePathsAndQueryParamsEqual', () => {
     it('returns true if they are equal', () => {
       expect(
-        utils.areRoutesEqual(
+        utils.arePathsAndQueryParamsEqual(
           {
             pathname: '/foo',
             queryParams: [],
@@ -324,7 +324,7 @@ describe('app_routing/utils', () => {
       ).toBe(true);
 
       expect(
-        utils.areRoutesEqual(
+        utils.arePathsAndQueryParamsEqual(
           {
             pathname: '/foo/bar',
             queryParams: [{key: 'a', value: '1'}],
@@ -339,7 +339,7 @@ describe('app_routing/utils', () => {
 
     it('returns false if paths are different', () => {
       expect(
-        utils.areRoutesEqual(
+        utils.arePathsAndQueryParamsEqual(
           {
             pathname: '/foo/bar',
             queryParams: [],
@@ -354,7 +354,7 @@ describe('app_routing/utils', () => {
 
     it('returns false if query params values are different', () => {
       expect(
-        utils.areRoutesEqual(
+        utils.arePathsAndQueryParamsEqual(
           {
             pathname: '/foo/bar',
             queryParams: [{key: 'a', value: '1'}],
@@ -369,7 +369,7 @@ describe('app_routing/utils', () => {
 
     it('returns false if query params has more values', () => {
       expect(
-        utils.areRoutesEqual(
+        utils.arePathsAndQueryParamsEqual(
           {
             pathname: '/foo/bar',
             queryParams: [{key: 'a', value: '1'}],
@@ -387,7 +387,7 @@ describe('app_routing/utils', () => {
 
     it('returns false when orders are different', () => {
       expect(
-        utils.areRoutesEqual(
+        utils.arePathsAndQueryParamsEqual(
           {
             pathname: '/foo/bar',
             queryParams: [

--- a/tensorboard/webapp/app_routing/location.ts
+++ b/tensorboard/webapp/app_routing/location.ts
@@ -16,7 +16,7 @@ import {Injectable} from '@angular/core';
 import {fromEvent, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {createURLSearchParamsFromSerializableQueryParams} from './internal_utils';
-import {NavigationFromHistory, Route, SerializableQueryParams} from './types';
+import {NavigationFromHistory, SerializableQueryParams} from './types';
 
 export interface LocationInterface {
   getHref(): string;
@@ -37,7 +37,11 @@ export interface LocationInterface {
 
   getResolvedPath(relativePath: string): string;
 
-  getFullPathFromRoute(route: Route): string;
+  getFullPath(
+    pathname: string,
+    queryParams: SerializableQueryParams,
+    shouldPreserveHash?: boolean
+  ): string;
 }
 
 const utils = {
@@ -107,19 +111,22 @@ export class Location implements LocationInterface {
     return url.pathname;
   }
 
-  getFullPathFromRoute(route: Route, shouldPreserveHash?: boolean): string {
-    // TODO(stephanwlee): support hashes in the route.
-    const pathname = this.getResolvedPath(route.pathname);
+  getFullPath(
+    pathname: string,
+    queryParams: SerializableQueryParams,
+    shouldPreserveHash?: boolean
+  ): string {
+    const resolvedPathname = this.getResolvedPath(pathname);
     let search = '';
-    if (route.queryParams.length) {
+    if (queryParams.length) {
       search =
         '?' +
         createURLSearchParamsFromSerializableQueryParams(
-          route.queryParams
+          queryParams
         ).toString();
     }
     const hash = shouldPreserveHash ? this.getHash() : '';
-    return `${pathname}${search}${hash}`;
+    return `${resolvedPathname}${search}${hash}`;
   }
 }
 

--- a/tensorboard/webapp/app_routing/location_test.ts
+++ b/tensorboard/webapp/app_routing/location_test.ts
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 import {Location, TEST_ONLY} from './location';
-import {buildRoute} from './testing';
 
 describe('location', () => {
   let location: Location;
@@ -65,24 +64,12 @@ describe('location', () => {
   describe('#getFullPathFromRouteOrNav', () => {
     it('forms the full path', () => {
       expect(
-        location.getFullPathFromRoute(
-          buildRoute({
-            pathname: '/foo/bar/baz',
-            queryParams: [{key: 'a', value: '1'}],
-          })
-        )
+        location.getFullPath('/foo/bar/baz', [{key: 'a', value: '1'}])
       ).toBe('/foo/bar/baz?a=1');
     });
 
     it('does not add "?" when queryParams is empty', () => {
-      expect(
-        location.getFullPathFromRoute(
-          buildRoute({
-            pathname: '/foo',
-            queryParams: [],
-          })
-        )
-      ).toBe('/foo');
+      expect(location.getFullPath('/foo', [])).toBe('/foo');
     });
   });
 });

--- a/tensorboard/webapp/app_routing/namespaced_state_reducer_helper_test.ts
+++ b/tensorboard/webapp/app_routing/namespaced_state_reducer_helper_test.ts
@@ -86,12 +86,10 @@ describe('route_contexted_reducer_helper', () => {
           before: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'xyz'},
-            queryParams: [],
           }),
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'abc'},
-            queryParams: [],
           }),
           beforeNamespaceId: 'namespace1',
           afterNamespaceId: 'namespace2',
@@ -106,12 +104,10 @@ describe('route_contexted_reducer_helper', () => {
           before: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'abc'},
-            queryParams: [],
           }),
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'xyz'},
-            queryParams: [],
           }),
           beforeNamespaceId: 'namespace2',
           afterNamespaceId: 'namespace1',
@@ -134,12 +130,10 @@ describe('route_contexted_reducer_helper', () => {
           before: buildRoute({
             routeKind: RouteKind.EXPERIMENTS,
             params: {},
-            queryParams: [],
           }),
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'xyz'},
-            queryParams: [],
           }),
           beforeNamespaceId: 'namespace1',
           afterNamespaceId: 'namespace2',
@@ -166,7 +160,6 @@ describe('route_contexted_reducer_helper', () => {
             after: buildRoute({
               routeKind: RouteKind.EXPERIMENT,
               params: {experimentId: 'xyz'},
-              queryParams: [],
             }),
             beforeNamespaceId: null,
             afterNamespaceId: 'namespace1',
@@ -195,7 +188,6 @@ describe('route_contexted_reducer_helper', () => {
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'abc'},
-            queryParams: [],
           }),
           beforeNamespaceId: null,
           afterNamespaceId: 'namespace1',
@@ -222,12 +214,10 @@ describe('route_contexted_reducer_helper', () => {
           before: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'abc'},
-            queryParams: [],
           }),
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'xyz'},
-            queryParams: [],
           }),
           beforeNamespaceId: 'namespace1',
           afterNamespaceId: 'namespace1',
@@ -270,12 +260,10 @@ describe('route_contexted_reducer_helper', () => {
           before: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'xyz'},
-            queryParams: [],
           }),
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'abc'},
-            queryParams: [],
           }),
           beforeNamespaceId: 'namespace1',
           afterNamespaceId: 'namespace2',
@@ -290,12 +278,10 @@ describe('route_contexted_reducer_helper', () => {
           before: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'abc'},
-            queryParams: [],
           }),
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
             params: {experimentId: 'xyz'},
-            queryParams: [],
           }),
           beforeNamespaceId: 'namespace2',
           afterNamespaceId: 'namespace1',

--- a/tensorboard/webapp/app_routing/route_config.ts
+++ b/tensorboard/webapp/app_routing/route_config.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {DeepLinkProvider} from './deep_link_provider';
 import {
   ConcreteRouteDef,
   isConcreteRouteDef,
@@ -20,7 +21,7 @@ import {
   RedirectionRouteDef,
   RouteDef,
 } from './route_config_types';
-import {Route, RouteKind, RouteParams, SerializableQueryParams} from './types';
+import {RouteKind, RouteParams, SerializableQueryParams} from './types';
 
 interface NegativeMatch {
   result: false;
@@ -273,12 +274,12 @@ class ProgrammaticalRedirectionRouteConfigMatcher extends RouteConfigMatcher {
 }
 
 interface BaseRedirectionRouteMatch {
-  routeKind: Route['routeKind'];
-  pathname: Route['pathname'];
+  routeKind: RouteKind;
+  pathname: string;
   // Route parameters. An object. Its keys are defined to be parameter defined
   // in the path spec while their respective values are string.
-  params: Route['params'];
-  deepLinkProvider: ConcreteRouteDef['deepLinkProvider'] | null;
+  params: RouteParams;
+  deepLinkProvider: DeepLinkProvider | null;
   originateFromRedirection: boolean;
 }
 
@@ -288,7 +289,7 @@ export interface NonRedirectionRouteMatch extends BaseRedirectionRouteMatch {
 
 export interface RedirectionRouteMatch extends BaseRedirectionRouteMatch {
   originateFromRedirection: true;
-  redirectionOnlyQueryParams: Route['queryParams'] | undefined;
+  redirectionOnlyQueryParams: SerializableQueryParams | undefined;
 }
 
 export type RouteMatch = NonRedirectionRouteMatch | RedirectionRouteMatch;

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
@@ -32,11 +32,9 @@ describe('app_routing_reducers', () => {
         actions.navigating({
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
-            pathname: '/experiment/234',
             params: {
               experimentId: '234',
             },
-            queryParams: [],
           }),
         })
       );
@@ -44,11 +42,9 @@ describe('app_routing_reducers', () => {
       expect(nextState.nextRoute).toEqual(
         buildRoute({
           routeKind: RouteKind.EXPERIMENT,
-          pathname: '/experiment/234',
           params: {
             experimentId: '234',
           },
-          queryParams: [],
         })
       );
     });
@@ -67,11 +63,9 @@ describe('app_routing_reducers', () => {
           before: null,
           after: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
-            pathname: '/experiment/234',
             params: {
               experimentId: '234',
             },
-            queryParams: [],
           }),
           beforeNamespaceId: null,
           afterNamespaceId: 'namespace1',
@@ -81,11 +75,9 @@ describe('app_routing_reducers', () => {
       expect(nextState.activeRoute).toEqual(
         buildRoute({
           routeKind: RouteKind.EXPERIMENT,
-          pathname: '/experiment/234',
           params: {
             experimentId: '234',
           },
-          queryParams: [],
         })
       );
       expect(nextState.activeNamespaceId).toEqual('namespace1');

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -29,22 +29,18 @@ describe('app_routing_selectors', () => {
         buildAppRoutingState({
           activeRoute: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
-            pathname: '/experiment/234',
             params: {
               experimentId: '234',
             },
-            queryParams: [],
           }),
         })
       );
 
       expect(selectors.getActiveRoute(state)).toEqual({
         routeKind: RouteKind.EXPERIMENT,
-        pathname: '/experiment/234',
         params: {
           experimentId: '234',
         },
-        queryParams: [],
       });
     });
   });
@@ -93,11 +89,9 @@ describe('app_routing_selectors', () => {
         buildAppRoutingState({
           activeRoute: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
-            pathname: '/experiment/234',
             params: {
               experimentId: '234',
             },
-            queryParams: [],
           }),
         })
       );
@@ -126,11 +120,9 @@ describe('app_routing_selectors', () => {
         buildAppRoutingState({
           activeRoute: buildRoute({
             routeKind: RouteKind.EXPERIMENT,
-            pathname: '/experiment/234',
             params: {
               experimentId: '234',
             },
-            queryParams: [],
           }),
         })
       );
@@ -153,11 +145,9 @@ describe('app_routing_selectors', () => {
             routeKind: RouteKind.COMPARE_EXPERIMENT,
             // exp2 maps to two experiment ids. This is illegal but FE should not
             // break because of it.
-            pathname: '/compare/exp1:123,exp2:234,exp2:345',
             params: {
               experimentIds: 'exp1:123,exp2:234,exp2:345',
             },
-            queryParams: [],
           }),
         })
       );
@@ -174,9 +164,7 @@ describe('app_routing_selectors', () => {
         buildAppRoutingState({
           activeRoute: buildRoute({
             routeKind: RouteKind.UNKNOWN,
-            pathname: '/foob',
             params: {},
-            queryParams: [],
           }),
         })
       );

--- a/tensorboard/webapp/app_routing/store_only_utils_test.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils_test.ts
@@ -87,8 +87,6 @@ describe('app_routing store_only_utils test', () => {
         buildRoute({
           routeKind: RouteKind.COMPARE_EXPERIMENT,
           params: {experimentIds: 'e1:1,e2:2'},
-          pathname: '/compare',
-          queryParams: [],
         })
       );
       expect(actual).toEqual(['1', '2']);
@@ -99,8 +97,6 @@ describe('app_routing store_only_utils test', () => {
         buildRoute({
           routeKind: RouteKind.EXPERIMENT,
           params: {experimentId: '1234'},
-          pathname: '/experiment',
-          queryParams: [],
         })
       );
       expect(actual).toEqual(['1234']);
@@ -111,8 +107,6 @@ describe('app_routing store_only_utils test', () => {
         buildRoute({
           routeKind: RouteKind.EXPERIMENTS,
           params: {},
-          pathname: '/experiments',
-          queryParams: [],
         })
       );
       expect(actual).toBeNull();

--- a/tensorboard/webapp/app_routing/testing.ts
+++ b/tensorboard/webapp/app_routing/testing.ts
@@ -21,9 +21,7 @@ import {Route, RouteKind} from './types';
 export function buildRoute(routeOverride: Partial<Route> = {}): Route {
   return {
     routeKind: RouteKind.EXPERIMENTS,
-    pathname: '/experiments',
     params: {},
-    queryParams: [],
     ...routeOverride,
   };
 }
@@ -34,9 +32,7 @@ export function buildCompareRoute(
 ): Route {
   return {
     routeKind: RouteKind.COMPARE_EXPERIMENT,
-    pathname: '/compare',
     params: {experimentIds: aliasAndExperimentIds.join(',')},
-    queryParams: [],
     ...routeOverride,
   };
 }
@@ -44,9 +40,7 @@ export function buildCompareRoute(
 export function buildExperimentRouteFromId(experimentId: string): Route {
   return {
     routeKind: RouteKind.EXPERIMENT,
-    pathname: '/experiment',
     params: {experimentId},
-    queryParams: [],
   };
 }
 

--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -80,8 +80,6 @@ export interface NavigationFromHistory {
 export interface Route {
   routeKind: RouteKind;
   params: RouteParams;
-  pathname: string;
-  queryParams: SerializableQueryParams;
 }
 
 /**

--- a/tensorboard/webapp/app_routing/views/router_outlet_test.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_test.ts
@@ -79,8 +79,6 @@ describe('router_outlet', () => {
       getActiveRoute,
       buildRoute({
         routeKind,
-        pathname: 'test',
-        queryParams: [],
         params: {},
       })
     );
@@ -127,8 +125,6 @@ describe('router_outlet', () => {
       getActiveRoute,
       buildRoute({
         routeKind: RouteKind.EXPERIMENT,
-        pathname: 'test',
-        queryParams: [],
         params: {experimentId: 'foobar'},
       })
     );
@@ -136,8 +132,6 @@ describe('router_outlet', () => {
       getNextRouteForRouterOutletOnly,
       buildRoute({
         routeKind: RouteKind.EXPERIMENT,
-        pathname: 'test',
-        queryParams: [],
         params: {experimentId: 'foobarbaz'},
       })
     );
@@ -159,8 +153,6 @@ describe('router_outlet', () => {
       getActiveRoute,
       buildRoute({
         routeKind: RouteKind.EXPERIMENT,
-        pathname: 'test',
-        queryParams: [],
         params: {experimentId: 'foobar'},
       })
     );
@@ -168,8 +160,6 @@ describe('router_outlet', () => {
       getNextRouteForRouterOutletOnly,
       buildRoute({
         routeKind: RouteKind.EXPERIMENT,
-        pathname: 'test',
-        queryParams: [],
         params: {experimentId: 'foobar'},
       })
     );
@@ -183,8 +173,6 @@ describe('router_outlet', () => {
       getNextRouteForRouterOutletOnly,
       buildRoute({
         routeKind: RouteKind.EXPERIMENT,
-        pathname: 'test',
-        queryParams: [],
         params: {experimentId: 'foobarbaz'},
       })
     );

--- a/tensorboard/webapp/util/ui_selectors_test.ts
+++ b/tensorboard/webapp/util/ui_selectors_test.ts
@@ -68,7 +68,6 @@ describe('ui_selectors test', () => {
           buildAppRoutingState({
             activeRoute: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
-              pathname: '/compare/exp1:123,exp2:234/',
               params: {experimentIds: 'exp1:123,exp2:234'},
             }),
           })
@@ -108,7 +107,6 @@ describe('ui_selectors test', () => {
           buildAppRoutingState({
             activeRoute: buildRoute({
               routeKind: RouteKind.UNKNOWN,
-              pathname: '/foobar/234',
               params: {},
             }),
           })
@@ -143,7 +141,6 @@ describe('ui_selectors test', () => {
             buildAppRoutingState({
               activeRoute: buildRoute({
                 routeKind: RouteKind.EXPERIMENT,
-                pathname: '/experiment/234/',
                 params: {experimentId: '234'},
               }),
             })
@@ -194,7 +191,6 @@ describe('ui_selectors test', () => {
             buildAppRoutingState({
               activeRoute: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
-                pathname: '/compare/apple:123,banana:234/',
                 params: {experimentIds: 'apple:123,banana:234'},
               }),
             })
@@ -264,7 +260,6 @@ describe('ui_selectors test', () => {
             buildAppRoutingState({
               activeRoute: buildRoute({
                 routeKind: RouteKind.COMPARE_EXPERIMENT,
-                pathname: '/compare/apple:123,banana:234/',
                 params: {experimentIds: 'apple:123,banana:234'},
               }),
             })


### PR DESCRIPTION
Move pathname and queryParams from the broadly-used Route type into app_routing_effects's InternalRoute. These properties are only really used by app_routing_effects. 

Deleting the properties means I can delete meaningless references to them in many tests.