### PR TITLE
pip: updates werkzeug to use Response in werkzeug 2.1

### DIFF
--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -163,7 +163,7 @@ class HandlingErrorsTest(tb_test.TestCase):
                 "All is well", 200, content_type="text/html"
             )
 
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, wrappers.Response)
         response = server.get("/")
         self.assertEqual(response.get_data(), b"All is well")
         self.assertEqual(response.status_code, 200)
@@ -177,7 +177,7 @@ class HandlingErrorsTest(tb_test.TestCase):
                 "who are you?", challenge='Digest realm="https://example.com"'
             )
 
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, wrappers.Response)
         response = server.get("/")
         self.assertEqual(
             response.get_data(),
@@ -198,7 +198,7 @@ class HandlingErrorsTest(tb_test.TestCase):
         def app(request):
             raise ValueError("something borked internally")
 
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, wrappers.Response)
         with self.assertRaises(ValueError) as cm:
             response = server.get("/")
         self.assertEqual(str(cm.exception), "something borked internally")
@@ -230,7 +230,7 @@ class ApplicationTest(tb_test.TestCase):
         self._install_server(app)
 
     def _install_server(self, app):
-        self.server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(app, wrappers.Response)
 
     def _get_json(self, path):
         response = self.server.get(path)
@@ -444,7 +444,7 @@ class ApplicationTest(tb_test.TestCase):
             ),
         ]
         app = application.TensorBoardWSGI(plugins)
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, wrappers.Response)
         with self.assertRaisesRegex(
             ValueError, "Expected es_module_path to be non-absolute path"
         ):
@@ -459,7 +459,7 @@ class ApplicationTest(tb_test.TestCase):
             ),
         ]
         app = application.TensorBoardWSGI(plugins)
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, wrappers.Response)
         with self.assertRaisesRegex(
             ValueError, "quux.*declared.*both Angular.*legacy"
         ):
@@ -474,7 +474,7 @@ class ApplicationTest(tb_test.TestCase):
             ),
         ]
         app = application.TensorBoardWSGI(plugins)
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, wrappers.Response)
         with self.assertRaisesRegex(
             ValueError, "quux.*declared.*both Angular.*iframed"
         ):
@@ -501,7 +501,7 @@ class ApplicationBaseUrlTest(tb_test.TestCase):
             ),
         ]
         app = application.TensorBoardWSGI(plugins, path_prefix=self.path_prefix)
-        self.server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(app, wrappers.Response)
 
     def _get_json(self, path):
         response = self.server.get(path)
@@ -706,7 +706,7 @@ class TensorBoardPluginsTest(tb_test.TestCase):
             experimental_middlewares=[self._auth_check_middleware],
         )
 
