### PR TITLE
Time Series: Elevate "Time Series" dashboard to first dashboard.

### DIFF
--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -72,6 +72,7 @@ class ExperimentalNpmiPlugin(
 # ordering of tabs in TensorBoard's GUI.
 _PLUGINS = [
     core_plugin.CorePluginLoader(include_debug_info=True),
+    metrics_plugin.MetricsPlugin,
     scalars_plugin.ScalarsPlugin,
     custom_scalars_plugin.CustomScalarsPlugin,
     images_plugin.ImagesPlugin,
@@ -85,7 +86,6 @@ _PLUGINS = [
     profile_redirect_plugin.ProfileRedirectPluginLoader,
     hparams_plugin.HParamsPlugin,
     mesh_plugin.MeshPlugin,
-    metrics_plugin.MetricsPlugin,
     ExperimentalTextV2Plugin,
     ExperimentalNpmiPlugin,
 ]


### PR DESCRIPTION
The "Time Series" dashboard is a unified view of scalars, histograms, and images data. It has been available for some time but is generally the last dashboard listed in the TensorBoard header. After quite a bit of work improving it and using it internally at Google, we've decided it is time to elevate it to be the first dashboard.

Please find more information or feel free to leave feedback at https://github.com/tensorflow/tensorboard/issues/5704.