### PR TITLE
time namespaced: fix reload operation after pinned card

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -396,6 +396,7 @@ const reducer = createReducer(
     const newState = {
       ...state,
       ...resolvedResult,
+      cardToPinnedCopyCache: resolvedResult.cardToPinnedCopy,
       settingOverrides: newSettings,
     };
 
@@ -573,6 +574,7 @@ const reducer = createReducer(
       return {
         ...state,
         ...resolvedResult,
+        cardToPinnedCopyCache: resolvedResult.cardToPinnedCopy,
         tagGroupExpanded,
         tagMetadataLoadState: {
           state: DataLoadState.LOADED,
@@ -909,6 +911,7 @@ const reducer = createReducer(
     if (isPinnedCopy) {
       const originalCardId = state.pinnedCardToOriginal.get(cardId);
       nextCardToPinnedCopy.delete(originalCardId!);
+      nextCardToPinnedCopyCache.delete(originalCardId!);
       nextPinnedCardToOriginal.delete(cardId);
       delete nextCardMetadataMap[cardId];
       delete nextCardStepIndexMap[cardId];
@@ -940,6 +943,7 @@ const reducer = createReducer(
       cardMetadataMap: nextCardMetadataMap,
       cardStepIndex: nextCardStepIndexMap,
       cardToPinnedCopy: nextCardToPinnedCopy,
+      cardToPinnedCopyCache: nextCardToPinnedCopyCache,
       pinnedCardToOriginal: nextPinnedCardToOriginal,
     };
   }),

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -362,10 +362,7 @@ describe('metrics reducers', () => {
         },
         cardList: [cardId1],
         cardToPinnedCopy: new Map([[cardId1, pinnedCopyId1]]),
-        cardToPinnedCopyCache: new Map([
-          [cardId1, pinnedCopyId1],
-          [cardId2, pinnedCopyId2],
-        ]),
+        cardToPinnedCopyCache: new Map([[cardId1, pinnedCopyId1]]),
         pinnedCardToOriginal: new Map([[pinnedCopyId1, cardId1]]),
       });
       expect(nextState.cardMetadataMap).toEqual(expectedState.cardMetadataMap);
@@ -1747,6 +1744,7 @@ describe('metrics reducers', () => {
           pinnedCopy1: 20,
         },
         cardToPinnedCopy: new Map([['card1', 'pinnedCopy1']]),
+        cardToPinnedCopyCache: new Map([['card1', 'pinnedCopy1']]),
         pinnedCardToOriginal: new Map([['pinnedCopy1', 'card1']]),
       });
       const nextState = reducers(
@@ -1767,6 +1765,7 @@ describe('metrics reducers', () => {
           card1: 10,
         },
         cardToPinnedCopy: new Map(),
+        cardToPinnedCopyCache: new Map(),
         pinnedCardToOriginal: new Map(),
       });
       expect(nextState).toEqual(expectedState);
@@ -1784,6 +1783,7 @@ describe('metrics reducers', () => {
           pinnedCopy1: 20,
         },
         cardToPinnedCopy: new Map([['card1', 'pinnedCopy1']]),
+        cardToPinnedCopyCache: new Map([['card1', 'pinnedCopy1']]),
         pinnedCardToOriginal: new Map([['pinnedCopy1', 'card1']]),
       });
       const nextState = reducers(
@@ -1804,6 +1804,7 @@ describe('metrics reducers', () => {
           card1: 10,
         },
         cardToPinnedCopy: new Map(),
+        cardToPinnedCopyCache: new Map(),
         pinnedCardToOriginal: new Map(),
       });
       expect(nextState).toEqual(expectedState);
@@ -1834,6 +1835,7 @@ describe('metrics reducers', () => {
           card1: stepCount - 1,
         },
         cardToPinnedCopy: new Map(),
+        cardToPinnedCopyCache: new Map(),
         pinnedCardToOriginal: new Map(),
         timeSeriesData,
       });
@@ -1858,6 +1860,7 @@ describe('metrics reducers', () => {
           [expectedPinnedCopyId]: stepCount - 1,
         },
         cardToPinnedCopy: new Map([['card1', expectedPinnedCopyId]]),
+        cardToPinnedCopyCache: new Map([['card1', expectedPinnedCopyId]]),
         pinnedCardToOriginal: new Map([[expectedPinnedCopyId, 'card1']]),
         timeSeriesData,
       });
@@ -2016,6 +2019,9 @@ describe('metrics reducers', () => {
         new Map([[pinnedCopyId, 'card1']])
       );
       expect(nextState.cardToPinnedCopy).toEqual(
+        new Map([['card1', pinnedCopyId]])
+      );
+      expect(nextState.cardToPinnedCopyCache).toEqual(
         new Map([['card1', pinnedCopyId]])
       );
       expect(nextState.unresolvedImportedPinnedCards).toEqual([]);


### PR DESCRIPTION
Issue:
Pinned cards disappear on clicking auto reload button on the top right cause. Googlers please see b/228606608.

Fix
After #5627 we use a new state, "cardToPinnedCopyCache", to remember all cards that have been previous pinned within the same namespace. The state intends to be updated whenever a card is pinned/unpinned (action "cardPinStateToggled"). Yet the update is somehow dropped at the reducer level. This PR puts it back. Alone with other "refresh" (metadata loaded, state rehydrate from url)

Test:
- This failure is better to be caught on webtest, which I just started work on and noticed something went wrong. User noticed this earlier. Will continue work on the webtest later.
- Updated a couple of places to also test the new state "cardToPinnedCopyCache"

TODO cleanup:
integrate this state into `unresolvedImportedPinnedCards ` and `buildOrReturnStateWithUnresolvedImportedPins`.