### PR TITLE
[FOR REFERENCE-DO NOT REVIEW]First Rough Draft of Data Table Feature

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -293,6 +293,7 @@ tf_ng_module(
         "//tensorboard/webapp/types:ui",
         "//tensorboard/webapp/util:value_formatter",
         "//tensorboard/webapp/widgets:resize_detector",
+        "//tensorboard/webapp/widgets/data_table",
         "//tensorboard/webapp/widgets/experiment_alias",
         "//tensorboard/webapp/widgets/intersection_observer",
         "//tensorboard/webapp/widgets/line_chart_v2",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -95,12 +95,6 @@ limitations under the License.
     </mat-menu>
   </span>
 </div>
-<div class="data-table-container">
-  <tb-data-table
-    [headers]="dataHeaders"
-    [data]="getSelectedTimeTableData()"
-  ></tb-data-table>
-</div>
 <div class="chart-container">
   <mat-spinner
     diameter="18"
@@ -174,7 +168,14 @@ limitations under the License.
     </table>
   </ng-template>
 </div>
-
+<ng-container *ngIf="selectedTime">
+  <div class="data-table-container">
+    <tb-data-table
+      [headers]="dataHeaders"
+      [data]="getSelectedTimeTableData()"
+    ></tb-data-table>
+  </div>
+</ng-container>
 <ng-template
   #lineChartCustomVis
   let-viewExtent="viewExtent"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -95,6 +95,12 @@ limitations under the License.
     </mat-menu>
   </span>
 </div>
+<div class="data-table-container">
+  <tb-data-table
+    [headers]="dataHeaders"
+    [data]="getSelectedTimeTableData()"
+  ></tb-data-table>
+</div>
 <div class="chart-container">
   <mat-spinner
     diameter="18"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -156,3 +156,9 @@ $_title-to-heading-gap: 12px;
     }
   }
 }
