### PR TITLE
linked time: color image slider in range selection

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -78,6 +78,7 @@ limitations under the License.
     <mat-slider
       class="step-slider"
       color="primary"
+      [ngClass]="[selectedTime && !selectedTime.clipped && selectedTime.endStep !== null ? 'hide-slider' : '']"
       [disabled]="stepValues.length <= 1"
       [min]="0"
       [max]="stepValues.length - 1"
@@ -87,9 +88,17 @@ limitations under the License.
       (input)="onSliderInput($event)"
     ></mat-slider>
     <div
-      class="linked-time-ticks-wrapper"
+      class="linked-time-wrapper"
       *ngIf="selectedTime && !selectedTime.clipped"
     >
+      <span *ngIf="selectedTime.endStep !== null">
+        <span class="slider-track"></span>
+        <span
+          class="slider-track-fill"
+          [style.left]="sliderStartPosition"
+          [style.width]="sliderTrackWidth"
+        ></span>
+      </span>
       <div
         class="linked-time-tick"
         *ngFor="let step of selectedSteps"

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -17,6 +17,7 @@ limitations under the License.
 @import '../common';
 
 $_title-to-heading-gap: 12px;
+$_tick_width: 14px;
 
 :host {
   display: flex;
@@ -147,12 +148,16 @@ $_title-to-heading-gap: 12px;
   background-color: mat.get-color-from-palette($tb-primary);
 }
 
+:host ::ng-deep .hide-slider.mat-slider-horizontal .mat-slider-track-wrapper {
+  height: 0;
+}
+
 .empty-message {
   margin-top: 1em;
   font-size: 13px;
 }
 
