### PR TITLE
linked time: highlight the closest step in histogram

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -22,7 +22,7 @@ import {
 } from '@angular/core';
 import {Store} from '@ngrx/store';
 import {combineLatest, Observable} from 'rxjs';
-import {combineLatestWith, filter, map} from 'rxjs/operators';
+import {filter, map} from 'rxjs/operators';
 import {State} from '../../../app_state';
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
@@ -42,7 +42,12 @@ import {
 import {CardId, CardMetadata, LinkedTime} from '../../types';
 import {CardRenderer} from '../metrics_view_types';
 import {getTagDisplayName} from '../utils';
-import {maybeClipSelectedTime, ViewSelectedTime} from './utils';
+import {
+  getClosestNonTargetStep,
+  maybeClipSelectedTime,
+  maybeSetClosestStartStep,
+  ViewSelectedTime,
+} from './utils';
 
 type HistogramCardMetadata = CardMetadata & {
   plugin: PluginType.HISTOGRAMS;
@@ -100,6 +105,8 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   isPinned$?: Observable<boolean>;
   selectedTime$?: Observable<ViewSelectedTime | null>;
   isSelectedTimeClipped$?: Observable<boolean>;
+  steps$?: Observable<number[]>;
+  closestStep$?: Observable<number | null>;
 
   private isHistogramCardMetadata(
     cardMetadata: CardMetadata
@@ -150,18 +157,43 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
       })
     );
 
