### PR TITLE
time-namespaced state: Remove timeNamespacedStateEnabled flag.

### DIFF
--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -87,32 +87,6 @@ export function getExperimentIdsFromRouteParams(
 }
 
 /**
- * Generates a namespace id based on route information.
- *
- * To be used only by app_routing_effects.ts (and only temporarily).
- */
-export function getRouteNamespaceId(
-  routeKind: RouteKind,
-  params: RouteParams
-): string {
-  switch (routeKind) {
-    case RouteKind.COMPARE_EXPERIMENT:
-    case RouteKind.EXPERIMENT: {
-      const experimentIds =
-        getExperimentIdsFromRouteParams(routeKind, params) ?? [];
-      experimentIds.sort();
-      return `${routeKind}/${experimentIds.join(',')}`;
-    }
-    case RouteKind.EXPERIMENTS:
-      return String(routeKind);
-    case RouteKind.NOT_SET:
-      return '__not_set';
-    default:
-      return '';
-  }
-}
-
-/**
  * Returns whether two routes are of the same kind and point to the same set of
  * experiments.
  *

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -133,58 +133,6 @@ describe('app_routing/utils', () => {
     });
   });
 
-  describe('#getRouteNamespaceId', () => {
-    [
-      {
-        kind: RouteKind.COMPARE_EXPERIMENT,
-        params: {experimentIds: 'bar:123'},
-        expectedVal: `${RouteKind.COMPARE_EXPERIMENT}/123`,
-      },
-      {
-        kind: RouteKind.EXPERIMENTS,
-        params: {},
-        expectedVal: `${RouteKind.EXPERIMENTS}`,
-      },
-      {
-        kind: RouteKind.EXPERIMENT,
-        params: {experimentId: '123'},
-        expectedVal: `${RouteKind.EXPERIMENT}/123`,
-      },
-      {
-        kind: RouteKind.UNKNOWN,
-        params: {random: 1},
-        expectedVal: '',
-      },
-    ].forEach(({kind, params, expectedVal}) => {
-      it(`returns unique identifier for ${RouteKind[kind]}`, () => {
-        const actual = utils.getRouteNamespaceId(kind, params);
-        expect(actual).toBe(expectedVal);
-      });
-    });
-
-    describe('COMPARE route', () => {
-      it('returns stable id as long as id sets are the same', () => {
-        const id1 = utils.getRouteNamespaceId(RouteKind.COMPARE_EXPERIMENT, {
-          experimentIds: 'foo:123,bar:456',
-        });
-        const id2 = utils.getRouteNamespaceId(RouteKind.COMPARE_EXPERIMENT, {
-          experimentIds: 'bar:456,foo:123',
-        });
-        expect(id1).toBe(id2);
-      });
-
-      it('does not differentiate compare of same eids with different display names', () => {
-        const id1 = utils.getRouteNamespaceId(RouteKind.COMPARE_EXPERIMENT, {
-          experimentIds: 'foo:123',
-        });
-        const id2 = utils.getRouteNamespaceId(RouteKind.COMPARE_EXPERIMENT, {
-          experimentIds: 'bar:123',
-        });
-        expect(id1).toBe(id2);
-      });
-    });
-  });
-
   describe('#areSameRouteKindAndExperiments', () => {
     it('returns true when both routes are null', () => {
       expect(utils.areSameRouteKindAndExperiments(null, null)).toBeTrue();

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -123,13 +123,6 @@ export const getEnabledCardWidthSetting = createSelector(
   }
 );
 
-export const getEnabledTimeNamespacedState = createSelector(
-  getFeatureFlags,
-  (flags: FeatureFlags): boolean => {
-    return flags.enabledTimeNamespacedState;
-  }
-);
-
 export const getForceSvgFeatureFlag = createSelector(
   getFeatureFlags,
   (flags: FeatureFlags): boolean => {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -340,29 +340,4 @@ describe('feature_flag_selectors', () => {
       expect(selectors.getEnabledCardWidthSetting(state)).toEqual(true);
     });
   });
-
-  describe('#getEnabledTimeNamespacedState', () => {
-    it('returns the proper value', () => {
-      let state = buildState(
-        buildFeatureFlagState({
-          defaultFlags: buildFeatureFlag({
-            enabledTimeNamespacedState: false,
-          }),
-        })
-      );
-      expect(selectors.getEnabledTimeNamespacedState(state)).toEqual(false);
-
-      state = buildState(
-        buildFeatureFlagState({
-          defaultFlags: buildFeatureFlag({
-            enabledTimeNamespacedState: false,
-          }),
-          flagOverrides: {
-            enabledTimeNamespacedState: true,
-          },
-        })
-      );
-      expect(selectors.getEnabledTimeNamespacedState(state)).toEqual(true);
-    });
-  });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -31,7 +31,6 @@ export const initialState: FeatureFlagState = {
     enabledLinkedTime: false,
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: true,
-    enabledTimeNamespacedState: true,
     forceSvg: false,
   },
   flagOverrides: {},

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -31,7 +31,6 @@ export function buildFeatureFlag(
     enabledLinkedTime: false,
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: false,
-    enabledTimeNamespacedState: false,
     forceSvg: false,
     ...override,
   };

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -47,9 +47,6 @@ export interface FeatureFlags {
   enableTimeSeriesPromotion: boolean;
   // Whether to enable card width adjustment on the right panle.
   enabledCardWidthSetting: boolean;
-  // Whether to enable time-namespaced state and how it impacts how user
-  // settings are kept during navigation.
-  enabledTimeNamespacedState: boolean;
   // Flag for the escape hatch from WebGL. This only effects the TimeSeries
   // Scalar cards.
   forceSvg: boolean;

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -309,8 +309,8 @@ export function buildOrReturnStateWithPinnedCopy(
  * set of pinned cards. It generates a cardMetadataMap object that is a combination
  * of the input nextCardMetadataMap as well as metadata for the new set of pinned cards.
  * @param previousCardToPinnedCopyCache The set of pinned cards that were previously
- *  pinned by the user within the same time-namespace. This is a superset of pinned
- *  cards in cardToPinnedCopy and the set remains the same after the update.
+ *  pinned by the user. This is a superset of pinned cards in cardToPinnedCopy and the
+ *  set remains the same after the update.
  * @param nextCardMetadataMap Metadata for all cards that will be present after
  *  the update (we assume it does not yet include metadata for pinned copies of cards).
  * @param nextCardList The set of base cards that will continue to be present in the

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -21,7 +21,6 @@ import {
   ENABLE_COLOR_GROUP_QUERY_PARAM_KEY,
   ENABLE_DARK_MODE_QUERY_PARAM_KEY,
   ENABLE_LINK_TIME_PARAM_KEY,
-  ENABLE_TIME_NAMESPACED_STATE,
   EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
   FORCE_SVG_RENDERER,
   SCALARS_BATCH_SIZE_PARAM_KEY,
@@ -84,11 +83,6 @@ export class QueryParamsFeatureFlagDataSource
     if (params.has(ENABLE_CARD_WIDTH_SETTING_PARAM_KEY)) {
       featureFlags.enabledCardWidthSetting =
         params.get(ENABLE_CARD_WIDTH_SETTING_PARAM_KEY) !== 'false';
-    }
-
-    if (params.has(ENABLE_TIME_NAMESPACED_STATE)) {
-      featureFlags.enabledTimeNamespacedState =
-        params.get(ENABLE_TIME_NAMESPACED_STATE) !== 'false';
     }
 
     if (params.has(FORCE_SVG_RENDERER)) {

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -161,28 +161,6 @@ describe('tb_feature_flag_data_source', () => {
         });
       });
 
-      it('returns enabledTimeNamespacedState from the query params', () => {
-        getParamsSpy.and.returnValues(
-          new URLSearchParams('enableTimeNamespacedState=false'),
-          new URLSearchParams('enableTimeNamespacedState='),
-          new URLSearchParams('enableTimeNamespacedState=true'),
-          new URLSearchParams('enableTimeNamespacedState=foo')
-        );
-
-        expect(dataSource.getFeatures()).toEqual({
-          enabledTimeNamespacedState: false,
-        });
-        expect(dataSource.getFeatures()).toEqual({
-          enabledTimeNamespacedState: true,
-        });
-        expect(dataSource.getFeatures()).toEqual({
-          enabledTimeNamespacedState: true,
-        });
-        expect(dataSource.getFeatures()).toEqual({
-          enabledTimeNamespacedState: true,
-        });
-      });
-
       it('returns forceSVG from the query params', () => {
         getParamsSpy.and.returnValues(
           new URLSearchParams('forceSVG=false'),

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -45,6 +45,4 @@ export const ENABLE_DARK_MODE_QUERY_PARAM_KEY = 'darkMode';
 
 export const ENABLE_LINK_TIME_PARAM_KEY = 'enableLinkTime';
 
-export const ENABLE_TIME_NAMESPACED_STATE = 'enableTimeNamespacedState';
-
 export const FORCE_SVG_RENDERER = 'forceSVG';


### PR DESCRIPTION
We have migrated all TensorBoards from route-namespaced state to time-namespaced state.

This PR removes the enabledTimeNamespacedState feature flag and removes any remaining route-namespaced-specific logic.

Googlers, see cl/449305283 for a clean copybara import.