### PR TITLE
pip: limit werkzeug version to less than 2.1

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -29,5 +29,5 @@ requests >= 2.21.0, < 3
 setuptools >= 41.0.0
 tensorboard-data-server >= 0.6.0, < 0.7.0
 tensorboard-plugin-wit >= 1.6.0
-werkzeug >= 0.11.15
+werkzeug >= 0.11.15, < 2.1.0
 wheel >= 0.26


### PR DESCRIPTION
werkzeug package 2.1.0 is released, which BaseResponse is no longer supported in that latest version.
https://werkzeug.palletsprojects.com/en/2.0.x/wrappers/
This breaks our py tests (#5637) in both tb-nightly and CI as the env install tf-nighly with the requirement of `>=0.11.15`. This PR limit the `werkzeug` pkg version to be less than `2.1.0`. This makes the syntax in current tests are still available.