### PR TITLE
time-namespaced state: Improve how we decide when to rehydrate state from URL.

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -430,6 +430,8 @@ export class AppRoutingEffects {
             rehydratedDeepLinks
           )
         ) {
+          // A deeplink has already been rehydrated for this RouteKind/Namespace
+          // combination so don't do it again.
           return;
         }
 

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -42,7 +42,7 @@ import {DirtyUpdatesRegistryModule} from '../dirty_updates_registry_module';
 import {
   areRoutesEqual,
   areSameRouteKindAndExperiments,
-  canBeRehydrated,
+  canRehydrateDeepLink,
   getRouteNamespaceId,
   serializeCompareExperimentParams,
 } from '../internal_utils';
@@ -422,7 +422,7 @@ export class AppRoutingEffects {
         if (
           options.namespaceUpdate.option ===
             NamespaceUpdateOption.FROM_HISTORY &&
-          !canBeRehydrated(
+          !canRehydrateDeepLink(
             routeMatch.routeKind,
             options.namespaceUpdate.namespaceId,
             rehydratedDeepLinks

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -42,6 +42,7 @@ import {DirtyUpdatesRegistryModule} from '../dirty_updates_registry_module';
 import {
   areRoutesEqual,
   areSameRouteKindAndExperiments,
+  canBeRehydrated,
   getRouteNamespaceId,
   serializeCompareExperimentParams,
 } from '../internal_utils';
@@ -52,7 +53,7 @@ import {RouteRegistryModule} from '../route_registry_module';
 import {
   getActiveNamespaceId,
   getActiveRoute,
-  getKnownNamespaceIds,
+  getRehydratedDeepLinks,
 } from '../store/app_routing_selectors';
 import {Route, RouteKind, RouteParams} from '../types';
 
@@ -410,23 +411,22 @@ export class AppRoutingEffects {
           })
         );
       }),
