### PR TITLE
alias: test mat-option DOM using Angular test harnesses

### DIFF
--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -211,6 +211,15 @@ tf_ts_library(
     ],
 )
 
+# This is a dummy rule used as a @angular/material/select/testing dependency.
+tf_ts_library(
+    name = "expect_angular_material_select_testing",
+    srcs = [],
+    deps = [
+        "@npm//@angular/material",
+    ],
+)
+
 # This is a dummy rule used as a @angular/material/slide_toggle dependency.
 tf_ts_library(
     name = "expect_angular_material_slide_toggle",

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -32,6 +32,7 @@ tf_ts_library(
     srcs = ["dropdown_test.ts"],
     deps = [
         ":dropdown",
+        "//tensorboard/webapp/angular:expect_angular_cdk_testing_testbed",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_material_select",
         "@npm//@angular/core",

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -35,6 +35,8 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_cdk_testing_testbed",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_material_select",
+        "//tensorboard/webapp/angular:expect_angular_material_select_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -42,7 +42,7 @@ export interface DropdownOption {
         [value]="option.value"
         [disabled]="option.disabled"
       >
-        <b *ngIf="option.displayAlias">{{ option.displayAlias }}: </b>
+        <b *ngIf="option.displayAlias">{{ option.displayAlias }}:</b>
         {{ option.displayText }}
       </mat-option>
     </mat-select>

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -52,5 +52,5 @@ export interface DropdownOption {
 export class DropdownComponent {
   @Input() value = '';
   @Input() options: DropdownOption[] = [];
-  @Output() selectionChange = new EventEmitter<any>();
+  @Output() readonly selectionChange = new EventEmitter<any>();
 }

--- a/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
@@ -143,9 +143,7 @@ describe('tb-dropdown', () => {
     const options = await selectHarness.getOptions();
     expect(options.length).toBe(1);
 
-    expect(await options[0].getText()).toBe(
-      'test alias:  test experiment name'
-    );
+    expect(await options[0].getText()).toBe('test alias: test experiment name');
     expect(await options[0].isDisabled()).toBeFalsy();
   });
 

--- a/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
@@ -12,10 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Component, Input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatSelectModule} from '@angular/material/select';
+import {MatSelectHarness} from '@angular/material/select/testing';
 import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {DropdownComponent, DropdownOption} from './dropdown_component';
 
 /**
@@ -47,7 +50,7 @@ describe('tb-dropdown', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatSelectModule],
+      imports: [MatSelectModule, NoopAnimationsModule],
       declarations: [DropdownComponent, TestableComponent],
     }).compileComponents();
   });
@@ -64,8 +67,8 @@ describe('tb-dropdown', () => {
     return fixture;
   }
 
-  it('renders options with no aliases', () => {
-    let fixture = createTestableComponent({
+  it('renders options with no aliases', async () => {
+    const fixture = createTestableComponent({
       expId: '1',
       configOptions: [
         {
@@ -81,6 +84,7 @@ describe('tb-dropdown', () => {
         },
       ],
     });
+    const loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
 
     const dropdown = fixture.debugElement.query(byCss.DROPDOWN);
@@ -93,21 +97,33 @@ describe('tb-dropdown', () => {
       }),
       jasmine.objectContaining({value: '1', displayText: 'abc'}),
     ]);
-    // TODO(ytjing): Figure out how to test DOM content.
+
+    // Test DOM content.
+    const selectHarness = await loader.getHarness(MatSelectHarness);
+    await selectHarness.open();
+
+    const options = await selectHarness.getOptions();
+    expect(options.length).toBe(2);
+
+    expect(await options[0].getText()).toBe('none');
+    expect(await options[0].isDisabled()).toBeTrue();
+
+    expect(await options[1].getText()).toBe('abc');
+    expect(await options[1].isDisabled()).toBeFalsy();
   });
 
-  it('renders options with valid aliases', () => {
-    let fixture = createTestableComponent({
+  it('renders options with valid aliases', async () => {
+    const fixture = createTestableComponent({
       expId: '2',
       configOptions: [
         {
           value: '2',
           displayText: 'test experiment name',
-          disabled: false,
           displayAlias: 'test alias',
         },
       ],
     });
+    const loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
 
     const dropdown = fixture.debugElement.query(byCss.DROPDOWN);
@@ -119,11 +135,22 @@ describe('tb-dropdown', () => {
         displayAlias: 'test alias',
       }),
     ]);
-    // TODO(ytjing): Figure out how to test DOM content.
+
+    // Test DOM content.
+    const selectHarness = await loader.getHarness(MatSelectHarness);
+    await selectHarness.open();
+
+    const options = await selectHarness.getOptions();
+    expect(options.length).toBe(1);
+
+    expect(await options[0].getText()).toBe(
+      'test alias:  test experiment name'
+    );
+    expect(await options[0].isDisabled()).toBeFalsy();
   });
 
   it('changes selection', async () => {
-    let fixture = createTestableComponent({
+    const fixture = createTestableComponent({
       expId: '1',
       configOptions: [
         {


### PR DESCRIPTION
The list of `mat-option` elements are rendered in a separate overlay container outside the DOM instead of as a descendent of `mat-select`, therefore we cannot directly query by css to check the text contents. Fortunately we can use the Angular component test harnesses ([MatSelectHarness](https://material.angular.io/components/select/api#MatSelectHarness)) to properly interact with `mat-select` and `mat-option` in the test environment.

Tested internally: cl/433235493