### PR TITLE
linked time: displays indicator when thumb is moved to closest step

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -186,7 +186,7 @@ function buildNormalizedCardStepIndexMap(
     const shouldClamp = stepIndex !== null && stepIndex > maxStepIndex;
     const shouldAutoSelectMax = stepIndex === null || prevWasMax;
     if (shouldClamp || shouldAutoSelectMax) {
-      result[cardId] = {index: maxStepIndex, closest: false};
+      result[cardId] = {index: maxStepIndex, isClosest: false};
     }
   }
   return result;
@@ -862,7 +862,7 @@ const reducer = createReducer(
       ...state,
       cardStepIndex: {
         ...state.cardStepIndex,
-        [cardId]: {index: nextStepIndex, closest: false},
+        [cardId]: {index: nextStepIndex, isClosest: false},
       },
     };
   }),

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -61,6 +61,7 @@ import {
 import {
   CardMetadataMap,
   CardStepIndexMap,
+  CardStepIndexMetaData,
   MetricsNamespacedState,
   MetricsNonNamespacedState,
   MetricsSettings,
@@ -174,7 +175,7 @@ function buildNormalizedCardStepIndexMap(
       continue;
     }
     const stepIndex = cardStepIndex.hasOwnProperty(cardId)
-      ? cardStepIndex[cardId]
+      ? cardStepIndex[cardId]!.index
       : null;
     const prevMaxStepIndex = getMaxStepIndex(
       cardId,
@@ -186,7 +187,7 @@ function buildNormalizedCardStepIndexMap(
     const shouldClamp = stepIndex !== null && stepIndex > maxStepIndex;
     const shouldAutoSelectMax = stepIndex === null || prevWasMax;
     if (shouldClamp || shouldAutoSelectMax) {
-      result[cardId] = maxStepIndex;
+      result[cardId] = {index: maxStepIndex, closest: false};
     }
   }
   return result;
@@ -255,7 +256,6 @@ const {initialState, reducers: namespaceContextedReducer} =
       unresolvedImportedPinnedCards: [],
       cardMetadataMap: {},
       cardStepIndex: {},
-
       tagFilter: '',
       tagGroupExpanded: new Map<string, boolean>(),
       selectedTime: null,
@@ -861,7 +861,7 @@ const reducer = createReducer(
     }
     return {
       ...state,
-      cardStepIndex: {...state.cardStepIndex, [cardId]: nextStepIndex},
+      cardStepIndex: {...state.cardStepIndex, [cardId]: {index: nextStepIndex, closest: false}},
     };
   }),
   on(actions.metricsTagGroupExpansionChanged, (state, {tagGroup}) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -61,7 +61,6 @@ import {
 import {
   CardMetadataMap,
   CardStepIndexMap,
-  CardStepIndexMetaData,
   MetricsNamespacedState,
   MetricsNonNamespacedState,
   MetricsSettings,
@@ -861,7 +860,10 @@ const reducer = createReducer(
     }
     return {
       ...state,
-      cardStepIndex: {...state.cardStepIndex, [cardId]: {index: nextStepIndex, closest: false}},
+      cardStepIndex: {
+        ...state.cardStepIndex,
+        [cardId]: {index: nextStepIndex, closest: false},
+      },
     };
   }),
   on(actions.metricsTagGroupExpansionChanged, (state, {tagGroup}) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -37,6 +37,7 @@ import {
   buildDataSourceTagMetadata,
   buildMetricsSettingsState,
   buildMetricsState,
+  buildStepIndexMetadata,
   buildTagMetadata,
   buildTimeSeriesData,
   createCardMetadata,
@@ -522,10 +523,10 @@ describe('metrics reducers', () => {
           [pinnedCopyId2]: cardMetadata2,
         },
         cardStepIndex: {
-          [pinnedCopyId1]: 1,
-          [pinnedCopyId2]: 2,
-          [cardId1]: 1,
-          [cardId2]: 2,
+          [pinnedCopyId1]: buildStepIndexMetadata({index: 1}),
+          [pinnedCopyId2]: buildStepIndexMetadata({index: 2}),
+          [cardId1]: buildStepIndexMetadata({index: 1}),
+          [cardId2]: buildStepIndexMetadata({index: 2}),
         },
         cardToPinnedCopy: new Map([
           [cardId1, pinnedCopyId1],
@@ -557,8 +558,8 @@ describe('metrics reducers', () => {
           [pinnedCopyId1]: cardMetadata1,
         },
         cardStepIndex: {
-          [pinnedCopyId1]: 1,
-          [cardId1]: 1,
+          [pinnedCopyId1]: buildStepIndexMetadata({index: 1}),
+          [cardId1]: buildStepIndexMetadata({index: 1}),
         },
       });
       expect(nextState.cardMetadataMap).toEqual(expectedState.cardMetadataMap);
@@ -586,7 +587,7 @@ describe('metrics reducers', () => {
           [cardId2]: cardMetadata2,
         },
         cardStepIndex: {
-          [cardId1]: 1,
+          [cardId1]: buildStepIndexMetadata({index: 1}),
         },
       });
       const action = actions.metricsTagMetadataLoaded({
@@ -605,7 +606,7 @@ describe('metrics reducers', () => {
           [cardId1]: cardMetadata1,
         },
         cardStepIndex: {
-          [cardId1]: 1,
+          [cardId1]: buildStepIndexMetadata({index: 1}),
         },
       });
       expect(nextState.cardMetadataMap).toEqual(expectedState.cardMetadataMap);
@@ -625,7 +626,7 @@ describe('metrics reducers', () => {
         cardMetadataMap: {},
         cardList: [],
         cardStepIndex: {
-          [expectedCardId]: stepCount - 1,
+          [expectedCardId]: buildStepIndexMetadata({index: stepCount - 1}),
         },
         cardToPinnedCopy: new Map(),
         pinnedCardToOriginal: new Map(),
@@ -669,8 +670,10 @@ describe('metrics reducers', () => {
         },
         cardList: [expectedCardId],
         cardStepIndex: {
-          [expectedCardId]: stepCount - 1,
-          [expectedPinnedCopyId]: stepCount - 1,
+          [expectedCardId]: buildStepIndexMetadata({index: stepCount - 1}),
+          [expectedPinnedCopyId]: buildStepIndexMetadata({
+            index: stepCount - 1,
+          }),
         },
         cardToPinnedCopy: new Map([[expectedCardId, expectedPinnedCopyId]]),
         pinnedCardToOriginal: new Map([[expectedPinnedCopyId, expectedCardId]]),
@@ -1456,7 +1459,9 @@ describe('metrics reducers', () => {
           stepIndex: nextStepIndex,
         });
         const nextState = reducers(beforeState, action);
-        expect(nextState.cardStepIndex).toEqual({card1: nextStepIndex});
+        expect(nextState.cardStepIndex).toEqual({
+          card1: {index: nextStepIndex, closest: false},
+        });
       });
 
       it('slider value clamps to time series length', () => {
@@ -1470,7 +1475,9 @@ describe('metrics reducers', () => {
           stepIndex: 100,
         });
         const nextState = reducers(beforeState, action);
-        expect(nextState.cardStepIndex).toEqual({card1: 2});
+        expect(nextState.cardStepIndex).toEqual({
+          card1: buildStepIndexMetadata({index: 2}),
+        });
       });
 
       it('sets step index to null when there is no time series', () => {
@@ -1482,7 +1489,9 @@ describe('metrics reducers', () => {
           stepIndex: 100,
         });
         const nextState = reducers(beforeState, action);
-        expect(nextState.cardStepIndex).toEqual({card1: null});
+        expect(nextState.cardStepIndex).toEqual({
+          card1: buildStepIndexMetadata({index: null}),
+        });
       });
     });
 
@@ -1512,7 +1521,10 @@ describe('metrics reducers', () => {
         );
         beforeState = {
           ...stateWithPinnedCopy(beforeState, 'card1', 'pinnedCopy1'),
-          cardStepIndex: {card1: 2, pinnedCopy1: 2},
+          cardStepIndex: {
+            card1: buildStepIndexMetadata({index: 2}),
+            pinnedCopy1: buildStepIndexMetadata({index: 2}),
+          },
         };
 
         const action = actions.fetchTimeSeriesLoaded({
@@ -1524,8 +1536,8 @@ describe('metrics reducers', () => {
         });
         const nextState = reducers(beforeState, action);
         expect(nextState.cardStepIndex).toEqual({
-          card1: 2,
-          pinnedCopy1: 2,
+          card1: buildStepIndexMetadata({index: 2}),
+          pinnedCopy1: buildStepIndexMetadata({index: 2}),
         });
       });
 
@@ -1539,7 +1551,10 @@ describe('metrics reducers', () => {
         );
         beforeState = {
           ...stateWithPinnedCopy(beforeState, 'card1', 'pinnedCopy1'),
-          cardStepIndex: {card1: stepCount - 1, pinnedCopy1: stepCount - 1},
+          cardStepIndex: {
+            card1: buildStepIndexMetadata({index: stepCount - 1}),
+            pinnedCopy1: buildStepIndexMetadata({index: stepCount - 1}),
+          },
         };
 
         const newStepCount = 10;
@@ -1552,8 +1567,8 @@ describe('metrics reducers', () => {
         });
         const nextState = reducers(beforeState, action);
         expect(nextState.cardStepIndex).toEqual({
-          card1: newStepCount - 1,
-          pinnedCopy1: newStepCount - 1,
+          card1: buildStepIndexMetadata({index: newStepCount - 1}),
+          pinnedCopy1: buildStepIndexMetadata({index: newStepCount - 1}),
         });
       });
 
@@ -1569,7 +1584,10 @@ describe('metrics reducers', () => {
         );
         beforeState = {
           ...stateWithPinnedCopy(beforeState, 'card1', 'pinnedCopy1'),
-          cardStepIndex: {card1: 9, pinnedCopy1: 9},
+          cardStepIndex: {
+            card1: buildStepIndexMetadata({index: 9}),
+            pinnedCopy1: buildStepIndexMetadata({index: 9}),
+          },
         };
 
         const action = actions.fetchTimeSeriesLoaded({
@@ -1584,8 +1602,8 @@ describe('metrics reducers', () => {
         });
         const nextState = reducers(beforeState, action);
         expect(nextState.cardStepIndex).toEqual({
-          card1: 2,
-          pinnedCopy1: 2,
+          card1: buildStepIndexMetadata({index: 2}),
+          pinnedCopy1: buildStepIndexMetadata({index: 2}),
         });
       });
 
@@ -1613,8 +1631,8 @@ describe('metrics reducers', () => {
         });
         const nextState = reducers(beforeState, action);
         expect(nextState.cardStepIndex).toEqual({
-          card1: 2,
-          pinnedCopy1: 2,
+          card1: buildStepIndexMetadata({index: 2}),
+          pinnedCopy1: buildStepIndexMetadata({index: 2}),
         });
       });
 
@@ -1627,7 +1645,10 @@ describe('metrics reducers', () => {
         );
         beforeState = {
           ...stateWithPinnedCopy(beforeState, 'card1', 'pinnedCopy1'),
-          cardStepIndex: {card1: 5, pinnedCopy1: 5},
+          cardStepIndex: {
+            card1: buildStepIndexMetadata({index: 5}),
+            pinnedCopy1: buildStepIndexMetadata({index: 5}),
+          },
         };
 
         const action = actions.fetchTimeSeriesLoaded({
@@ -1743,8 +1764,8 @@ describe('metrics reducers', () => {
         },
         cardList: ['card1'],
         cardStepIndex: {
-          card1: 10,
-          pinnedCopy1: 20,
+          card1: buildStepIndexMetadata({index: 10}),
+          pinnedCopy1: buildStepIndexMetadata({index: 20}),
         },
         cardToPinnedCopy: new Map([['card1', 'pinnedCopy1']]),
         pinnedCardToOriginal: new Map([['pinnedCopy1', 'card1']]),
@@ -1764,7 +1785,7 @@ describe('metrics reducers', () => {
         },
         cardList: ['card1'],
         cardStepIndex: {
-          card1: 10,
+          card1: buildStepIndexMetadata({index: 10}),
         },
         cardToPinnedCopy: new Map(),
         pinnedCardToOriginal: new Map(),
@@ -1780,8 +1801,8 @@ describe('metrics reducers', () => {
         },
         cardList: ['card1'],
         cardStepIndex: {
-          card1: 10,
-          pinnedCopy1: 20,
+          card1: buildStepIndexMetadata({index: 10}),
+          pinnedCopy1: buildStepIndexMetadata({index: 20}),
         },
         cardToPinnedCopy: new Map([['card1', 'pinnedCopy1']]),
         pinnedCardToOriginal: new Map([['pinnedCopy1', 'card1']]),
@@ -1801,7 +1822,7 @@ describe('metrics reducers', () => {
         },
         cardList: ['card1'],
         cardStepIndex: {
-          card1: 10,
+          card1: buildStepIndexMetadata({index: 10}),
         },
         cardToPinnedCopy: new Map(),
         pinnedCardToOriginal: new Map(),
@@ -1831,7 +1852,7 @@ describe('metrics reducers', () => {
         },
         cardList: ['card1'],
         cardStepIndex: {
-          card1: stepCount - 1,
+          card1: buildStepIndexMetadata({index: stepCount - 1}),
         },
         cardToPinnedCopy: new Map(),
         pinnedCardToOriginal: new Map(),
@@ -1854,8 +1875,10 @@ describe('metrics reducers', () => {
         },
         cardList: ['card1'],
         cardStepIndex: {
-          card1: stepCount - 1,
-          [expectedPinnedCopyId]: stepCount - 1,
+          card1: buildStepIndexMetadata({index: stepCount - 1}),
+          [expectedPinnedCopyId]: buildStepIndexMetadata({
+            index: stepCount - 1,
+          }),
         },
         cardToPinnedCopy: new Map([['card1', expectedPinnedCopyId]]),
         pinnedCardToOriginal: new Map([[expectedPinnedCopyId, 'card1']]),
@@ -2516,7 +2539,7 @@ describe('metrics reducers', () => {
               },
             },
           },
-          cardStepIndex: {[imageCardId]: 2},
+          cardStepIndex: {[imageCardId]: buildStepIndexMetadata({index: 2})},
         });
 
         const nextState = reducers(
@@ -2527,7 +2550,9 @@ describe('metrics reducers', () => {
           })
         );
 
-        expect(nextState.cardStepIndex).toEqual({[imageCardId]: 0});
+        expect(nextState.cardStepIndex).toEqual({
+          [imageCardId]: buildStepIndexMetadata({index: 0}),
+        });
       });
 
       it('does not set `cardStepIndex` when steps do not match selected time', () => {
@@ -2552,7 +2577,7 @@ describe('metrics reducers', () => {
               },
             },
           },
-          cardStepIndex: {[imageCardId]: 2},
+          cardStepIndex: {[imageCardId]: buildStepIndexMetadata({index: 2})},
         });
 
         const nextState = reducers(
@@ -2563,7 +2588,9 @@ describe('metrics reducers', () => {
           })
         );
 
-        expect(nextState.cardStepIndex).toEqual({[imageCardId]: 2});
+        expect(nextState.cardStepIndex).toEqual({
+          [imageCardId]: buildStepIndexMetadata({index: 2}),
+        });
       });
     });
 
@@ -2645,12 +2672,14 @@ describe('metrics reducers', () => {
               },
             },
           },
-          cardStepIndex: {[imageCardId]: 2},
+          cardStepIndex: {[imageCardId]: buildStepIndexMetadata({index: 2})},
         });
 
         const state2 = reducers(state1, actions.selectTimeEnableToggled());
 
