### PR TITLE
docs: update migration guide to include TF2 invocation in TF1 summary APIs

### DIFF
--- a/docs/migrate.ipynb
+++ b/docs/migrate.ipynb
@@ -269,7 +269,7 @@
         "\n",
         "Note that when TF2 summary implementation is invoked, the return value will be an empty bytestring tensor, to avoid duplicate summary writing. Additionally, the input argument forwarding is best-effort and not all arguments will be preserved (`family` argument will be supported whereas `collections` will be removed).\n",
         "\n",
-        "Example to invoke <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/scalar\"><code>tf.summary.scalar</code></a> behaviors in <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary\"><code>tf.compat.v1.summary</code></a>:"
+        "Example to invoke <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/scalar\"><code>tf.summary.scalar</code></a> behaviors in <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary/scalar\"><code>tf.compat.v1.summary.scalar</code></a>:"
       ],
       "cell_type": "markdown",
       "metadata": {}

--- a/docs/migrate.ipynb
+++ b/docs/migrate.ipynb
@@ -267,8 +267,9 @@
         " - A suitable TF2 summary writer exists\n",
         " - A non-empty value for step is set for the writer (using <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/SummaryWriter#as_default\"><code>tf.summary.SummaryWriter.as_default</code></a>, or alternatively <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/experimental/set_step\"><code>tf.summary.experimental.set_step</code></a>)\n",
         "\n",
-        "Example to invoke <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/scalar\"><code>tf.summary.scalar\n",
-        "</code></a> behaviors in <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary\"><code>tf.compat.v1.summary</code></a>:"
+        "Note that when TF2 summary implementation is invoked, the return value will be an empty bytestring tensor, to avoid duplicate summary writing. Additionally, the input argument forwarding is best-effort and not all arguments will be preserved (`family` argument will be supported whereas `collections` will be removed).\n",
+        "\n",
+        "Example to invoke <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/scalar\"><code>tf.summary.scalar</code></a> behaviors in <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary\"><code>tf.compat.v1.summary</code></a>:"
       ],
       "cell_type": "markdown",
       "metadata": {}
@@ -282,7 +283,7 @@
         "writer = tf.summary.create_file_writer(\"/tmp/mylogs/enable_v2_in_v1\")\n",
         "# A step is set for the writer.\n",
         "with writer.as_default(step=0):\n",
-        "  # Below invokes `tf.summary.scalar`.\n",
+        "  # Below invokes `tf.summary.scalar`, and the return value is an empty bytestring.\n",
         "  tf.compat.v1.summary.scalar('float', tf.constant(1.0), family=\"family\")"
       ],
       "cell_type": "code",

--- a/docs/migrate.ipynb
+++ b/docs/migrate.ipynb
@@ -265,13 +265,15 @@
       "source": [
         "### Partial Migration\n",
         "\n",
-        "It is possible to invoke TF 2.x behaviors within <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary\"><code>tf.compat.v1.summary</code></a> APIs under the following conditions:\n",
+        "To make migration to TF 2.x easier for users of model code that still depends heavily on the TF 1.x summary API logging ops like `tf.compat.v1.summary.scalar()`, it is possible to migrate only the writer APIs first, allowing for individual TF 1.x summary ops inside your model code to be fully migrated at a later point.\n",
+        "\n",
+        "To support this style of migration, <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary\"><code>tf.compat.v1.summary</code></a> will automatically forward to their TF 2.x equivalents under the following conditions:\n",
         "\n",
         " - The outermost context is eager mode\n",
-        " - A suitable TF2 summary writer exists\n",
-        " - A non-empty value for step is set for the writer (using <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/SummaryWriter#as_default\"><code>tf.summary.SummaryWriter.as_default</code></a>, or alternatively <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/experimental/set_step\"><code>tf.summary.experimental.set_step</code></a>)\n",
+        " - A default TF 2.x summary writer has been set\n",
+        " - A non-empty value for step has been set for the writer (using <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/SummaryWriter#as_default\"><code>tf.summary.SummaryWriter.as_default</code></a>, <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/experimental/set_step\"><code>tf.summary.experimental.set_step</code></a>, or alternatively <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/train/create_global_step\"><code>tf.compat.v1.train.create_global_step</code></a>)\n",
         "\n",
-        "Note that when TF2 summary implementation is invoked, the return value will be an empty bytestring tensor, to avoid duplicate summary writing. Additionally, the input argument forwarding is best-effort and not all arguments will be preserved (`family` argument will be supported whereas `collections` will be removed).\n",
+        "Note that when TF 2.x summary implementation is invoked, the return value will be an empty bytestring tensor, to avoid duplicate summary writing. Additionally, the input argument forwarding is best-effort and not all arguments will be preserved (for instance `family` argument will be supported whereas `collections` will be removed).\n",
         "\n",
         "Example to invoke <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/scalar\"><code>tf.summary.scalar</code></a> behaviors in <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary/scalar\"><code>tf.compat.v1.summary.scalar</code></a>:"
       ]
