### PR TITLE
time-namespaced state: Filter runs to include only those in current route.

### DIFF
--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -17,7 +17,9 @@ import {DataLoadState, LoadState} from '../../types/data';
 import {SortDirection} from '../../types/ui';
 import {GroupBy, SortKey} from '../types';
 import {
+  ExperimentId,
   Run,
+  RunId,
   RunsDataState,
   RunsState,
   RunsUiState,
@@ -36,7 +38,17 @@ const getDataState = createSelector(
 );
 
 /**
- * Returns Observable that emits run object.
+ * Returns Observable that emits map of RunId to ExperimentId.
+ */
+export const getRunIdToExperimentId = createSelector(
+  getDataState,
+  (state: RunsDataState): Record<RunId, ExperimentId> => {
+    return state.runIdToExpId;
+  }
+);
+
+/**
+ * Returns Observable that emits ExperimentId of given Run.
  */
 export const getExperimentIdForRunId = createSelector(
   getDataState,

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -19,6 +19,29 @@ import * as selectors from './runs_selectors';
 import {buildRun, buildRunsState, buildStateFromRunsState} from './testing';
 
 describe('runs_selectors', () => {
+  describe('#getRunIdToExperimentId', () => {
+    beforeEach(() => {
+      // Clear the memoization.
+      selectors.getRunIdToExperimentId.release();
+    });
+
+    it('returns runIdToExpId', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          runIdToExpId: {
+            run1: 'eid1',
+            run2: 'eid1',
+            run3: 'eid2',
+          },
+        })
+      );
+      expect(selectors.getRunIdToExperimentId(state)).toEqual({
+        run1: 'eid1',
+        run2: 'eid1',
+        run3: 'eid2',
+      });
+    });
+  });
   describe('#getExperimentIdForRunId', () => {
     beforeEach(() => {
       // Clear the memoization.

--- a/tensorboard/webapp/util/BUILD
+++ b/tensorboard/webapp/util/BUILD
@@ -80,6 +80,7 @@ tf_ts_library(
         "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/runs:types",
         "//tensorboard/webapp/runs/store:selectors",
+        "//tensorboard/webapp/runs/store:types",
         "//tensorboard/webapp/settings",
         "@npm//@ngrx/store",
     ],

--- a/tensorboard/webapp/util/ui_selectors.ts
+++ b/tensorboard/webapp/util/ui_selectors.ts
@@ -37,13 +37,48 @@ import {getDarkModeEnabled} from '../feature_flag/store/feature_flag_selectors';
 import {
   getDefaultRunColorIdMap,
   getRunColorOverride,
+  getRunIdToExperimentId,
   getRuns,
   getRunSelectionMap,
   getRunSelectorRegexFilter,
 } from '../runs/store/runs_selectors';
+import {ExperimentId, RunId} from '../runs/store/runs_types';
 import {selectors} from '../settings';
 import {ColorPalette} from './colors';
 import {matchRunToRegex, RunMatchable} from './matcher';
+
+/**
+ * Creates a copy of RunSelectionMap with entries filtered to runs that
+ * belong to one of the current experiments in the route.
+ */
+const getRunSelectionMapFilteredToCurrentRoute = createSelector<
+  State,
+  string[] | null,
+  Map<string, boolean>,
+  Record<RunId, ExperimentId>,
+  Map<string, boolean>
+>(
+  getExperimentIdsFromRoute,
+  getRunSelectionMap,
+  getRunIdToExperimentId,
+  (experimentIds, runSelectionMap, runIds) => {
+    if (!experimentIds) {
+      // No experiments in the route means there are no runs to select.
+      return new Map<string, boolean>();
+    }
+
+    const filteredRunSelectionMap = new Map<string, boolean>();
+    for (const [runId, value] of runSelectionMap.entries()) {
+      const experimentId = runIds[runId];
+      if (experimentId && experimentIds.indexOf(experimentId) >= 0) {
+        // Run belongs to one of the Route's experiments. Add it to the filtered
+        // result.
+        filteredRunSelectionMap.set(runId, value);
+      }
+    }
+    return filteredRunSelectionMap;
+  }
+);
 
 /**
  * Selects the run selection (runId to boolean) of current set of experiments.
@@ -51,11 +86,8 @@ import {matchRunToRegex, RunMatchable} from './matcher';
  * Note that emits null when current route is not about an experiment.
  */
 export const getCurrentRouteRunSelection = createSelector(
-  (state: State): boolean => {
-    return !!getExperimentIdsFromRoute(state);
-  },
-
-  getRunSelectionMap,
+  getExperimentIdsFromRoute,
+  getRunSelectionMapFilteredToCurrentRoute,
   getRunSelectorRegexFilter,
   (state: State): Map<string, RunMatchable> => {
     const experimentIds = getExperimentIdsFromRoute(state) ?? [];
@@ -74,8 +106,8 @@ export const getCurrentRouteRunSelection = createSelector(
     return runMatchableMap;
   },
   getRouteKind,
-  (hasExperiments, runSelection, regexFilter, runMatchableMap, routeKind) => {
-    if (!hasExperiments) {
+  (experimentIds, runSelection, regexFilter, runMatchableMap, routeKind) => {
+    if (!experimentIds) {
       // There are no experiments in the route. Return null.
       return null;
     }

--- a/tensorboard/webapp/util/ui_selectors_test.ts
+++ b/tensorboard/webapp/util/ui_selectors_test.ts
@@ -62,9 +62,10 @@ describe('ui_selectors test', () => {
   });
 
   describe('#getCurrentRouteRunSelection', () => {
-    it('returns selection map of current eid', () => {
+    it('returns selection map of current experiments', () => {
       const state = {
         ...buildStateFromAppRoutingState(
+          // The route only contains experiments 123 and 234
           buildAppRoutingState({
             activeRoute: buildRoute({
               routeKind: RouteKind.COMPARE_EXPERIMENT,
@@ -74,11 +75,18 @@ describe('ui_selectors test', () => {
         ),
         ...buildStateFromRunsState(
           buildRunsState(
-            {},
+            {
+              runIdToExpId: {
+                r1: '123',
+                r2: '234',
+                r3: '345',
+              },
+            },
             {
               selectionState: new Map([
                 ['r1', true],
                 ['r2', false],
+                ['r3', true],
               ]),
             }
           )
@@ -88,11 +96,13 @@ describe('ui_selectors test', () => {
             experimentMap: {
               '123': buildExperiment({id: '123', name: 'Experiment 123'}),
               '234': buildExperiment({id: '234', name: 'Experiment 234'}),
+              '345': buildExperiment({id: '345', name: 'Experiment 345'}),
             },
           })
         ),
       };
 
+      // Runs form experiment 345 are not included in the final result.
       expect(getCurrentRouteRunSelection(state)).toEqual(
         new Map([
           ['r1', true],
@@ -113,7 +123,12 @@ describe('ui_selectors test', () => {
         ),
         ...buildStateFromRunsState(
           buildRunsState(
-            {},
+            {
+              runIdToExpId: {
+                r1: '234',
+                r2: '234',
+              },
+            },
             {
               selectionState: new Map([
                 ['r1', true],
@@ -150,6 +165,11 @@ describe('ui_selectors test', () => {
               {
                 runIds: {
                   '234': ['234/run1', '234/run2', '234/run3'],
+                },
+                runIdToExpId: {
+                  '234/run1': '234',
+                  '234/run2': '234',
+                  '234/run3': '234',
                 },
                 runMetadata: {
                   '234/run1': buildRun({id: '234/run1', name: 'run1'}),
@@ -201,6 +221,14 @@ describe('ui_selectors test', () => {
                 runIds: {
                   '123': ['123/run1', '123/run2', '123/run3'],
                   '234': ['234/run1', '234/run2', '234/run3'],
+                },
+                runIdToExpId: {
+                  '123/run1': '123',
+                  '123/run2': '123',
+                  '123/run3': '123',
+                  '234/run1': '234',
+                  '234/run2': '234',
+                  '234/run3': '234',
                 },
                 runMetadata: {
                   '123/run1': buildRun({id: '123/run1', name: 'run1'}),
@@ -270,6 +298,12 @@ describe('ui_selectors test', () => {
                 runIds: {
                   '123': ['123/run1', '123/run2'],
                   '234': ['234/run1', '234/run2'],
+                },
+                runIdToExpId: {
+                  '123/run1': '123',
+                  '123/run2': '123',
+                  '234/run1': '234',
+                  '234/run2': '234',
                 },
                 runMetadata: {
                   '123/run1': buildRun({id: '123/run1', name: 'run1'}),


### PR DESCRIPTION
#5525 introduced a regression in some multi-experiment environments where the runs from experiments no longer included in the dashboard view were still being displayed in charts. (Googlers, see b/216530111)

We no longer store run selection keyed by the experiments in a route (again, because of #5525). So instead of relying on the state layer naturally filtering the runs for us, we must now do it in the ui_selectors layer. We use runIdToExpId map to filter the runs to only those in the existing set of experiments.

