### PR TITLE
linked time: add indicator on highlighting the closest step for histogram

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -19,6 +19,7 @@ limitations under the License.
     <tb-truncated-path [title]="tag" [value]="title"></tb-truncated-path>
     <vis-selected-time-warning
       [isClipped]="selectedTime && selectedTime.clipped"
+      [isClosestStepHighlighted]="isClosestStepHighlighted"
     ></vis-selected-time-warning>
   </div>
   <div class="run">

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -49,6 +49,7 @@ export class HistogramCardComponent {
   @Input() showFullSize!: boolean;
   @Input() isPinned!: boolean;
   @Input() selectedTime!: ViewSelectedTime | null;
+  @Input() isClosestStepHighlighted!: boolean | null;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -415,5 +415,85 @@ describe('histogram card', () => {
         expect(indicatorAfter).toBeNull();
       });
     });
+
+    describe('closest step warning', () => {
+      beforeEach(() => {
+        provideMockCardSeriesData(
+          selectSpy,
+          PluginType.HISTOGRAMS,
+          'card1',
+          undefined,
+          [
+            buildHistogramStepData({step: 50}),
+            buildHistogramStepData({step: 100}),
+            buildHistogramStepData({step: 200}),
+          ]
+        );
+      });
+
+      it('renders warning when no data on the selected step', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 99},
+          end: null,
+        });
+        const fixture = createHistogramCardContainer();
+        fixture.detectChanges();
+
+        const indicator = fixture.debugElement.query(
+          By.css(
+            'vis-selected-time-warning mat-icon[data-value="closestStepHighlighted"]'
+          )
+        );
+        expect(indicator).toBeTruthy();
+      });
+
+      it('dose not render warning when data exist on selected step', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 100},
+          end: null,
+        });
+        const fixture = createHistogramCardContainer();
+        fixture.detectChanges();
+
+        const indicator = fixture.debugElement.query(
+          By.css(
+            'vis-selected-time-warning mat-icon[data-value="closestStepHighlighted"]'
+          )
+        );
+        expect(indicator).toBeFalsy();
+      });
+
+      it('dose not render warning when selectedTime is clipped', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 49},
+          end: null,
+        });
+        const fixture = createHistogramCardContainer();
+        fixture.detectChanges();
+
+        const indicator = fixture.debugElement.query(
+          By.css(
+            'vis-selected-time-warning mat-icon[data-value="closestStepHighlighted"]'
+          )
+        );
+        expect(indicator).toBeFalsy();
+      });
+
+      it('dose not render warning on range selection', () => {
+        store.overrideSelector(selectors.getMetricsSelectedTime, {
+          start: {step: 99},
+          end: {step: 102},
+        });
+        const fixture = createHistogramCardContainer();
+        fixture.detectChanges();
+
+        const indicator = fixture.debugElement.query(
+          By.css(
+            'vis-selected-time-warning mat-icon[data-value="closestStepHighlighted"]'
+          )
+        );
+        expect(indicator).toBeFalsy();
+      });
+    });
   });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -447,7 +447,7 @@ describe('histogram card', () => {
         expect(indicator).toBeTruthy();
       });
 
-      it('dose not render warning when data exist on selected step', () => {
+      it('does not render warning when data exist on selected step', () => {
         store.overrideSelector(selectors.getMetricsSelectedTime, {
           start: {step: 100},
           end: null,
@@ -463,7 +463,7 @@ describe('histogram card', () => {
         expect(indicator).toBeFalsy();
       });
 
-      it('dose not render warning when selectedTime is clipped', () => {
+      it('does not render warning when selectedTime is clipped', () => {
         store.overrideSelector(selectors.getMetricsSelectedTime, {
           start: {step: 49},
           end: null,
@@ -479,7 +479,7 @@ describe('histogram card', () => {
         expect(indicator).toBeFalsy();
       });
 
-      it('dose not render warning on range selection', () => {
+      it('does not render warning on range selection', () => {
         store.overrideSelector(selectors.getMetricsSelectedTime, {
           start: {step: 99},
           end: {step: 102},


### PR DESCRIPTION
* Motivation for features / changes
Show indicator when we highlight the closest step in histogram card. Yet we don't want to show it if the card is clipped (only show the clipped value).

* Technical description of changes
With reusing of "vis-selected-time-warning" module we only need to pass down "isClosestStepHighlighted" from container, which is based on the "viewSelectedTime". Previously we adjust start step to be closest step if no data on selected step. We only need to check if the start step is different from getMetricsSelectedTime value.

* Screenshots of UI changes

selected step=36, closest step=35
![Screen Shot 2022-04-19 at 3 34 52 PM](https://user-images.githubusercontent.com/1131010/164112497-cb051734-5e6d-48c9-b788-dc74f13ce25b.png)

card is clipped
![Screen Shot 2022-04-19 at 3 35 26 PM](https://user-images.githubusercontent.com/1131010/164112556-39426ecb-2fec-4bfb-9a39-2376018678fc.png)

What is _not_ included in this PR: 
rename of "selectedTime" in `histogram_card_component`
