### PR TITLE
Show histogram tooltips that bleed out of content box.

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
@@ -106,7 +106,6 @@ mat-spinner {
 
 tb-histogram {
   flex-grow: 1;
-  overflow: hidden;
 }
 
 .empty-message {

--- a/tensorboard/webapp/widgets/histogram/histogram_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.scss
@@ -140,6 +140,12 @@ svg {
 
 .content {
   grid-area: content;
+  // Allow overflow to be visible so that the tooltip can be shown for points
+  // near the edges.
+  overflow: visible;
+  // Raise the content area above the axes so that the tooltip can be shown over
+  // the axes marks.
+  z-index: 1;
 
   .tick {
     stroke-width: 1px;


### PR DESCRIPTION
* Motivation for features / changes

  The small histogram tooltip can be cutoff by the top or right edges (Googlers, see b/226775031).

* Technical description of changes

  A couple of ancestor elements of the tooltip element currently set `overflow: hidden`. We change these elements so that the effective value is 'overflow: visible'.

  This has the somewhat unintended side effect of exposing an additional ~1px height flat line just above the x axis (because the set of lines in the '.content' element ever so slightly overflow). This is probably ok since we'd prefer for the user to see all histogram lines. We should consider in the future tightening up the histogram rendering so that all the lines fit nicely into the '.content' element. (Googlers, see screenshot diffs in cl/437279846).

* Screenshots

  Tooltip at top before: 

  ![image](https://user-images.githubusercontent.com/17152369/160172804-c314586a-ef2b-4248-858e-39f6af003583.png)

  Tooltip at top after:

  ![image](https://user-images.githubusercontent.com/17152369/160172854-69907d39-e314-4453-871f-1855f0f44d32.png)

  Tooltip at right before: 

  ![image](https://user-images.githubusercontent.com/17152369/160172892-23424ca7-041b-4404-8f73-7e1cd80f2895.png)

  Tooltip at right after:

![image](https://user-images.githubusercontent.com/17152369/160172919-e2957cd8-6cee-4aa5-9369-77ffbc55fb12.png)

