### PR TITLE
Suppress external/com_google_protobuf warning in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           ( set -o pipefail;
             bazel build //tensorboard/... |&\
             grep -v 'external/com_google_protobuf/python: warning: directory' |&\
-            grep -v 'INFO: From ProtoCompile external/com_google_protobuf/python/google/protobuf/' )
+            grep -v 'INFO: From ProtoCompile ' )
       - name: 'Bazel: test (with TensorFlow support)'
         run: bazel test //tensorboard/...
         if: matrix.tf_version_id != 'notf'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,9 @@ jobs:
         run: bazel fetch //tensorboard/...
       - name: 'Bazel: build'
         run: |
-          bazel build //tensorboard/... |&\
-          grep -v 'external/com_google_protobuf/python: warning: directory'
+          ( set -o pipefail; 
+            bazel build //tensorboard/... |&\
+            grep -v 'external/com_google_protobuf/python: warning: directory' )
       - name: 'Bazel: test (with TensorFlow support)'
         run: bazel test //tensorboard/...
         if: matrix.tf_version_id != 'notf'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
       - name: 'Bazel: fetch'
         run: bazel fetch //tensorboard/...
       - name: 'Bazel: build'
-        run: bazel build //tensorboard/...
+        run: |
+          bazel build //tensorboard/... |\
+          grep -v 'external/com_google_protobuf/python: warning: directory'
       - name: 'Bazel: test (with TensorFlow support)'
         run: bazel test //tensorboard/...
         if: matrix.tf_version_id != 'notf'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: bazel fetch //tensorboard/...
       - name: 'Bazel: build'
         run: |
-          ( set -o pipefail; 
+          ( set -o pipefail;
             bazel build //tensorboard/... |&\
             grep -v 'external/com_google_protobuf/python: warning: directory' )
       - name: 'Bazel: test (with TensorFlow support)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: bazel fetch //tensorboard/...
       - name: 'Bazel: build'
         run: |
-          bazel build //tensorboard/... |\
+          bazel build //tensorboard/... |&\
           grep -v 'external/com_google_protobuf/python: warning: directory'
       - name: 'Bazel: test (with TensorFlow support)'
         run: bazel test //tensorboard/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,14 @@ jobs:
       - name: 'Bazel: fetch'
         run: bazel fetch //tensorboard/...
       - name: 'Bazel: build'
+        # Note we suppress a flood of warnings from the proto compiler.
+        # Googlers see b/222706811 & b/182876485 discussion and preconditions
+        # for removing this kludge.
         run: |
           ( set -o pipefail;
             bazel build //tensorboard/... |&\
-            grep -v 'external/com_google_protobuf/python: warning: directory' )
+            grep -v 'external/com_google_protobuf/python: warning: directory' |&\
+            grep -v 'INFO: From ProtoCompile external/com_google_protobuf/python/google/protobuf/' )
       - name: 'Bazel: test (with TensorFlow support)'
         run: bazel test //tensorboard/...
         if: matrix.tf_version_id != 'notf'


### PR DESCRIPTION
Bazel build CI is getting clogged with many warnings of the form:

`external/com_google_protobuf/python: warning: directory does not exist.`

The correct fix for this is to incorporate a version of proto which includes https://github.com/protocolbuffers/protobuf/issues/6049.   In the meantime, this kludge will make it easier to debug genuine issues.

Googlers: see b/222706811
