### PR TITLE
linked time: rename truncated path class

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -18,7 +18,7 @@ limitations under the License.
   <div class="line">
     <span class="tag">
       <tb-truncated-path
-        class="tag"
+        class="tag-path"
         title="{{ tag }}"
         value="{{ title }}"
       ></tb-truncated-path>

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -63,7 +63,7 @@ $_tick_width: 14px;
   text-align: end;
 }
 
-.tag {
+.tag-path {
   overflow: hidden;
 }
 


### PR DESCRIPTION
When adding a extra layer to include `vis-selected-warning` module in #5612, I accidentally named the layer the same name as `<tb-truncated-path>` (both named as "tag"). Luckily the extra css effects did not change the style. 
Rename the inner layer to "tag-path".
 