-        self.server = werkzeug_test.Client(self.app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(self.app, wrappers.Response)
 
     def _auth_check_middleware(self, app):
         def auth_check_app(environ, start_response):

--- a/tensorboard/backend/empty_path_redirect_test.py
+++ b/tensorboard/backend/empty_path_redirect_test.py
@@ -34,7 +34,7 @@ class EmptyPathRedirectMiddlewareTest(tb_test.TestCase):
         app = self._lax_strip_foo_middleware(app)
         self.app = app
         self.server = werkzeug_test.Client(
-            self.app, werkzeug.wrappers.BaseResponse
+            self.app, werkzeug.wrappers.Response
         )
 
     def _lax_strip_foo_middleware(self, app):

--- a/tensorboard/backend/empty_path_redirect_test.py
+++ b/tensorboard/backend/empty_path_redirect_test.py
@@ -33,9 +33,7 @@ class EmptyPathRedirectMiddlewareTest(tb_test.TestCase):
         app = empty_path_redirect.EmptyPathRedirectMiddleware(app)
         app = self._lax_strip_foo_middleware(app)
         self.app = app
-        self.server = werkzeug_test.Client(
-            self.app, werkzeug.wrappers.Response
-        )
+        self.server = werkzeug_test.Client(self.app, werkzeug.wrappers.Response)
 
     def _lax_strip_foo_middleware(self, app):
         """Strips a `/foo` prefix if it exists; no-op otherwise."""

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -45,9 +45,7 @@ class BaseTest(object):
         super(BaseTest, self).setUp()
 
         self.app = self._create_app()
-        self.server = werkzeug_test.Client(
-            self.app, werkzeug.wrappers.Response
-        )
+        self.server = werkzeug_test.Client(self.app, werkzeug.wrappers.Response)
 
     def _assert_ok(self, response, eid, path, script):
         self.assertEqual(response.status_code, 200)

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -46,7 +46,7 @@ class BaseTest(object):
 
         self.app = self._create_app()
         self.server = werkzeug_test.Client(
-            self.app, werkzeug.wrappers.BaseResponse
+            self.app, werkzeug.wrappers.Response
         )
 
     def _assert_ok(self, response, eid, path, script):

--- a/tensorboard/backend/path_prefix_test.py
+++ b/tensorboard/backend/path_prefix_test.py
@@ -60,7 +60,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
 
     def test_empty_path_prefix(self):
         app = path_prefix.PathPrefixMiddleware(self._echo_app, "")
-        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
 
         with self.subTest("at empty"):
             self._assert_ok(server.get(""), path="", script="")
@@ -74,7 +74,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
 
     def test_nonempty_path_prefix(self):
         app = path_prefix.PathPrefixMiddleware(self._echo_app, "/pfx")
-        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
 
         with self.subTest("at root"):
             response = server.get("/pfx")
@@ -100,7 +100,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
         app = self._echo_app
         app = path_prefix.PathPrefixMiddleware(app, "/bar")
         app = path_prefix.PathPrefixMiddleware(app, "/foo")
-        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
 
         response = server.get("/foo/bar/baz/quux")
         self._assert_ok(response, path="/baz/quux", script="/foo/bar")

--- a/tensorboard/backend/security_validator_test.py
+++ b/tensorboard/backend/security_validator_test.py
@@ -20,7 +20,7 @@ from unittest import mock
 import werkzeug
 from werkzeug import test as werkzeug_test
 from werkzeug.datastructures import Headers
-from werkzeug.wrappers import BaseResponse
+from werkzeug.wrappers import Response
 
 from tensorboard import test as tb_test
 from tensorboard.backend import security_validator
@@ -58,7 +58,7 @@ class SecurityValidatorMiddlewareTest(tb_test.TestCase):
             return werkzeug.Response("OK", headers=headers)
 
         app = security_validator.SecurityValidatorMiddleware(_simple_app)
-        server = werkzeug_test.Client(app, BaseResponse)
+        server = werkzeug_test.Client(app, Response)
 
         with mock.patch.object(logger, "warning") as mock_warn:
             server.get("")

--- a/tensorboard/examples/plugins/example_raw_scalars/test.py
+++ b/tensorboard/examples/plugins/example_raw_scalars/test.py
@@ -31,7 +31,7 @@ def is_path_safe(path):
     example_plugin = plugin.ExampleRawScalarsPlugin(base_plugin.TBContext())
     serve_static_file = example_plugin._serve_static_file
 
-    client = test.Client(serve_static_file, wrappers.BaseResponse)
+    client = test.Client(serve_static_file, wrappers.Response)
     response = client.get(plugin._PLUGIN_DIRECTORY_PATH_PART + path)
     return response.status_code == 200
 

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -29,5 +29,5 @@ requests >= 2.21.0, < 3
 setuptools >= 41.0.0
 tensorboard-data-server >= 0.6.0, < 0.7.0
 tensorboard-plugin-wit >= 1.6.0
-werkzeug >= 0.11.15
+werkzeug >= 1.0.1
 wheel >= 0.26

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -29,5 +29,5 @@ requests >= 2.21.0, < 3
 setuptools >= 41.0.0
 tensorboard-data-server >= 0.6.0, < 0.7.0
 tensorboard-plugin-wit >= 1.6.0
-werkzeug >= 0.11.15, < 2.1.0
+werkzeug >= 0.11.15
 wheel >= 0.26

--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -127,7 +127,7 @@ class AudioPluginTest(tf.test.TestCase):
         )
         self.plugin = audio_plugin.AudioPlugin(context)
         wsgi_app = application.TensorBoardWSGI([self.plugin])
-        self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(wsgi_app, wrappers.Response)
 
     def tearDown(self):
         shutil.rmtree(self.log_dir, ignore_errors=True)

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -148,7 +148,7 @@ class CorePluginTest(tf.test.TestCase):
         )
         self.plugin = core_plugin.CorePlugin(context)
         app = application.TensorBoardWSGI([self.plugin])
-        self.server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(app, wrappers.Response)
 
     def _add_run(self, run_name):
         run_path = os.path.join(self.logdir, run_name)
@@ -240,7 +240,7 @@ class CorePluginTest(tf.test.TestCase):
 
         self.plugin = core_plugin.CorePlugin(self.context)
         app = application.TensorBoardWSGI([self.plugin])
