### PR TITLE
linked time: cleanup: rename stepValues to steps

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -192,10 +192,10 @@ export const getCardStepIndex = createSelector(
 /**
  * Returns step values of an image card.
  */
-export const getMetricsImageCardStepValues = createSelector(
+export const getMetricsImageCardSteps = createSelector(
   selectMetricsState,
   (state: MetricsState, cardId: CardId): number[] => {
-    return storeUtils.getImageCardStepValues(
+    return storeUtils.getImageCardSteps(
       cardId,
       state.cardMetadataMap,
       state.timeSeriesData

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -385,11 +385,7 @@ export function generateNextCardStepIndexFromSelectedTime(
   Object.keys(previousCardStepIndex).forEach((cardId) => {
     if (!cardId.includes('"plugin":"images"')) return;
 
-    const steps = getImageCardStepValues(
-      cardId,
-      cardMetadataMap,
-      timeSeriesData
-    );
+    const steps = getImageCardSteps(cardId, cardMetadataMap, timeSeriesData);
 
     let nextStepIndex = null;
     if (selectedTime.end === null) {
@@ -422,7 +418,7 @@ export function generateNextCardStepIndexFromSelectedTime(
 /**
  * Returns step values of an image card.
  */
-export function getImageCardStepValues(
+export function getImageCardSteps(
   cardId: string,
   cardMetadataMap: CardMetadataMap,
   timeSeriesData: TimeSeriesData
@@ -531,7 +527,7 @@ function getNextImageCardStepIndexFromRangeSelection(
 }
 
 export const TEST_ONLY = {
-  getImageCardStepValues,
+  getImageCardSteps,
   getSelectedSteps,
   getNextImageCardStepIndexFromRangeSelection,
   getNextImageCardStepIndexFromSingleSelection,

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -416,7 +416,7 @@ export function generateNextCardStepIndexFromSelectedTime(
 }
 
 /**
- * Returns step values of an image card.
+ * Returns steps of an image card.
  */
 export function getImageCardSteps(
   cardId: string,

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -37,7 +37,7 @@ import {
 import {ImageTimeSeriesData, TimeSeriesData} from './metrics_types';
 
 const {
-  getImageCardStepValues,
+  getImageCardSteps,
   getSelectedSteps,
   getNextImageCardStepIndexFromRangeSelection,
   getNextImageCardStepIndexFromSingleSelection,
@@ -798,7 +798,7 @@ describe('metrics store utils', () => {
     });
   });
 
-  describe('getImageCardStepValues', () => {
+  describe('getImageCardSteps', () => {
     const cardId = 'test-card-id';
     const cardId2 = 'test-card-id-non-image';
     const cardMetadataMap = {
@@ -831,7 +831,7 @@ describe('metrics store utils', () => {
 
     it(`gets empty step value when no run id in time series data`, () => {
       expect(
-        getImageCardStepValues(cardId, cardMetadataMap, timeSeriesData)
+        getImageCardSteps(cardId, cardMetadataMap, timeSeriesData)
       ).toEqual([]);
     });
 
@@ -841,13 +841,13 @@ describe('metrics store utils', () => {
       };
 
       expect(
-        getImageCardStepValues(cardId, cardMetadataMap, timeSeriesData)
+        getImageCardSteps(cardId, cardMetadataMap, timeSeriesData)
       ).toEqual([]);
     });
 
     it(`gets empty step value when time series loadable returns null`, () => {
       expect(
-        getImageCardStepValues(cardId2, cardMetadataMap, timeSeriesData)
+        getImageCardSteps(cardId2, cardMetadataMap, timeSeriesData)
       ).toEqual([]);
     });
 
@@ -864,7 +864,7 @@ describe('metrics store utils', () => {
       };
 
       expect(
-        getImageCardStepValues(cardId, cardMetadataMap, timeSeriesData)
+        getImageCardSteps(cardId, cardMetadataMap, timeSeriesData)
       ).toEqual([10]);
     });
 
@@ -885,13 +885,13 @@ describe('metrics store utils', () => {
       };
 
       expect(
-        getImageCardStepValues(cardId, cardMetadataMap, timeSeriesData)
+        getImageCardSteps(cardId, cardMetadataMap, timeSeriesData)
       ).toEqual([10, 20, 30]);
     });
 
     it('gets empty step value if no card id exists in cardMetadataMap', () => {
       expect(
-        getImageCardStepValues(
+        getImageCardSteps(
           'card id not in cardMetadataMap',
           cardMetadataMap,
           timeSeriesData

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -279,14 +279,14 @@ export function provideMockCardSeriesData(
   const cardMetadata = {...createCardMetadata(plugin), ...metadataOverride};
   const runId = cardMetadata.runId;
   let runToSeries = null;
-  let stepValues: number[] = [];
+  let steps: number[] = [];
 
   if (timeSeries !== null) {
     runToSeries = {
       [runId as string]: timeSeries || createStepData(plugin),
     };
     if (runId !== null) {
-      stepValues = runToSeries[runId].map((stepDatum) => stepDatum.step);
+      steps = runToSeries[runId].map((stepDatum) => stepDatum.step);
     }
   }
 
@@ -300,8 +300,8 @@ export function provideMockCardSeriesData(
     .withArgs(selectors.getCardStepIndex, cardId)
     .and.returnValue(of(stepIndex));
   storeSelectSpy
-    .withArgs(selectors.getMetricsImageCardStepValues, cardId)
-    .and.returnValue(of(stepValues));
+    .withArgs(selectors.getMetricsImageCardSteps, cardId)
+    .and.returnValue(of(steps));
 }
 
 export function provideMockCardRunToSeriesData(

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -60,9 +60,7 @@ limitations under the License.
       <card-run-name class="run-text" [runId]="runId"></card-run-name>
     </span>
     <div class="metadata">
-      <span
-        class="step"
-        *ngIf="stepIndex !== null && stepIndex < steps.length"
+      <span class="step" *ngIf="stepIndex !== null && stepIndex < steps.length"
         >Step {{ steps[stepIndex] | number }}</span
       >
       <span class="sample" *ngIf="numSample > 1"

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -62,8 +62,8 @@ limitations under the License.
     <div class="metadata">
       <span
         class="step"
-        *ngIf="stepIndex !== null && stepIndex < stepValues.length"
-        >Step {{ stepValues[stepIndex] | number }}</span
+        *ngIf="stepIndex !== null && stepIndex < steps.length"
+        >Step {{ steps[stepIndex] | number }}</span
       >
       <span class="sample" *ngIf="numSample > 1"
         >Sample {{ sample + 1 | number }}/{{ numSample | number}}</span
@@ -77,16 +77,16 @@ limitations under the License.
   </div>
 </div>
 <ng-container
-  *ngIf="stepIndex !== null && stepIndex < stepValues.length; else noImageData"
+  *ngIf="stepIndex !== null && stepIndex < steps.length; else noImageData"
 >
   <div class="slider-row">
     <mat-slider
       class="step-slider"
       color="primary"
       [ngClass]="[selectedTime && !selectedTime.clipped && selectedTime.endStep !== null ? 'hide-slider' : '']"
-      [disabled]="stepValues.length <= 1"
+      [disabled]="steps.length <= 1"
       [min]="0"
-      [max]="stepValues.length - 1"
+      [max]="steps.length - 1"
       [step]="1"
       [tickInterval]="1"
       [value]="stepIndex"
@@ -114,7 +114,7 @@ limitations under the License.
   </div>
   <div class="img-container">
     <img
-      alt="Image at step {{ stepValues[stepIndex] }}"
+      alt="Image at step {{ steps[stepIndex] }}"
       src="{{ imageUrl }}"
       [ngStyle]="{'filter': cssFilter()}"
     />

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
@@ -49,7 +49,7 @@ export class ImageCardComponent {
   @Input() numSample!: number;
   @Input() imageUrl!: string | null;
   @Input() stepIndex!: number | null;
-  @Input() stepValues!: number[];
+  @Input() steps!: number[];
   @Input() brightnessInMilli!: number;
   @Input() contrastInMilli!: number;
   @Input() showActualSize!: boolean;
@@ -100,14 +100,14 @@ export class ImageCardComponent {
       return;
     }
 
-    const boundSize = this.stepValues.length - 1;
+    const boundSize = this.steps.length - 1;
     const startStep =
-      this.selectedTime.startStep < this.stepValues[0]
-        ? this.stepValues[0]
+      this.selectedTime.startStep < this.steps[0]
+        ? this.steps[0]
         : this.selectedTime.startStep;
     const endStep =
-      this.selectedTime.endStep > this.stepValues[boundSize]
-        ? this.stepValues[boundSize]
+      this.selectedTime.endStep > this.steps[boundSize]
+        ? this.steps[boundSize]
         : this.selectedTime.endStep;
 
     const {startPosition, width} = this.getTrackStartPositionAndWidth(
@@ -131,9 +131,9 @@ export class ImageCardComponent {
     let i = 0;
 
     // Calculates the track start position
-    for (; i < this.stepValues.length - 1; i++) {
-      const currentStep = this.stepValues[i];
-      const nextStep = this.stepValues[i + 1];
+    for (; i < this.steps.length - 1; i++) {
+      const currentStep = this.steps[i];
+      const nextStep = this.steps[i + 1];
       if (currentStep <= startStep && startStep <= nextStep) {
         startPosition += (startStep - currentStep) / (nextStep - currentStep);
         break;
@@ -142,9 +142,9 @@ export class ImageCardComponent {
     startPosition = (startPosition + i) * sliderUnit;
 
     // Calculates the track width
-    for (; i < this.stepValues.length - 1; i++) {
-      const currentStep = this.stepValues[i];
-      const nextStep = this.stepValues[i + 1];
+    for (; i < this.steps.length - 1; i++) {
+      const currentStep = this.steps[i];
+      const nextStep = this.steps[i + 1];
       // --o--S====E--o--
       //  cur        next
       if (startStep >= currentStep && endStep <= nextStep) {
@@ -179,27 +179,24 @@ export class ImageCardComponent {
   }
 
   getLinkedTimeTickLeftStyle(step: number) {
-    if (this.stepValues.indexOf(step) == -1) {
+    if (this.steps.indexOf(step) == -1) {
       throw new Error(
-        'Invalid stepIndex: stepIndex value is not included in stepValues'
+        'Invalid stepIndex: stepIndex value is not included in steps'
       );
     }
-    return `${
-      (this.stepValues.indexOf(step) / (this.stepValues.length - 1)) * 100
-    }%`;
+    return `${(this.steps.indexOf(step) / (this.steps.length - 1)) * 100}%`;
   }
 
   getLinkedTimeTickMarginLeftStyle(step: number) {
-    if (this.stepValues.indexOf(step) == -1) {
+    if (this.steps.indexOf(step) == -1) {
       throw new Error(
-        'Invalid stepIndex: stepIndex value is not included in stepValues'
+        'Invalid stepIndex: stepIndex value is not included in steps'
       );
     }
     // Moves the tick position to the left for a fixed value because of the tick width.
     // The length is correlated to the slider proportion.
     return `-${
-      (this.stepValues.indexOf(step) / (this.stepValues.length - 1)) *
-      TICK_WIDTH
+      (this.steps.indexOf(step) / (this.steps.length - 1)) * TICK_WIDTH
     }px`;
   }
 }


### PR DESCRIPTION
As in previous PR comment #5624 from @bmd3k, the "value" in "stepValues" are meaningless. This PR simply renames all "stepValues" to "steps" for image card.

No additional logic are addressed.