### PR TITLE
time namespaced: fix preserving pinned card of previous experiments 

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -573,7 +573,6 @@ const reducer = createReducer(
       return {
         ...state,
         ...resolvedResult,
-        cardToPinnedCopyCache: resolvedResult.cardToPinnedCopy,
         tagGroupExpanded,
         tagMetadataLoadState: {
           state: DataLoadState.LOADED,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -363,7 +363,10 @@ describe('metrics reducers', () => {
         },
         cardList: [cardId1],
         cardToPinnedCopy: new Map([[cardId1, pinnedCopyId1]]),
-        cardToPinnedCopyCache: new Map([[cardId1, pinnedCopyId1]]),
+        cardToPinnedCopyCache: new Map([
+          [cardId1, pinnedCopyId1],
+          [cardId2, pinnedCopyId2],
+        ]),
         pinnedCardToOriginal: new Map([[pinnedCopyId1, cardId1]]),
       });
       expect(nextState.cardMetadataMap).toEqual(expectedState.cardMetadataMap);


### PR DESCRIPTION
* Motivation for features / changes
When fixing a previous bug where pinned cards disappear after hitting reload button (#5663), I also assign "" for `stateRehydratedFromUrl` action. Yet the assignment for `metricsTagMetadataLoaded` action was incorrect, which make `cardToPinnedCopyCache` identical to `cardToPinnedCopy`, which makes the initial purpose (#5627) not working.
This PR removes the assignment.

* Technical description of changes
The unit tests are "unpins a pinned copy", which we _should_ update `cardToPinnedCopyCache` and "updates pinned/original cards mapping on pinned cards removal" which we should _not_ update `cardToPinnedCopyCache` but `cardToPinnedCopy`

TODO: add webtests after sync (actually, this bug was caught in the process of adding the tests)
