### PR TITLE
linked time: Wire up timeSelectionChange action

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -274,6 +274,7 @@ tf_ng_module(
         "//tensorboard/webapp/experiments:types",
         "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/metrics:types",
+        "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/store",
         "//tensorboard/webapp/metrics/views:types",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -85,6 +85,7 @@ export class ScalarCardComponent<Downloader> {
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
+  @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
 
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -51,6 +51,8 @@ import {
 import {DataLoadState} from '../../../types/data';
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
+import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
+import {timeSelectionChanged} from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
   getCardLoadState,
@@ -133,6 +135,7 @@ function areSeriesEqual(
       (onPinClicked)="pinStateChanged.emit($event)"
       observeIntersection
       (onVisibilityChange)="onVisibilityChange($event)"
+      (onSelectTimeChanged)="onSelectTimeChanged($event)"
     ></scalar-card-component>
   `,
   styles: [
@@ -516,5 +519,14 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         relativeTimeInMs: 0,
       };
     });
+  }
+
+  onSelectTimeChanged(linkedTime: LinkedTime) {
+    this.store.dispatch(
+      timeSelectionChanged({
+        startStep: linkedTime.start.step,
+        endStep: linkedTime.end ? linkedTime.end.step : undefined,
+      })
+    );
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -521,11 +521,11 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     });
   }
 
-  onSelectTimeChanged(linkedTime: LinkedTime) {
+  onSelectTimeChanged(newLinkedTime: LinkedTime) {
     this.store.dispatch(
       timeSelectionChanged({
-        startStep: linkedTime.start.step,
-        endStep: linkedTime.end ? linkedTime.end.step : undefined,
+        startStep: newLinkedTime.start.step,
+        endStep: newLinkedTime.end ? newLinkedTime.end.step : undefined,
       })
     );
   }


### PR DESCRIPTION
In order to allow the LinkedTimeFobController to implement dragging it must be able to dispatch the timeSelectionChanged action. This pulls that action into the ScalarCardContainer and passes it down to give the controller access.