### PR TITLE
angular: update FormControl usages to be forward compatible with typed forms.

### DIFF
--- a/tensorboard/webapp/settings/_views/settings_dialog_component.ts
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.ts
@@ -57,12 +57,12 @@ export class SettingsDialogComponent implements OnInit, OnDestroy, OnChanges {
   readonly reloadPeriodControl = new FormControl(this.MIN_RELOAD_PERIOD_IN_S, [
     Validators.required,
     Validators.min(this.MIN_RELOAD_PERIOD_IN_S),
-  ]);
+  ]) as FormControl;
   readonly paginationControl = new FormControl(1, [
     Validators.required,
     Validators.min(1),
     createIntegerValidator(),
-  ]);
+  ]) as FormControl;
 
   private ngUnsubscribe = new Subject<void>();
 


### PR DESCRIPTION
Tensorboard has a couple `FormControl`s which will be broken when typed forms lands in v14 inside google3. Ordinarily, you'd want to use the opt-out symbol (`UntypedFormControl`). However, since Tensorboard needs to be simultaneously compatible with both v12 (on Github) and v14 (inside google3), we can use this cast as a trick to disable the new types.

* Motivation for features / changes

Forward compatibility with upcoming changes in google3.

* Technical description of changes

Add casts to `FormControl` in order to prevent type inference.

* Screenshots of UI changes

N/A -- types only change. No runtime effect is possible.

* Detailed steps to verify changes work correctly (as executed by you)

`blaze build //third_party/tensorboard/webapp/settings/_views:_views`

* Alternate designs / implementations considered

go/typed-forms-lsc
