### PR TITLE
Move AxisDirection definition to linked-time-types file

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -288,7 +288,6 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2:line_chart_utils",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "//tensorboard/webapp/widgets/linked_time_fob",
-        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -288,6 +288,7 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2:line_chart_utils",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -229,7 +229,6 @@ limitations under the License.
       <linked-time-fob
         class="selected-time-fob"
         [step]="selectedTime.startStep"
-        [axisDirection]="axisDirection"
       ></linked-time-fob>
     </div>
     <div

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -37,7 +37,6 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
-import {AxisDirection} from '../../../widgets/linked_time_fob/linked_time_fob_controller_component';
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardDataSeries,
@@ -63,7 +62,6 @@ export class ScalarCardComponent<Downloader> {
   readonly DataLoadState = DataLoadState;
   readonly RendererType = RendererType;
   readonly ScaleType = ScaleType;
-  readonly axisDirection = AxisDirection.HORIZONTAL;
 
   @Input() cardId!: string;
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -11,8 +11,11 @@ limitations under the License.
 ==============================================================================*/
 
 import {Component, EventEmitter, Input, Output} from '@angular/core';
-import {AxisDirection} from '../linked_time_fob/linked_time_fob_controller_component';
-import {FobCardAdapter, LinkedTime} from '../linked_time_fob/linked_time_types';
+import {
+  AxisDirection,
+  FobCardAdapter,
+  LinkedTime,
+} from '../linked_time_fob/linked_time_types';
 import {TemporalScale} from './histogram_component';
 
 @Component({

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -22,18 +22,12 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import {FobCardAdapter, LinkedTime} from './linked_time_types';
-
-export enum AxisDirection {
-  HORIZONTAL,
-  VERTICAL,
-}
-
-export enum Fob {
-  NONE,
-  START,
-  END,
-}
+import {
+  AxisDirection,
+  Fob,
+  FobCardAdapter,
+  LinkedTime,
+} from './linked_time_types';
 
 @Component({
   selector: 'linked-time-fob-controller',

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -22,12 +22,13 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import {
-  AxisDirection,
-  Fob,
-  FobCardAdapter,
-  LinkedTime,
-} from './linked_time_types';
+import {AxisDirection, FobCardAdapter, LinkedTime} from './linked_time_types';
+
+export enum Fob {
+  NONE,
+  START,
+  END,
+}
 
 @Component({
   selector: 'linked-time-fob-controller',

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -19,11 +19,10 @@ import {By} from '@angular/platform-browser';
 import {sendKeys} from '../../testing/dom';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
 import {
-  AxisDirection,
   Fob,
   LinkedTimeFobControllerComponent,
 } from './linked_time_fob_controller_component';
-import {FobCardAdapter, LinkedTime} from './linked_time_types';
+import {AxisDirection, FobCardAdapter, LinkedTime} from './linked_time_types';
 
 @Component({
   selector: 'testable-comp',

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
@@ -18,7 +18,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {sendKeys} from '../../testing/dom';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
-import {AxisDirection} from './linked_time_fob_controller_component';
+import {AxisDirection} from './linked_time_types';
 
 @Component({
   selector: 'testable-fob-comp',

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
@@ -21,9 +21,7 @@ export interface LinkedTime {
 }
 
 /**
- * The linked time fob controller can be used inside both horizontal and
- * vertical axis. This enum is a utility used to inform to the controller of
- * that direction.
+ * The direction of the axis used to control the fob movements.
  */
 export enum AxisDirection {
   HORIZONTAL,

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
@@ -21,6 +21,26 @@ export interface LinkedTime {
 }
 
 /**
+ * The linked time fob controller can be used inside both horizontal and
+ * vertical axis. This enum is a utility used to inform to the controller of
+ * that direction.
+ */
+export enum AxisDirection {
+  HORIZONTAL,
+  VERTICAL,
+}
+
+/**
+ * Each chart can have up to 2 fobs. This enum is used to help distinguish
+ * between the two.
+ */
+export enum Fob {
+  NONE,
+  START,
+  END,
+}
+
+/**
  * This class is intended to be implemented by the card that has a
  * LinkedTimeFobControllerComponent.
  *

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts
@@ -31,16 +31,6 @@ export enum AxisDirection {
 }
 
 /**
- * Each chart can have up to 2 fobs. This enum is used to help distinguish
- * between the two.
- */
-export enum Fob {
-  NONE,
-  START,
-  END,
-}
-
-/**
  * This class is intended to be implemented by the card that has a
  * LinkedTimeFobControllerComponent.
  *


### PR DESCRIPTION
This change moves the AxisDirection definition from the linked_time_fob_controller_component.ts file to the linked_time_types.ts file.

The AxisDirection is used in multiple places and going to be used in more places in the future. It makes more sense to have it's type definitions in the file specifically made for types.

Also, I realized the ScalarCardComponent was still using AxisDirection when it did not need to so I simply removed it instead of updating the path.