+
+.data-table-container {
+  width: 100%;
+  height: 100px;
+  overflow: scroll;
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -18,6 +18,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {DataTableModule} from '../../../widgets/data_table/data_table_module';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
 import {IntersectionObserverModule} from '../../../widgets/intersection_observer/intersection_observer_module';
 import {LineChartModule as LineChartV2Module} from '../../../widgets/line_chart_v2/line_chart_module';
@@ -40,6 +41,7 @@ import {VisSelectedTimeWarningModule} from './vis_selected_time_warning_module';
   imports: [
     CommonModule,
     DataDownloadModule,
+    DataTableModule,
     ExperimentAliasModule,
     IntersectionObserverModule,
     LineChartV2Module,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -26,6 +26,19 @@ export enum SeriesType {
   DERIVED,
 }
 
+export enum ColumnHeaders {
+  RUN,
+  VALUE,
+  STEP,
+  START_STEP,
+  END_STEP,
+  START_VALUE,
+  END_VALUE,
+  SMOOTHED,
+  TIME,
+  RELATIVE_TIME,
+}
+
 // Smoothed series is derived from a data serie. The additional information on the
 // metadata allows us to render smoothed value and its original value in the tooltip.
 export interface SmoothedSeriesMetadata extends DataSeriesMetadata {
@@ -56,9 +69,10 @@ export interface ScalarCardPoint extends Point {
 
 export type ScalarCardDataSeries = DataSeries<ScalarCardPoint>;
 
-export interface RunData {
+export interface RunStepData {
   metadata: ScalarCardSeriesMetadata;
-  data: (string | number)[];
+  closestStartPoint: ScalarCardPoint;
+  closestEndPoint: ScalarCardPoint | null;
 }
 
 export interface PartialSeries {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -56,6 +56,11 @@ export interface ScalarCardPoint extends Point {
 
 export type ScalarCardDataSeries = DataSeries<ScalarCardPoint>;
 
+export interface RunData {
+  metadata: ScalarCardSeriesMetadata;
+  data: (string | number)[];
+}
+
 export interface PartialSeries {
   runId: string;
   points: ScalarCardPoint[];

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -1,0 +1,52 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_sass_binary(
+    name = "data_table_styles",
+    src = "data_table_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_sass_deps"],
+)
+
+tf_ng_module(
+    name = "data_table",
+    srcs = [
+        "data_table_component.ts",
+        "data_table_module.ts",
+    ],
+    assets = [
+        "data_table_component.ng.html",
+        ":data_table_styles",
+    ],
+    deps = [
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)
+
+# tf_ts_library(
+#     name = "linked_time_fob_test",
+#     testonly = True,
+#     srcs = [
+#         "linked_time_fob_controller_test.ts",
+#         "linked_time_fob_test.ts",
+#     ],
+#     deps = [
+#         ":linked_time_fob",
+#         ":types",
+#         "//tensorboard/webapp/angular:expect_angular_core_testing",
+#         "//tensorboard/webapp/testing:dom",
+#         "//tensorboard/webapp/third_party:d3",
+#         "@npm//@angular/core",
+#         "@npm//@angular/platform-browser",
+#         "@npm//@types/jasmine",
+#     ],
+# )
+
+# tf_ts_library(
+#     name = "types",
+#     srcs = [
+#         "linked_time_types.ts",
+#     ],
+# )

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -20,6 +20,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -21,7 +21,7 @@ limitations under the License.
       <tr>
         <th class="circle-header"></th>
         <ng-container *ngFor="let header of headers;">
-          <th>{{header}}</th>
+          <th>{{getHeaderTextColumn(header)}}</th>
         </ng-container>
       </tr>
     </thead>
@@ -31,9 +31,9 @@ limitations under the License.
           <td class="row-circle">
             <span [style.backgroundColor]="runData.metadata.color"></span>
           </td>
-          <ng-container *ngFor="let datum of runData.data;">
+          <ng-container *ngFor="let header of headers;">
             <td>
-              <span>{{datum}}</span>
+              <span>{{getFormattedDataForColumn(header, runData)}}</span>
             </td>
           </ng-container>
         </tr>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -1,0 +1,43 @@
+<!--
+@license
+Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div>
+  <table class="tooltip">
+    <thead>
+      <tr>
+        <th class="circle-header"></th>
+        <ng-container *ngFor="let header of headers;">
+          <th>{{header}}</th>
+        </ng-container>
+      </tr>
+    </thead>
+    <tbody>
+      <ng-container *ngFor="let runData of data;">
+        <tr class="row">
+          <td class="row-circle">
+            <span [style.backgroundColor]="runData.metadata.color"></span>
+          </td>
+          <ng-container *ngFor="let datum of runData.data;">
+            <td>
+              <span>{{datum}}</span>
+            </td>
+          </ng-container>
+        </tr>
+      </ng-container>
+    </tbody>
+  </table>
+</div>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -1,3 +1,10 @@
+.data-table {
+  font-size: 13px;
+}
+th {
+  text-align: left;
+}
+
 .row {
   white-space: nowrap;
 }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -1,0 +1,21 @@
+.row {
+  white-space: nowrap;
+}
+
+$_circle-size: 12px;
+
+.row-circle {
+  align-items: center;
+  display: inline-flex;
+  height: $_circle-size;
+  width: $_circle-size;
+}
+
+.row-circle > span {
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  display: inline-block;
+  // Subtract by border width (1px on both sides)
+  height: $_circle-size - 2px;
+  width: $_circle-size - 2px;
+}

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -14,7 +14,18 @@ limitations under the License.
 ==============================================================================*/
 
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
-import {RunData} from '../../metrics/views/card_renderer/scalar_card_types';
+import {
+  ColumnHeaders,
+  RunStepData,
+} from '../../metrics/views/card_renderer/scalar_card_types';
+
+import {
+  // Formatter,
+  // intlNumberFormatter,
+  numberFormatter,
+  relativeTimeFormatter,
+  // relativeTimeFormatter,
+} from '../../widgets/line_chart_v2/lib/formatter';
 
 @Component({
   selector: 'tb-data-table',
@@ -23,6 +34,47 @@ import {RunData} from '../../metrics/views/card_renderer/scalar_card_types';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataTableComponent {
-  @Input() headers!: string[];
-  @Input() data!: RunData[];
+  @Input() headers!: ColumnHeaders[];
+  @Input() data!: RunStepData[];
+
+  getHeaderTextColumn(columnHeader: ColumnHeaders): string {
+    switch (columnHeader) {
+      case ColumnHeaders.RUN:
+        return 'Run';
+      case ColumnHeaders.VALUE:
+        return 'Value';
+      case ColumnHeaders.STEP:
+        return 'Step';
+      case ColumnHeaders.TIME:
+        return 'Time';
+      case ColumnHeaders.RELATIVE_TIME:
+        return 'Relative';
+      default:
+        return '';
+    }
+  }
+
+  getFormattedDataForColumn(
+    columnHeader: ColumnHeaders,
+    runStepData: RunStepData
+  ): string {
+    console.log('getFormattedDataForColumn', columnHeader, ', ', runStepData);
+    switch (columnHeader) {
+      case ColumnHeaders.RUN:
+        return runStepData.metadata.displayName;
+      case ColumnHeaders.VALUE:
+        return numberFormatter.formatShort(runStepData.closestStartPoint.value);
+      case ColumnHeaders.STEP:
+        return numberFormatter.formatShort(runStepData.closestStartPoint.step);
+      case ColumnHeaders.TIME:
+        const time = new Date(runStepData.closestStartPoint.wallTime);
+        return time.toISOString();
+      case ColumnHeaders.RELATIVE_TIME:
+        return relativeTimeFormatter.formatReadable(
+          runStepData.closestStartPoint.relativeTimeInMs
+        );
+      default:
+        return '';
+    }
+  }
 }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -1,0 +1,28 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {RunData} from '../../metrics/views/card_renderer/scalar_card_types';
+
+@Component({
+  selector: 'tb-data-table',
+  templateUrl: 'data_table_component.ng.html',
+  styleUrls: ['data_table_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DataTableComponent {
+  @Input() headers!: string[];
+  @Input() data!: RunData[];
+}

--- a/tensorboard/webapp/widgets/data_table/data_table_module.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_module.ts
@@ -1,0 +1,25 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {DataTableComponent} from './data_table_component';
+
+@NgModule({
+  declarations: [DataTableComponent],
+  exports: [DataTableComponent],
+  imports: [CommonModule],
+})
+export class DataTableModule {}

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -519,10 +519,15 @@ export class LineChartInteractiveViewComponent
       this.tooltipDisplayAttached = false;
       return;
     }
-
+    console.log(
+      'seriesData used for cursoredData',
+      JSON.parse(JSON.stringify(this.seriesData)) as DataSeries[]
+    );
     this.cursoredData = this.isCursorInside
       ? (this.seriesData
           .map((seriesDatum) => {
+            console.log('seriesDatum', seriesDatum);
+            console.log('metadata', this.seriesMetadataMap[seriesDatum.id]);
             return {
               seriesDatum: seriesDatum,
               metadata: this.seriesMetadataMap[seriesDatum.id],
@@ -542,6 +547,10 @@ export class LineChartInteractiveViewComponent
           })
           .filter((tooltipDatumOrNull) => tooltipDatumOrNull) as TooltipDatum[])
       : [];
+    console.log(
+      'this.cursoredData',
+      JSON.parse(JSON.stringify(this.cursoredData)) as TooltipDatum[]
+    );
     this.tooltipDisplayAttached = Boolean(this.cursoredData.length);
   }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -519,15 +519,9 @@ export class LineChartInteractiveViewComponent
       this.tooltipDisplayAttached = false;
       return;
     }
-    console.log(
-      'seriesData used for cursoredData',
-      JSON.parse(JSON.stringify(this.seriesData)) as DataSeries[]
-    );
     this.cursoredData = this.isCursorInside
       ? (this.seriesData
           .map((seriesDatum) => {
-            console.log('seriesDatum', seriesDatum);
-            console.log('metadata', this.seriesMetadataMap[seriesDatum.id]);
             return {
               seriesDatum: seriesDatum,
               metadata: this.seriesMetadataMap[seriesDatum.id],
@@ -547,10 +541,6 @@ export class LineChartInteractiveViewComponent
           })
           .filter((tooltipDatumOrNull) => tooltipDatumOrNull) as TooltipDatum[])
       : [];
-    console.log(
-      'this.cursoredData',
-      JSON.parse(JSON.stringify(this.cursoredData)) as TooltipDatum[]
-    );
     this.tooltipDisplayAttached = Boolean(this.cursoredData.length);
   }
 }


### PR DESCRIPTION
* Motivation for features / changes
The motivation for this change is to help provide context to future PRs that implement each piece.

* Technical description of changes
This PR creates a data_table widget and uses it when linked time is enabled. The widget is dynamic in which headers it shows. Currently the headers are hard coded into the ScalarCardComponent. However, we plan on having those be changeable by the user soon. 

* Screenshots of UI changes
![Screen Shot 2022-05-23 at 4 29 44 PM](https://user-images.githubusercontent.com/8672809/169920380-be554bfb-11b3-4340-9670-15fd43683f9f.png)

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
Adding a ScalarCardDataTableContainer and component that sat beside the ScalarCardContainer was an option I tried. The amount of work that the ScalarCardContainer does to consolidate and format the data from the ngrx state was too much to recreate. I decided it was better to allow that container to continue maintaining that logic and passing that down to a dumber component which is the widget.