### PR TITLE
chore: upgrade marked to version 4.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "d3": "5.7.0",
     "dagre": "^0.8.5",
     "lodash": "^4.17.19",
-    "marked": "^2.1.3",
+    "marked": "^4.0.10",
     "monaco-editor-core": "^0.26.0",
     "monaco-languages": "^2.6.0",
     "ngx-color-picker": "^11.0.0",

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -154,7 +154,7 @@ def tf_ng_web_test_suite(runtime_deps = [], bootstrap = [], deps = [], **kwargs)
             "@npm//:node_modules/d3/dist/d3.js",
             "@npm//:node_modules/three/build/three.js",
             "@npm//:node_modules/dagre/dist/dagre.js",
-            "@npm//:node_modules/marked/lib/marked.js",
+            "@npm//:node_modules/marked/marked.min.js",
         ],
         **kwargs
     )

--- a/tensorboard/defs/internal/js.bzl
+++ b/tensorboard/defs/internal/js.bzl
@@ -131,7 +131,7 @@ tf_dev_js_binary = rule(
                 "@npm//:node_modules/d3/dist/d3.js": "d3",
                 "@npm//:node_modules/three/build/three.js": "three",
                 "@npm//:node_modules/zone.js/dist/zone.js": "zone.js/dist/zone.js",
-                "@npm//:node_modules/marked/lib/marked.js": "marked",
+                "@npm//:node_modules/marked/marked.min.js": "marked",
                 "@npm//:node_modules/@tensorflow/tfjs-core/dist/tf-core.js": "@tensorflow/tfjs-core",
                 "@npm//:node_modules/@tensorflow/tfjs-backend-cpu/dist/tf-backend-cpu.js": "@tensorflow/tfjs-backend-cpu",
                 "@npm//:node_modules/@tensorflow/tfjs-backend-webgl/dist/tf-backend-webgl.js": "@tensorflow/tfjs-backend-webgl",

--- a/tensorboard/webapp/testing/require_js_karma_config.js
+++ b/tensorboard/webapp/testing/require_js_karma_config.js
@@ -32,6 +32,6 @@ require.config({
     d3: '/base/npm/node_modules/d3/dist/d3',
     three: '/base/npm/node_modules/three/build/three',
     dagre: '/base/npm/node_modules/dagre/dist/dagre',
-    marked: '/base/npm/node_modules/marked/lib/marked',
+    marked: '/base/npm/node_modules/marked/marked.min',
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3914,10 +3914,10 @@ make-fetch-happen@^9.0.1:
     socks-proxy-agent "^5.0.0"
     ssri "^8.0.0"
 
-marked@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
-  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+marked@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.10.tgz#423e295385cc0c3a70fa495e0df68b007b879423"
+  integrity sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Upgrade `marked` to version 4.0.10 to fix a [security vulnerability](https://github.com/tensorflow/tensorboard/security/dependabot/yarn.lock/marked/open).

Original request: https://github.com/tensorflow/tensorboard/pull/5506

Tested internally: cl/424877602