### PR TITLE
add FobCardAdapter interface definition

### DIFF
--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
@@ -24,10 +24,9 @@ export interface LinkedTime {
  * This class is intended to be implemented by the card that has a
  * LinkedTimeFobControllerComponent.
  *
- * Each implementer will have some sort of Scale that is used to translate
- * convert between step and pixel so that the fob lines up with the axis
- * properly. In future comments this scale will be refered to as
- * ImplementerScale
+ * Each implementer will have some sort of Scale that is used to convert between
+ * step and pixel so that the fob lines up with the axis properly. In future
+ * comments this scale will be refered to as ImplementerScale.
  *
  * It also allows cards to implement the dragging functionality in different
  * ways. By deciding which step to return in the getStepHigherThanMousePosition
@@ -36,7 +35,7 @@ export interface LinkedTime {
  */
 export interface FobCardAdapter {
   /**
-   * gets the highest step for this card.
+   * Gets the highest step for this card.
    */
   getHighestStep(): number;
 
@@ -49,19 +48,19 @@ export interface FobCardAdapter {
    * Uses ImplementerScale to translate the proper pixel offset.
    * @param step the step which needs to be translated.
    */
-  stepToPixel(step: number): number;
+  getAxisPositionFromStep(step: number): number;
 
   /**
    * Uses ImplementerScale to determine the step that is at the current mouse
-   * position or the closes step that is higher than the current mouse position.
+   * position or the closest step that is higher than the current mouse position.
    * @param position The mouse position
    */
-  getStepHigherThanMousePosition(position: number): number;
+  getStepHigherThanAxisPosition(position: number): number;
 
   /**
    * Uses ImplementerScale to determine the step that is at the current mouse
-   * position or the closes step that is lower than the current mouse position.
+   * position or the closest step that is lower than the current mouse position.
    * @param position The mouse position
    */
-  getStepLowerThanMousePosition(position: number): number;
+  getStepLowerThanAxisPosition(position: number): number;
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
@@ -19,3 +19,49 @@ export interface LinkedTime {
   start: {step: number};
   end: {step: number} | null;
 }
+
+/**
+ * This class is intended to be implemented by the card that has a
+ * LinkedTimeFobControllerComponent.
+ *
+ * Each implementer will have some sort of Scale that is used to translate
+ * convert between step and pixel so that the fob lines up with the axis
+ * properly. In future comments this scale will be refered to as
+ * ImplementerScale
+ *
+ * It also allows cards to implement the dragging functionality in different
+ * ways. By deciding which step to return in the getStepHigherThanMousePosition
+ * and getStepLowerThanMousePosition functions the implementer can decide if the
+ * fob "snaps" to certain steps or drags in in a smooth continuous way.
+ */
+export interface FobCardAdapter {
+  /**
+   * gets the highest step for this card.
+   */
+  getHighestStep(): number;
+
+  /**
+   * Gets the lowest step for this card.
+   */
+  getLowestStep(): number;
+
+  /**
+   * Uses ImplementerScale to translate the proper pixel offset.
+   * @param step the step which needs to be translated.
+   */
+  stepToPixel(step: number): number;
+
+  /**
+   * Uses ImplementerScale to determine the step that is at the current mouse
+   * position or the closes step that is higher than the current mouse position.
+   * @param position The mouse position
+   */
+  getStepHigherThanMousePosition(position: number): number;
+
+  /**
+   * Uses ImplementerScale to determine the step that is at the current mouse
+   * position or the closes step that is lower than the current mouse position.
+   * @param position The mouse position
+   */
+  getStepLowerThanMousePosition(position: number): number;
+}


### PR DESCRIPTION
Creates interface definition that will be used to implement a draggable fob in both histogram and scalar cards