### PR TITLE
Use LinkedTimeFobController in ScalarCardComponent

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -251,6 +251,7 @@ tf_ng_module(
     srcs = [
         "scalar_card_component.ts",
         "scalar_card_container.ts",
+        "scalar_card_linked_time_fob_controller.ts",
         "scalar_card_module.ts",
     ],
     assets = [
@@ -287,7 +288,9 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2",
         "//tensorboard/webapp/widgets/line_chart_v2:line_chart_utils",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
         "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -216,7 +216,14 @@ limitations under the License.
   let-formatter="formatter"
 >
   <ng-container *ngIf="selectedTime">
-    <div
+    <scalar-card-linked-time-fob-controller
+      [linkedTime]="getLinkedTime()"
+      [scale]="xScale"
+      [minMax]="viewExtent.x"
+      [axisSize]="domDim.width"
+      (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+    ></scalar-card-linked-time-fob-controller>
+    <!-- <div
       class="linked-time-fob-container"
       [style.transform]="'translate(' +
         xScale.forward(
@@ -246,6 +253,6 @@ limitations under the License.
         class="selected-time-fob"
         [step]="selectedTime.endStep"
       ></linked-time-fob>
-    </div>
+    </div> -->
   </ng-container>
 </ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -223,36 +223,5 @@ limitations under the License.
       [axisSize]="domDim.width"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
     ></scalar-card-linked-time-fob-controller>
-    <!-- <div
-      class="linked-time-fob-container"
-      [style.transform]="'translate(' +
-        xScale.forward(
-          viewExtent.x,
-          [0, domDim.width],
-          selectedTime.startStep
-        ) + 'px, 0)'
-      "
-    >
-      <linked-time-fob
-        class="selected-time-fob"
-        [step]="selectedTime.startStep"
-      ></linked-time-fob>
-    </div>
-    <div
-      *ngIf="selectedTime.endStep"
-      class="linked-time-fob-container"
-      [style.transform]="'translate(' +
-        xScale.forward(
-          viewExtent.x,
-          [0, domDim.width],
-          selectedTime.endStep
-        ) + 'px, 0)'
-      "
-    >
-      <linked-time-fob
-        class="selected-time-fob"
-        [step]="selectedTime.endStep"
-      ></linked-time-fob>
-    </div> -->
   </ng-container>
 </ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -37,6 +37,7 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
+import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardDataSeries,
@@ -183,5 +184,16 @@ export class ScalarCardComponent<Downloader> {
     this.dialog.open(this.DataDownloadComponent, {
       data: {cardId: this.cardId},
     });
+  }
+
+  getLinkedTime(): LinkedTime {
+    return {
+      start: {
+        step: this.selectedTime!.startStep,
+      },
+      end: this.selectedTime!.endStep
+        ? {step: this.selectedTime!.endStep}
+        : null,
+    };
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -1,0 +1,61 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  AxisDirection,
+  FobCardAdapter,
+  LinkedTime,
+} from '../../../widgets/linked_time_fob/linked_time_types';
+import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
+
+@Component({
+  selector: 'scalar-card-linked-time-fob-controller',
+  template: `
+    <linked-time-fob-controller
+      [axisDirection]="axisDirection"
+      [linkedTime]="linkedTime"
+      [cardAdapter]="this"
+      (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+    ></linked-time-fob-controller>
+  `,
+})
+export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
+  @Input() linkedTime!: LinkedTime;
+  @Input() scale!: Scale;
+  @Input() minMax!: [number, number];
+  @Input() axisSize!: number;
+  @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+
+  readonly axisDirection = AxisDirection.HORIZONTAL;
+
+  // FobCardAdapter implementation.
+  getHighestStep(): number {
+    let minMax = this.minMax;
+    return minMax[0] < minMax[1] ? minMax[1] : minMax[0];
+  }
+  getLowestStep(): number {
+    let minMax = this.minMax;
+    return minMax[0] < minMax[1] ? minMax[0] : minMax[1];
+  }
+  getAxisPositionFromStep(step: number): number {
+    return this.scale.forward(this.minMax, [0, this.axisSize], step);
+  }
+  getStepHigherThanAxisPosition(position: number): number {
+    // TODO: Implement Dragging features.
+    return 0;
+  }
+  getStepLowerThanAxisPosition(position: number): number {
+    // TODO: Implement Dragging features.
+    return 0;
+  }
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -27,10 +27,15 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {DataDownloadModule} from './data_download_module';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
+import {ScalarCardLinkedTimeFobController} from './scalar_card_linked_time_fob_controller';
 import {VisSelectedTimeWarningModule} from './vis_selected_time_warning_module';
 
 @NgModule({
-  declarations: [ScalarCardContainer, ScalarCardComponent],
+  declarations: [
+    ScalarCardContainer,
+    ScalarCardComponent,
+    ScalarCardLinkedTimeFobController,
+  ],
   exports: [ScalarCardContainer],
   imports: [
     CommonModule,

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -20,7 +20,7 @@ tf_ts_library(
     srcs = [
         "public_types.ts",
     ],
-    visibility = ["//tensorboard/webapp/widgets/line_chart_v2:__subpackages__"],
+    visibility = ["//tensorboard/webapp:__subpackages__"],
     deps = [
         ":chart_types",
         ":formatter",

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
@@ -34,5 +34,5 @@ limitations under the License.
 }
 
 .horizontalFob {
-  transform: translateY(-50%);
+  transform: translateX(-50%);
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -65,6 +65,7 @@ export class LinkedTimeFobControllerComponent {
   }
 
   startDrag(fob: Fob) {
+    console.log('starting drag?');
     this.currentDraggingFob = fob;
   }
 
@@ -73,6 +74,7 @@ export class LinkedTimeFobControllerComponent {
   }
 
   isVertical() {
+    console.log('isvertical', this.axisDirection === AxisDirection.VERTICAL);
     return this.axisDirection === AxisDirection.VERTICAL;
   }
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -65,7 +65,6 @@ export class LinkedTimeFobControllerComponent {
   }
 
   startDrag(fob: Fob) {
-    console.log('starting drag?');
     this.currentDraggingFob = fob;
   }
 
@@ -74,7 +73,6 @@ export class LinkedTimeFobControllerComponent {
   }
 
   isVertical() {
-    console.log('isvertical', this.axisDirection === AxisDirection.VERTICAL);
     return this.axisDirection === AxisDirection.VERTICAL;
   }
 


### PR DESCRIPTION
The LinkedTimeFobController is a generalized widget that controls the placement of the fob on an axis and allows for features like dragging the fob. The fob placement was previously implemented inside the ScalarCardComponent itself. This PR adds the ScalarCardLinkedTimeFobController which implements the FobCardAdapter interface(which is defined in the [linked_time_types](https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/webapp/widgets/linked_time_fob/linked_time_types.ts) file.

This PR only adds the structure and implements the components needed to set the placement of the fob. The dragging feature is turned off because all pointer events are currently ignored(pointer-events are set to none [here](https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/components/vz_line_chart2/vz-line-chart2.ts)). 

The only functional change is that the LinkedTimeFobController now centers the fob as a [horizontalFob](https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss;l=36).