### PR TITLE
linked time: reconstruct scalar html for fob extended line

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -246,6 +246,14 @@ tf_sass_binary(
     ],
 )
 
+tf_sass_binary(
+    name = "scalar_card_linked_time_fob_controller_styles",
+    src = "scalar_card_linked_time_fob_controller.scss",
+    deps = [
+        "//tensorboard/webapp/metrics/views:metrics_common_styles",
+    ],
+)
+
 tf_ng_module(
     name = "scalar_card",
     srcs = [
@@ -256,6 +264,7 @@ tf_ng_module(
     ],
     assets = [
         ":scalar_card_styles",
+        ":scalar_card_linked_time_fob_controller_styles",
         "scalar_card_component.ng.html",
     ],
     deps = [

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -113,7 +113,7 @@ limitations under the License.
     [useDarkMode]="useDarkMode"
     (onViewBoxOverridden)="isViewBoxOverridden = $event"
     [customVisTemplate]="lineChartCustomVis"
-    [customXAxisTemplate]="lineChartCustomXAxisVis"
+    [customChartOverlayTemplate]="lineChartCustomXAxisVis"
   ></line-chart>
   <ng-template
     #tooltip
@@ -213,7 +213,6 @@ limitations under the License.
   let-viewExtent="viewExtent"
   let-domDim="domDimension"
   let-xScale="xScale"
-  let-formatter="formatter"
 >
   <ng-container *ngIf="selectedTime">
     <scalar-card-linked-time-fob-controller

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -127,7 +127,6 @@ $_title-to-heading-gap: 12px;
 }
 
 .out-of-selected-time {
-  border: 0 dashed currentColor;
   height: 100%;
   position: absolute;
 
@@ -156,11 +155,4 @@ $_title-to-heading-gap: 12px;
       background-color: rgba(0, 0, 0, 0.4);
     }
   }
-}
-
-.linked-time-fob-container {
-  display: inline-block;
-  left: 0;
-  position: absolute;
-  top: 0;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.scss
@@ -1,51 +1,16 @@
 /* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-:host {
-  pointer-events: all;
-}
 
-.time-fob-wrapper {
-  display: inline-block;
-  position: absolute;
-  width: 0;
-}
-
-.vertical-fob {
-  transform: translateY(-50%);
-}
-
-.horizontal-fob {
-  transform: translateX(-50%);
-}
-
-.extended-line {
-  border-style: dashed;
-  border-width: 0 1px;
-  height: calc(100% - 30px);
-
-  &:hover {
-    background: linear-gradient(
-      to right,
-      transparent 18px,
-      #ccc 19px,
-      #ccc 21px,
-      transparent 22px
-    );
-    border: 0;
-    cursor: ew-resize;
-    margin-left: -20px;
-    padding: 0 20px;
-  }
+// Creates height space for vertical lines
+::ng-deep scalar-card-linked-time-fob-controller .time-fob-wrapper {
+  height: 100%;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_linked_time_fob_controller.ts
@@ -25,10 +25,12 @@ import {
       [axisDirection]="axisDirection"
       [linkedTime]="linkedTime"
       [cardAdapter]="this"
+      [showExtendedLine]="true"
       (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
       (onSelectTimeToggle)="onSelectTimeToggle.emit($event)"
     ></linked-time-fob-controller>
   `,
+  styleUrls: ['scalar_card_linked_time_fob_controller.css'],
 })
 export class ScalarCardLinkedTimeFobController implements FobCardAdapter {
   @Input() linkedTime!: LinkedTime;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -100,8 +100,8 @@ import {VisSelectedTimeWarningModule} from './vis_selected_time_warning_module';
       }"
     ></ng-container>
     <ng-container
-      *ngIf="customXAxisTemplate"
-      [ngTemplateOutlet]="customXAxisTemplate"
+      *ngIf="customChartOverlayTemplate"
+      [ngTemplateOutlet]="customChartOverlayTemplate"
       [ngTemplateOutletContext]="axisTemplateContext"
     >
     </ng-container>
@@ -121,7 +121,7 @@ class TestableLineChart {
   tooltipTemplate!: TemplateRef<{data: TooltipDatum[]}>;
 
   @Input()
-  customXAxisTemplate!: TemplateRef<{}>;
+  customChartOverlayTemplate!: TemplateRef<{}>;
 
   axisTemplateContext = {
     viewExtent: {x: [0, 100], y: [0, 1000]},

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -91,18 +91,17 @@ limitations under the License.
   </div>
   <div class="dot" *ngIf="!lineOnly"><span class="rect"></span></div>
   <div
-    *ngIf="customXAxisTemplate"
-    class="custom-vis custom-x-axis-vis"
-    #customXAxis
+    *ngIf="customChartOverlayTemplate"
+    class="custom-vis custom-chart-overlay-vis"
+    #customChartOverlay
   >
     <ng-container
-      [ngTemplateOutlet]="customXAxisTemplate"
+      [ngTemplateOutlet]="customChartOverlayTemplate"
       [ngTemplateOutletContext]="{
         xScale: xScale,
         yScale: yScale,
-        domDimension: domDimensions.xAxis,
-        viewExtent: viewBox,
-        formatter: customXFormatter || xScale.defaultFormatter
+        domDimension: domDimensions.main,
+        viewExtent: viewBox
       }"
     ></ng-container>
   </div>

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -88,18 +88,22 @@ limitations under the License.
       [scale]="xScale"
       (onViewExtentChange)="onViewBoxChangedFromAxis($event, 'x')"
     ></line-chart-axis>
-    <div *ngIf="customXAxisTemplate" class="custom-vis">
-      <ng-container
-        [ngTemplateOutlet]="customXAxisTemplate"
-        [ngTemplateOutletContext]="{
-          xScale: xScale,
-          yScale: yScale,
-          domDimension: domDimensions.xAxis,
-          viewExtent: viewBox,
-          formatter: customXFormatter || xScale.defaultFormatter
-        }"
-      ></ng-container>
-    </div>
   </div>
   <div class="dot" *ngIf="!lineOnly"><span class="rect"></span></div>
+  <div
+    *ngIf="customXAxisTemplate"
+    class="custom-vis custom-x-axis-vis"
+    #customXAxis
+  >
+    <ng-container
+      [ngTemplateOutlet]="customXAxisTemplate"
+      [ngTemplateOutletContext]="{
+        xScale: xScale,
+        yScale: yScale,
+        domDimension: domDimensions.xAxis,
+        viewExtent: viewBox,
+        formatter: customXFormatter || xScale.defaultFormatter
+      }"
+    ></ng-container>
+  </div>
 </div>

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -34,9 +34,10 @@ limitations under the License.
   width: 100%;
   grid-template-areas:
     'yaxis series'
-    'dot xaxis';
+    'dot xaxis'
+    '. customXAxis';
   grid-template-columns: 50px 1fr;
-  grid-auto-rows: 1fr 30px;
+  grid-auto-rows: 1fr 30px 0px;
 
   // Unlike other Angular components, we may use this component outside
   // of the Angular app and want to control the dark mode styling based on
@@ -103,6 +104,12 @@ limitations under the License.
 .x-axis {
   grid-area: xaxis;
   position: relative;
+}
+
+.custom-x-axis-vis {
+  grid-area: customXAxis;
+  grid-row-end: 2;
+  grid-row-start: 1;
 }
 
 .y-axis {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.scss
@@ -35,7 +35,7 @@ limitations under the License.
   grid-template-areas:
     'yaxis series'
     'dot xaxis'
-    '. customXAxis';
+    '. customChartOverlay';
   grid-template-columns: 50px 1fr;
   grid-auto-rows: 1fr 30px 0px;
 
@@ -106,12 +106,6 @@ limitations under the License.
   position: relative;
 }
 
-.custom-x-axis-vis {
-  grid-area: customXAxis;
-  grid-row-end: 2;
-  grid-row-start: 1;
-}
-
 .y-axis {
   grid-area: yaxis;
 }
@@ -127,4 +121,10 @@ limitations under the License.
     width: 1px;
     background-color: #aaa;
   }
+}
+
+.custom-chart-overlay-vis {
+  grid-area: customChartOverlay;
+  grid-row-end: 2;
+  grid-row-start: 1;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -98,7 +98,9 @@ export class LineChartComponent
   customVisTemplate?: TemplateRef<TemplateContext>;
 
   @Input()
-  customXAxisTemplate?: TemplateRef<TemplateContext & {formatter: Formatter}>;
+  customChartOverlayTemplate?: TemplateRef<
+    TemplateContext & {formatter: Formatter}
+  >;
 
   @Input()
   useDarkMode: boolean = false;

--- a/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/linked_time_fob/linked_time_fob_controller_test.ts
@@ -580,6 +580,67 @@ describe('linked_time_fob_controller', () => {
       );
       expect(extendedLines.length).toBe(2);
     });
+
+    it('clicks and drags the line to change selected step in horizontal axis', () => {
+      const fixture = createComponent({
+        linkedTime: {start: {step: 1}, end: {step: 3}},
+        axisDirection: AxisDirection.HORIZONTAL,
+        showExtendedLine: true,
+      });
+      fixture.detectChanges();
+
+      const fobController = fixture.componentInstance.fobController;
+      const extendedLines = fixture.debugElement.queryAll(
+        By.css('.extended-line')
+      );
+      const startFobExtendedLine = extendedLines[0];
+      const endFobExtendedLine = extendedLines[1];
+      expect(
+        startFobExtendedLine.nativeElement.getBoundingClientRect().left
+      ).toEqual(1);
+      expect(
+        endFobExtendedLine.nativeElement.getBoundingClientRect().left
+      ).toEqual(3);
+
+      // Clicks and drags extended line from start fob
+      startFobExtendedLine.nativeElement.dispatchEvent(
+        new MouseEvent('mousedown', {bubbles: true})
+      );
+      fobController.mouseMove(
+        new MouseEvent('mousemove', {clientX: 3, movementX: 1})
+      );
+      fixture.detectChanges();
+
+      expect(getStepHigherSpy).toHaveBeenCalledWith(3);
+      expect(
+        startFobExtendedLine.nativeElement.getBoundingClientRect().left
+      ).toEqual(3);
+      expect(onSelectTimeChanged).toHaveBeenCalledWith({
+        start: {step: 3},
+        end: {step: 3},
+      });
+
+      // Clicks and drags extended line from end fob
+      startFobExtendedLine.nativeElement.dispatchEvent(
+        new MouseEvent('mouseup', {bubbles: true})
+      );
+      endFobExtendedLine.nativeElement.dispatchEvent(
+        new MouseEvent('mousedown', {bubbles: true})
+      );
+      fobController.mouseMove(
+        new MouseEvent('mousemove', {clientX: 5, movementX: 1})
+      );
+      fixture.detectChanges();
+
+      expect(getStepHigherSpy).toHaveBeenCalledWith(5);
+      expect(
+        endFobExtendedLine.nativeElement.getBoundingClientRect().left
+      ).toEqual(5);
+      expect(onSelectTimeChanged).toHaveBeenCalledWith({
+        start: {step: 3},
+        end: {step: 5},
+      });
+    });
   });
 
   describe('typing step into fob', () => {


### PR DESCRIPTION
* Motivation for features / changes
We have created an extended line in fob. The line is draggable to change the selected time as our fob. This PR turns on the line rendering for scalar card and applies some css changes.

* Technical description of changes
  * Moves `scalar-card-linked-time-fob-controller` out of x-axis component and makes it cover the space of "series view + x-axis".
  * The "out-of-selected-time" component inside line-chart "interactive-utils" is to just for the visual effects. We keep it for fade-out like effect on range selection with only remove the border style (which now replaced by the extended line in fob controller)


* Screenshots of UI changes

https://user-images.githubusercontent.com/1131010/168173413-787c9a07-eda1-4772-a520-13a3aeb9e482.mov


TODO: updates webtest screenshots
