### PR TITLE
keras: skip config if it's a policy obj

### DIFF
--- a/tensorboard/plugins/graph/keras_util.py
+++ b/tensorboard/plugins/graph/keras_util.py
@@ -235,13 +235,15 @@ def keras_model_to_graph_def(keras_layer):
             node_def.attr["keras_class"].s = keras_cls_name
 
         dtype_or_policy = layer_config.get("dtype")
+        print(dtype_or_policy)
         # Skip dtype processing if this is a dict, since it's presumably a instance of
         # tf/keras/mixed_precision/Policy rather than a single dtype.
         # TODO(#5548): parse the policy dict and populate the dtype attr with the variable dtype.
-        if dtype_or_policy is not None and not isinstance(dtype_or_policy, dict):
-          tf_dtype = dtypes.as_dtype(layer_config.get("dtype"))
-          node_def.attr["dtype"].type = tf_dtype.as_datatype_enum
-
+        if dtype_or_policy is not None and not isinstance(
+            dtype_or_policy, dict
+        ):
+            tf_dtype = dtypes.as_dtype(layer_config.get("dtype"))
+            node_def.attr["dtype"].type = tf_dtype.as_datatype_enum
         if layer.get("inbound_nodes") is not None:
             for maybe_inbound_node in layer.get("inbound_nodes"):
                 inbound_nodes = _norm_to_list_of_layers(maybe_inbound_node)

--- a/tensorboard/plugins/graph/keras_util.py
+++ b/tensorboard/plugins/graph/keras_util.py
@@ -235,7 +235,6 @@ def keras_model_to_graph_def(keras_layer):
             node_def.attr["keras_class"].s = keras_cls_name
 
         dtype_or_policy = layer_config.get("dtype")
-        print(dtype_or_policy)
         # Skip dtype processing if this is a dict, since it's presumably a instance of
         # tf/keras/mixed_precision/Policy rather than a single dtype.
         # TODO(#5548): parse the policy dict and populate the dtype attr with the variable dtype.

--- a/tensorboard/plugins/graph/keras_util.py
+++ b/tensorboard/plugins/graph/keras_util.py
@@ -234,9 +234,13 @@ def keras_model_to_graph_def(keras_layer):
             keras_cls_name = layer.get("class_name").encode("ascii")
             node_def.attr["keras_class"].s = keras_cls_name
 
-        if layer_config.get("dtype") is not None:
-            tf_dtype = dtypes.as_dtype(layer_config.get("dtype"))
-            node_def.attr["dtype"].type = tf_dtype.as_datatype_enum
+        dtype_or_policy = layer_config.get("dtype")
+        # Skip dtype processing if this is a dict, since it's presumably a instance of
+        # tf/keras/mixed_precision/Policy rather than a single dtype.
+        # TODO(#5548): parse the policy dict and populate the dtype attr with the variable dtype.
+        if dtype_or_policy is not None and not isinstance(dtype_or_policy, dict):
+          tf_dtype = dtypes.as_dtype(layer_config.get("dtype"))
+          node_def.attr["dtype"].type = tf_dtype.as_datatype_enum
 
         if layer.get("inbound_nodes") is not None:
             for maybe_inbound_node in layer.get("inbound_nodes"):


### PR DESCRIPTION
`layer_config` could be a keras Policy object. Gracefully fall with checking the type. #5548 