### PR TITLE
ci: unpin tf-nightly from 20220427

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  # See https://github.com/tensorflow/tensorboard/pull/5709.
-  TENSORFLOW_VERSION: 'tf-nightly==2.10.0.dev20220427'
+  TENSORFLOW_VERSION: 'tf-nightly'
 
 jobs:
   build:


### PR DESCRIPTION
Unpin tf-nightly as it is fixed in version `2.10.0.dev20220518`. Revert #5709

Googlers, please see b/232717508 and rollback cl cl/449359447