### PR TITLE
linked time: Rename parameter to indicate newness

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -188,11 +188,11 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
     this.isPinned$ = this.store.select(getCardPinnedState, this.cardId);
   }
 
-  onSelectTimeChanged(linkedTime: LinkedTime) {
+  onSelectTimeChanged(newLinkedTime: LinkedTime) {
     this.store.dispatch(
       timeSelectionChanged({
-        startStep: linkedTime.start.step,
-        endStep: linkedTime.end ? linkedTime.end.step : undefined,
+        startStep: newLinkedTime.start.step,
+        endStep: newLinkedTime.end ? newLinkedTime.end.step : undefined,
       })
     );
   }


### PR DESCRIPTION
We decided to rename this parameter in a similar location in PR #5665. So I am doing it here for consistency.