-        self.server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(app, wrappers.Response)
 
         parsed_object = self._get_json(self.server, "/data/environment")
         self.assertEqual(parsed_object["data_location"], "/tmp/logs")
@@ -269,7 +269,7 @@ class CorePluginTest(tf.test.TestCase):
         )
         plugin = core_plugin.CorePlugin(context, include_debug_info=True)
         app = application.TensorBoardWSGI([plugin])
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, wrappers.Response)
 
         parsed_object = self._get_json(server, "/data/environment")
         self.assertIn("debug", parsed_object)
@@ -375,7 +375,7 @@ class CorePluginPathPrefixTest(tf.test.TestCase):
         )
         plugin = core_plugin.CorePlugin(context)
         app = application.TensorBoardWSGI([plugin], path_prefix=path_prefix)
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(app, wrappers.Response)
         return server.get(pathname)
 
     def _assert_index(self, response, expected_tb_relative_root):

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -184,7 +184,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
 
     def test_download_url_json(self):
         wsgi_app = application.TensorBoardWSGI([self.plugin])
-        server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(wsgi_app, wrappers.Response)
         response = server.get(
             "/data/plugin/custom_scalars/download_data?run=%s&tag=%s"
             % ("foo", "squares/scalar_summary")
@@ -201,7 +201,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
 
     def test_download_url_csv(self):
         wsgi_app = application.TensorBoardWSGI([self.plugin])
-        server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(wsgi_app, wrappers.Response)
         response = server.get(
             "/data/plugin/custom_scalars/download_data?run=%s&tag=%s&format=csv"
             % ("foo", "squares/scalar_summary")

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -115,7 +115,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         context = base_plugin.TBContext(logdir=self.logdir)
         self.plugin = debugger_v2_plugin.DebuggerV2Plugin(context)
         wsgi_app = application.TensorBoardWSGI([self.plugin])
-        self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(wsgi_app, wrappers.Response)
         # The multiplexer reads data asynchronously on a separate thread, so
         # as not to block the main thread of the TensorBoard backend. During
         # unit test, we disable the asynchronous behavior, so that we can

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -48,7 +48,7 @@ class ImagesPluginTest(tf.test.TestCase):
         ctx = base_plugin.TBContext(logdir=logdir, data_provider=provider)
         plugin = images_plugin.ImagesPlugin(ctx)
         wsgi_app = application.TensorBoardWSGI([plugin])
-        self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(wsgi_app, wrappers.Response)
         self.routes = plugin.get_plugin_apps()
 
     def _create_data(self):

--- a/tensorboard/plugins/mesh/mesh_plugin_test.py
+++ b/tensorboard/plugins/mesh/mesh_plugin_test.py
@@ -158,7 +158,7 @@ class MeshPluginTest(tf.test.TestCase):
         # after the multiplexer is created.
         multiplexer.Reload()
         wsgi_app = application.TensorBoardWSGI([self.plugin])
-        self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(wsgi_app, wrappers.Response)
         self.routes = self.plugin.get_plugin_apps()
 
     def tearDown(self):

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -281,7 +281,7 @@ class ProjectorAppTest(tf.test.TestCase):
         context = base_plugin.TBContext(logdir=logdir, data_provider=provider)
         self.plugin = projector_plugin.ProjectorPlugin(context)
         wsgi_app = application.TensorBoardWSGI([self.plugin])
-        self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        self.server = werkzeug_test.Client(wsgi_app, wrappers.Response)
 
     def _Get(self, path):
         return self.server.get(path)

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -81,7 +81,7 @@ class ScalarsPluginTest(tf.test.TestCase):
     def load_server(self, run_names):
         plugin = self.load_plugin(run_names)
         wsgi_app = application.TensorBoardWSGI([plugin])
-        server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(wsgi_app, wrappers.Response)
         return server
 
     def generate_run(self, logdir, run_name):
@@ -337,7 +337,7 @@ class ScalarsPluginTest(tf.test.TestCase):
     def test_download_url_json(self):
         plugin = self.load_plugin([self._RUN_WITH_SCALARS])
         wsgi_app = application.TensorBoardWSGI([plugin])
-        server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(wsgi_app, wrappers.Response)
         response = server.get(
             "/data/plugin/scalars/scalars?run=%s&tag=%s"
             % (
@@ -353,7 +353,7 @@ class ScalarsPluginTest(tf.test.TestCase):
     def test_download_url_csv(self):
         plugin = self.load_plugin([self._RUN_WITH_SCALARS])
         wsgi_app = application.TensorBoardWSGI([plugin])
-        server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        server = werkzeug_test.Client(wsgi_app, wrappers.Response)
         response = server.get(
             "/data/plugin/scalars/scalars?run=%s&tag=%s&format=csv"
             % (

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -68,7 +68,7 @@ class FetchServerInfoTest(tb_test.TestCase):
             request_pb = server_info_pb2.ServerInfoRequest.FromString(body)
             self.assertEqual(request_pb.version, version.VERSION)
             self.assertEqual(request_pb.plugin_specification.upload_plugins, [])
-            return wrappers.BaseResponse(expected_result.SerializeToString())
+            return wrappers.Response(expected_result.SerializeToString())
 
         origin = self._start_server(app)
         result = server_info.fetch_server_info(origin, [])
@@ -84,7 +84,7 @@ class FetchServerInfoTest(tb_test.TestCase):
                 request_pb.plugin_specification.upload_plugins,
                 ["plugin1", "plugin2"],
             )
-            return wrappers.BaseResponse(
+            return wrappers.Response(
                 server_info_pb2.ServerInfoResponse().SerializeToString()
             )
 
@@ -109,7 +109,7 @@ class FetchServerInfoTest(tb_test.TestCase):
         @wrappers.BaseRequest.application
         def app(request):
             del request  # unused
-            return wrappers.BaseResponse(b"very sad", status="502 Bad Gateway")
+            return wrappers.Response(b"very sad", status="502 Bad Gateway")
 
         origin = self._start_server(app)
         with self.assertRaises(server_info.CommunicationError) as cm:
@@ -122,7 +122,7 @@ class FetchServerInfoTest(tb_test.TestCase):
         @wrappers.BaseRequest.application
         def app(request):
             del request  # unused
-            return wrappers.BaseResponse(b"\x7a\x7ftruncated proto")
+            return wrappers.Response(b"\x7a\x7ftruncated proto")
 
         origin = self._start_server(app)
         with self.assertRaises(server_info.CommunicationError) as cm:
@@ -136,7 +136,7 @@ class FetchServerInfoTest(tb_test.TestCase):
         def app(request):
             result = server_info_pb2.ServerInfoResponse()
             result.compatibility.details = request.headers["User-Agent"]
-            return wrappers.BaseResponse(result.SerializeToString())
+            return wrappers.Response(result.SerializeToString())
 
         origin = self._start_server(app)
         result = server_info.fetch_server_info(origin, [])

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -60,7 +60,7 @@ class FetchServerInfoTest(tb_test.TestCase):
         expected_result.url_format.template = "http://localhost:8080/{{eid}}"
         expected_result.url_format.id_placeholder = "{{eid}}"
 
-        @wrappers.BaseRequest.application
+        @wrappers.Request.application
         def app(request):
             self.assertEqual(request.method, "POST")
             self.assertEqual(request.path, "/api/uploader")
@@ -75,7 +75,7 @@ class FetchServerInfoTest(tb_test.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_fetches_with_plugins(self):
-        @wrappers.BaseRequest.application
+        @wrappers.Request.application
         def app(request):
             body = request.get_data()
             request_pb = server_info_pb2.ServerInfoRequest.FromString(body)
@@ -106,7 +106,7 @@ class FetchServerInfoTest(tb_test.TestCase):
             self.assertIn(os.strerror(errno.ECONNREFUSED), msg)
 
     def test_non_ok_response(self):
-        @wrappers.BaseRequest.application
+        @wrappers.Request.application
         def app(request):
             del request  # unused
             return wrappers.Response(b"very sad", status="502 Bad Gateway")
@@ -119,7 +119,7 @@ class FetchServerInfoTest(tb_test.TestCase):
         self.assertIn("very sad", msg)
 
     def test_corrupt_response(self):
-        @wrappers.BaseRequest.application
+        @wrappers.Request.application
         def app(request):
             del request  # unused
             return wrappers.Response(b"\x7a\x7ftruncated proto")
@@ -132,7 +132,7 @@ class FetchServerInfoTest(tb_test.TestCase):
         self.assertIn("truncated proto", msg)
 
     def test_user_agent(self):
-        @wrappers.BaseRequest.application
+        @wrappers.Request.application
         def app(request):
             result = server_info_pb2.ServerInfoResponse()
             result.compatibility.details = request.headers["User-Agent"]


### PR DESCRIPTION
werkzeug package is updated to 2.1 which `BaseResponse` is no longer supported. 
https://werkzeug.palletsprojects.com/en/2.0.x/wrappers/
This PR updates all `BaseResponse/BaseRequest` usage to the newer `Response/Request` and removes the constraint of werkzeug version