### PR TITLE
linked time: Remove axis-overlay from linked_time_fob_controller.

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2210,7 +2210,7 @@ describe('scalar card', () => {
           By.directive(LinkedTimeFobControllerComponent)
         ).componentInstance;
         const controllerStartPosition =
-          testController.axisOverlay.nativeElement.getBoundingClientRect().left;
+          testController.root.nativeElement.getBoundingClientRect().left;
 
         // Simulate dragging fob to step 25.
         testController.startDrag(Fob.START);

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -52,6 +52,7 @@ limitations under the License.
     <!-- Disable the feature when in non-offset and non-step mode. -->
     <ng-container *ngIf="isLinkedTimeEnabled(linkedTime)">
       <histogram-linked-time-fob-controller
+        class="linked-time"
         [linkedTime]="linkedTime"
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"

--- a/tensorboard/webapp/widgets/histogram/histogram_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.scss
@@ -129,6 +129,12 @@ svg {
   }
 }
 
+.linked-time {
+  // Shift the linked time fobs slightly away from the axis to reduce crowding.
+  left: 9px;
+  position: absolute;
+}
+
 .content .tick,
 .axis ::ng-deep .tick line {
   stroke: #ddd;

--- a/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_linked_time_fob_test.ts
@@ -38,6 +38,13 @@ describe('HistogramLinkedTimeFobController', () => {
     linkedTime?: LinkedTime;
   }): ComponentFixture<HistogramLinkedTimeFobController> {
     const fixture = TestBed.createComponent(HistogramLinkedTimeFobController);
+
+    // Absolutely place the fixture at the top left of the page to keep
+    // position calculations in the test easier.
+    fixture.debugElement.nativeElement.style.position = 'absolute';
+    fixture.debugElement.nativeElement.style.left = '0';
+    fixture.debugElement.nativeElement.style.top = '0';
+
     fixture.componentInstance.steps = input.steps ?? [100, 200, 300, 400];
     fixture.componentInstance.linkedTime = input.linkedTime ?? {
       start: {step: 200},
@@ -138,7 +145,7 @@ describe('HistogramLinkedTimeFobController', () => {
         testController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3000);
     });
-    it('moves the fob to the next highest step when draggin down', () => {
+    it('moves the fob to the next highest step when dragging down', () => {
       let fixture = createComponent({
         steps: [100, 200, 300, 400],
         linkedTime: {start: {step: 300}, end: null},
@@ -148,17 +155,20 @@ describe('HistogramLinkedTimeFobController', () => {
         By.directive(LinkedTimeFobControllerComponent)
       ).componentInstance;
       testController.startDrag(Fob.START);
+      // Starting step '300' renders the fob at 3000px. Mouse event at 3020px
+      // mimics a drag down (towards higher steps).
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 3020,
         movementY: 1,
       });
       testController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      // Move to next step '400', which renders the fob at 4000px.
       expect(
         testController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4000);
     });
-    it('moves the fob to the next lowest step when draggin up', () => {
+    it('moves the fob to the next lowest step when dragging up', () => {
       let fixture = createComponent({
         steps: [100, 200, 300, 400],
         linkedTime: {start: {step: 300}, end: null},
@@ -168,12 +178,15 @@ describe('HistogramLinkedTimeFobController', () => {
         By.directive(LinkedTimeFobControllerComponent)
       ).componentInstance;
       testController.startDrag(Fob.START);
+      // Starting step '300' renders the fob at 3000px. Mouse event at 2980px
+      // mimics a drag up (towards lower steps).
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2980,
         movementY: -1,
       });
       testController.mouseMove(fakeEvent);
       fixture.detectChanges();
+      // Move to previous step '200', which renders the fob at 2000px.
       expect(
         testController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2000);

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ng.html
@@ -16,9 +16,6 @@ limitations under the License.
 -->
 
 <div
-  #axisOverlay
-  class="axis-overlay"
-  [ngClass]="{'vertical' : isVertical()}"
   (mousemove)="mouseMove($event)"
   (mouseup)="stopDrag()"
   (mouseleave)="stopDrag()"

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.scss
@@ -12,22 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-.axis-overlay {
-  height: 100%;
-  left: 0;
-  position: absolute;
+:host {
   pointer-events: all;
-  right: 0;
-  top: 0;
-  &.vertical {
-    // To avoid a cluttered feeling on vertical charts a 9px gap is added
-    // between the fob and the edge of the chart
-    left: 9px;
-  }
-  .time-fob-wrapper {
-    display: inline-block;
-    position: absolute;
-  }
+}
+
+.time-fob-wrapper {
+  display: inline-block;
+  position: absolute;
 }
 
 .vertical-fob {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_component.ts
@@ -37,7 +37,6 @@ export enum Fob {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LinkedTimeFobControllerComponent {
-  @ViewChild('axisOverlay') private readonly axisOverlay!: ElementRef;
   @ViewChild('startFobWrapper') readonly startFobWrapper!: ElementRef;
   @ViewChild('endFobWrapper') readonly endFobWrapper!: ElementRef;
   @Input() axisDirection!: AxisDirection;
@@ -48,6 +47,8 @@ export class LinkedTimeFobControllerComponent {
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
 
   private currentDraggingFob: Fob = Fob.NONE;
+
+  constructor(private readonly root: ElementRef) {}
 
   // Helper function to check enum in template.
   public FobType(): typeof Fob {
@@ -144,14 +145,14 @@ export class LinkedTimeFobControllerComponent {
         (this.currentDraggingFob !== Fob.END
           ? this.startFobWrapper.nativeElement.getBoundingClientRect().top
           : this.endFobWrapper.nativeElement.getBoundingClientRect().top) -
-        this.axisOverlay.nativeElement.getBoundingClientRect().top
+        this.root.nativeElement.getBoundingClientRect().top
       );
     } else {
       return (
         (this.currentDraggingFob !== Fob.END
           ? this.startFobWrapper.nativeElement.getBoundingClientRect().left
           : this.endFobWrapper.nativeElement.getBoundingClientRect().left) -
-        this.axisOverlay.nativeElement.getBoundingClientRect().left
+        this.root.nativeElement.getBoundingClientRect().left
       );
     }
   }
@@ -164,10 +165,8 @@ export class LinkedTimeFobControllerComponent {
 
   getMousePositionFromEvent(event: MouseEvent): number {
     return this.axisDirection === AxisDirection.VERTICAL
-      ? event.clientY -
-          this.axisOverlay.nativeElement.getBoundingClientRect().top
-      : event.clientX -
-          this.axisOverlay.nativeElement.getBoundingClientRect().left;
+      ? event.clientY - this.root.nativeElement.getBoundingClientRect().top
+      : event.clientX - this.root.nativeElement.getBoundingClientRect().left;
   }
 
   stepTyped(fob: Fob, step: number | null) {

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -74,6 +74,13 @@ describe('linked_time_fob_controller', () => {
     linkedTime: LinkedTime;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
+
+    // Absolutely place the fixture at the top left of the page to keep
+    // position calculations in the test easier.
+    fixture.debugElement.nativeElement.style.position = 'absolute';
+    fixture.debugElement.nativeElement.style.left = '0';
+    fixture.debugElement.nativeElement.style.top = '0';
+
     getHighestStepSpy = jasmine.createSpy();
     getLowestStepSpy = jasmine.createSpy();
     getAxisPositionFromStepSpy = jasmine.createSpy();


### PR DESCRIPTION
Remove "axis-overlay" from linked_time_fob_controller and make scalars and histograms both responsible for properly positioning the linked_time_fob_controller in the page layout.

The histograms card was relying on axis-overlay to properly position the linked_time_fob_controller rather than doing itself. Scalars card, however, was already properly positioning the linked_time_fob_controller itself. Since axis-overlay was becomign a small maintenance burden we just remove it and change histograms to behave more like scalars in this response.

The changes have no practical impact on the feature but it does require some adjustments in test.

Googlers, see cl/448303779 for results of internal sync.