-.linked-time-ticks-wrapper {
+.linked-time-wrapper {
   position: absolute;
   top: 5px;
   width: 100%;
@@ -164,4 +169,25 @@ $_title-to-heading-gap: 12px;
   height: 14px;
   position: absolute;
   width: 14px;
+}
+
+.slider-track,
+.slider-track-fill {
+  height: 2px;
+  top: 6px;
+  position: absolute;
+}
+
+.slider-track {
+  @include tb-theme-foreground-prop(background, slider-off);
+  left: $_tick_width / 2;
+  width: calc(100% - #{$_tick_width});
+}
+
+.slider-track-fill {
+  background: mat.get-color-from-palette($tb-primary);
+
+  @include tb-dark-theme {
+    background: mat.get-color-from-palette($tb-dark-primary);
+  }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
@@ -83,11 +83,14 @@ export class ImageCardComponent {
 
   ngOnChanges(changes: SimpleChanges) {
     if (
-      !this.changeDistinct(changes['selectedSteps']) ||
-      !this.changeDistinct(changes['selectedTime'])
+      this.changeDistinct(changes['selectedSteps']) ||
+      this.changeDistinct(changes['selectedTime'])
     ) {
-      return;
+      this.renderRangeSlider();
     }
+  }
+
+  renderRangeSlider() {
     if (
       !this.selectedTime ||
       !this.selectedTime.endStep ||
@@ -161,7 +164,6 @@ export class ImageCardComponent {
     this.sliderStartPosition = `${startPosition * 100}%`;
     this.sliderTrackWidth = `${width * 100}%`;
   }
-
   getLinkedTimeTickLeftStyle(step: number) {
     if (this.stepValues.indexOf(step) == -1) {
       throw new Error(

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
@@ -101,7 +101,6 @@ export class ImageCardComponent {
     }
 
     const boundSize = this.stepValues.length - 1;
-    const sliderUnit = 1 / boundSize;
     const startStep =
       this.selectedTime.startStep < this.stepValues[0]
         ? this.stepValues[0]
@@ -110,61 +109,75 @@ export class ImageCardComponent {
       this.selectedTime.endStep > this.stepValues[boundSize]
         ? this.stepValues[boundSize]
         : this.selectedTime.endStep;
+
+    const {startPosition, width} = this.getTrackStartPositionAndWidth(
+      startStep,
+      endStep,
+      boundSize
+    );
+
+    this.sliderStartPosition = `${startPosition * 100}%`;
+    this.sliderTrackWidth = `${width * 100}%`;
+  }
+
+  getTrackStartPositionAndWidth(
+    startStep: number,
+    endStep: number,
+    boundSize: number
+  ) {
+    const sliderUnit = 1 / boundSize;
     let startPosition = 0;
     let width = 0;
-
     let i = 0;
+
+    // Calculates the track start position
     for (; i < this.stepValues.length - 1; i++) {
       const currentStep = this.stepValues[i];
       const nextStep = this.stepValues[i + 1];
-      if (startStep > nextStep) {
-        startPosition += sliderUnit;
-      } else if (currentStep <= startStep && startStep <= nextStep) {
-        startPosition +=
-          ((startStep - currentStep) / (nextStep - currentStep)) * sliderUnit;
-        break;
-      } else {
+      if (currentStep <= startStep && startStep <= nextStep) {
+        startPosition += (startStep - currentStep) / (nextStep - currentStep);
         break;
       }
     }
+    startPosition = (startPosition + i) * sliderUnit;
 
+    // Calculates the track width
     for (; i < this.stepValues.length - 1; i++) {
       const currentStep = this.stepValues[i];
       const nextStep = this.stepValues[i + 1];
       // --o--S====E--o--
       //  cur        next
       if (startStep >= currentStep && endStep <= nextStep) {
-        width = ((endStep - startStep) / (nextStep - currentStep)) * sliderUnit;
+        width = (endStep - startStep) / (nextStep - currentStep);
         break;
       }
       // --o--S==o==E--o--
       //  cur   next
       if (startStep >= currentStep && endStep >= nextStep) {
-        width +=
-          ((nextStep - startStep) / (nextStep - currentStep)) * sliderUnit;
+        width += (nextStep - startStep) / (nextStep - currentStep);
         continue;
       }
 
       // -=o=====o==E--o--
       //  cur   next
       if (endStep >= nextStep) {
-        width += sliderUnit;
+        width += 1;
       } else {
         // -=o==E--o--
         //  cur   next
-        width +=
-          ((endStep - currentStep) / (nextStep - currentStep)) * sliderUnit;
+        width += (endStep - currentStep) / (nextStep - currentStep);
         break;
       }
     }
+    width = width * sliderUnit;
 
     if (startPosition > 1 || startPosition < 0) {
       startPosition = 0;
     }
 
-    this.sliderStartPosition = `${startPosition * 100}%`;
-    this.sliderTrackWidth = `${width * 100}%`;
+    return {startPosition, width};
   }
+
   getLinkedTimeTickLeftStyle(step: number) {
     if (this.stepValues.indexOf(step) == -1) {
       throw new Error(

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
@@ -83,8 +83,9 @@ export class ImageCardComponent {
 
   ngOnChanges(changes: SimpleChanges) {
     if (
-      this.changeDistinct(changes['selectedSteps']) ||
-      this.changeDistinct(changes['selectedTime'])
+      (changes['selectedSteps'] &&
+        this.changeDistinct(changes['selectedSteps'])) ||
+      (changes['selectedTime'] && this.changeDistinct(changes['selectedTime']))
     ) {
       this.renderRangeSlider();
     }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
@@ -18,6 +18,8 @@ import {
   EventEmitter,
   Input,
   Output,
+  SimpleChange,
+  SimpleChanges,
 } from '@angular/core';
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
@@ -36,6 +38,8 @@ const TICK_WIDTH = 14; // In px
 })
 export class ImageCardComponent {
   readonly DataLoadState = DataLoadState;
+  sliderStartPosition = '';
+  sliderTrackWidth = '';
 
   @Input() loadState!: DataLoadState;
   @Input() title!: string;
@@ -71,6 +75,91 @@ export class ImageCardComponent {
     // `number` on input events.
     // https://github.com/angular/components/blob/master/src/material/slider/slider.ts
     this.stepIndexChange.emit($event.value as number);
+  }
+
+  changeDistinct(change: SimpleChange) {
+    return change.currentValue !== change.previousValue;
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (
+      !this.changeDistinct(changes['selectedSteps']) ||
+      !this.changeDistinct(changes['selectedTime'])
+    ) {
+      return;
+    }
+    if (
+      !this.selectedTime ||
+      !this.selectedTime.endStep ||
+      this.selectedTime.clipped
+    ) {
+      return;
+    }
+
+    const boundSize = this.stepValues.length - 1;
+    const sliderUnit = 1 / boundSize;
+    const startStep =
+      this.selectedTime.startStep < this.stepValues[0]
+        ? this.stepValues[0]
+        : this.selectedTime.startStep;
+    const endStep =
+      this.selectedTime.endStep > this.stepValues[boundSize]
+        ? this.stepValues[boundSize]
+        : this.selectedTime.endStep;
+    let startPosition = 0;
+    let width = 0;
+
+    let i = 0;
+    for (; i < this.stepValues.length - 1; i++) {
+      const currentStep = this.stepValues[i];
+      const nextStep = this.stepValues[i + 1];
+      if (startStep > nextStep) {
+        startPosition += sliderUnit;
+      } else if (currentStep <= startStep && startStep <= nextStep) {
+        startPosition +=
+          ((startStep - currentStep) / (nextStep - currentStep)) * sliderUnit;
+        break;
+      } else {
+        break;
+      }
+    }
+
+    for (; i < this.stepValues.length - 1; i++) {
+      const currentStep = this.stepValues[i];
+      const nextStep = this.stepValues[i + 1];
+      // --o--S====E--o--
+      //  cur        next
+      if (startStep >= currentStep && endStep <= nextStep) {
+        width = ((endStep - startStep) / (nextStep - currentStep)) * sliderUnit;
+        break;
+      }
+      // --o--S==o==E--o--
+      //  cur   next
+      if (startStep >= currentStep && endStep >= nextStep) {
+        width +=
+          ((nextStep - startStep) / (nextStep - currentStep)) * sliderUnit;
+        continue;
+      }
+
+      // -=o=====o==E--o--
+      //  cur   next
+      if (endStep >= nextStep) {
+        width += sliderUnit;
+      } else {
+        // -=o==E--o--
+        //  cur   next
+        width +=
+          ((endStep - currentStep) / (nextStep - currentStep)) * sliderUnit;
+        break;
+      }
+    }
+
+    if (startPosition > 1 || startPosition < 0) {
+      startPosition = 0;
+    }
+
+    this.sliderStartPosition = `${startPosition * 100}%`;
+    this.sliderTrackWidth = `${width * 100}%`;
   }
 
   getLinkedTimeTickLeftStyle(step: number) {

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -670,6 +670,42 @@ describe('image card', () => {
         );
       });
 
+      it('renders range slider with end step at no data step', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 20},
+          end: {step: 35},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 25%; width: 37.5%;'
+        );
+      });
+
+      it('renders range slider with start step at no data step', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 15},
+          end: {step: 30},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 12.5%; width: 37.5%;'
+        );
+      });
+
       it('renders range slider on no data steps with propotion of the unit', () => {
         store.overrideSelector(selectors.getMetricsSelectedTime, {
           start: {step: 20},

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -490,176 +490,287 @@ describe('image card', () => {
       'left: 100%; margin-left: -14px;',
     ];
 
-    it('renders a single tick on selected time', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 10},
-        end: null,
+    describe('ticks', () => {
+      beforeEach(() => {
+        const timeSeries = [
+          {wallTime: 100, imageId: 'ImageId1', step: 10},
+          {wallTime: 101, imageId: 'ImageId2', step: 20},
+          {wallTime: 102, imageId: 'ImageId3', step: 30},
+          {wallTime: 103, imageId: 'ImageId4', step: 40},
+        ];
+        provideMockCardSeriesData(
+          selectSpy,
+          PluginType.IMAGES,
+          'card1',
+          null /* metadataOverride */,
+          timeSeries
+        );
       });
 
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries
-      );
+      it('renders a single tick on selected time', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 10},
+          end: null,
+        });
 
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
 
-      const dots = fixture.debugElement.queryAll(
-        By.css('.linked-time-ticks-wrapper .linked-time-tick')
-      );
-      expect(dots.length).toBe(1);
-      expect(dots[0].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[0]);
+        const dots = fixture.debugElement.queryAll(
+          By.css('.linked-time-wrapper .linked-time-tick')
+        );
+        expect(dots.length).toBe(1);
+        expect(dots[0].nativeElement.getAttribute('style')).toBe(
+          TICKS_STYLE[0]
+        );
+      });
+
+      it('renders a single tick at correct propositional position', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 20},
+          end: null,
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+        const dot = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .linked-time-tick')
+        );
+
+        expect(dot.nativeElement.getAttribute('style')).toBe(TICKS_STYLE[1]);
+      });
+
+      it('renders ticks when steps are within selected time', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 15},
+          end: {step: 35},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const dots = fixture.debugElement.queryAll(
+          By.css('.linked-time-wrapper .linked-time-tick')
+        );
+        expect(dots.length).toBe(2);
+        // The second and third tick is selected.
+        expect(dots[0].nativeElement.getAttribute('style')).toBe(
+          TICKS_STYLE[1]
+        );
+        expect(dots[1].nativeElement.getAttribute('style')).toBe(
+          TICKS_STYLE[2]
+        );
+      });
+
+      it('renders ticks on selected steps are particially in range', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 25},
+          end: {step: 350},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const dots = fixture.debugElement.queryAll(
+          By.css('.linked-time-wrapper .linked-time-tick')
+        );
+        // The third and fourth ticks are selected.
+        expect(dots[0].nativeElement.getAttribute('style')).toBe(
+          TICKS_STYLE[2]
+        );
+        expect(dots[1].nativeElement.getAttribute('style')).toBe(
+          TICKS_STYLE[3]
+        );
+      });
+
+      it('does not render ticks on slected range wrapped between steps ', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 11},
+          end: {step: 14},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const dots = fixture.debugElement.queryAll(
+          By.css('.linked-time-wrapper .linked-time-tick')
+        );
+        // The third and fourth ticks are selected.
+        expect(dots.length).toBe(0);
+      });
+
+      it('does not render ticks when the slected range is clipped', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 45},
+          end: {step: 55},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const dots = fixture.debugElement.queryAll(
+          By.css('.linked-time-wrapper .linked-time-tick')
+        );
+        // The third and fourth ticks are selected.
+        expect(dots.length).toBe(0);
+      });
     });
 
