### PR TITLE
linked time: Adds gray ticks to sliders on image cards

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -139,6 +139,7 @@ tf_ng_module(
     ],
     deps = [
         ":run_name",
+        ":utils",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_icon",

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -86,6 +86,17 @@ limitations under the License.
       [value]="stepIndex"
       (input)="onSliderInput($event)"
     ></mat-slider>
+    <div
+      class="linked-time-ticks-wrapper"
+      *ngIf="selectedTime && !selectedTime.clipped"
+    >
+      <div
+        class="linked-time-tick"
+        *ngFor="let step of selectedSteps"
+        [style.left]="getLinkedTimeTickLeftStyle(step)"
+        [style.margin-left]="getLinkedTimeTickMarginLeftStyle(step)"
+      ></div>
+    </div>
   </div>
   <div class="img-container">
     <img

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -136,6 +136,7 @@ $_title-to-heading-gap: 12px;
   // Reset mat-slider's internal extra space on top
   // https://github.com/angular/components/blob/master/src/material/slider/slider.scss#L10
   height: 24px;
+  position: relative;
 }
 
 .step-slider {
@@ -149,4 +150,18 @@ $_title-to-heading-gap: 12px;
 .empty-message {
   margin-top: 1em;
   font-size: 13px;
+}
+
+.linked-time-ticks-wrapper {
+  position: absolute;
+  top: 5px;
+  width: 100%;
+}
+
+.linked-time-tick {
+  @include tb-theme-background-prop(background-color, selected-button);
+  border-radius: 50%;
+  height: 14px;
+  position: absolute;
+  width: 14px;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
@@ -21,6 +21,9 @@ import {
 } from '@angular/core';
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
+import {ViewSelectedTime} from './utils';
+
+const TICK_WIDTH = 14; // In px
 
 @Component({
   selector: 'image-card-component',
@@ -49,6 +52,8 @@ export class ImageCardComponent {
   @Input() runColorScale!: RunColorScale;
   @Input() allowToggleActualSize!: boolean;
   @Input() isPinned!: boolean;
+  @Input() selectedSteps!: number[];
+  @Input() selectedTime?: ViewSelectedTime | null = null;
 
   @Output() onActualSizeToggle = new EventEmitter<void>();
   @Output() stepIndexChange = new EventEmitter<number>();
@@ -66,5 +71,30 @@ export class ImageCardComponent {
     // `number` on input events.
     // https://github.com/angular/components/blob/master/src/material/slider/slider.ts
     this.stepIndexChange.emit($event.value as number);
+  }
+
+  getLinkedTimeTickLeftStyle(step: number) {
+    if (this.stepValues.indexOf(step) == -1) {
+      throw new Error(
+        'Invalid stepIndex: stepIndex value is not included in stepValues'
+      );
+    }
+    return `${
+      (this.stepValues.indexOf(step) / (this.stepValues.length - 1)) * 100
+    }%`;
+  }
+
+  getLinkedTimeTickMarginLeftStyle(step: number) {
+    if (this.stepValues.indexOf(step) == -1) {
+      throw new Error(
+        'Invalid stepIndex: stepIndex value is not included in stepValues'
+      );
+    }
+    // Moves the tick position to the left for a fixed value because of the tick width.
+    // The length is correlated to the slider proportion.
+    return `-${
+      (this.stepValues.indexOf(step) / (this.stepValues.length - 1)) *
+      TICK_WIDTH
+    }px`;
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -24,6 +24,7 @@ import {
 import {Store} from '@ngrx/store';
 import {BehaviorSubject, combineLatest, Observable, Subject} from 'rxjs';
 import {
+  combineLatestWith,
   distinctUntilChanged,
   filter,
   map,
@@ -49,10 +50,12 @@ import {
   getMetricsImageBrightnessInMilli,
   getMetricsImageContrastInMilli,
   getMetricsImageShowActualSize,
+  getMetricsSelectedTime,
 } from '../../store';
 import {CardId, CardMetadata} from '../../types';
 import {CardRenderer} from '../metrics_view_types';
 import {getTagDisplayName} from '../utils';
+import {maybeClipSelectedTime, ViewSelectedTime} from './utils';
 
 type ImageCardMetadata = CardMetadata & {
   plugin: PluginType.IMAGES;
@@ -81,6 +84,8 @@ type ImageCardMetadata = CardMetadata & {
       [showActualSize]="showActualSize"
       [allowToggleActualSize]="(actualSizeGlobalSetting$ | async) === false"
       [isPinned]="isPinned$ | async"
+      [selectedTime]="selectedTime$ | async"
+      [selectedSteps]="selectedSteps$ | async"
       (onActualSizeToggle)="onActualSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
     ></image-card-component>
@@ -118,6 +123,8 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
   stepIndex$?: Observable<number | null>;
   stepValues$?: Observable<number[]>;
   isPinned$?: Observable<boolean>;
+  selectedTime$?: Observable<ViewSelectedTime | null>;
+  selectedSteps$?: Observable<number[]>;
   brightnessInMilli$ = this.store.select(getMetricsImageBrightnessInMilli);
   contrastInMilli$ = this.store.select(getMetricsImageContrastInMilli);
   actualSizeGlobalSetting$ = this.store.select(getMetricsImageShowActualSize);
@@ -256,6 +263,42 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
     );
 
     this.isPinned$ = this.store.select(getCardPinnedState, this.cardId);
+
+    this.selectedTime$ = this.store.select(getMetricsSelectedTime).pipe(
+      combineLatestWith(this.stepValues$),
+      map(([selectedTime, stepValues]) => {
+        if (!selectedTime) return null;
+
+        let minStep = Infinity;
+        let maxStep = -Infinity;
+        for (const step of stepValues) {
+          minStep = Math.min(step, minStep);
+          maxStep = Math.max(step, maxStep);
+        }
+        return maybeClipSelectedTime(selectedTime, minStep, maxStep);
+      })
+    );
+
+    this.selectedSteps$ = this.selectedTime$.pipe(
+      combineLatestWith(this.stepValues$),
+      map(([selectedTime, stepValues]) => {
+        if (!selectedTime) return [];
+
+        if (!selectedTime.endStep) {
+          if (stepValues.indexOf(selectedTime.startStep) !== -1)
+            return [selectedTime.startStep];
+          return [];
+        }
+
+        const selectedSteps = [];
+        for (const step of stepValues) {
+          if (step >= selectedTime.startStep && step <= selectedTime.endStep) {
+            selectedSteps.push(step);
+          }
+        }
+        return selectedSteps;
+      })
+    );
   }
 
   ngOnDestroy() {

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -290,13 +290,13 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
           return [];
         }
 
-        const selectedSteps = [];
+        const selectedStepsInRange = [];
         for (const step of stepValues) {
           if (step >= selectedTime.startStep && step <= selectedTime.endStep) {
-            selectedSteps.push(step);
+            selectedStepsInRange.push(step);
           }
         }
-        return selectedSteps;
+        return selectedStepsInRange;
       })
     );
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -480,4 +480,186 @@ describe('image card', () => {
       expect(fullWidthSpy.calls.mostRecent().args).toEqual([true]);
     });
   });
+
+  describe('linked time', () => {
+    // The left and margin-left style for an image card with 4 ticks.
+    const TICKS_STYLE = [
+      'left: 0%; margin-left: 0px;',
+      'left: 33.3333%; margin-left: -4.66667px;',
+      'left: 66.6667%; margin-left: -9.33333px;',
+      'left: 100%; margin-left: -14px;',
+    ];
+
+    it('renders a single tick on selected time', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 10},
+        end: null,
+      });
+
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries
+      );
+
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+
+      const dots = fixture.debugElement.queryAll(
+        By.css('.linked-time-ticks-wrapper .linked-time-tick')
+      );
+      expect(dots.length).toBe(1);
+      expect(dots[0].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[0]);
+    });
+
+    it('renders a single tick at correct propositional position', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 20},
+        end: null,
+      });
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries
+      );
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+      const dot = fixture.debugElement.query(
+        By.css('.linked-time-ticks-wrapper .linked-time-tick')
+      );
+
+      expect(dot.nativeElement.getAttribute('style')).toBe(TICKS_STYLE[1]);
+    });
+
+    it('renders ticks when steps are within selected time', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 15},
+        end: {step: 35},
+      });
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries
+      );
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+
+      const dots = fixture.debugElement.queryAll(
+        By.css('.linked-time-ticks-wrapper .linked-time-tick')
+      );
+      expect(dots.length).toBe(2);
+      // The second and third tick is selected.
+      expect(dots[0].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[1]);
+      expect(dots[1].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[2]);
+    });
+
+    it('renders ticks on steps are particially in range', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 25},
+        end: {step: 350},
+      });
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries
+      );
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+
+      const dots = fixture.debugElement.queryAll(
+        By.css('.linked-time-ticks-wrapper .linked-time-tick')
+      );
+      // The third and fourth ticks are selected.
+      expect(dots[0].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[2]);
+      expect(dots[1].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[3]);
+    });
+
+    it('does not render ticks on slected range wrapped between steps ', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 11},
+        end: {step: 14},
+      });
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries
+      );
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+
+      const dots = fixture.debugElement.queryAll(
+        By.css('.linked-time-ticks-wrapper .linked-time-tick')
+      );
+      // The third and fourth ticks are selected.
+      expect(dots.length).toBe(0);
+    });
+
+    it('does not render ticks when the slected range is clipped', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 45},
+        end: {step: 55},
+      });
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries
+      );
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+
+      const dots = fixture.debugElement.queryAll(
+        By.css('.linked-time-ticks-wrapper .linked-time-tick')
+      );
+      // The third and fourth ticks are selected.
+      expect(dots.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
The small black "tick" shown on hover in Angular `<mat-slider>` is actually created by background (with `repeating-linear-gradient`) which is not customizable. It is difficult to create dots as well as control how many ticks we want to show. 
I then created another layer on top of it to generate the gray dots. In single selection, only a single tick shows. In range selection, those ticks included in a range appears. 
There is no control over the thumb position for now. 

single selection (the steps of this image is 0 to 7)
<img width="566" alt="Screen Shot 2022-02-07 at 4 55 03 PM" src="https://user-images.githubusercontent.com/1131010/153043093-a55013ac-91d5-4d5b-a430-ffdf83163a91.png">

range selection
<img width="418" alt="Screen Shot 2022-02-07 at 3 44 08 PM" src="https://user-images.githubusercontent.com/1131010/153043255-24af81cd-f461-4b33-881f-e9b535385374.png">

steps included in partial range 
<img width="718" alt="Screen Shot 2022-02-07 at 4 55 30 PM" src="https://user-images.githubusercontent.com/1131010/153043153-85303cb4-dabb-48c8-94ab-8ad26fc50b77.png">

