### PR TITLE
timenamespaced state: Turns time namespaced state on by default.

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -31,7 +31,7 @@ export const initialState: FeatureFlagState = {
     enabledLinkedTime: false,
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: true,
-    enabledTimeNamespacedState: false,
+    enabledTimeNamespacedState: true,
     forceSvg: false,
   },
   flagOverrides: {},


### PR DESCRIPTION
This flips the default value of feature flag `enabledTimeNamespacedState` to `true`.

This has no practical impact on OSS or any other TensorBoard (this
feature is already turned on in places where it does matter). This will
allow us to begin removing old code for the old route-based namespace mechanism.

