### PR TITLE
core: updates `--samples_per_plugin` help command

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -642,10 +642,10 @@ An optional comma separated list of plugin_name=num_samples pairs to
 explicitly specify how many samples to keep per tag for that plugin. For
 unspecified plugins, TensorBoard randomly downsamples logged summaries
 to reasonable values to prevent out-of-memory errors for long running
-jobs. This flag allows fine control over that downsampling. Note that 0
-means keep all samples of that type. For instance "scalars=500,images=0"
-keeps 500 scalars and all images. Most users should not need to set this
-flag.\
+jobs. This flag allows fine control over that downsampling. Note that
+downsampling is required for all plugins. Without specifying the number
+it would be set to default number (10 for images, 500 for historgrams,
+and 1000 for scalars). Most users should not need to set this flag.\
 """,
         )
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -643,8 +643,8 @@ explicitly specify how many samples to keep per tag for that plugin. For
 unspecified plugins, TensorBoard randomly downsamples logged summaries
 to reasonable values to prevent out-of-memory errors for long running
 jobs. This flag allows fine control over that downsampling. Note that
-downsampling is required for all plugins. Without specifying the number
-it would be set to default number (10 for images, 500 for historgrams,
+downsampling is required for all plugins. Without specifying the numbers
+it would be set as the default numbers (10 for images, 500 for historgrams,
 and 1000 for scalars). Most users should not need to set this flag.\
 """,
         )

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -642,9 +642,9 @@ An optional comma separated list of plugin_name=num_samples pairs to
 explicitly specify how many samples to keep per tag for that plugin. For
 unspecified plugins, TensorBoard randomly downsamples logged summaries
 to reasonable values to prevent out-of-memory errors for long running
-jobs. This flag allows fine control over that downsampling. Note that
-downsampling is required for all plugins. Without specifying the numbers
-it would be set as the default numbers (10 for images, 500 for historgrams,
+jobs. This flag allows fine control over that downsampling. Note that if a
+plugin is not specified in this list, a plugin-specific default number of
+samples will be enforced. (for example, 10 for images, 500 for historgrams,
 and 1000 for scalars). Most users should not need to set this flag.\
 """,
         )


### PR DESCRIPTION
The help doc is stale. "Setting `"images=0"` to show all samples" is not supported anymore. Updates it to match the actual implementation. #5550 