### PR TITLE
Disable Bazel node modules linker.

### DIFF
--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -62,6 +62,11 @@ nodejs_binary(
         "@npm//@angular/compiler-cli",
         "@npm//@bazel/typescript",
     ],
+    # Disables the Bazel node modules linker. The node module linker is unreliable for the
+    # persistent worker executable, as it would rely on the `node_modules/` folder in the
+    # execroot that can be shared in non-sandbox environments or for persistent workers.
+    # https://docs.bazel.build/versions/main/command-line-reference.html#flag--worker_sandboxing.
+    templated_args = ["--nobazel_run_linker"],
     entry_point = "@npm//:node_modules/@bazel/typescript/internal/tsc_wrapped/tsc_wrapped.js",
     visibility = ["//tensorboard:__subpackages__"],
 )

--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -62,11 +62,11 @@ nodejs_binary(
         "@npm//@angular/compiler-cli",
         "@npm//@bazel/typescript",
     ],
+    entry_point = "@npm//:node_modules/@bazel/typescript/internal/tsc_wrapped/tsc_wrapped.js",
     # Disables the Bazel node modules linker. The node module linker is unreliable for the
     # persistent worker executable, as it would rely on the `node_modules/` folder in the
     # execroot that can be shared in non-sandbox environments or for persistent workers.
     # https://docs.bazel.build/versions/main/command-line-reference.html#flag--worker_sandboxing.
     templated_args = ["--nobazel_run_linker"],
-    entry_point = "@npm//:node_modules/@bazel/typescript/internal/tsc_wrapped/tsc_wrapped.js",
     visibility = ["//tensorboard:__subpackages__"],
 )


### PR DESCRIPTION
updates `nodejs_binary` build rule to specify flag `templated_args = ["--nobazel_run_linker"],`.

This is to fix the build in environments without `--worker_sandboxing`, such as in the machine which pushes `tensorboard-nightly`.

Tested:
*  With this change the bazel build in our CI machine works both at head and at `9fbcf8255`, the first change that exhibits consistent breakage.

(Explanation courtesy of @devversion)
"""
A little context: The Bazel NodeJS rules rely on a linker tool for emulating/creating a `node_modules` directory in the execroot (for build actions). Previously, in older versions of the Bazel NodeJS rules the NodeJS module resolution got patched to support runfiles.

This linker concept/the creation of the `node_modules` directory in the execroot is *very* brittle for workers/non-sandbox actions operating asynchronously because the `node_modules` directory could already be gone when the module is attempted to be resolved.

My theory is that [your failure] is happening now because the `@angular/compiler-cli` package is no longer loaded synchronously when the TSC compilation action is executing. And since the `tf_ng_module` compilation relies on workers, this issue surfaces now.

In the Github action it works because `--worker_sandboxing` is enabled (which mitigates this issue). I think the better solution (if this is the actual issue -- I cannot confirm) would be to disable the Bazel NodeJS linker and use the patched resolution/or using `ng_module` directly from `@angular/bazel`.
"""

Googlers - See: 
*  https://yaqs.corp.google.com/eng/q/293070426337181696 for context.
*  Possibly related : b/188559854
