### PR TITLE
linked time: use 'safe' way of setting innerHTML

### DIFF
--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ng.html
@@ -21,6 +21,7 @@ limitations under the License.
     #stepSpan
     role="textbox"
     aria-label="Edit step"
+    [innerHTML]="step"
     (blur)="stepTyped($event)"
     (keypress)="validateStep($event)"
     (keydown.enter)="stepTyped($event)"

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_component.ts
@@ -41,7 +41,6 @@ export class LinkedTimeFobComponent {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['step']) {
-      this.stepSpan.nativeElement.innerHTML = `${this.step}`;
       if (document.activeElement === this.stepSpan.nativeElement) {
         this.stepSpan.nativeElement.blur();
       }


### PR DESCRIPTION
* Motivation for features / changes
When dragging the fob, we want the number in the fob to reflect the step change. With the change of contenteditable, we need to change the html of the span element. Previously we grab the element and change ".innerText" directly. I didn't check and do any kind of sanitization at all. That was a mistake.

* Technical description of changes
Angular has its way of making sure the html is safe with "[innerHtml]" attribute, which use Angular’s [DomSanitizer](https://angular.io/api/platform-browser/DomSanitizer). We can directly use this attribute to set the (updated) step.

Googlers, please see sync check 
before: [link](https://fusion2.corp.google.com/invocations/07040fed-a465-4b63-82f7-becf95a779e5/targets/%2F%2Fthird_party%2Ftensorboard%2Fwebapp%2Fwidgets%2Fhistogram:histogram;config=25846168bd18f875df7c3bc6720d2da5ec25b9a50f5822914bddd54a449d4603/log)
after: cl/438908607
