### PR TITLE
linked time: updates range input to contain single selection

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -936,10 +936,7 @@ const reducer = createReducer(
 
     // When end step value is provided but useRangeSelectTime is still false,
     // this means the current selection state is single. We flip it to range selection.
-    let useRangeSelectTime = state.useRangeSelectTime;
-    if (!state.useRangeSelectTime && change.endStep) {
-      useRangeSelectTime = true;
-    }
+    const useRangeSelectTime = change.endStep !== undefined;
 
     return {
       ...state,

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -934,8 +934,8 @@ const reducer = createReducer(
       nextEndStep = nextStartStep;
     }
 
-    // When end step value is provided but useRangeSelectTime is still false,
-    // this means the current selection state is single. We flip it to range selection.
+    // If there is no endStep then current selection state is single.
+    // Otherwise selection state is range.
     const useRangeSelectTime = change.endStep !== undefined;
 
     return {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -934,6 +934,13 @@ const reducer = createReducer(
       nextEndStep = nextStartStep;
     }
 
+    // When end step value is provided but useRangeSelectTime is still false,
+    // this means the current selection state is single. We flip it to range selection.
+    let useRangeSelectTime = state.useRangeSelectTime;
+    if (!state.useRangeSelectTime && change.endStep) {
+      useRangeSelectTime = true;
+    }
+
     return {
       ...state,
       selectTimeEnabled: true,
@@ -945,6 +952,7 @@ const reducer = createReducer(
           step: nextEndStep,
         },
       },
+      useRangeSelectTime,
     };
   }),
   on(actions.useRangeSelectTimeToggled, (state) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2412,10 +2412,33 @@ describe('metrics reducers', () => {
         }
       );
 
-      it('sets `useRangeSelectTime` to true when `endStep` is present', () => {
+      it('sets `useRangeSelectTime` to true when `endStep` is present and selected time is null', () => {
         const beforeState = buildMetricsState({
           useRangeSelectTime: false,
           selectedTime: null,
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.timeSelectionChanged({
+            startStep: 2,
+            endStep: 5,
+          })
+        );
+
+        expect(nextState.useRangeSelectTime).toEqual(true);
+      });
+
+      // This test case represents <tb-range-input> renders range slider from single slider.
+      it('sets `useRangeSelectTime` to true when `endStep` is present selected time is not null', () => {
+        const beforeState = buildMetricsState({
+          useRangeSelectTime: false,
+          selectedTime: {
+            start: {step: 0},
+            // When single slider is rendered, the end step is set to step max.
+            // Here set it as an arbitrary number.
+            end: {step: 100},
+          },
         });
 
         const nextState = reducers(
@@ -2449,22 +2472,42 @@ describe('metrics reducers', () => {
         expect(nextState.useRangeSelectTime).toEqual(true);
       });
 
-      it('remains `useRangeSelectTime` the same when only sets `startStep`', () => {
-        const beforeState = buildMetricsState({
+      it('keeps `useRangeSelectTime` to be false when only sets `startStep`', () => {
+        const beforeState1 = buildMetricsState({
           useRangeSelectTime: false,
           selectedTime: null,
         });
 
-        const nextState = reducers(
-          beforeState,
+        const nextState1 = reducers(
+          beforeState1,
           actions.timeSelectionChanged({
             startStep: 2,
             endStep: undefined,
           })
         );
 
-        expect(nextState.useRangeSelectTime).toEqual(false);
+        expect(nextState1.useRangeSelectTime).toEqual(false);
       });
+    });
+
+    it('sets `useRangeSelectTime` to false when `endStep` is undefinded', () => {
+      const beforeState = buildMetricsState({
+        useRangeSelectTime: true,
+        selectedTime: {
+          start: {step: 2},
+          end: {step: 100},
+        },
+      });
+
+      const nextState = reducers(
+        beforeState,
+        actions.timeSelectionChanged({
+          startStep: 3,
+          endStep: undefined,
+        })
+      );
+
+      expect(nextState.useRangeSelectTime).toEqual(false);
     });
 
     describe('#timeSelectionCleared', () => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2411,6 +2411,60 @@ describe('metrics reducers', () => {
           });
         }
       );
+
+      it('sets `useRangeSelectTime` to true when `endStep` is present', () => {
+        const beforeState = buildMetricsState({
+          useRangeSelectTime: false,
+          selectedTime: null,
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.timeSelectionChanged({
+            startStep: 2,
+            endStep: 5,
+          })
+        );
+
+        expect(nextState.useRangeSelectTime).toEqual(true);
+      });
+
+      it('sets `useRangeSelectTime` to true when `endStep` is 0', () => {
+        const beforeState = buildMetricsState({
+          useRangeSelectTime: false,
+          selectedTime: {
+            start: {step: 2},
+            end: {step: 100},
+          },
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.timeSelectionChanged({
+            startStep: 2,
+            endStep: 0,
+          })
+        );
+
+        expect(nextState.useRangeSelectTime).toEqual(true);
+      });
+
+      it('remains `useRangeSelectTime` the same when only sets `startStep`', () => {
+        const beforeState = buildMetricsState({
+          useRangeSelectTime: false,
+          selectedTime: null,
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.timeSelectionChanged({
+            startStep: 2,
+            endStep: undefined,
+          })
+        );
+
+        expect(nextState.useRangeSelectTime).toEqual(false);
+      });
     });
 
     describe('#timeSelectionCleared', () => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2490,7 +2490,7 @@ describe('metrics reducers', () => {
       });
     });
 
-    it('sets `useRangeSelectTime` to false when `endStep` is undefinded', () => {
+    it('sets `useRangeSelectTime` to false when `endStep` is undefined', () => {
       const beforeState = buildMetricsState({
         useRangeSelectTime: true,
         selectedTime: {

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -451,7 +451,7 @@ describe('metrics right_pane', () => {
           const el = fixture.debugElement.query(By.css('.linked-time'));
           const rangeInput = el.query(By.css('tb-range-input'));
 
-          rangeInput.triggerEventHandler('rangeValues', {
+          rangeInput.triggerEventHandler('rangeValuesChanged', {
             lowerValue: 10,
             upperValue: 200,
           });
@@ -476,7 +476,7 @@ describe('metrics right_pane', () => {
           const el = fixture.debugElement.query(By.css('.linked-time'));
           const rangeInput = el.query(By.css('tb-range-input'));
 
-          rangeInput.triggerEventHandler('singleValue', 10);
+          rangeInput.triggerEventHandler('singleValueChanged', 10);
 
           expect(dispatchSpy).toHaveBeenCalledOnceWith(
             actions.timeSelectionChanged({

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -376,6 +376,15 @@ describe('metrics right_pane', () => {
       });
     });
 
+    it('does not display link time setting on link time disnabled', () => {
+      store.overrideSelector(selectors.getIsLinkedTimeEnabled, false);
+      const fixture = TestBed.createComponent(SettingsViewContainer);
+      fixture.detectChanges();
+
+      const el = fixture.debugElement.query(By.css('.linked-time'));
+      expect(el).toBeFalsy();
+    });
+
     describe('linked time feature enabled', () => {
       beforeEach(() => {
         store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
@@ -439,7 +448,35 @@ describe('metrics right_pane', () => {
           expect(el.query(By.css('tb-range-input'))).toBeTruthy();
         });
 
-        it('dispatches actions when step changes when making range step change', () => {
+        it('disables tb-range-input on select time disabled', () => {
+          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
+          store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
+          store.overrideSelector(selectors.getMetricsSelectTimeEnabled, false);
+          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
+          const fixture = TestBed.createComponent(SettingsViewContainer);
+          fixture.detectChanges();
+
+          const el = fixture.debugElement.query(
+            By.css('.linked-time tb-range-input')
+          );
+          expect(el.nativeElement.getAttribute('disabled')).toBe('true');
+        });
+
+        it('enables tb-range-input on select time enabled', () => {
+          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
+          store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
+          store.overrideSelector(selectors.getMetricsSelectTimeEnabled, true);
+          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
+          const fixture = TestBed.createComponent(SettingsViewContainer);
+          fixture.detectChanges();
+
+          const el = fixture.debugElement.query(
+            By.css('.linked-time tb-range-input')
+          );
+          expect(el.nativeElement.getAttribute('disabled')).toBe('false');
+        });
+
+        it('dispatches actions when making range step change', () => {
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
           store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
             start: {step: 0},
@@ -464,7 +501,7 @@ describe('metrics right_pane', () => {
           );
         });
 
-        it('dispatches actions when step changes when making single step change', () => {
+        it('dispatches actions when making single step change', () => {
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
           store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
             start: {step: 0},

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -376,7 +376,7 @@ describe('metrics right_pane', () => {
       });
     });
 
-    it('does not display link time setting on link time disnabled', () => {
+    it('does not display link time setting on link time disabled', () => {
       store.overrideSelector(selectors.getIsLinkedTimeEnabled, false);
       const fixture = TestBed.createComponent(SettingsViewContainer);
       fixture.detectChanges();

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -420,93 +420,10 @@ describe('metrics right_pane', () => {
           fixture.detectChanges();
           expect(enabled.nativeElement.ariaChecked).toBe('true');
         });
-
-        it('renders and dispatches action when toggling range mode', () => {
-          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-          const fixture = TestBed.createComponent(SettingsViewContainer);
-          fixture.detectChanges();
-
-          const el = fixture.debugElement.query(By.css('.linked-time'));
-          const [, range] = el.queryAll(By.css('mat-checkbox input'));
-          expect(range.nativeElement.ariaChecked).toBe('false');
-
-          range.nativeElement.click();
-
-          expect(dispatchSpy).toHaveBeenCalledOnceWith(
-            actions.useRangeSelectTimeToggled()
-          );
-
-          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
-          store.refreshState();
-          fixture.detectChanges();
-          expect(range.nativeElement.ariaChecked).toBe('true');
-        });
       });
 
       describe('step selector', () => {
-        it('displays mat-slider on single step selection mode', () => {
-          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-          const fixture = TestBed.createComponent(SettingsViewContainer);
-          fixture.detectChanges();
-
-          const el = fixture.debugElement.query(By.css('.linked-time'));
-          expect(el.query(By.css('mat-slider'))).toBeTruthy();
-
-          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
-          store.refreshState();
-          fixture.detectChanges();
-          expect(el.query(By.css('mat-slider'))).toBeFalsy();
-        });
-
-        it('dispatches actions when step changes when making single step change', () => {
-          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-          store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
-            start: {step: 0},
-            end: {step: 1000},
-          });
-          const fixture = TestBed.createComponent(SettingsViewContainer);
-          fixture.detectChanges();
-
-          const el = fixture.debugElement.query(By.css('.linked-time'));
-          const slider = el.query(By.css('mat-slider'));
-
-          slider.triggerEventHandler('input', {
-            value: 5,
-          });
-
-          expect(dispatchSpy).toHaveBeenCalledOnceWith(
-            actions.timeSelectionChanged({
-              startStep: 5,
-              endStep: undefined,
-            })
-          );
-        });
-
-        it('sets endStep to undefined when single step range changes', () => {
-          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-          store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
-            start: {step: 0, wallTime: -1},
-            end: {step: 100, wallTime: 100},
-          });
-          const fixture = TestBed.createComponent(SettingsViewContainer);
-          fixture.detectChanges();
-
-          const el = fixture.debugElement.query(By.css('.linked-time'));
-          const slider = el.query(By.css('mat-slider'));
-
-          slider.triggerEventHandler('input', {
-            value: 5,
-          });
-
-          expect(dispatchSpy).toHaveBeenCalledOnceWith(
-            actions.timeSelectionChanged({
-              startStep: 5,
-              endStep: undefined,
-            })
-          );
-        });
-
-        it('displays tb-range-input on range step selection mode', () => {
+        it('displays tb-range-input on both single and range step selection mode', () => {
           store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
           store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
@@ -514,7 +431,7 @@ describe('metrics right_pane', () => {
           fixture.detectChanges();
 
           const el = fixture.debugElement.query(By.css('.linked-time'));
-          expect(el.query(By.css('tb-range-input'))).toBeFalsy();
+          expect(el.query(By.css('tb-range-input'))).toBeTruthy();
 
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
           store.refreshState();
@@ -534,7 +451,7 @@ describe('metrics right_pane', () => {
           const el = fixture.debugElement.query(By.css('.linked-time'));
           const rangeInput = el.query(By.css('tb-range-input'));
 
-          rangeInput.triggerEventHandler('value', {
+          rangeInput.triggerEventHandler('rangeValues', {
             lowerValue: 10,
             upperValue: 200,
           });
@@ -543,6 +460,28 @@ describe('metrics right_pane', () => {
             actions.timeSelectionChanged({
               startStep: 10,
               endStep: 200,
+            })
+          );
+        });
+
+        it('dispatches actions when step changes when making single step change', () => {
+          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
+          store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
+            start: {step: 0},
+            end: null,
+          });
+          const fixture = TestBed.createComponent(SettingsViewContainer);
+          fixture.detectChanges();
+
+          const el = fixture.debugElement.query(By.css('.linked-time'));
+          const rangeInput = el.query(By.css('tb-range-input'));
+
+          rangeInput.triggerEventHandler('singleValue', 10);
+
+          expect(dispatchSpy).toHaveBeenCalledOnceWith(
+            actions.timeSelectionChanged({
+              startStep: 10,
+              endStep: undefined,
             })
           );
         });

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -74,8 +74,8 @@ limitations under the License.
           [upperValue]="selectedTime?.end?.step"
           [useRange]="useRangeSelectTime"
           [inputEnabled]="selectTimeEnabled"
-          (singleValue)="onStepStartChanged($event)"
-          (rangeValues)="onStepRangeChanged($event)"
+          (singleValueChanged)="onSingleValueChanged($event)"
+          (rangeValuesChanged)="onRangeValuesChanged($event)"
           (upperValueRemoved)="useRangeSelectTimeToggled.emit()"
         ></tb-range-input>
       </div>

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -65,35 +65,19 @@ limitations under the License.
           >Enabled</mat-checkbox
         >
       </div>
-      <div>
-        <mat-checkbox
-          [checked]="useRangeSelectTime"
-          (change)="useRangeSelectTimeToggled.emit()"
-          >Use range</mat-checkbox
-        >
-      </div>
       <div class="step-selector">
-        <mat-slider
-          *ngIf="!useRangeSelectTime; else range"
-          [disabled]="!selectTimeEnabled"
-          color="primary"
+        <tb-range-input
+          [attr.disabled]="!selectTimeEnabled"
           [min]="stepMinMax.min"
           [max]="stepMinMax.max"
-          [step]="1"
-          [value]="selectedTime?.start.step"
-          [thumbLabel]="true"
-          (input)="onStepStartChanged($event.value)"
-        ></mat-slider>
-        <ng-template #range>
-          <tb-range-input
-            [attr.disabled]="!selectTimeEnabled"
-            [min]="stepMinMax.min"
-            [max]="stepMinMax.max"
-            [lowerValue]="selectedTime?.start.step"
-            [upperValue]="selectedTime?.end?.step "
-            (value)="onStepRangeChanged($event)"
-          ></tb-range-input>
-        </ng-template>
+          [lowerValue]="selectedTime?.start.step"
+          [upperValue]="selectedTime?.end?.step"
+          [useRange]="useRangeSelectTime"
+          [inputEnabled]="selectTimeEnabled"
+          (singleValue)="onStepStartChanged($event)"
+          (rangeValues)="onStepRangeChanged($event)"
+          (upperValueRemoved)="useRangeSelectTimeToggled.emit()"
+        ></tb-range-input>
       </div>
     </div>
   </div>

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -105,11 +105,6 @@ tb-dropdown {
     padding: 0 10px;
   }
 
-  mat-slider,
-  tb-range-input {
-    width: 100%;
-  }
-
   .controls {
     padding: 5px;
   }

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -173,25 +173,20 @@ export class SettingsViewComponent {
     );
   }
 
-  onStepStartChanged(stepValue: number) {
+  onSingleValueChanged(stepValue: number) {
     this.selectTimeChanged.emit({
       start: {step: stepValue},
       end: null,
     });
   }
 
-  onStepRangeChanged({
+  onRangeValuesChanged({
     lowerValue,
     upperValue,
   }: {
     lowerValue: number;
     upperValue: number;
   }) {
-    // When range values are updated but useRange is still false, this means the
-    // current selection state is single. We flip it to range selection.
-    if (!this.useRangeSelectTime) {
-      this.useRangeSelectTimeToggled.emit();
-    }
     this.selectTimeChanged.emit({
       start: {step: lowerValue},
       end: {step: upperValue},

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -187,6 +187,11 @@ export class SettingsViewComponent {
     lowerValue: number;
     upperValue: number;
   }) {
+    // When range values are updated but useRange is still false, this means the
+    // current selection state is single. We flip it to range selection.
+    if (!this.useRangeSelectTime) {
+      this.useRangeSelectTimeToggled.emit();
+    }
     this.selectTimeChanged.emit({
       start: {step: lowerValue},
       end: {step: upperValue},

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -144,9 +144,7 @@ limitations under the License.
                   [max]="column.filter.maxValue"
                   [lowerValue]="column.filter.filterLowerValue"
                   [upperValue]="column.filter.filterUpperValue"
-                  [useRange]="true"
-                  [inputEnabled]="true"
-                  (rangeValues)="handleHparamIntervalChanged(column, $event)"
+                  (rangeValuesChanged)="handleHparamIntervalChanged(column, $event)"
                 ></tb-range-input>
               </div>
             </ng-container>
@@ -213,9 +211,7 @@ limitations under the License.
                 [max]="column.filter.maxValue"
                 [lowerValue]="column.filter.filterLowerValue"
                 [upperValue]="column.filter.filterUpperValue"
-                [useRange]="true"
-                [inputEnabled]="true"
-                (rangeValues)="handleMetricFilterChanged(column, $event)"
+                (rangeValuesChanged)="handleMetricFilterChanged(column, $event)"
               ></tb-range-input>
             </div>
           </mat-menu>

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -144,7 +144,9 @@ limitations under the License.
                   [max]="column.filter.maxValue"
                   [lowerValue]="column.filter.filterLowerValue"
                   [upperValue]="column.filter.filterUpperValue"
-                  (value)="handleHparamIntervalChanged(column, $event)"
+                  [useRange]="true"
+                  [inputEnabled]="true"
+                  (rangeValues)="handleHparamIntervalChanged(column, $event)"
                 ></tb-range-input>
               </div>
             </ng-container>
@@ -211,7 +213,9 @@ limitations under the License.
                 [max]="column.filter.maxValue"
                 [lowerValue]="column.filter.filterLowerValue"
                 [upperValue]="column.filter.filterUpperValue"
-                (value)="handleMetricFilterChanged(column, $event)"
+                [useRange]="true"
+                [inputEnabled]="true"
+                (rangeValues)="handleMetricFilterChanged(column, $event)"
               ></tb-range-input>
             </div>
           </mat-menu>

--- a/tensorboard/webapp/widgets/range_input/BUILD
+++ b/tensorboard/webapp/widgets/range_input/BUILD
@@ -34,8 +34,8 @@ tf_ts_library(
     deps = [
         ":range_input",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
-        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/angular:expect_angular_material_slider",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/widgets/range_input/BUILD
+++ b/tensorboard/webapp/widgets/range_input/BUILD
@@ -20,6 +20,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/angular:expect_angular_cdk_drag_drop",
+        "//tensorboard/webapp/angular:expect_angular_material_slider",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//rxjs",
@@ -34,6 +35,7 @@ tf_ts_library(
         ":range_input",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/angular:expect_angular_material_slider",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ng.html
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ng.html
@@ -17,14 +17,14 @@ limitations under the License.
 <input
   class="lower-input"
   type="number"
-  [disabled]="!inputEnabled"
+  [disabled]="!enabled"
   [value]="lowerValue"
   (change)="handleInputChange($event, Position.LEFT)"
 />
 <input
   class="upper-input"
   type="number"
-  [disabled]="!inputEnabled"
+  [disabled]="!enabled"
   [value]="useRange ? upperValue : ''"
   (change)="handleInputChange($event, Position.RIGHT)"
 />
@@ -32,13 +32,12 @@ limitations under the License.
 <mat-slider
   class="single-slider"
   *ngIf="!useRange; else range"
-  [disabled]="!inputEnabled"
+  [disabled]="!enabled"
   color="primary"
   [min]="min"
   [max]="max"
   [step]="1"
   [value]="lowerValue"
-  [thumbLabel]="false"
   (input)="singleValueChanged.emit($event.value)"
 ></mat-slider>
 

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ng.html
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ng.html
@@ -39,7 +39,7 @@ limitations under the License.
   [step]="1"
   [value]="lowerValue"
   [thumbLabel]="false"
-  (input)="singleValue.emit($event.value)"
+  (input)="singleValueChanged.emit($event.value)"
 ></mat-slider>
 
 <ng-template #range>

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ng.html
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ng.html
@@ -17,33 +17,50 @@ limitations under the License.
 <input
   class="lower-input"
   type="number"
+  [disabled]="!inputEnabled"
   [value]="lowerValue"
   (change)="handleInputChange($event, Position.LEFT)"
 />
 <input
   class="upper-input"
   type="number"
-  [value]="upperValue"
+  [disabled]="!inputEnabled"
+  [value]="useRange ? upperValue : ''"
   (change)="handleInputChange($event, Position.RIGHT)"
 />
 
-<span class="container" #container>
-  <span class="slider-track"></span>
-  <span
-    class="slider-track-fill"
-    [style.left]="getThumbPosition(lowerValue)"
-    [style.width]="getTrackWidth()"
-  ></span>
-  <span
-    class="thumb"
-    (mousedown)="handleMouseDown($event, Position.LEFT)"
-    [style.left]="getThumbPosition(lowerValue)"
-    [class.active]="isThumbActive(Position.LEFT)"
-  ></span>
-  <span
-    class="thumb"
-    (mousedown)="handleMouseDown($event, Position.RIGHT)"
-    [style.left]="getThumbPosition(upperValue)"
-    [class.active]="isThumbActive(Position.RIGHT)"
-  ></span>
-</span>
+<mat-slider
+  class="single-slider"
+  *ngIf="!useRange; else range"
+  [disabled]="!inputEnabled"
+  color="primary"
+  [min]="min"
+  [max]="max"
+  [step]="1"
+  [value]="lowerValue"
+  [thumbLabel]="false"
+  (input)="singleValue.emit($event.value)"
+></mat-slider>
+
+<ng-template #range>
+  <span class="container" #container>
+    <span class="slider-track"></span>
+    <span
+      class="slider-track-fill"
+      [style.left]="getThumbPosition(lowerValue)"
+      [style.width]="getTrackWidth()"
+    ></span>
+    <span
+      class="thumb"
+      (mousedown)="handleMouseDown($event, Position.LEFT)"
+      [style.left]="getThumbPosition(lowerValue)"
+      [class.active]="isThumbActive(Position.LEFT)"
+    ></span>
+    <span
+      class="thumb"
+      (mousedown)="handleMouseDown($event, Position.RIGHT)"
+      [style.left]="getThumbPosition(upperValue)"
+      [class.active]="isThumbActive(Position.RIGHT)"
+    ></span>
+  </span>
+</ng-template>

--- a/tensorboard/webapp/widgets/range_input/range_input_component.scss
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.scss
@@ -58,7 +58,7 @@ input {
     right: 0px;
   }
 }
-::ng-deep .mat-slider-horizontal {
+::ng-deep .single-slider.mat-slider-horizontal {
   height: 12px;
 }
 

--- a/tensorboard/webapp/widgets/range_input/range_input_component.scss
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.scss
@@ -25,6 +25,7 @@ $_thumb-size: 12px;
   grid-template-areas:
     'lower-input upper-input'
     'slider slider';
+  grid-template-columns: 1fr 1fr;
   font-size: 0;
   min-width: 100px;
   padding: $_thumb-size * 0.5;
@@ -46,6 +47,19 @@ input {
 .upper-input {
   grid-area: upper-input;
   justify-self: flex-end;
+}
+
+.single-slider {
+  grid-area: slider;
+  padding: 0px;
+  ::ng-deep .mat-slider-wrapper {
+    top: 5px;
+    left: 0px;
+    right: 0px;
+  }
+}
+::ng-deep .mat-slider-horizontal {
+  height: 12px;
 }
 
 .container {

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ts
@@ -46,9 +46,9 @@ enum Position {
  *
  *        left input             right input
  *   +-----------------+     +----------------+
- *   |                 |     |       X        |
+ *   |                 |     |    [empty]     |
  *   +-----------------+     +----------------+
- *       <lowerValue>           <no upperValue
+ *       <lowerValue>          <no upperValue>
  *
  *                 thumb
  *                 +---+
@@ -76,7 +76,7 @@ enum Position {
  *        <lowerValue>        <upperValue>
  *
  * Features:
- * - `useRange` controlls it renders a single or double thumbed slider
+ * - `useRange` controls whether renders a single or double thumbed slider
  * - you can drag a thumb to change lowerValue or upperValue
  * - you cannot click on track to change any value on double thumbed slider
  *   but click anywhere in a single slider sets the value to where clicked.
@@ -86,7 +86,8 @@ enum Position {
  * - does not validate input (e.g., lowerValue can be lower than min) but thumbs
  *   are clipped to `min` and `max`. Also, when emitting changes, the values can
  *   never exceed `min` and `max`.
- * - emits actions on uppper value removed
+ * - emits actions on both single and range value changed
+ * - emits actions on upper value removed
  */
 @Component({
   selector: 'tb-range-input',
@@ -129,13 +130,13 @@ export class RangeInputComponent implements OnInit, OnDestroy {
    */
   @Input() tickCount: number | null = 20;
   /**
-   * Renders single or range slider. Sets default to range slider for compatibility.
+   * Renders single or range slider.
    */
   @Input() useRange: boolean = true;
   /**
-   * Whether the text input is editable. Default enabled for compatibility.
+   * Whether the text input is editable.
    */
-  @Input() inputEnabled: boolean = true;
+  @Input() enabled: boolean = true;
 
   @Output()
   rangeValuesChanged = new EventEmitter<{
@@ -339,7 +340,7 @@ export class RangeInputComponent implements OnInit, OnDestroy {
 
     // Cleans input value. If the upper value is removed, we go from range to
     // single selection. If the lower value is removed, we set it to the min
-    // for both single ang range seleciton.
+    // for both single and range seleciton.
     // For example, for min=50, max=1000,
     // range  [100, 500]  → delete upper value → single [100, X]
     // single [100, X]    → delete lower value → single [50, X]

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ts
@@ -138,7 +138,10 @@ export class RangeInputComponent implements OnInit, OnDestroy {
   @Input() inputEnabled: boolean = true;
 
   @Output()
-  rangeValuesChanged = new EventEmitter<{lowerValue: number; upperValue: number}>();
+  rangeValuesChanged = new EventEmitter<{
+    lowerValue: number;
+    upperValue: number;
+  }>();
 
   @Output() singleValueChanged = new EventEmitter<number>();
 

--- a/tensorboard/webapp/widgets/range_input/range_input_module.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_module.ts
@@ -14,10 +14,11 @@ limitations under the License.
 ==============================================================================*/
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {MatSliderModule} from '@angular/material/slider';
 import {RangeInputComponent} from './range_input_component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, MatSliderModule],
   exports: [RangeInputComponent],
   declarations: [RangeInputComponent],
 })

--- a/tensorboard/webapp/widgets/range_input/range_input_test.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_test.ts
@@ -108,7 +108,12 @@ describe('range input test', () => {
     fixture.componentInstance.onSingleValueChanged = onSingleValueChanged;
     fixture.componentInstance.onUpperValueRemoved = onUpperValueRemoved;
     fixture.detectChanges();
-    return {fixture, onRangeValuesChanged, onSingleValueChanged, onUpperValueRemoved};
+    return {
+      fixture,
+      onRangeValuesChanged,
+      onSingleValueChanged,
+      onUpperValueRemoved,
+    };
   }
 
   function getThumbsOnRange(
@@ -427,11 +432,19 @@ describe('range input test', () => {
       });
 
       const fixture = fixtureAndonRangeValuesChanged.fixture;
-      const onRangeValuesChanged = fixtureAndonRangeValuesChanged.onRangeValuesChanged;
-      const onSingleValueChanged = fixtureAndonRangeValuesChanged.onSingleValueChanged;
-      const onUpperValueRemoved = fixtureAndonRangeValuesChanged.onUpperValueRemoved;
+      const onRangeValuesChanged =
+        fixtureAndonRangeValuesChanged.onRangeValuesChanged;
+      const onSingleValueChanged =
+        fixtureAndonRangeValuesChanged.onSingleValueChanged;
+      const onUpperValueRemoved =
+        fixtureAndonRangeValuesChanged.onUpperValueRemoved;
 
-      return {fixture, onRangeValuesChanged, onSingleValueChanged, onUpperValueRemoved};
+      return {
+        fixture,
+        onRangeValuesChanged,
+        onSingleValueChanged,
+        onUpperValueRemoved,
+      };
     }
 
     function createSingleComponent() {
@@ -443,8 +456,10 @@ describe('range input test', () => {
       });
 
       const fixture = fixtureAndonRangeValuesChanged.fixture;
-      const onRangeValuesChanged = fixtureAndonRangeValuesChanged.onRangeValuesChanged;
-      const onSingleValueChanged = fixtureAndonRangeValuesChanged.onSingleValueChanged;
+      const onRangeValuesChanged =
+        fixtureAndonRangeValuesChanged.onRangeValuesChanged;
+      const onSingleValueChanged =
+        fixtureAndonRangeValuesChanged.onSingleValueChanged;
 
       return {fixture, onRangeValuesChanged, onSingleValueChanged};
     }

--- a/tensorboard/webapp/widgets/range_input/range_input_test.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_test.ts
@@ -13,8 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input} from '@angular/core';
+import {Component, DebugElement, Input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatSliderModule} from '@angular/material/slider';
 import {By} from '@angular/platform-browser';
 import {RangeInputComponent, TEST_ONLY} from './range_input_component';
 
@@ -26,8 +27,12 @@ import {RangeInputComponent, TEST_ONLY} from './range_input_component';
       [max]="max"
       [lowerValue]="lowerValue"
       [upperValue]="upperValue"
+      [useRange]="useRange"
+      [inputEnabled]="inputEnabled"
       [tickCount]="tickCount"
-      (value)="onValue($event)"
+      (rangeValues)="onRangeValues($event)"
+      (singleValue)="onSingleValue($event)"
+      (upperValueRemoved)="onUpperValueRemoved()"
     ></tb-range-input>
   `,
   styles: [
@@ -51,9 +56,20 @@ class TestableComponent {
 
   @Input() upperValue!: number;
 
+  @Input() useRange!: boolean;
+
+  @Input() inputEnabled!: boolean;
+
   @Input() tickCount!: number | null;
 
-  @Input() onValue!: (event: {lowerValue: number; upperValue: number}) => void;
+  @Input() onRangeValues!: (event: {
+    lowerValue: number;
+    upperValue: number;
+  }) => void;
+
+  @Input() onSingleValue!: (event: {value: number}) => void;
+
+  @Input() onUpperValueRemoved!: () => void;
 }
 
 describe('range input test', () => {
@@ -62,7 +78,8 @@ describe('range input test', () => {
     max?: number;
     tickCount?: number | null;
     lowerValue: number;
-    upperValue: number;
+    upperValue?: number;
+    useRange?: boolean;
   }
 
   function createComponent(props: CreateComponentInput) {
@@ -70,22 +87,31 @@ describe('range input test', () => {
       min: -5,
       max: 5,
       tickCount: 10,
+      useRange: false,
+      inputEnabled: true,
       ...props,
     };
     const fixture = TestBed.createComponent(TestableComponent);
 
-    const onValue = jasmine.createSpy();
+    const onRangeValues = jasmine.createSpy();
+    const onSingleValue = jasmine.createSpy();
+    const onUpperValueRemoved = jasmine.createSpy();
     fixture.componentInstance.lowerValue = propsWithDefault.lowerValue;
-    fixture.componentInstance.upperValue = propsWithDefault.upperValue;
+    if (propsWithDefault.upperValue !== undefined) {
+      fixture.componentInstance.upperValue = propsWithDefault.upperValue;
+    }
+    fixture.componentInstance.useRange = propsWithDefault.useRange;
     fixture.componentInstance.min = propsWithDefault.min;
     fixture.componentInstance.max = propsWithDefault.max;
     fixture.componentInstance.tickCount = propsWithDefault.tickCount;
-    fixture.componentInstance.onValue = onValue;
+    fixture.componentInstance.onRangeValues = onRangeValues;
+    fixture.componentInstance.onSingleValue = onSingleValue;
+    fixture.componentInstance.onUpperValueRemoved = onUpperValueRemoved;
     fixture.detectChanges();
-    return {fixture, onValue};
+    return {fixture, onRangeValues, onSingleValue, onUpperValueRemoved};
   }
 
-  function getThumbs(
+  function getThumbsOnRange(
     fixture: ComponentFixture<TestableComponent>
   ): HTMLElement[] {
     const thumbs = fixture.debugElement.queryAll(By.css('.thumb'));
@@ -99,48 +125,75 @@ describe('range input test', () => {
     return input.map((inputDebugElement) => inputDebugElement.nativeElement);
   }
 
+  function getMatSliderValue(el: DebugElement): string {
+    return el.query(By.css('.mat-slider-thumb-label-text')).nativeElement
+      .textContent;
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [MatSliderModule],
       declarations: [RangeInputComponent, TestableComponent],
     }).compileComponents();
   });
 
   describe('render', () => {
-    function getThumbsStyleLeft(
+    function getRangeThumbsStyleLeft(
       fixture: ComponentFixture<TestableComponent>
     ): string[] {
-      return getThumbs(fixture).map((debugEl) => {
+      return getThumbsOnRange(fixture).map((debugEl) => {
         return debugEl.style.left;
       });
     }
-
-    it('renders correct thumb positions', () => {
-      const {fixture} = createComponent({lowerValue: 2, upperValue: 3});
-
-      expect(getThumbsStyleLeft(fixture)).toEqual(['70%', '80%']);
+    describe('single selection', () => {
+      it('renders correct slider value', () => {
+        const {fixture} = createComponent({lowerValue: 2, useRange: false});
+        expect(getMatSliderValue(fixture.debugElement)).toEqual('2');
+      });
     });
 
-    it('clips min and max within the slider', () => {
-      const {fixture} = createComponent({lowerValue: -100, upperValue: 100});
+    describe('range selection', () => {
+      it('renders correct thumb positions', () => {
+        const {fixture} = createComponent({
+          lowerValue: 2,
+          upperValue: 3,
+          useRange: true,
+        });
 
-      expect(getThumbsStyleLeft(fixture)).toEqual(['0%', '100%']);
-    });
-
-    it('does not check lowerValue > upperValue and render them', () => {
-      const {fixture} = createComponent({lowerValue: 3, upperValue: -1});
-
-      expect(getThumbsStyleLeft(fixture)).toEqual(['80%', '40%']);
-    });
-
-    it('puts thumb at 50% when min === max', () => {
-      const {fixture} = createComponent({
-        min: 10,
-        max: 10,
-        lowerValue: 10,
-        upperValue: 10,
+        expect(getRangeThumbsStyleLeft(fixture)).toEqual(['70%', '80%']);
       });
 
-      expect(getThumbsStyleLeft(fixture)).toEqual(['50%', '50%']);
+      it('clips min and max within the slider', () => {
+        const {fixture} = createComponent({
+          lowerValue: -100,
+          upperValue: 100,
+          useRange: true,
+        });
+
+        expect(getRangeThumbsStyleLeft(fixture)).toEqual(['0%', '100%']);
+      });
+
+      it('does not check lowerValue > upperValue and render them', () => {
+        const {fixture} = createComponent({
+          lowerValue: 3,
+          upperValue: -1,
+          useRange: true,
+        });
+
+        expect(getRangeThumbsStyleLeft(fixture)).toEqual(['80%', '40%']);
+      });
+
+      it('puts thumb at 50% when min === max', () => {
+        const {fixture} = createComponent({
+          min: 10,
+          max: 10,
+          lowerValue: 10,
+          upperValue: 10,
+          useRange: true,
+        });
+
+        expect(getRangeThumbsStyleLeft(fixture)).toEqual(['50%', '50%']);
+      });
     });
   });
 
@@ -167,198 +220,319 @@ describe('range input test', () => {
       document.dispatchEvent(mouseMoveEvent);
     }
 
-    it('calls `value` when thumb is dragged', () => {
-      const {fixture, onValue} = createComponent({
-        lowerValue: -1,
-        upperValue: 1,
-        tickCount: null,
-      });
-      const [leftThumb] = getThumbs(fixture);
-      startMovingThumb(leftThumb);
-      // range-input starts from 100px and ends at 300px.
-      moveThumb(leftThumb, 120);
-      expect(onValue).toHaveBeenCalledWith({lowerValue: -4, upperValue: 1});
-    });
+    describe('single selection', () => {
+      it('dispatches actions when step changes when making single step change', () => {
+        const {fixture, onSingleValue} = createComponent({
+          lowerValue: -1,
+          tickCount: null,
+          useRange: false,
+        });
 
-    it('rounds number to filter out floating point math noise', () => {
-      const {fixture, onValue} = createComponent({
-        min: 0.1,
-        max: 0.3,
-        lowerValue: 0.1,
-        upperValue: 0.3,
-        tickCount: null,
-      });
-      const [leftThumb] = getThumbs(fixture);
-      startMovingThumb(leftThumb);
-      // range-input starts from 100px and ends at 300px so 102px is about 2%
-      // from left edge.
-      moveThumb(leftThumb, 102);
-      // Without our logic to round, lowerValue would be 0.10200000000000001.
-      expect(onValue).toHaveBeenCalledWith({
-        lowerValue: 0.102,
-        upperValue: 0.3,
+        const slider = fixture.debugElement.query(By.css('mat-slider'));
+
+        slider.triggerEventHandler('input', {
+          value: 5,
+        });
+
+        expect(onSingleValue).toHaveBeenCalledOnceWith(5);
       });
     });
 
-    it('compensates position of mousedown relative to thumb center', () => {
-      const {fixture, onValue} = createComponent({
-        lowerValue: -1,
-        upperValue: 1,
-        tickCount: null,
-      });
-      const values: Array<{lowerValue: number; upperValue: number}> = [];
-      onValue.and.callFake(
-        (value: {lowerValue: number; upperValue: number}) => {
-          values.push(value);
-        }
-      );
-      const [leftThumb] = getThumbs(fixture);
-      startMovingThumb(leftThumb, TEST_ONLY.THUMB_SIZE_PX);
-      // Because we started to drag from right edge of the thumb, moving the
-      // thumb to 120 is equivalent to putting it at 126px (thumb radius is
-      // 6px).
-      moveThumb(leftThumb, 120);
-      expect(values).toEqual([{lowerValue: -4.3, upperValue: 1}]);
-
-      startMovingThumb(leftThumb, 0);
-      // Because we started to drag from left edge of the thumb, moving the
-      // thumb to 120 is equivalent to putting it at 114px (thumb radius is
-      // 6px).
-      moveThumb(leftThumb, 120);
-      expect(values).toEqual([
-        {lowerValue: -4.3, upperValue: 1},
-        {lowerValue: -3.7, upperValue: 1},
-      ]);
-    });
-
-    it('ignores mousemove when mousedown never happened', () => {
-      const {fixture, onValue} = createComponent({
-        lowerValue: -1,
-        upperValue: 1,
-      });
-      const [leftThumb] = getThumbs(fixture);
-
-      moveThumb(leftThumb, 0);
-      expect(onValue).not.toHaveBeenCalled();
-
-      moveThumb(leftThumb, 1000);
-      expect(onValue).not.toHaveBeenCalled();
-    });
-
-    it('does not trigger change when value does not change', () => {
-      const {fixture, onValue} = createComponent({
-        lowerValue: -5,
-        upperValue: 1,
-        tickCount: 10,
-      });
-      const [leftThumb] = getThumbs(fixture);
-      startMovingThumb(leftThumb);
-
-      moveThumb(leftThumb, 101);
-      expect(onValue).not.toHaveBeenCalled();
-    });
-
-    it('emits change when moved by more than one', () => {
-      const {fixture, onValue} = createComponent({
-        lowerValue: -5,
-        upperValue: 1,
-        tickCount: 10,
-      });
-      const [leftThumb] = getThumbs(fixture);
-      startMovingThumb(leftThumb);
-
-      moveThumb(leftThumb, 109);
-      expect(onValue).not.toHaveBeenCalled();
-
-      // In 200px wide slider, we have 10 ticks which means every tick should
-      // occupy 20px. When you move the cursor a little bit left/right between
-      // two ticks, we change the value.
-      moveThumb(leftThumb, 111);
-      expect(onValue).toHaveBeenCalledWith({lowerValue: -4, upperValue: 1});
-    });
-
-    it('triggers change for minute movement when tickCount is null', () => {
-      const {fixture, onValue} = createComponent({
-        lowerValue: -5,
-        upperValue: 1,
-        tickCount: null,
-      });
-      const [leftThumb] = getThumbs(fixture);
-      startMovingThumb(leftThumb);
-
-      moveThumb(leftThumb, 101);
-      expect(onValue).toHaveBeenCalledWith({lowerValue: -4.95, upperValue: 1});
-    });
-
-    it('changes upperValue when min knob crosses upperValue', () => {
-      const {fixture, onValue} = createComponent({
-        lowerValue: -5,
-        upperValue: 0,
-        tickCount: null,
-      });
-      const [leftThumb] = getThumbs(fixture);
-      startMovingThumb(leftThumb);
-
-      moveThumb(leftThumb, 250);
-      expect(onValue).toHaveBeenCalledWith({lowerValue: 0, upperValue: 2.5});
-    });
-
-    it('does not change anything when min === max', () => {
-      const {fixture, onValue} = createComponent({
-        min: 10,
-        max: 10,
-        lowerValue: 10,
-        upperValue: 10,
+    describe('range selection', () => {
+      it('calls `value` when thumb is dragged', () => {
+        const {fixture, onRangeValues} = createComponent({
+          lowerValue: -1,
+          upperValue: 1,
+          tickCount: null,
+          useRange: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+        // range-input starts from 100px and ends at 300px.
+        moveThumb(leftThumb, 120);
+        expect(onRangeValues).toHaveBeenCalledWith({
+          lowerValue: -4,
+          upperValue: 1,
+        });
       });
 
-      const [leftThumb] = getThumbs(fixture);
-      startMovingThumb(leftThumb);
+      it('rounds number to filter out floating point math noise', () => {
+        const {fixture, onRangeValues} = createComponent({
+          min: 0.1,
+          max: 0.3,
+          lowerValue: 0.1,
+          upperValue: 0.3,
+          tickCount: null,
+          useRange: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+        // range-input starts from 100px and ends at 300px so 102px is about 2%
+        // from left edge.
+        moveThumb(leftThumb, 102);
+        // Without our logic to round, lowerValue would be 0.10200000000000001.
+        expect(onRangeValues).toHaveBeenCalledWith({
+          lowerValue: 0.102,
+          upperValue: 0.3,
+        });
+      });
 
-      moveThumb(leftThumb, 250);
-      expect(onValue).not.toHaveBeenCalled();
+      it('compensates position of mousedown relative to thumb center', () => {
+        const {fixture, onRangeValues} = createComponent({
+          lowerValue: -1,
+          upperValue: 1,
+          tickCount: null,
+          useRange: true,
+        });
+        const values: Array<{lowerValue: number; upperValue: number}> = [];
+        onRangeValues.and.callFake(
+          (value: {lowerValue: number; upperValue: number}) => {
+            values.push(value);
+          }
+        );
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb, TEST_ONLY.THUMB_SIZE_PX);
+        // Because we started to drag from right edge of the thumb, moving the
+        // thumb to 120 is equivalent to putting it at 126px (thumb radius is
+        // 6px).
+        moveThumb(leftThumb, 120);
+        expect(values).toEqual([{lowerValue: -4.3, upperValue: 1}]);
+
+        startMovingThumb(leftThumb, 0);
+        // Because we started to drag from left edge of the thumb, moving the
+        // thumb to 120 is equivalent to putting it at 114px (thumb radius is
+        // 6px).
+        moveThumb(leftThumb, 120);
+        expect(values).toEqual([
+          {lowerValue: -4.3, upperValue: 1},
+          {lowerValue: -3.7, upperValue: 1},
+        ]);
+      });
+
+      it('ignores mousemove when mousedown never happened', () => {
+        const {fixture, onRangeValues} = createComponent({
+          lowerValue: -1,
+          upperValue: 1,
+          useRange: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+
+        moveThumb(leftThumb, 0);
+        expect(onRangeValues).not.toHaveBeenCalled();
+
+        moveThumb(leftThumb, 1000);
+        expect(onRangeValues).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger change when value does not change', () => {
+        const {fixture, onRangeValues} = createComponent({
+          lowerValue: -5,
+          upperValue: 1,
+          tickCount: 10,
+          useRange: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+
+        moveThumb(leftThumb, 101);
+        expect(onRangeValues).not.toHaveBeenCalled();
+      });
+
+      it('emits change when moved by more than one', () => {
+        const {fixture, onRangeValues} = createComponent({
+          lowerValue: -5,
+          upperValue: 1,
+          tickCount: 10,
+          useRange: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+
+        moveThumb(leftThumb, 109);
+        expect(onRangeValues).not.toHaveBeenCalled();
+
+        // In 200px wide slider, we have 10 ticks which means every tick should
+        // occupy 20px. When you move the cursor a little bit left/right between
+        // two ticks, we change the value.
+        moveThumb(leftThumb, 111);
+        expect(onRangeValues).toHaveBeenCalledWith({
+          lowerValue: -4,
+          upperValue: 1,
+        });
+      });
+
+      it('triggers change for minute movement when tickCount is null', () => {
+        const {fixture, onRangeValues} = createComponent({
+          lowerValue: -5,
+          upperValue: 1,
+          tickCount: null,
+          useRange: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+
+        moveThumb(leftThumb, 101);
+        expect(onRangeValues).toHaveBeenCalledWith({
+          lowerValue: -4.95,
+          upperValue: 1,
+        });
+      });
+
+      it('changes upperValue when min knob crosses upperValue', () => {
+        const {fixture, onRangeValues} = createComponent({
+          lowerValue: -5,
+          upperValue: 0,
+          tickCount: null,
+          useRange: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+
+        moveThumb(leftThumb, 250);
+        expect(onRangeValues).toHaveBeenCalledWith({
+          lowerValue: 0,
+          upperValue: 2.5,
+        });
+      });
+
+      it('does not change anything when min === max', () => {
+        const {fixture, onRangeValues} = createComponent({
+          min: 10,
+          max: 10,
+          lowerValue: 10,
+          upperValue: 10,
+          useRange: true,
+        });
+
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+
+        moveThumb(leftThumb, 250);
+        expect(onRangeValues).not.toHaveBeenCalled();
+      });
     });
   });
 
   describe('input control', () => {
     let fixture: ComponentFixture<TestableComponent>;
-    let onValue: jasmine.Spy;
+    let onRangeValues: jasmine.Spy;
 
-    beforeEach(() => {
-      const fixtureAndOnValue = createComponent({
+    function createRangeComponent() {
+      const fixtureAndonRangeValues = createComponent({
         min: 0,
         max: 10,
         lowerValue: 5,
         upperValue: 5,
+        useRange: true,
       });
 
-      fixture = fixtureAndOnValue.fixture;
-      onValue = fixtureAndOnValue.onValue;
-    });
+      const fixture = fixtureAndonRangeValues.fixture;
+      const onRangeValues = fixtureAndonRangeValues.onRangeValues;
+      const onSingleValue = fixtureAndonRangeValues.onSingleValue;
+      const onUpperValueRemoved = fixtureAndonRangeValues.onUpperValueRemoved;
+
+      return {fixture, onRangeValues, onSingleValue, onUpperValueRemoved};
+    }
+
+    function createSingleComponent() {
+      const fixtureAndonRangeValues = createComponent({
+        min: 0,
+        max: 10,
+        lowerValue: 5,
+        useRange: false,
+      });
+
+      const fixture = fixtureAndonRangeValues.fixture;
+      const onRangeValues = fixtureAndonRangeValues.onRangeValues;
+      const onSingleValue = fixtureAndonRangeValues.onSingleValue;
+
+      return {fixture, onRangeValues, onSingleValue};
+    }
 
     it('emits change when user changes input', () => {
+      const {fixture, onRangeValues} = createRangeComponent();
       const [minInput] = getInputs(fixture);
       minInput.value = '0';
       minInput.dispatchEvent(new InputEvent('change'));
 
-      expect(onValue).toHaveBeenCalledWith({lowerValue: 0, upperValue: 5});
+      expect(onRangeValues).toHaveBeenCalledWith({
+        lowerValue: 0,
+        upperValue: 5,
+      });
     });
 
     it('does not react to keydown or input', () => {
+      const {fixture, onRangeValues} = createRangeComponent();
       const [minInput] = getInputs(fixture);
       minInput.value = '0';
       minInput.dispatchEvent(new InputEvent('keydown'));
       minInput.dispatchEvent(new InputEvent('input'));
       minInput.dispatchEvent(new InputEvent('up'));
 
-      expect(onValue).not.toHaveBeenCalled();
+      expect(onRangeValues).not.toHaveBeenCalled();
     });
 
     it('swaps min and max when new upperValue is smaller than lowerValue', () => {
+      const {fixture, onRangeValues} = createRangeComponent();
       const [, maxInput] = getInputs(fixture);
       maxInput.value = '2';
       maxInput.dispatchEvent(new InputEvent('change'));
 
-      expect(onValue).toHaveBeenCalledWith({lowerValue: 2, upperValue: 5});
+      expect(onRangeValues).toHaveBeenCalledWith({
+        lowerValue: 2,
+        upperValue: 5,
+      });
+    });
+
+    it('updates value on single slider', () => {
+      const {fixture, onSingleValue} = createSingleComponent();
+      const [minInput] = getInputs(fixture);
+      minInput.value = '2';
+      minInput.dispatchEvent(new InputEvent('change'));
+
+      expect(onSingleValue).toHaveBeenCalledWith(2);
+    });
+
+    it('updates value to be min in single slider on input cleared', () => {
+      const {fixture, onSingleValue} = createSingleComponent();
+      const [minInput] = getInputs(fixture);
+      minInput.value = '';
+      minInput.dispatchEvent(new InputEvent('change'));
+
+      expect(onSingleValue).toHaveBeenCalledWith(0);
+    });
+
+    it('updates value to be min in range slider on lower value cleared', () => {
+      const {fixture, onRangeValues} = createRangeComponent();
+      const [minInput] = getInputs(fixture);
+      minInput.value = '';
+      minInput.dispatchEvent(new InputEvent('change'));
+
+      expect(onRangeValues).toHaveBeenCalledWith({
+        lowerValue: 0,
+        upperValue: 5,
+      });
+    });
+
+    it('renders range slider on adding upper value to single slider', () => {
+      const {fixture, onRangeValues} = createSingleComponent();
+      const [, maxInput] = getInputs(fixture);
+      maxInput.value = '7';
+      maxInput.dispatchEvent(new InputEvent('change'));
+
+      expect(onRangeValues).toHaveBeenCalledWith({
+        lowerValue: 5,
+        upperValue: 7,
+      });
+    });
+
+    it('dispatches action on upper value removed in range selection', () => {
+      const {fixture, onUpperValueRemoved} = createRangeComponent();
+      const [, maxInput] = getInputs(fixture);
+      maxInput.value = '';
+      maxInput.dispatchEvent(new InputEvent('change'));
+
+      expect(onUpperValueRemoved).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Now on single selection we only provides a slider to drag while under range selections there are two input area to set the exact selected steps. We want to enable users to set exact number in single slider too. 
By doing this we extend `tb-range-input` component to also cable of rendering single slider. The output of the component now contains `singleValue` in addition to `rangeValues`. In addition, an action is dispatched on upperValue removed. This is for syncing the `useRange` to decide it is single or range selection across the app. (for example, we need to update the fob(s) from two to one or vice versa)

Summary of changes:
* The "use range" checkbox is removed.
* `<mat-slider>` is moved from`settings_view_component` to inside `<tb-range-input>`
* `handleInputChange()` handles the logics shown as below

for min=50, max=1000,
single  [100, X]     → add upper value     → range [100, 500]
range  [100, 500]  → delete upper value → single [100, X]
single [100, X]    → delete lower value → single [50, X]
range  [100, 500]  → delete lower value → range  [50, 500]

demo
https://user-images.githubusercontent.com/1131010/154117923-0ad99b83-b001-4586-a9b9-5fb685be33c9.mov


