### PR TITLE
Clear tag and chart metrics data on navigated action.

### DIFF
--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -224,8 +224,8 @@ export class MetricsEffects implements OnInitEffects {
 
   private readonly visibleCardsWithoutDataChanged$ = this.actions$.pipe(
     ofType(actions.cardVisibilityChanged),
-    switchMap(() => this.getVisibleCardFetchInfos().pipe(take(1))),
-    map((fetchInfos) => {
+    withLatestFrom(this.getVisibleCardFetchInfos()),
+    map(([, fetchInfos]) => {
       return fetchInfos.filter((fetchInfo) => {
         return fetchInfo.loadState === DataLoadState.NOT_LOADED;
       });
@@ -233,8 +233,8 @@ export class MetricsEffects implements OnInitEffects {
   );
 
   private readonly visibleCardsReloaded$ = this.reloadRequestedWhileShown$.pipe(
-    switchMap(() => this.getVisibleCardFetchInfos().pipe(take(1))),
-    map((fetchInfos) => {
+    withLatestFrom(this.getVisibleCardFetchInfos()),
+    map(([, fetchInfos]) => {
       return fetchInfos.filter((fetchInfo) => {
         return fetchInfo.loadState !== DataLoadState.LOADING;
       });
@@ -262,8 +262,10 @@ export class MetricsEffects implements OnInitEffects {
   /**
    * In general, this effect dispatch the following actions:
    *
-   * On dashboard shown with visible cards:
+   * On dashboard shown without data loaded:
    * - metricsTagMetadataRequested
+   *
+   * On changes to the set of cards that are visible:
    * - multipleTimeSeriesRequested
    *
    * On reloads:

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -283,11 +283,31 @@ const {initialState, reducers: namespaceContextedReducer} =
       if (!areSameRouteKindAndExperiments(oldRoute, newRoute)) {
         return {
           ...state,
-          // The route changes, we want to trigger tag metadata to reload.
+          // When the route changes we want to trigger tag metadata reload and
+          // clear some of the metadata that is derived from that request:
+          // tagMetadata, cardList, cardMetadataMap. These are the key inputs
+          // for deciding which cards to render and which runs to render on
+          // those cards (See b/225162725).
           tagMetadataLoadState: {
             state: DataLoadState.NOT_LOADED,
             lastLoadedTimeInMs: null,
           },
+          tagMetadata: {
+            scalars: {
+              tagDescriptions: {},
+              tagToRuns: {},
+            },
+            histograms: {
+              tagDescriptions: {},
+              tagToRuns: {},
+            },
+            images: {
+              tagDescriptions: {},
+              tagRunSampledInfo: {},
+            },
+          },
+          cardList: [],
+          cardMetadataMap: {},
           // Reset visible cards in case we resume a route that was left dirty.
           // Since visibility tracking is async, the state may not have received
           // 'exited card' updates when it was cached by the router.


### PR DESCRIPTION
* Motivation for features / changes

For Google-internal TensorBoards with more complex navigation, users are running into bugs where loading new experiments is not loading any chart data or loading new comparisons is not loading new chart data. (see b/225162725).

* Technical description of changes

The root cause is stale tag and chart metadata that is being used to render the charts before new tag metadata is retrieved. We replace this data with the new tag metadata, anyway, so the change is to clear this data earlier, on navigated event whenever the sets of experiments in a route changes.

