### PR TITLE
linked time: fix range input param rename

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -448,34 +448,6 @@ describe('metrics right_pane', () => {
           expect(el.query(By.css('tb-range-input'))).toBeTruthy();
         });
 
-        it('disables tb-range-input on select time disabled', () => {
-          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
-          store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
-          store.overrideSelector(selectors.getMetricsSelectTimeEnabled, false);
-          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-          const fixture = TestBed.createComponent(SettingsViewContainer);
-          fixture.detectChanges();
-
-          const el = fixture.debugElement.query(
-            By.css('.linked-time tb-range-input')
-          );
-          expect(el.nativeElement.getAttribute('disabled')).toBe('true');
-        });
-
-        it('enables tb-range-input on select time enabled', () => {
-          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
-          store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
-          store.overrideSelector(selectors.getMetricsSelectTimeEnabled, true);
-          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
-          const fixture = TestBed.createComponent(SettingsViewContainer);
-          fixture.detectChanges();
-
-          const el = fixture.debugElement.query(
-            By.css('.linked-time tb-range-input')
-          );
-          expect(el.nativeElement.getAttribute('disabled')).toBe('false');
-        });
-
         it('dispatches actions when making range step change', () => {
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
           store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -462,7 +462,7 @@ describe('metrics right_pane', () => {
           expect(el.properties.enabled).toBe(false);
         });
 
-        it('disables tb-range-input on select time disabled', () => {
+        it('enables tb-range-input on select time enabled', () => {
           store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
           store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
           store.overrideSelector(selectors.getMetricsSelectTimeEnabled, true);

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -448,6 +448,34 @@ describe('metrics right_pane', () => {
           expect(el.query(By.css('tb-range-input'))).toBeTruthy();
         });
 
+        it('disables tb-range-input on select time disabled', () => {
+          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
+          store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
+          store.overrideSelector(selectors.getMetricsSelectTimeEnabled, false);
+          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
+          const fixture = TestBed.createComponent(SettingsViewContainer);
+          fixture.detectChanges();
+
+          const el = fixture.debugElement.query(
+            By.css('.linked-time tb-range-input')
+          );
+          expect(el.properties.enabled).toBe(false);
+        });
+
+        it('disables tb-range-input on select time disabled', () => {
+          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
+          store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
+          store.overrideSelector(selectors.getMetricsSelectTimeEnabled, true);
+          store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
+          const fixture = TestBed.createComponent(SettingsViewContainer);
+          fixture.detectChanges();
+
+          const el = fixture.debugElement.query(
+            By.css('.linked-time tb-range-input')
+          );
+          expect(el.properties.enabled).toBe(true);
+        });
+
         it('dispatches actions when making range step change', () => {
           store.overrideSelector(selectors.getMetricsUseRangeSelectTime, true);
           store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -67,7 +67,6 @@ limitations under the License.
       </div>
       <div class="step-selector">
         <tb-range-input
-          [attr.disabled]="!selectTimeEnabled"
           [min]="stepMinMax.min"
           [max]="stepMinMax.max"
           [lowerValue]="selectedTime?.start.step"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -73,7 +73,7 @@ limitations under the License.
           [lowerValue]="selectedTime?.start.step"
           [upperValue]="selectedTime?.end?.step"
           [useRange]="useRangeSelectTime"
-          [inputEnabled]="selectTimeEnabled"
+          [enabled]="selectTimeEnabled"
           (singleValueChanged)="onSingleValueChanged($event)"
           (rangeValuesChanged)="onRangeValuesChanged($event)"
           (upperValueRemoved)="useRangeSelectTimeToggled.emit()"


### PR DESCRIPTION
I was renaming the param of range input and overlooked the one in settings.  This pr should fix it.
This was not caught due to unused attr of tb-range-input. This pr also removed useless tests to avoid false tests pass. The elements inside tb-range-input is not testable in settings_view component.

before 
<img width="220" alt="Screen Shot 2022-02-23 at 9 47 07 AM" src="https://user-images.githubusercontent.com/1131010/155379039-cf8b92a2-14b0-4493-9944-94e34eaf1261.png">

after (without checked enabled the input stays disabled)
<img width="223" alt="Screen Shot 2022-02-23 at 9 46 04 AM" src="https://user-images.githubusercontent.com/1131010/155379062-42e136c6-da0b-419f-b9fc-9a2a056febab.png">

