### PR TITLE
Use new types in fob controller

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -287,6 +287,7 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2:line_chart_utils",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -37,7 +37,7 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
-import {AxisDirection} from '../../../widgets/linked_time_fob/linked_time_fob_controller_component';
+import {AxisDirection} from '../../../widgets/linked_time_fob/types';
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardDataSeries,

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -26,6 +26,7 @@ tf_ng_module(
         "//tensorboard/webapp/widgets:resize_detector",
         "//tensorboard/webapp/widgets/intersection_observer",
         "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//rxjs",
@@ -46,6 +47,7 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",
         "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",
@@ -60,5 +62,6 @@ tf_ts_library(
     ],
     deps = [
         "//tensorboard/webapp:tb_polymer_interop_types",
+        "//tensorboard/webapp/third_party:d3",
     ],
 )

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -54,8 +54,7 @@ limitations under the License.
       <linked-time-fob-controller
         [axisDirection]="axisDirection"
         [linkedTime]="linkedTime"
-        [steps]="getSteps()"
-        [temporalScale]="scales.temporalScale"
+        [histogramFobData]="getFobData()"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
       ></linked-time-fob-controller>
     </ng-container>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -30,20 +30,18 @@ import {takeUntil} from 'rxjs/operators';
 import {LinkedTime} from '../../metrics/types';
 import * as d3 from '../../third_party/d3';
 import {HCLColor} from '../../third_party/d3';
-import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
+import {AxisDirection} from '../linked_time_fob/types';
 import {
   Bin,
   HistogramData,
   HistogramDatum,
   HistogramMode,
   TimeProperty,
+  TemporalScale,
 } from './histogram_types';
 
 type BinScale = d3.ScaleLinear<number, number>;
 type CountScale = d3.ScaleLinear<number, number>;
-type TemporalScale =
-  | d3.ScaleLinear<number, number>
-  | d3.ScaleTime<number, number>;
 type D3ColorScale = d3.ScaleLinear<HCLColor, string>;
 
 interface Layout {
@@ -239,6 +237,13 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
         this.scales &&
         linkedTime
     );
