### PR TITLE
linked time: add deselect button

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -59,6 +59,7 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
+import {LinkedTimeFobComponent} from '../../../widgets/linked_time_fob/linked_time_fob_component';
 import {
   Fob,
   LinkedTimeFobControllerComponent,
@@ -2140,11 +2141,11 @@ describe('scalar card', () => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
 
-        const testController = fixture.debugElement.query(
-          By.directive(LinkedTimeFobControllerComponent)
-        ).componentInstance;
+        const fobs = fixture.debugElement.queryAll(
+          By.directive(LinkedTimeFobComponent)
+        );
         expect(
-          testController.startFobWrapper.nativeElement.textContent.trim()
+          fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('10');
       }));
 
@@ -2168,11 +2169,11 @@ describe('scalar card', () => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
 
-        const testController = fixture.debugElement.query(
-          By.directive(LinkedTimeFobControllerComponent)
-        ).componentInstance;
+        const fobs = fixture.debugElement.queryAll(
+          By.directive(LinkedTimeFobComponent)
+        );
         expect(
-          testController.startFobWrapper.nativeElement.textContent.trim()
+          fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('30');
       }));
 

--- a/tensorboard/webapp/widgets/linked_time_fob/BUILD
+++ b/tensorboard/webapp/widgets/linked_time_fob/BUILD
@@ -29,6 +29,7 @@ tf_ng_module(
     ],
     deps = [
         ":types",
+        "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/third_party:d3",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
@@ -16,10 +16,10 @@ limitations under the License.
 -->
 
 <div class="fob" (dblclick)="typeStepRequested()">
-  <span *ngIf="!isTyping">
-    <div>{{ step | number }}</div>
-  </span>
-  <button *ngIf="!isTyping" (click)="removeStep.emit()">X</button>
+  <span *ngIf="!isTyping"> {{ step | number }} </span>
+  <button aria-label="close" *ngIf="!isTyping" (click)="removeStep.emit()">
+    <mat-icon svgIcon="close_24px"></mat-icon>
+  </button>
   <input
     *ngIf="isTyping"
     type="number"

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
@@ -15,15 +15,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div (dblclick)="typeStepRequested()">
-  <span>
-    <input
-      *ngIf="isTyping"
-      type="number"
-      [value]="step"
-      (change)="stepTyped($event)"
-      (focusout)="lostFocus()"
-    />
-    <div *ngIf="!isTyping">{{ step | number }}</div>
+<div class="fob" (dblclick)="typeStepRequested()">
+  <span *ngIf="!isTyping">
+    <div>{{ step | number }}</div>
   </span>
+  <button *ngIf="!isTyping" (click)="removeStep.emit()">X</button>
+  <input
+    *ngIf="isTyping"
+    type="number"
+    [value]="step"
+    (change)="stepTyped($event)"
+    (focusout)="lostFocus()"
+  />
 </div>

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
@@ -17,7 +17,11 @@ limitations under the License.
 
 <div class="fob" (dblclick)="typeStepRequested()">
   <span *ngIf="!isTyping"> {{ step | number }} </span>
-  <button aria-label="close" *ngIf="!isTyping" (click)="removeStep.emit()">
+  <button
+    aria-label="deselect fob"
+    *ngIf="!isTyping"
+    (click)="removeStep.emit()"
+  >
     <mat-icon svgIcon="close_24px"></mat-icon>
   </button>
   <input

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -81,14 +81,18 @@ span {
 }
 
 button {
-  display: inline;
   margin-left: 2px;
-  padding: 1px 3px 1px 3px;
+  padding: 0;
   border: 0;
   border-radius: 50%;
-  font-size: 9px;
+  width: 11px;
+  height: 11px;
   background-color: inherit;
   color: inherit;
+  .mat-icon {
+    width: 100%;
+    height: 110%;
+  }
 }
 
 button:hover {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -19,8 +19,18 @@ limitations under the License.
   display: inline-block;
 }
 
+.fob {
+  display: inline-flex;
+  background-color: mat.get-color-from-palette(mat.$gray-palette, 300);
+  border-radius: 25px;
+  padding: 2px 2px 2px 4px;
+  font-size: 11px;
+  width: min-content;
+}
+
 input {
-  width: 80%;
+  width: 30px;
+  margin-right: 2px;
   font-size: 11px;
   background-color: inherit;
   border: none;
@@ -43,13 +53,8 @@ input[type='number'] {
 }
 
 span {
-  background-color: mat.get-color-from-palette(mat.$gray-palette, 300);
-  border-radius: 25px;
   color: inherit;
   display: inline-block;
-  font-size: 11px;
-  padding: 2px 5px;
-
   &:hover,
   &:active {
     border-color: mat.get-color-from-palette(mat.$gray-palette, 700);
@@ -73,4 +78,20 @@ span {
       border-color: mat.get-color-from-palette(mat.$gray-palette, 200);
     }
   }
+}
+
+button {
+  display: inline;
+  margin-left: 2px;
+  padding: 1px 3px 1px 3px;
+  border: 0;
+  border-radius: 50%;
+  font-size: 9px;
+  background-color: inherit;
+  color: inherit;
+}
+
+button:hover {
+  background-color: mat.get-color-from-palette(mat.$gray-palette, 500);
+  color: mat.get-color-from-palette(mat.$gray-palette, 200);
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -91,6 +91,9 @@ button {
   color: inherit;
   .mat-icon {
     width: 100%;
+    // The close icon is not a proportioned to fit nicely inside a circle.
+    // Stretching the height to 110% helps it sit closer to the center of the
+    // circular button.
     height: 110%;
   }
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
@@ -31,6 +31,7 @@ export class LinkedTimeFobComponent {
   @Input() step!: number;
 
   @Output() stepChange = new EventEmitter<number>();
+  @Output() removeStep = new EventEmitter();
 
   isTyping = false;
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_module.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_module.ts
@@ -15,12 +15,13 @@ limitations under the License.
 
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {MatIconModule} from '@angular/material/icon';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
 import {LinkedTimeFobControllerComponent} from './linked_time_fob_controller_component';
 
 @NgModule({
   declarations: [LinkedTimeFobComponent, LinkedTimeFobControllerComponent],
   exports: [LinkedTimeFobComponent, LinkedTimeFobControllerComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, MatIconModule],
 })
 export class LinkedTimeFobModule {}


### PR DESCRIPTION
* Motivation for features / changes
This changes adds the button for deselecting a fob. That button currently does not work(feature is currently behind a flag so a useless button is ok). Logic will be added later to remove the fob when clicked.

* Technical description of changes
These changes are all for style. I tried my best to make it look as I would expect a delete button to look. 

* Screenshots of UI changes
The button looks like this:
<img width="67" alt="Screen Shot 2022-04-22 at 1 36 31 PM" src="https://user-images.githubusercontent.com/8672809/164790144-402961d8-3eab-4278-abc4-526a4dc1ccda.png">

When the mouse is hovering over the button it looks like this(screenshot did not show mouse):
<img width="70" alt="Screen Shot 2022-04-22 at 1 36 36 PM" src="https://user-images.githubusercontent.com/8672809/164790180-8f581050-29d3-4e7e-8310-ca515774cf43.png">