-    it('renders a single tick at correct propositional position', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 20},
-        end: null,
+    fdescribe('sliders', () => {
+      beforeEach(() => {
+        const timeSeries = [
+          {wallTime: 100, imageId: 'ImageId1', step: 10},
+          {wallTime: 101, imageId: 'ImageId2', step: 20},
+          {wallTime: 102, imageId: 'ImageId3', step: 30},
+          {wallTime: 103, imageId: 'ImageId4', step: 40},
+          {wallTime: 104, imageId: 'ImageId5', step: 50},
+        ];
+        provideMockCardSeriesData(
+          selectSpy,
+          PluginType.IMAGES,
+          'card1',
+          null /* metadataOverride */,
+          timeSeries
+        );
       });
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries
-      );
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
-      const dot = fixture.debugElement.query(
-        By.css('.linked-time-ticks-wrapper .linked-time-tick')
-      );
 
-      expect(dot.nativeElement.getAttribute('style')).toBe(TICKS_STYLE[1]);
-    });
+      it('renders range slider on selected range', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 20},
+          end: {step: 30},
+        });
 
-    it('renders ticks when steps are within selected time', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 15},
-        end: {step: 35},
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 25%; width: 25%;'
+        );
       });
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries
-      );
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
 
-      const dots = fixture.debugElement.queryAll(
-        By.css('.linked-time-ticks-wrapper .linked-time-tick')
-      );
-      expect(dots.length).toBe(2);
-      // The second and third tick is selected.
-      expect(dots[0].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[1]);
-      expect(dots[1].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[2]);
-    });
+      it('renders range slider on no data steps', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 15},
+          end: {step: 35},
+        });
 
