### PR TITLE
time namespaced: fix pinned card order

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -309,6 +309,68 @@ describe('metrics reducers', () => {
       );
     });
 
+    it('does not change pinned card order', () => {
+      const cardMetadata1 = {
+        plugin: PluginType.IMAGES,
+        tag: 'tagA',
+        runId: 'run1',
+        sample: 1,
+        numSample: 3,
+      };
+      const cardMetadata2 = {
+        plugin: PluginType.HISTOGRAMS,
+        tag: 'tagB',
+        runId: 'run2',
+      };
+      const cardId1 = getCardId(cardMetadata1);
+      const cardId2 = getCardId(cardMetadata2);
+      const pinnedCopyId1 = getPinnedCardId(cardId1);
+      const pinnedCopyId2 = getPinnedCardId(cardId2);
+      const beforeState = buildMetricsState({
+        cardMetadataMap: {
+          [cardId1]: cardMetadata1,
+          [cardId1]: cardMetadata2,
+          [pinnedCopyId1]: cardMetadata1,
+          [pinnedCopyId2]: cardMetadata2,
+        },
+        cardList: [cardId1, cardId2],
+        cardToPinnedCopy: new Map([
+          [cardId1, pinnedCopyId1],
+          [cardId2, pinnedCopyId2],
+        ]),
+        cardToPinnedCopyCache: new Map([
+          [cardId1, pinnedCopyId1],
+          [cardId2, pinnedCopyId2],
+        ]),
+        pinnedCardToOriginal: new Map([
+          [pinnedCopyId1, cardId1],
+          [pinnedCopyId2, cardId2],
+        ]),
+      });
+      const action = actions.metricsTagMetadataLoaded({
+        tagMetadata: {
+          ...buildDataSourceTagMetadata(),
+          [PluginType.IMAGES]: {
+            tagDescriptions: {},
+            tagRunSampledInfo: {tagA: {run1: {maxSamplesPerStep: 1}}},
+          },
+          [PluginType.HISTOGRAMS]: {
+            tagDescriptions: {},
+            runTagInfo: {run1: ['tagB']},
+          },
+        },
+      });
+
+      const nextState = reducers(beforeState, action);
+
+      expect(nextState.pinnedCardToOriginal.keys()).toEqual(
+        new Map([
+          [pinnedCopyId1, cardId1],
+          [pinnedCopyId2, cardId2],
+        ]).keys()
+      );
+    });
+
     it('updates pinned/original cards mapping on pinned cards removal', () => {
       const cardMetadata1 = {
         plugin: PluginType.HISTOGRAMS,

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -324,14 +324,13 @@ export function generateNextPinnedCardMappings(
   const nextCardToPinnedCopy = new Map() as CardToPinnedCard;
   const nextPinnedCardToOriginal = new Map() as PinnedCardToCard;
   const pinnedCardMetadataMap = {} as CardMetadataMap;
-  for (const cardId of nextCardList) {
-    if (previousCardToPinnedCopyCache.has(cardId)) {
-      const pinnedCardId = previousCardToPinnedCopyCache.get(cardId)!;
+  previousCardToPinnedCopyCache.forEach((pinnedCardId, cardId) => {
+    if (nextCardList.indexOf(cardId) !== -1) {
       nextCardToPinnedCopy.set(cardId, pinnedCardId);
       nextPinnedCardToOriginal.set(pinnedCardId, cardId);
       pinnedCardMetadataMap[pinnedCardId] = nextCardMetadataMap[cardId];
     }
-  }
+  });
 
   return {
     nextCardToPinnedCopy,


### PR DESCRIPTION
* Motivation for features / changes
After hitting refresh button on the top right, the order of pinned cards is different from the pin sequence. (It becomes the order of cards, sorted by the tag name). This PR fixes the bug. (TODO: add webtest)

* Technical description of changes
The order of pinned cards is based on the insertion order of `cardToPinnedCopy` Map ([code](https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/webapp/metrics/store/metrics_selectors.ts;l=231?q=%5C%5B.*%5C.values%5C(%5C)%5C%5D&ss=tensorflow%2Ftensorboard), [Map mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values)). However when hitting refresh button we reload the tag metadata, which generates the next `cardToPinnedCopy` Map in "generateNextPinnedCardMappings". In this function we iterate the list of card first then check whether the card id is in cache ("previousCardToPinnedCopyCache") to insert it in the "next cardToPinnedCopy map", this changes the order to be the card list order.

  This pr switches the order of cardList and "previousCardToPinnedCopyCache". We iterates the key of "previousCardToPinnedCopyCache" map, which will go as the insertion sequence, then check if the card id  is in the cardList.
This does increases the complexity (O(number of cards) => O(number of cards x number of pinned cards)) but it maintains the insertion order.

* Screenshots of UI changes

actions: pin image card (tag: box_to_gaussian/image_summary) then histogram card (tag: all_combined/histogram_summary), hit refresh button

before change (histogram card goes before image card)
<img width="550" alt="Screen Shot 2022-04-19 at 1 33 07 PM" src="https://user-images.githubusercontent.com/1131010/164090780-ae976978-ea2c-481b-b4d8-6933fce4be8c.png">

after change (histogram card stays after image card)
<img width="549" alt="Screen Shot 2022-04-19 at 1 40 11 PM" src="https://user-images.githubusercontent.com/1131010/164091849-d28721f1-81d5-4936-800d-f3be2f89a642.png">