@@ -287,7 +289,7 @@
         "# Enable eager execution.\n",
         "tf.compat.v1.enable_v2_behavior()\n",
         "\n",
-        "# A default TF2 summary writer is available.\n",
+        "# A default TF 2.x summary writer is available.\n",
         "writer = tf.summary.create_file_writer(\"/tmp/mylogs/enable_v2_in_v1\")\n",
         "# A step is set for the writer.\n",
         "with writer.as_default(step=0):\n",

--- a/docs/migrate.ipynb
+++ b/docs/migrate.ipynb
@@ -247,17 +247,21 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xEJIh4btVVRb"
+      },
       "source": [
         "## Converting your code\n",
         "\n",
         "Converting existing `tf.summary` usage to the TF 2.x API cannot be reliably automated, so the [`tf_upgrade_v2` script](https://www.tensorflow.org/guide/upgrade) just rewrites it all to `tf.compat.v1.summary` and will not enable the TF 2.x behaviors automatically."
-      ],
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xEJIh4btVVRb"
-      }
+      ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1972f8ff0073"
+      },
       "source": [
         "### Partial Migration\n",
         "\n",
@@ -270,11 +274,15 @@
         "Note that when TF2 summary implementation is invoked, the return value will be an empty bytestring tensor, to avoid duplicate summary writing. Additionally, the input argument forwarding is best-effort and not all arguments will be preserved (`family` argument will be supported whereas `collections` will be removed).\n",
         "\n",
         "Example to invoke <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/scalar\"><code>tf.summary.scalar</code></a> behaviors in <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary/scalar\"><code>tf.compat.v1.summary.scalar</code></a>:"
-      ],
-      "cell_type": "markdown",
-      "metadata": {}
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6457297c0b9d"
+      },
+      "outputs": [],
       "source": [
         "# Enable eager execution.\n",
         "tf.compat.v1.enable_v2_behavior()\n",
@@ -285,13 +293,13 @@
         "with writer.as_default(step=0):\n",
         "  # Below invokes `tf.summary.scalar`, and the return value is an empty bytestring.\n",
         "  tf.compat.v1.summary.scalar('float', tf.constant(1.0), family=\"family\")"
-      ],
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Pq4Fy1bSUdrZ"
+      },
       "source": [
         "### Full Migration\n",
         "\n",
@@ -323,11 +331,7 @@
         "    -   Flush the writer with `v1.Session.run(writer.flush())` and likewise for `close()`\n",
         "\n",
         "If your TF 1.x code was instead using `tf.contrib.summary` API, it's much more similar to the TF 2.x API, so `tf_upgrade_v2` script will automate most of the migration steps (and emit warnings or errors for any usage that cannot be fully migrated).  For the most part it just rewrites the API calls to `tf.compat.v2.summary`; if you only need compatibility with TF 2.x you can drop the `compat.v2` and just reference it as `tf.summary`."
-      ],
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Pq4Fy1bSUdrZ"
-      }
+      ]
     },
     {
       "cell_type": "markdown",

--- a/docs/migrate.ipynb
+++ b/docs/migrate.ipynb
@@ -247,22 +247,55 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xEJIh4btVVRb"
-      },
       "source": [
         "## Converting your code\n",
         "\n",
-        "Converting existing `tf.summary` usage to the TF 2.x API cannot be reliably automated, so the [`tf_upgrade_v2` script](https://www.tensorflow.org/guide/upgrade) just rewrites it all to `tf.compat.v1.summary`.  To migrate to TF 2.x, you'll need to adapt your code as follows:"
-      ]
-    },
-    {
+        "Converting existing `tf.summary` usage to the TF 2.x API cannot be reliably automated, so the [`tf_upgrade_v2` script](https://www.tensorflow.org/guide/upgrade) just rewrites it all to `tf.compat.v1.summary` and will not enable the TF 2.x behaviors automatically."
+      ],
       "cell_type": "markdown",
       "metadata": {
-        "id": "Pq4Fy1bSUdrZ"
-      },
+        "id": "xEJIh4btVVRb"
+      }
+    },
+    {
       "source": [
+        "### Partial Migration\n",
+        "\n",
+        "It is possible to invoke TF 2.x behaviors within <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary\"><code>tf.compat.v1.summary</code></a> APIs under the following conditions:\n",
+        "\n",
+        " - The outermost context is eager mode\n",
+        " - A suitable TF2 summary writer exists\n",
+        " - A non-empty value for step is set for the writer (using <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/SummaryWriter#as_default\"><code>tf.summary.SummaryWriter.as_default</code></a>, or alternatively <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/experimental/set_step\"><code>tf.summary.experimental.set_step</code></a>)\n",
+        "\n",
+        "Example to invoke <a href=\"https://www.tensorflow.org/api_docs/python/tf/summary/scalar\"><code>tf.summary.scalar\n",
+        "</code></a> behaviors in <a href=\"https://www.tensorflow.org/api_docs/python/tf/compat/v1/summary\"><code>tf.compat.v1.summary</code></a>:"
+      ],
+      "cell_type": "markdown",
+      "metadata": {}
+    },
+    {
+      "source": [
+        "# Enable eager execution.\n",
+        "tf.compat.v1.enable_v2_behavior()\n",
+        "\n",
+        "# A default TF2 summary writer is available.\n",
+        "writer = tf.summary.create_file_writer(\"/tmp/mylogs/enable_v2_in_v1\")\n",
+        "# A step is set for the writer.\n",
+        "with writer.as_default(step=0):\n",
+        "  # Below invokes `tf.summary.scalar`.\n",
+        "  tf.compat.v1.summary.scalar('float', tf.constant(1.0), family=\"family\")"
+      ],
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "source": [
+        "### Full Migration\n",
+        "\n",
+        "To fully migrate to TF 2.x, you'll need to adapt your code as follows:\n",
+        "\n",
         "1.  A default writer set via `.as_default()` must be present to use summary ops\n",
         "\n",
         "    -   This means executing ops eagerly or using ops in graph construction\n",
@@ -289,7 +322,11 @@
         "    -   Flush the writer with `v1.Session.run(writer.flush())` and likewise for `close()`\n",
         "\n",
         "If your TF 1.x code was instead using `tf.contrib.summary` API, it's much more similar to the TF 2.x API, so `tf_upgrade_v2` script will automate most of the migration steps (and emit warnings or errors for any usage that cannot be fully migrated).  For the most part it just rewrites the API calls to `tf.compat.v2.summary`; if you only need compatibility with TF 2.x you can drop the `compat.v2` and just reference it as `tf.summary`."
-      ]
+      ],
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Pq4Fy1bSUdrZ"
+      }
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
Preview: https://github.com/yatbear/tensorboard/blob/summary_docs/docs/migrate.ipynb

#tf_summary #v1_to_v2