-    it('renders ticks on steps are particially in range', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 25},
-        end: {step: 350},
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 12.5%; width: 50%;'
+        );
       });
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries
-      );
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
 
-      const dots = fixture.debugElement.queryAll(
-        By.css('.linked-time-ticks-wrapper .linked-time-tick')
-      );
-      // The third and fourth ticks are selected.
-      expect(dots[0].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[2]);
-      expect(dots[1].nativeElement.getAttribute('style')).toBe(TICKS_STYLE[3]);
-    });
+      it('renders range slider on no data steps with propotion of the unit', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 20},
+          end: {step: 32.5},
+        });
 
-    it('does not render ticks on slected range wrapped between steps ', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 11},
-        end: {step: 14},
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 25%; width: 31.25%;'
+        );
       });
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries
-      );
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
 
-      const dots = fixture.debugElement.queryAll(
-        By.css('.linked-time-ticks-wrapper .linked-time-tick')
-      );
-      // The third and fourth ticks are selected.
-      expect(dots.length).toBe(0);
-    });
+      it('renders range slider on selected steps which end step is out of range, ', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 15},
+          end: {step: 55},
+        });
 
-    it('does not render ticks when the slected range is clipped', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 45},
-        end: {step: 55},
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 12.5%; width: 87.5%;'
+        );
       });
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries
-      );
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
 
-      const dots = fixture.debugElement.queryAll(
-        By.css('.linked-time-ticks-wrapper .linked-time-tick')
-      );
-      // The third and fourth ticks are selected.
-      expect(dots.length).toBe(0);
+      it('renders range slider on selected steps which start step is out of range, ', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 5},
+          end: {step: 35},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 0%; width: 62.5%;'
+        );
+      });
+
+      it('renders range slider where range is between two steps, ', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 12.5},
+          end: {step: 17.5},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 6.25%; width: 12.5%;'
+        );
+      });
+
+      it('does not render range slider on single selection', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 15},
+          end: null,
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeFalsy();
+      });
+
+      it('does not render range slider when the slected range is clipped', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 55},
+          end: {step: 60},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeFalsy();
+      });
     });
 
     it('moves slider thumb to selected time on single selection', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -616,7 +616,7 @@ describe('image card', () => {
       });
     });
 
-    fdescribe('sliders', () => {
+    describe('sliders', () => {
       beforeEach(() => {
         const timeSeries = [
           {wallTime: 100, imageId: 'ImageId1', step: 10},


### PR DESCRIPTION
Previously we have gray ticks indicate selected steps in range. This pr further colors the range. The coloring also supports selected steps does not have data (image here).

Current Image slider places ticks with the number of steps not the step values makes us cannot directly use end step and start step to calculate the tracker width. I choose to check the unit where start/end step exists and make the width proportional to the value. For example, we have steps [10,20,30,100] and range [20,65]. The range slider looks like:

<img width="270" alt="Screen Shot 2022-02-23 at 1 10 10 PM" src="https://user-images.githubusercontent.com/1131010/155408971-0b0fec32-a778-478f-bc47-1ada30a1babf.png">

The track takes 50% of the unit between step 30 and 100.

Screenshots
<img width="566" alt="Screen Shot 2022-02-23 at 1 02 24 PM" src="https://user-images.githubusercontent.com/1131010/155407916-b8eff707-0874-4890-8e5c-e42e0be4a355.png">

start step and end step in between two steps: track with no gray ticks
<img width="478" alt="Screen Shot 2022-02-23 at 1 01 36 PM" src="https://user-images.githubusercontent.com/1131010/155407791-8a9636b8-e23a-4a04-b1e3-97f6adf08c1b.png">

steps are patricianly in range
<img width="416" alt="Screen Shot 2022-02-23 at 1 03 43 PM" src="https://user-images.githubusercontent.com/1131010/155408091-320b6838-44fa-427c-b064-8970064e540f.png">

Summary of technical changes:
* Hide the slider of `<mat-slider>` (only keeps the thumb) when it is in range selection
* Render slider on range selection1
* Calculate the position and width of 'track-fill' based on start/end steps


What is also included in this pr but not directly related:
the tests of `ticks` in image_card_test is cleaned up by moving the card generation to `beforeEach`
