### PR TITLE
plugins: add permission denied code to tb server

### DIFF
--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
@@ -38,6 +38,9 @@ function handleError(e: any) {
     if (e.status === 404) {
       status = PluginsListFailureCode.NOT_FOUND;
     }
+    if (e.status === 403) {
+      status = PluginsListFailureCode.PERMISSION_DENIED;
+    }
   }
   return throwError(new TBServerError(status));
 }

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source_test.ts
@@ -145,6 +145,23 @@ describe('tb_server_data_source', () => {
         );
       }));
 
+      it('handles 403 failures as PERMISSION_DENIED', fakeAsync(() => {
+        const error = jasmine.createSpy();
+        dataSource
+          .fetchPluginsListing([])
+          .subscribe(jasmine.createSpy(), error);
+
+        httpMock
+          .expectOne('data/plugins_listing')
+          .error(new ErrorEvent('FakeError'), {status: 403});
+        // Flush the promise in the microtask.
+        flush();
+
+        expect(error).toHaveBeenCalledWith(
+          new TBServerError(PluginsListFailureCode.PERMISSION_DENIED)
+        );
+      }));
+
       it('handles other failures as UNKNOWN', fakeAsync(() => {
         const error = jasmine.createSpy();
         dataSource


### PR DESCRIPTION
In #5582  we added "Permission denied" to the failure code. Here in this pr we check the return http error code; if it is 403 then we set the failure code to be `PERMISSION_DENIED`