### PR TITLE
plugins: extends plugins component to take permission denied template

### DIFF
--- a/tensorboard/webapp/core/types.ts
+++ b/tensorboard/webapp/core/types.ts
@@ -24,6 +24,7 @@ export interface Run {
 export enum PluginsListFailureCode {
   UNKNOWN = 'UNKNOWN',
   NOT_FOUND = 'NOT_FOUND',
+  PERMISSION_DENIED = 'PERMISSION_DENIED',
 }
 
 export const TB_BRAND_NAME = new InjectionToken<string>(

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -47,6 +47,18 @@ limitations under the License.
       </ng-container>
     </ng-container>
 
+    <ng-container
+      *ngSwitchCase="PluginLoadState.ENVIRONMENT_FAILURE_PERMISSION_DENIED"
+    >
+      <!-- This error template can be injected by the parent component. -->
+      <ng-container
+        *ngTemplateOutlet="environmentFailurePermissionDeniedTemplate ?
+                             environmentFailurePermissionDeniedTemplate :
+                             environmentFailureDefaultTemplate"
+      >
+      </ng-container>
+    </ng-container>
+
     <ng-container *ngSwitchCase="PluginLoadState.ENVIRONMENT_FAILURE_UNKNOWN">
       <!-- This error template can be injected by the parent component. -->
       <ng-container

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -47,6 +47,7 @@ interface PolymerDashboard extends HTMLElement {
 
 export enum PluginLoadState {
   ENVIRONMENT_FAILURE_NOT_FOUND,
+  ENVIRONMENT_FAILURE_PERMISSION_DENIED,
   ENVIRONMENT_FAILURE_UNKNOWN,
   NO_ENABLED_PLUGINS,
   UNKNOWN_PLUGIN_ID,
@@ -104,6 +105,9 @@ export class PluginsComponent implements OnChanges {
 
   @Input()
   environmentFailureNotFoundTemplate?: TemplateRef<any>;
+
+  @Input()
+  environmentFailurePermissionDeniedTemplate?: TemplateRef<any>;
 
   @Input()
   environmentFailureUnknownTemplate?: TemplateRef<any>;

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -65,6 +65,9 @@ const activePlugin = createSelector(
       [settingsLoadState]="settingsLoadState$ | async"
       [featureFlags]="featureFlags$ | async"
       [environmentFailureNotFoundTemplate]="environmentFailureNotFoundTemplate"
+      [environmentFailurePermissionDeniedTemplate]="
+        environmentFailurePermissionDeniedTemplate
+      "
       [environmentFailureUnknownTemplate]="environmentFailureUnknownTemplate"
     ></plugins-component>
   `,
@@ -77,6 +80,9 @@ export class PluginsContainer {
 
   @Input()
   environmentFailureNotFoundTemplate?: TemplateRef<any>;
+
+  @Input()
+  environmentFailurePermissionDeniedTemplate?: TemplateRef<any>;
 
   @Input()
   environmentFailureUnknownTemplate?: TemplateRef<any>;
@@ -93,6 +99,10 @@ export class PluginsContainer {
         // environment.
         if (loadState.failureCode === PluginsListFailureCode.NOT_FOUND) {
           return PluginLoadState.ENVIRONMENT_FAILURE_NOT_FOUND;
+        } else if (
+          loadState.failureCode === PluginsListFailureCode.PERMISSION_DENIED
+        ) {
+          return PluginLoadState.ENVIRONMENT_FAILURE_PERMISSION_DENIED;
         } else {
           return PluginLoadState.ENVIRONMENT_FAILURE_UNKNOWN;
         }

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -67,11 +67,17 @@ function expectPluginIframe(element: HTMLElement, name: string) {
     <ng-template #environmentFailureNotFoundTemplate>
       <h3 class="custom-not-found-template">Custom Not Found Error</h3>
     </ng-template>
+    <ng-template #environmentFailurePermissionDeniedTemplate>
+      <h3 class="custom-not-found-template">Custom Permission Denied Error</h3>
+    </ng-template>
     <ng-template #environmentFailureUnknownTemplate>
       <h3 class="custom-unknown-template">Custom Unknown Error</h3>
     </ng-template>
     <plugins
       [environmentFailureNotFoundTemplate]="environmentFailureNotFoundTemplate"
+      [environmentFailurePermissionDeniedTemplate]="
+        environmentFailurePermissionDeniedTemplate
+      "
       [environmentFailureUnknownTemplate]="environmentFailureUnknownTemplate"
     >
     </plugins>
@@ -689,6 +695,21 @@ describe('plugins_component', () => {
       );
     });
 
+    it('shows warning when environment failed PERMISSION_DENIED', () => {
+      store.overrideSelector(getActivePlugin, null);
+      store.overrideSelector(getPluginsListLoaded, {
+        state: DataLoadState.FAILED,
+        lastLoadedTimeInMs: null,
+        failureCode: PluginsListFailureCode.PERMISSION_DENIED,
+      });
+      const fixture = TestBed.createComponent(PluginsContainer);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.nativeElement.textContent).toContain(
+        'Data could not be loaded.'
+      );
+    });
+
     it('shows warning when environment failed UNKNOWN', () => {
       store.overrideSelector(getActivePlugin, null);
       store.overrideSelector(getPluginsListLoaded, {
@@ -753,6 +774,23 @@ describe('plugins_component', () => {
 
         expect(fixture.debugElement.nativeElement.textContent).toBe(
           'Custom Not Found Error'
+        );
+      });
+
+      it('shows warning when environment failed PERMISSION_DENIED', () => {
+        store.overrideSelector(getActivePlugin, null);
+        store.overrideSelector(getPluginsListLoaded, {
+          state: DataLoadState.FAILED,
+          lastLoadedTimeInMs: null,
+          failureCode: PluginsListFailureCode.PERMISSION_DENIED,
+        });
+        const fixture = TestBed.createComponent(
+          CustomizedErrorTemplatesComponent
+        );
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.nativeElement.textContent).toBe(
+          'Custom Permission Denied Error'
         );
       });
 


### PR DESCRIPTION
Currently on data load failure the plugin page can render two different templates, "unknown" and "not found", but they are used only by tb.dev. Therefore the default template, which is showing "Data could not be loaded" without further information, is shown most of the time.
Now we want to show meaningful message on the page when the error return from server is **permission denied**.  The plugin component now also takes the permission denied template input if provided.

Googlers, please see cl/432024734 for screenshots and test result.