### PR TITLE
Implement Scalar Dragging

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -63,8 +63,18 @@ export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
   }
 
   // Utility functions.
+  /**
+   * For the purposes of linked time Scalar charts are considered continuous.
+   * This means that we assume there is a step at any point along the chart.
+   * getStepHigherThanAxisPosition and getStepLowerThanAxisPosition are actually
+   * defined in the FobCardAdapter as getting the step higher than or equal to
+   * and less than or equal to, respectivelty. Therefore since we assume there
+   * is data at each step we always return the step at the position. This means
+   * both getStepHigherThanAxisPosition and getStepLowerThanAxisPosition will
+   * always return the same thing.
+   */
   getStepAtMousePostion(position: number): number {
-    let stepAtMouse = Math.round(
+    const stepAtMouse = Math.round(
       this.scale.reverse(this.minMax, [0, this.axisSize], position)
     );
     if (stepAtMouse > this.getHighestStep()) {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -39,7 +39,7 @@ export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
 
   readonly axisDirection = AxisDirection.HORIZONTAL;
 
-  // TODO(jameshollyer): Implements remaining methods for scalar card fob controller.
+  // FobCardAdapter implementation.
   getHighestStep(): number {
     const minMax = this.minMax;
     return minMax[0] < minMax[1] ? minMax[1] : minMax[0];
@@ -55,10 +55,24 @@ export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
   }
 
   getStepHigherThanAxisPosition(position: number): number {
-    return -1;
+    return this.getStepAtMousePostion(position);
   }
 
   getStepLowerThanAxisPosition(position: number): number {
-    return -1;
+    return this.getStepAtMousePostion(position);
+  }
+
+  // Utility functions.
+  getStepAtMousePostion(position: number): number {
+    let stepAtMouse = Math.round(
+      this.scale.reverse(this.minMax, [0, this.axisSize], position)
+    );
+    if (stepAtMouse > this.getHighestStep()) {
+      return this.getHighestStep();
+    }
+    if (stepAtMouse < this.getLowestStep()) {
+      return this.getLowestStep();
+    }
+    return stepAtMouse;
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
@@ -123,7 +123,7 @@ describe('ScalarLinkedTimeFobController', () => {
     });
   });
 
-  fdescribe('getStepHigherThanAxisPosition', () => {
+  describe('getStepHigherThanAxisPosition', () => {
     it('gets step at given position', () => {
       const fixture = createComponent({});
 
@@ -148,7 +148,8 @@ describe('ScalarLinkedTimeFobController', () => {
       expect(step).toBe(1);
     });
   });
-  fdescribe('getStepLowerThanAxisPosition', () => {
+
+  describe('getStepLowerThanAxisPosition', () => {
     it('gets step at given position', () => {
       const fixture = createComponent({});
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_test.ts
@@ -122,4 +122,55 @@ describe('ScalarLinkedTimeFobController', () => {
       expect(lowestStep).toBe(0);
     });
   });
+
+  fdescribe('getStepHigherThanAxisPosition', () => {
+    it('gets step at given position', () => {
+      const fixture = createComponent({});
+
+      const step = fixture.componentInstance.getStepHigherThanAxisPosition(10);
+
+      expect(step).toBe(10 / SCALE_RATIO);
+    });
+
+    it('gets highest step if given position is higher than the position at highest step', () => {
+      const fixture = createComponent({minMax: [0, 2]});
+
+      const step = fixture.componentInstance.getStepHigherThanAxisPosition(30);
+
+      expect(step).toBe(2);
+    });
+
+    it('gets lowest step if given position is lower than the position at lowest step', () => {
+      const fixture = createComponent({minMax: [1, 3]});
+
+      const step = fixture.componentInstance.getStepHigherThanAxisPosition(0);
+
+      expect(step).toBe(1);
+    });
+  });
+  fdescribe('getStepLowerThanAxisPosition', () => {
+    it('gets step at given position', () => {
+      const fixture = createComponent({});
+
+      const step = fixture.componentInstance.getStepLowerThanAxisPosition(10);
+
+      expect(step).toBe(10 / SCALE_RATIO);
+    });
+
+    it('gets highest step if given position is higher than the position at highest step', () => {
+      const fixture = createComponent({minMax: [0, 2]});
+
+      const step = fixture.componentInstance.getStepLowerThanAxisPosition(30);
+
+      expect(step).toBe(2);
+    });
+
+    it('gets lowest step if given position is lower than the position at lowest step', () => {
+      const fixture = createComponent({minMax: [1, 3]});
+
+      const step = fixture.componentInstance.getStepLowerThanAxisPosition(0);
+
+      expect(step).toBe(1);
+    });
+  });
 });

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
@@ -16,6 +16,7 @@ limitations under the License.
   height: 100%;
   left: 0;
   position: absolute;
+  pointer-events: all;
   right: 0;
   top: 0;
   &.vertical {


### PR DESCRIPTION
* Motivation for features / changes
This is the final change needed to implement a feature which allows users to drag the linked time fob on Scalar Cards as a way to alter the selectedTime.

* Technical description of changes
We have decided to consider scalar charts as continuous. This means that we assume there is a step at any point along the chart. Therefore we return the step that is directly at the mouse position. This is different from the histogram which jumps to steps with data. This means that getStepHigherThanAxisPosition and getStepLowerThanAxisPosition will return the same thing.

* Screenshots of UI changes
https://user-images.githubusercontent.com/8672809/163608806-8721a20d-37b8-4924-a151-a578c70a1111.mp4