-    this.selectedTime$ = this.store.select(getMetricsSelectedTime).pipe(
-      combineLatestWith(this.data$),
-      map(([selectedTime, data]) => {
+    this.steps$ = this.data$.pipe(
+      map((data) => data.map((datum) => datum.step))
+    );
+
+    this.closestStep$ = combineLatest([
+      this.store.select(getMetricsSelectedTime),
+      this.steps$,
+    ]).pipe(
+      map(([selectedTime, steps]) => {
+        // Only calculates the closest step in single selection.
+        if (!selectedTime || !selectedTime.start || selectedTime.end !== null)
+          return null;
+
+        return getClosestNonTargetStep(selectedTime.start.step, steps);
+      })
+    );
+
+    this.selectedTime$ = combineLatest([
+      this.store.select(getMetricsSelectedTime),
+      this.steps$,
+      this.closestStep$,
+    ]).pipe(
+      map(([selectedTime, steps, closestStep]) => {
         if (!selectedTime) return null;
 
         let minStep = Infinity;
         let maxStep = -Infinity;
-        for (const datum of data) {
-          minStep = Math.min(datum.step, minStep);
-          maxStep = Math.max(datum.step, maxStep);
+        for (const step of steps) {
+          minStep = Math.min(step, minStep);
+          maxStep = Math.max(step, maxStep);
         }
-        return maybeClipSelectedTime(selectedTime, minStep, maxStep);
+        const viewSelectedTime = maybeClipSelectedTime(
+          selectedTime,
+          minStep,
+          maxStep
+        );
+        return maybeSetClosestStartStep(viewSelectedTime, closestStep);
       })
     );
 

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -43,7 +43,7 @@ import {CardId, CardMetadata, LinkedTime} from '../../types';
 import {CardRenderer} from '../metrics_view_types';
 import {getTagDisplayName} from '../utils';
 import {
-  getClosestNonTargetStep,
+  getClosestNonSelectedStep,
   maybeClipSelectedTime,
   maybeSetClosestStartStep,
   ViewSelectedTime,
@@ -106,7 +106,7 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   selectedTime$?: Observable<ViewSelectedTime | null>;
   isSelectedTimeClipped$?: Observable<boolean>;
   steps$?: Observable<number[]>;
-  closestStep$?: Observable<number | null>;
+  closestNonSelectedStep$?: Observable<number | null>;
 
   private isHistogramCardMetadata(
     cardMetadata: CardMetadata
@@ -161,7 +161,7 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
       map((data) => data.map((datum) => datum.step))
     );
 
-    this.closestStep$ = combineLatest([
+    this.closestNonSelectedStep$ = combineLatest([
       this.store.select(getMetricsSelectedTime),
       this.steps$,
     ]).pipe(
@@ -170,14 +170,14 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
         if (!selectedTime || !selectedTime.start || selectedTime.end !== null)
           return null;
 
-        return getClosestNonTargetStep(selectedTime.start.step, steps);
+        return getClosestNonSelectedStep(selectedTime.start.step, steps);
       })
     );
 
     this.selectedTime$ = combineLatest([
       this.store.select(getMetricsSelectedTime),
       this.steps$,
-      this.closestStep$,
+      this.closestNonSelectedStep$,
     ]).pipe(
       map(([selectedTime, steps, closestStep]) => {
         if (!selectedTime) return null;

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -298,7 +298,7 @@ describe('histogram card', () => {
         By.directive(TestableHistogramWidget)
       );
       expect(viz.componentInstance.linkedTime).toEqual({
-        // Steps in mock data is [0, 1, 99]
+        // Steps are [0, 1, 99] in mock data
         start: {step: 1},
         end: null,
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -298,6 +298,7 @@ describe('histogram card', () => {
         By.directive(TestableHistogramWidget)
       );
       expect(viz.componentInstance.linkedTime).toEqual({
+        // Steps in mock data is [0, 1, 99]
         start: {step: 1},
         end: null,
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -285,7 +285,7 @@ describe('histogram card', () => {
       expect(viz.componentInstance.linkedTime).toBeNull();
     });
 
-    it('passes single step linked time parameter to histogram viz', () => {
+    it('passes closest step linked time parameter to histogram viz', () => {
       provideMockCardSeriesData(selectSpy, PluginType.HISTOGRAMS, 'card1');
       store.overrideSelector(selectors.getMetricsSelectedTime, {
         start: {step: 5},
@@ -298,7 +298,7 @@ describe('histogram card', () => {
         By.directive(TestableHistogramWidget)
       );
       expect(viz.componentInstance.linkedTime).toEqual({
-        start: {step: 5},
+        start: {step: 1},
         end: null,
       });
     });

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -143,26 +143,33 @@ export function maybeClipSelectedTime(
  */
 export function maybeSetClosestStartStep(
   viewSelectedTime: ViewSelectedTime,
-  closestStep: number | null
+  steps: number[]
 ): ViewSelectedTime {
-  if (closestStep === null || viewSelectedTime.endStep !== null) {
+  // Only sets start step on single selection.
+  if (viewSelectedTime.endStep !== null) {
     return viewSelectedTime;
   }
 
-  viewSelectedTime.startStep = closestStep;
+  const closestStep = getClosestStep(viewSelectedTime.startStep, steps);
+  if (closestStep !== null) {
+    return {
+      ...viewSelectedTime,
+      startStep: closestStep,
+    };
+  }
 
   return viewSelectedTime;
 }
 
 /**
  * Given an array of steps, returns the closest step to the selected step. Returns null
- * if selected step has existed in the array.
+ * if there is no closest step, which only happens with empty steps array.
  */
-export function getClosestNonSelectedStep(
+export function getClosestStep(
   selectedStep: number,
   steps: number[]
 ): number | null {
-  if (steps.length === 0 || steps.indexOf(selectedStep) !== -1) {
+  if (steps.length === 0) {
     return null;
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -170,10 +170,6 @@ export function getClosestStep(
   selectedStep: number,
   steps: number[]
 ): number | null {
-  if (steps.length === 0) {
-    return null;
-  }
-
   let minDistance = Infinity;
   let closestStep = null;
   for (const step of steps) {

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -155,21 +155,21 @@ export function maybeSetClosestStartStep(
 }
 
 /**
- * Given an array of steps, returns the closest step to the target step. Returns null
- * if target step has existed in the array.
+ * Given an array of steps, returns the closest step to the selected step. Returns null
+ * if selected step has existed in the array.
  */
-export function getClosestNonTargetStep(
-  targetStep: number,
+export function getClosestNonSelectedStep(
+  selectedStep: number,
   steps: number[]
 ): number | null {
-  if (steps.length === 0 || steps.indexOf(targetStep) !== -1) {
+  if (steps.length === 0 || steps.indexOf(selectedStep) !== -1) {
     return null;
   }
 
   let minDistance = Infinity;
   let closestStep = null;
   for (const step of steps) {
-    const distance = Math.abs(targetStep - step);
+    const distance = Math.abs(selectedStep - step);
     // With the same distance between two steps, this method favors smaller step than larger
     // step. It is chosen unintentionally.
     if (distance < minDistance) {

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -152,6 +152,7 @@ export function maybeSetClosestStartStep(
 
   const closestStep = getClosestStep(viewSelectedTime.startStep, steps);
   if (closestStep !== null) {
+    // If the closest step is startStep itself, this is equvalent to viewSelectedTime.
     return {
       ...viewSelectedTime,
       startStep: closestStep,

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -137,3 +137,45 @@ export function maybeClipSelectedTime(
     clipped: true,
   };
 }
+
+/**
+ * Sets startStep of ViewSelectedTime to the closest step if the closeset step is not null.
+ */
+export function maybeSetClosestStartStep(
+  viewSelectedTime: ViewSelectedTime,
+  closestStep: number | null
+): ViewSelectedTime {
+  if (closestStep === null || viewSelectedTime.endStep !== null) {
+    return viewSelectedTime;
+  }
+
+  viewSelectedTime.startStep = closestStep;
+
+  return viewSelectedTime;
+}
+
+/**
+ * Given an array of steps, returns the closest step to the target step. Returns null
+ * if target step has existed in the array.
+ */
+export function getClosestNonTargetStep(
+  targetStep: number,
+  steps: number[]
+): number | null {
+  if (steps.length === 0 || steps.indexOf(targetStep) !== -1) {
+    return null;
+  }
+
+  let minDistance = Infinity;
+  let closestStep = null;
+  for (const step of steps) {
+    const distance = Math.abs(targetStep - step);
+    // With the same distance between two steps, this method favors smaller step than larger
+    // step. It is chosen unintentionally.
+    if (distance < minDistance) {
+      minDistance = distance;
+      closestStep = step;
+    }
+  }
+  return closestStep;
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {buildRun} from '../../../runs/store/testing';
 import {PartialSeries} from './scalar_card_types';
 import {
-  getClosestNonTargetStep,
+  getClosestNonSelectedStep,
   getDisplayNameForRun,
   maybeSetClosestStartStep,
   partitionSeries,
@@ -293,17 +293,17 @@ describe('metrics card_renderer utils test', () => {
     });
   });
 
-  describe('#getClosestNonTargetStep', () => {
+  describe('#getClosestNonSelectedStep', () => {
     it('gets closest step', () => {
-      expect(getClosestNonTargetStep(11, [0, 10, 20])).toBe(10);
+      expect(getClosestNonSelectedStep(11, [0, 10, 20])).toBe(10);
     });
 
     it('gets null on empty steps', () => {
-      expect(getClosestNonTargetStep(11, [])).toBe(null);
+      expect(getClosestNonSelectedStep(11, [])).toBe(null);
     });
 
-    it('gets null on target step existing in steps', () => {
-      expect(getClosestNonTargetStep(10, [0, 10, 20])).toBe(null);
+    it('gets null on selected step existing in steps', () => {
+      expect(getClosestNonSelectedStep(10, [0, 10, 20])).toBe(null);
     });
   });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -264,7 +264,7 @@ describe('metrics card_renderer utils test', () => {
       });
     });
 
-    it('does not set startStep when closest step is null', () => {
+    it('does not set startStep on an empty array of steps', () => {
       const viewSelectedTime = {
         startStep: 0,
         endStep: null,

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -257,7 +257,7 @@ describe('metrics card_renderer utils test', () => {
         clipped: false,
       };
 
-      expect(maybeSetClosestStartStep(viewSelectedTime, 3)).toBe({
+      expect(maybeSetClosestStartStep(viewSelectedTime, 3)).toEqual({
         startStep: 3,
         endStep: null,
         clipped: false,
@@ -271,7 +271,7 @@ describe('metrics card_renderer utils test', () => {
         clipped: false,
       };
 
-      expect(maybeSetClosestStartStep(viewSelectedTime, null)).toBe({
+      expect(maybeSetClosestStartStep(viewSelectedTime, null)).toEqual({
         startStep: 0,
         endStep: null,
         clipped: false,
@@ -285,7 +285,7 @@ describe('metrics card_renderer utils test', () => {
         clipped: false,
       };
 
-      expect(maybeSetClosestStartStep(viewSelectedTime, 4)).toBe({
+      expect(maybeSetClosestStartStep(viewSelectedTime, 4)).toEqual({
         startStep: 0,
         endStep: 3,
         clipped: false,

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -14,7 +14,12 @@ limitations under the License.
 ==============================================================================*/
 import {buildRun} from '../../../runs/store/testing';
 import {PartialSeries} from './scalar_card_types';
-import {getDisplayNameForRun, partitionSeries} from './utils';
+import {
+  getClosestNonTargetStep,
+  getDisplayNameForRun,
+  maybeSetClosestStartStep,
+  partitionSeries,
+} from './utils';
 
 describe('metrics card_renderer utils test', () => {
   describe('#getDisplayNameForRun', () => {
@@ -241,6 +246,64 @@ describe('metrics card_renderer utils test', () => {
           },
         ]);
       });
+    });
+  });
+
+  describe('#maybeSetClosestStartStep', () => {
+    it('sets startStep to closest step', () => {
+      const viewSelectedTime = {
+        startStep: 0,
+        endStep: null,
+        clipped: false,
+      };
+
+      expect(maybeSetClosestStartStep(viewSelectedTime, 3)).toBe({
+        startStep: 3,
+        endStep: null,
+        clipped: false,
+      });
+    });
+
+    it('does not set startStep when closest step is null', () => {
+      const viewSelectedTime = {
+        startStep: 0,
+        endStep: null,
+        clipped: false,
+      };
+
+      expect(maybeSetClosestStartStep(viewSelectedTime, null)).toBe({
+        startStep: 0,
+        endStep: null,
+        clipped: false,
+      });
+    });
+
+    it('does not set startStep when selected time is range selection', () => {
+      const viewSelectedTime = {
+        startStep: 0,
+        endStep: 3,
+        clipped: false,
+      };
+
+      expect(maybeSetClosestStartStep(viewSelectedTime, 4)).toBe({
+        startStep: 0,
+        endStep: 3,
+        clipped: false,
+      });
+    });
+  });
+
+  describe('#getClosestNonTargetStep', () => {
+    it('gets closest step', () => {
+      expect(getClosestNonTargetStep(11, [0, 10, 20])).toBe(10);
+    });
+
+    it('gets null on empty steps', () => {
+      expect(getClosestNonTargetStep(11, [])).toBe(null);
+    });
+
+    it('gets null on target step existing in steps', () => {
+      expect(getClosestNonTargetStep(10, [0, 10, 20])).toBe(null);
     });
   });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {buildRun} from '../../../runs/store/testing';
 import {PartialSeries} from './scalar_card_types';
 import {
-  getClosestNonSelectedStep,
+  getClosestStep,
   getDisplayNameForRun,
   maybeSetClosestStartStep,
   partitionSeries,
@@ -257,8 +257,8 @@ describe('metrics card_renderer utils test', () => {
         clipped: false,
       };
 
-      expect(maybeSetClosestStartStep(viewSelectedTime, 3)).toEqual({
-        startStep: 3,
+      expect(maybeSetClosestStartStep(viewSelectedTime, [10, 20, 30])).toEqual({
+        startStep: 10,
         endStep: null,
         clipped: false,
       });
@@ -271,7 +271,7 @@ describe('metrics card_renderer utils test', () => {
         clipped: false,
       };
 
-      expect(maybeSetClosestStartStep(viewSelectedTime, null)).toEqual({
+      expect(maybeSetClosestStartStep(viewSelectedTime, [])).toEqual({
         startStep: 0,
         endStep: null,
         clipped: false,
@@ -285,7 +285,7 @@ describe('metrics card_renderer utils test', () => {
         clipped: false,
       };
 
-      expect(maybeSetClosestStartStep(viewSelectedTime, 4)).toEqual({
+      expect(maybeSetClosestStartStep(viewSelectedTime, [10, 20, 30])).toEqual({
         startStep: 0,
         endStep: 3,
         clipped: false,
@@ -293,17 +293,17 @@ describe('metrics card_renderer utils test', () => {
     });
   });
 
-  describe('#getClosestNonSelectedStep', () => {
+  describe('#getClosestStep', () => {
     it('gets closest step', () => {
-      expect(getClosestNonSelectedStep(11, [0, 10, 20])).toBe(10);
+      expect(getClosestStep(11, [0, 10, 20])).toBe(10);
     });
 
     it('gets null on empty steps', () => {
-      expect(getClosestNonSelectedStep(11, [])).toBe(null);
+      expect(getClosestStep(11, [])).toBe(null);
     });
 
-    it('gets null on selected step existing in steps', () => {
-      expect(getClosestNonSelectedStep(10, [0, 10, 20])).toBe(null);
+    it('gets closeset step equal to selected step', () => {
+      expect(getClosestStep(10, [0, 10, 20])).toBe(10);
     });
   });
 });


### PR DESCRIPTION
* Motivation for features / changes
When there is no selected step on histogram card in single selection, it's easy to get confused (no color). We want to highlight the closest step with data on this case.

* Technical description of changes
Summary: update `this.selectedTime$` in `histogram_card_container.ts`
On histogram, to determine whether this card is "clipped" we have created "ViewSelectedTime" type and make the decision in histogram_container. Similarly, we adjust the step (to be specific, `startStep`) of `selectedTime` to the closest step accordingly. This makes sense to me because "selectedTime" is type "ViewSelectedTime". This type is to use in view only. 
Also all these changes are in view.  We don't change the LinkedTime-type state. Adjust the step here, and propagates it to  widget/historgram and histogram fob, both of which are passively rendering the view.


* Screenshots of UI changes
selected step=129; closest step=133
![Screen Shot 2022-04-12 at 3 43 16 PM](https://user-images.githubusercontent.com/1131010/163067524-950e9ff7-7f11-4568-84ca-8aab0bdfcbba.png)


* TODO:
1. Show icon indicator when we highlight the closest step instead of selected step.
2.  Consider change the input of <tb-histogram [linkedTime]=".."> to be other names. We can use slectedTime (type ViewSelectedTime) or change the name. To avoid confusion in the widget that we actually _not_ use state-level linked time.