-      withLatestFrom(this.store.select(getKnownNamespaceIds)),
-      tap(([{routeMatch, options}, knownNamespaceIds]) => {
+      withLatestFrom(this.store.select(getRehydratedDeepLinks)),
+      tap(([{routeMatch, options}, rehydratedDeepLinks]) => {
         // Possibly rehydrate state from the URL.
-        //
-        // We do this on "browser initiated" events (like a page load or
-        // navigation in browser history) but we only do this when we don't yet
-        // have in-memory state for the namespace being navigated to.
 
-        const isKnownNamespace =
-          options.namespaceUpdate.option ===
-            NamespaceUpdateOption.FROM_HISTORY &&
-          knownNamespaceIds.has(options.namespaceUpdate.namespaceId);
+        if (!options.browserInitiated || !routeMatch.deepLinkProvider) {
+          return;
+        }
 
         if (
-          !options.browserInitiated ||
-          isKnownNamespace ||
-          !routeMatch.deepLinkProvider
+          options.namespaceUpdate.option ===
+            NamespaceUpdateOption.FROM_HISTORY &&
+          !canBeRehydrated(
+            routeMatch.routeKind,
+            options.namespaceUpdate.namespaceId,
+            rehydratedDeepLinks
+          )
         ) {
           return;
         }

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -916,7 +916,7 @@ describe('app_routing_effects', () => {
         }));
       });
 
-      it('dispatches stateRehydratedFromUrl if canBeRehydrated()', fakeAsync(() => {
+      it('dispatches stateRehydratedFromUrl if canRehydrateDeepLink()', fakeAsync(() => {
         deserializeQueryParamsSpy.and.returnValue({a: 'A', b: 'B'});
         getPathSpy.and.returnValue('/compare/a:b');
 
@@ -953,7 +953,7 @@ describe('app_routing_effects', () => {
         ]);
       }));
 
-      it('does not dispatch stateRehydratedFromUrl if not canBeRehydrated()', fakeAsync(() => {
+      it('does not dispatch stateRehydratedFromUrl if not canRehydrateDeepLink()', fakeAsync(() => {
         deserializeQueryParamsSpy.and.returnValue({a: 'A', b: 'B'});
         getPathSpy.and.returnValue('/compare/a:b');
 

--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -231,7 +231,7 @@ export function getDeepLinkGroup(routeKind: RouteKind): DeepLinkGroup | null {
  *    namespace, then once again rehydrate state for the DASHBOARD deep link
  *    group.
  */
-export function canBeRehydrated(
+export function canRehydrateDeepLink(
   routeKind: RouteKind,
   namespaceId: string,
   rehydratedDeepLinks: RehydratedDeepLink[]

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -19,7 +19,7 @@ import {
   buildExperimentRouteFromId,
   buildRoute,
 } from './testing';
-import {RouteKind} from './types';
+import {DeepLinkGroup, RouteKind} from './types';
 
 describe('app_routing/utils', () => {
   describe('#parseCompareExperimentStr', () => {
@@ -123,7 +123,7 @@ describe('app_routing/utils', () => {
     });
   });
 
-  describe('getRouteNamespaceId', () => {
+  describe('#getRouteNamespaceId', () => {
     [
       {
         kind: RouteKind.COMPARE_EXPERIMENT,
@@ -175,7 +175,7 @@ describe('app_routing/utils', () => {
     });
   });
 
-  describe('areSameRouteKindAndExperiments', () => {
+  describe('#areSameRouteKindAndExperiments', () => {
     it('returns true when both routes are null', () => {
       expect(utils.areSameRouteKindAndExperiments(null, null)).toBeTrue();
     });
@@ -404,6 +404,69 @@ describe('app_routing/utils', () => {
           }
         )
       ).toBe(false);
+    });
+  });
+
+  describe('#getDeepLinkGroup', () => {
+    it('maps RouteKind to DeepLinkGroup', () => {
+      expect(utils.getDeepLinkGroup(RouteKind.EXPERIMENTS)).toEqual(
+        DeepLinkGroup.EXPERIMENTS
+      );
+      expect(utils.getDeepLinkGroup(RouteKind.EXPERIMENT)).toEqual(
+        DeepLinkGroup.DASHBOARD
+      );
+      expect(utils.getDeepLinkGroup(RouteKind.COMPARE_EXPERIMENT)).toEqual(
+        DeepLinkGroup.DASHBOARD
+      );
+      expect(utils.getDeepLinkGroup(RouteKind.UNKNOWN)).toBeNull();
+      expect(utils.getDeepLinkGroup(RouteKind.NOT_SET)).toBeNull();
+    });
+  });
+
+  describe('#canBeRehydrated', () => {
+    it('allows rehydration if namespaceId does not match', () => {
+      expect(
+        utils.canBeRehydrated(RouteKind.EXPERIMENTS, 'namespaceC', [
+          {
+            deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
+            namespaceId: 'namespaceA',
+          },
+          {
+            deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
+            namespaceId: 'namespaceB',
+          },
+        ])
+      ).toBeTrue();
+    });
+
+    it('allows rehydration if deepLinkGroup does not match', () => {
+      expect(
+        utils.canBeRehydrated(RouteKind.COMPARE_EXPERIMENT, 'namespaceA', [
+          {
+            deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
+            namespaceId: 'namespaceA',
+          },
+          {
+            deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
+            namespaceId: 'namespaceB',
+          },
+        ])
+      ).toBeTrue();
+    });
+
+    it('does not allow rehydration if match is found', () => {
+      expect(
+        utils.canBeRehydrated(RouteKind.EXPERIMENTS, 'namespaceA', [
+          {
+            deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
+            namespaceId: 'namespaceA',
+          },
+          {
+            deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
+            namespaceId: 'namespaceB',
+          },
+        ])
+      ).toBeFalse();
     });
   });
 });

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -423,10 +423,10 @@ describe('app_routing/utils', () => {
     });
   });
 
-  describe('#canBeRehydrated', () => {
+  describe('#canRehydrateDeepLink', () => {
     it('allows rehydration if namespaceId does not match', () => {
       expect(
-        utils.canBeRehydrated(RouteKind.EXPERIMENTS, 'namespaceC', [
+        utils.canRehydrateDeepLink(RouteKind.EXPERIMENTS, 'namespaceC', [
           {
             deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
             namespaceId: 'namespaceA',
@@ -441,7 +441,7 @@ describe('app_routing/utils', () => {
 
     it('allows rehydration if deepLinkGroup does not match', () => {
       expect(
-        utils.canBeRehydrated(RouteKind.COMPARE_EXPERIMENT, 'namespaceA', [
+        utils.canRehydrateDeepLink(RouteKind.COMPARE_EXPERIMENT, 'namespaceA', [
           {
             deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
             namespaceId: 'namespaceA',
@@ -456,7 +456,7 @@ describe('app_routing/utils', () => {
 
     it('does not allow rehydration if match is found', () => {
       expect(
-        utils.canBeRehydrated(RouteKind.EXPERIMENTS, 'namespaceA', [
+        utils.canRehydrateDeepLink(RouteKind.EXPERIMENTS, 'namespaceA', [
           {
             deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
             namespaceId: 'namespaceA',

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -468,5 +468,20 @@ describe('app_routing/utils', () => {
         ])
       ).toBeFalse();
     });
+
+    it('does not allow rehydration if route kind has null deep link group', () => {
+      expect(
+        utils.canRehydrateDeepLink(RouteKind.UNKNOWN, 'namespaceA', [
+          {
+            deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
+            namespaceId: 'namespaceA',
+          },
+          {
+            deepLinkGroup: DeepLinkGroup.EXPERIMENTS,
+            namespaceId: 'namespaceB',
+          },
+        ])
+      ).toBeFalse();
+    });
   });
 });

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
@@ -42,7 +42,7 @@ const reducer = createReducer(
       rehydratedDeepLinks = [...rehydratedDeepLinks];
       rehydratedDeepLinks.push({
         // Note: getDeepLinkGroup() should return non-null given that
-        // canBeRehydrated() returned true.
+        // canRehydrateDeepLink() returned true.
         deepLinkGroup: getDeepLinkGroup(after.routeKind)!,
         namespaceId: afterNamespaceId,
       });

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
 import * as actions from '../actions';
-import {canBeRehydrated, getDeepLinkGroup} from '../internal_utils';
+import {canRehydrateDeepLink, getDeepLinkGroup} from '../internal_utils';
 import {AppRoutingState} from './app_routing_types';
 
 const initialState: AppRoutingState = {
@@ -33,7 +33,11 @@ const reducer = createReducer(
   on(actions.navigated, (state, {after, afterNamespaceId}) => {
     let rehydratedDeepLinks = state.rehydratedDeepLinks;
     if (
-      canBeRehydrated(after.routeKind, afterNamespaceId, rehydratedDeepLinks)
+      canRehydrateDeepLink(
+        after.routeKind,
+        afterNamespaceId,
+        rehydratedDeepLinks
+      )
     ) {
       rehydratedDeepLinks = [...rehydratedDeepLinks];
       rehydratedDeepLinks.push({

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers.ts
@@ -14,13 +14,14 @@ limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
 import * as actions from '../actions';
+import {canBeRehydrated, getDeepLinkGroup} from '../internal_utils';
 import {AppRoutingState} from './app_routing_types';
 
 const initialState: AppRoutingState = {
   activeRoute: null,
   nextRoute: null,
   activeNamespaceId: null,
-  knownNamespaceIds: new Set(),
+  rehydratedDeepLinks: [],
   registeredRouteKeys: new Set(),
 };
 
@@ -30,17 +31,24 @@ const reducer = createReducer(
     return {...state, nextRoute: after};
   }),
   on(actions.navigated, (state, {after, afterNamespaceId}) => {
-    let knownNamespaceIds = state.knownNamespaceIds;
-    if (!state.knownNamespaceIds.has(afterNamespaceId)) {
-      knownNamespaceIds = new Set(state.knownNamespaceIds);
-      knownNamespaceIds.add(afterNamespaceId);
+    let rehydratedDeepLinks = state.rehydratedDeepLinks;
+    if (
+      canBeRehydrated(after.routeKind, afterNamespaceId, rehydratedDeepLinks)
+    ) {
+      rehydratedDeepLinks = [...rehydratedDeepLinks];
+      rehydratedDeepLinks.push({
+        // Note: getDeepLinkGroup() should return non-null given that
+        // canBeRehydrated() returned true.
+        deepLinkGroup: getDeepLinkGroup(after.routeKind)!,
+        namespaceId: afterNamespaceId,
+      });
     }
     return {
       ...state,
       activeRoute: after,
       nextRoute: null,
       activeNamespaceId: afterNamespaceId,
-      knownNamespaceIds,
+      rehydratedDeepLinks,
     };
   }),
   on(actions.routeConfigLoaded, (state, {routeKinds}) => {

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
@@ -83,7 +83,7 @@ describe('app_routing_reducers', () => {
       expect(nextState.activeNamespaceId).toEqual('namespace1');
     });
 
-    it('replaces and adds to rehydratedDeepLinks if canBeRehydrated()', () => {
+    it('replaces and adds to rehydratedDeepLinks if canRehydrateDeepLink()', () => {
       const originalRehydratedDeepLinks = [
         {namespaceId: 'n1', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
         {namespaceId: 'n2', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
@@ -112,7 +112,7 @@ describe('app_routing_reducers', () => {
       );
     });
 
-    it('does not replace or add to rehydratedDeepLinks if not canBeRehydrated()', () => {
+    it('does not replace or add to rehydratedDeepLinks if not canRehydrateDeepLink()', () => {
       const originalRehydratedDeepLinks = [
         {namespaceId: 'n1', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
         {namespaceId: 'n2', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},

--- a/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_reducers_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import * as actions from '../actions';
 import {buildRoute} from '../testing';
-import {RouteKind} from '../types';
+import {DeepLinkGroup, RouteKind} from '../types';
 import * as appRoutingReducers from './app_routing_reducers';
 import {buildAppRoutingState} from './testing';
 
@@ -91,10 +91,13 @@ describe('app_routing_reducers', () => {
       expect(nextState.activeNamespaceId).toEqual('namespace1');
     });
 
-    it('adds to knownNamespaceIds', () => {
-      const originalKnownNamespaceIds = new Set<string>(['n1', 'n2']);
+    it('replaces and adds to rehydratedDeepLinks if canBeRehydrated()', () => {
+      const originalRehydratedDeepLinks = [
+        {namespaceId: 'n1', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+        {namespaceId: 'n2', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+      ];
       const state = buildAppRoutingState({
-        knownNamespaceIds: originalKnownNamespaceIds,
+        rehydratedDeepLinks: originalRehydratedDeepLinks,
       });
 
       const nextState = appRoutingReducers.reducers(
@@ -107,16 +110,23 @@ describe('app_routing_reducers', () => {
         })
       );
 
-      expect(nextState.knownNamespaceIds).toEqual(
-        new Set<string>(['n1', 'n2', 'n3'])
+      expect(nextState.rehydratedDeepLinks).toEqual([
+        {namespaceId: 'n1', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+        {namespaceId: 'n2', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+        {namespaceId: 'n3', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+      ]);
+      expect(nextState.rehydratedDeepLinks).not.toBe(
+        originalRehydratedDeepLinks
       );
-      expect(nextState.knownNamespaceIds).not.toBe(originalKnownNamespaceIds);
     });
 
-    it('does not create new knownNamespaceIds when no changes necessary', () => {
-      const originalKnownNamespaceIds = new Set<string>(['n1', 'n2']);
+    it('does not replace or add to rehydratedDeepLinks if not canBeRehydrated()', () => {
+      const originalRehydratedDeepLinks = [
+        {namespaceId: 'n1', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+        {namespaceId: 'n2', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+      ];
       const state = buildAppRoutingState({
-        knownNamespaceIds: originalKnownNamespaceIds,
+        rehydratedDeepLinks: originalRehydratedDeepLinks,
       });
 
       const nextState = appRoutingReducers.reducers(
@@ -129,10 +139,11 @@ describe('app_routing_reducers', () => {
         })
       );
 
-      expect(nextState.knownNamespaceIds).toEqual(
-        new Set<string>(['n1', 'n2'])
-      );
-      expect(nextState.knownNamespaceIds).toBe(originalKnownNamespaceIds);
+      expect(nextState.rehydratedDeepLinks).toEqual([
+        {namespaceId: 'n1', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+        {namespaceId: 'n2', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+      ]);
+      expect(nextState.rehydratedDeepLinks).toBe(originalRehydratedDeepLinks);
     });
   });
 

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors.ts
@@ -19,7 +19,12 @@ import {
   getCompareExperimentIdAliasSpec,
   getCompareExperimentIdAliasWithNumberSpec,
 } from '../store_only_utils';
-import {CompareRouteParams, Route, RouteKind} from '../types';
+import {
+  CompareRouteParams,
+  RehydratedDeepLink,
+  Route,
+  RouteKind,
+} from '../types';
 import {
   AppRoutingState,
   APP_ROUTING_FEATURE_KEY,
@@ -51,10 +56,10 @@ export const getActiveNamespaceId = createSelector(
   }
 );
 
-export const getKnownNamespaceIds = createSelector(
+export const getRehydratedDeepLinks = createSelector(
   getAppRoutingState,
-  (state): Set<string> => {
-    return state.knownNamespaceIds;
+  (state): RehydratedDeepLink[] => {
+    return state.rehydratedDeepLinks;
   }
 );
 

--- a/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_selectors_test.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {buildRoute} from '../testing';
-import {RouteKind} from '../types';
+import {DeepLinkGroup, RouteKind} from '../types';
 import * as selectors from './app_routing_selectors';
 import {buildAppRoutingState, buildStateFromAppRoutingState} from './testing';
 
@@ -65,21 +65,25 @@ describe('app_routing_selectors', () => {
     });
   });
 
-  describe('getKnownNamespaceIds', () => {
+  describe('getRehydratedDeepLinks', () => {
     beforeEach(() => {
-      selectors.getKnownNamespaceIds.release();
+      selectors.getRehydratedDeepLinks.release();
     });
 
     it('returns knownNamespaceIds', () => {
       const state = buildStateFromAppRoutingState(
         buildAppRoutingState({
-          knownNamespaceIds: new Set<string>(['n1', 'n2', 'n3']),
+          rehydratedDeepLinks: [
+            {namespaceId: 'n1', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+            {namespaceId: 'n2', deepLinkGroup: DeepLinkGroup.DASHBOARD},
+          ],
         })
       );
 
-      expect(selectors.getKnownNamespaceIds(state)).toEqual(
-        new Set<string>(['n1', 'n2', 'n3'])
-      );
+      expect(selectors.getRehydratedDeepLinks(state)).toEqual([
+        {namespaceId: 'n1', deepLinkGroup: DeepLinkGroup.EXPERIMENTS},
+        {namespaceId: 'n2', deepLinkGroup: DeepLinkGroup.DASHBOARD},
+      ]);
     });
   });
 

--- a/tensorboard/webapp/app_routing/store/app_routing_types.ts
+++ b/tensorboard/webapp/app_routing/store/app_routing_types.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Route, RouteKind} from '../types';
+import {RehydratedDeepLink, Route, RouteKind} from '../types';
 
 export const APP_ROUTING_FEATURE_KEY = 'app_routing';
 
@@ -24,9 +24,9 @@ export interface AppRoutingState {
   nextRoute: Route | null;
   // The id of the namespace that is currently active.
   activeNamespaceId: string | null;
-  // All namespaces that currently have a representation in state. This includes
-  // the active namespace but also any cached namespaces.
-  knownNamespaceIds: Set<string>;
+  // The set of deep links that have been rehydrated since the page was last
+  // (re)loaded by the browser.
+  rehydratedDeepLinks: RehydratedDeepLink[];
   registeredRouteKeys: Set<RouteKind>;
 }
 

--- a/tensorboard/webapp/app_routing/store/testing.ts
+++ b/tensorboard/webapp/app_routing/store/testing.ts
@@ -25,7 +25,7 @@ export function buildAppRoutingState(
     activeRoute: null,
     nextRoute: null,
     activeNamespaceId: null,
-    knownNamespaceIds: new Set(),
+    rehydratedDeepLinks: [],
     registeredRouteKeys: new Set(),
     ...override,
   };

--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -85,6 +85,24 @@ export interface Route {
 }
 
 /**
+ * Identifies groups of routes where we wish to only rehydrate deep links one
+ * time for each group.
+ */
+export enum DeepLinkGroup {
+  EXPERIMENTS,
+  DASHBOARD,
+}
+
+/**
+ * Represents a DeepLinkGroup/NamespaceId combination that has been rehydrated
+ * since last browser (re)load.
+ */
+export interface RehydratedDeepLink {
+  deepLinkGroup: DeepLinkGroup;
+  namespaceId: string;
+}
+
+/**
  * Information about unsaved metadata updates to experiments.
  */
 export interface DirtyUpdates {


### PR DESCRIPTION
There are some browser history navigations where we were not appropriately rehydrating URL state. The root cause was that we were only rehydrating URL state at most one time for each namespace. But, in reality, we might need to do it multiple times: one time for the experiment list view and another time for the dashboard view.

(Googlers, see internal bug b/216829997).

This change fixes the issue by adding another dimension when determining whether we can rehydrate URL state. The dimension is based on `RouteKind` but actually represented by a new `DeepLinkGroup` enum.

The mapping of `RouteKind` to `DeepLinkGroup` is explicitly defined in the app routing code:
* `DeepLinkGroup.EXPERIMENTS` = `[RouteKind.EXPERIMENTS]`
* `DeepLinkGroup.DASHBOARD` = `[RouteKind.EXPERIMENT, RouteKind.COMPARE_EXPERIMENT]`

I considered making `DeepLinkGroup` (or some equivalent) a per-app configuration, either in the route configurations or in the `DeepLinkProvider` interface. But after playing around with these ideas, I realized the API and code would be quite messy for little gain. Besides, we don't currently see a world where the `DeepLinkGroup` definition differs between different versions of Tensorboard.

I also renamed `knownNamespaceIds` to `rehydatedDeepLinks` to make the purpose clearer and narrower.



