### PR TITLE
linked time: adds clipped text hint on image card

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -141,6 +141,7 @@ tf_ng_module(
     deps = [
         ":run_name",
         ":utils",
+        ":vis_selected_time_clipped",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_icon",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -141,7 +141,7 @@ tf_ng_module(
     deps = [
         ":run_name",
         ":utils",
-        ":vis_selected_time_clipped",
+        ":vis_selected_time_warning",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_icon",

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -21,9 +21,9 @@ limitations under the License.
       title="{{ tag }}"
       value="{{ title }}"
     ></tb-truncated-path>
-    <vis-selected-time-clipped
+    <vis-selected-time-warning
       *ngIf="selectedTime && selectedTime.clipped"
-    ></vis-selected-time-clipped>
+    ></vis-selected-time-warning>
     <span class="controls">
       <button
         mat-icon-button

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -21,9 +21,9 @@ limitations under the License.
       title="{{ tag }}"
       value="{{ title }}"
     ></tb-truncated-path>
-    <vis-selected-time-warning
+    <vis-selected-time-clipped
       *ngIf="selectedTime && selectedTime.clipped"
-    ></vis-selected-time-warning>
+    ></vis-selected-time-clipped>
     <span class="controls">
       <button
         mat-icon-button

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -16,14 +16,16 @@ limitations under the License.
 -->
 <div class="heading">
   <div class="line">
-    <tb-truncated-path
-      class="tag"
-      title="{{ tag }}"
-      value="{{ title }}"
-    ></tb-truncated-path>
-    <vis-selected-time-clipped
-      *ngIf="selectedTime && selectedTime.clipped"
-    ></vis-selected-time-clipped>
+    <span class="tag">
+      <tb-truncated-path
+        class="tag"
+        title="{{ tag }}"
+        value="{{ title }}"
+      ></tb-truncated-path>
+      <vis-selected-time-clipped
+        *ngIf="selectedTime && selectedTime.clipped"
+      ></vis-selected-time-clipped>
+    </span>
     <span class="controls">
       <button
         mat-icon-button

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -21,6 +21,9 @@ limitations under the License.
       title="{{ tag }}"
       value="{{ title }}"
     ></tb-truncated-path>
+    <vis-selected-time-clipped
+      *ngIf="selectedTime && selectedTime.clipped"
+    ></vis-selected-time-clipped>
     <span class="controls">
       <button
         mat-icon-button

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -45,7 +45,13 @@ $_tick_width: 14px;
 .line {
   align-items: center;
   display: grid;
-  grid-template-columns: 1fr 1fr max-content;
+  grid-template-columns: 1fr max-content;
+}
+
+.tag {
+  align-items: center;
+  display: flex;
+  gap: 5px;
 }
 
 .metadata {

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -45,7 +45,7 @@ $_tick_width: 14px;
 .line {
   align-items: center;
   display: grid;
-  grid-template-columns: 1fr max-content;
+  grid-template-columns: 1fr 1fr max-content;
 }
 
 .metadata {

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_module.ts
@@ -22,7 +22,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {ImageCardComponent} from './image_card_component';
 import {ImageCardContainer} from './image_card_container';
 import {RunNameModule} from './run_name_module';
-import {VisSelectedTimeClippedModule} from './vis_selected_time_clipped_module';
+import {VisSelectedTimeWarningModule} from './vis_selected_time_warning_module';
 
 @NgModule({
   declarations: [ImageCardContainer, ImageCardComponent],
@@ -35,7 +35,7 @@ import {VisSelectedTimeClippedModule} from './vis_selected_time_clipped_module';
     MatSliderModule,
     RunNameModule,
     TruncatedPathModule,
-    VisSelectedTimeClippedModule,
+    VisSelectedTimeWarningModule,
   ],
 })
 export class ImageCardModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_module.ts
@@ -22,6 +22,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {ImageCardComponent} from './image_card_component';
 import {ImageCardContainer} from './image_card_container';
 import {RunNameModule} from './run_name_module';
+import {VisSelectedTimeClippedModule} from './vis_selected_time_clipped_module';
 
 @NgModule({
   declarations: [ImageCardContainer, ImageCardComponent],
@@ -34,6 +35,7 @@ import {RunNameModule} from './run_name_module';
     MatSliderModule,
     RunNameModule,
     TruncatedPathModule,
+    VisSelectedTimeClippedModule,
   ],
 })
 export class ImageCardModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -42,7 +42,7 @@ import {CardId} from '../../types';
 import {ImageCardComponent} from './image_card_component';
 import {ImageCardContainer} from './image_card_container';
 import {RunNameModule} from './run_name_module';
-import {VisSelectedTimeClippedModule} from './vis_selected_time_clipped_module';
+import {VisSelectedTimeWarningModule} from './vis_selected_time_warning_module';
 
 @Component({
   selector: 'card-view',
@@ -91,7 +91,7 @@ describe('image card', () => {
         MatSliderModule,
         RunNameModule,
         TruncatedPathModule,
-        VisSelectedTimeClippedModule,
+        VisSelectedTimeWarningModule,
       ],
       declarations: [ImageCardContainer, ImageCardComponent, TestableCardView],
       providers: [
@@ -1233,7 +1233,7 @@ describe('image card', () => {
         fixture.detectChanges();
 
         const indicatorBefore = fixture.debugElement.query(
-          By.css('vis-selected-time-clipped')
+          By.css('vis-selected-time-warning')
         );
         expect(indicatorBefore).toBeTruthy();
 
@@ -1244,7 +1244,7 @@ describe('image card', () => {
         store.refreshState();
         fixture.detectChanges();
         const indicatorAfter = fixture.debugElement.query(
-          By.css('vis-selected-time-clipped')
+          By.css('vis-selected-time-warning')
         );
         expect(indicatorAfter).toBeNull();
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -42,6 +42,7 @@ import {CardId} from '../../types';
 import {ImageCardComponent} from './image_card_component';
 import {ImageCardContainer} from './image_card_container';
 import {RunNameModule} from './run_name_module';
+import {VisSelectedTimeClippedModule} from './vis_selected_time_clipped_module';
 
 @Component({
   selector: 'card-view',
@@ -90,6 +91,7 @@ describe('image card', () => {
         MatSliderModule,
         RunNameModule,
         TruncatedPathModule,
+        VisSelectedTimeClippedModule,
       ],
       declarations: [ImageCardContainer, ImageCardComponent, TestableCardView],
       providers: [
@@ -1139,6 +1141,112 @@ describe('image card', () => {
 
           expect(getSliderThumbPosition(fixture)).toBe('2');
         });
+      });
+    });
+
+    describe('selectedTime beyond range of data', () => {
+      it('clips the selectedTime to max step', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 45},
+          end: {step: 50},
+        });
+        const timeSeries = [
+          {wallTime: 100, imageId: 'ImageId1', step: 10},
+          {wallTime: 101, imageId: 'ImageId2', step: 20},
+          {wallTime: 102, imageId: 'ImageId3', step: 30},
+          {wallTime: 103, imageId: 'ImageId4', step: 40},
+        ];
+        provideMockCardSeriesData(
+          selectSpy,
+          PluginType.IMAGES,
+          'card1',
+          null /* metadataOverride */,
+          timeSeries
+        );
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+        const selectedTimeChangeSpy = jasmine.createSpy();
+        fixture.componentInstance.selectedTime$!.subscribe(
+          selectedTimeChangeSpy
+        );
+        fixture.detectChanges();
+
+        expect(selectedTimeChangeSpy).toHaveBeenCalledWith({
+          startStep: 40,
+          endStep: null,
+          clipped: true,
+        });
+      });
+
+      it('clips the selectedTime to min step when it is too small', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 5},
+          end: {step: 8},
+        });
+        const timeSeries = [
+          {wallTime: 100, imageId: 'ImageId1', step: 10},
+          {wallTime: 101, imageId: 'ImageId2', step: 20},
+          {wallTime: 102, imageId: 'ImageId3', step: 30},
+          {wallTime: 103, imageId: 'ImageId4', step: 40},
+        ];
+        provideMockCardSeriesData(
+          selectSpy,
+          PluginType.IMAGES,
+          'card1',
+          null /* metadataOverride */,
+          timeSeries
+        );
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const selectedTimeChangeSpy = jasmine.createSpy();
+        fixture.componentInstance.selectedTime$!.subscribe(
+          selectedTimeChangeSpy
+        );
+
+        expect(selectedTimeChangeSpy).toHaveBeenCalledWith({
+          startStep: 10,
+          endStep: null,
+          clipped: true,
+        });
+      });
+
+      it('renders warning when the selectedTime is clipped', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 5},
+          end: {step: 8},
+        });
+        const timeSeries = [
+          {wallTime: 100, imageId: 'ImageId1', step: 10},
+          {wallTime: 101, imageId: 'ImageId2', step: 20},
+          {wallTime: 102, imageId: 'ImageId3', step: 30},
+          {wallTime: 103, imageId: 'ImageId4', step: 40},
+        ];
+        provideMockCardSeriesData(
+          selectSpy,
+          PluginType.IMAGES,
+          'card1',
+          null /* metadataOverride */,
+          timeSeries
+        );
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const indicatorBefore = fixture.debugElement.query(
+          By.css('vis-selected-time-clipped')
+        );
+        expect(indicatorBefore).toBeTruthy();
+
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 0},
+          end: {step: 100},
+        });
+        store.refreshState();
+        fixture.detectChanges();
+        const indicatorAfter = fixture.debugElement.query(
+          By.css('vis-selected-time-clipped')
+        );
+        expect(indicatorAfter).toBeNull();
       });
     });
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -1233,7 +1233,7 @@ describe('image card', () => {
         fixture.detectChanges();
 
         const indicatorBefore = fixture.debugElement.query(
-          By.css('vis-selected-time-warning')
+          By.css('vis-selected-time-clipped')
         );
         expect(indicatorBefore).toBeTruthy();
 
@@ -1244,7 +1244,7 @@ describe('image card', () => {
         store.refreshState();
         fixture.detectChanges();
         const indicatorAfter = fixture.debugElement.query(
-          By.css('vis-selected-time-warning')
+          By.css('vis-selected-time-clipped')
         );
         expect(indicatorAfter).toBeNull();
       });


### PR DESCRIPTION
As the escalation mark shown in histogram and scalar card when linked time is clipped, we want to add the same for image card by reusing module `vis_selected_time_warning` The logic follows what already used by histogram/scalar card. 

screenshot
<img width="560" alt="Screen Shot 2022-03-14 at 8 21 45 PM" src="https://user-images.githubusercontent.com/1131010/158299692-93787ffd-2f93-44c9-b0be-620f12185f73.png">

<img width="431" alt="Screen Shot 2022-03-14 at 8 23 11 PM" src="https://user-images.githubusercontent.com/1131010/158299783-c31ba0e6-dc89-4a0c-a313-d36e3577510c.png">

