### PR TITLE
Make summary_minimal target publicly visible

### DIFF
--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -24,6 +24,7 @@ py_library(
     name = "summary_minimal",
     srcs = ["__init__.py"],
     srcs_version = "PY3",
+    visibility = ["//visibility:public"],
     deps = [
         ":writer",
     ],


### PR DESCRIPTION
This allows usage of `tensorboard.summary.Writer` while satisfying strict dependency requirements in google3.