### PR TITLE
Disable IfChange / ThenChange Lint clause from vended protos

### DIFF
--- a/tensorboard/compat/proto/attr_value.proto
+++ b/tensorboard/compat/proto/attr_value.proto
@@ -16,7 +16,7 @@ option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framewo
 // Comment indicates the corresponding attr type.  Only the field matching the
 // attr type may be filled.
 message AttrValue {
-  // LINT.IfChange
+  // DISABLED.IfChange
   message ListValue {
     repeated bytes s = 2;                        // "list(string)"
     repeated int64 i = 3 [packed = true];        // "list(int)"
@@ -27,7 +27,7 @@ message AttrValue {
     repeated TensorProto tensor = 8;             // "list(tensor)"
     repeated NameAttrList func = 9;              // "list(attr)"
   }
-  // LINT.ThenChange(//tensorflow/c/c_api.cc)
+  // DISABLED.ThenChange(//tensorflow/c/c_api.cc)
 
   oneof value {
     bytes s = 2;                 // "string"

--- a/tensorboard/compat/proto/full_type.proto
+++ b/tensorboard/compat/proto/full_type.proto
@@ -8,7 +8,7 @@ option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
 option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/full_type_go_proto";
 
-// LINT.IfChange
+// DISABLED.IfChange
 // Experimental. Represents the complete type information of a TensorFlow value.
 enum FullTypeId {
   // The default represents an uninitialized values.
@@ -275,4 +275,4 @@ message FullTypeDef {
     // TODO(mdan): list/tensor, map? Need to reconcile with TFT_RECORD, etc.
   }
 }
-// LINT.ThenChange(../ir/types/attributes.td)
+// DISABLED.ThenChange(../ir/types/attributes.td)

--- a/tensorboard/compat/proto/op_def.proto
+++ b/tensorboard/compat/proto/op_def.proto
@@ -15,7 +15,7 @@ option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framewo
 
 // Defines an operation. A NodeDef in a GraphDef specifies an Op by
 // using the "op" field which should match the name of a OpDef.
-// LINT.IfChange
+// DISABLED.IfChange
 message OpDef {
   // Op names starting with an underscore are reserved for internal use.
   // Names should be CamelCase and match the regexp "[A-Z][a-zA-Z0-9>_]*".
@@ -175,7 +175,7 @@ message OpDef {
   // trigger TF network failure handling logics.
   bool is_distributed_communication = 21;
 }
-// LINT.ThenChange(
+// DISABLED.ThenChange(
 //     https://www.tensorflow.org/code/tensorboard/compat/proto/op_def_util.cc)
 
 // Information about version-dependent deprecation of an op

--- a/tensorboard/compat/proto/types.proto
+++ b/tensorboard/compat/proto/types.proto
@@ -9,7 +9,7 @@ option java_package = "org.tensorflow.framework";
 option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/types_go_proto";
 
 // (== suppress_warning documentation-presence ==)
-// LINT.IfChange
+// DISABLED.IfChange
 enum DataType {
   // Not a legal value for DataType.  Used to indicate a DataType field
   // has not been set.
@@ -67,7 +67,7 @@ enum DataType {
   DT_UINT32_REF = 122;
   DT_UINT64_REF = 123;
 }
-// LINT.ThenChange(
+// DISABLED.ThenChange(
 //    https://www.tensorflow.org/code/tensorflow/c/tf_datatype.h,
 //    https://www.tensorflow.org/code/tensorflow/go/tensor.go,
 //    https://www.tensorflow.org/code/tensorboard/compat/proto/tensor.cc,


### PR DESCRIPTION
These lint clauses make sense in the original repo these files are vended from.  They are not useful here as the linked file does not exist in our repo, and we should not be manually changing these files anyway.

The change is innocuous in open source but the lint clauses trigger warning within Google's internal CI.

A subsequent change to `tensorboard/compat/proto/update.sh` will disable these lints automatically to prevent their reintroduction.