### PR TITLE
linked time: Show histogram with color on mouse hovering

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -82,6 +82,8 @@ limitations under the License.
         [class.histogram]="true"
         [class.no-color]="!isDatumInLinkedTimeRange(datum)"
         [style.color]="getHistogramFill(datum)"
+        (mouseenter)="updateColorOnHover($event, true)"
+        (mouseleave)="updateColorOnHover($event, false)"
       >
         <line
           *ngIf="mode === HistogramMode.OFFSET"

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -261,6 +261,7 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
   }
 
   updateColorOnHover(event: MouseEvent, isHover: boolean) {
+    // When link time is disabled all histogram should be colored.
     if (!this.isLinkedTimeEnabled(this.linkedTime)) {
       return;
     }

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -260,6 +260,17 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
       : '';
   }
 
+  updateColorOnHover(event: MouseEvent, isHover: boolean) {
+    if (!this.isLinkedTimeEnabled(this.linkedTime)) {
+      return;
+    }
+    if (isHover) {
+      (event.target! as HTMLElement).classList.remove('no-color');
+    } else {
+      (event.target! as HTMLElement).classList.add('no-color');
+    }
+  }
+
   getGridTickYLocs(): number[] {
     if (!this.scales || this.mode === HistogramMode.OFFSET) return [];
     const yScale = this.scales.countScale;

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -906,6 +906,29 @@ describe('histogram test', () => {
         fixture.detectChanges();
         expect(doHistogramsHaveColor(fixture)).toEqual([false, false, false]);
       });
+
+      it('puts color on histogram that mouse hovers over', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: 400}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.componentInstance.linkedTime = {start: {step: 5}, end: null};
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const gs = fixture.debugElement.queryAll(By.css('g.histogram'));
+
+        gs[0].triggerEventHandler('mouseenter', {target: gs[0].nativeElement});
+        fixture.detectChanges();
+        expect(doHistogramsHaveColor(fixture)).toEqual([true, true, false]);
+
+        gs[0].triggerEventHandler('mouseleave', {target: gs[0].nativeElement});
+        fixture.detectChanges();
+        expect(doHistogramsHaveColor(fixture)).toEqual([false, true, false]);
+      });
     });
 
     describe('multi step', () => {

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -927,13 +927,48 @@ describe('histogram test', () => {
           target: firstHistogram.nativeElement,
         });
         fixture.detectChanges();
+        // StepIndex 1 is hightlight on selected step;  stepIndex 0 is hightlight on
+        // mouse hovering.
         expect(doHistogramsHaveColor(fixture)).toEqual([true, true, false]);
 
         firstHistogram.triggerEventHandler('mouseleave', {
           target: firstHistogram.nativeElement,
         });
         fixture.detectChanges();
+        // StepIndex 1 is hightlight on selected step;  stepIndex 0 is not hightlight
+        // because the mouse has left.
         expect(doHistogramsHaveColor(fixture)).toEqual([false, true, false]);
+      });
+
+      it('does not affect colored histogram on linked time disabled', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: 400}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.componentInstance.linkedTime = null;
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const firstHistogram = fixture.debugElement.queryAll(
+          By.css('g.histogram')
+        )[0];
+
+        firstHistogram.triggerEventHandler('mouseenter', {
+          target: firstHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // All histograms are colored.
+        expect(doHistogramsHaveColor(fixture)).toEqual([true, true, true]);
+
+        firstHistogram.triggerEventHandler('mouseleave', {
+          target: firstHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // All histograms are colored.
+        expect(doHistogramsHaveColor(fixture)).toEqual([true, true, true]);
       });
     });
 

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -919,13 +919,13 @@ describe('histogram test', () => {
         fixture.detectChanges();
         intersectionObserver.simulateVisibilityChange(fixture, true);
 
-        const gs = fixture.debugElement.queryAll(By.css('g.histogram'));
+        const firstHistogram = fixture.debugElement.queryAll(By.css('g.histogram'))[0];
 
-        gs[0].triggerEventHandler('mouseenter', {target: gs[0].nativeElement});
+        firstHistogram.triggerEventHandler('mouseenter', {target: firstHistogram.nativeElement});
         fixture.detectChanges();
         expect(doHistogramsHaveColor(fixture)).toEqual([true, true, false]);
 
-        gs[0].triggerEventHandler('mouseleave', {target: gs[0].nativeElement});
+        firstHistogram.triggerEventHandler('mouseleave', {target: firstHistogram.nativeElement});
         fixture.detectChanges();
         expect(doHistogramsHaveColor(fixture)).toEqual([false, true, false]);
       });

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -919,13 +919,19 @@ describe('histogram test', () => {
         fixture.detectChanges();
         intersectionObserver.simulateVisibilityChange(fixture, true);
 
-        const firstHistogram = fixture.debugElement.queryAll(By.css('g.histogram'))[0];
+        const firstHistogram = fixture.debugElement.queryAll(
+          By.css('g.histogram')
+        )[0];
 
-        firstHistogram.triggerEventHandler('mouseenter', {target: firstHistogram.nativeElement});
+        firstHistogram.triggerEventHandler('mouseenter', {
+          target: firstHistogram.nativeElement,
+        });
         fixture.detectChanges();
         expect(doHistogramsHaveColor(fixture)).toEqual([true, true, false]);
 
-        firstHistogram.triggerEventHandler('mouseleave', {target: firstHistogram.nativeElement});
+        firstHistogram.triggerEventHandler('mouseleave', {
+          target: firstHistogram.nativeElement,
+        });
         fixture.detectChanges();
         expect(doHistogramsHaveColor(fixture)).toEqual([false, true, false]);
       });


### PR DESCRIPTION
On single selection currently histogram card only show data with the matched step. We want to enable color displaying on those hovered steps.

This could not be done in css (using `:hover`) is because the color comes from d3 (with `d3ColorScale`). Thus we add/remove `.no-color` class on mouse enter/leave.

Screenshot: selected step 0, hover over step 235
<img width="583" alt="Screen Shot 2022-03-03 at 8 25 16 PM" src="https://user-images.githubusercontent.com/1131010/156826708-537a1433-000d-40f7-b209-8800bd7cfccb.png">