-        expect(state2.cardStepIndex).toEqual({[imageCardId]: 0});
+        expect(state2.cardStepIndex).toEqual({
+          [imageCardId]: buildStepIndexMetadata({index: 0}),
+        });
       });
 
       it('updates step index using pre-existing selectedTime', () => {
@@ -2675,11 +2704,13 @@ describe('metrics reducers', () => {
             },
           },
           selectedTime: {start: {step: 20}, end: null},
-          cardStepIndex: {[imageCardId]: 2},
+          cardStepIndex: {[imageCardId]: buildStepIndexMetadata({index: 2})},
         });
 
         const state2 = reducers(state1, actions.selectTimeEnableToggled());
-        expect(state2.cardStepIndex).toEqual({[imageCardId]: 1});
+        expect(state2.cardStepIndex).toEqual({
+          [imageCardId]: buildStepIndexMetadata({index: 1}),
+        });
       });
 
       it('does not update step index when toggle to disable selectedTime', () => {
@@ -2711,11 +2742,13 @@ describe('metrics reducers', () => {
             },
           },
           selectedTime: {start: {step: 20}, end: null},
-          cardStepIndex: {[imageCardId]: 2},
+          cardStepIndex: {[imageCardId]: buildStepIndexMetadata({index: 2})},
         });
 
         const state2 = reducers(state1, actions.selectTimeEnableToggled());
