### PR TITLE
Create FobCardAdapter interface and use it for Histograms

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -334,6 +334,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/widgets:resize_detector_test",
         "//tensorboard/webapp/widgets:resize_detector_testing",
         "//tensorboard/webapp/widgets/content_wrapping_input:content_wrapping_input_tests",
+        "//tensorboard/webapp/widgets/dropdown:dropdown_tests",
         "//tensorboard/webapp/widgets/experiment_alias:experiment_alias_test",
         "//tensorboard/webapp/widgets/filter_input:filter_input_test",
         "//tensorboard/webapp/widgets/histogram:histogram_test",

--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -211,6 +211,15 @@ tf_ts_library(
     ],
 )
 
+# This is a dummy rule used as a @angular/material/select/testing dependency.
+tf_ts_library(
+    name = "expect_angular_material_select_testing",
+    srcs = [],
+    deps = [
+        "@npm//@angular/material",
+    ],
+)
+
 # This is a dummy rule used as a @angular/material/slide_toggle dependency.
 tf_ts_library(
     name = "expect_angular_material_slide_toggle",

--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -47,6 +47,7 @@ tf_ts_library(
     visibility = ["//tensorboard/webapp/metrics:__subpackages__"],
     deps = [
         "//tensorboard/webapp/widgets/histogram:types",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
     ],
 )
 

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -13,8 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {HistogramMode} from '../widgets/histogram/histogram_types';
+import {LinkedTime} from '../widgets/linked_time_fob/linked_time_types';
 
-export {HistogramMode};
+export {HistogramMode, LinkedTime};
 
 export enum PluginType {
   SCALARS = 'scalars',
@@ -102,8 +103,3 @@ export interface URLDeserializedState {
 
 export const SCALARS_SMOOTHING_MIN = 0;
 export const SCALARS_SMOOTHING_MAX = 0.999;
-
-export interface LinkedTime {
-  start: {step: number};
-  end: {step: number} | null;
-}

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -32,8 +32,11 @@ tf_ts_library(
     srcs = ["dropdown_test.ts"],
     deps = [
         ":dropdown",
+        "//tensorboard/webapp/angular:expect_angular_cdk_testing_testbed",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_material_select",
+        "//tensorboard/webapp/angular:expect_angular_material_select_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -23,5 +23,19 @@ tf_ng_module(
         "//tensorboard/webapp/angular:expect_angular_material_select",
         "@npm//@angular/common",
         "@npm//@angular/core",
+    ],
+)
+
+tf_ts_library(
+    name = "dropdown_tests",
+    testonly = True,
+    srcs = ["dropdown_test.ts"],
+    deps = [
+        ":dropdown",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_material_select",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@types/jasmine",
     ],
 )

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -21,6 +21,10 @@ export interface DropdownOption {
    * Whether the option should appear non-interactable. 'enabled' by default.
    */
   disabled?: boolean;
+  /**
+   * Optional alias for the displayText.
+   */
+  displayAlias?: string;
 }
 
 /**
@@ -38,6 +42,7 @@ export interface DropdownOption {
         [value]="option.value"
         [disabled]="option.disabled"
       >
+        <b *ngIf="option.displayAlias">{{ option.displayAlias }}: </b>
         {{ option.displayText }}
       </mat-option>
     </mat-select>

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -42,7 +42,7 @@ export interface DropdownOption {
         [value]="option.value"
         [disabled]="option.disabled"
       >
-        <b *ngIf="option.displayAlias">{{ option.displayAlias }}: </b>
+        <b *ngIf="option.displayAlias">{{ option.displayAlias }}:</b>
         {{ option.displayText }}
       </mat-option>
     </mat-select>
@@ -52,5 +52,5 @@ export interface DropdownOption {
 export class DropdownComponent {
   @Input() value = '';
   @Input() options: DropdownOption[] = [];
-  @Output() selectionChange = new EventEmitter<any>();
+  @Output() readonly selectionChange = new EventEmitter<any>();
 }

--- a/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
@@ -12,10 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component, Input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatSelectModule} from '@angular/material/select';
+import {MatSelectHarness} from '@angular/material/select/testing';
 import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {DropdownComponent, DropdownOption} from './dropdown_component';
 
 /**
@@ -47,7 +50,7 @@ describe('tb-dropdown', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatSelectModule],
+      imports: [MatSelectModule, NoopAnimationsModule],
       declarations: [DropdownComponent, TestableComponent],
     }).compileComponents();
   });
@@ -64,8 +67,8 @@ describe('tb-dropdown', () => {
     return fixture;
   }
 
-  it('renders options with no aliases', () => {
-    let fixture = createTestableComponent({
+  it('renders options with no aliases', async () => {
+    const fixture = createTestableComponent({
       expId: '1',
       configOptions: [
         {
@@ -81,6 +84,7 @@ describe('tb-dropdown', () => {
         },
       ],
     });
+    const loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
 
     const dropdown = fixture.debugElement.query(byCss.DROPDOWN);
@@ -93,21 +97,33 @@ describe('tb-dropdown', () => {
       }),
       jasmine.objectContaining({value: '1', displayText: 'abc'}),
     ]);
-    // TODO(ytjing): Figure out how to test DOM content.
+
+    // Test DOM content.
+    const selectHarness = await loader.getHarness(MatSelectHarness);
+    await selectHarness.open();
+
+    const options = await selectHarness.getOptions();
+    expect(options.length).toBe(2);
+
+    expect(await options[0].getText()).toBe('none');
+    expect(await options[0].isDisabled()).toBeTrue();
+
+    expect(await options[1].getText()).toBe('abc');
+    expect(await options[1].isDisabled()).toBeFalsy();
   });
 
-  it('renders options with valid aliases', () => {
-    let fixture = createTestableComponent({
+  it('renders options with valid aliases', async () => {
+    const fixture = createTestableComponent({
       expId: '2',
       configOptions: [
         {
           value: '2',
           displayText: 'test experiment name',
-          disabled: false,
           displayAlias: 'test alias',
         },
       ],
     });
+    const loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
 
     const dropdown = fixture.debugElement.query(byCss.DROPDOWN);
@@ -119,11 +135,20 @@ describe('tb-dropdown', () => {
         displayAlias: 'test alias',
       }),
     ]);
-    // TODO(ytjing): Figure out how to test DOM content.
+
+    // Test DOM content.
+    const selectHarness = await loader.getHarness(MatSelectHarness);
+    await selectHarness.open();
+
+    const options = await selectHarness.getOptions();
+    expect(options.length).toBe(1);
+
+    expect(await options[0].getText()).toBe('test alias: test experiment name');
+    expect(await options[0].isDisabled()).toBeFalsy();
   });
 
   it('changes selection', async () => {
-    let fixture = createTestableComponent({
+    const fixture = createTestableComponent({
       expId: '1',
       configOptions: [
         {

--- a/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
@@ -1,0 +1,148 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Component, Input} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatSelectModule} from '@angular/material/select';
+import {By} from '@angular/platform-browser';
+import {DropdownComponent, DropdownOption} from './dropdown_component';
+
+/**
+ * Test class that uses the <tb-dropdown> component.
+ */
+@Component({
+  selector: 'testing-component',
+  template: `
+    <tb-dropdown
+      [value]="expId"
+      [options]="configOptions"
+      (selectionChange)="onSelectionChange($event)"
+    ></tb-dropdown>
+  `,
+})
+class TestableComponent {
+  @Input() expId!: string;
+  @Input() configOptions!: DropdownOption[];
+  @Input() onSelectionChange!: (event: {value: string}) => void;
+}
+
+describe('tb-dropdown', () => {
+  let selectionChangeSpy: jasmine.Spy;
+
+  const byCss = {
+    DROPDOWN: By.directive(DropdownComponent),
+    MAT_SELECT: By.css('mat-select'),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatSelectModule],
+      declarations: [DropdownComponent, TestableComponent],
+    }).compileComponents();
+  });
+
+  function createTestableComponent(input: {
+    expId?: string;
+    configOptions?: DropdownOption[];
+  }): ComponentFixture<TestableComponent> {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.componentInstance.expId = input.expId || '';
+    fixture.componentInstance.configOptions = input.configOptions || [];
+    selectionChangeSpy = jasmine.createSpy();
+    fixture.componentInstance.onSelectionChange = selectionChangeSpy;
+    return fixture;
+  }
+
+  it('renders options with no aliases', () => {
+    let fixture = createTestableComponent({
+      expId: '1',
+      configOptions: [
+        {
+          value: '',
+          displayText: 'none',
+          disabled: true,
+        },
+        {
+          value: '1',
+          displayText: 'abc',
+          disabled: false,
+          displayAlias: '', // empty aliases will be ignored
+        },
+      ],
+    });
+    fixture.detectChanges();
+
+    const dropdown = fixture.debugElement.query(byCss.DROPDOWN);
+    expect(dropdown.componentInstance.value).toEqual('1');
+    expect(dropdown.componentInstance.options).toEqual([
+      jasmine.objectContaining({
+        value: '',
+        displayText: 'none',
+        disabled: true,
+      }),
+      jasmine.objectContaining({value: '1', displayText: 'abc'}),
+    ]);
+    // TODO(ytjing): Figure out how to test DOM content.
+  });
+
+  it('renders options with valid aliases', () => {
+    let fixture = createTestableComponent({
+      expId: '2',
+      configOptions: [
+        {
+          value: '2',
+          displayText: 'test experiment name',
+          disabled: false,
+          displayAlias: 'test alias',
+        },
+      ],
+    });
+    fixture.detectChanges();
+
+    const dropdown = fixture.debugElement.query(byCss.DROPDOWN);
+    expect(dropdown.componentInstance.value).toEqual('2');
+    expect(dropdown.componentInstance.options).toEqual([
+      jasmine.objectContaining({
+        value: '2',
+        displayText: 'test experiment name',
+        displayAlias: 'test alias',
+      }),
+    ]);
+    // TODO(ytjing): Figure out how to test DOM content.
+  });
+
+  it('changes selection', async () => {
+    let fixture = createTestableComponent({
+      expId: '1',
+      configOptions: [
+        {
+          value: '1',
+          displayText: 'abc',
+        },
+        {
+          value: '2',
+          displayText: 'efg',
+        },
+      ],
+    });
+    fixture.detectChanges();
+
+    // Triggers selection change event.
+    const matSelect = fixture.debugElement.query(byCss.MAT_SELECT);
+    matSelect.triggerEventHandler('selectionChange', {value: '2'});
+    fixture.detectChanges();
+
+    expect(selectionChangeSpy).toHaveBeenCalledOnceWith('2');
+  });
+});

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -22,7 +22,6 @@ tf_ng_module(
     ],
     deps = [
         ":types",
-        "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/third_party:d3",
         "//tensorboard/webapp/widgets:resize_detector",
         "//tensorboard/webapp/widgets/intersection_observer",

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -13,8 +13,8 @@ tf_ng_module(
     name = "histogram",
     srcs = [
         "histogram_component.ts",
-        "histogram_module.ts",
         "histogram_fob_adapter.ts",
+        "histogram_module.ts",
     ],
     assets = [
         "histogram_component.ng.html",
@@ -38,9 +38,9 @@ tf_ts_library(
     name = "histogram_test",
     testonly = True,
     srcs = [
+        "histogram_fob_adapter_test.ts",
         "histogram_test.ts",
         "histogram_util_test.ts",
-        "histogram_fob_adapter_test.ts"
     ],
     deps = [
         ":histogram",

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -15,6 +15,7 @@ tf_ng_module(
         "histogram_component.ts",
         "histogram_fob_adapter.ts",
         "histogram_module.ts",
+        "histogram_fob_adapter.ts",
     ],
     assets = [
         "histogram_component.ng.html",
@@ -40,6 +41,7 @@ tf_ts_library(
         "histogram_fob_adapter_test.ts",
         "histogram_test.ts",
         "histogram_util_test.ts",
+        "histogram_fob_adapter_test.ts"
     ],
     deps = [
         ":histogram",

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -14,6 +14,7 @@ tf_ng_module(
     srcs = [
         "histogram_component.ts",
         "histogram_module.ts",
+        "histogram_fob_adapter.ts",
     ],
     assets = [
         "histogram_component.ng.html",
@@ -26,6 +27,7 @@ tf_ng_module(
         "//tensorboard/webapp/widgets:resize_detector",
         "//tensorboard/webapp/widgets/intersection_observer",
         "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//rxjs",
@@ -38,14 +40,16 @@ tf_ts_library(
     srcs = [
         "histogram_test.ts",
         "histogram_util_test.ts",
+        "histogram_fob_adapter_test.ts"
     ],
     deps = [
         ":histogram",
         ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/third_party:d3",
         "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",
-        "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -34,7 +34,7 @@ limitations under the License.
       </g>
     </g>
   </svg>
-  <div class="axis y-axis">
+  <div #yAxisOverlay class="axis y-axis">
     <svg>
       <g #yAxis></g>
       <!-- d3 places axis label at 9px right from the left edge. -->
@@ -54,8 +54,6 @@ limitations under the License.
       <linked-time-fob-controller
         [axisDirection]="axisDirection"
         [linkedTime]="linkedTime"
-        [steps]="getSteps()"
-        [temporalScale]="scales.temporalScale"
         [cardAdapter]="cardAdapter"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
       ></linked-time-fob-controller>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -83,6 +83,7 @@ limitations under the License.
         [style.color]="getHistogramFill(datum)"
         (mouseenter)="updateColorOnHover($event, true)"
         (mouseleave)="updateColorOnHover($event, false)"
+        (click)="onSelectTimeRangeChange(datum)"
       >
         <line
           *ngIf="mode === HistogramMode.OFFSET"

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -81,8 +81,8 @@ limitations under the License.
         [class.histogram]="true"
         [class.no-color]="!isDatumInLinkedTimeRange(datum)"
         [style.color]="getHistogramFill(datum)"
-        (mouseenter)="updateColorOnHover($event, true)"
-        (mouseleave)="updateColorOnHover($event, false)"
+        (mouseenter)="updateColorOnHover($event, datum, true)"
+        (mouseleave)="updateColorOnHover($event, datum, false)"
         (click)="onSelectTimeRangeChange(datum)"
       >
         <line

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -54,11 +54,6 @@ limitations under the License.
       <linked-time-fob-controller
         [axisDirection]="axisDirection"
         [linkedTime]="linkedTime"
-<<<<<<< HEAD
-=======
-        [steps]="getSteps()"
-        [temporalScale]="scales.temporalScale"
->>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
         [cardAdapter]="cardAdapter"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
       ></linked-time-fob-controller>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -54,6 +54,11 @@ limitations under the License.
       <linked-time-fob-controller
         [axisDirection]="axisDirection"
         [linkedTime]="linkedTime"
+<<<<<<< HEAD
+=======
+        [steps]="getSteps()"
+        [temporalScale]="scales.temporalScale"
+>>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
         [cardAdapter]="cardAdapter"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
       ></linked-time-fob-controller>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -56,6 +56,7 @@ limitations under the License.
         [linkedTime]="linkedTime"
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"
+        [cardAdapter]="cardAdapter"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
       ></linked-time-fob-controller>
     </ng-container>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.scss
@@ -235,3 +235,10 @@ svg {
     display: block;
   }
 }
+
+.fob-container {
+  height: 100%;
+  position: absolute;
+  right: 0;
+  top: 0;
+}

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -30,7 +30,8 @@ import {takeUntil} from 'rxjs/operators';
 import {LinkedTime} from '../../metrics/types';
 import * as d3 from '../../third_party/d3';
 import {HCLColor} from '../../third_party/d3';
-import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
+import {AxisDirection} from '../linked_time_fob/types';
+import {HistogramFobAdapter} from './histogram_fob_adapter';
 import {
   Bin,
   HistogramData,
@@ -41,7 +42,7 @@ import {
 
 type BinScale = d3.ScaleLinear<number, number>;
 type CountScale = d3.ScaleLinear<number, number>;
-type TemporalScale =
+export type TemporalScale =
   | d3.ScaleLinear<number, number>
   | d3.ScaleTime<number, number>;
 type D3ColorScale = d3.ScaleLinear<HCLColor, string>;
@@ -106,6 +107,8 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   readonly HistogramMode = HistogramMode;
   readonly TimeProperty = TimeProperty;
+
+  private cardAdapter: HistogramFobAdapter | null = null;
 
   tooltipData: null | TooltipData = null;
 
@@ -317,6 +320,14 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
     this.renderYAxis();
     // Update Angular rendered part of the histogram.
     this.changeDetector.detectChanges();
+    if (this.cardAdapter === null) {
+      this.cardAdapter = new HistogramFobAdapter(
+        this.scales!.temporalScale,
+        this.getSteps()
+      );
+    } else {
+      this.cardAdapter.scale = this.scales.temporalScale;
+    }
   }
 
   private computeScales(data: HistogramData): Scales {

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -27,11 +27,11 @@ import {
 } from '@angular/core';
 import {fromEvent, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
-import {LinkedTime} from '../../metrics/types';
 import * as d3 from '../../third_party/d3';
 import {HCLColor} from '../../third_party/d3';
-import {AxisDirection} from '../linked_time_fob/types';
 import {HistogramFobAdapter} from './histogram_fob_adapter';
+import {AxisDirection} from '../linked_time_fob/types';
+import {LinkedTime} from '../linked_time_fob/linked_time_types';
 import {
   Bin,
   HistogramData,

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -29,11 +29,6 @@ import {fromEvent, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import * as d3 from '../../third_party/d3';
 import {HCLColor} from '../../third_party/d3';
-<<<<<<< HEAD
-import {HistogramFobAdapter} from './histogram_fob_adapter';
-import {AxisDirection} from '../linked_time_fob/types';
-=======
->>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
 import {LinkedTime} from '../linked_time_fob/linked_time_types';
 import {AxisDirection} from '../linked_time_fob/types';
 import {HistogramFobAdapter} from './histogram_fob_adapter';
@@ -373,6 +368,7 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
       this.cardAdapter = new HistogramFobAdapter(
         this.scales!.temporalScale,
 <<<<<<< HEAD
+<<<<<<< HEAD
         this.getSteps(),
         this.yAxisOverlay?.nativeElement.getBoundingClientRect()
       );
@@ -383,6 +379,10 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
       }
 =======
         this.getSteps()
+=======
+        this.getSteps(),
+        this.yAxisOverlay!.nativeElement.getBoundingClientRect()
+>>>>>>> d4a26bf02 (remove AxisOverlay dependency)
       );
     } else {
 >>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -90,6 +90,8 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
   @ViewChild('yAxis') private readonly yAxis!: ElementRef;
   @ViewChild('content') private readonly content!: ElementRef;
   @ViewChild('histograms') private readonly histograms!: ElementRef;
+  @ViewChild('yAxisOverlay')
+  private readonly yAxisOverlay!: ElementRef;
 
   @Input() mode: HistogramMode = HistogramMode.OFFSET;
 
@@ -323,9 +325,14 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
     if (this.cardAdapter === null) {
       this.cardAdapter = new HistogramFobAdapter(
         this.scales!.temporalScale,
-        this.getSteps()
+        this.getSteps(),
+        this.yAxisOverlay?.nativeElement.getBoundingClientRect()
       );
     } else {
+      if (this.yAxisOverlay) {
+        this.cardAdapter.containerRect =
+          this.yAxisOverlay.nativeElement.getBoundingClientRect();
+      }
       this.cardAdapter.scale = this.scales.temporalScale;
     }
   }

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -29,9 +29,14 @@ import {fromEvent, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import * as d3 from '../../third_party/d3';
 import {HCLColor} from '../../third_party/d3';
+<<<<<<< HEAD
 import {HistogramFobAdapter} from './histogram_fob_adapter';
 import {AxisDirection} from '../linked_time_fob/types';
+=======
+>>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
 import {LinkedTime} from '../linked_time_fob/linked_time_types';
+import {AxisDirection} from '../linked_time_fob/types';
+import {HistogramFobAdapter} from './histogram_fob_adapter';
 import {
   Bin,
   HistogramData,
@@ -367,6 +372,7 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
     if (this.cardAdapter === null) {
       this.cardAdapter = new HistogramFobAdapter(
         this.scales!.temporalScale,
+<<<<<<< HEAD
         this.getSteps(),
         this.yAxisOverlay?.nativeElement.getBoundingClientRect()
       );
@@ -375,6 +381,11 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
         this.cardAdapter.containerRect =
           this.yAxisOverlay.nativeElement.getBoundingClientRect();
       }
+=======
+        this.getSteps()
+      );
+    } else {
+>>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
       this.cardAdapter.scale = this.scales.temporalScale;
     }
   }

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -265,9 +265,17 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
       : '';
   }
 
-  updateColorOnHover(event: MouseEvent, isHover: boolean) {
+  updateColorOnHover(
+    event: MouseEvent,
+    datum: HistogramDatum,
+    isHover: boolean
+  ) {
     // When link time is disabled all histogram should be colored.
     if (!this.isLinkedTimeEnabled(this.linkedTime)) {
+      return;
+    }
+    // Target histogram should be colored When datum is in range.
+    if (this.isDatumInLinkedTimeRange(datum)) {
       return;
     }
     if (isHover) {

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -295,6 +295,40 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
     this.updateChartIfVisible();
   }
 
+  /**
+   * Handles linked time range change on clicking a histogram. When a single step is
+   * currently selected, clicking on a histogram step will create a range incorporating
+   * the currently selected step and the clicked step. When a range is currently
+   * selected, clicking on a histogram step outside that range will expand the range to
+   * include the clicked step.
+   */
+  onSelectTimeRangeChange(datum: HistogramDatum) {
+    if (!this.isLinkedTimeEnabled(this.linkedTime)) {
+      return;
+    }
+
+    const startStep = this.linkedTime.start.step;
+    const endStep = this.linkedTime.end?.step;
+    const nextStartStep = datum.step < startStep ? datum.step : startStep;
+    let nextEndStep = endStep;
+
+    if (nextEndStep === undefined) {
+      nextEndStep = datum.step > startStep ? datum.step : startStep;
+    } else {
+      nextEndStep = datum.step > nextEndStep ? datum.step : nextEndStep;
+    }
+
+    if (
+      (nextStartStep !== startStep || nextEndStep !== endStep) &&
+      nextStartStep !== nextEndStep
+    ) {
+      this.onSelectTimeChanged.emit({
+        start: {step: nextStartStep},
+        end: {step: nextEndStep},
+      });
+    }
+  }
+
   private getTimeValue(datum: HistogramDatum): number {
     switch (this.timeProperty) {
       case TimeProperty.WALL_TIME:

--- a/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
@@ -20,11 +20,13 @@ import {TemporalScale} from './histogram_component';
 export class HistogramFobAdapter implements FobCardAdapter {
   scale: TemporalScale;
   steps: number[];
+  containerRect: DOMRect;
   upperBound: number;
   lowerBound: number;
-  constructor(scale: TemporalScale, steps: number[]) {
+  constructor(scale: TemporalScale, steps: number[], containerRect: DOMRect) {
     this.scale = scale;
     this.steps = steps;
+    this.containerRect = containerRect;
     this.lowerBound = steps[0];
     this.upperBound = steps[steps.length - 1];
   }
@@ -36,14 +38,10 @@ export class HistogramFobAdapter implements FobCardAdapter {
   stepToPixel(step: number, domain: [number, number]): number {
     return this.scale(step);
   }
-  getStepHigherThanMousePosition(
-    position: number,
-    axisOverlay: ElementRef
-  ): number {
+  getStepHigherThanMousePosition(position: number): number {
     let stepIndex = 0;
     while (
-      position - axisOverlay.nativeElement.getBoundingClientRect().top >
-        this.scale(this.steps[stepIndex]) &&
+      position - this.containerRect.top > this.scale(this.steps[stepIndex]) &&
       this.steps[stepIndex] < this.upperBound
     ) {
       stepIndex++;
@@ -51,14 +49,10 @@ export class HistogramFobAdapter implements FobCardAdapter {
     return this.steps[stepIndex];
   }
 
-  getStepLowerThanMousePosition(
-    position: number,
-    axisOverlay: ElementRef
-  ): number {
+  getStepLowerThanMousePosition(position: number): number {
     let stepIndex = this.steps.length - 1;
     while (
-      position - axisOverlay.nativeElement.getBoundingClientRect().top <
-        this.scale(this.steps[stepIndex]) &&
+      position - this.containerRect.top < this.scale(this.steps[stepIndex]) &&
       this.steps[stepIndex] > this.lowerBound
     ) {
       stepIndex--;

--- a/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 /* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+=======
+>>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
 import {ElementRef} from '@angular/core';
 import {FobCardAdapter} from '../linked_time_fob/types';
 import {TemporalScale} from './histogram_component';
@@ -20,6 +23,7 @@ import {TemporalScale} from './histogram_component';
 export class HistogramFobAdapter implements FobCardAdapter {
   scale: TemporalScale;
   steps: number[];
+<<<<<<< HEAD
   containerRect: DOMRect;
   upperBound: number;
   lowerBound: number;
@@ -27,6 +31,13 @@ export class HistogramFobAdapter implements FobCardAdapter {
     this.scale = scale;
     this.steps = steps;
     this.containerRect = containerRect;
+=======
+  upperBound: number;
+  lowerBound: number;
+  constructor(scale: TemporalScale, steps: number[]) {
+    this.scale = scale;
+    this.steps = steps;
+>>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
     this.lowerBound = steps[0];
     this.upperBound = steps[steps.length - 1];
   }
@@ -38,10 +49,21 @@ export class HistogramFobAdapter implements FobCardAdapter {
   stepToPixel(step: number, domain: [number, number]): number {
     return this.scale(step);
   }
+<<<<<<< HEAD
   getStepHigherThanMousePosition(position: number): number {
     let stepIndex = 0;
     while (
       position - this.containerRect.top > this.scale(this.steps[stepIndex]) &&
+=======
+  getStepHigherThanMousePosition(
+    position: number,
+    axisOverlay: ElementRef
+  ): number {
+    let stepIndex = 0;
+    while (
+      position - axisOverlay.nativeElement.getBoundingClientRect().top >
+        this.scale(this.steps[stepIndex]) &&
+>>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
       this.steps[stepIndex] < this.upperBound
     ) {
       stepIndex++;
@@ -49,10 +71,21 @@ export class HistogramFobAdapter implements FobCardAdapter {
     return this.steps[stepIndex];
   }
 
+<<<<<<< HEAD
   getStepLowerThanMousePosition(position: number): number {
     let stepIndex = this.steps.length - 1;
     while (
       position - this.containerRect.top < this.scale(this.steps[stepIndex]) &&
+=======
+  getStepLowerThanMousePosition(
+    position: number,
+    axisOverlay: ElementRef
+  ): number {
+    let stepIndex = this.steps.length - 1;
+    while (
+      position - axisOverlay.nativeElement.getBoundingClientRect().top <
+        this.scale(this.steps[stepIndex]) &&
+>>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
       this.steps[stepIndex] > this.lowerBound
     ) {
       stepIndex--;

--- a/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 /* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-=======
->>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
-import {ElementRef} from '@angular/core';
 import {FobCardAdapter} from '../linked_time_fob/types';
 import {TemporalScale} from './histogram_component';
 
 export class HistogramFobAdapter implements FobCardAdapter {
   scale: TemporalScale;
   steps: number[];
-<<<<<<< HEAD
   containerRect: DOMRect;
   upperBound: number;
   lowerBound: number;
@@ -31,13 +26,6 @@ export class HistogramFobAdapter implements FobCardAdapter {
     this.scale = scale;
     this.steps = steps;
     this.containerRect = containerRect;
-=======
-  upperBound: number;
-  lowerBound: number;
-  constructor(scale: TemporalScale, steps: number[]) {
-    this.scale = scale;
-    this.steps = steps;
->>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
     this.lowerBound = steps[0];
     this.upperBound = steps[steps.length - 1];
   }
@@ -49,21 +37,11 @@ export class HistogramFobAdapter implements FobCardAdapter {
   stepToPixel(step: number, domain: [number, number]): number {
     return this.scale(step);
   }
-<<<<<<< HEAD
+
   getStepHigherThanMousePosition(position: number): number {
     let stepIndex = 0;
     while (
       position - this.containerRect.top > this.scale(this.steps[stepIndex]) &&
-=======
-  getStepHigherThanMousePosition(
-    position: number,
-    axisOverlay: ElementRef
-  ): number {
-    let stepIndex = 0;
-    while (
-      position - axisOverlay.nativeElement.getBoundingClientRect().top >
-        this.scale(this.steps[stepIndex]) &&
->>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
       this.steps[stepIndex] < this.upperBound
     ) {
       stepIndex++;
@@ -71,21 +49,10 @@ export class HistogramFobAdapter implements FobCardAdapter {
     return this.steps[stepIndex];
   }
 
-<<<<<<< HEAD
   getStepLowerThanMousePosition(position: number): number {
     let stepIndex = this.steps.length - 1;
     while (
       position - this.containerRect.top < this.scale(this.steps[stepIndex]) &&
-=======
-  getStepLowerThanMousePosition(
-    position: number,
-    axisOverlay: ElementRef
-  ): number {
-    let stepIndex = this.steps.length - 1;
-    while (
-      position - axisOverlay.nativeElement.getBoundingClientRect().top <
-        this.scale(this.steps[stepIndex]) &&
->>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
       this.steps[stepIndex] > this.lowerBound
     ) {
       stepIndex--;

--- a/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
@@ -1,3 +1,18 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 import {ElementRef} from '@angular/core';
 import {FobCardAdapter} from '../linked_time_fob/types';
 import {TemporalScale} from './histogram_component';

--- a/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_fob_adapter.ts
@@ -1,0 +1,53 @@
+import {ElementRef} from '@angular/core';
+import {FobCardAdapter} from '../linked_time_fob/types';
+import {TemporalScale} from './histogram_component';
+
+export class HistogramFobAdapter implements FobCardAdapter {
+  scale: TemporalScale;
+  steps: number[];
+  upperBound: number;
+  lowerBound: number;
+  constructor(scale: TemporalScale, steps: number[]) {
+    this.scale = scale;
+    this.steps = steps;
+    this.lowerBound = steps[0];
+    this.upperBound = steps[steps.length - 1];
+  }
+  setBounds(overrides: {lowerOverride?: number; higherOverride?: number}) {
+    this.lowerBound = overrides.lowerOverride || this.steps[0];
+    this.upperBound =
+      overrides.higherOverride || this.steps[this.steps.length - 1];
+  }
+  stepToPixel(step: number, domain: [number, number]): number {
+    return this.scale(step);
+  }
+  getStepHigherThanMousePosition(
+    position: number,
+    axisOverlay: ElementRef
+  ): number {
+    let stepIndex = 0;
+    while (
+      position - axisOverlay.nativeElement.getBoundingClientRect().top >
+        this.scale(this.steps[stepIndex]) &&
+      this.steps[stepIndex] < this.upperBound
+    ) {
+      stepIndex++;
+    }
+    return this.steps[stepIndex];
+  }
+
+  getStepLowerThanMousePosition(
+    position: number,
+    axisOverlay: ElementRef
+  ): number {
+    let stepIndex = this.steps.length - 1;
+    while (
+      position - axisOverlay.nativeElement.getBoundingClientRect().top <
+        this.scale(this.steps[stepIndex]) &&
+      this.steps[stepIndex] > this.lowerBound
+    ) {
+      stepIndex--;
+    }
+    return this.steps[stepIndex];
+  }
+}

--- a/tensorboard/webapp/widgets/histogram/histogram_fob_adapter_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_fob_adapter_test.ts
@@ -1,0 +1,143 @@
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ScaleLinear} from '../../third_party/d3';
+import {HistogramFobAdapter} from './histogram_fob_adapter';
+
+@Component({
+  selector: 'axis-overlay',
+  template: ` <div></div> `,
+})
+class AxisOverlayComponent {}
+
+describe('HistogramFobAdapter', () => {
+  let temporalScaleSpy: jasmine.Spy;
+  beforeEach;
+  function createInterface(customSteps?: number[]) {
+    temporalScaleSpy = jasmine.createSpy();
+    let scale = temporalScaleSpy as unknown as ScaleLinear<number, number>;
+    let steps = customSteps || [0, 1, 2, 3];
+    temporalScaleSpy.and.callFake((step: number) => {
+      return step;
+    });
+    return new HistogramFobAdapter(scale, steps);
+  }
+  describe('setBounds', () => {
+    it('sets bounds properly when given no overrides', () => {
+      let fobInterface = createInterface([100, 200, 5000]);
+      fobInterface.setBounds({});
+      expect(fobInterface.lowerBound).toEqual(100);
+      expect(fobInterface.upperBound).toEqual(5000);
+    });
+    it('sets bounds properly when given lower bound override', () => {
+      let fobInterface = createInterface([100, 200, 5000]);
+      fobInterface.setBounds({lowerOverride: 150});
+      expect(fobInterface.lowerBound).toEqual(150);
+      expect(fobInterface.upperBound).toEqual(5000);
+    });
+    it('sets bounds when given higher bound override', () => {
+      let fobInterface = createInterface([100, 200, 5000]);
+      fobInterface.setBounds({higherOverride: 250});
+      expect(fobInterface.lowerBound).toEqual(100);
+      expect(fobInterface.upperBound).toEqual(250);
+    });
+  });
+
+  describe('getStepHigherThanPosition', () => {
+    let fixture: ComponentFixture<AxisOverlayComponent>;
+    let overlayTop: number;
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        declarations: [AxisOverlayComponent],
+        schemas: [],
+      }).compileComponents();
+      fixture = TestBed.createComponent(AxisOverlayComponent);
+      fixture.detectChanges();
+      overlayTop = fixture.nativeElement.getBoundingClientRect().top;
+    });
+    it('gets step higher when position is not on a step', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      let stepHigher = fobInterface.getStepHigherThanMousePosition(
+        150 + overlayTop,
+        fixture
+      );
+      expect(stepHigher).toEqual(200);
+    });
+    it('gets step on given position when that position is on a step', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      let stepHigher = fobInterface.getStepHigherThanMousePosition(
+        300 + overlayTop,
+        fixture
+      );
+      expect(stepHigher).toEqual(300);
+    });
+    it('gets highest step when given position is higher than the max step', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      let stepHigher = fobInterface.getStepHigherThanMousePosition(
+        800 + overlayTop,
+        fixture
+      );
+      expect(stepHigher).toEqual(400);
+    });
+    it('gets lower step when given position is lower than the min step', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      let stepHigher = fobInterface.getStepHigherThanMousePosition(
+        10 + overlayTop,
+        fixture
+      );
+      expect(stepHigher).toEqual(100);
+    });
+  });
+
+  describe('getStepLowerThanPosition', () => {
+    let fixture: ComponentFixture<AxisOverlayComponent>;
+    let overlayTop: number;
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        declarations: [AxisOverlayComponent],
+        schemas: [],
+      }).compileComponents();
+      fixture = TestBed.createComponent(AxisOverlayComponent);
+      fixture.detectChanges();
+      overlayTop = fixture.nativeElement.getBoundingClientRect().top;
+    });
+    it('gets step lower when position is not on a step', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      let stepHigher = fobInterface.getStepLowerThanMousePosition(
+        250 + overlayTop,
+        fixture
+      );
+      expect(stepHigher).toEqual(200);
+    });
+    it('gets step on given position when that position is on a step', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      let stepHigher = fobInterface.getStepLowerThanMousePosition(
+        300 + overlayTop,
+        fixture
+      );
+      expect(stepHigher).toEqual(300);
+    });
+    it('gets highest step when given position is higher than the max step', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      let stepHigher = fobInterface.getStepLowerThanMousePosition(
+        800 + overlayTop,
+        fixture
+      );
+      expect(stepHigher).toEqual(400);
+    });
+    it('gets lower step when given position is lower than the min step', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      let stepHigher = fobInterface.getStepLowerThanMousePosition(
+        10 + overlayTop,
+        fixture
+      );
+      expect(stepHigher).toEqual(100);
+    });
+  });
+  describe('stepToPixel', () => {
+    it('calls the scale function', () => {
+      let fobInterface = createInterface([100, 200, 300, 400]);
+      fobInterface.stepToPixel(150, [0, 0]);
+      expect(temporalScaleSpy).toHaveBeenCalledOnceWith(150);
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/histogram/histogram_fob_adapter_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_fob_adapter_test.ts
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 /* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+=======
+>>>>>>> dcda3f4a0 (create shared adapter interface that will be used in multiple cards and use it in histogram card)
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ScaleLinear} from '../../third_party/d3';

--- a/tensorboard/webapp/widgets/histogram/histogram_fob_adapter_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_fob_adapter_test.ts
@@ -1,3 +1,18 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ScaleLinear} from '../../third_party/d3';

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -23,6 +23,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {IntersectionObserverTestingModule} from '../intersection_observer/intersection_observer_testing_module';
+import {LinkedTime} from '../linked_time_fob/linked_time_types';
 import {HistogramComponent, TooltipData} from './histogram_component';
 import {
   Bin,
@@ -65,6 +66,7 @@ function buildHistogramDatum(
       [name]="name"
       [data]="data"
       [linkedTime]="linkedTime"
+      (onSelectTimeChanged)="onSelectTimeChanged($event)"
     >
     </tb-histogram>
   `,
@@ -90,6 +92,7 @@ class TestableComponent {
     start: {step: number};
     end: {step: number} | null;
   } | null;
+  @Input() onSelectTimeChanged!: (linkedTime: LinkedTime) => void;
 
   simulateMouseMove(event: {
     target: SVGElement;
@@ -1003,6 +1006,126 @@ describe('histogram test', () => {
         };
         fixture.detectChanges();
         expect(doHistogramsHaveColor(fixture)).toEqual([false, false, false]);
+      });
+    });
+
+    describe('multi step range updated on click', () => {
+      let onSelectTimeChangedSpy: jasmine.Spy;
+      function createHistogramComponent() {
+        onSelectTimeChangedSpy = jasmine.createSpy();
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: 400}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+          buildHistogramDatum({step: 20, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.componentInstance.onSelectTimeChanged = onSelectTimeChangedSpy;
+
+        return fixture;
+      }
+
+      it('triggers select time action from single step to multi step', () => {
+        const fixture = createHistogramComponent();
+        fixture.componentInstance.linkedTime = {start: {step: 5}, end: null};
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const histograms = fixture.debugElement.queryAll(By.css('g.histogram'));
+
+        histograms[3].triggerEventHandler('click', null);
+        fixture.detectChanges();
+        expect(onSelectTimeChangedSpy).toHaveBeenCalledWith({
+          start: {step: 5},
+          end: {step: 20},
+        });
+      });
+
+      it('triggers select time action when clicked step is smaller than selected step', () => {
+        const fixture = createHistogramComponent();
+        fixture.componentInstance.linkedTime = {start: {step: 5}, end: null};
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const histograms = fixture.debugElement.queryAll(By.css('g.histogram'));
+
+        histograms[0].triggerEventHandler('click', null);
+        fixture.detectChanges();
+        expect(onSelectTimeChangedSpy).toHaveBeenCalledWith({
+          start: {step: 0},
+          end: {step: 5},
+        });
+      });
+
+      it('triggers select time action when clicked step is smaller than start step', () => {
+        const fixture = createHistogramComponent();
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: {step: 10},
+        };
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const histograms = fixture.debugElement.queryAll(By.css('g.histogram'));
+
+        histograms[0].triggerEventHandler('click', null);
+        fixture.detectChanges();
+        expect(onSelectTimeChangedSpy).toHaveBeenCalledWith({
+          start: {step: 0},
+          end: {step: 10},
+        });
+      });
+
+      it('triggers select time action when clicked step is larger than end step', () => {
+        const fixture = createHistogramComponent();
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: {step: 10},
+        };
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const histograms = fixture.debugElement.queryAll(By.css('g.histogram'));
+
+        histograms[3].triggerEventHandler('click', null);
+        fixture.detectChanges();
+        expect(onSelectTimeChangedSpy).toHaveBeenCalledWith({
+          start: {step: 5},
+          end: {step: 20},
+        });
+      });
+
+      it('does not trigger select time action when clicked step is within range', () => {
+        const fixture = createHistogramComponent();
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: {step: 20},
+        };
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const histograms = fixture.debugElement.queryAll(By.css('g.histogram'));
+
+        histograms[2].triggerEventHandler('click', null);
+        fixture.detectChanges();
+        expect(onSelectTimeChangedSpy).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger select time action when clicked step is same as start step', () => {
+        const fixture = createHistogramComponent();
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: null,
+        };
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const histograms = fixture.debugElement.queryAll(By.css('g.histogram'));
+
+        histograms[1].triggerEventHandler('click', null);
+        fixture.detectChanges();
+        expect(onSelectTimeChangedSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -1007,6 +1007,76 @@ describe('histogram test', () => {
         fixture.detectChanges();
         expect(doHistogramsHaveColor(fixture)).toEqual([false, false, false]);
       });
+
+      it('puts color on none-ranged histogram when mouse hovers over', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: 400}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: {step: 10},
+        };
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const firstHistogram = fixture.debugElement.queryAll(
+          By.css('g.histogram')
+        )[0];
+
+        firstHistogram.triggerEventHandler('mouseenter', {
+          target: firstHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // StepIndex 1,2 are hightlight because of selected range; stepIndex 0 is hightlight on
+        // mouse hovering.
+        expect(doHistogramsHaveColor(fixture)).toEqual([true, true, true]);
+
+        firstHistogram.triggerEventHandler('mouseleave', {
+          target: firstHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // StepIndex 1,2 are hightlight because of selected range; stepIndex 0 is not hightlight
+        // because the mouse has left.
+        expect(doHistogramsHaveColor(fixture)).toEqual([false, true, true]);
+      });
+
+      it('does not update color on ranged histogram when mouse hovers over', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: 400}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: {step: 10},
+        };
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const inRangeHistogram = fixture.debugElement.queryAll(
+          By.css('g.histogram')
+        )[1];
+
+        inRangeHistogram.triggerEventHandler('mouseenter', {
+          target: inRangeHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // StepIndex 1,2 are hightlight because of selected range;
+        expect(doHistogramsHaveColor(fixture)).toEqual([false, true, true]);
+
+        inRangeHistogram.triggerEventHandler('mouseleave', {
+          target: inRangeHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // StepIndex 1,2 are hightlight because of selected range;
+        expect(doHistogramsHaveColor(fixture)).toEqual([false, true, true]);
+      });
     });
 
     describe('multi step range updated on click', () => {

--- a/tensorboard/webapp/widgets/linked_time_fob/BUILD
+++ b/tensorboard/webapp/widgets/linked_time_fob/BUILD
@@ -60,6 +60,10 @@ tf_ts_library(
     srcs = [
         "types.ts",
         "linked_time_types.ts",
+        "types.ts",
+    ],
+    deps = [
+        "@npm//@angular/core",
     ],
     deps = [
         "@npm//@angular/core",

--- a/tensorboard/webapp/widgets/linked_time_fob/BUILD
+++ b/tensorboard/webapp/widgets/linked_time_fob/BUILD
@@ -47,7 +47,6 @@ tf_ts_library(
         ":linked_time_fob",
         ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
-        "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/testing:dom",
         "//tensorboard/webapp/third_party:d3",
         "@npm//@angular/core",
@@ -60,6 +59,7 @@ tf_ts_library(
     name = "types",
     srcs = [
         "types.ts",
+        "linked_time_types.ts",
     ],
     deps = [
         "@npm//@angular/core",

--- a/tensorboard/webapp/widgets/linked_time_fob/BUILD
+++ b/tensorboard/webapp/widgets/linked_time_fob/BUILD
@@ -28,6 +28,7 @@ tf_ng_module(
         ":linked_time_fob_controller_styles",
     ],
     deps = [
+        ":types",
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/third_party:d3",
         "@npm//@angular/common",
@@ -44,6 +45,7 @@ tf_ts_library(
     ],
     deps = [
         ":linked_time_fob",
+        ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/testing:dom",
@@ -51,5 +53,15 @@ tf_ts_library(
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",
+    ],
+)
+
+tf_ts_library(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+    deps = [
+        "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -97,15 +97,9 @@ export class LinkedTimeFobControllerComponent {
     let newLinkedTime = this.linkedTime;
     let newStep: number;
     if (this.isDraggingHigher(event.clientY, event.movementY)) {
-      newStep = this.cardAdapter.getStepHigherThanMousePosition(
-        event.clientY,
-        this.axisOverlay
-      );
+      newStep = this.cardAdapter.getStepHigherThanMousePosition(event.clientY);
     } else if (this.isDraggingLower(event.clientY, event.movementY)) {
-      newStep = this.cardAdapter.getStepLowerThanMousePosition(
-        event.clientY,
-        this.axisOverlay
-      );
+      newStep = this.cardAdapter.getStepLowerThanMousePosition(event.clientY);
     } else {
       return;
     }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -22,9 +22,9 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import {LinkedTime} from '../../metrics/types';
 import {ScaleLinear, ScaleTime} from '../../third_party/d3';
 import {FobCardAdapter} from './types';
+import {LinkedTime} from './linked_time_types';
 
 export enum AxisDirection {
   HORIZONTAL,

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -24,6 +24,7 @@ import {
 } from '@angular/core';
 import {LinkedTime} from '../../metrics/types';
 import {ScaleLinear, ScaleTime} from '../../third_party/d3';
+import {FobCardAdapter} from './types';
 
 export enum AxisDirection {
   HORIZONTAL,
@@ -48,15 +49,11 @@ export class LinkedTimeFobControllerComponent {
   @ViewChild('startFobWrapper') readonly startFobWrapper!: ElementRef;
   @ViewChild('endFobWrapper') readonly endFobWrapper!: ElementRef;
   @Input() axisDirection!: AxisDirection;
-  @Input() steps!: number[];
   @Input() linkedTime!: LinkedTime;
-  @Input() temporalScale!: TemporalScale;
+  @Input() cardAdapter!: FobCardAdapter;
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
 
   private currentDraggingFob: Fob = Fob.NONE;
-
-  private currentDraggingFobUpperBoundIndex: number = -1;
-  private currentDraggingFobLowerBoundIndex: number = -1;
 
   // Helper function to check enum in template.
   public FobType(): typeof Fob {
@@ -65,58 +62,67 @@ export class LinkedTimeFobControllerComponent {
 
   getCssTranslatePx(step: number): string {
     if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.temporalScale(step)}px)`;
+      return `translate(0px, ${this.cardAdapter.stepToPixel(step, [
+        0,
+        this.axisOverlay?.nativeElement.getBoundingClientRect().height || 10,
+      ])}px)`;
     }
 
-    return `translate(${this.temporalScale(step)}px, 0px)`;
+    return `translate(${this.cardAdapter.stepToPixel(step, [
+      0,
+      this.axisOverlay?.nativeElement.getBoundingClientRect().width || 10,
+    ])}px, 0px)`;
   }
 
   startDrag(fob: Fob) {
     this.currentDraggingFob = fob;
-    this.currentDraggingFobUpperBoundIndex =
-      this.getDraggingFobUpperBoundIndex();
-    this.currentDraggingFobLowerBoundIndex =
-      this.getDraggingFobLowerBoundIndex();
+
+    if (this.currentDraggingFob === Fob.START && this.linkedTime.end !== null) {
+      this.cardAdapter.setBounds({higherOverride: this.linkedTime.end.step});
+    }
+
+    if (this.currentDraggingFob === Fob.END) {
+      this.cardAdapter.setBounds({lowerOverride: this.linkedTime.start.step});
+    }
   }
 
   stopDrag() {
     this.currentDraggingFob = Fob.NONE;
-    this.currentDraggingFobUpperBoundIndex = -1;
-    this.currentDraggingFobLowerBoundIndex = -1;
+    this.cardAdapter.setBounds({});
   }
 
   mouseMove(event: MouseEvent) {
     if (this.currentDraggingFob === Fob.NONE) return;
 
     let newLinkedTime = this.linkedTime;
+    let newStep: number;
     if (this.isDraggingHigher(event.clientY, event.movementY)) {
-      const stepAbove =
-        this.steps[this.getStepIndexHigherThanMousePosition(event.clientY)];
-      if (this.currentDraggingFob === Fob.END) {
-        newLinkedTime.end!.step = stepAbove;
-      } else {
-        newLinkedTime.start.step = stepAbove;
-      }
-      this.onSelectTimeChanged.emit(newLinkedTime);
+      newStep = this.cardAdapter.getStepHigherThanMousePosition(
+        event.clientY,
+        this.axisOverlay
+      );
+    } else if (this.isDraggingLower(event.clientY, event.movementY)) {
+      newStep = this.cardAdapter.getStepLowerThanMousePosition(
+        event.clientY,
+        this.axisOverlay
+      );
+    } else {
+      return;
     }
 
-    if (this.isDraggingLower(event.clientY, event.movementY)) {
-      const stepBelow =
-        this.steps[this.getStepIndexLowerThanMousePosition(event.clientY)];
-      if (this.currentDraggingFob === Fob.END) {
-        newLinkedTime.end!.step = stepBelow;
-      } else {
-        newLinkedTime.start.step = stepBelow;
-      }
-      this.onSelectTimeChanged.emit(newLinkedTime);
+    if (this.currentDraggingFob === Fob.END) {
+      newLinkedTime.end!.step = newStep;
+    } else {
+      newLinkedTime.start.step = newStep;
     }
+    this.onSelectTimeChanged.emit(newLinkedTime);
   }
 
   isDraggingLower(position: number, movement: number): boolean {
     return (
       position < this.getDraggingFobTop() &&
       movement < 0 &&
-      this.getDraggingFobStep() > this.steps[0]
+      this.getDraggingFobStep() > this.cardAdapter.lowerBound
     );
   }
 
@@ -124,7 +130,7 @@ export class LinkedTimeFobControllerComponent {
     return (
       position > this.getDraggingFobTop() &&
       movement > 0 &&
-      this.getDraggingFobStep() < this.steps[this.steps.length - 1]
+      this.getDraggingFobStep() < this.cardAdapter.upperBound
     );
   }
 
@@ -138,61 +144,6 @@ export class LinkedTimeFobControllerComponent {
     return this.currentDraggingFob !== Fob.END
       ? this.linkedTime!.start.step
       : this.linkedTime!.end!.step;
-  }
-
-  getStepIndexHigherThanMousePosition(position: number) {
-    let stepIndex = 0;
-    while (
-      position - this.axisOverlay.nativeElement.getBoundingClientRect().top >
-        this.temporalScale(this.steps[stepIndex]) &&
-      stepIndex < this.currentDraggingFobUpperBoundIndex
-    ) {
-      stepIndex++;
-    }
-    return stepIndex;
-  }
-
-  getStepIndexLowerThanMousePosition(position: number) {
-    let stepIndex = this.steps.length - 1;
-    while (
-      position - this.axisOverlay.nativeElement.getBoundingClientRect().top <
-        this.temporalScale(this.steps[stepIndex]) &&
-      stepIndex > this.currentDraggingFobLowerBoundIndex
-    ) {
-      stepIndex--;
-    }
-    return stepIndex;
-  }
-
-  // Gets the index of largest step that the currentDraggingFob is allowed to go.
-  getDraggingFobUpperBoundIndex() {
-    // When dragging the START fob while there is an END fob the upper bound is
-    // the step before or equal to the endFob's step.
-    if (this.currentDraggingFob === Fob.START && this.linkedTime.end !== null) {
-      let index = 0;
-      while (this.steps[index] < this.linkedTime.end.step) {
-        index++;
-      }
-      return index;
-    }
-
-    // In all other cases the largest step is the upper bound.
-    return this.steps.length - 1;
-  }
-
-  // Gets the index of smallest step that the currentDraggingFob is allowed to go.
-  getDraggingFobLowerBoundIndex() {
-    // The END fob cannot pass the START fob.
-    if (this.currentDraggingFob === Fob.END) {
-      let index = this.steps.length - 1;
-      while (this.steps[index] > this.linkedTime.start.step) {
-        index--;
-      }
-      return index;
-    }
-
-    // No fobs can pass the lowest step in this graph.
-    return 0;
   }
 
   stepTyped(fob: Fob, step: number) {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -25,6 +25,7 @@ import {
 import {ScaleLinear, ScaleTime} from '../../third_party/d3';
 import {FobCardAdapter} from './types';
 import {LinkedTime} from './linked_time_types';
+import {FobCardAdapter} from './types';
 
 export enum AxisDirection {
   HORIZONTAL,

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -26,6 +26,7 @@ import {
 } from './linked_time_fob_controller_component';
 import {FobCardAdapter} from './types';
 import {LinkedTime} from './linked_time_types';
+import {FobCardAdapter} from './types';
 
 @Component({
   selector: 'testable-comp',
@@ -50,7 +51,7 @@ class TestableComponent {
   @Input() onSelectTimeChanged!: (newLinkedTime: LinkedTime) => void;
 }
 
-describe('linked_time_fob_controller', () => {
+fdescribe('linked_time_fob_controller', () => {
   let onSelectTimeChanged: jasmine.Spy;
   let setBoundsSpy: jasmine.Spy;
   let stepToPixelSpy: jasmine.Spy;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -52,7 +52,7 @@ class TestableComponent {
   @Input() onSelectTimeChanged!: (newLinkedTime: LinkedTime) => void;
 }
 
-fdescribe('linked_time_fob_controller', () => {
+describe('linked_time_fob_controller', () => {
   let onSelectTimeChanged: jasmine.Spy;
   let setBoundsSpy: jasmine.Spy;
   let stepToPixelSpy: jasmine.Spy;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -25,6 +25,7 @@ import {
   Fob,
   LinkedTimeFobControllerComponent,
 } from './linked_time_fob_controller_component';
+import {FobCardAdapter} from './types';
 
 type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
 
@@ -35,8 +36,7 @@ type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
       #FobController
       [axisDirection]="axisDirection"
       [linkedTime]="linkedTime"
-      [steps]="steps"
-      [temporalScale]="temporalScale"
+      [cardAdapter]="fobCardAdapter"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
     ></linked-time-fob-controller>
   `,
@@ -45,17 +45,20 @@ class TestableComponent {
   @ViewChild('FobController')
   fobController!: LinkedTimeFobControllerComponent;
 
-  @Input() steps!: number[];
   @Input() axisDirection!: AxisDirection;
   @Input() linkedTime!: LinkedTime;
-  @Input() temporalScale!: TemporalScale;
+  @Input() fobCardAdapter!: FobCardAdapter;
 
   @Input() onSelectTimeChanged!: (newLinkedTime: LinkedTime) => void;
 }
 
-describe('linked_time_fob_controller', () => {
+fdescribe('linked_time_fob_controller', () => {
   let onSelectTimeChanged: jasmine.Spy;
-  let temporalScaleSpy: jasmine.Spy;
+  let setBoundsSpy: jasmine.Spy;
+  let stepToPixelSpy: jasmine.Spy;
+  let getStepHigherSpy: jasmine.Spy;
+  let getStepLowerSpy: jasmine.Spy;
+  let fobCardAdapter: FobCardAdapter;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
@@ -73,20 +76,34 @@ describe('linked_time_fob_controller', () => {
     linkedTime: LinkedTime;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
-    fixture.componentInstance.steps = input.steps || [1, 2, 3, 4];
+    setBoundsSpy = jasmine.createSpy();
+    stepToPixelSpy = jasmine.createSpy();
+    getStepHigherSpy = jasmine.createSpy();
+    getStepLowerSpy = jasmine.createSpy();
+    fobCardAdapter = {
+      upperBound: 10,
+      lowerBound: 0,
+      setBounds: setBoundsSpy,
+      stepToPixel: stepToPixelSpy,
+      getStepHigherThanMousePosition: getStepHigherSpy,
+      getStepLowerThanMousePosition: getStepLowerSpy,
+    };
+
+    stepToPixelSpy.and.callFake((step: number) => {
+      return step;
+    });
+    getStepHigherSpy.and.callFake((step: number) => {
+      return step;
+    });
+    getStepLowerSpy.and.callFake((step: number) => {
+      return step;
+    });
+    fixture.componentInstance.fobCardAdapter = fobCardAdapter;
 
     fixture.componentInstance.axisDirection =
       input.axisDirection || AxisDirection.VERTICAL;
 
     fixture.componentInstance.linkedTime = input.linkedTime;
-
-    temporalScaleSpy = jasmine.createSpy();
-    fixture.componentInstance.temporalScale =
-      temporalScaleSpy as unknown as ScaleLinear<number, number>;
-
-    temporalScaleSpy.and.callFake((step: number) => {
-      return step;
-    });
 
     onSelectTimeChanged = jasmine.createSpy();
     fixture.componentInstance.onSelectTimeChanged = onSelectTimeChanged;
@@ -94,8 +111,46 @@ describe('linked_time_fob_controller', () => {
     return fixture;
   }
 
+  it('sets fob position based on linked time and stepToPixel call', () => {
+    const fixture = createComponent({
+      linkedTime: {start: {step: 2}, end: null},
+    });
+    fixture.detectChanges();
+    expect(stepToPixelSpy).toHaveBeenCalledOnceWith(2, jasmine.any(Array));
+  });
+  it('Sets bounds when dragging start fob during range selection and resets bounds when done dragging', () => {
+    const fixture = createComponent({
+      linkedTime: {start: {step: 2}, end: {step: 3}},
+    });
+    fixture.detectChanges();
+    const fobController = fixture.componentInstance.fobController;
+    expect(
+      fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
+    ).toEqual(2);
+    fobController.startDrag(Fob.START);
+    expect(setBoundsSpy).toHaveBeenCalledOnceWith({higherOverride: 3});
+    setBoundsSpy.calls.reset();
+    fobController.stopDrag();
+    expect(setBoundsSpy).toHaveBeenCalledOnceWith({});
+  });
+  it('Sets bounds when dragging end fob during range selection and resets bounds when done dragging', () => {
+    const fixture = createComponent({
+      linkedTime: {start: {step: 2}, end: {step: 3}},
+    });
+    fixture.detectChanges();
+    const fobController = fixture.componentInstance.fobController;
+    expect(
+      fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
+    ).toEqual(2);
+    fobController.startDrag(Fob.END);
+    expect(setBoundsSpy).toHaveBeenCalledOnceWith({lowerOverride: 2});
+    setBoundsSpy.calls.reset();
+    fobController.stopDrag();
+    expect(setBoundsSpy).toHaveBeenCalledOnceWith({});
+  });
+
   describe('vertical dragging', () => {
-    it('moves the start fob down to mouse when mouse is dragging down and is below fob', () => {
+    it('moves the start fob based on adapter getStepHigherThanMousePosition when mouse is dragging down and is below fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: null},
       });
@@ -108,6 +163,7 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 3, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3, jasmine.any(Object));
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
@@ -117,7 +173,7 @@ describe('linked_time_fob_controller', () => {
       });
     });
 
-    it('moves the start fob above mouse when mouse is dragging up and above the fob', () => {
+    it('moves the start fob based on adapter getStepLowerThanMousePosition when mouse is dragging up and above the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 4}, end: null},
       });
@@ -133,6 +189,7 @@ describe('linked_time_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledOnceWith(2, jasmine.any(Object));
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
@@ -141,8 +198,7 @@ describe('linked_time_fob_controller', () => {
         end: null,
       });
     });
-
-    it('does not move the start fob when mouse is dragging up but, is below the fob', () => {
+    it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging up but, is below the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 2}, end: null},
       });
@@ -158,13 +214,14 @@ describe('linked_time_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
     });
-
-    it('does not move the start fob when mouse is dragging down but, is above the fob', () => {
+    it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging down but, is above the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 4}, end: null},
       });
@@ -177,16 +234,18 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 2, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
     });
-
-    it('does not move the start fob when mouse is dragging down but, the fob is already on the final step', () => {
+    it('does not move the start fob or call call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging down but, the fob is already on the final step', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 4}, end: null},
       });
+      fobCardAdapter.upperBound = 4;
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
       expect(
@@ -196,34 +255,13 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 8, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
     });
-
-    it('start fob moves does not pass the end fob when being dragged passed it.', () => {
-      const fixture = createComponent({
-        linkedTime: {start: {step: 2}, end: {step: 3}},
-      });
-      fixture.detectChanges();
-      const fobController = fixture.componentInstance.fobController;
-      expect(
-        fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(2);
-      fobController.startDrag(Fob.START);
-      const fakeEvent = new MouseEvent('mousemove', {clientY: 4, movementY: 1});
-      fobController.mouseMove(fakeEvent);
-      fixture.detectChanges();
-      expect(
-        fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(3);
-      expect(onSelectTimeChanged).toHaveBeenCalledOnceWith({
-        start: {step: 3},
-        end: {step: 3},
-      });
-    });
-
     it('end fob moves to the mouse when mouse is dragging up and mouse is above the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: {step: 1}},
@@ -238,6 +276,7 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 3, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3, jasmine.any(Object));
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
@@ -246,7 +285,6 @@ describe('linked_time_fob_controller', () => {
         end: {step: 3},
       });
     });
-
     it('end fob moves to the mouse when mouse is dragging down and mouse is below the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: {step: 4}},
@@ -263,6 +301,7 @@ describe('linked_time_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledOnceWith(2, jasmine.any(Object));
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
@@ -271,7 +310,6 @@ describe('linked_time_fob_controller', () => {
         end: {step: 2},
       });
     });
-
     it('end fob does not move when mouse is dragging down but, mouse is above the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: {step: 2}},
@@ -288,12 +326,13 @@ describe('linked_time_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
     });
-
     it('end fob does not move when mouse is dragging up but, mouse is below the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: {step: 3}},
@@ -307,35 +346,12 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 2, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
-    });
-
-    it('end fob does not pass the start fob when being dragged passed it.', () => {
-      const fixture = createComponent({
-        linkedTime: {start: {step: 2}, end: {step: 3}},
-      });
-      fixture.detectChanges();
-      const fobController = fixture.componentInstance.fobController;
-      expect(
-        fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(3);
-      fobController.startDrag(Fob.END);
-      const fakeEvent = new MouseEvent('mousemove', {
-        clientY: 1,
-        movementY: -1,
-      });
-      fobController.mouseMove(fakeEvent);
-      fixture.detectChanges();
-      expect(
-        fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(2);
-      expect(onSelectTimeChanged).toHaveBeenCalledOnceWith({
-        start: {step: 2},
-        end: {step: 2},
-      });
     });
   });
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -16,7 +16,6 @@ limitations under the License.
 import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {LinkedTime} from '../../metrics/types';
 import {sendKeys} from '../../testing/dom';
 import {ScaleLinear, ScaleTime} from '../../third_party/d3';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
@@ -26,8 +25,7 @@ import {
   LinkedTimeFobControllerComponent,
 } from './linked_time_fob_controller_component';
 import {FobCardAdapter} from './types';
-
-type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
+import {LinkedTime} from './linked_time_types';
 
 @Component({
   selector: 'testable-comp',

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
@@ -1,0 +1,21 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * The start and end time to define a linked time.
+ */
+export interface LinkedTime {
+  start: {step: number};
+  end: {step: number} | null;
+}

--- a/tensorboard/webapp/widgets/linked_time_fob/types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/types.ts
@@ -26,12 +26,22 @@ export enum Fob {
 export interface FobCardAdapter {
   upperBound: number;
   lowerBound: number;
+  // Set the upper and lower bounds. Implementation can determine lower and
+  // upper bounds as it needs to. However, if the overrides are set those must
+  // be used.
   setBounds(overrides: {lowerOverride?: number; higherOverride?: number}): void;
+  // Uses whatever underlying scale is need to translate the proper pixel offset
   stepToPixel(step: number, domain: [number, number]): number;
+  // Using the same scale that is used in the stepToPixel function return a step
+  // that is greater than or equal to the step that would be at the given mouse
+  // position.
   getStepHigherThanMousePosition(
     position: number,
     axisOverlay: ElementRef
   ): number;
+  // Using the same scale that is used in the stepToPixel function return a step
+  // that is less than or equal to the step that would be at the given mouse
+  // position.
   getStepLowerThanMousePosition(
     position: number,
     axisOverlay: ElementRef

--- a/tensorboard/webapp/widgets/linked_time_fob/types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/types.ts
@@ -1,0 +1,39 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {ElementRef} from '@angular/core';
+
+export enum AxisDirection {
+  HORIZONTAL,
+  VERTICAL,
+}
+
+export enum Fob {
+  NONE,
+  START,
+  END,
+}
+
+export interface FobCardAdapter {
+  upperBound: number;
+  lowerBound: number;
+  setBounds(overrides: {lowerOverride?: number; higherOverride?: number}): void;
+  stepToPixel(step: number, domain: [number, number]): number;
+  getStepHigherThanMousePosition(
+    position: number,
+    axisOverlay: ElementRef
+  ): number;
+  getStepLowerThanMousePosition(
+    position: number,
+    axisOverlay: ElementRef
+  ): number;
+}

--- a/tensorboard/webapp/widgets/linked_time_fob/types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/types.ts
@@ -23,27 +23,43 @@ export enum Fob {
   END,
 }
 
+/**
+ * This class is intended to be implemented by the card that has a
+ * LinkedTimeFobControllerComponent.
+ *
+ * Each implementer will have some sort of Scale that is used to translate
+ * convert between step and pixel so that the fob lines up with the axis
+ * properly. In future comments this scale will be refered to as
+ * ImplementerScale
+ *
+ * It also allows cards to implement the dragging functionality in different
+ * ways. By deciding which step to return in the getStepHigherThanMousePosition
+ * and getStepLowerThanMousePosition functions the implementer can decide if the
+ * fob "snaps" to certain steps or drags in in a smooth continuous way.
+ */
 export interface FobCardAdapter {
   upperBound: number;
   lowerBound: number;
+  /**
+   *
+   * @param overrides
+   */
   // Set the upper and lower bounds. Implementation can determine lower and
   // upper bounds as it needs to. However, if the overrides are set those must
   // be used.
   setBounds(overrides: {lowerOverride?: number; higherOverride?: number}): void;
-  // Uses whatever underlying scale is need to translate the proper pixel offset
+  /**
+   * Uses ImplementerScale to translate the proper pixel offset.
+   * @param step the step which needs to be translated.
+   * @param domain The thing that I might not need.
+   */
   stepToPixel(step: number, domain: [number, number]): number;
   // Using the same scale that is used in the stepToPixel function return a step
   // that is greater than or equal to the step that would be at the given mouse
   // position.
-  getStepHigherThanMousePosition(
-    position: number,
-    axisOverlay: ElementRef
-  ): number;
+  getStepHigherThanMousePosition(position: number): number;
   // Using the same scale that is used in the stepToPixel function return a step
   // that is less than or equal to the step that would be at the given mouse
   // position.
-  getStepLowerThanMousePosition(
-    position: number,
-    axisOverlay: ElementRef
-  ): number;
+  getStepLowerThanMousePosition(position: number): number;
 }


### PR DESCRIPTION
This change adds an interface that will be used to encapsulate card specific logic. This interface is implemented in the HistogramFobAdapter and used in the Fob Controller.

There is no functional change in this PR.

This change is to prepare for adding fob dragging functionality to Scalar cards which is bring done [here](https://github.com/tensorflow/tensorboard/pull/5607).