### PR TITLE
linked time: moves thumb to closest step on single selection when they're "close enough"

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -291,21 +291,22 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
         // When there is no selected steps. We check if start step is
         // "close" enough to a step value and move it.
         if (selectedSteps.length === 0) {
+          if (stepValues.length === 1) return stepIndex;
+
           const step = selectedTime.startStep;
           for (let i = 0; i < stepValues.length - 2; i++) {
             const currentSelectedStep = stepValues[i];
             const nextSelectedStep = stepValues[i + 1];
             const distance =
               (nextSelectedStep - currentSelectedStep) * DISTANCE_RATIO;
+            if (step < currentSelectedStep) return stepIndex;
 
-            if (Math.abs(step - currentSelectedStep) <= distance) {
+            if (step - currentSelectedStep <= distance) {
               return stepValues.indexOf(currentSelectedStep);
             }
-            if (Math.abs(step - nextSelectedStep) <= distance) {
+            if (nextSelectedStep - step <= distance) {
               return stepValues.indexOf(nextSelectedStep);
             }
-
-            if (step < currentSelectedStep) return stepIndex;
           }
         }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -293,19 +293,19 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
         if (selectedSteps.length === 0) {
           if (stepValues.length === 1) return stepIndex;
 
-          const step = selectedTime.startStep;
+          const selectedTimeStepValue = selectedTime.startStep;
           for (let i = 0; i < stepValues.length - 2; i++) {
-            const currentSelectedStep = stepValues[i];
-            const nextSelectedStep = stepValues[i + 1];
+            const currentStepValue = stepValues[i];
+            const nextStepValue = stepValues[i + 1];
             const distance =
-              (nextSelectedStep - currentSelectedStep) * DISTANCE_RATIO;
-            if (step < currentSelectedStep) return stepIndex;
+              (nextStepValue - currentStepValue) * DISTANCE_RATIO;
+            if (selectedTimeStepValue < currentStepValue) return stepIndex;
 
-            if (step - currentSelectedStep <= distance) {
-              return stepValues.indexOf(currentSelectedStep);
+            if (selectedTimeStepValue - currentStepValue <= distance) {
+              return i;
             }
-            if (nextSelectedStep - step <= distance) {
-              return stepValues.indexOf(nextSelectedStep);
+            if (nextStepValue - selectedTimeStepValue <= distance) {
+              return i + 1;
             }
           }
         }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -616,7 +616,7 @@ describe('image card', () => {
       });
     });
 
-    describe('sliders', () => {
+    describe('render sliders', () => {
       beforeEach(() => {
         const timeSeries = [
           {wallTime: 100, imageId: 'ImageId1', step: 10},
@@ -809,187 +809,255 @@ describe('image card', () => {
       });
     });
 
-    it('moves slider thumb to selected time on single selection', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 20},
-        end: null,
-      });
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries,
-        2 /* stepIndex */
-      );
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
-      let slider = fixture.debugElement.query(By.css('mat-slider'));
-      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('1');
+    describe('thumb movement', () => {
+      describe('single selection', () => {
+        it('moves slider thumb to matched selected time', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 20},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            2 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('1');
 
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 30},
-        end: null,
-      });
-      store.refreshState();
-      fixture.detectChanges();
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 30},
+            end: null,
+          });
+          store.refreshState();
+          fixture.detectChanges();
 
-      slider = fixture.debugElement.query(By.css('mat-slider'));
-      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
-    });
-
-    it('does not move slider thumb on selected step with no image', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 15},
-        end: null,
-      });
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries,
-        2 /* stepIndex */
-      );
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
-      let slider = fixture.debugElement.query(By.css('mat-slider'));
-      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
-    });
-
-    it('does not move slider thumb to selected time on range selection', () => {
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 15},
-        end: {step: 55},
-      });
-      const timeSeries = [
-        {wallTime: 100, imageId: 'ImageId1', step: 10},
-        {wallTime: 101, imageId: 'ImageId2', step: 20},
-        {wallTime: 102, imageId: 'ImageId3', step: 30},
-        {wallTime: 103, imageId: 'ImageId4', step: 40},
-      ];
-      provideMockCardSeriesData(
-        selectSpy,
-        PluginType.IMAGES,
-        'card1',
-        null /* metadataOverride */,
-        timeSeries,
-        2 /* stepIndex */
-      );
-      const fixture = createImageCardContainer('card1');
-      fixture.detectChanges();
-
-      let slider = fixture.debugElement.query(By.css('mat-slider'));
-      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
-
-      store.overrideSelector(selectors.getMetricsSelectedTime, {
-        start: {step: 25},
-        end: {step: 35},
-      });
-      store.refreshState();
-      fixture.detectChanges();
-
-      slider = fixture.debugElement.query(By.css('mat-slider'));
-      expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
-    });
-
-    describe('range selection', () => {
-      function createImageCardContainerWithStepIndex(stepIndex: number) {
-        const timeSeries = [
-          {wallTime: 100, imageId: 'ImageId1', step: 10},
-          {wallTime: 101, imageId: 'ImageId2', step: 20},
-          {wallTime: 102, imageId: 'ImageId3', step: 30},
-          {wallTime: 103, imageId: 'ImageId4', step: 40},
-        ];
-        provideMockCardSeriesData(
-          selectSpy,
-          PluginType.IMAGES,
-          'card1',
-          null /* metadataOverride */,
-          timeSeries,
-          stepIndex /* stepIndex */
-        );
-        const fixture = createImageCardContainer('card1');
-        fixture.detectChanges();
-
-        return fixture;
-      }
-
-      function getSliderThumbPosition(
-        fixture: ComponentFixture<ImageCardContainer>
-      ) {
-        const slider = fixture.debugElement.query(By.css('mat-slider'));
-        return slider.nativeElement.getAttribute('aria-valuenow');
-      }
-
-      it('moves slider thumb to the highest step in range when the thumb is larger than end step', () => {
-        store.overrideSelector(selectors.getMetricsSelectedTime, {
-          start: {step: 15},
-          end: {step: 35},
+          slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
         });
-        const fixture = createImageCardContainerWithStepIndex(3);
 
-        expect(getSliderThumbPosition(fixture)).toBe('2');
+        it('does not move slider thumb on selected step with no image', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 15},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            2 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+        });
+
+        it('moves slider thumb to smaller closest step when they are close enough', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 11},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            2 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('0');
+        });
+
+        it('moves slider thumb to larger closest step when they are close enough', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 19},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            2 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('1');
+        });
+
+        it('does not move slider thumb to larger closest step when it is clipped', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 9},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            2 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+        });
+
+        it('does not move slider thumb to smaller closest step when it is clipped', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 41},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            2 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+        });
       });
 
