### PR TITLE
linked time: Create minimal usable ScalarCardLinkedTimeFobController

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -251,6 +251,7 @@ tf_ng_module(
     srcs = [
         "scalar_card_component.ts",
         "scalar_card_container.ts",
+        "scalar_card_linked_time_fob_controller.ts",
         "scalar_card_module.ts",
     ],
     assets = [
@@ -287,7 +288,9 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2",
         "//tensorboard/webapp/widgets/line_chart_v2:line_chart_utils",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
         "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -311,6 +311,7 @@ tf_ts_library(
         "image_card_test.ts",
         "run_name_test.ts",
         "scalar_card_test.ts",
+        "scalar_card_linked_time_fob_test.ts",
         "utils_test.ts",
     ],
     deps = [
@@ -354,7 +355,9 @@ tf_ts_library(
         "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",
         "//tensorboard/webapp/widgets/line_chart_v2",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:scale",
         "//tensorboard/webapp/widgets/linked_time_fob",
+        "//tensorboard/webapp/widgets/linked_time_fob:types",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/core",
         "@npm//@angular/forms",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -310,8 +310,8 @@ tf_ts_library(
         "histogram_card_test.ts",
         "image_card_test.ts",
         "run_name_test.ts",
-        "scalar_card_test.ts",
         "scalar_card_linked_time_fob_test.ts",
+        "scalar_card_test.ts",
         "utils_test.ts",
     ],
     deps = [

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -1,0 +1,61 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  AxisDirection,
+  FobCardAdapter,
+  LinkedTime,
+} from '../../../widgets/linked_time_fob/linked_time_types';
+import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
+
+@Component({
+  selector: 'scalar-card-linked-time-fob-controller',
+  template: `
+    <linked-time-fob-controller
+      [axisDirection]="axisDirection"
+      [linkedTime]="linkedTime"
+      [cardAdapter]="this"
+      (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+    ></linked-time-fob-controller>
+  `,
+})
+export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
+  @Input() linkedTime!: LinkedTime;
+  @Input() scale!: Scale;
+  @Input() minMax!: [number, number];
+  @Input() axisSize!: number;
+  @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+
+  readonly axisDirection = AxisDirection.HORIZONTAL;
+
+  // FobCardAdapter implementation.
+  getAxisPositionFromStep(step: number): number {
+    return this.scale.forward(this.minMax, [0, this.axisSize], step);
+  }
+  getHighestStep(): number {
+    // TODO: Implement Dragging features.
+    return -1;
+  }
+  getLowestStep(): number {
+    // TODO: Implement Dragging features.
+    return -1;
+  }
+  getStepHigherThanAxisPosition(position: number): number {
+    // TODO: Implement Dragging features.
+    return -1;
+  }
+  getStepLowerThanAxisPosition(position: number): number {
+    // TODO: Implement Dragging features.
+    return -1;
+  }
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -34,28 +34,29 @@ export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
   @Input() scale!: Scale;
   @Input() minMax!: [number, number];
   @Input() axisSize!: number;
+
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
 
   readonly axisDirection = AxisDirection.HORIZONTAL;
 
-  // FobCardAdapter implementation.
+  // TODO(jameshollyer): Implements remaining methods for scalar card fob controller.
+  getHighestStep(): number {
+    return -1;
+  }
+
+  getLowestStep(): number {
+    return -1;
+  }
+
   getAxisPositionFromStep(step: number): number {
     return this.scale.forward(this.minMax, [0, this.axisSize], step);
   }
-  getHighestStep(): number {
-    // TODO: Implement Dragging features.
-    return -1;
-  }
-  getLowestStep(): number {
-    // TODO: Implement Dragging features.
-    return -1;
-  }
+
   getStepHigherThanAxisPosition(position: number): number {
-    // TODO: Implement Dragging features.
     return -1;
   }
+
   getStepLowerThanAxisPosition(position: number): number {
-    // TODO: Implement Dragging features.
     return -1;
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -11,12 +11,12 @@ limitations under the License.
 ==============================================================================*/
 
 import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
 import {
   AxisDirection,
   FobCardAdapter,
   LinkedTime,
 } from '../../../widgets/linked_time_fob/linked_time_types';
-import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
 
 @Component({
   selector: 'scalar-card-linked-time-fob-controller',

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
@@ -12,12 +12,12 @@ limitations under the License.
 
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {LinearScale} from '../../../widgets/line_chart_v2/lib/scale';
 import {LinkedTimeFobControllerComponent} from '../../../widgets/linked_time_fob/linked_time_fob_controller_component';
 import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
-import {LinearScale} from '../../../widgets/line_chart_v2/lib/scale';
 import {ScalarCardLinkedTimeFobController} from './scalar_card_linked_time_fob_controller';
 
-fdescribe('ScalarLinkedTimeFobController', () => {
+describe('ScalarLinkedTimeFobController', () => {
   let forwardScaleSpy: jasmine.Spy;
   let reverseScaleSpy: jasmine.Spy;
   beforeEach(async () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
@@ -1,0 +1,80 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {LinkedTimeFobControllerComponent} from '../../../widgets/linked_time_fob/linked_time_fob_controller_component';
+import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
+import {LinearScale} from '../../../widgets/line_chart_v2/lib/scale';
+import {ScalarCardLinkedTimeFobController} from './scalar_card_linked_time_fob_controller';
+
+fdescribe('ScalarLinkedTimeFobController', () => {
+  let forwardScaleSpy: jasmine.Spy;
+  let reverseScaleSpy: jasmine.Spy;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        ScalarCardLinkedTimeFobController,
+        LinkedTimeFobControllerComponent,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  });
+
+  function createComponent(input: {
+    linkedTime?: LinkedTime;
+    minMax?: [number, number];
+    axisSize?: number;
+  }): ComponentFixture<ScalarCardLinkedTimeFobController> {
+    const fixture = TestBed.createComponent(ScalarCardLinkedTimeFobController);
+    fixture.componentInstance.linkedTime = input.linkedTime ?? {
+      start: {step: 200},
+      end: null,
+    };
+
+    fixture.componentInstance.minMax = input.minMax ?? [0, 10];
+    fixture.componentInstance.axisSize = input.axisSize ?? 100;
+
+    const fakeScale = new LinearScale();
+    forwardScaleSpy = jasmine.createSpy();
+    reverseScaleSpy = jasmine.createSpy();
+    fakeScale.forward = forwardScaleSpy;
+    fakeScale.reverse = reverseScaleSpy;
+    // Imitate a 10:1 scale.
+    forwardScaleSpy.and.callFake(
+      (domain: [number, number], range: [number, number], x: number) => {
+        return x * 10;
+      }
+    );
+    reverseScaleSpy.and.callFake(
+      (domain: [number, number], range: [number, number], x: number) => {
+        return x / 10;
+      }
+    );
+    fixture.componentInstance.scale = fakeScale;
+    return fixture;
+  }
+
+  describe('getAxisPositionFromStep', () => {
+    it('calls the scale function', () => {
+      const minMax: [number, number] = [0, 2];
+      const axisSize = 20;
+      let fixture = createComponent({minMax, axisSize});
+      expect(fixture.componentInstance.getAxisPositionFromStep(1)).toBe(10);
+      expect(forwardScaleSpy).toHaveBeenCalledOnceWith(
+        minMax,
+        [0, axisSize],
+        1
+      );
+    });
+  });
+});

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
@@ -76,7 +76,7 @@ fdescribe('ScalarLinkedTimeFobController', () => {
       const axisSize = 20;
       const fixture = createComponent({minMax, axisSize});
 
-      let position = fixture.componentInstance.getAxisPositionFromStep(1);
+      const position = fixture.componentInstance.getAxisPositionFromStep(1);
 
       expect(position).toBe(1 * SCALE_RATIO);
       expect(forwardScaleSpy).toHaveBeenCalledOnceWith(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
@@ -17,9 +17,12 @@ import {LinkedTimeFobControllerComponent} from '../../../widgets/linked_time_fob
 import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
 import {ScalarCardLinkedTimeFobController} from './scalar_card_linked_time_fob_controller';
 
-describe('ScalarLinkedTimeFobController', () => {
+const SCALE_RATIO = 10;
+
+fdescribe('ScalarLinkedTimeFobController', () => {
   let forwardScaleSpy: jasmine.Spy;
   let reverseScaleSpy: jasmine.Spy;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
@@ -41,23 +44,26 @@ describe('ScalarLinkedTimeFobController', () => {
       end: null,
     };
 
-    fixture.componentInstance.minMax = input.minMax ?? [0, 10];
-    fixture.componentInstance.axisSize = input.axisSize ?? 100;
+    fixture.componentInstance.minMax = input.minMax ?? [0, 1];
+    fixture.componentInstance.axisSize = input.axisSize ?? 1;
 
     const fakeScale = new LinearScale();
     forwardScaleSpy = jasmine.createSpy();
     reverseScaleSpy = jasmine.createSpy();
     fakeScale.forward = forwardScaleSpy;
     fakeScale.reverse = reverseScaleSpy;
-    // Imitate a 10:1 scale.
     forwardScaleSpy.and.callFake(
-      (domain: [number, number], range: [number, number], x: number) => {
-        return x * 10;
+      (domain: [number, number], range: [number, number], step: number) => {
+        return step * SCALE_RATIO;
       }
     );
     reverseScaleSpy.and.callFake(
-      (domain: [number, number], range: [number, number], x: number) => {
-        return x / 10;
+      (
+        domain: [number, number],
+        range: [number, number],
+        axisPosition: number
+      ) => {
+        return axisPosition / SCALE_RATIO;
       }
     );
     fixture.componentInstance.scale = fakeScale;
@@ -68,8 +74,11 @@ describe('ScalarLinkedTimeFobController', () => {
     it('calls the scale function', () => {
       const minMax: [number, number] = [0, 2];
       const axisSize = 20;
-      let fixture = createComponent({minMax, axisSize});
-      expect(fixture.componentInstance.getAxisPositionFromStep(1)).toBe(10);
+      const fixture = createComponent({minMax, axisSize});
+
+      let position = fixture.componentInstance.getAxisPositionFromStep(1);
+
+      expect(position).toBe(1 * SCALE_RATIO);
       expect(forwardScaleSpy).toHaveBeenCalledOnceWith(
         minMax,
         [0, axisSize],

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
@@ -19,7 +19,7 @@ import {ScalarCardLinkedTimeFobController} from './scalar_card_linked_time_fob_c
 
 const SCALE_RATIO = 10;
 
-fdescribe('ScalarLinkedTimeFobController', () => {
+describe('ScalarLinkedTimeFobController', () => {
   let forwardScaleSpy: jasmine.Spy;
   let reverseScaleSpy: jasmine.Spy;
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -27,10 +27,15 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {DataDownloadModule} from './data_download_module';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
+import {ScalarCardLinkedTimeFobController} from './scalar_card_linked_time_fob_controller';
 import {VisSelectedTimeWarningModule} from './vis_selected_time_warning_module';
 
 @NgModule({
-  declarations: [ScalarCardContainer, ScalarCardComponent],
+  declarations: [
+    ScalarCardContainer,
+    ScalarCardComponent,
+    ScalarCardLinkedTimeFobController,
+  ],
   exports: [ScalarCardContainer],
   imports: [
     CommonModule,

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -20,7 +20,7 @@ tf_ts_library(
     srcs = [
         "public_types.ts",
     ],
-    visibility = ["//tensorboard/webapp/widgets/line_chart_v2:__subpackages__"],
+    visibility = ["//tensorboard/webapp:__subpackages__"],
     deps = [
         ":chart_types",
         ":formatter",


### PR DESCRIPTION
This PR creates the ScalarCardLinkedTimeFobController. This will be used to replace the fob logic in ScalarCardComponent and will eventually be used to implement the fob dragging feature.  Currently it only implements enough to handle the placement of the fobs.

This new component will be used in a similar way to the [HistogramLinkedTimeController](https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts).