### PR TITLE
scalar: removes self-provided context param in WebGLRenderer

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -283,7 +283,6 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
 
     this.renderer = new THREE.WebGLRenderer({
       canvas: canvas as HTMLCanvasElement,
-      context: canvas.getContext('webgl2') as WebGLRenderingContext,
       antialias: true,
       alpha: true,
     });

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -287,6 +287,8 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
       antialias: true,
       alpha: true,
     });
+    // Workaround to fix background transparency is not set propoerly in threejs WebGLRenderer.
+    this.renderer.setClearColor(0x000000, 0);
     this.renderer.setPixelRatio(devicePixelRatio);
   }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -287,8 +287,6 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
       antialias: true,
       alpha: true,
     });
-    // Workaround to fix background transparency is not set propoerly in threejs WebGLRenderer.
-    this.renderer.setClearColor(0x000000, 0);
     this.renderer.setPixelRatio(devicePixelRatio);
   }
 


### PR DESCRIPTION
Removes self-provided context in threejs WebGLRenderer to let alpha attribute applied to the context. 

It is suggested by threejs developers yet I am not sure why it is not affecting our chart (the background is still transparent with provided context param)

screenshot
![Screen Shot 2022-02-16 at 12 33 33 PM](https://user-images.githubusercontent.com/1131010/154352319-d72174c7-5231-490a-b747-f03cf3b02bca.png)

googlers please see cl/363052284 for webtests result