-      it('moves slider thumb to the lowest step in range when the thumb is smaller than start step', () => {
-        store.overrideSelector(selectors.getMetricsSelectedTime, {
-          start: {step: 15},
-          end: {step: 35},
+      describe('range selection', () => {
+        function createImageCardContainerWithStepIndex(stepIndex: number) {
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            stepIndex /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+
+          return fixture;
+        }
+
+        function getSliderThumbPosition(
+          fixture: ComponentFixture<ImageCardContainer>
+        ) {
+          const slider = fixture.debugElement.query(By.css('mat-slider'));
+          return slider.nativeElement.getAttribute('aria-valuenow');
+        }
+
+        it('moves slider thumb to the highest step in range when the thumb is larger than end step', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 15},
+            end: {step: 35},
+          });
+          const fixture = createImageCardContainerWithStepIndex(3);
+
+          expect(getSliderThumbPosition(fixture)).toBe('2');
         });
-        const fixture = createImageCardContainerWithStepIndex(0);
 
-        expect(getSliderThumbPosition(fixture)).toBe('1');
-      });
+        it('moves slider thumb to the lowest step in range when the thumb is smaller than start step', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 15},
+            end: {step: 35},
+          });
+          const fixture = createImageCardContainerWithStepIndex(0);
 
-      it('does not moves slider thumb when the thumb is in range', () => {
-        store.overrideSelector(selectors.getMetricsSelectedTime, {
-          start: {step: 15},
-          end: {step: 35},
+          expect(getSliderThumbPosition(fixture)).toBe('1');
         });
-        const fixture = createImageCardContainerWithStepIndex(2);
 
-        expect(getSliderThumbPosition(fixture)).toBe('2');
-      });
+        it('does not moves slider thumb when the thumb is in range', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 15},
+            end: {step: 35},
+          });
+          const fixture = createImageCardContainerWithStepIndex(2);
 
-      it('does not moves slider thumb when selected time is clipped', () => {
-        store.overrideSelector(selectors.getMetricsSelectedTime, {
-          start: {step: 55},
-          end: {step: 65},
+          expect(getSliderThumbPosition(fixture)).toBe('2');
         });
-        const fixture = createImageCardContainerWithStepIndex(2);
 
-        expect(getSliderThumbPosition(fixture)).toBe('2');
+        it('does not moves slider thumb when selected time is clipped', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 55},
+            end: {step: 65},
+          });
+          const fixture = createImageCardContainerWithStepIndex(2);
 
-        store.overrideSelector(selectors.getMetricsSelectedTime, {
-          start: {step: 5},
-          end: {step: 9},
+          expect(getSliderThumbPosition(fixture)).toBe('2');
+
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 5},
+            end: {step: 9},
+          });
+          const fixture2 = createImageCardContainerWithStepIndex(2);
+
+          expect(getSliderThumbPosition(fixture2)).toBe('2');
         });
-        const fixture2 = createImageCardContainerWithStepIndex(2);
 
-        expect(getSliderThumbPosition(fixture2)).toBe('2');
-      });
+        it('does not moves slider thumb when selected range had no image', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 15},
+            end: {step: 18},
+          });
+          const fixture = createImageCardContainerWithStepIndex(2);
 
