### PR TITLE
linked time: adds extended-line element to fob component

### DIFF
--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
@@ -28,6 +28,11 @@ limitations under the License.
     class="time-fob-wrapper"
     [style.transform]="getCssTranslatePx(linkedTime.start.step)"
   >
+    <div
+      *ngIf="showExtendedLine"
+      class="extended-line"
+      (mousedown)="startDrag(FobType().START)"
+    ></div>
     <linked-time-fob
       class="startFob"
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
@@ -43,6 +48,11 @@ limitations under the License.
     class="time-fob-wrapper"
     [style.transform]="getCssTranslatePx(linkedTime.end.step)"
   >
+    <div
+      *ngIf="showExtendedLine"
+      class="extended-line"
+      (mousedown)="startDrag(FobType().END)"
+    ></div>
     <linked-time-fob
       class="endFob"
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
@@ -37,3 +37,23 @@ limitations under the License.
 .horizontal-fob {
   transform: translateX(-50%);
 }
+
+.extended-line {
+  border-style: dashed;
+  border-width: 0 1px;
+  height: calc(100% - 30px);
+
+  &:hover {
+    background: linear-gradient(
+      to right,
+      transparent 18px,
+      #ccc 19px,
+      #ccc 21px,
+      transparent 22px
+    );
+    border: 0;
+    cursor: ew-resize;
+    margin-left: -20px;
+    padding: 0 20px;
+  }
+}

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -43,6 +43,7 @@ export class LinkedTimeFobControllerComponent {
   @Input() axisDirection!: AxisDirection;
   @Input() linkedTime!: LinkedTime;
   @Input() cardAdapter!: FobCardAdapter;
+  @Input() showExtendedLine?: Boolean = false;
 
   @Output() onSelectTimeToggle = new EventEmitter();
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -550,7 +550,7 @@ describe('linked_time_fob_controller', () => {
   });
 
   describe('extended line', () => {
-    it('renders single line on horizontal axis', () => {
+    it('renders single line on setting showExtendedLine true', () => {
       const fixture = createComponent({
         linkedTime: {start: {step: 1}, end: null},
         showExtendedLine: true,

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -31,6 +31,7 @@ import {AxisDirection, FobCardAdapter, LinkedTime} from './linked_time_types';
       [axisDirection]="axisDirection"
       [linkedTime]="linkedTime"
       [cardAdapter]="fobCardAdapter"
+      [showExtendedLine]="showExtendedLine"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
       (onSelectTimeToggle)="onSelectTimeToggle()"
     ></linked-time-fob-controller>
@@ -43,6 +44,7 @@ class TestableComponent {
   @Input() axisDirection!: AxisDirection;
   @Input() linkedTime!: LinkedTime;
   @Input() fobCardAdapter!: FobCardAdapter;
+  @Input() showExtendedLine?: Boolean;
 
   @Input() onSelectTimeChanged!: (newLinkedTime: LinkedTime) => void;
   @Input() onSelectTimeToggle!: () => void;
@@ -69,9 +71,10 @@ describe('linked_time_fob_controller', () => {
   });
 
   function createComponent(input: {
-    steps?: number[];
     axisDirection?: AxisDirection;
     linkedTime: LinkedTime;
+    showExtendedLine?: Boolean;
+    steps?: number[];
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
     getHighestStepSpy = jasmine.createSpy();
@@ -104,6 +107,9 @@ describe('linked_time_fob_controller', () => {
       input.axisDirection ?? AxisDirection.VERTICAL;
 
     fixture.componentInstance.linkedTime = input.linkedTime;
+
+    fixture.componentInstance.showExtendedLine =
+      input.showExtendedLine ?? false;
 
     onSelectTimeChanged = jasmine.createSpy();
     fixture.componentInstance.onSelectTimeChanged = onSelectTimeChanged;
@@ -543,6 +549,32 @@ describe('linked_time_fob_controller', () => {
     });
   });
 
+  describe('extended line', () => {
+    it('renders single line on horizontal axis', () => {
+      const fixture = createComponent({
+        linkedTime: {start: {step: 1}, end: null},
+        showExtendedLine: true,
+      });
+      fixture.detectChanges();
+
+      const extendedLine = fixture.debugElement.query(By.css('.extended-line'));
+      expect(extendedLine).toBeTruthy();
+    });
+
+    it('renders two lines on range selection', () => {
+      const fixture = createComponent({
+        linkedTime: {start: {step: 1}, end: {step: 4}},
+        showExtendedLine: true,
+      });
+      fixture.detectChanges();
+
+      const extendedLines = fixture.debugElement.queryAll(
+        By.css('.extended-line')
+      );
+      expect(extendedLines.length).toBe(2);
+    });
+  });
+
   describe('typing step into fob', () => {
     it('single time selection changed with fob typing', () => {
       const fixture = createComponent({
@@ -672,6 +704,7 @@ describe('linked_time_fob_controller', () => {
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
   });
+
   describe('deselecting fob', () => {
     it('fires onSelectTimeToggle when in single selection', () => {
       const fixture = createComponent({


### PR DESCRIPTION
* Motivation for features / changes
We want to make the dash line in scalar also draggable to update the linked time as the current fob (gray oval) does. 

* Technical description of changes
This PR adds an element to `linked_time_fob_controller_component`. Name it as "extended-line" to potentially make it both vertical and horizontal. (For now we only needs vertical line and we don't really have any css for horizontal line)

* Screenshots of UI changes

Default
![Screen Shot 2022-05-11 at 3 43 46 PM](https://user-images.githubusercontent.com/1131010/167959375-1b0f0b5a-df30-4bee-afe7-0707128ffffe.png)
Hover 
<img width="337" alt="Screen Shot 2022-05-11 at 3 44 51 PM" src="https://user-images.githubusercontent.com/1131010/167959652-57b4aa2b-5e25-4c7c-bb5e-c770c4c7d1f2.png">

TODO: add dragging tests; since the line position is same as the fob, now the position in test will be exactly the same as previous test cases