### PR TITLE
linked time: wire selectTimeEnableToggled action down to LinkedTimeFobController

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -65,6 +65,7 @@ limitations under the License.
   [color]="runColorScale(runId)"
   [linkedTime]="convertToLinkedTime(selectedTime)"
   (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+  (onSelectTimeToggle)="onSelectTimeToggle.emit()"
 ></tb-histogram>
 <ng-template #noData>
   <div *ngIf="loadState === DataLoadState.FAILED" class="empty-message">

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -53,6 +53,7 @@ export class HistogramCardComponent {
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter<LinkedTime>();
 
   timeProperty(xAxisType: XAxisType) {
     switch (xAxisType) {

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -28,7 +28,7 @@ import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
 import {HistogramDatum} from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
-import {timeSelectionChanged} from '../../actions';
+import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
 import {HistogramStepDatum, PluginType} from '../../data_source';
 import {
   getCardLoadState,
@@ -67,6 +67,7 @@ type HistogramCardMetadata = CardMetadata & {
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle()"
     ></histogram-card-component>
   `,
   styles: [
@@ -195,5 +196,9 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
         endStep: linkedTime.end ? linkedTime.end.step : undefined,
       })
     );
+  }
+
+  onSelectTimeToggle() {
+    this.store.dispatch(selectTimeEnableToggled());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -222,6 +222,7 @@ limitations under the License.
       [minMax]="viewExtent.x"
       [axisSize]="domDim.width"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit()"
     ></scalar-card-linked-time-fob-controller>
   </ng-container>
 </ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -86,6 +86,7 @@ export class ScalarCardComponent<Downloader> {
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter<LinkedTime>();
 
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -52,7 +52,7 @@ import {DataLoadState} from '../../../types/data';
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
-import {timeSelectionChanged} from '../../actions';
+import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
   getCardLoadState,
@@ -136,6 +136,7 @@ function areSeriesEqual(
       observeIntersection
       (onVisibilityChange)="onVisibilityChange($event)"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle()"
     ></scalar-card-component>
   `,
   styles: [
@@ -528,5 +529,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         endStep: newLinkedTime.end ? newLinkedTime.end.step : undefined,
       })
     );
+  }
+
+  onSelectTimeToggle() {
+    this.store.dispatch(selectTimeEnableToggled());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -26,6 +26,7 @@ import {
       [linkedTime]="linkedTime"
       [cardAdapter]="this"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit($event)"
     ></linked-time-fob-controller>
   `,
 })
@@ -36,6 +37,7 @@ export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
   @Input() axisSize!: number;
 
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter<LinkedTime>();
 
   readonly axisDirection = AxisDirection.HORIZONTAL;
 

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -56,6 +56,7 @@ limitations under the License.
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+        (onSelectTimeToggle)="onSelectTimeToggle.emit()"
       ></histogram-linked-time-fob-controller>
     </ng-container>
   </div>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -100,6 +100,7 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() linkedTime: LinkedTime | null = null;
 
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter<LinkedTime>();
 
   readonly HistogramMode = HistogramMode;
   readonly TimeProperty = TimeProperty;

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -26,6 +26,7 @@ import {TemporalScale} from './histogram_component';
       [linkedTime]="linkedTime"
       [cardAdapter]="this"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit()"
     ></linked-time-fob-controller>
   `,
 })
@@ -33,7 +34,9 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
   @Input() steps!: number[];
   @Input() linkedTime!: LinkedTime;
   @Input() temporalScale!: TemporalScale;
+
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter<LinkedTime>();
 
   readonly axisDirection = AxisDirection.VERTICAL;
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -43,7 +43,9 @@ export class LinkedTimeFobControllerComponent {
   @Input() axisDirection!: AxisDirection;
   @Input() linkedTime!: LinkedTime;
   @Input() cardAdapter!: FobCardAdapter;
+
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   private currentDraggingFob: Fob = Fob.NONE;
 


### PR DESCRIPTION
* Motivation for features / changes
Our goal is to eventually add a delete button on the fobs. This is the first change towards that goal.  When in range selection the deletion of a fob will put us into single selection with the remaining fob as the selected step. When we are in single selection the delete button will disable the selected time entirely.

* Technical description of changes
Since we will need the ability to disable selected time from a fob we need to be able to dispatch the selectTimeEnableToggled action from the fob controller. In order to follow our structure this action is imported into the containers(HistogramCardContainer and ScalarCardContainer) and is passed down as an event until it reaches the LinkedTimeFobController.

* Detailed steps to verify changes work correctly (as executed by you)
I change the fob click event to call the event and ensured it did properly disable the selectedTime
