### PR TITLE
linked time: utilize ScalarCardLinkedTimeFobController in the ScalarCardComponent

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -216,36 +216,12 @@ limitations under the License.
   let-formatter="formatter"
 >
   <ng-container *ngIf="selectedTime">
-    <div
-      class="linked-time-fob-container"
-      [style.transform]="'translate(' +
-        xScale.forward(
-          viewExtent.x,
-          [0, domDim.width],
-          selectedTime.startStep
-        ) + 'px, 0)'
-      "
-    >
-      <linked-time-fob
-        class="selected-time-fob"
-        [step]="selectedTime.startStep"
-      ></linked-time-fob>
-    </div>
-    <div
-      *ngIf="selectedTime.endStep"
-      class="linked-time-fob-container"
-      [style.transform]="'translate(' +
-        xScale.forward(
-          viewExtent.x,
-          [0, domDim.width],
-          selectedTime.endStep
-        ) + 'px, 0)'
-      "
-    >
-      <linked-time-fob
-        class="selected-time-fob"
-        [step]="selectedTime.endStep"
-      ></linked-time-fob>
-    </div>
+    <scalar-card-linked-time-fob-controller
+      [linkedTime]="getLinkedTime()"
+      [scale]="xScale"
+      [minMax]="viewExtent.x"
+      [axisSize]="domDim.width"
+      (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+    ></scalar-card-linked-time-fob-controller>
   </ng-container>
 </ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -186,7 +186,10 @@ export class ScalarCardComponent<Downloader> {
     });
   }
 
-  getLinkedTime(): LinkedTime {
+  getLinkedTime(): LinkedTime | null {
+    if (this.selectedTime === null) {
+      return null;
+    }
     return {
       start: {
         step: this.selectedTime!.startStep,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -37,6 +37,7 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
+import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ScalarCardDataSeries,
@@ -183,5 +184,16 @@ export class ScalarCardComponent<Downloader> {
     this.dialog.open(this.DataDownloadComponent, {
       data: {cardId: this.cardId},
     });
+  }
+
+  getLinkedTime(): LinkedTime {
+    return {
+      start: {
+        step: this.selectedTime!.startStep,
+      },
+      end: this.selectedTime!.endStep
+        ? {step: this.selectedTime!.endStep}
+        : null,
+    };
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -60,6 +60,7 @@ import {
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
 import {LinkedTimeFobModule} from '../../../widgets/linked_time_fob/linked_time_fob_module';
+import {LinkedTimeFobControllerComponent} from '../../../widgets/linked_time_fob/linked_time_fob_controller_component';
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {PluginType} from '../../data_source';
@@ -73,6 +74,7 @@ import {
 import {TooltipSort, XAxisType} from '../../types';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
+import {ScalarCardLinkedTimeFobController} from './scalar_card_linked_time_fob_controller';
 import {
   ScalarCardPoint,
   ScalarCardSeriesMetadata,
@@ -169,7 +171,7 @@ function buildAlias(override: Partial<ExperimentAlias> = {}): ExperimentAlias {
   };
 }
 
-describe('scalar card', () => {
+fdescribe('scalar card', () => {
   let store: MockStore<State>;
   let selectSpy: jasmine.Spy;
   let overlayContainer: OverlayContainer;
@@ -262,6 +264,7 @@ describe('scalar card', () => {
       declarations: [
         ScalarCardContainer,
         ScalarCardComponent,
+        ScalarCardLinkedTimeFobController,
         TestableDataDownload,
         TestableLineChart,
       ],
@@ -2033,7 +2036,7 @@ describe('scalar card', () => {
     }));
   });
 
-  describe('linked time feature integration', () => {
+  fdescribe('linked time feature integration', () => {
     describe('selectedTime and dataset', () => {
       it('shows clipped warning when selectedTime is outside the extent of dataset', fakeAsync(() => {
         const runToSeries = {
@@ -2124,12 +2127,12 @@ describe('scalar card', () => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
 
-        const fobs = fixture.debugElement.queryAll(
-          Selector.LINKED_TIME_AXIS_FOB
-        );
+        let testController = fixture.debugElement.query(
+          By.directive(LinkedTimeFobControllerComponent)
+        ).componentInstance;
         expect(
-          fobs.map((debugEl) => debugEl.nativeElement.textContent.trim())
-        ).toEqual(['10']);
+          testController.startFobWrapper.nativeElement.textContent.trim()
+        ).toEqual('10');
       }));
 
       it('selects selectedTime to max extent when global setting is too large', fakeAsync(() => {
@@ -2152,12 +2155,12 @@ describe('scalar card', () => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
 
-        const fobs = fixture.debugElement.queryAll(
-          Selector.LINKED_TIME_AXIS_FOB
-        );
+        let testController = fixture.debugElement.query(
+          By.directive(LinkedTimeFobControllerComponent)
+        ).componentInstance;
         expect(
-          fobs.map((debugEl) => debugEl.nativeElement.textContent.trim())
-        ).toEqual(['30']);
+          testController.startFobWrapper.nativeElement.textContent.trim()
+        ).toEqual('30');
       }));
     });
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -59,8 +59,8 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
-import {LinkedTimeFobModule} from '../../../widgets/linked_time_fob/linked_time_fob_module';
 import {LinkedTimeFobControllerComponent} from '../../../widgets/linked_time_fob/linked_time_fob_controller_component';
+import {LinkedTimeFobModule} from '../../../widgets/linked_time_fob/linked_time_fob_module';
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {PluginType} from '../../data_source';

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2127,7 +2127,7 @@ describe('scalar card', () => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
 
-        let testController = fixture.debugElement.query(
+        const testController = fixture.debugElement.query(
           By.directive(LinkedTimeFobControllerComponent)
         ).componentInstance;
         expect(
@@ -2155,7 +2155,7 @@ describe('scalar card', () => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
 
-        let testController = fixture.debugElement.query(
+        const testController = fixture.debugElement.query(
           By.directive(LinkedTimeFobControllerComponent)
         ).componentInstance;
         expect(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -171,7 +171,7 @@ function buildAlias(override: Partial<ExperimentAlias> = {}): ExperimentAlias {
   };
 }
 
-fdescribe('scalar card', () => {
+describe('scalar card', () => {
   let store: MockStore<State>;
   let selectSpy: jasmine.Spy;
   let overlayContainer: OverlayContainer;
@@ -2036,7 +2036,7 @@ fdescribe('scalar card', () => {
     }));
   });
 
-  fdescribe('linked time feature integration', () => {
+  describe('linked time feature integration', () => {
     describe('selectedTime and dataset', () => {
       it('shows clipped warning when selectedTime is outside the extent of dataset', fakeAsync(() => {
         const runToSeries = {


### PR DESCRIPTION
This PR replaces the linked time fob and all the logic for that fob inside the ScalarCardComponent with the ScalarCardLinkedTimeController. Currently the ScalarCardLinkedTimeController only has logic for fob placement. Therefore the only functional change here is that the fob will now be centered properly(this resolves #5656 )

The goal is to eventually implement all the necessary logic to add the fob dragging feature in the Scalar Card. Currently pointer events are set to none(this is done [here](https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/components/vz_line_chart2/vz-line-chart2.ts;l=572)) so clicking and dragging does nothing. Once the logic for dragging is added that will be turned on.