### PR TITLE
Update debugger_v2.md to fix an invalid link

### DIFF
--- a/docs/debugger_v2.md
+++ b/docs/debugger_v2.md
@@ -273,7 +273,7 @@ The debugging API introduces performance overhead to the instrumented TensorFlow
 program. The overhead varies by `tensor_debug_mode`, hardware type, and nature
 of the instrumented TensorFlow program. As a reference point, on a GPU, the
 `NO_TENSOR` mode adds a 15% overhead during the training of a
-[Transformer model](https://github.com/tensorflow/models/tree/master/official/nlp/transformer)
+[Transformer model](https://github.com/tensorflow/models/tree/master/official/legacy/transformer)
 under batch size 64. The percent overhead for other tensor_debug_modes are
 higher: approximately 50% for the `CURT_HEALTH`, `CONCISE_HEALTH`, `FULL_HEALTH`
 and `SHAPE` modes. On CPUs, the overhead is slightly lower. On TPUs, the


### PR DESCRIPTION


* Motivation for features / changes

> Changing the broken link as the existing link throws 404 error

* Technical description of changes

> Fixing the broken link in debugger_v2.md for `Transformer model` in [this section](https://www.tensorflow.org/tensorboard/debugger_v2#performance_overhead)

* Screenshots of UI changes

> No UI change and its just a documentation fix

* Detailed steps to verify changes work correctly (as executed by you)

> Added the correct hyperlink for transformers folder in models repo.

* Alternate designs / implementations considered

> None
