### PR TITLE
Create histogram fob adapter component and use with LinkedTimeFobControllerComponent

### DIFF
--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -13,6 +13,7 @@ tf_ng_module(
     name = "histogram",
     srcs = [
         "histogram_component.ts",
+        "histogram_linked_time_fob_controller.ts",
         "histogram_module.ts",
     ],
     assets = [

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -37,8 +37,8 @@ tf_ts_library(
     name = "histogram_test",
     testonly = True,
     srcs = [
-        "histogram_test.ts",
         "histogram_linked_time_fob_test.ts",
+        "histogram_test.ts",
         "histogram_util_test.ts",
     ],
     deps = [

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -38,6 +38,7 @@ tf_ts_library(
     testonly = True,
     srcs = [
         "histogram_test.ts",
+        "histogram_linked_time_fob_test.ts",
         "histogram_util_test.ts",
     ],
     deps = [
@@ -45,6 +46,7 @@ tf_ts_library(
         ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/third_party:d3",
         "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",
         "//tensorboard/webapp/widgets/linked_time_fob",
         "//tensorboard/webapp/widgets/linked_time_fob:types",

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -34,7 +34,7 @@ limitations under the License.
       </g>
     </g>
   </svg>
-  <div class="axis y-axis">
+  <div #yAxisOverlay class="axis y-axis">
     <svg>
       <g #yAxis></g>
       <!-- d3 places axis label at 9px right from the left edge. -->
@@ -51,13 +51,14 @@ limitations under the License.
     </svg>
     <!-- Disable the feature when in non-offset and non-step mode. -->
     <ng-container *ngIf="isLinkedTimeEnabled(linkedTime)">
-      <linked-time-fob-controller
+      <histogram-linked-time-fob-controller
         [axisDirection]="axisDirection"
         [linkedTime]="linkedTime"
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"
+        [startingPosition]="getAxisTop()"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
-      ></linked-time-fob-controller>
+      ></histogram-linked-time-fob-controller>
     </ng-container>
   </div>
   <svg #content class="content">

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -34,7 +34,7 @@ limitations under the License.
       </g>
     </g>
   </svg>
-  <div #yAxisOverlay class="axis y-axis">
+  <div class="axis y-axis">
     <svg>
       <g #yAxis></g>
       <!-- d3 places axis label at 9px right from the left edge. -->

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -52,7 +52,6 @@ limitations under the License.
     <!-- Disable the feature when in non-offset and non-step mode. -->
     <ng-container *ngIf="isLinkedTimeEnabled(linkedTime)">
       <histogram-linked-time-fob-controller
-        [axisDirection]="axisDirection"
         [linkedTime]="linkedTime"
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -56,7 +56,6 @@ limitations under the License.
         [linkedTime]="linkedTime"
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"
-        [startingPosition]="getAxisTop()"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
       ></histogram-linked-time-fob-controller>
     </ng-container>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -29,7 +29,6 @@ import {fromEvent, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import * as d3 from '../../third_party/d3';
 import {HCLColor} from '../../third_party/d3';
-import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
 import {LinkedTime} from '../linked_time_fob/linked_time_types';
 import {
   Bin,
@@ -101,8 +100,6 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() linkedTime: LinkedTime | null = null;
 
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
-
-  readonly axisDirection = AxisDirection.VERTICAL;
 
   readonly HistogramMode = HistogramMode;
   readonly TimeProperty = TimeProperty;

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -41,7 +41,7 @@ import {
 
 type BinScale = d3.ScaleLinear<number, number>;
 type CountScale = d3.ScaleLinear<number, number>;
-type TemporalScale =
+export type TemporalScale =
   | d3.ScaleLinear<number, number>
   | d3.ScaleTime<number, number>;
 type D3ColorScale = d3.ScaleLinear<HCLColor, string>;

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -89,6 +89,8 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
   @ViewChild('yAxis') private readonly yAxis!: ElementRef;
   @ViewChild('content') private readonly content!: ElementRef;
   @ViewChild('histograms') private readonly histograms!: ElementRef;
+  @ViewChild('yAxisOverlay')
+  private readonly yAxisOverlay!: ElementRef;
 
   @Input() mode: HistogramMode = HistogramMode.OFFSET;
 
@@ -330,6 +332,10 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
         end: {step: nextEndStep},
       });
     }
+  }
+
+  getAxisTop() {
+    return this.yAxisOverlay.nativeElement.getBoundingClientRect().top;
   }
 
   private getTimeValue(datum: HistogramDatum): number {

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -89,8 +89,6 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
   @ViewChild('yAxis') private readonly yAxis!: ElementRef;
   @ViewChild('content') private readonly content!: ElementRef;
   @ViewChild('histograms') private readonly histograms!: ElementRef;
-  @ViewChild('yAxisOverlay')
-  private readonly yAxisOverlay!: ElementRef;
 
   @Input() mode: HistogramMode = HistogramMode.OFFSET;
 
@@ -332,10 +330,6 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
         end: {step: nextEndStep},
       });
     }
-  }
-
-  getAxisTop() {
-    return this.yAxisOverlay.nativeElement.getBoundingClientRect().top;
   }
 
   private getTimeValue(datum: HistogramDatum): number {

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -33,7 +33,6 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
   @Input() steps!: number[];
   @Input() linkedTime!: LinkedTime;
   @Input() temporalScale!: TemporalScale;
-  @Input() startingPosition!: number;
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
 
   getHighestStep(): number {
@@ -50,7 +49,7 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
     let steps = this.steps;
     let stepIndex = 0;
     while (
-      position - this.startingPosition > this.temporalScale(steps[stepIndex]) &&
+      position > this.temporalScale(steps[stepIndex]) &&
       stepIndex < steps.length
     ) {
       stepIndex++;
@@ -60,10 +59,7 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
   getStepLowerThanAxisPosition(position: number): number {
     let steps = this.steps;
     let stepIndex = steps.length - 1;
-    while (
-      position - this.startingPosition < this.temporalScale(steps[stepIndex]) &&
-      stepIndex > 0
-    ) {
+    while (position < this.temporalScale(steps[stepIndex]) && stepIndex > 0) {
       stepIndex--;
     }
     return steps[stepIndex];

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -11,9 +11,9 @@ limitations under the License.
 ==============================================================================*/
 
 import {Component, EventEmitter, Input, Output} from '@angular/core';
-import {TemporalScale} from './histogram_component';
 import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
 import {FobCardAdapter, LinkedTime} from '../linked_time_fob/linked_time_types';
+import {TemporalScale} from './histogram_component';
 
 @Component({
   selector: 'histogram-linked-time-fob-controller',

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -11,11 +11,9 @@ limitations under the License.
 ==============================================================================*/
 
 import {Component, EventEmitter, Input, Output} from '@angular/core';
-import {ScaleLinear, ScaleTime} from '../../third_party/d3';
+import {TemporalScale} from './histogram_component';
 import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
 import {FobCardAdapter, LinkedTime} from '../linked_time_fob/linked_time_types';
-
-type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
 
 @Component({
   selector: 'histogram-linked-time-fob-controller',
@@ -46,22 +44,23 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
     return this.temporalScale(step);
   }
   getStepHigherThanAxisPosition(position: number): number {
-    let steps = this.steps;
     let stepIndex = 0;
     while (
-      position > this.temporalScale(steps[stepIndex]) &&
-      stepIndex < steps.length
+      position > this.temporalScale(this.steps[stepIndex]) &&
+      stepIndex < this.steps.length - 1
     ) {
       stepIndex++;
     }
-    return steps[stepIndex];
+    return this.steps[stepIndex];
   }
   getStepLowerThanAxisPosition(position: number): number {
-    let steps = this.steps;
-    let stepIndex = steps.length - 1;
-    while (position < this.temporalScale(steps[stepIndex]) && stepIndex > 0) {
+    let stepIndex = this.steps.length - 1;
+    while (
+      position < this.temporalScale(this.steps[stepIndex]) &&
+      stepIndex > 0
+    ) {
       stepIndex--;
     }
-    return steps[stepIndex];
+    return this.steps[stepIndex];
   }
 }

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -43,10 +43,10 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
   getLowestStep(): number {
     return this.steps[0];
   }
-  stepToPixel(step: number): number {
+  getAxisPositionFromStep(step: number): number {
     return this.temporalScale(step);
   }
-  getStepHigherThanMousePosition(position: number): number {
+  getStepHigherThanAxisPosition(position: number): number {
     let steps = this.steps;
     let stepIndex = 0;
     while (
@@ -57,7 +57,7 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
     }
     return steps[stepIndex];
   }
-  getStepLowerThanMousePosition(position: number): number {
+  getStepLowerThanAxisPosition(position: number): number {
     let steps = this.steps;
     let stepIndex = steps.length - 1;
     while (

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -27,11 +27,12 @@ import {TemporalScale} from './histogram_component';
   `,
 })
 export class HistogramLinkedTimeFobController implements FobCardAdapter {
-  @Input() axisDirection!: AxisDirection;
   @Input() steps!: number[];
   @Input() linkedTime!: LinkedTime;
   @Input() temporalScale!: TemporalScale;
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+
+  readonly axisDirection = AxisDirection.VERTICAL;
 
   getHighestStep(): number {
     return this.steps[this.steps.length - 1];

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -1,0 +1,71 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {ScaleLinear, ScaleTime} from '../../third_party/d3';
+import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
+import {FobCardAdapter, LinkedTime} from '../linked_time_fob/linked_time_types';
+
+type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
+
+@Component({
+  selector: 'histogram-linked-time-fob-controller',
+  template: `
+    <linked-time-fob-controller
+      [axisDirection]="axisDirection"
+      [linkedTime]="linkedTime"
+      [cardAdapter]="this"
+      (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+    ></linked-time-fob-controller>
+  `,
+})
+export class HistogramLinkedTimeFobController implements FobCardAdapter {
+  @Input() axisDirection!: AxisDirection;
+  @Input() steps!: number[];
+  @Input() linkedTime!: LinkedTime;
+  @Input() temporalScale!: TemporalScale;
+  @Input() startingPosition!: number;
+  @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+
+  getHighestStep(): number {
+    const steps = this.steps;
+    return steps[steps.length - 1];
+  }
+  getLowestStep(): number {
+    return this.steps[0];
+  }
+  stepToPixel(step: number): number {
+    return this.temporalScale(step);
+  }
+  getStepHigherThanMousePosition(position: number): number {
+    let steps = this.steps;
+    let stepIndex = 0;
+    while (
+      position - this.startingPosition > this.temporalScale(steps[stepIndex]) &&
+      stepIndex < steps.length
+    ) {
+      stepIndex++;
+    }
+    return steps[stepIndex];
+  }
+  getStepLowerThanMousePosition(position: number): number {
+    let steps = this.steps;
+    let stepIndex = steps.length - 1;
+    while (
+      position - this.startingPosition < this.temporalScale(steps[stepIndex]) &&
+      stepIndex > 0
+    ) {
+      stepIndex--;
+    }
+    return steps[stepIndex];
+  }
+}

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -34,8 +34,7 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
 
   getHighestStep(): number {
-    const steps = this.steps;
-    return steps[steps.length - 1];
+    return this.steps[this.steps.length - 1];
   }
   getLowestStep(): number {
     return this.steps[0];

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
@@ -14,13 +14,13 @@ import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ScaleLinear} from '../../third_party/d3';
-import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
-import {HistogramLinkedTimeFobController} from './histogram_linked_time_fob_controller';
 import {
-  LinkedTimeFobControllerComponent,
+  AxisDirection,
   Fob,
+  LinkedTimeFobControllerComponent,
 } from '../linked_time_fob/linked_time_fob_controller_component';
 import {LinkedTime} from '../linked_time_fob/linked_time_types';
+import {HistogramLinkedTimeFobController} from './histogram_linked_time_fob_controller';
 
 describe('HistogramLinkedTimeFobController', () => {
   let temporalScaleSpy: jasmine.Spy;
@@ -107,6 +107,7 @@ describe('HistogramLinkedTimeFobController', () => {
       expect(stepLower).toEqual(100);
     });
   });
+
   describe('getAxisPositionFromStep', () => {
     it('calls the scale function', () => {
       let fixture = createComponent({steps: [100, 200, 300, 400]});
@@ -114,6 +115,7 @@ describe('HistogramLinkedTimeFobController', () => {
       expect(temporalScaleSpy).toHaveBeenCalledOnceWith(150);
     });
   });
+
   describe('interaction with base controller', () => {
     it('properly uses scale when setting fob position', () => {
       let fixture = createComponent({
@@ -130,7 +132,6 @@ describe('HistogramLinkedTimeFobController', () => {
         testController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(600);
     });
-
     it('moves the fob to the next highest step when draggin down', () => {
       let fixture = createComponent({
         steps: [100, 200, 300, 400],
@@ -151,7 +152,6 @@ describe('HistogramLinkedTimeFobController', () => {
         testController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(400);
     });
-
     it('moves the fob to the next lowest step when draggin up', () => {
       let fixture = createComponent({
         steps: [100, 200, 300, 400],

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
@@ -38,8 +38,8 @@ describe('HistogramLinkedTimeFobController', () => {
     linkedTime?: LinkedTime;
   }): ComponentFixture<HistogramLinkedTimeFobController> {
     const fixture = TestBed.createComponent(HistogramLinkedTimeFobController);
-    fixture.componentInstance.steps = input.steps || [100, 200, 300, 400];
-    fixture.componentInstance.linkedTime = input.linkedTime || {
+    fixture.componentInstance.steps = input.steps ?? [100, 200, 300, 400];
+    fixture.componentInstance.linkedTime = input.linkedTime ?? {
       start: {step: 200},
       end: null,
     };
@@ -47,7 +47,7 @@ describe('HistogramLinkedTimeFobController', () => {
     fixture.componentInstance.temporalScale =
       temporalScaleSpy as unknown as TemporalScale;
     temporalScaleSpy.and.callFake((step: number) => {
-      // imitate a 10 to 1 scale.
+      // Imitate a 10 to 1 scale.
       return step * 10;
     });
     return fixture;

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
@@ -10,40 +10,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input, NO_ERRORS_SCHEMA} from '@angular/core';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ScaleLinear} from '../../third_party/d3';
 import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
-import {LinkedTime} from '../linked_time_fob/linked_time_types';
-import {TemporalScale} from './histogram_component';
 import {HistogramLinkedTimeFobController} from './histogram_linked_time_fob_controller';
-
-@Component({
-  selector: 'testable-tb-histogram-linked-time-fob',
-  template: `
-    <histogram-linked-time-fob-controller
-      [axisDirection]="axisDirection"
-      [linkedTime]="linkedTime"
-      [steps]="steps"
-      [temporalScale]="temporalScale"
-      (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
-    >
-    </histogram-linked-time-fob-controller>
-  `,
-})
-class TestableComponent {
-  @Input() axisDirection!: AxisDirection;
-  @Input() steps!: number[];
-  @Input() linkedTime!: LinkedTime;
-  @Input() temporalScale!: TemporalScale;
-  @Input() onSelectTimeChanged!: (linkedTime: LinkedTime) => void;
-}
 
 describe('HistogramLinkedTimeFobController', () => {
   let temporalScaleSpy: jasmine.Spy;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [HistogramLinkedTimeFobController, TestableComponent],
+      declarations: [HistogramLinkedTimeFobController],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
@@ -14,7 +14,6 @@ import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {
-  AxisDirection,
   Fob,
   LinkedTimeFobControllerComponent,
 } from '../linked_time_fob/linked_time_fob_controller_component';

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
@@ -41,12 +41,6 @@ describe('HistogramLinkedTimeFobController', () => {
     return fixture;
   }
 
-  it('builds a component', () => {
-    let fixture = createComponent({});
-    console.log(fixture);
-    expect(fixture).toBeTruthy;
-  });
-
   describe('getStepHigherThanAxisPosition', () => {
     it('gets step higher when position is not on a step', () => {
       let fixture = createComponent({steps: [100, 200, 300, 400]});

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
@@ -1,0 +1,133 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, Input, NO_ERRORS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ScaleLinear} from '../../third_party/d3';
+import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
+import {LinkedTime} from '../linked_time_fob/linked_time_types';
+import {TemporalScale} from './histogram_component';
+import {HistogramLinkedTimeFobController} from './histogram_linked_time_fob_controller';
+
+@Component({
+  selector: 'testable-tb-histogram-linked-time-fob',
+  template: `
+    <histogram-linked-time-fob-controller
+      [axisDirection]="axisDirection"
+      [linkedTime]="linkedTime"
+      [steps]="steps"
+      [temporalScale]="temporalScale"
+      (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+    >
+    </histogram-linked-time-fob-controller>
+  `,
+})
+class TestableComponent {
+  @Input() axisDirection!: AxisDirection;
+  @Input() steps!: number[];
+  @Input() linkedTime!: LinkedTime;
+  @Input() temporalScale!: TemporalScale;
+  @Input() onSelectTimeChanged!: (linkedTime: LinkedTime) => void;
+}
+
+describe('HistogramLinkedTimeFobController', () => {
+  let temporalScaleSpy: jasmine.Spy;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HistogramLinkedTimeFobController, TestableComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  });
+
+  function createComponent(input: {
+    steps?: number[];
+  }): ComponentFixture<HistogramLinkedTimeFobController> {
+    const fixture = TestBed.createComponent(HistogramLinkedTimeFobController);
+    fixture.componentInstance.axisDirection = AxisDirection.VERTICAL;
+    fixture.componentInstance.steps = input.steps || [1, 2, 3, 4];
+    fixture.componentInstance.linkedTime = {start: {step: 2}, end: null};
+    temporalScaleSpy = jasmine.createSpy();
+    fixture.componentInstance.temporalScale =
+      temporalScaleSpy as unknown as ScaleLinear<number, number>;
+    temporalScaleSpy.and.callFake((step: number) => {
+      return step;
+    });
+    return fixture;
+  }
+
+  it('builds a component', () => {
+    let fixture = createComponent({});
+    console.log(fixture);
+    expect(fixture).toBeTruthy;
+  });
+
+  describe('getStepHigherThanAxisPosition', () => {
+    it('gets step higher when position is not on a step', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      let stepHigher =
+        fixture.componentInstance.getStepHigherThanAxisPosition(150);
+      expect(stepHigher).toEqual(200);
+    });
+    it('gets step on given position when that position is on a step', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      let stepHigher =
+        fixture.componentInstance.getStepHigherThanAxisPosition(300);
+      expect(stepHigher).toEqual(300);
+    });
+    it('gets highest step when given position is higher than the max step', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      let stepHigher =
+        fixture.componentInstance.getStepHigherThanAxisPosition(800);
+      expect(stepHigher).toEqual(400);
+    });
+    it('gets lower step when given position is lower than the min step', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      let stepHigher =
+        fixture.componentInstance.getStepHigherThanAxisPosition(10);
+      expect(stepHigher).toEqual(100);
+    });
+  });
+
+  describe('getStepLowerThanAxisPosition', () => {
+    it('gets step lower when position is not on a step', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      let stepLower =
+        fixture.componentInstance.getStepLowerThanAxisPosition(250);
+      expect(stepLower).toEqual(200);
+    });
+    it('gets step on given position when that position is on a step', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      let stepLower =
+        fixture.componentInstance.getStepLowerThanAxisPosition(300);
+      expect(stepLower).toEqual(300);
+    });
+    it('gets highest step when given position is higher than the max step', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      let stepLower =
+        fixture.componentInstance.getStepLowerThanAxisPosition(800);
+      expect(stepLower).toEqual(400);
+    });
+    it('gets lower step when given position is lower than the min step', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      let stepLower =
+        fixture.componentInstance.getStepLowerThanAxisPosition(10);
+      expect(stepLower).toEqual(100);
+    });
+  });
+  describe('getAxisPositionFromStep', () => {
+    it('calls the scale function', () => {
+      let fixture = createComponent({steps: [100, 200, 300, 400]});
+      fixture.componentInstance.getAxisPositionFromStep(150);
+      expect(temporalScaleSpy).toHaveBeenCalledOnceWith(150);
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
@@ -39,7 +39,6 @@ describe('HistogramLinkedTimeFobController', () => {
     linkedTime?: LinkedTime;
   }): ComponentFixture<HistogramLinkedTimeFobController> {
     const fixture = TestBed.createComponent(HistogramLinkedTimeFobController);
-    fixture.componentInstance.axisDirection = AxisDirection.VERTICAL;
     fixture.componentInstance.steps = input.steps || [100, 200, 300, 400];
     fixture.componentInstance.linkedTime = input.linkedTime || {
       start: {step: 200},

--- a/tensorboard/webapp/widgets/histogram/histogram_module.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_module.ts
@@ -18,9 +18,10 @@ import {IntersectionObserverModule} from '../intersection_observer/intersection_
 import {LinkedTimeFobModule} from '../linked_time_fob/linked_time_fob_module';
 import {ResizeDetectorModule} from '../resize_detector_module';
 import {HistogramComponent} from './histogram_component';
+import {HistogramLinkedTimeFobController} from './histogram_linked_time_fob_controller';
 
 @NgModule({
-  declarations: [HistogramComponent],
+  declarations: [HistogramComponent, HistogramLinkedTimeFobController],
   exports: [HistogramComponent],
   imports: [
     CommonModule,

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -36,7 +36,6 @@ export enum Fob {
   END,
 }
 
-type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
 @Component({
   selector: 'linked-time-fob-controller',
   templateUrl: 'linked_time_fob_controller_component.ng.html',
@@ -61,10 +60,14 @@ export class LinkedTimeFobControllerComponent {
 
   getCssTranslatePx(step: number): string {
     if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.cardAdapter.stepToPixel(step)}px)`;
+      return `translate(0px, ${this.cardAdapter.getAxisPositionFromStep(
+        step
+      )}px)`;
     }
 
-    return `translate(${this.cardAdapter.stepToPixel(step)}px, 0px)`;
+    return `translate(${this.cardAdapter.getAxisPositionFromStep(
+      step
+    )}px, 0px)`;
   }
 
   startDrag(fob: Fob) {
@@ -81,9 +84,9 @@ export class LinkedTimeFobControllerComponent {
     let newLinkedTime = this.linkedTime;
     let newStep: number;
     if (this.isDraggingHigher(event.clientY, event.movementY)) {
-      newStep = this.cardAdapter.getStepHigherThanMousePosition(event.clientY);
+      newStep = this.cardAdapter.getStepHigherThanAxisPosition(event.clientY);
     } else if (this.isDraggingLower(event.clientY, event.movementY)) {
-      newStep = this.cardAdapter.getStepLowerThanMousePosition(event.clientY);
+      newStep = this.cardAdapter.getStepLowerThanAxisPosition(event.clientY);
     } else {
       return;
     }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -80,16 +80,18 @@ export class LinkedTimeFobControllerComponent {
   mouseMove(event: MouseEvent) {
     if (this.currentDraggingFob === Fob.NONE) return;
 
-    let newLinkedTime = this.linkedTime;
-    let newStep: number;
-    let mousePosition =
+    const newLinkedTime = this.linkedTime;
+    let newStep: number | null = null;
+    const mousePosition =
       event.clientY -
       this.axisOverlay.nativeElement.getBoundingClientRect().top;
     if (this.isDraggingHigher(mousePosition, event.movementY)) {
       newStep = this.cardAdapter.getStepHigherThanAxisPosition(mousePosition);
     } else if (this.isDraggingLower(mousePosition, event.movementY)) {
       newStep = this.cardAdapter.getStepLowerThanAxisPosition(mousePosition);
-    } else {
+    }
+
+    if (newStep === null) {
       return;
     }
 
@@ -128,7 +130,7 @@ export class LinkedTimeFobControllerComponent {
   }
 
   getDraggingFobTop(): number {
-    let absoluteTop =
+    const absoluteTop =
       this.currentDraggingFob !== Fob.END
         ? this.startFobWrapper.nativeElement.getBoundingClientRect().top
         : this.endFobWrapper.nativeElement.getBoundingClientRect().top;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -83,10 +83,13 @@ export class LinkedTimeFobControllerComponent {
 
     let newLinkedTime = this.linkedTime;
     let newStep: number;
-    if (this.isDraggingHigher(event.clientY, event.movementY)) {
-      newStep = this.cardAdapter.getStepHigherThanAxisPosition(event.clientY);
-    } else if (this.isDraggingLower(event.clientY, event.movementY)) {
-      newStep = this.cardAdapter.getStepLowerThanAxisPosition(event.clientY);
+    let mousePosition =
+      event.clientY -
+      this.axisOverlay.nativeElement.getBoundingClientRect().top;
+    if (this.isDraggingHigher(mousePosition, event.movementY)) {
+      newStep = this.cardAdapter.getStepHigherThanAxisPosition(mousePosition);
+    } else if (this.isDraggingLower(mousePosition, event.movementY)) {
+      newStep = this.cardAdapter.getStepLowerThanAxisPosition(mousePosition);
     } else {
       return;
     }
@@ -126,9 +129,13 @@ export class LinkedTimeFobControllerComponent {
   }
 
   getDraggingFobTop(): number {
-    return this.currentDraggingFob !== Fob.END
-      ? this.startFobWrapper.nativeElement.getBoundingClientRect().top
-      : this.endFobWrapper.nativeElement.getBoundingClientRect().top;
+    let absoluteTop =
+      this.currentDraggingFob !== Fob.END
+        ? this.startFobWrapper.nativeElement.getBoundingClientRect().top
+        : this.endFobWrapper.nativeElement.getBoundingClientRect().top;
+    return (
+      absoluteTop - this.axisOverlay.nativeElement.getBoundingClientRect().top
+    );
   }
 
   getDraggingFobStep(): number {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -22,8 +22,7 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import {ScaleLinear, ScaleTime} from '../../third_party/d3';
-import {LinkedTime, FobCardAdapter} from './linked_time_types';
+import {FobCardAdapter, LinkedTime} from './linked_time_types';
 
 export enum AxisDirection {
   HORIZONTAL,

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -48,7 +48,7 @@ class TestableComponent {
   @Input() onSelectTimeChanged!: (newLinkedTime: LinkedTime) => void;
 }
 
-fdescribe('linked_time_fob_controller', () => {
+describe('linked_time_fob_controller', () => {
   let onSelectTimeChanged: jasmine.Spy;
   let getHighestStepSpy: jasmine.Spy;
   let getLowestStepSpy: jasmine.Spy;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -17,16 +17,13 @@ import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {sendKeys} from '../../testing/dom';
-import {ScaleLinear, ScaleTime} from '../../third_party/d3';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
 import {
   AxisDirection,
   Fob,
   LinkedTimeFobControllerComponent,
 } from './linked_time_fob_controller_component';
-import {LinkedTime} from './linked_time_types';
-
-type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
+import {FobCardAdapter, LinkedTime} from './linked_time_types';
 
 @Component({
   selector: 'testable-comp',
@@ -35,8 +32,7 @@ type TemporalScale = ScaleLinear<number, number> | ScaleTime<number, number>;
       #FobController
       [axisDirection]="axisDirection"
       [linkedTime]="linkedTime"
-      [steps]="steps"
-      [temporalScale]="temporalScale"
+      [cardAdapter]="fobCardAdapter"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
     ></linked-time-fob-controller>
   `,
@@ -45,17 +41,21 @@ class TestableComponent {
   @ViewChild('FobController')
   fobController!: LinkedTimeFobControllerComponent;
 
-  @Input() steps!: number[];
   @Input() axisDirection!: AxisDirection;
   @Input() linkedTime!: LinkedTime;
-  @Input() temporalScale!: TemporalScale;
+  @Input() fobCardAdapter!: FobCardAdapter;
 
   @Input() onSelectTimeChanged!: (newLinkedTime: LinkedTime) => void;
 }
 
-describe('linked_time_fob_controller', () => {
+fdescribe('linked_time_fob_controller', () => {
   let onSelectTimeChanged: jasmine.Spy;
-  let temporalScaleSpy: jasmine.Spy;
+  let getHighestStepSpy: jasmine.Spy;
+  let getLowestStepSpy: jasmine.Spy;
+  let getAxisPositionFromStepSpy: jasmine.Spy;
+  let getStepHigherSpy: jasmine.Spy;
+  let getStepLowerSpy: jasmine.Spy;
+  let fobCardAdapter: FobCardAdapter;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
@@ -73,20 +73,36 @@ describe('linked_time_fob_controller', () => {
     linkedTime: LinkedTime;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
-    fixture.componentInstance.steps = input.steps || [1, 2, 3, 4];
+    getHighestStepSpy = jasmine.createSpy();
+    getLowestStepSpy = jasmine.createSpy();
+    getAxisPositionFromStepSpy = jasmine.createSpy();
+    getStepHigherSpy = jasmine.createSpy();
+    getStepLowerSpy = jasmine.createSpy();
+    fobCardAdapter = {
+      getHighestStep: getHighestStepSpy,
+      getLowestStep: getLowestStepSpy,
+      getAxisPositionFromStep: getAxisPositionFromStepSpy,
+      getStepHigherThanAxisPosition: getStepHigherSpy,
+      getStepLowerThanAxisPosition: getStepLowerSpy,
+    };
+
+    getHighestStepSpy.and.callFake(() => 4);
+    getLowestStepSpy.and.callFake(() => 0);
+    getAxisPositionFromStepSpy.and.callFake((step: number) => {
+      return step;
+    });
+    getStepHigherSpy.and.callFake((step: number) => {
+      return step;
+    });
+    getStepLowerSpy.and.callFake((step: number) => {
+      return step;
+    });
+    fixture.componentInstance.fobCardAdapter = fobCardAdapter;
 
     fixture.componentInstance.axisDirection =
       input.axisDirection || AxisDirection.VERTICAL;
 
     fixture.componentInstance.linkedTime = input.linkedTime;
-
-    temporalScaleSpy = jasmine.createSpy();
-    fixture.componentInstance.temporalScale =
-      temporalScaleSpy as unknown as ScaleLinear<number, number>;
-
-    temporalScaleSpy.and.callFake((step: number) => {
-      return step;
-    });
 
     onSelectTimeChanged = jasmine.createSpy();
     fixture.componentInstance.onSelectTimeChanged = onSelectTimeChanged;
@@ -94,8 +110,16 @@ describe('linked_time_fob_controller', () => {
     return fixture;
   }
 
+  it('sets fob position based on linked time and getAxisPositionFromStep call', () => {
+    const fixture = createComponent({
+      linkedTime: {start: {step: 2}, end: null},
+    });
+    fixture.detectChanges();
+    expect(getAxisPositionFromStepSpy).toHaveBeenCalledOnceWith(2);
+  });
+
   describe('vertical dragging', () => {
-    it('moves the start fob down to mouse when mouse is dragging down and is below fob', () => {
+    it('moves the start fob based on adapter getStepHigherThanMousePosition when mouse is dragging down and is below fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: null},
       });
@@ -108,6 +132,7 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 3, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
@@ -117,7 +142,7 @@ describe('linked_time_fob_controller', () => {
       });
     });
 
-    it('moves the start fob above mouse when mouse is dragging up and above the fob', () => {
+    it('moves the start fob based on adapter getStepLowerThanMousePosition when mouse is dragging up and above the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 4}, end: null},
       });
@@ -133,6 +158,7 @@ describe('linked_time_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledOnceWith(2);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
@@ -141,8 +167,7 @@ describe('linked_time_fob_controller', () => {
         end: null,
       });
     });
-
-    it('does not move the start fob when mouse is dragging up but, is below the fob', () => {
+    it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging up but, is below the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 2}, end: null},
       });
@@ -158,13 +183,14 @@ describe('linked_time_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
     });
-
-    it('does not move the start fob when mouse is dragging down but, is above the fob', () => {
+    it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging down but, is above the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 4}, end: null},
       });
@@ -177,16 +203,18 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 2, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
     });
-
-    it('does not move the start fob when mouse is dragging down but, the fob is already on the final step', () => {
+    it('does not move the start fob or call call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging down but, the fob is already on the final step', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 4}, end: null},
       });
+      getHighestStepSpy.and.callFake(() => 4);
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
       expect(
@@ -196,34 +224,13 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 8, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
     });
-
-    it('start fob moves does not pass the end fob when being dragged passed it.', () => {
-      const fixture = createComponent({
-        linkedTime: {start: {step: 2}, end: {step: 3}},
-      });
-      fixture.detectChanges();
-      const fobController = fixture.componentInstance.fobController;
-      expect(
-        fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(2);
-      fobController.startDrag(Fob.START);
-      const fakeEvent = new MouseEvent('mousemove', {clientY: 4, movementY: 1});
-      fobController.mouseMove(fakeEvent);
-      fixture.detectChanges();
-      expect(
-        fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(3);
-      expect(onSelectTimeChanged).toHaveBeenCalledOnceWith({
-        start: {step: 3},
-        end: {step: 3},
-      });
-    });
-
     it('end fob moves to the mouse when mouse is dragging up and mouse is above the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: {step: 1}},
@@ -238,6 +245,7 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 3, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
@@ -246,7 +254,6 @@ describe('linked_time_fob_controller', () => {
         end: {step: 3},
       });
     });
-
     it('end fob moves to the mouse when mouse is dragging down and mouse is below the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: {step: 4}},
@@ -263,6 +270,7 @@ describe('linked_time_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledOnceWith(2);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
@@ -271,7 +279,6 @@ describe('linked_time_fob_controller', () => {
         end: {step: 2},
       });
     });
-
     it('end fob does not move when mouse is dragging down but, mouse is above the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: {step: 2}},
@@ -288,12 +295,13 @@ describe('linked_time_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
     });
-
     it('end fob does not move when mouse is dragging up but, mouse is below the fob', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: {step: 3}},
@@ -307,35 +315,12 @@ describe('linked_time_fob_controller', () => {
       const fakeEvent = new MouseEvent('mousemove', {clientY: 2, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
+      expect(getStepHigherSpy).toHaveBeenCalledTimes(0);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
       expect(onSelectTimeChanged).toHaveBeenCalledTimes(0);
-    });
-
-    it('end fob does not pass the start fob when being dragged passed it.', () => {
-      const fixture = createComponent({
-        linkedTime: {start: {step: 2}, end: {step: 3}},
-      });
-      fixture.detectChanges();
-      const fobController = fixture.componentInstance.fobController;
-      expect(
-        fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(3);
-      fobController.startDrag(Fob.END);
-      const fakeEvent = new MouseEvent('mousemove', {
-        clientY: 1,
-        movementY: -1,
-      });
-      fobController.mouseMove(fakeEvent);
-      fixture.detectChanges();
-      expect(
-        fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(2);
-      expect(onSelectTimeChanged).toHaveBeenCalledOnceWith({
-        start: {step: 2},
-        end: {step: 2},
-      });
     });
   });
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
@@ -53,14 +53,14 @@ export interface FobCardAdapter {
   /**
    * Uses ImplementerScale to determine the step that is at the current mouse
    * position or the closest step that is higher than the current mouse position.
-   * @param position The mouse position
+   * @param position The mouse position relative to the start of the axis
    */
   getStepHigherThanAxisPosition(position: number): number;
 
   /**
    * Uses ImplementerScale to determine the step that is at the current mouse
    * position or the closest step that is lower than the current mouse position.
-   * @param position The mouse position
+   * @param position The mouse position relative to the start of the axis
    */
   getStepLowerThanAxisPosition(position: number): number;
 }


### PR DESCRIPTION
This is a refactoring of the logic used for dragging the linked time fob in the Histogram Card. The previous implementation did not allow for the use cases needed in the Scalar Card. Our goal is to pull out the logic that will be histogram specific into a class that is generalizable. The CardFobAdapter interface created in #5623 is the generalization that will be implemented in both the Histogram and Scalar cards to allow for different uses of the draggable fob.