+  }
+
+  getFobData() {
+    return {
+      steps: this.getSteps(),
+      scale: this.scales!.temporalScale,
+    };
   }
 
   isDatumInLinkedTimeRange(datum: HistogramDatum): boolean {

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -36,8 +36,8 @@ import {
   HistogramData,
   HistogramDatum,
   HistogramMode,
-  TimeProperty,
   TemporalScale,
+  TimeProperty,
 } from './histogram_types';
 
 type BinScale = d3.ScaleLinear<number, number>;

--- a/tensorboard/webapp/widgets/histogram/histogram_types.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_types.ts
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {ScaleLinear, ScaleTime} from '../../third_party/d3';
+
 export {HistogramMode, TimeProperty} from '../../tb_polymer_interop_types';
 
 export interface ColorScale {
@@ -34,3 +36,7 @@ export interface HistogramDatum {
 }
 
 export type HistogramData = HistogramDatum[];
+
+export type TemporalScale =
+  | ScaleLinear<number, number>
+  | ScaleTime<number, number>;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -20,7 +20,7 @@ tf_ts_library(
     srcs = [
         "public_types.ts",
     ],
-    visibility = ["//tensorboard/webapp/widgets/line_chart_v2:__subpackages__"],
+    visibility = ["//tensorboard/webapp/widgets:__subpackages__"],
     deps = [
         ":chart_types",
         ":formatter",

--- a/tensorboard/webapp/widgets/linked_time_fob/BUILD
+++ b/tensorboard/webapp/widgets/linked_time_fob/BUILD
@@ -27,6 +27,7 @@ tf_ng_module(
         ":linked_time_fob_controller_styles",
     ],
     deps = [
+        ":types",
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/third_party:d3",
         "@npm//@angular/common",
@@ -42,10 +43,23 @@ tf_ts_library(
     ],
     deps = [
         ":linked_time_fob",
+        ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/third_party:d3",
         "@npm//@angular/core",
         "@npm//@types/jasmine",
+    ],
+)
+
+tf_ts_library(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/metrics:types",
+        "//tensorboard/webapp/widgets/histogram:types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
     ],
 )

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
-import {AxisDirection} from './linked_time_fob_controller_component';
+import {AxisDirection} from './types';
 
 @Component({
   selector: 'linked-time-fob',

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -23,7 +23,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import {LinkedTime} from '../../metrics/types';
-import {AxisDirection, Fob, HistogramFobData} from './types';
+import {AxisDirection, Fob, DiscreteFobData} from './types';
 
 @Component({
   selector: 'linked-time-fob-controller',
@@ -37,7 +37,7 @@ export class LinkedTimeFobControllerComponent {
   @ViewChild('endFobWrapper') readonly endFobWrapper!: ElementRef;
   @Input() axisDirection!: AxisDirection;
   @Input() linkedTime!: LinkedTime;
-  @Input() histogramFobData!: HistogramFobData;
+  @Input() discreteFobData!: DiscreteFobData;
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
 
   private currentDraggingFob: Fob = Fob.NONE;
@@ -52,10 +52,10 @@ export class LinkedTimeFobControllerComponent {
 
   getCssTranslatePx(step: number): string {
     if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.histogramFobData.scale(step)}px)`;
+      return `translate(0px, ${this.discreteFobData.scale(step)}px)`;
     }
 
-    return `translate(${this.histogramFobData.scale(step)}px, 0px)`;
+    return `translate(${this.discreteFobData.scale(step)}px, 0px)`;
   }
 
   startDrag(fob: Fob) {
@@ -78,7 +78,7 @@ export class LinkedTimeFobControllerComponent {
     let newLinkedTime = this.linkedTime;
     if (this.isDraggingHigher(event.clientY, event.movementY)) {
       const stepAbove =
-        this.histogramFobData.steps[
+        this.discreteFobData.steps[
           this.getStepIndexHigherThanMousePosition(event.clientY)
         ];
       if (this.currentDraggingFob === Fob.END) {
@@ -91,7 +91,7 @@ export class LinkedTimeFobControllerComponent {
 
     if (this.isDraggingLower(event.clientY, event.movementY)) {
       const stepBelow =
-        this.histogramFobData.steps[
+        this.discreteFobData.steps[
           this.getStepIndexLowerThanMousePosition(event.clientY)
         ];
       if (this.currentDraggingFob === Fob.END) {
@@ -107,7 +107,7 @@ export class LinkedTimeFobControllerComponent {
     return (
       position < this.getDraggingFobTop() &&
       movement < 0 &&
-      this.getDraggingFobStep() > this.histogramFobData.steps[0]
+      this.getDraggingFobStep() > this.discreteFobData.steps[0]
     );
   }
 
@@ -116,7 +116,7 @@ export class LinkedTimeFobControllerComponent {
       position > this.getDraggingFobTop() &&
       movement > 0 &&
       this.getDraggingFobStep() <
-        this.histogramFobData.steps[this.histogramFobData.steps.length - 1]
+        this.discreteFobData.steps[this.discreteFobData.steps.length - 1]
     );
   }
 
@@ -136,7 +136,7 @@ export class LinkedTimeFobControllerComponent {
     let stepIndex = 0;
     while (
       position - this.axisOverlay.nativeElement.getBoundingClientRect().top >
-        this.histogramFobData.scale(this.histogramFobData.steps[stepIndex]) &&
+        this.discreteFobData.scale(this.discreteFobData.steps[stepIndex]) &&
       stepIndex < this.currentDraggingFobUpperBoundIndex
     ) {
       stepIndex++;
@@ -145,10 +145,10 @@ export class LinkedTimeFobControllerComponent {
   }
 
   getStepIndexLowerThanMousePosition(position: number) {
-    let stepIndex = this.histogramFobData.steps.length - 1;
+    let stepIndex = this.discreteFobData.steps.length - 1;
     while (
       position - this.axisOverlay.nativeElement.getBoundingClientRect().top <
-        this.histogramFobData.scale(this.histogramFobData.steps[stepIndex]) &&
+        this.discreteFobData.scale(this.discreteFobData.steps[stepIndex]) &&
       stepIndex > this.currentDraggingFobLowerBoundIndex
     ) {
       stepIndex--;
@@ -162,22 +162,22 @@ export class LinkedTimeFobControllerComponent {
     // the step before or equal to the endFob's step.
     if (this.currentDraggingFob === Fob.START && this.linkedTime.end !== null) {
       let index = 0;
-      while (this.histogramFobData.steps[index] < this.linkedTime.end.step) {
+      while (this.discreteFobData.steps[index] < this.linkedTime.end.step) {
         index++;
       }
       return index;
     }
 
     // In all other cases the largest step is the upper bound.
-    return this.histogramFobData.steps.length - 1;
+    return this.discreteFobData.steps.length - 1;
   }
 
   // Gets the index of smallest step that the currentDraggingFob is allowed to go.
   getDraggingFobLowerBoundIndex() {
     // The END fob cannot pass the START fob.
     if (this.currentDraggingFob === Fob.END) {
-      let index = this.histogramFobData.steps.length - 1;
-      while (this.histogramFobData.steps[index] > this.linkedTime.start.step) {
+      let index = this.discreteFobData.steps.length - 1;
+      while (this.discreteFobData.steps[index] > this.linkedTime.start.step) {
         index--;
       }
       return index;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
@@ -19,7 +19,7 @@ import {LinkedTime} from '../../metrics/types';
 import {ScaleLinear} from '../../third_party/d3';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
 import {LinkedTimeFobControllerComponent} from './linked_time_fob_controller_component';
-import {AxisDirection, Fob, HistogramFobData} from './types';
+import {AxisDirection, Fob, DiscreteFobData} from './types';
 
 @Component({
   selector: 'testable-comp',
@@ -28,7 +28,7 @@ import {AxisDirection, Fob, HistogramFobData} from './types';
       #FobController
       [axisDirection]="axisDirection"
       [linkedTime]="linkedTime"
-      [histogramFobData]="histogramFobData"
+      [discreteFobData]="discreteFobData"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
     ></linked-time-fob-controller>
   `,
@@ -38,7 +38,7 @@ class TestableComponent {
   fobController!: LinkedTimeFobControllerComponent;
 
   @Input() axisDirection!: AxisDirection;
-  @Input() histogramFobData!: HistogramFobData;
+  @Input() discreteFobData!: DiscreteFobData;
   @Input() linkedTime!: LinkedTime;
 
   @Input() onSelectTimeChanged!: (newLinkedTime: LinkedTime) => void;
@@ -65,7 +65,7 @@ describe('linked_time_fob_controller', () => {
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
     temporalScaleSpy = jasmine.createSpy();
-    fixture.componentInstance.histogramFobData = {
+    fixture.componentInstance.discreteFobData = {
       steps: input.steps || [1, 2, 3, 4],
       scale: temporalScaleSpy as unknown as ScaleLinear<number, number>,
     };

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
@@ -16,15 +16,10 @@ limitations under the License.
 import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {LinkedTime} from '../../metrics/types';
-import {ScaleLinear, ScaleTime} from '../../third_party/d3';
+import {ScaleLinear} from '../../third_party/d3';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
-import {
-  AxisDirection,
-  Fob,
-  LinkedTimeFobControllerComponent,
-} from './linked_time_fob_controller_component';
-
-type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
+import {LinkedTimeFobControllerComponent} from './linked_time_fob_controller_component';
+import {AxisDirection, Fob, HistogramFobData} from './types';
 
 @Component({
   selector: 'testable-comp',
@@ -33,8 +28,7 @@ type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
       #FobController
       [axisDirection]="axisDirection"
       [linkedTime]="linkedTime"
-      [steps]="steps"
-      [temporalScale]="temporalScale"
+      [histogramFobData]="histogramFobData"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
     ></linked-time-fob-controller>
   `,
@@ -43,10 +37,9 @@ class TestableComponent {
   @ViewChild('FobController')
   fobController!: LinkedTimeFobControllerComponent;
 
-  @Input() steps!: number[];
   @Input() axisDirection!: AxisDirection;
+  @Input() histogramFobData!: HistogramFobData;
   @Input() linkedTime!: LinkedTime;
-  @Input() temporalScale!: TemporalScale;
 
   @Input() onSelectTimeChanged!: (newLinkedTime: LinkedTime) => void;
 }
@@ -71,7 +64,11 @@ describe('linked_time_fob_controller', () => {
     linkedTime?: LinkedTime;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
-    fixture.componentInstance.steps = input.steps || [1, 2, 3, 4];
+    temporalScaleSpy = jasmine.createSpy();
+    fixture.componentInstance.histogramFobData = {
+      steps: input.steps || [1, 2, 3, 4],
+      scale: temporalScaleSpy as unknown as ScaleLinear<number, number>,
+    };
 
     fixture.componentInstance.axisDirection =
       input.axisDirection || AxisDirection.VERTICAL;
@@ -80,10 +77,6 @@ describe('linked_time_fob_controller', () => {
       start: {step: 1},
       end: null,
     };
-
-    temporalScaleSpy = jasmine.createSpy();
-    fixture.componentInstance.temporalScale =
-      temporalScaleSpy as unknown as ScaleLinear<number, number>;
 
     temporalScaleSpy.and.callFake((step: number) => {
       return step;

--- a/tensorboard/webapp/widgets/linked_time_fob/types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/types.ts
@@ -23,7 +23,7 @@ export enum Fob {
   END,
 }
 
-export interface HistogramFobData {
+export interface DiscreteFobData {
   scale: TemporalScale;
   steps: number[];
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/types.ts
@@ -1,0 +1,33 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {PluginType} from '../../metrics/types';
+import {Scale} from '../line_chart_v2/lib/public_types';
+import {TemporalScale} from '../histogram/histogram_types';
+
+export {Scale} from '../line_chart_v2/lib/public_types';
+
+export enum AxisDirection {
+  HORIZONTAL,
+  VERTICAL,
+}
+
+export enum Fob {
+  NONE,
+  START,
+  END,
+}
+
+export interface HistogramFobData {
+  scale: TemporalScale;
+  steps: number[];
+}

--- a/tensorboard/webapp/widgets/linked_time_fob/types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/types.ts
@@ -10,11 +10,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {PluginType} from '../../metrics/types';
-import {Scale} from '../line_chart_v2/lib/public_types';
 import {TemporalScale} from '../histogram/histogram_types';
-
-export {Scale} from '../line_chart_v2/lib/public_types';
 
 export enum AxisDirection {
   HORIZONTAL,


### PR DESCRIPTION
The purpose of this PR is to prepare the fob controller to be used in other cards. We are doing that by encapsulating Histogram specific data into a specific interface. Histogram is the only card that uses a temporal scale so that is included. The steps array are used to skip all steps that do not have data on that histogram. The current plan for Scalar cards is to have dragging be continuous so the array of steps will not be needed.

There is no functional change in this PR.