### PR TITLE
Adjusts Input type for CustomizableComponent for better template type checking.

### DIFF
--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -83,7 +83,7 @@ import {
   `,
 })
 export class CustomizableComponent implements OnInit {
-  @Input() customizableComponent!: {constructor: Type<unknown>} | undefined;
+  @Input() customizableComponent!: Type<Component> | undefined;
 
   constructor(
     private readonly viewContainerRef: ViewContainerRef,
@@ -94,7 +94,7 @@ export class CustomizableComponent implements OnInit {
     if (this.customizableComponent) {
       const componentFactory =
         this.componentFactoryResolver.resolveComponentFactory(
-          this.customizableComponent.constructor
+          this.customizableComponent.constructor as Type<unknown>
         );
       this.viewContainerRef.createComponent(componentFactory);
     }


### PR DESCRIPTION
Googlers, see cl/443089340 for an example of usage.

As part of effort to enabel strict Angular template checking in our internal code base, I need to make an adjustment to CustomizableComponent's @Input type. It is now typed as Type\<Component\> - this is what the callers are all actually passing, so it is strictly a better type.

We still cast the constructor to Type\<unknown\> when passing it to the underlying ComponentFactoryResolver to satisfy the TypeScript compiler.