### PR TITLE
linked time: moves Image thumb on range selection

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -938,6 +938,12 @@ const reducer = createReducer(
     // Otherwise selection state is range.
     const useRangeSelectTime = change.endStep !== undefined;
 
+    const nextCardStepIndex = {...state.cardStepIndex};
+    Object.keys(state.cardStepIndex).forEach((cardId) => {
+      // Getting the 'closet' stepIndex is not trivial.
+      nextCardStepIndex[cardId] = 1;
+    })
+
     return {
       ...state,
       selectTimeEnabled: true,

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -938,12 +938,6 @@ const reducer = createReducer(
     // Otherwise selection state is range.
     const useRangeSelectTime = change.endStep !== undefined;
 
-    const nextCardStepIndex = {...state.cardStepIndex};
-    Object.keys(state.cardStepIndex).forEach((cardId) => {
-      // Getting the 'closet' stepIndex is not trivial.
-      nextCardStepIndex[cardId] = 1;
-    })
-
     return {
       ...state,
       selectTimeEnabled: true,

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -284,9 +284,32 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       this.stepValues$
     ).pipe(
       map(([stepIndex, selectedTime, selectedSteps, stepValues]) => {
-        if (!selectedTime || selectedTime.endStep) return stepIndex;
+        const firstSelectedStep =  selectedSteps[0];
+        const lastSelectedStep = selectedSteps[selectedSteps.length - 1];
+        if (!selectedTime || selectedTime.startStep > lastSelectedStep) return stepIndex;
 
-        const nextStepIndex = stepValues.indexOf(selectedSteps[0]);
+        // Moves thumb to the closest stepIndex on range selection.
+        if (selectedTime.endStep !== null && stepIndex !== null) {
+          const step = stepValues[stepIndex];
+
+          if (selectedTime.endStep < firstSelectedStep) {
+            return stepIndex;
+          }
+          // Does not move index when it is already in selected range.
+          if (selectedTime.startStep <= step && step <= selectedTime.endStep) {
+            return stepIndex;
+          }
+
+          if (step >= lastSelectedStep) {
+            return stepValues.indexOf(lastSelectedStep);
+          }
+          if (step <= firstSelectedStep) {
+            return stepValues.indexOf(firstSelectedStep);
+          }
+        }
+
+        // Moves thumb to the selected stepIndex on single selection.
+        const nextStepIndex = stepValues.indexOf(firstSelectedStep);
         if (nextStepIndex === -1) return stepIndex;
         return nextStepIndex;
       })

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -284,22 +284,20 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       this.stepValues$
     ).pipe(
       map(([stepIndex, selectedTime, selectedSteps, stepValues]) => {
-        const firstSelectedStep =  selectedSteps[0];
+        const firstSelectedStep = selectedSteps[0];
         const lastSelectedStep = selectedSteps[selectedSteps.length - 1];
-        if (!selectedTime || selectedTime.startStep > lastSelectedStep) return stepIndex;
+        if (!selectedTime || selectedTime.clipped) return stepIndex;
 
-        // Moves thumb to the closest stepIndex on range selection.
+        // Range selection
         if (selectedTime.endStep !== null && stepIndex !== null) {
           const step = stepValues[stepIndex];
 
-          if (selectedTime.endStep < firstSelectedStep) {
-            return stepIndex;
-          }
           // Does not move index when it is already in selected range.
           if (selectedTime.startStep <= step && step <= selectedTime.endStep) {
             return stepIndex;
           }
 
+          // Moves thumb to the closest stepIndex.
           if (step >= lastSelectedStep) {
             return stepValues.indexOf(lastSelectedStep);
           }
@@ -308,7 +306,7 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
           }
         }
 
-        // Moves thumb to the selected stepIndex on single selection.
+        // Single selection
         const nextStepIndex = stepValues.indexOf(firstSelectedStep);
         if (nextStepIndex === -1) return stepIndex;
         return nextStepIndex;

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -757,5 +757,83 @@ describe('image card', () => {
       slider = fixture.debugElement.query(By.css('mat-slider'));
       expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
     });
+
+    describe('range selection', () => {
+      function createCardWithStepIndex(stepIndex: number) {
+        const timeSeries = [
+          {wallTime: 100, imageId: 'ImageId1', step: 10},
+          {wallTime: 101, imageId: 'ImageId2', step: 20},
+          {wallTime: 102, imageId: 'ImageId3', step: 30},
+          {wallTime: 103, imageId: 'ImageId4', step: 40},
+        ];
+        provideMockCardSeriesData(
+          selectSpy,
+          PluginType.IMAGES,
+          'card1',
+          null /* metadataOverride */,
+          timeSeries,
+          stepIndex /* stepIndex */
+        );
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        return fixture;
+      }
+
+      function getSliderThumbPosition(
+        fixture: ComponentFixture<ImageCardContainer>
+      ) {
+        const slider = fixture.debugElement.query(By.css('mat-slider'));
+        return slider.nativeElement.getAttribute('aria-valuenow');
+      }
+
+      it('moves slider thumb to the highest step in range when the thumb is larger than end step', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 15},
+          end: {step: 35},
+        });
+        const fixture = createCardWithStepIndex(3);
+
+        expect(getSliderThumbPosition(fixture)).toBe('2');
+      });
+
+      it('moves slider thumb to the lowest step in range when the thumb is smaller than start step', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 15},
+          end: {step: 35},
+        });
+        const fixture = createCardWithStepIndex(0);
+
+        expect(getSliderThumbPosition(fixture)).toBe('1');
+      });
+
+      it('dose not moves slider thumb when the thumb is in range', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 15},
+          end: {step: 35},
+        });
+        const fixture = createCardWithStepIndex(2);
+
+        expect(getSliderThumbPosition(fixture)).toBe('2');
+      });
+
+      it('dose not moves slider thumb when selected time is clipped', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 55},
+          end: {step: 65},
+        });
+        const fixture = createCardWithStepIndex(2);
+
+        expect(getSliderThumbPosition(fixture)).toBe('2');
+
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 5},
+          end: {step: 9},
+        });
+        const fixture2 = createCardWithStepIndex(2);
+
+        expect(getSliderThumbPosition(fixture2)).toBe('2');
+      });
+    });
   });
 });


### PR DESCRIPTION
The slider thumb of image card on range selection was only moved on single selection (and there is a matched step). This pr moves the thumb on range selection based on the thumb's current position.