### PR TITLE
linked time: refactor fob step editing with contenteditable

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -66,6 +66,7 @@ limitations under the License.
   [color]="runColorScale(runId)"
   [linkedTime]="convertToLinkedTime(selectedTime)"
   (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+  (onSelectTimeToggle)="onSelectTimeToggle.emit()"
 ></tb-histogram>
 <ng-template #noData>
   <div *ngIf="loadState === DataLoadState.FAILED" class="empty-message">

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -54,6 +54,7 @@ export class HistogramCardComponent {
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   timeProperty(xAxisType: XAxisType) {
     switch (xAxisType) {

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -28,7 +28,7 @@ import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
 import {HistogramDatum} from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
-import {timeSelectionChanged} from '../../actions';
+import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
 import {HistogramStepDatum, PluginType} from '../../data_source';
 import {
   getCardLoadState,
@@ -72,6 +72,7 @@ type HistogramCardMetadata = CardMetadata & {
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle()"
     ></histogram-card-component>
   `,
   styles: [
@@ -229,5 +230,9 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
         endStep: newLinkedTime.end ? newLinkedTime.end.step : undefined,
       })
     );
+  }
+
+  onSelectTimeToggle() {
+    this.store.dispatch(selectTimeEnableToggled());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -222,6 +222,7 @@ limitations under the License.
       [minMax]="viewExtent.x"
       [axisSize]="domDim.width"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit()"
     ></scalar-card-linked-time-fob-controller>
   </ng-container>
 </ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -86,6 +86,7 @@ export class ScalarCardComponent<Downloader> {
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -52,7 +52,7 @@ import {DataLoadState} from '../../../types/data';
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
-import {timeSelectionChanged} from '../../actions';
+import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
   getCardLoadState,
@@ -136,6 +136,7 @@ function areSeriesEqual(
       observeIntersection
       (onVisibilityChange)="onVisibilityChange($event)"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle()"
     ></scalar-card-component>
   `,
   styles: [
@@ -528,5 +529,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         endStep: newLinkedTime.end ? newLinkedTime.end.step : undefined,
       })
     );
+  }
+
+  onSelectTimeToggle() {
+    this.store.dispatch(selectTimeEnableToggled());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -26,6 +26,7 @@ import {
       [linkedTime]="linkedTime"
       [cardAdapter]="this"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit($event)"
     ></linked-time-fob-controller>
   `,
 })
@@ -36,6 +37,7 @@ export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
   @Input() axisSize!: number;
 
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   readonly axisDirection = AxisDirection.HORIZONTAL;
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2239,7 +2239,7 @@ describe('scalar card', () => {
         const fobComponent = fixture.debugElement.query(
           By.directive(LinkedTimeFobComponent)
         ).componentInstance;
-        fobComponent.removeStep.emit();
+        fobComponent.fobRemoved.emit();
 
         expect(dispatchedActions).toEqual([selectTimeEnableToggled()]);
       }));

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -67,7 +67,7 @@ import {
 import {LinkedTimeFobModule} from '../../../widgets/linked_time_fob/linked_time_fob_module';
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
-import {timeSelectionChanged} from '../../actions';
+import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
 import {PluginType} from '../../data_source';
 import {getMetricsScalarSmoothing, getMetricsSelectedTime} from '../../store';
 import {
@@ -2176,14 +2176,17 @@ describe('scalar card', () => {
           fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('30');
       }));
+    });
 
-      it('dispatches timeSelectionChanged action when fob is dragged', fakeAsync(() => {
+    describe('fob controls', () => {
+      let dispatchedActions: Action[] = [];
+      beforeEach(() => {
+        dispatchedActions = [];
         const runToSeries = {
           run1: [buildScalarStepData({step: 10})],
           run2: [buildScalarStepData({step: 20})],
           run3: [buildScalarStepData({step: 30})],
         };
-        const dispatchedActions: Action[] = [];
         spyOn(store, 'dispatch').and.callFake((action: Action) => {
           dispatchedActions.push(action);
         });
@@ -2194,6 +2197,9 @@ describe('scalar card', () => {
           null /* metadataOverride */,
           runToSeries
         );
+      });
+
+      it('dispatches timeSelectionChanged action when fob is dragged', fakeAsync(() => {
         store.overrideSelector(getMetricsSelectedTime, {
           start: {step: 20},
           end: null,
@@ -2221,6 +2227,21 @@ describe('scalar card', () => {
             endStep: undefined,
           }),
         ]);
+      }));
+
+      it('toggles selected time when single fob is deselected', fakeAsync(() => {
+        store.overrideSelector(getMetricsSelectedTime, {
+          start: {step: 20},
+          end: null,
+        });
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+        const fobComponent = fixture.debugElement.query(
+          By.directive(LinkedTimeFobComponent)
+        ).componentInstance;
+        fobComponent.removeStep.emit();
+
+        expect(dispatchedActions).toEqual([selectTimeEnableToggled()]);
       }));
     });
   });

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -56,6 +56,7 @@ limitations under the License.
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+        (onSelectTimeToggle)="onSelectTimeToggle.emit()"
       ></histogram-linked-time-fob-controller>
     </ng-container>
   </div>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -100,6 +100,7 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() linkedTime: LinkedTime | null = null;
 
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   readonly HistogramMode = HistogramMode;
   readonly TimeProperty = TimeProperty;

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -26,6 +26,7 @@ import {TemporalScale} from './histogram_component';
       [linkedTime]="linkedTime"
       [cardAdapter]="this"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit()"
     ></linked-time-fob-controller>
   `,
 })
@@ -34,6 +35,7 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
   @Input() linkedTime!: LinkedTime;
   @Input() temporalScale!: TemporalScale;
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   readonly axisDirection = AxisDirection.VERTICAL;
 

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -1229,7 +1229,7 @@ describe('histogram test', () => {
         const fobComponent = fixture.debugElement.query(
           By.directive(LinkedTimeFobComponent)
         ).componentInstance;
-        fobComponent.removeStep.emit();
+        fobComponent.fobRemoved.emit();
 
         expect(onSelectTimeToggleSpy).toHaveBeenCalledOnceWith();
       });

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -23,8 +23,11 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {IntersectionObserverTestingModule} from '../intersection_observer/intersection_observer_testing_module';
+import {LinkedTimeFobComponent} from '../linked_time_fob/linked_time_fob_component';
+import {LinkedTimeFobControllerComponent} from '../linked_time_fob/linked_time_fob_controller_component';
 import {LinkedTime} from '../linked_time_fob/linked_time_types';
 import {HistogramComponent, TooltipData} from './histogram_component';
+import {HistogramLinkedTimeFobController} from './histogram_linked_time_fob_controller';
 import {
   Bin,
   HistogramData,
@@ -67,6 +70,7 @@ function buildHistogramDatum(
       [data]="data"
       [linkedTime]="linkedTime"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle()"
     >
     </tb-histogram>
   `,
@@ -93,6 +97,7 @@ class TestableComponent {
     end: {step: number} | null;
   } | null;
   @Input() onSelectTimeChanged!: (linkedTime: LinkedTime) => void;
+  @Input() onSelectTimeToggle!: () => void;
 
   simulateMouseMove(event: {
     target: SVGElement;
@@ -120,7 +125,13 @@ describe('histogram test', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, IntersectionObserverTestingModule],
-      declarations: [HistogramComponent, TestableComponent],
+      declarations: [
+        HistogramComponent,
+        HistogramLinkedTimeFobController,
+        LinkedTimeFobComponent,
+        LinkedTimeFobControllerComponent,
+        TestableComponent,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
@@ -1196,6 +1207,31 @@ describe('histogram test', () => {
         histograms[1].triggerEventHandler('click', null);
         fixture.detectChanges();
         expect(onSelectTimeChangedSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('fob deselect', () => {
+      it('toggles SelectTime when in single selection', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({step: 0, wallTime: 100}),
+          buildHistogramDatum({step: 5, wallTime: 400}),
+          buildHistogramDatum({step: 10, wallTime: 400}),
+        ]);
+        const onSelectTimeToggleSpy = jasmine.createSpy();
+        fixture.componentInstance.linkedTime = {
+          start: {step: 5},
+          end: null,
+        };
+        fixture.componentInstance.onSelectTimeToggle = onSelectTimeToggleSpy;
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        const fobComponent = fixture.debugElement.query(
+          By.directive(LinkedTimeFobComponent)
+        ).componentInstance;
+        fobComponent.removeStep.emit();
+
+        expect(onSelectTimeToggleSpy).toHaveBeenCalledOnceWith();
       });
     });
   });

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
@@ -15,16 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="fob">
+<div class="fob" aria-label="Drag fob to change selected step" role="button">
   <span
     contenteditable
     #stepSpan
+    role="textbox"
+    aria-label="Edit step"
     (blur)="stepTyped($event)"
     (keypress)="validateStep($event)"
     (keydown.enter)="stepTyped($event)"
     (keydown.shift.enter)="$event.preventDefault()"
   ></span>
-  <button aria-label="deselect fob" (click)="fobRemoved.emit()">
+  <button aria-label="Deselect fob" (click)="fobRemoved.emit()">
     <mat-icon svgIcon="close_24px"></mat-icon>
   </button>
 </div>

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="fob" aria-label="Drag fob to change selected step" role="button">
+<div class="fob" aria-label="Drag fob to change selected step">
   <span
     contenteditable
     #stepSpan

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="fob" aria-label="Drag fob to change selected step">
+<div class="fob">
   <span
     contenteditable
     #stepSpan

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
@@ -15,20 +15,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="fob" (dblclick)="typeStepRequested()">
-  <span *ngIf="!isTyping"> {{ step | number }} </span>
-  <button
-    aria-label="deselect fob"
-    *ngIf="!isTyping"
-    (click)="removeStep.emit()"
-  >
+<div class="fob">
+  <span
+    contenteditable
+    #stepSpan
+    (blur)="stepTyped($event)"
+    (keypress)="validateStep($event)"
+    (keydown.enter)="stepTyped($event)"
+    (keydown.shift.enter)="$event.preventDefault()"
+  ></span>
+  <button aria-label="deselect fob" (click)="fobRemoved.emit()">
     <mat-icon svgIcon="close_24px"></mat-icon>
   </button>
-  <input
-    *ngIf="isTyping"
-    type="number"
-    [value]="step"
-    (change)="stepTyped($event)"
-    (focusout)="lostFocus()"
-  />
 </div>

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -26,6 +26,10 @@ limitations under the License.
   padding: 2px 2px 2px 4px;
   font-size: 11px;
   width: min-content;
+
+  [contenteditable] {
+    outline: 0px;
+  }
 }
 
 span {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -27,10 +27,6 @@ limitations under the License.
   font-size: 11px;
   width: min-content;
 
-  [contenteditable] {
-    outline: 0px;
-  }
-
   &:hover {
     cursor: pointer;
   }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -28,7 +28,10 @@ limitations under the License.
   width: min-content;
 
   &:hover {
-    cursor: pointer;
+    cursor: grab;
+  }
+  &:active {
+    cursor: grabbing;
   }
 }
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -28,30 +28,6 @@ limitations under the License.
   width: min-content;
 }
 
-input {
-  width: 30px;
-  margin-right: 2px;
-  font-size: 11px;
-  background-color: inherit;
-  border: none;
-  color: inherit;
-  border-bottom: 2px solid darkgrey;
-}
-
-// Removes the arrows that appear on number input's in all browsers.
-
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type='number'] {
-  -moz-appearance: textfield;
-}
-
 span {
   color: inherit;
   display: inline-block;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -41,8 +41,7 @@ span {
   display: inline-block;
 
   @include tb-dark-theme {
-    background-color: mat.get-color-from-palette(mat.$gray-palette, 700);
-    border-color: mat.get-color-from-palette($tf-slate, 500);
+    color: mat.get-color-from-palette(mat.$gray-palette, 700);
   }
 }
 
@@ -62,9 +61,19 @@ button {
     // circular button.
     height: 110%;
   }
+
+  @include tb-dark-theme {
+    color: mat.get-color-from-palette(mat.$gray-palette, 700);
+  }
 }
 
 button:hover {
   background-color: mat.get-color-from-palette(mat.$gray-palette, 500);
   color: mat.get-color-from-palette(mat.$gray-palette, 200);
+  cursor: pointer;
+
+  @include tb-dark-theme {
+    background-color: mat.get-color-from-palette(mat.$gray-palette, 700);
+    color: mat.get-color-from-palette(mat.$gray-palette, 300);
+  }
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.scss
@@ -30,33 +30,19 @@ limitations under the License.
   [contenteditable] {
     outline: 0px;
   }
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 span {
   color: inherit;
   display: inline-block;
-  &:hover,
-  &:active {
-    border-color: mat.get-color-from-palette(mat.$gray-palette, 700);
-  }
-
-  // Do not allow text selection as it messed up the dragging functionality
-  -webkit-touch-callout: none; /* iOS Safari */
-  -webkit-user-select: none; /* Safari */
-  -khtml-user-select: none; /* Konqueror HTML */
-  -moz-user-select: none; /* Old versions of Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently
-                                  supported by Chrome, Edge, Opera and Firefox */
 
   @include tb-dark-theme {
     background-color: mat.get-color-from-palette(mat.$gray-palette, 700);
     border-color: mat.get-color-from-palette($tf-slate, 500);
-
-    &:hover,
-    &:active {
-      border-color: mat.get-color-from-palette(mat.$gray-palette, 200);
-    }
   }
 }
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
@@ -36,8 +36,8 @@ export class LinkedTimeFobComponent {
 
   @Input() step!: number;
 
-  @Output() stepChange = new EventEmitter<number>();
-  @Output() stepRemoved = new EventEmitter();
+  @Output() stepChanged = new EventEmitter<number | null>();
+  @Output() fobRemoved = new EventEmitter();
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['step']) {
@@ -56,9 +56,10 @@ export class LinkedTimeFobComponent {
     const stepString = (event.target! as HTMLInputElement).innerText;
 
     if (stepString === '') {
-      this.stepRemoved.emit();
+      this.stepChanged.emit(null);
       return;
     }
-    this.stepChange.emit(Number(stepString));
+
+    this.stepChanged.emit(Number(stepString));
   }
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
@@ -42,6 +42,7 @@ export class LinkedTimeFobComponent {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['step']) {
       this.stepSpan.nativeElement.innerHTML = `${this.step}`;
+      this.stepSpan.nativeElement.blur();
     }
   }
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
@@ -42,7 +42,9 @@ export class LinkedTimeFobComponent {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['step']) {
       this.stepSpan.nativeElement.innerHTML = `${this.step}`;
-      this.stepSpan.nativeElement.blur();
+      if (document.activeElement === this.stepSpan.nativeElement) {
+        this.stepSpan.nativeElement.blur();
+      }
     }
   }
 

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
@@ -16,9 +16,12 @@ limitations under the License.
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   EventEmitter,
   Input,
   Output,
+  SimpleChanges,
+  ViewChild,
 } from '@angular/core';
 
 @Component({
@@ -28,26 +31,34 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LinkedTimeFobComponent {
+  @ViewChild('stepSpan', {static: true, read: ElementRef})
+  private readonly stepSpan!: ElementRef<HTMLInputElement>;
+
   @Input() step!: number;
 
   @Output() stepChange = new EventEmitter<number>();
-  @Output() removeStep = new EventEmitter();
+  @Output() stepRemoved = new EventEmitter();
 
-  isTyping = false;
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['step']) {
+      this.stepSpan.nativeElement.innerHTML = `${this.step}`;
+    }
+  }
 
-  typeStepRequested() {
-    this.isTyping = true;
+  validateStep(event: KeyboardEvent) {
+    const charcode = String.fromCharCode(event.which);
+    // Handles space separately because the charcode is 32, which is converted to 0 in Number().
+    if (event.key === ' ' || isNaN(Number(charcode))) event.preventDefault();
   }
 
   stepTyped(event: InputEvent) {
-    const input = event.target! as HTMLInputElement;
-    let newStep = Number(input.value);
-    if (isNaN(newStep)) return;
-    this.stepChange.emit(newStep);
-    this.isTyping = false;
-  }
+    event.preventDefault();
+    const stepString = (event.target! as HTMLInputElement).innerText;
 
-  lostFocus() {
-    this.isTyping = false;
+    if (stepString === '') {
+      this.stepRemoved.emit();
+      return;
+    }
+    this.stepChange.emit(Number(stepString));
   }
 }

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
@@ -33,8 +33,8 @@ limitations under the License.
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="linkedTime.start.step"
       (mousedown)="startDrag(FobType().START)"
-      (stepChange)="stepTyped(FobType().START, $event)"
-      (fobRemoved)="fobRemoved(FobType().START)"
+      (stepChanged)="stepTyped(FobType().START, $event)"
+      (fobRemoved)="onFobRemoved(FobType().START)"
     ></linked-time-fob>
   </div>
   <div
@@ -48,8 +48,8 @@ limitations under the License.
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="linkedTime.end.step"
       (mousedown)="startDrag(FobType().END)"
-      (stepChange)="stepTyped(FobType().END, $event)"
-      (fobRemoved)="fobRemoved(FobType().END)"
+      (stepChanged)="stepTyped(FobType().END, $event)"
+      (fobRemoved)="onFobRemoved(FobType().END)"
     ></linked-time-fob>
   </div>
 </div>

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
@@ -34,7 +34,7 @@ limitations under the License.
       [step]="linkedTime.start.step"
       (mousedown)="startDrag(FobType().START)"
       (stepChange)="stepTyped(FobType().START, $event)"
-      (removeStep)="deselectFob(FobType().START)"
+      (fobRemoved)="fobRemoved(FobType().START)"
     ></linked-time-fob>
   </div>
   <div
@@ -49,7 +49,7 @@ limitations under the License.
       [step]="linkedTime.end.step"
       (mousedown)="startDrag(FobType().END)"
       (stepChange)="stepTyped(FobType().END, $event)"
-      (removeStep)="deselectFob(FobType().END)"
+      (fobRemoved)="fobRemoved(FobType().END)"
     ></linked-time-fob>
   </div>
 </div>

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -207,12 +207,12 @@ export class LinkedTimeFobControllerComponent {
 
   /**
    * When in range selection(which means we have a start and an end
-   * fob) deselecting a fob will leave the remaining fob in place. This means we
-   * switch to single selection. If the end fob is deselected we simply remove
-   * it. However, if the start fob is deselected we must change the end fob to
-   * the start fob before removing the end fob. This gives the effect that the
-   * start fob was remove. Lastly when in single selection deselecting the fob
-   * toggles the feature entirely.
+   * fob) clicking "X" to remove a fob will leave the remaining fob in place.
+   * This means we switch to single selection. If the end fob is removed we
+   * simply remove it. However, if the start fob is removed we must change the
+   * end fob to the start fob before removing the end fob. This gives the effect
+   * that the start fob was removed. Lastly when in single selection removing the
+   * fob toggles the feature entirely.
    */
   onFobRemoved(fob: Fob) {
     if (fob === Fob.END) {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -170,22 +170,6 @@ export class LinkedTimeFobControllerComponent {
           this.axisOverlay.nativeElement.getBoundingClientRect().left;
   }
 
-  stepRemoved(fob: Fob) {
-    const newLinkedTime = {...this.linkedTime};
-
-    if (fob === Fob.START) {
-      if (this.linkedTime.end === null) {
-        // TODO(jieweiwu): Set start step to min step
-        return;
-      } else {
-        newLinkedTime.start = {step: this.linkedTime.end.step};
-      }
-    }
-    newLinkedTime.end = null;
-
-    this.onSelectTimeChanged.emit(newLinkedTime);
-  }
-
   stepTyped(fob: Fob, step: number | null) {
     // Types empty string in fob.
     if (step === null) {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -186,7 +186,19 @@ export class LinkedTimeFobControllerComponent {
     this.onSelectTimeChanged.emit(newLinkedTime);
   }
 
-  stepTyped(fob: Fob, step: number) {
+  stepTyped(fob: Fob, step: number | null) {
+    // Types empty string in fob.
+    if (step === null) {
+      // Removes fob on range selection and sets step to minimum on single selection.
+      if (this.linkedTime.end !== null) {
+        this.onFobRemoved(fob);
+      } else {
+        // TODO(jieweiwu): sets start step to minum.
+      }
+
+      return;
+    }
+
     let newLinkedTime = {...this.linkedTime};
     if (fob === Fob.START) {
       newLinkedTime.start = {step};
@@ -218,7 +230,7 @@ export class LinkedTimeFobControllerComponent {
    * start fob was remove. Lastly when in single selection deselecting the fob
    * toggles the feature entirely.
    */
-   fobRemoved(fob: Fob) {
+  onFobRemoved(fob: Fob) {
     if (fob === Fob.END) {
       this.onSelectTimeChanged.emit({...this.linkedTime, end: null});
       return;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -170,6 +170,22 @@ export class LinkedTimeFobControllerComponent {
           this.axisOverlay.nativeElement.getBoundingClientRect().left;
   }
 
+  stepRemoved(fob: Fob, step: number) {
+    const newLinkedTime = {...this.linkedTime};
+
+    if (fob === Fob.START) {
+      if (this.linkedTime.end === null) {
+        // TODO(jieweiwu): Set start step to min step
+        return;
+      } else {
+        newLinkedTime.start = {step: this.linkedTime.end.step};
+      }
+    }
+    newLinkedTime.end = null;
+
+    this.onSelectTimeChanged.emit(newLinkedTime);
+  }
+
   stepTyped(fob: Fob, step: number) {
     let newLinkedTime = {...this.linkedTime};
     if (fob === Fob.START) {
@@ -189,6 +205,7 @@ export class LinkedTimeFobControllerComponent {
       };
     }
 
+    // TODO(jieweiwu): Only emits action when linked time is changed.
     this.onSelectTimeChanged.emit(newLinkedTime);
   }
 
@@ -201,7 +218,7 @@ export class LinkedTimeFobControllerComponent {
    * start fob was remove. Lastly when in single selection deselecting the fob
    * toggles the feature entirely.
    */
-  deselectFob(fob: Fob) {
+   fobRemoved(fob: Fob) {
     if (fob === Fob.END) {
       this.onSelectTimeChanged.emit({...this.linkedTime, end: null});
       return;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -170,7 +170,7 @@ export class LinkedTimeFobControllerComponent {
           this.axisOverlay.nativeElement.getBoundingClientRect().left;
   }
 
-  stepRemoved(fob: Fob, step: number) {
+  stepRemoved(fob: Fob) {
     const newLinkedTime = {...this.linkedTime};
 
     if (fob === Fob.START) {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -16,7 +16,6 @@ limitations under the License.
 import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {sendKeys} from '../../testing/dom';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
 import {
   Fob,
@@ -635,17 +634,14 @@ describe('linked_time_fob_controller', () => {
       });
       fixture.detectChanges();
 
-      const fobDiv = fixture.debugElement.query(
-        By.css('linked-time-fob.startFob div')
+      const stepSpan = fixture.debugElement.query(
+        By.css('linked-time-fob.startFob span')
       );
-      fobDiv.triggerEventHandler('dblclick', {});
-      fixture.detectChanges();
-
-      const input = fobDiv.query(By.css('input'));
-
-      sendKeys(fixture, input, '8');
-      input.triggerEventHandler('change', {target: input.nativeElement});
-      fixture.detectChanges();
+      stepSpan.nativeElement.innerText = '8';
+      stepSpan.triggerEventHandler('keydown.enter', {
+        target: stepSpan.nativeElement,
+        preventDefault: () => {},
+      });
 
       expect(onSelectTimeChanged).toHaveBeenCalledOnceWith({
         start: {step: 8},
@@ -659,22 +655,21 @@ describe('linked_time_fob_controller', () => {
       });
       fixture.detectChanges();
 
-      const fobDiv = fixture.debugElement.query(
-        By.css('linked-time-fob.endFob div')
+      const stepSpan = fixture.debugElement.query(
+        By.css('linked-time-fob.endFob span')
       );
-      fobDiv.triggerEventHandler('dblclick', {});
-      fixture.detectChanges();
-
-      const input = fobDiv.query(By.css('input'));
-
-      sendKeys(fixture, input, '8');
-      input.triggerEventHandler('change', {target: input.nativeElement});
-      fixture.detectChanges();
+      stepSpan.nativeElement.innerText = '8';
+      const preventDefaultSpy = jasmine.createSpy();
+      stepSpan.triggerEventHandler('keydown.enter', {
+        target: stepSpan.nativeElement,
+        preventDefault: preventDefaultSpy,
+      });
 
       expect(onSelectTimeChanged).toHaveBeenCalledOnceWith({
         start: {step: 1},
         end: {step: 8},
       });
+      expect(preventDefaultSpy).toHaveBeenCalled();
     });
   });
   describe('deselecting fob', () => {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
@@ -38,7 +38,6 @@ class TestableFobComponent {
   @Input() axisDirection!: AxisDirection;
 
   @Input() stepChanged!: (newStep: number) => void;
-  @Input() stepRemoved!: () => void;
 }
 
 describe('linked time fob', () => {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
@@ -16,7 +16,6 @@ limitations under the License.
 import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {sendKeys} from '../../testing/dom';
 import {LinkedTimeFobComponent} from './linked_time_fob_component';
 import {AxisDirection} from './linked_time_types';
 
@@ -28,6 +27,7 @@ import {AxisDirection} from './linked_time_types';
       [axisDirection]="axisDirection"
       [step]="step"
       (stepChange)="stepChange($event)"
+      (stepRemoved)="stepRemoved($event)"
     ></linked-time-fob>
   `,
 })
@@ -39,10 +39,13 @@ class TestableFobComponent {
   @Input() axisDirection!: AxisDirection;
 
   @Input() stepChange!: (newStep: number) => void;
+  @Input() stepRemoved!: () => void;
 }
 
 describe('linked time fob', () => {
-  let stepTypedSpy: jasmine.Spy;
+  let stepChangedSpy: jasmine.Spy;
+  let stepRemovedSpy: jasmine.Spy;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [TestableFobComponent, LinkedTimeFobComponent],
@@ -60,54 +63,126 @@ describe('linked time fob', () => {
       ? input.axisDirection
       : AxisDirection.HORIZONTAL;
 
-    stepTypedSpy = jasmine.createSpy();
-    fixture.componentInstance.stepChange = stepTypedSpy;
+    stepChangedSpy = jasmine.createSpy();
+    stepRemovedSpy = jasmine.createSpy();
+    fixture.componentInstance.stepChange = stepChangedSpy;
+    fixture.componentInstance.stepRemoved = stepRemovedSpy;
+
     return fixture;
   }
 
-  it('double clicking fob changes to input', () => {
-    const fixture = createFobComponent({});
-    fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('input'))).toBeFalsy();
-
-    const mainDiv = fixture.debugElement.query(By.css('div'));
-    mainDiv.triggerEventHandler('dblclick', {});
-    fixture.detectChanges();
-
-    expect(fixture.debugElement.query(By.css('input'))).toBeTruthy();
-  });
-
-  it('input element holds step value when activated', () => {
+  it('renders step span in fob', () => {
     const fixture = createFobComponent({step: 3});
     fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('input'))).toBeFalsy();
 
-    const mainDiv = fixture.debugElement.query(By.css('div'));
-    mainDiv.triggerEventHandler('dblclick', {});
-    fixture.detectChanges();
-
-    const input = fixture.debugElement.query(By.css('input'));
-    expect(input).toBeTruthy();
-    expect(input.nativeElement.value).toEqual('3');
+    const stepSpan = fixture.debugElement.query(By.css('span'));
+    expect(stepSpan.nativeElement.innerText).toBe('3');
   });
 
-  it('Entering input after double clicking emits the proper event', () => {
+  it('emits stepChange when pressing enter key', () => {
     const fixture = createFobComponent({});
     fixture.detectChanges();
-    expect(fixture.debugElement.query(By.css('input'))).toBeFalsy();
 
-    const mainDiv = fixture.debugElement.query(By.css('div'));
-    mainDiv.triggerEventHandler('dblclick', {});
+    const stepSpan = fixture.debugElement.query(By.css('span'));
+    stepSpan.nativeElement.innerText = '3';
+    stepSpan.triggerEventHandler('keydown.enter', {
+      target: stepSpan.nativeElement,
+      preventDefault: () => {},
+    });
+
+    expect(stepChangedSpy).toHaveBeenCalledWith(3);
+  });
+
+  it('emits stepChange on blur', () => {
+    const fixture = createFobComponent({});
     fixture.detectChanges();
 
-    const input = fixture.debugElement.query(By.css('input'));
-    expect(input).toBeTruthy();
+    const stepSpan = fixture.debugElement.query(By.css('span'));
+    stepSpan.nativeElement.innerText = '3';
+    stepSpan.triggerEventHandler('blur', {
+      target: stepSpan.nativeElement,
+      preventDefault: () => {},
+    });
 
-    sendKeys(fixture, input, '3');
-    input.triggerEventHandler('change', {target: input.nativeElement});
+    expect(stepChangedSpy).toHaveBeenCalledWith(3);
+  });
+
+  it('emits stepRemoved when pressing enter key on empty string', () => {
+    const fixture = createFobComponent({});
     fixture.detectChanges();
 
-    expect(stepTypedSpy).toHaveBeenCalledOnceWith(3);
-    expect(fixture.debugElement.query(By.css('input'))).toBeFalsy();
+    const stepSpan = fixture.debugElement.query(By.css('span'));
+    stepSpan.nativeElement.innerText = '';
+    stepSpan.triggerEventHandler('keydown.enter', {
+      target: stepSpan.nativeElement,
+      preventDefault: () => {},
+    });
+
+    expect(stepRemovedSpy).toHaveBeenCalled();
+  });
+
+  it('does not emit preventDefault when pressing number', () => {
+    const fixture = createFobComponent({});
+    fixture.detectChanges();
+
+    const stepSpan = fixture.debugElement.query(By.css('span'));
+    const keyboardEvent = new KeyboardEvent('keypress', {
+      key: '2',
+      keyCode: 50,
+    });
+    const preventDefaultSpy = jasmine.createSpy();
+    keyboardEvent.preventDefault = preventDefaultSpy;
+
+    stepSpan.triggerEventHandler('keypress', keyboardEvent);
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits preventDefault when pressing space key', () => {
+    const fixture = createFobComponent({});
+    fixture.detectChanges();
+
+    const stepSpan = fixture.debugElement.query(By.css('span'));
+    const keyboardEvent = new KeyboardEvent('keypress', {
+      key: ' ',
+      keyCode: 32,
+    });
+    const preventDefaultSpy = jasmine.createSpy();
+    keyboardEvent.preventDefault = preventDefaultSpy;
+
+    stepSpan.triggerEventHandler('keypress', keyboardEvent);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('emits preventDefault when pressing character key', () => {
+    const fixture = createFobComponent({});
+    fixture.detectChanges();
+
+    const stepSpan = fixture.debugElement.query(By.css('span'));
+    const keyboardEvent = new KeyboardEvent('keypress', {
+      key: 'd',
+      keyCode: 100,
+    });
+    const preventDefaultSpy = jasmine.createSpy();
+    keyboardEvent.preventDefault = preventDefaultSpy;
+
+    stepSpan.triggerEventHandler('keypress', keyboardEvent);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('emits preventDefault when pressing shift enter key', () => {
+    const fixture = createFobComponent({});
+    fixture.detectChanges();
+
+    const stepSpan = fixture.debugElement.query(By.css('span'));
+    const preventDefaultSpy = jasmine.createSpy();
+
+    stepSpan.triggerEventHandler('keydown.shift.enter', {
+      preventDefault: preventDefaultSpy,
+    });
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
   });
 });

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_test.ts
@@ -26,8 +26,7 @@ import {AxisDirection} from './linked_time_types';
       #Fob
       [axisDirection]="axisDirection"
       [step]="step"
-      (stepChange)="stepChange($event)"
-      (stepRemoved)="stepRemoved($event)"
+      (stepChanged)="stepChanged($event)"
     ></linked-time-fob>
   `,
 })
@@ -38,13 +37,12 @@ class TestableFobComponent {
   @Input() step!: number;
   @Input() axisDirection!: AxisDirection;
 
-  @Input() stepChange!: (newStep: number) => void;
+  @Input() stepChanged!: (newStep: number) => void;
   @Input() stepRemoved!: () => void;
 }
 
 describe('linked time fob', () => {
   let stepChangedSpy: jasmine.Spy;
-  let stepRemovedSpy: jasmine.Spy;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -64,9 +62,7 @@ describe('linked time fob', () => {
       : AxisDirection.HORIZONTAL;
 
     stepChangedSpy = jasmine.createSpy();
-    stepRemovedSpy = jasmine.createSpy();
-    fixture.componentInstance.stepChange = stepChangedSpy;
-    fixture.componentInstance.stepRemoved = stepRemovedSpy;
+    fixture.componentInstance.stepChanged = stepChangedSpy;
 
     return fixture;
   }
@@ -107,7 +103,7 @@ describe('linked time fob', () => {
     expect(stepChangedSpy).toHaveBeenCalledWith(3);
   });
 
-  it('emits stepRemoved when pressing enter key on empty string', () => {
+  it('emits stepChange with null when entering empty string', () => {
     const fixture = createFobComponent({});
     fixture.detectChanges();
 
@@ -118,7 +114,7 @@ describe('linked time fob', () => {
       preventDefault: () => {},
     });
 
-    expect(stepRemovedSpy).toHaveBeenCalled();
+    expect(stepChangedSpy).toHaveBeenCalledWith(null);
   });
 
   it('does not emit preventDefault when pressing number', () => {


### PR DESCRIPTION
* Motivation for features / changes
Previously we can edit the step within the fob with the help of adding an input element. The actions were double clicking the div and then click to focus the input. This PR refactor removes input and directly use contenteditable in span element, which allows user to click the number and edit it right away.

* Technical description of changes
In `linked_time_fob_component.ng.html`, input element is removed; add `contenteditable ` attribute to span element. 
Since editing the content makes `{{ step | number}}` rendering buggy. (It will not render anything once it's cleared). We change it to set innerHtml once step input changed in `ngOnChanges`

  Naming changes: 
  removeStep --> fobRemoved; stepChange --> stepChanged

* Screenshots of UI changes
before

<img width="460" alt="Screen Shot 2022-04-26 at 10 47 56 PM" src="https://user-images.githubusercontent.com/1131010/165449911-59bbc8dd-ca8a-41ed-b988-bebf5d52c712.png">

after  


https://user-images.githubusercontent.com/1131010/166061959-ea21e4e0-5090-4c5d-98dd-7f83c569f5a8.mov




The actions include:
 * click the span to edit
 *  hit enter to change selected step
 *  handle non-number input, including space and shift+enter
 *  enter empty string on range selection changes it to single selection 

TODOs: 
* [FIXED] only show blue boarder when editing
* empty string on single selection sets start step to min step of the experiment