-      it('does not moves slider thumb when selected range had no image', () => {
-        store.overrideSelector(selectors.getMetricsSelectedTime, {
-          start: {step: 15},
-          end: {step: 18},
+          expect(getSliderThumbPosition(fixture)).toBe('2');
         });
-        const fixture = createImageCardContainerWithStepIndex(2);
-
-        expect(getSliderThumbPosition(fixture)).toBe('2');
       });
     });
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -976,9 +976,7 @@ describe('image card', () => {
             start: {step: 15},
             end: null,
           });
-          const timeSeries = [
-            {wallTime: 100, imageId: 'ImageId1', step: 10},
-          ];
+          const timeSeries = [{wallTime: 100, imageId: 'ImageId1', step: 10}];
           provideMockCardSeriesData(
             selectSpy,
             PluginType.IMAGES,

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -970,6 +970,28 @@ describe('image card', () => {
           let slider = fixture.debugElement.query(By.css('mat-slider'));
           expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
         });
+
+        it('does not move slider thumb when there is only one unmatched step', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            start: {step: 15},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            0 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('0');
+        });
       });
 
       describe('range selection', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -873,6 +873,9 @@ describe('image card', () => {
 
         it('moves slider thumb to smaller closest step when they are close enough', () => {
           store.overrideSelector(selectors.getMetricsSelectedTime, {
+            // Step 11 is between steps 10 and 20. The distance between 11 and 10 is 1, which is less
+            // or equal to the ditsance between 10 and 20 multiplied by DISTANCE_RATIO. Thus we move
+            // stepIndex to 10.
             start: {step: 11},
             end: null,
           });
@@ -896,8 +899,39 @@ describe('image card', () => {
           expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('0');
         });
 
+        it('does not move slider thumb when selected step is not close to any step values', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            // Step 12 is between steps 10 and 20. The distance between 12 and 10 is 2, which is larger
+            // than the ditsance between 10 and 20 multiplied by DISTANCE_RATIO. Thus we do not move
+            // stepIndex.
+            start: {step: 12},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            2 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+        });
+
         it('moves slider thumb to larger closest step when they are close enough', () => {
           store.overrideSelector(selectors.getMetricsSelectedTime, {
+            // Step 19 is between steps 10 and 20. The distance between 19 and 20 is 1, which is less
+            // or equal to the ditsance between 10 and 20 multiplied by DISTANCE_RATIO. Thus we move
+            // stepIndex to 20.
             start: {step: 19},
             end: null,
           });
@@ -948,7 +982,34 @@ describe('image card', () => {
 
         it('does not move slider thumb to smaller closest step when it is clipped', () => {
           store.overrideSelector(selectors.getMetricsSelectedTime, {
+            // Linked time is clipped since step 41 is larger than the largest step 40.
             start: {step: 41},
+            end: null,
+          });
+          const timeSeries = [
+            {wallTime: 100, imageId: 'ImageId1', step: 10},
+            {wallTime: 101, imageId: 'ImageId2', step: 20},
+            {wallTime: 102, imageId: 'ImageId3', step: 30},
+            {wallTime: 103, imageId: 'ImageId4', step: 40},
+          ];
+          provideMockCardSeriesData(
+            selectSpy,
+            PluginType.IMAGES,
+            'card1',
+            null /* metadataOverride */,
+            timeSeries,
+            2 /* stepIndex */
+          );
+          const fixture = createImageCardContainer('card1');
+          fixture.detectChanges();
+          let slider = fixture.debugElement.query(By.css('mat-slider'));
+          expect(slider.nativeElement.getAttribute('aria-valuenow')).toBe('2');
+        });
+
+        it('does not move slider thumb to larger closest step when it is clipped', () => {
+          store.overrideSelector(selectors.getMetricsSelectedTime, {
+            // Linked time is clipped since step 9 is smaller than the smallest step 10.
+            start: {step: 9},
             end: null,
           });
           const timeSeries = [


### PR DESCRIPTION
Previously on single selection we only move the thumb to steps when it is exactly matched with selected step. Now we want to move the thumb (to show the corresponding image) when the selected step is "close enough".

We define the "close enough" to be 10% of the distance between two step values. For example we have steps [20, 50, 200, 400]. We move the thumb to 50 when its range is within 47-65. Calculated by 10% of (50-20) and 10% of (200-50).

<img width="176" alt="Screen Shot 2022-03-03 at 4 42 02 PM" src="https://user-images.githubusercontent.com/1131010/156677347-b3cb750e-f29a-4348-b37a-ca9017d085a2.png">

screenshot shows the step is 91800 and the thumb moved to the step when selected time is 918100.
![Screen Shot 2022-03-03 at 3 57 12 PM](https://user-images.githubusercontent.com/1131010/156677314-58d9cbc0-351d-4cac-aaf8-3922cc363d8b.png)


Note: this pr also includes some refactor of tests hierarchy, most of the tests are not intended to be re-reviewed. Only four new tests are added into "single selection"

Test hierarchy
```
linked time
    |-ticks
    |-render sliders
    |-thumb movement
          |-single selection
          |-range selection
```