### PR TITLE
ci: pin tf-nightly to 20220427

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  # See https://github.com/tensorflow/tensorboard/pull/5684.
+  # See https://github.com/tensorflow/tensorboard/pull/5709.
   TENSORFLOW_VERSION: 'tf-nightly-2.10.0.dev20220427'
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
   # See https://github.com/tensorflow/tensorboard/pull/5709.
-  TENSORFLOW_VERSION: 'tf-nightly-2.10.0.dev20220427'
+  TENSORFLOW_VERSION: 'tf-nightly==2.10.0.dev20220427'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  TENSORFLOW_VERSION: 'tf-nightly'
+  # See https://github.com/tensorflow/tensorboard/pull/5684.
+  TENSORFLOW_VERSION: 'tf-nightly-2.10.0.dev20220427'
 
 jobs:
   build:


### PR DESCRIPTION
`tf-nightly==2.10.0.dev20220514` broken TensorBoard CI, pin to the latest working version,  `tf-nightly==2.10.0.dev20220427`


CI Log https://github.com/tensorflow/tensorboard/runs/6434770729?check_suite_focus=true
Googlers please see bug report b/232717508