### PR TITLE
Unsubscribes ReloaderComponent from state changes when destroyed.

### DIFF
--- a/tensorboard/webapp/reloader/reloader_component_test.ts
+++ b/tensorboard/webapp/reloader/reloader_component_test.ts
@@ -175,7 +175,6 @@ describe('reloader_component', () => {
         })
       )
     );
-    fixture.detectChanges();
     expect(dispatchSpy).not.toHaveBeenCalled();
 
     tick(1);
@@ -200,6 +199,41 @@ describe('reloader_component', () => {
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
 
     fixture.destroy();
+  }));
+
+  it('ignores store value changes after destroy', fakeAsync(() => {
+    store.setState(
+      createState(
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 0,
+            reloadEnabled: false,
+          }),
+        })
+      )
+    );
+    const fixture = TestBed.createComponent(ReloaderComponent);
+    fixture.detectChanges();
+
+    // Destroy the component.
+    fixture.destroy();
+
+    // Enable auto reload after the component has been destroyed.
+    store.setState(
+      createState(
+        createSettingsState({
+          settings: createSettings({
+            reloadPeriodInMs: 5,
+            reloadEnabled: true,
+          }),
+        })
+      )
+    );
+
+    // Advance clock to trigger auto reload.
+    tick(5);
+    // But reload should not have been triggered.
+    expect(dispatchSpy).toHaveBeenCalledTimes(0);
   }));
 
   it('does not reload if document is not visible', fakeAsync(() => {


### PR DESCRIPTION
In Google-internal TensorBoard instances, the ReloaderComponent might be loaded and destroyed multiple times. Unfortunately ReloaderComponent does not properly unsubscribe from ngrx Store changes when being destroyed. As described in b/230111530 this leads to strange behavior where we can end up having multiple auto-reload cycles in parallel because we have multiple ReloaderComponent instances (all but one is stale) trying to create these cycles. 

ReloaderCompoment manually subscribes to the Store in ngOnInit(). As we've seen in other Components in our codebase this requires a special mechanism to unsubscribe (this is the takeUntil(ngUnsubscribe) line). We reuse the pattern used in the other Components and apply it here.