### PR TITLE
Support for Chinese and other UTF8 characters as folder names

### DIFF
--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -87,7 +87,11 @@ export const {
   getObserver: getObjectObserver,
   disposeBinding: disposeObjectBinding,
 } = makeBindings(
-  (s) => JSON.parse(decodeURIComponent(escape(window.atob(s)))) as Record<string, string>,
+  (s) =>
+    JSON.parse(decodeURIComponent(escape(window.atob(s)))) as Record<
+      string,
+      string
+    >,
   (o) => btoa(unescape(encodeURIComponent(JSON.stringify(o))))
 );
 export interface StorageOptions<T> {

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -87,8 +87,8 @@ export const {
   getObserver: getObjectObserver,
   disposeBinding: disposeObjectBinding,
 } = makeBindings(
-  (s) => JSON.parse(atob(s)) as Record<string, string>,
-  (o) => btoa(JSON.stringify(o))
+  (s) => JSON.parse(decodeURIComponent(escape(window.atob(s)))) as Record<string, string>,
+  (o) => btoa(unescape(encodeURIComponent(JSON.stringify(o))))
 );
 export interface StorageOptions<T> {
   defaultValue?: T;


### PR DESCRIPTION
* Motivation for features / changes

When the folder is named Chinese and other UTF8 characters, it is not possible to toggle Runs on the front end.

As shown below, the toggle will not work because of the `btoa` function.

<img width="1364" alt="Screen Shot 2022-03-29 at 19 45 41" src="https://user-images.githubusercontent.com/51821219/160605171-91e6ad40-44e7-439c-b1dc-e49fc27dd33e.png">

* Technical description of changes

The encoding method of the characters before `atob` has been added to avoid the above problem.

* Screenshots of UI changes

None

* Detailed steps to verify changes work correctly (as executed by you)

Create a folder called `中文字符` in the log path and store ri in it, then start tensorboard, toggle Runs in the lower left corner of SCALARS does not work and the console reports an error (see above)

* Alternate designs / implementations considered

None