### PR TITLE
Fix option wrapping within tb-toolbar

### DIFF
--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
@@ -44,7 +44,6 @@ mat-select:focus {
   word-break: break-all;
 }
 
-
 .option-content {
   white-space: nowrap;
 }

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.scss
@@ -43,3 +43,8 @@ mat-select:focus {
   white-space: normal;
   word-break: break-all;
 }
+
+
+.option-content {
+  white-space: nowrap;
+}

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -42,8 +42,9 @@ export interface DropdownOption {
         [value]="option.value"
         [disabled]="option.disabled"
       >
-        <span class="option-content"
-          title="{{option.displayAlias}}: {{option.displayText}}"
+        <span
+          class="option-content"
+          title="{{ option.displayAlias }}: {{ option.displayText }}"
         >
           <b *ngIf="option.displayAlias">{{ option.displayAlias }}:</b>
           {{ option.displayText }}

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -42,8 +42,12 @@ export interface DropdownOption {
         [value]="option.value"
         [disabled]="option.disabled"
       >
-        <b *ngIf="option.displayAlias">{{ option.displayAlias }}:</b>
-        {{ option.displayText }}
+        <span class="option-content"
+          title="{{option.displayAlias}}: {{option.displayText}}"
+        >
+          <b *ngIf="option.displayAlias">{{ option.displayAlias }}:</b>
+          {{ option.displayText }}
+        </span>
       </mat-option>
     </mat-select>
   `,


### PR DESCRIPTION
* Motivation for features / changes
Long options within a tb-toolbar would wrap in an overlapping way.

* Technical description of changes
Added a span around the option, with the non-truncated/full value as the title and the suppressed the wrapping.
