### PR TITLE
linked time: rendering warning component with isClipped param

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -17,9 +17,9 @@ limitations under the License.
 <div class="heading">
   <div class="tag">
     <tb-truncated-path [title]="tag" [value]="title"></tb-truncated-path>
-    <vis-selected-time-clipped
-      *ngIf="selectedTime && selectedTime.clipped"
-    ></vis-selected-time-clipped>
+    <vis-selected-time-warning
+      [isClipped]="selectedTime && selectedTime.clipped"
+    ></vis-selected-time-warning>
   </div>
   <div class="run">
     <span

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -398,7 +398,7 @@ describe('histogram card', () => {
         fixture.detectChanges();
 
         const indicatorBefore = fixture.debugElement.query(
-          By.css('vis-selected-time-warning')
+          By.css('vis-selected-time-warning mat-icon[data-value="clipped"]')
         );
         expect(indicatorBefore).toBeTruthy();
 
@@ -409,7 +409,7 @@ describe('histogram card', () => {
         store.refreshState();
         fixture.detectChanges();
         const indicatorAfter = fixture.debugElement.query(
-          By.css('vis-selected-time-warning')
+          By.css('vis-selected-time-warning mat-icon[data-value="clipped"]')
         );
         expect(indicatorAfter).toBeNull();
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -398,7 +398,7 @@ describe('histogram card', () => {
         fixture.detectChanges();
 
         const indicatorBefore = fixture.debugElement.query(
-          By.css('vis-selected-time-clipped')
+          By.css('vis-selected-time-warning')
         );
         expect(indicatorBefore).toBeTruthy();
 
@@ -409,7 +409,7 @@ describe('histogram card', () => {
         store.refreshState();
         fixture.detectChanges();
         const indicatorAfter = fixture.debugElement.query(
-          By.css('vis-selected-time-clipped')
+          By.css('vis-selected-time-warning')
         );
         expect(indicatorAfter).toBeNull();
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -22,9 +22,9 @@ limitations under the License.
         title="{{ tag }}"
         value="{{ title }}"
       ></tb-truncated-path>
-      <vis-selected-time-clipped
-        *ngIf="selectedTime && selectedTime.clipped"
-      ></vis-selected-time-clipped>
+      <vis-selected-time-warning
+        [isClipped]="selectedTime && selectedTime.clipped"
+      ></vis-selected-time-warning>
     </span>
     <span class="controls">
       <button

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -1233,7 +1233,7 @@ describe('image card', () => {
         fixture.detectChanges();
 
         const indicatorBefore = fixture.debugElement.query(
-          By.css('vis-selected-time-warning')
+          By.css('vis-selected-time-warning mat-icon[data-value="clipped"]')
         );
         expect(indicatorBefore).toBeTruthy();
 
@@ -1244,7 +1244,7 @@ describe('image card', () => {
         store.refreshState();
         fixture.detectChanges();
         const indicatorAfter = fixture.debugElement.query(
-          By.css('vis-selected-time-warning')
+          By.css('vis-selected-time-warning mat-icon[data-value="clipped"]')
         );
         expect(indicatorAfter).toBeNull();
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -1233,7 +1233,7 @@ describe('image card', () => {
         fixture.detectChanges();
 
         const indicatorBefore = fixture.debugElement.query(
-          By.css('vis-selected-time-clipped')
+          By.css('vis-selected-time-warning')
         );
         expect(indicatorBefore).toBeTruthy();
 
@@ -1244,7 +1244,7 @@ describe('image card', () => {
         store.refreshState();
         fixture.detectChanges();
         const indicatorAfter = fixture.debugElement.query(
-          By.css('vis-selected-time-clipped')
+          By.css('vis-selected-time-warning')
         );
         expect(indicatorAfter).toBeNull();
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -21,9 +21,9 @@ limitations under the License.
       title="{{ tag }}"
       value="{{ title }}"
     ></tb-truncated-path>
-    <vis-selected-time-clipped
-      *ngIf="selectedTime && selectedTime.clipped"
-    ></vis-selected-time-clipped>
+    <vis-selected-time-warning
+      [isClipped]="selectedTime && selectedTime.clipped"
+    ></vis-selected-time-warning>
   </span>
   <span class="controls">
     <button

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -78,6 +78,7 @@ import {
   ScalarCardSeriesMetadata,
   SeriesType,
 } from './scalar_card_types';
+import {VisSelectedTimeWarningModule} from './vis_selected_time_warning_module';
 
 @Component({
   selector: 'line-chart',
@@ -179,7 +180,9 @@ describe('scalar card', () => {
     LINE_CHART: By.directive(TestableLineChart),
     TOOLTIP_HEADER_COLUMN: By.css('table.tooltip th'),
     TOOLTIP_ROW: By.css('table.tooltip .tooltip-row'),
-    HEADER_WARNING: By.css('vis-selected-time-warning'),
+    HEADER_WARNING_CLIPPED: By.css(
+      'vis-selected-time-warning mat-icon[data-value="clipped"]'
+    ),
     LINKED_TIME_AXIS_FOB: By.css('.selected-time-fob'),
   };
 
@@ -254,6 +257,7 @@ describe('scalar card', () => {
         NoopAnimationsModule,
         ResizeDetectorTestingModule,
         TruncatedPathModule,
+        VisSelectedTimeWarningModule,
       ],
       declarations: [
         ScalarCardContainer,
@@ -2031,7 +2035,7 @@ describe('scalar card', () => {
 
   describe('linked time feature integration', () => {
     describe('selectedTime and dataset', () => {
-      it('shows warning when selectedTime is outside the extent of dataset', fakeAsync(() => {
+      it('shows clipped warning when selectedTime is outside the extent of dataset', fakeAsync(() => {
         const runToSeries = {
           run1: [buildScalarStepData({step: 10})],
           run2: [buildScalarStepData({step: 20})],
@@ -2052,11 +2056,11 @@ describe('scalar card', () => {
         fixture.detectChanges();
 
         expect(
-          fixture.debugElement.query(Selector.HEADER_WARNING)
+          fixture.debugElement.query(Selector.HEADER_WARNING_CLIPPED)
         ).toBeTruthy();
       }));
 
-      it('does not show warning if there is an overlap', fakeAsync(() => {
+      it('does not show clipped warning if there is an overlap', fakeAsync(() => {
         const runToSeries = {
           run1: [buildScalarStepData({step: 10})],
           run2: [buildScalarStepData({step: 20})],
@@ -2075,7 +2079,9 @@ describe('scalar card', () => {
         });
         const fixture = createComponent('card1');
         fixture.detectChanges();
-        expect(fixture.debugElement.query(Selector.HEADER_WARNING)).toBeNull();
+        expect(
+          fixture.debugElement.query(Selector.HEADER_WARNING_CLIPPED)
+        ).toBeNull();
 
         store.overrideSelector(getMetricsSelectedTime, {
           start: {step: -10},
@@ -2083,7 +2089,9 @@ describe('scalar card', () => {
         });
         store.refreshState();
         fixture.detectChanges();
-        expect(fixture.debugElement.query(Selector.HEADER_WARNING)).toBeNull();
+        expect(
+          fixture.debugElement.query(Selector.HEADER_WARNING_CLIPPED)
+        ).toBeNull();
 
         store.overrideSelector(getMetricsSelectedTime, {
           start: {step: -1000},
@@ -2091,7 +2099,9 @@ describe('scalar card', () => {
         });
         store.refreshState();
         fixture.detectChanges();
-        expect(fixture.debugElement.query(Selector.HEADER_WARNING)).toBeNull();
+        expect(
+          fixture.debugElement.query(Selector.HEADER_WARNING_CLIPPED)
+        ).toBeNull();
       }));
 
       it('selects selectedTime to min extent when global setting is too small', fakeAsync(() => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -179,7 +179,7 @@ describe('scalar card', () => {
     LINE_CHART: By.directive(TestableLineChart),
     TOOLTIP_HEADER_COLUMN: By.css('table.tooltip th'),
     TOOLTIP_ROW: By.css('table.tooltip .tooltip-row'),
-    HEADER_WARNING: By.css('vis-selected-time-clipped'),
+    HEADER_WARNING: By.css('vis-selected-time-warning'),
     LINKED_TIME_AXIS_FOB: By.css('.selected-time-fob'),
   };
 

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_warning_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_warning_component.ts
@@ -18,8 +18,7 @@ import {LinkedTime} from '../../types';
 export type LinkedTimeWithClipped = LinkedTime & {clipped: boolean};
 
 @Component({
-  // TODO(japie1235813): Renames to `vis-selected-time-warning` on module applied to cards.
-  selector: 'vis-selected-time-clipped',
+  selector: 'vis-selected-time-warning',
   template: `
     <mat-icon
       *ngIf="isClipped"
@@ -36,7 +35,6 @@ export type LinkedTimeWithClipped = LinkedTime & {clipped: boolean};
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VisSelectedTimeWarningComponent {
-  // TODO(japie1235813): Switch default to false on module applied to cards.
-  @Input() isClipped?: boolean = true;
+  @Input() isClipped?: boolean = false;
   @Input() isClosestStepHighlighted?: boolean = false;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_warning_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_selected_time_warning_component.ts
@@ -22,11 +22,13 @@ export type LinkedTimeWithClipped = LinkedTime & {clipped: boolean};
   template: `
     <mat-icon
       *ngIf="isClipped"
+      data-value="clipped"
       svgIcon="info_outline_24px"
       title="Linked step is not found in this visualization. We highlighted the closest step for you."
     ></mat-icon>
     <mat-icon
       *ngIf="isClosestStepHighlighted"
+      data-value="closestStepHighlighted"
       svgIcon="info_outline_24px"
       title="Data is not found on selected step(s). We highlighted the closest step for you."
     ></mat-icon>


### PR DESCRIPTION
Replace the current `*ngIf=` with the param `isClipped` to apply `selected_time_warning_module`. This PR should not change current behavior and existing tests.

Note: Adding ``isClosestStepHighted`` is blocked.
The reasoning usage for `isClosestStepHighted` is to pass in a method. 
```
// ...ng.html
<vis-selected-time-warning
        [isClosestStepHighted]="isClosestStepHighted()"
      ></vis-selected-time-warning>
// ..componet.ts
isClosestStepHighted() {
  return ..;
}
```
For scalar/histogram, we want to move the fob position, which is blocked by fob implementation.
For image card, the movement of stepIndex is moving to reducer in #5615 . That is to say, at the views level, it does not know if the stepIndex has been adjusted based on selected time change. We will need to introduce additional state for this.