### PR TITLE
linked time: fix colored histogram uncolored on mouse hovering

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -82,8 +82,8 @@ limitations under the License.
         [class.histogram]="true"
         [class.no-color]="!isDatumInLinkedTimeRange(datum)"
         [style.color]="getHistogramFill(datum)"
-        (mouseenter)="updateColorOnHover($event, true)"
-        (mouseleave)="updateColorOnHover($event, false)"
+        (mouseenter)="updateColorOnHover($event, datum, true)"
+        (mouseleave)="updateColorOnHover($event, datum, false)"
         (click)="onSelectTimeRangeChange(datum)"
       >
         <line

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -260,9 +260,17 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
       : '';
   }
 
-  updateColorOnHover(event: MouseEvent, isHover: boolean) {
+  updateColorOnHover(
+    event: MouseEvent,
+    datum: HistogramDatum,
+    isHover: boolean
+  ) {
     // When link time is disabled all histogram should be colored.
     if (!this.isLinkedTimeEnabled(this.linkedTime)) {
+      return;
+    }
+    // Target histogram should be colored When datum is in range.
+    if (this.isDatumInLinkedTimeRange(datum)) {
       return;
     }
     if (isHover) {

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -1007,6 +1007,76 @@ describe('histogram test', () => {
         fixture.detectChanges();
         expect(doHistogramsHaveColor(fixture)).toEqual([false, false, false]);
       });
+
+      it('puts color on none-ranged histogram when mouse hovers over', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: 400}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: {step: 10},
+        };
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const firstHistogram = fixture.debugElement.queryAll(
+          By.css('g.histogram')
+        )[0];
+
+        firstHistogram.triggerEventHandler('mouseenter', {
+          target: firstHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // StepIndex 1,2 are hightlight because of selected range; stepIndex 0 is hightlight on
+        // mouse hovering.
+        expect(doHistogramsHaveColor(fixture)).toEqual([true, true, true]);
+
+        firstHistogram.triggerEventHandler('mouseleave', {
+          target: firstHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // StepIndex 1,2 are hightlight because of selected range; stepIndex 0 is not hightlight
+        // because the mouse has left.
+        expect(doHistogramsHaveColor(fixture)).toEqual([false, true, true]);
+      });
+
+      it('does not update color on ranged histogram when mouse hovers over', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: 400}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: {step: 10},
+        };
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const inRangeHistogram = fixture.debugElement.queryAll(
+          By.css('g.histogram')
+        )[1];
+
+        inRangeHistogram.triggerEventHandler('mouseenter', {
+          target: inRangeHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // StepIndex 1,2 are hightlight because of selected range;
+        expect(doHistogramsHaveColor(fixture)).toEqual([false, true, true]);
+
+        inRangeHistogram.triggerEventHandler('mouseleave', {
+          target: inRangeHistogram.nativeElement,
+        });
+        fixture.detectChanges();
+        // StepIndex 1,2 are hightlight because of selected range;
+        expect(doHistogramsHaveColor(fixture)).toEqual([false, true, true]);
+      });
     });
 
     describe('multi step range updated on click', () => {


### PR DESCRIPTION
Previous the implement, coloring histogram on mouse hovering, cause a bug where those colored histogram will be uncolored on mouseleave. This was due to lack of checking when adding `.no-color` class. 
This pr adds a condition to check whether datum is in range. If it is in range, means we don't want to update the color on hovering. (includes removing .no-color because the class should not exist when datum is in range)

Before (in-range histogram uncolored on mouseleave)
<img width="609" alt="Screen Shot 2022-03-14 at 12 46 23 PM" src="https://user-images.githubusercontent.com/1131010/158249384-7fa6519d-1e06-4706-94f6-a490e20b83f4.png">

After (hovering does not affect in-range histogram)
<img width="918" alt="Screen Shot 2022-03-14 at 12 48 41 PM" src="https://user-images.githubusercontent.com/1131010/158249753-d2ff72de-76bf-49ae-bdb1-73fe7f40f2c4.png">

<img width="658" alt="Screen Shot 2022-03-14 at 12 49 21 PM" src="https://user-images.githubusercontent.com/1131010/158249769-84b93261-cd5d-4f24-a756-51f96f41ee29.png">


