### PR TITLE
scalar: manually set background to transparent

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -283,14 +283,10 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
 
     this.renderer = new THREE.WebGLRenderer({
       canvas: canvas as HTMLCanvasElement,
-      context: canvas.getContext('webgl2', {
-        antialias: true,
-        precision: 'highp',
-        alpha: true,
-      } as WebGLContextAttributes) as WebGLRenderingContext,
+      context: canvas.getContext('webgl2') as WebGLRenderingContext,
+      antialias: true,
+      alpha: true,
     });
-    // Workaround to fix background transparency is not set propoerly in threejs WebGLRenderer.
-    this.renderer.setClearColor(0x000000, 0);
     this.renderer.setPixelRatio(devicePixelRatio);
   }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -289,6 +289,8 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
         alpha: true,
       } as WebGLContextAttributes) as WebGLRenderingContext,
     });
+    // Workaround to fix background transparency is not set propoerly in threejs WebGLRenderer.
+    this.renderer.setClearColor(0x000000, 0);
     this.renderer.setPixelRatio(devicePixelRatio);
   }
 


### PR DESCRIPTION
The background of charts in scalar card have black backgrounds. It is because of the threejs upgrades https://github.com/tensorflow/tensorboard/commit/420916a6e4c80740432f1e2bd0c83d6dd145da10. Before we find a long-term solution, we can set the background opacity to zero as the temporary fix 

before 
<img width="434" alt="Screen Shot 2022-02-14 at 4 21 45 PM" src="https://user-images.githubusercontent.com/1131010/153969077-fd08428f-ac58-4e0f-97af-2f5b8af28fb7.png">

after
<img width="425" alt="Screen Shot 2022-02-14 at 4 22 58 PM" src="https://user-images.githubusercontent.com/1131010/153969160-9c19492d-aa3a-4f13-b46d-7e0e876fda9c.png">
 