-        expect(state2.cardStepIndex).toEqual({[imageCardId]: 2});
+        expect(state2.cardStepIndex).toEqual({
+          [imageCardId]: buildStepIndexMetadata({index: 2}),
+        });
       });
 
       it('sets selectedTime to step 0 when selectedTime is null before toggling', () => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1460,7 +1460,7 @@ describe('metrics reducers', () => {
         });
         const nextState = reducers(beforeState, action);
         expect(nextState.cardStepIndex).toEqual({
-          card1: {index: nextStepIndex, closest: false},
+          card1: {index: nextStepIndex, isClosest: false},
         });
       });
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -33,6 +33,7 @@ import {
 import * as storeUtils from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
+  CardStepIndexMetaData,
   MetricsSettings,
   MetricsState,
   METRICS_FEATURE_KEY,
@@ -176,12 +177,12 @@ export const getNonEmptyCardIdsWithMetadata = createSelector(
 );
 
 /**
- * The index into the step values array for a card's UI. This may be greater
+ * The index metadata into the step values array for a card's UI. This may be greater
  * than the number of step values available, if time series data is not loaded.
  */
-export const getCardStepIndex = createSelector(
+export const getCardStepIndexMetaData = createSelector(
   selectMetricsState,
-  (state: MetricsState, cardId: CardId): number | null => {
+  (state: MetricsState, cardId: CardId): CardStepIndexMetaData | null => {
     if (!state.cardStepIndex.hasOwnProperty(cardId)) {
       return null;
     }

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -20,6 +20,7 @@ import {
   appStateFromMetricsState,
   buildMetricsSettingsState,
   buildMetricsState,
+  buildStepIndexMetadata,
   createCardMetadata,
   createImageStepData,
   createScalarStepData,
@@ -395,10 +396,12 @@ describe('metrics selectors', () => {
 
       const state = appStateFromMetricsState(
         buildMetricsState({
-          cardStepIndex: {card1: 5},
+          cardStepIndex: {card1: buildStepIndexMetadata({index: 5})},
         })
       );
-      expect(selectors.getCardStepIndexMetaData(state, 'card1')).toBe(5);
+      expect(selectors.getCardStepIndexMetaData(state, 'card1')).toEqual(
+        buildStepIndexMetadata({index: 5})
+      );
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -380,25 +380,25 @@ describe('metrics selectors', () => {
 
   describe('getCardStepIndex', () => {
     it('returns null if no card exists', () => {
-      selectors.getCardStepIndex.release();
+      selectors.getCardStepIndexMetaData.release();
 
       const state = appStateFromMetricsState(
         buildMetricsState({
           cardStepIndex: {},
         })
       );
-      expect(selectors.getCardStepIndex(state, 'card1')).toBe(null);
+      expect(selectors.getCardStepIndexMetaData(state, 'card1')).toBe(null);
     });
 
     it('properly returns card ids', () => {
-      selectors.getCardStepIndex.release();
+      selectors.getCardStepIndexMetaData.release();
 
       const state = appStateFromMetricsState(
         buildMetricsState({
           cardStepIndex: {card1: 5},
         })
       );
-      expect(selectors.getCardStepIndex(state, 'card1')).toBe(5);
+      expect(selectors.getCardStepIndexMetaData(state, 'card1')).toBe(5);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -476,7 +476,7 @@ function getNextImageCardStepIndexFromSingleSelection(
   // Checks exact match.
   const maybeMatchedStepIndex = steps.indexOf(selectedStep);
   if (maybeMatchedStepIndex !== -1) {
-    return {index: maybeMatchedStepIndex, closest: false};
+    return {index: maybeMatchedStepIndex, isClosest: false};
   }
 
   // Checks if start step is "close" enough to a step value and move it
@@ -489,10 +489,10 @@ function getNextImageCardStepIndexFromSingleSelection(
     if (selectedStep > nextStep) continue;
 
     if (selectedStep - currentStep <= distance) {
-      return {index: i, closest: true};
+      return {index: i, isClosest: true};
     }
     if (nextStep - selectedStep <= distance) {
-      return {index: i + 1, closest: true};
+      return {index: i + 1, isClosest: true};
     }
   }
 
@@ -517,10 +517,10 @@ function getNextImageCardStepIndexFromRangeSelection(
 
   // Updates step index to the closest index if it is outside the range.
   if (step > lastSelectedStep) {
-    return {index: steps.indexOf(lastSelectedStep), closest: false};
+    return {index: steps.indexOf(lastSelectedStep), isClosest: false};
   }
   if (step < firstSelectedStep) {
-    return {index: steps.indexOf(firstSelectedStep), closest: false};
+    return {index: steps.indexOf(firstSelectedStep), isClosest: false};
   }
 
   // Does not update index when it is in selected range.

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -28,6 +28,7 @@ import {
 import {
   CardMetadataMap,
   CardStepIndexMap,
+  CardStepIndexMetaData,
   CardToPinnedCard,
   MetricsState,
   PinnedCardToCard,
@@ -387,28 +388,28 @@ export function generateNextCardStepIndexFromSelectedTime(
 
     const steps = getImageCardSteps(cardId, cardMetadataMap, timeSeriesData);
 
-    let nextStepIndex = null;
+    let nextStepIndexMetaData = null;
     if (selectedTime.end === null) {
       // Single Selection
-      nextStepIndex = getNextImageCardStepIndexFromSingleSelection(
+      nextStepIndexMetaData = getNextImageCardStepIndexFromSingleSelection(
         selectedTime.start.step,
         steps
       );
     } else {
       // Range Selection
-      const currentStepIndex = previousCardStepIndex[cardId]!;
+      const currentStepIndex = previousCardStepIndex[cardId]!.index!;
       const step = steps[currentStepIndex];
       const selectedSteps = getSelectedSteps(selectedTime, steps);
 
-      nextStepIndex = getNextImageCardStepIndexFromRangeSelection(
+      nextStepIndexMetaData = getNextImageCardStepIndexFromRangeSelection(
         selectedSteps,
         steps,
         step
       );
     }
 
-    if (nextStepIndex !== null) {
-      nextCardStepIndex[cardId] = nextStepIndex;
+    if (nextStepIndexMetaData !== null) {
+      nextCardStepIndex[cardId] = nextStepIndexMetaData;
     }
   });
 
@@ -471,11 +472,11 @@ function getSelectedSteps(selectedTime: LinkedTime | null, steps: number[]) {
 function getNextImageCardStepIndexFromSingleSelection(
   selectedStep: number,
   steps: number[]
-): number | null {
+): CardStepIndexMetaData | null {
   // Checks exact match.
   const maybeMatchedStepIndex = steps.indexOf(selectedStep);
   if (maybeMatchedStepIndex !== -1) {
-    return maybeMatchedStepIndex;
+    return {index: maybeMatchedStepIndex, closest: false};
   }
 
   // Checks if start step is "close" enough to a step value and move it
@@ -488,10 +489,10 @@ function getNextImageCardStepIndexFromSingleSelection(
     if (selectedStep > nextStep) continue;
 
     if (selectedStep - currentStep <= distance) {
-      return i;
+      return {index: i, closest: true};
     }
     if (nextStep - selectedStep <= distance) {
-      return i + 1;
+      return {index: i + 1, closest: true};
     }
   }
 
@@ -508,7 +509,7 @@ function getNextImageCardStepIndexFromRangeSelection(
   selectedSteps: number[],
   steps: number[],
   step: number
-): number | null {
+): CardStepIndexMetaData | null {
   if (selectedSteps.length === 0) return null;
 
   const firstSelectedStep = selectedSteps[0];
@@ -516,10 +517,10 @@ function getNextImageCardStepIndexFromRangeSelection(
 
   // Updates step index to the closest index if it is outside the range.
   if (step > lastSelectedStep) {
-    return steps.indexOf(lastSelectedStep);
+    return {index: steps.indexOf(lastSelectedStep), closest: false};
   }
   if (step < firstSelectedStep) {
-    return steps.indexOf(firstSelectedStep);
+    return {index: steps.indexOf(firstSelectedStep), closest: false};
   }
 
   // Does not update index when it is in selected range.

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -16,6 +16,7 @@ import {DataLoadState} from '../../types/data';
 import {PluginType} from '../data_source';
 import {
   buildMetricsState,
+  buildStepIndexMetadata,
   buildTagMetadata,
   buildTimeSeriesData,
   createCardMetadata,
@@ -372,7 +373,7 @@ describe('metrics store utils', () => {
         {card1: {plugin: PluginType.SCALARS, tag: 'accuracy', runId: null}},
         new Map(),
         new Map(),
-        {card1: 2}
+        {card1: buildStepIndexMetadata({index: 2})}
       );
 
       const pinnedCardId = getPinnedCardId('card1');
@@ -397,7 +398,7 @@ describe('metrics store utils', () => {
         'card1',
         new Map(),
         new Map(),
-        {card1: 2},
+        {card1: buildStepIndexMetadata({index: 2})},
         {card1: createCardMetadata()}
       );
       const pinnedCardId = getPinnedCardId('card1');
@@ -405,8 +406,8 @@ describe('metrics store utils', () => {
       expect(cardToPinnedCopy).toEqual(new Map([['card1', pinnedCardId]]));
       expect(pinnedCardToOriginal).toEqual(new Map([[pinnedCardId, 'card1']]));
       expect(cardStepIndex).toEqual({
-        card1: 2,
-        [pinnedCardId]: 2,
+        card1: buildStepIndexMetadata({index: 2}),
+        [pinnedCardId]: buildStepIndexMetadata({index: 2}),
       });
       expect(cardMetadataMap).toEqual({
         card1: createCardMetadata(),
@@ -632,7 +633,10 @@ describe('metrics store utils', () => {
 
   describe('generateNextCardStepIndex', () => {
     it(`keeps nextCardStepIndexMap unchanged on cards included in cardMetadataMap`, () => {
-      const cardStepIndex = {card1: 1, card2: 2};
+      const cardStepIndex = {
+        card1: buildStepIndexMetadata({index: 1}),
+        card2: buildStepIndexMetadata({index: 2}),
+      };
       const cardMetadataMap = {
         card1: createCardMetadata(),
         card2: createCardMetadata(),
@@ -643,11 +647,17 @@ describe('metrics store utils', () => {
         cardMetadataMap
       );
 
-      expect(nextCardStepIndexMap).toEqual({card1: 1, card2: 2});
+      expect(nextCardStepIndexMap).toEqual({
+        card1: buildStepIndexMetadata({index: 1}),
+        card2: buildStepIndexMetadata({index: 2}),
+      });
     });
 
     it(`removes card mapping from nextCardStepIndexMap on cards not in cardMetadataMap`, () => {
-      const cardStepIndex = {card1: 1, card4: 2};
+      const cardStepIndex = {
+        card1: buildStepIndexMetadata({index: 1}),
+        card4: buildStepIndexMetadata({index: 2}),
+      };
       const cardMetadataMap = {
         card1: createCardMetadata(),
         card2: createCardMetadata(),
@@ -658,11 +668,13 @@ describe('metrics store utils', () => {
         cardMetadataMap
       );
 
-      expect(nextCardStepIndexMap).toEqual({card1: 1});
+      expect(nextCardStepIndexMap).toEqual({
+        card1: buildStepIndexMetadata({index: 1}),
+      });
     });
 
     it(`keeps nextCardStepIndexMap unchanged on cards not in nextCardStepIndexMap but in cardMetadataMap`, () => {
-      const cardStepIndex = {card1: 1};
+      const cardStepIndex = {card1: buildStepIndexMetadata({index: 1})};
       const cardMetadataMap = {
         card1: createCardMetadata(),
         card2: createCardMetadata(),
@@ -673,7 +685,9 @@ describe('metrics store utils', () => {
         cardMetadataMap
       );
 
-      expect(nextCardStepIndexMap).toEqual({card1: 1});
+      expect(nextCardStepIndexMap).toEqual({
+        card1: buildStepIndexMetadata({index: 1}),
+      });
     });
   });
 
@@ -712,13 +726,15 @@ describe('metrics store utils', () => {
 
     it(`updates cardStepIndex to matched selected time`, () => {
       const nextCardStepIndex = generateNextCardStepIndexFromSelectedTime(
-        {[imageCardId]: 3},
+        {[imageCardId]: buildStepIndexMetadata({index: 3})},
         cardMetadataMap,
         timeSeriesData,
         {start: {step: 20}, end: null}
       );
 
-      expect(nextCardStepIndex).toEqual({[imageCardId]: 1});
+      expect(nextCardStepIndex).toEqual({
+        [imageCardId]: buildStepIndexMetadata({index: 1}),
+      });
     });
 
     it(`does not update cardStepIndex on other non-image plugin`, () => {
@@ -765,36 +781,42 @@ describe('metrics store utils', () => {
 
     it(`does not update cardStepIndex on selected step with no image`, () => {
       const nextCardStepIndex = generateNextCardStepIndexFromSelectedTime(
-        {[imageCardId]: 3},
+        {[imageCardId]: buildStepIndexMetadata({index: 3})},
         cardMetadataMap,
         timeSeriesData,
         {start: {step: 15}, end: null}
       );
 
-      expect(nextCardStepIndex).toEqual({[imageCardId]: 3});
+      expect(nextCardStepIndex).toEqual({
+        [imageCardId]: buildStepIndexMetadata({index: 3}),
+      });
     });
 
     it(`updates cardStepIndex in range selection`, () => {
       const nextCardStepIndex = generateNextCardStepIndexFromSelectedTime(
-        {[imageCardId]: 3},
+        {[imageCardId]: buildStepIndexMetadata({index: 3})},
         cardMetadataMap,
         timeSeriesData,
         {start: {step: 15}, end: {step: 35}}
       );
 
       // Updates index to 2, which is the highest step with image data in range
-      expect(nextCardStepIndex).toEqual({[imageCardId]: 2});
+      expect(nextCardStepIndex).toEqual({
+        [imageCardId]: buildStepIndexMetadata({index: 2}),
+      });
     });
 
     it(`does not update cardStepIndex when there is no image in range`, () => {
       const nextCardStepIndex = generateNextCardStepIndexFromSelectedTime(
-        {[imageCardId]: 3},
+        {[imageCardId]: buildStepIndexMetadata({index: 3})},
         cardMetadataMap,
         timeSeriesData,
         {start: {step: 15}, end: {step: 18}}
       );
 
-      expect(nextCardStepIndex).toEqual({[imageCardId]: 3});
+      expect(nextCardStepIndex).toEqual({
+        [imageCardId]: buildStepIndexMetadata({index: 3}),
+      });
     });
   });
 
@@ -951,7 +973,7 @@ describe('metrics store utils', () => {
         [10, 20, 30, 40]
       );
 
-      expect(nextStepIndex).toEqual(1);
+      expect(nextStepIndex).toEqual({index: 1, closest: false});
     });
 
     it(`does not return step Index on selected step with no image`, () => {
@@ -969,7 +991,7 @@ describe('metrics store utils', () => {
         [10, 20, 30, 40]
       );
 
-      expect(nextStepIndex).toEqual(0);
+      expect(nextStepIndex).toEqual({index: 0, closest: true});
     });
 
     it('does not return step Index when selected step is not close to any step values', () => {
@@ -987,7 +1009,7 @@ describe('metrics store utils', () => {
         [10, 20, 30, 40]
       );
 
-      expect(nextStepIndex).toEqual(1);
+      expect(nextStepIndex).toEqual({index: 1, closest: true});
     });
 
     it('does not return step Index when there is only one unmatched step', () => {
@@ -1016,7 +1038,7 @@ describe('metrics store utils', () => {
         35
       );
 
-      expect(nextCardStepIndex).toEqual(2);
+      expect(nextCardStepIndex).toEqual({index: 2, closest: false});
     });
 
     it('returns cardStepIndex to the lowest step in range when current step is smaller than first selected step', () => {
@@ -1026,7 +1048,7 @@ describe('metrics store utils', () => {
         10
       );
 
-      expect(nextCardStepIndex).toEqual(1);
+      expect(nextCardStepIndex).toEqual({index: 1, closest: false});
     });
 
     it('returns null when current step is in range', () => {

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -973,7 +973,7 @@ describe('metrics store utils', () => {
         [10, 20, 30, 40]
       );
 
-      expect(nextStepIndex).toEqual({index: 1, closest: false});
+      expect(nextStepIndex).toEqual({index: 1, isClosest: false});
     });
 
     it(`does not return step Index on selected step with no image`, () => {
@@ -991,7 +991,7 @@ describe('metrics store utils', () => {
         [10, 20, 30, 40]
       );
 
-      expect(nextStepIndex).toEqual({index: 0, closest: true});
+      expect(nextStepIndex).toEqual({index: 0, isClosest: true});
     });
 
     it('does not return step Index when selected step is not close to any step values', () => {
@@ -1009,7 +1009,7 @@ describe('metrics store utils', () => {
         [10, 20, 30, 40]
       );
 
-      expect(nextStepIndex).toEqual({index: 1, closest: true});
+      expect(nextStepIndex).toEqual({index: 1, isClosest: true});
     });
 
     it('does not return step Index when there is only one unmatched step', () => {
@@ -1038,7 +1038,7 @@ describe('metrics store utils', () => {
         35
       );
 
-      expect(nextCardStepIndex).toEqual({index: 2, closest: false});
+      expect(nextCardStepIndex).toEqual({index: 2, isClosest: false});
     });
 
     it('returns cardStepIndex to the lowest step in range when current step is smaller than first selected step', () => {
@@ -1048,7 +1048,7 @@ describe('metrics store utils', () => {
         10
       );
 
-      expect(nextCardStepIndex).toEqual({index: 1, closest: false});
+      expect(nextCardStepIndex).toEqual({index: 1, isClosest: false});
     });
 
     it('returns null when current step is in range', () => {

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -116,12 +116,21 @@ export type CardMetadataMap = Record<
 >;
 
 /**
+ * A step index in a card could be the index set from view or the closest step index
+ * set when selected time changed. When it is set from selected time, closest is true.
+ */
+export type CardStepIndexMetaData = {
+  index: number | null;
+  closest: boolean | null;
+}
+
+/**
  * Map from cards to their step index into the time series. Step index may be
  * null when the time series becomes empty.
  */
 export type CardStepIndexMap = Record<
   NonPinnedCardId | PinnedCardId,
-  number | null
+  CardStepIndexMetaData | null
 >;
 
 export type CardToPinnedCard = Map<NonPinnedCardId, PinnedCardId>;

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -116,16 +116,19 @@ export type CardMetadataMap = Record<
 >;
 
 /**
- * A step index in a card could be the index set from view or the closest step index
+ * A step index in a card could be set from actions or "modified" from the closest step index
  * set when selected time changed. When it is set from selected time, closest is true.
+ * index: The step index
+ * isClosest: Only used in linked time. When the index is adjusted on selected time changed, we
+ * set this attribute to true.
  */
 export type CardStepIndexMetaData = {
   index: number | null;
-  closest: boolean | null;
+  isClosest: boolean | null;
 };
 
 /**
- * Map from cards to their step index into the time series. Step index may be
+ * Map from cards to their step index metadata into the time series. Step index may be
  * null when the time series becomes empty.
  */
 export type CardStepIndexMap = Record<

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -122,7 +122,7 @@ export type CardMetadataMap = Record<
 export type CardStepIndexMetaData = {
   index: number | null;
   closest: boolean | null;
-}
+};
 
 /**
  * Map from cards to their step index into the time series. Step index may be

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -373,7 +373,7 @@ export function buildStepIndexMetadata(
 ) {
   return {
     index: 0,
-    closest: false,
+    isClosest: false,
     ...override,
   };
 }

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -35,7 +35,12 @@ import {
   TimeSeriesData,
 } from './store';
 import * as selectors from './store/metrics_selectors';
-import {MetricsSettings, RunToSeries, StepDatum} from './store/metrics_types';
+import {
+  CardStepIndexMetaData,
+  MetricsSettings,
+  RunToSeries,
+  StepDatum,
+} from './store/metrics_types';
 import {CardId, CardMetadata, TooltipSort, XAxisType} from './types';
 
 export function buildMetricsSettingsState(
@@ -298,7 +303,7 @@ export function provideMockCardSeriesData(
     .and.returnValue(of(runToSeries));
   storeSelectSpy
     .withArgs(selectors.getCardStepIndexMetaData, cardId)
-    .and.returnValue(of(stepIndex));
+    .and.returnValue(of({index: stepIndex, closest: false}));
   storeSelectSpy
     .withArgs(selectors.getMetricsImageCardSteps, cardId)
     .and.returnValue(of(steps));
@@ -327,7 +332,7 @@ export function provideMockCardRunToSeriesData(
     .and.returnValue(of(runToSeries));
   storeSelectSpy
     .withArgs(selectors.getCardStepIndexMetaData, cardId)
-    .and.returnValue(of(stepIndex));
+    .and.returnValue(of({index: stepIndex, closest: false}));
 }
 
 @Injectable()
@@ -361,4 +366,14 @@ export function provideTestingMetricsDataSource() {
     TestingMetricsDataSource,
     {provide: MetricsDataSource, useExisting: TestingMetricsDataSource},
   ];
+}
+
+export function buildStepIndexMetadata(
+  override: Partial<CardStepIndexMetaData> | null
+) {
+  return {
+    index: 0,
+    closest: false,
+    ...override,
+  };
 }

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -297,7 +297,7 @@ export function provideMockCardSeriesData(
     .withArgs(selectors.getCardTimeSeries, cardId)
     .and.returnValue(of(runToSeries));
   storeSelectSpy
-    .withArgs(selectors.getCardStepIndex, cardId)
+    .withArgs(selectors.getCardStepIndexMetaData, cardId)
     .and.returnValue(of(stepIndex));
   storeSelectSpy
     .withArgs(selectors.getMetricsImageCardSteps, cardId)
@@ -326,7 +326,7 @@ export function provideMockCardRunToSeriesData(
     .withArgs(selectors.getCardTimeSeries, cardId)
     .and.returnValue(of(runToSeries));
   storeSelectSpy
-    .withArgs(selectors.getCardStepIndex, cardId)
+    .withArgs(selectors.getCardStepIndexMetaData, cardId)
     .and.returnValue(of(stepIndex));
 }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -24,6 +24,7 @@ limitations under the License.
       ></tb-truncated-path>
       <vis-selected-time-warning
         [isClipped]="selectedTime && selectedTime.clipped"
+        [isClosestStepHighlighted]="isClosestStepHighlighted"
       ></vis-selected-time-warning>
     </span>
     <span class="controls">

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
@@ -58,6 +58,7 @@ export class ImageCardComponent {
   @Input() isPinned!: boolean;
   @Input() selectedSteps!: number[];
   @Input() selectedTime?: ViewSelectedTime | null = null;
+  @Input() isClosestStepHighlighted?: boolean = false;
 
   @Output() onActualSizeToggle = new EventEmitter<void>();
   @Output() stepIndexChange = new EventEmitter<number>();

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -45,7 +45,7 @@ import {
   getCardLoadState,
   getCardMetadata,
   getCardPinnedState,
-  getCardStepIndex,
+  getCardStepIndexMetaData,
   getCardTimeSeries,
   getMetricsImageBrightnessInMilli,
   getMetricsImageCardSteps,
@@ -80,6 +80,7 @@ type ImageCardMetadata = CardMetadata & {
       [imageUrl]="imageUrl$ | async"
       [stepIndex]="stepIndex$ | async"
       [steps]="steps$ | async"
+      [isClosestStepHighlighted]="isClosestStepHighlighted$ | async"
       (stepIndexChange)="onStepIndexChanged($event)"
       [brightnessInMilli]="brightnessInMilli$ | async"
       [contrastInMilli]="contrastInMilli$ | async"
@@ -124,6 +125,7 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
   numSample$?: Observable<number>;
   imageUrl$?: Observable<string | null>;
   stepIndex$?: Observable<number | null>;
+  isClosestStepHighlighted$?: Observable<boolean | null>;
   steps$?: Observable<number[]>;
   isPinned$?: Observable<boolean>;
   selectedTime$?: Observable<ViewSelectedTime | null>;
@@ -204,7 +206,12 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       shareReplay(1)
     );
 
-    this.stepIndex$ = this.store.select(getCardStepIndex, this.cardId);
+    this.stepIndex$ = this.store.select(getCardStepIndexMetaData, this.cardId).pipe(
+      map((stepIndexMetaData) => stepIndexMetaData ? stepIndexMetaData.index : null )
+    );
+    this.isClosestStepHighlighted$ = this.store.select(getCardStepIndexMetaData, this.cardId).pipe(
+      map((stepIndexMetaData) => stepIndexMetaData ? stepIndexMetaData.closest : false)
+    );
     this.loadState$ = this.store.select(getCardLoadState, this.cardId);
 
     this.tag$ = cardMetadata$.pipe(

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -217,7 +217,7 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       .select(getCardStepIndexMetaData, this.cardId)
       .pipe(
         map((stepIndexMetaData) =>
-          stepIndexMetaData ? stepIndexMetaData.closest : false
+          stepIndexMetaData ? stepIndexMetaData.isClosest : false
         )
       );
     this.loadState$ = this.store.select(getCardLoadState, this.cardId);

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -206,12 +206,20 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
       shareReplay(1)
     );
 
-    this.stepIndex$ = this.store.select(getCardStepIndexMetaData, this.cardId).pipe(
-      map((stepIndexMetaData) => stepIndexMetaData ? stepIndexMetaData.index : null )
-    );
-    this.isClosestStepHighlighted$ = this.store.select(getCardStepIndexMetaData, this.cardId).pipe(
-      map((stepIndexMetaData) => stepIndexMetaData ? stepIndexMetaData.closest : false)
-    );
+    this.stepIndex$ = this.store
+      .select(getCardStepIndexMetaData, this.cardId)
+      .pipe(
+        map((stepIndexMetaData) =>
+          stepIndexMetaData ? stepIndexMetaData.index : null
+        )
+      );
+    this.isClosestStepHighlighted$ = this.store
+      .select(getCardStepIndexMetaData, this.cardId)
+      .pipe(
+        map((stepIndexMetaData) =>
+          stepIndexMetaData ? stepIndexMetaData.closest : false
+        )
+      );
     this.loadState$ = this.store.select(getCardLoadState, this.cardId);
 
     this.tag$ = cardMetadata$.pipe(


### PR DESCRIPTION
* Motivation
In image card, when there is no data on selected step, we automatically move the thumb position to the closest step. We don't want to confused user to think about the data exist on this selected step so we add an icon indicator on the top of the card to show user something is happening.

* Technical context
Previously we moved the logics of adjusting index to reducer to avoid "flashing"(#5615). Thus there is no way in view level to know whether the step index has been adjusted or not. For example, for steps [10,20,30], we only want to show the indicator when selected step is 11 but not 10. But both of them set the cardStepIndex to 0 (step 10).
As a result, to solve this we need to have a variable remember whether the step index has been "auto adjusted" in the reducer level. Specifically in `store_internal_util`, methods `getNextImageCardStepIndexFromSingleSelection` and `getNextImageCardStepIndexFromRangeSelection`.  These two methods handle whether to adjust cardStepIndex based on the current thumb position. 

* Technical considerations
It is obvious we need the change in state. Two options are considered:
  1. create a new state similar to CardStepIndex but the value is a boolean indicate whether the step is adjusted to closest step; do some checking in views/ on both map
  2. remember this with existing CardStepIndex with extended value pari. Similar to "clipped" in linked time which we remember whether the card is "clipped", we remember whether the step is adjusted for each card.

   Option 2 looks more reasonable to me. It reduces the logic complexity in views/ compared to option 1.

* Tech changes
It seems a lot of files are changed but most of them are tests and result from type change of `CardStepIndex` changed. Some key files to look at:
  * metrics_types.ts: add new type `StepIndexMetaData` to include both index value and whether the index value is adjusted on selected time changes for a specific card. Replace the value of `CardStepIndex` from stepIndex (type number) to `StepIndexMetaData`
  * store_internal_util.ts: updates "closest" attribute accordingly
  * image_card_container.ts: extract index and closest value from "new CardStepIndex"' "isClosestStepHighlighted" set in "image_contrainer" to know whether thumb has been "adjusted to closest step" for this card

 * minor changes
   * getCardStepIndex is renamed to `getCardStepIndexMetaData`
   * the "closest" will be reset once user drags the thumb from view (because it is no longer moved by us).

   * create `buildStepIndexMetadata` in test for those tests which I don't care about the closest value. (Tests related changed could be viewed separately in https://github.com/tensorflow/tensorboard/commit/9efab4fe4e3a634c2020ce4745b952265c6fe565 (also includes some lint change)

* Screenshots
Shows text indicator when we moved thumb to the closest step (3) while the selected step is 3.01
<img width="720" alt="Screen Shot 2022-04-08 at 2 07 21 PM" src="https://user-images.githubusercontent.com/1131010/162531344-cd356f43-d30f-45cd-b425-10f3e36bbb79.png">

Does not show  text indicator when data exists on selected step (4)
<img width="719" alt="Screen Shot 2022-04-08 at 2 10 29 PM" src="https://user-images.githubusercontent.com/1131010/162531826-d2e74f75-3ae7-4157-b02f-5dfd11ba68bf.png">

