### PR TITLE
Horizontal fobs should be centered on X axis not Y axis

### DIFF
--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
@@ -30,7 +30,7 @@ limitations under the License.
   >
     <linked-time-fob
       class="startFob"
-      [ngClass]="isVertical() ? 'verticalFob' : 'horizontalFob'"
+      [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="linkedTime.start.step"
       (mousedown)="startDrag(FobType().START)"
       (stepChange)="stepTyped(FobType().START, $event)"
@@ -44,7 +44,7 @@ limitations under the License.
   >
     <linked-time-fob
       class="endFob"
-      [ngClass]="isVertical() ? 'verticalFob' : 'horizontalFob'"
+      [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="linkedTime.end.step"
       (mousedown)="startDrag(FobType().END)"
       (stepChange)="stepTyped(FobType().END, $event)"

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
@@ -29,10 +29,10 @@ limitations under the License.
   }
 }
 
-.verticalFob {
+.vertical-fob {
   transform: translateY(-50%);
 }
 
-.horizontalFob {
+.horizontal-fob {
   transform: translateX(-50%);
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
@@ -34,5 +34,5 @@ limitations under the License.
 }
 
 .horizontalFob {
-  transform: translateY(-50%);
+  transform: translateX(-50%);
 }


### PR DESCRIPTION
This fixes a bug that centers the fob in the wrong direction when the axisDirection is set to horizontal.

The horizontal-fob class is currently not used but, it will be used when the LinkedTimeFobController is used in ScalarCards. Therefore there is currently no functional change.