### PR TITLE
linked time: stepIndex moving: moving thumb movement of range selection to stepIndex update in reducer

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -394,8 +394,8 @@ export function generateNextCardStepIndexFromSelectedTime(
     );
 
     let nextStepIndex = null;
-    // Single Selection
     if (selectedTime.end === null) {
+      // Single Selection
       nextStepIndex = getNextImageCardStepIndexFromSingleSelection(
         selectedTime.start.step,
         steps
@@ -506,7 +506,7 @@ function getNextImageCardStepIndexFromSingleSelection(
 
 /**
  * Gets next stepIndex for an image card based on range selection. Returns null if nothing should change.
- * @param selectedSteps The selected steps from selected time. It should contain one or mutliple steps.
+ * @param selectedSteps The selected steps from selected time. It should contain empty or one to multple steps.
  * @param steps The steps in an image card.
  * @param step The step where the current step index locates.
  */
@@ -515,19 +515,17 @@ function getNextImageCardStepIndexFromRangeSelection(
   steps: number[],
   step: number
 ): number | null {
+  if (selectedSteps.length === 0) return null;
+
   const firstSelectedStep = selectedSteps[0];
   const lastSelectedStep = selectedSteps[selectedSteps.length - 1];
 
   // Updates step index to the closest index if it is outside the range.
   if (step > lastSelectedStep) {
-    return steps.indexOf(lastSelectedStep) !== -1
-      ? steps.indexOf(lastSelectedStep)
-      : null;
+    return steps.indexOf(lastSelectedStep);
   }
   if (step < firstSelectedStep) {
-    return steps.indexOf(firstSelectedStep) !== -1
-      ? steps.indexOf(firstSelectedStep)
-      : null;
+    return steps.indexOf(firstSelectedStep);
   }
 
   // Does not update index when it is in selected range.

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -506,7 +506,7 @@ function getNextImageCardStepIndexFromSingleSelection(
 
 /**
  * Gets next stepIndex for an image card based on range selection. Returns null if nothing should change.
- * @param selectedSteps The selected steps from selected time. It should contain empty or one to multple steps.
+ * @param selectedSteps The selected steps from selected time. Empty array means no steps within range.
  * @param steps The steps in an image card.
  * @param step The step where the current step index locates.
  */

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -400,6 +400,17 @@ export function generateNextCardStepIndexFromSelectedTime(
         selectedTime.start.step,
         steps
       );
+    } else {
+      // Range Selection
+      const currentStepIndex = previousCardStepIndex[cardId]!;
+      const step = steps[currentStepIndex];
+      const selectedSteps = getSelectedSteps(selectedTime, steps);
+
+      nextStepIndex = getNextImageCardStepIndexFromRangeSelection(
+        selectedSteps,
+        steps,
+        step
+      );
     }
 
     if (nextStepIndex !== null) {
@@ -459,7 +470,7 @@ function getSelectedSteps(selectedTime: LinkedTime | null, steps: number[]) {
 }
 
 /**
- * Gets next stepIndex for a card based on single selection. Returns null if nothing should change.
+ * Gets next stepIndex for an image card based on single selection. Returns null if nothing should change.
  * @param selectedStep The selected step from selected time. It is equivalent to start step here
  *  since there is no `end` in selected time when it is single seleciton.
  */
@@ -493,9 +504,40 @@ function getNextImageCardStepIndexFromSingleSelection(
   return null;
 }
 
+/**
+ * Gets next stepIndex for an image card based on range selection. Returns null if nothing should change.
+ * @param selectedSteps The selected steps from selected time. It should contain one or mutliple steps.
+ * @param steps The steps in an image card.
+ * @param step The step where the current step index locates.
+ */
+function getNextImageCardStepIndexFromRangeSelection(
+  selectedSteps: number[],
+  steps: number[],
+  step: number
+): number | null {
+  const firstSelectedStep = selectedSteps[0];
+  const lastSelectedStep = selectedSteps[selectedSteps.length - 1];
+
+  // Updates step index to the closest index if it is outside the range.
+  if (step > lastSelectedStep) {
+    return steps.indexOf(lastSelectedStep) !== -1
+      ? steps.indexOf(lastSelectedStep)
+      : null;
+  }
+  if (step < firstSelectedStep) {
+    return steps.indexOf(firstSelectedStep) !== -1
+      ? steps.indexOf(firstSelectedStep)
+      : null;
+  }
+
+  // Does not update index when it is in selected range.
+  return null;
+}
+
 export const TEST_ONLY = {
   getImageCardStepValues,
   getSelectedSteps,
+  getNextImageCardStepIndexFromRangeSelection,
   getNextImageCardStepIndexFromSingleSelection,
   generateNextCardStepIndexFromSelectedTime,
   util,

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -1020,25 +1020,5 @@ describe('metrics store utils', () => {
 
       expect(nextCardStepIndex).toEqual(null);
     });
-
-    it('returns null when step is smaller than first selected step and selected steps not in steps', () => {
-      const nextCardStepIndex = getNextImageCardStepIndexFromRangeSelection(
-        [25, 29],
-        [10, 20, 30, 40],
-        20
-      );
-
-      expect(nextCardStepIndex).toEqual(null);
-    });
-
-    it('returns null when step is larger than last selected step and selected steps not in steps', () => {
-      const nextCardStepIndex = getNextImageCardStepIndexFromRangeSelection(
-        [25, 29],
-        [10, 20, 30, 40],
-        30
-      );
-
-      expect(nextCardStepIndex).toEqual(null);
-    });
   });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -204,6 +204,7 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       shareReplay(1)
     );
 
+    this.stepIndex$ = this.store.select(getCardStepIndex, this.cardId);
     this.loadState$ = this.store.select(getCardLoadState, this.cardId);
 
     this.tag$ = cardMetadata$.pipe(
@@ -275,40 +276,6 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
           }
         }
         return selectedStepsInRange;
-      })
-    );
-
-    this.stepIndex$ = combineLatest(
-      this.store.select(getCardStepIndex, this.cardId),
-      this.selectedTime$,
-      this.selectedSteps$,
-      this.stepValues$
-    ).pipe(
-      map(([stepIndex, selectedTime, selectedSteps, stepValues]) => {
-        if (!selectedTime || selectedTime.clipped) return stepIndex;
-
-        const firstSelectedStep = selectedSteps[0];
-        const lastSelectedStep = selectedSteps[selectedSteps.length - 1];
-
-        // Range selection
-        if (selectedTime.endStep !== null && stepIndex !== null) {
-          const step = stepValues[stepIndex];
-
-          // Does not move index when it is already in selected range.
-          if (selectedTime.startStep <= step && step <= selectedTime.endStep) {
-            return stepIndex;
-          }
-
-          // Moves thumb to the closest stepIndex.
-          if (step >= lastSelectedStep) {
-            return stepValues.indexOf(lastSelectedStep);
-          }
-          if (step <= firstSelectedStep) {
-            return stepValues.indexOf(firstSelectedStep);
-          }
-        }
-
-        return stepIndex;
       })
     );
 

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -920,36 +920,6 @@ describe('image card', () => {
           return slider.nativeElement.getAttribute('aria-valuenow');
         }
 
-        it('moves slider thumb to the highest step in range when the thumb is larger than end step', () => {
-          store.overrideSelector(selectors.getMetricsSelectedTime, {
-            start: {step: 15},
-            end: {step: 35},
-          });
-          const fixture = createImageCardContainerWithStepIndex(3);
-
-          expect(getSliderThumbPosition(fixture)).toBe('2');
-        });
-
-        it('moves slider thumb to the lowest step in range when the thumb is smaller than start step', () => {
-          store.overrideSelector(selectors.getMetricsSelectedTime, {
-            start: {step: 15},
-            end: {step: 35},
-          });
-          const fixture = createImageCardContainerWithStepIndex(0);
-
-          expect(getSliderThumbPosition(fixture)).toBe('1');
-        });
-
-        it('does not moves slider thumb when the thumb is in range', () => {
-          store.overrideSelector(selectors.getMetricsSelectedTime, {
-            start: {step: 15},
-            end: {step: 35},
-          });
-          const fixture = createImageCardContainerWithStepIndex(2);
-
-          expect(getSliderThumbPosition(fixture)).toBe('2');
-        });
-
         it('does not moves slider thumb when selected time is clipped', () => {
           store.overrideSelector(selectors.getMetricsSelectedTime, {
             start: {step: 55},
@@ -966,16 +936,6 @@ describe('image card', () => {
           const fixture2 = createImageCardContainerWithStepIndex(2);
 
           expect(getSliderThumbPosition(fixture2)).toBe('2');
-        });
-
-        it('does not moves slider thumb when selected range had no image', () => {
-          store.overrideSelector(selectors.getMetricsSelectedTime, {
-            start: {step: 15},
-            end: {step: 18},
-          });
-          const fixture = createImageCardContainerWithStepIndex(2);
-
-          expect(getSliderThumbPosition(fixture)).toBe('2');
         });
       });
     });


### PR DESCRIPTION
Motivation and full context please see https://github.com/tensorflow/tensorboard/pull/5615.

This PR updates stepIndex on range selection:
* Removes the stepIndex in image_container entirely
* Moves the logics (update within/outside range) to `metrics_store_internal_utils`
* Moves corresponding tests in `image_card_test` to `metrics_store_internal_utils_test` cause the thumb movements are no longer updated in the view

This PR also includes some clean up in `metrics_store_internal_utils_test.ts`