### PR TITLE
images: reset sampling size to default on "images=0"

### DIFF
--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -65,6 +65,11 @@ class ImagesPlugin(base_plugin.TBPlugin):
         self._downsample_to = (context.sampling_hints or {}).get(
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
+        self._downsample_to = (
+            _DEFAULT_DOWNSAMPLING
+            if self._downsample_to == 0
+            else self._downsample_to
+        )
         self._data_provider = context.data_provider
         self._version_checker = plugin_util._MetadataVersionChecker(
             data_kind="image",


### PR DESCRIPTION
When running TensorBoard with param `--samples_per_plugin "image=0"`, the down sampling size is 0 instead of "all samples" as suggested in readme. (https://github.com/tensorflow/tensorboard/issues/5550)
This pr reset it to `_DEFAULT_DOWNSAMPLING` which is still slightly from "keep all samples of that type". Please suggest whether increasing the number of sample makes sense.
