### PR TITLE
linked time: Wire up onSelectTimeEnableToggle action for deselecting fob

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -66,6 +66,7 @@ limitations under the License.
   [color]="runColorScale(runId)"
   [linkedTime]="convertToLinkedTime(selectedTime)"
   (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+  (onSelectTimeToggle)="onSelectTimeToggle.emit()"
 ></tb-histogram>
 <ng-template #noData>
   <div *ngIf="loadState === DataLoadState.FAILED" class="empty-message">

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -54,6 +54,7 @@ export class HistogramCardComponent {
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   timeProperty(xAxisType: XAxisType) {
     switch (xAxisType) {

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -28,7 +28,7 @@ import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
 import {HistogramDatum} from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
-import {timeSelectionChanged} from '../../actions';
+import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
 import {HistogramStepDatum, PluginType} from '../../data_source';
 import {
   getCardLoadState,
@@ -72,6 +72,7 @@ type HistogramCardMetadata = CardMetadata & {
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle()"
     ></histogram-card-component>
   `,
   styles: [
@@ -229,5 +230,9 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
         endStep: newLinkedTime.end ? newLinkedTime.end.step : undefined,
       })
     );
+  }
+
+  onSelectTimeToggle() {
+    this.store.dispatch(selectTimeEnableToggled());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -222,6 +222,7 @@ limitations under the License.
       [minMax]="viewExtent.x"
       [axisSize]="domDim.width"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit()"
     ></scalar-card-linked-time-fob-controller>
   </ng-container>
 </ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -86,6 +86,7 @@ export class ScalarCardComponent<Downloader> {
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -52,7 +52,7 @@ import {DataLoadState} from '../../../types/data';
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {LinkedTime} from '../../../widgets/linked_time_fob/linked_time_types';
-import {timeSelectionChanged} from '../../actions';
+import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
   getCardLoadState,
@@ -136,6 +136,7 @@ function areSeriesEqual(
       observeIntersection
       (onVisibilityChange)="onVisibilityChange($event)"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle()"
     ></scalar-card-component>
   `,
   styles: [
@@ -528,5 +529,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         endStep: newLinkedTime.end ? newLinkedTime.end.step : undefined,
       })
     );
+  }
+
+  onSelectTimeToggle() {
+    this.store.dispatch(selectTimeEnableToggled());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -26,6 +26,7 @@ import {
       [linkedTime]="linkedTime"
       [cardAdapter]="this"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit($event)"
     ></linked-time-fob-controller>
   `,
 })
@@ -36,6 +37,7 @@ export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
   @Input() axisSize!: number;
 
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   readonly axisDirection = AxisDirection.HORIZONTAL;
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2177,14 +2177,16 @@ describe('scalar card', () => {
         ).toEqual('30');
       }));
     });
+
     describe('fob controls', () => {
-      it('dispatches timeSelectionChanged action when fob is dragged', fakeAsync(() => {
+      let dispatchedActions: Action[] = [];
+      beforeEach(() => {
+        dispatchedActions = [];
         const runToSeries = {
           run1: [buildScalarStepData({step: 10})],
           run2: [buildScalarStepData({step: 20})],
           run3: [buildScalarStepData({step: 30})],
         };
-        const dispatchedActions: Action[] = [];
         spyOn(store, 'dispatch').and.callFake((action: Action) => {
           dispatchedActions.push(action);
         });
@@ -2195,6 +2197,9 @@ describe('scalar card', () => {
           null /* metadataOverride */,
           runToSeries
         );
+      });
+
+      it('dispatches timeSelectionChanged action when fob is dragged', fakeAsync(() => {
         store.overrideSelector(getMetricsSelectedTime, {
           start: {step: 20},
           end: null,
@@ -2225,22 +2230,6 @@ describe('scalar card', () => {
       }));
 
       it('toggles selected time when single fob is deselected', fakeAsync(() => {
-        const runToSeries = {
-          run1: [buildScalarStepData({step: 10})],
-          run2: [buildScalarStepData({step: 20})],
-          run3: [buildScalarStepData({step: 30})],
-        };
-        const dispatchedActions: Action[] = [];
-        spyOn(store, 'dispatch').and.callFake((action: Action) => {
-          dispatchedActions.push(action);
-        });
-        provideMockCardRunToSeriesData(
-          selectSpy,
-          PluginType.SCALARS,
-          'card1',
-          null /* metadataOverride */,
-          runToSeries
-        );
         store.overrideSelector(getMetricsSelectedTime, {
           start: {step: 20},
           end: null,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -67,7 +67,7 @@ import {
 import {LinkedTimeFobModule} from '../../../widgets/linked_time_fob/linked_time_fob_module';
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
-import {timeSelectionChanged} from '../../actions';
+import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
 import {PluginType} from '../../data_source';
 import {getMetricsScalarSmoothing, getMetricsSelectedTime} from '../../store';
 import {
@@ -2176,7 +2176,8 @@ describe('scalar card', () => {
           fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('30');
       }));
-
+    });
+    describe('fob controls', () => {
       it('dispatches timeSelectionChanged action when fob is dragged', fakeAsync(() => {
         const runToSeries = {
           run1: [buildScalarStepData({step: 10})],
@@ -2221,6 +2222,37 @@ describe('scalar card', () => {
             endStep: undefined,
           }),
         ]);
+      }));
+
+      it('toggles selected time when single fob is deselected', fakeAsync(() => {
+        const runToSeries = {
+          run1: [buildScalarStepData({step: 10})],
+          run2: [buildScalarStepData({step: 20})],
+          run3: [buildScalarStepData({step: 30})],
+        };
+        const dispatchedActions: Action[] = [];
+        spyOn(store, 'dispatch').and.callFake((action: Action) => {
+          dispatchedActions.push(action);
+        });
+        provideMockCardRunToSeriesData(
+          selectSpy,
+          PluginType.SCALARS,
+          'card1',
+          null /* metadataOverride */,
+          runToSeries
+        );
+        store.overrideSelector(getMetricsSelectedTime, {
+          start: {step: 20},
+          end: null,
+        });
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+        const fobComponent = fixture.debugElement.query(
+          By.directive(LinkedTimeFobComponent)
+        ).componentInstance;
+        fobComponent.removeStep.emit();
+
+        expect(dispatchedActions).toEqual([selectTimeEnableToggled()]);
       }));
     });
   });

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -56,6 +56,7 @@ limitations under the License.
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"
         (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+        (onSelectTimeToggle)="onSelectTimeToggle.emit()"
       ></histogram-linked-time-fob-controller>
     </ng-container>
   </div>

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -100,6 +100,7 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() linkedTime: LinkedTime | null = null;
 
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   readonly HistogramMode = HistogramMode;
   readonly TimeProperty = TimeProperty;

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_controller.ts
@@ -26,6 +26,7 @@ import {TemporalScale} from './histogram_component';
       [linkedTime]="linkedTime"
       [cardAdapter]="this"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeToggle)="onSelectTimeToggle.emit()"
     ></linked-time-fob-controller>
   `,
 })
@@ -34,6 +35,7 @@ export class HistogramLinkedTimeFobController implements FobCardAdapter {
   @Input() linkedTime!: LinkedTime;
   @Input() temporalScale!: TemporalScale;
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
+  @Output() onSelectTimeToggle = new EventEmitter();
 
   readonly axisDirection = AxisDirection.VERTICAL;
 

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -1217,9 +1217,7 @@ describe('histogram test', () => {
           buildHistogramDatum({step: 5, wallTime: 400}),
           buildHistogramDatum({step: 10, wallTime: 400}),
         ]);
-        let onSelectTimeToggleSpy = jasmine.createSpy();
-        fixture.componentInstance.mode = HistogramMode.OFFSET;
-        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        const onSelectTimeToggleSpy = jasmine.createSpy();
         fixture.componentInstance.linkedTime = {
           start: {step: 5},
           end: null,


### PR DESCRIPTION
* Motivation for features / changes
This PR finishes the deselect fob feature. When in single selection(only 1 fob) deselecting the fob toggles the entire selected time. The logic for when this happens was added in [my previous pr](https://github.com/tensorflow/tensorboard/pull/5685). However it emitted an event that was not linked to anything. This PR gets the correct action from the ScalarCardContainer and the HistogramCardContainer and passes it as an event all the way down to the LinkedTimeFobControllerComponent.

* Technical description of changes
This change is pretty straight forward. The tests however had to be done differently for the ScalarCard and the HistogramCard. In the ScalarCardTest file we are able to do a full integration test all the way down to the LinkedTimeFobComponent. However, the HistogramCardTest uses a dummy HistogramComponent so we cannot test it with elements lower in the stack. For this test I simply ensured correct action is fired when the dummy component fires the given action and then tested that the actual HistogramComponent fired that same event when the LinkedTimeFobComponent fires it's removeStep event.

* Screenshots of UI changes
This UI change was added in [this PR](https://github.com/tensorflow/tensorboard/pull/5681).
However, I will add the screenshots here to help understand the feature this is helping to add.
<img width="70" alt="Screen Shot 2022-04-22 at 1 36 36 PM" src="https://user-images.githubusercontent.com/8672809/165815787-1b1b5689-576b-4656-8ac0-ca0a849c3457.png">

