### PR TITLE
linked time: updates cardStepIndex on selected time toggled

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -942,8 +942,10 @@ const reducer = createReducer(
   }),
   on(actions.selectTimeEnableToggled, (state) => {
     let nextCardStepIndexMap = {...state.cardStepIndex};
+    const nextSelectTimeEnabled = !state.selectTimeEnabled;
+
     // Updates cardStepIndex only when toggle to enable selectedTime.
-    if (!state.selectTimeEnabled) {
+    if (nextSelectTimeEnabled) {
       const {min} = state.stepMinMax;
       const startStep = min === Infinity ? 0 : min;
       nextCardStepIndexMap = generateNextCardStepIndexFromSelectedTime(
@@ -958,7 +960,7 @@ const reducer = createReducer(
     return {
       ...state,
       cardStepIndex: nextCardStepIndexMap,
-      selectTimeEnabled: !state.selectTimeEnabled,
+      selectTimeEnabled: nextSelectTimeEnabled,
     };
   }),
   on(actions.timeSelectionChanged, (state, change) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -943,17 +943,20 @@ const reducer = createReducer(
   on(actions.selectTimeEnableToggled, (state) => {
     let nextCardStepIndexMap = {...state.cardStepIndex};
     const nextSelectTimeEnabled = !state.selectTimeEnabled;
+    const {min} = state.stepMinMax;
+    const startStep = min === Infinity ? 0 : min;
+    const nextSelectedTime = state.selectedTime ?? {
+      start: {step: startStep},
+      end: null,
+    };
 
     // Updates cardStepIndex only when toggle to enable selectedTime.
     if (nextSelectTimeEnabled) {
-      const {min} = state.stepMinMax;
-      const startStep = min === Infinity ? 0 : min;
       nextCardStepIndexMap = generateNextCardStepIndexFromSelectedTime(
         state.cardStepIndex,
         state.cardMetadataMap,
         state.timeSeriesData,
-        // Sets start step to min step when select time is null
-        state.selectedTime ?? {start: {step: startStep}, end: null}
+        nextSelectedTime
       );
     }
 
@@ -961,6 +964,7 @@ const reducer = createReducer(
       ...state,
       cardStepIndex: nextCardStepIndexMap,
       selectTimeEnabled: nextSelectTimeEnabled,
+      selectedTime: nextSelectedTime,
     };
   }),
   on(actions.timeSelectionChanged, (state, change) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -941,17 +941,18 @@ const reducer = createReducer(
     };
   }),
   on(actions.selectTimeEnableToggled, (state) => {
-    let nextCardStepIndexMap = {...state.cardStepIndex};
     const nextSelectTimeEnabled = !state.selectTimeEnabled;
-    const {min} = state.stepMinMax;
-    const startStep = min === Infinity ? 0 : min;
-    const nextSelectedTime = state.selectedTime ?? {
-      start: {step: startStep},
-      end: null,
-    };
+    let nextCardStepIndexMap = {...state.cardStepIndex};
+    let nextSelectedTime = state.selectedTime;
 
     // Updates cardStepIndex only when toggle to enable selectedTime.
     if (nextSelectTimeEnabled) {
+      const {min} = state.stepMinMax;
+      const startStep = min === Infinity ? 0 : min;
+      nextSelectedTime = state.selectedTime ?? {
+        start: {step: startStep},
+        end: null,
+      };
       nextCardStepIndexMap = generateNextCardStepIndexFromSelectedTime(
         state.cardStepIndex,
         state.cardMetadataMap,

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -941,8 +941,23 @@ const reducer = createReducer(
     };
   }),
   on(actions.selectTimeEnableToggled, (state) => {
+    let nextCardStepIndexMap = {...state.cardStepIndex};
+    // Updates cardStepIndex only when toggle to enable selectedTime.
+    if (!state.selectTimeEnabled) {
+      const {min} = state.stepMinMax;
+      const startStep = min === Infinity ? 0 : min;
+      nextCardStepIndexMap = generateNextCardStepIndexFromSelectedTime(
+        state.cardStepIndex,
+        state.cardMetadataMap,
+        state.timeSeriesData,
+        // Sets start step to min step when select time is null
+        state.selectedTime ?? {start: {step: startStep}, end: null}
+      );
+    }
+
     return {
       ...state,
+      cardStepIndex: nextCardStepIndexMap,
       selectTimeEnabled: !state.selectTimeEnabled,
     };
   }),

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2511,7 +2511,7 @@ describe('metrics reducers', () => {
         expect(state3.selectTimeEnabled).toBe(false);
       });
 
-      it('sets cardStepIndex to step 0 when there is no selectedTime in state', () => {
+      it('sets cardStepIndex to step 0 when selectedTime is null before toggling', () => {
         const state1 = buildMetricsState({
           selectTimeEnabled: false,
           cardMetadataMap,
@@ -2538,10 +2538,11 @@ describe('metrics reducers', () => {
         });
 
         const state2 = reducers(state1, actions.selectTimeEnableToggled());
+
         expect(state2.cardStepIndex).toEqual({[imageCardId]: 0});
       });
 
-      it('sets cardStepIndex to min step when there is no selectedTime in state', () => {
+      it('sets cardStepIndex to min step when selectedTime is null before toggling', () => {
         const state1 = buildMetricsState({
           selectTimeEnabled: false,
           cardMetadataMap,
@@ -2571,7 +2572,7 @@ describe('metrics reducers', () => {
         expect(state2.cardStepIndex).toEqual({[imageCardId]: 1});
       });
 
-      it('does not update step index when there is no selectedTime and no matched min step', () => {
+      it('does not update step index when selectedTime is null before toggling and no matched min step', () => {
         const state1 = buildMetricsState({
           selectTimeEnabled: false,
           cardMetadataMap,
@@ -2662,6 +2663,35 @@ describe('metrics reducers', () => {
 
         const state2 = reducers(state1, actions.selectTimeEnableToggled());
         expect(state2.cardStepIndex).toEqual({[imageCardId]: 2});
+      });
+
+      it('sets selectedTime to step 0 when selectedTime is null before toggling', () => {
+        const state1 = buildMetricsState({
+          stepMinMax: {min: Infinity, max: -Infinity},
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+
+        expect(state2.selectedTime).toEqual({start: {step: 0}, end: null});
+      });
+
+      it('sets selectedTime to min step when selectedTime is null before toggling', () => {
+        const state1 = buildMetricsState({
+          stepMinMax: {min: 10, max: 100},
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+
+        expect(state2.selectedTime).toEqual({start: {step: 10}, end: null});
+      });
+
+      it('dose not update selectedTime on toggling when it is pre-existed', () => {
+        const state1 = buildMetricsState({
+          selectedTime: {start: {step: 20}, end: null},
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+        expect(state2.selectedTime).toEqual({start: {step: 20}, end: null});
       });
     });
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2489,6 +2489,16 @@ describe('metrics reducers', () => {
     });
 
     describe('#selectTimeEnableToggled', () => {
+      const imageCardId = 'test image card id "plugin":"images"';
+      const cardMetadataMap = {
+        [imageCardId]: {
+          runId: 'test run Id',
+          plugin: PluginType.IMAGES,
+          tag: 'tagC',
+          sample: 111,
+        },
+      };
+
       it('toggles whether selectTime is enabled or not', () => {
         const state1 = buildMetricsState({
           selectTimeEnabled: false,
@@ -2499,6 +2509,159 @@ describe('metrics reducers', () => {
 
         const state3 = reducers(state2, actions.selectTimeEnableToggled());
         expect(state3.selectTimeEnabled).toBe(false);
+      });
+
+      it('sets cardStepIndex to step 0 when there is no selectedTime in state', () => {
+        const state1 = buildMetricsState({
+          selectTimeEnabled: false,
+          cardMetadataMap,
+          stepMinMax: {min: Infinity, max: -Infinity},
+          timeSeriesData: {
+            ...buildTimeSeriesData(),
+            images: {
+              tagC: {
+                111: {
+                  runToLoadState: {},
+                  runToSeries: {
+                    'test run Id': [
+                      {step: 0, wallTime: 0, imageId: '1'},
+                      {step: 10, wallTime: 0, imageId: '1'},
+                      {step: 20, wallTime: 10, imageId: '2'},
+                      {step: 30, wallTime: 15, imageId: '3'},
+                    ],
+                  },
+                },
+              },
+            },
+          },
+          cardStepIndex: {[imageCardId]: 2},
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+        expect(state2.cardStepIndex).toEqual({[imageCardId]: 0});
+      });
+
+      it('sets cardStepIndex to min step when there is no selectedTime in state', () => {
+        const state1 = buildMetricsState({
+          selectTimeEnabled: false,
+          cardMetadataMap,
+          stepMinMax: {min: 10, max: 100},
+          timeSeriesData: {
+            ...buildTimeSeriesData(),
+            images: {
+              tagC: {
+                111: {
+                  runToLoadState: {},
+                  runToSeries: {
+                    'test run Id': [
+                      {step: 0, wallTime: 0, imageId: '1'},
+                      {step: 10, wallTime: 0, imageId: '1'},
+                      {step: 20, wallTime: 10, imageId: '2'},
+                      {step: 30, wallTime: 15, imageId: '3'},
+                    ],
+                  },
+                },
+              },
+            },
+          },
+          cardStepIndex: {[imageCardId]: 2},
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+        expect(state2.cardStepIndex).toEqual({[imageCardId]: 1});
+      });
+
+      it('does not update step index when there is no selectedTime and no matched min step', () => {
+        const state1 = buildMetricsState({
+          selectTimeEnabled: false,
+          cardMetadataMap,
+          timeSeriesData: {
+            ...buildTimeSeriesData(),
+            images: {
+              tagC: {
+                111: {
+                  runToLoadState: {},
+                  runToSeries: {
+                    'test run Id': [
+                      {step: 10, wallTime: 0, imageId: '1'},
+                      {step: 20, wallTime: 10, imageId: '2'},
+                      {step: 30, wallTime: 15, imageId: '3'},
+                    ],
+                  },
+                },
+              },
+            },
+          },
+          cardStepIndex: {[imageCardId]: 2},
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+        expect(state2.cardStepIndex).toEqual({[imageCardId]: 2});
+      });
+
+      it('updates step index to pre-existed selectedTime', () => {
+        const state1 = buildMetricsState({
+          selectTimeEnabled: false,
+          cardMetadataMap,
+          timeSeriesData: {
+            ...buildTimeSeriesData(),
+            images: {
+              tagC: {
+                111: {
+                  runToLoadState: {},
+                  runToSeries: {
+                    'test run Id': [
+                      {step: 10, wallTime: 0, imageId: '1'},
+                      {step: 20, wallTime: 10, imageId: '2'},
+                      {step: 30, wallTime: 15, imageId: '3'},
+                    ],
+                  },
+                },
+              },
+            },
+          },
+          selectedTime: {start: {step: 20}, end: null},
+          cardStepIndex: {[imageCardId]: 2},
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+        expect(state2.cardStepIndex).toEqual({[imageCardId]: 1});
+      });
+
+      it('dose not update step index when toggle to disable selectedTime', () => {
+        const state1 = buildMetricsState({
+          selectTimeEnabled: true,
+          cardMetadataMap: {
+            [imageCardId]: {
+              runId: 'test run Id',
+              plugin: PluginType.IMAGES,
+              tag: 'tagC',
+              sample: 111,
+            },
+          },
+          timeSeriesData: {
+            ...buildTimeSeriesData(),
+            images: {
+              tagC: {
+                111: {
+                  runToLoadState: {},
+                  runToSeries: {
+                    'test run Id': [
+                      {step: 10, wallTime: 0, imageId: '1'},
+                      {step: 20, wallTime: 10, imageId: '2'},
+                      {step: 30, wallTime: 15, imageId: '3'},
+                    ],
+                  },
+                },
+              },
+            },
+          },
+          selectedTime: {start: {step: 20}, end: null},
+          cardStepIndex: {[imageCardId]: 2},
+        });
+
+        const state2 = reducers(state1, actions.selectTimeEnableToggled());
+        expect(state2.cardStepIndex).toEqual({[imageCardId]: 2});
       });
     });
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2542,65 +2542,7 @@ describe('metrics reducers', () => {
         expect(state2.cardStepIndex).toEqual({[imageCardId]: 0});
       });
 
-      it('sets cardStepIndex to min step when selectedTime is null before toggling', () => {
-        const state1 = buildMetricsState({
-          selectTimeEnabled: false,
-          cardMetadataMap,
-          stepMinMax: {min: 10, max: 100},
-          timeSeriesData: {
-            ...buildTimeSeriesData(),
-            images: {
-              tagC: {
-                111: {
-                  runToLoadState: {},
-                  runToSeries: {
-                    'test run Id': [
-                      {step: 0, wallTime: 0, imageId: '1'},
-                      {step: 10, wallTime: 0, imageId: '1'},
-                      {step: 20, wallTime: 10, imageId: '2'},
-                      {step: 30, wallTime: 15, imageId: '3'},
-                    ],
-                  },
-                },
-              },
-            },
-          },
-          cardStepIndex: {[imageCardId]: 2},
-        });
-
-        const state2 = reducers(state1, actions.selectTimeEnableToggled());
-        expect(state2.cardStepIndex).toEqual({[imageCardId]: 1});
-      });
-
-      it('does not update step index when selectedTime is null before toggling and no matched min step', () => {
-        const state1 = buildMetricsState({
-          selectTimeEnabled: false,
-          cardMetadataMap,
-          timeSeriesData: {
-            ...buildTimeSeriesData(),
-            images: {
-              tagC: {
-                111: {
-                  runToLoadState: {},
-                  runToSeries: {
-                    'test run Id': [
-                      {step: 10, wallTime: 0, imageId: '1'},
-                      {step: 20, wallTime: 10, imageId: '2'},
-                      {step: 30, wallTime: 15, imageId: '3'},
-                    ],
-                  },
-                },
-              },
-            },
-          },
-          cardStepIndex: {[imageCardId]: 2},
-        });
-
-        const state2 = reducers(state1, actions.selectTimeEnableToggled());
-        expect(state2.cardStepIndex).toEqual({[imageCardId]: 2});
-      });
-
-      it('updates step index to pre-existed selectedTime', () => {
+      it('updates step index using pre-existing selectedTime', () => {
         const state1 = buildMetricsState({
           selectTimeEnabled: false,
           cardMetadataMap,
@@ -2629,7 +2571,7 @@ describe('metrics reducers', () => {
         expect(state2.cardStepIndex).toEqual({[imageCardId]: 1});
       });
 
-      it('dose not update step index when toggle to disable selectedTime', () => {
+      it('does not update step index when toggle to disable selectedTime', () => {
         const state1 = buildMetricsState({
           selectTimeEnabled: true,
           cardMetadataMap: {


### PR DESCRIPTION
We've updated cardStepIndex on and only on select time changed. This causes issue when select time is enabled the very first time, there is no linked time set yet and the card step index remain unchanged. However, in settings panel we still show the min step and single selection (while the select time is null in ngrx state). This causes a bad ux when the image steps actually matches the min step: logically we should move the step index but we did not. 

This PR sets card step index when linked time is enabled. `generateNextCardStepIndexFromSelectedTime` is reused. If select time is not set, we take the min step and apply single selection to update the image card step index.

Full context please see #5615 

Note: we did not test `generateNextCardStepIndexFromSelectedTime` on `timeSelectionChanged` action. Will add in a follow-up PR.