### PR TITLE
directory_watcher: Demote logger.info to .debug

### DIFF
--- a/tensorboard/backend/event_processing/directory_watcher.py
+++ b/tensorboard/backend/event_processing/directory_watcher.py
@@ -120,7 +120,7 @@ class DirectoryWatcher(object):
 
             next_path = self._GetNextPath()
             if not next_path:
-                logger.info("No path found after %s", self._path)
+                logger.debug("No path found after %s", self._path)
                 # Current path is empty and there are no new paths, so we're done.
                 return
 
@@ -143,7 +143,7 @@ class DirectoryWatcher(object):
             for event in self._loader.Load():
                 yield event
 
-            logger.info(
+            logger.debug(
                 "Directory watcher advancing from %s to %s",
                 self._path,
                 next_path,


### PR DESCRIPTION
* Motivation for features / changes: See #5577. This is one alternative, to just demote to .debug for this component.

* Technical description of changes: In `directory_watcher`, demote usages of `logger.info` to `logger.debug`

* Screenshots of UI changes: N/A

* Detailed steps to verify changes work correctly (as executed by you): See workaround in https://github.com/wandb/client/issues/3274

* Alternate designs / implementations considered: See #5577 and https://github.com/wandb/client/issues/3274
