### PR TITLE
Re add cached lines when updating

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
@@ -36,6 +36,7 @@ export class PaintBrush {
       paintOpt
     );
     if (newCacheValue) {
+      console.log('new cache value for', cacheId);
       this.renderCache.setToCurrentFrame(cacheId, newCacheValue);
     }
   }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
@@ -95,6 +95,7 @@ export class SeriesLineView extends DataDrawable {
   }
 
   redraw() {
+    console.log('redrawing', this.series);
     for (const series of this.series) {
       const map = this.getMetadataMap();
       const metadata = map[series.id];

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -422,6 +422,7 @@ export class LineChartComponent
    * with `recoverRendererIfNeeded`.
    */
   private updateLineChart() {
+    console.log('update line chart');
     this.recoverRendererIfNeeded();
     if (!this.lineChart || this.disableUpdate) return;
 
@@ -437,6 +438,7 @@ export class LineChartComponent
     }
 
     if (this.isDataUpdated) {
+      console.log('is data updated', this.seriesData);
       this.isDataUpdated = false;
       this.lineChart.setData(this.seriesData);
     }


### PR DESCRIPTION
Since cached lines are changed in place when we receive new lines they are painted on top of old lines. This is what is causing #5573. This changes removes the line from the scene and re-adds it after changes. This keeps the ordering consistent with a fresh scene. 

A better solution to this would be to create a second Mesh scene on top of the original one and paint all smooth lines in that scene.