### PR TITLE
linked time: moves Image thumb slider on single selection

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -286,9 +286,9 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       map(([stepIndex, selectedTime, selectedSteps, stepValues]) => {
         if (!selectedTime || selectedTime.endStep) return stepIndex;
 
-        const nextStepInex = stepValues.indexOf(selectedSteps[0]);
-        if (nextStepInex === -1) return stepIndex;
-        return nextStepInex;
+        const nextStepIndex = stepValues.indexOf(selectedSteps[0]);
+        if (nextStepIndex === -1) return stepIndex;
+        return nextStepIndex;
       })
     );
 

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -281,13 +281,13 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       this.store.select(getCardStepIndex, this.cardId),
       this.selectedTime$,
       this.selectedSteps$,
-      this.stepValues$,
+      this.stepValues$
     ).pipe(
       map(([stepIndex, selectedTime, selectedSteps, stepValues]) => {
         if (!selectedTime || selectedTime.endStep) return stepIndex;
 
         const nextStepInex = stepValues.indexOf(selectedSteps[0]);
-        if (nextStepInex === -1 ) return stepIndex;
+        if (nextStepInex === -1) return stepIndex;
         return nextStepInex;
       })
     );

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -201,21 +201,7 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       shareReplay(1)
     );
 
-    this.stepIndex$ = this.store.select(getCardStepIndex, this.cardId);
     this.loadState$ = this.store.select(getCardLoadState, this.cardId);
-
-    const timeSeriesAndStepIndex$ = combineLatest([
-      timeSeries$,
-      this.stepIndex$,
-    ]);
-    const stepDatum$ = timeSeriesAndStepIndex$.pipe(
-      map(([timeSeries, stepIndex]) => {
-        if (stepIndex === null || !timeSeries[stepIndex]) {
-          return null;
-        }
-        return timeSeries[stepIndex];
-      })
-    );
 
     this.tag$ = cardMetadata$.pipe(
       map((cardMetadata) => {
@@ -243,15 +229,6 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
 
     this.numSample$ = cardMetadata$.pipe(
       map((cardMetadata) => cardMetadata.numSample)
-    );
-
-    this.imageUrl$ = stepDatum$.pipe(
-      map((stepDatum: ImageStepDatum | null) => {
-        if (!stepDatum) {
-          return null;
-        }
-        return this.dataSource.imageUrl(stepDatum.imageId);
-      })
     );
 
     this.stepValues$ = timeSeries$.pipe(
@@ -297,6 +274,43 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
           }
         }
         return selectedStepsInRange;
+      })
+    );
+
+    this.stepIndex$ = combineLatest(
+      this.store.select(getCardStepIndex, this.cardId),
+      this.selectedTime$,
+      this.selectedSteps$,
+      this.stepValues$,
+    ).pipe(
+      map(([stepIndex, selectedTime, selectedSteps, stepValues]) => {
+        if (!selectedTime || selectedTime.endStep) return stepIndex;
+
+        const nextStepInex = stepValues.indexOf(selectedSteps[0]);
+        if (nextStepInex === -1 ) return stepIndex;
+        return nextStepInex;
+      })
+    );
+
+    const timeSeriesAndStepIndex$ = combineLatest([
+      timeSeries$,
+      this.stepIndex$,
+    ]);
+    const stepDatum$ = timeSeriesAndStepIndex$.pipe(
+      map(([timeSeries, stepIndex]) => {
+        if (stepIndex === null || !timeSeries[stepIndex]) {
+          return null;
+        }
+        return timeSeries[stepIndex];
+      })
+    );
+
+    this.imageUrl$ = stepDatum$.pipe(
+      map((stepDatum: ImageStepDatum | null) => {
+        if (!stepDatum) {
+          return null;
+        }
+        return this.dataSource.imageUrl(stepDatum.imageId);
       })
     );
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -697,6 +697,31 @@ describe('image card', () => {
       expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
     });
 
+    it('does not move slider thumb on selected step with no image', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 15},
+        end: null,
+      });
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries,
+        2 /* stepIndex */
+      );
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+      let slider = fixture.debugElement.query(By.css('mat-slider'));
+      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+    });
+
     it('dose not move slider thumb to selected time on range selection', () => {
       store.overrideSelector(selectors.getMetricsSelectedTime, {
         start: {step: 15},

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -697,7 +697,7 @@ describe('image card', () => {
       expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
     });
 
-    it('dose not move slider thumb to selected time on single selection', () => {
+    it('dose not move slider thumb to selected time on range selection', () => {
       store.overrideSelector(selectors.getMetricsSelectedTime, {
         start: {step: 15},
         end: {step: 55},

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -661,5 +661,77 @@ describe('image card', () => {
       // The third and fourth ticks are selected.
       expect(dots.length).toBe(0);
     });
+
+    it('moves slider thumb to selected time on single selection', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 20},
+        end: null,
+      });
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries,
+        2 /* stepIndex */
+      );
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+      let slider = fixture.debugElement.query(By.css('mat-slider'));
+      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('1');
+
+
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 30},
+        end: null,
+      });
+      store.refreshState();
+      fixture.detectChanges();
+
+      slider = fixture.debugElement.query(By.css('mat-slider'));
+      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+    });
+
+    it('dose not move slider thumb to selected time on single selection', () => {
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 15},
+        end: {step: 55},
+      });
+      const timeSeries = [
+        {wallTime: 100, imageId: 'ImageId1', step: 10},
+        {wallTime: 101, imageId: 'ImageId2', step: 20},
+        {wallTime: 102, imageId: 'ImageId3', step: 30},
+        {wallTime: 103, imageId: 'ImageId4', step: 40},
+      ];
+      provideMockCardSeriesData(
+        selectSpy,
+        PluginType.IMAGES,
+        'card1',
+        null /* metadataOverride */,
+        timeSeries,
+        2 /* stepIndex */
+      );
+      const fixture = createImageCardContainer('card1');
+      fixture.detectChanges();
+
+      let slider = fixture.debugElement.query(By.css('mat-slider'));
+      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+
+      store.overrideSelector(selectors.getMetricsSelectedTime, {
+        start: {step: 25},
+        end: {step: 35},
+      });
+      store.refreshState();
+      fixture.detectChanges();
+
+      slider = fixture.debugElement.query(By.css('mat-slider'));
+      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+    });
   });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -686,7 +686,6 @@ describe('image card', () => {
       let slider = fixture.debugElement.query(By.css('mat-slider'));
       expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('1');
 
-
       store.overrideSelector(selectors.getMetricsSelectedTime, {
         start: {step: 30},
         end: null,


### PR DESCRIPTION
Previously we have those gray ticks to show the selected step(s) in linked time. This pr moves the thumb to the selected step, the image also changes correspondingly. There is still one tick rendered but it will be covered by orange thumb.

Note that this pr only moves the thumb (controlled by `stepIndex`) when selected step matches. Not move to the closest step. Also because of the nature of image cards (which shows one image at a time) we do not move the thumb on range selection for now before more complicated decision is made. 

demo
https://user-images.githubusercontent.com/1131010/154165453-efe655ff-864a-4af1-90f3-52ab9fa162fa.mov


