### PR TITLE
Add DataTable Basic structure

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -293,6 +293,7 @@ tf_ng_module(
         "//tensorboard/webapp/types:ui",
         "//tensorboard/webapp/util:value_formatter",
         "//tensorboard/webapp/widgets:resize_detector",
+        "//tensorboard/webapp/widgets/data_table",
         "//tensorboard/webapp/widgets/experiment_alias",
         "//tensorboard/webapp/widgets/intersection_observer",
         "//tensorboard/webapp/widgets/line_chart_v2",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -168,7 +168,11 @@ limitations under the License.
     </table>
   </ng-template>
 </div>
-
+<ng-container *ngIf="selectedTime">
+  <div>
+    <tb-data-table></tb-data-table>
+  </div>
+</ng-container>
 <ng-template
   #lineChartCustomVis
   let-viewExtent="viewExtent"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -18,6 +18,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {DataTableModule} from '../../../widgets/data_table/data_table_module';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
 import {IntersectionObserverModule} from '../../../widgets/intersection_observer/intersection_observer_module';
 import {LineChartModule as LineChartV2Module} from '../../../widgets/line_chart_v2/line_chart_module';
@@ -40,6 +41,7 @@ import {VisSelectedTimeWarningModule} from './vis_selected_time_warning_module';
   imports: [
     CommonModule,
     DataDownloadModule,
+    DataTableModule,
     ExperimentAliasModule,
     IntersectionObserverModule,
     LineChartV2Module,

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -1,0 +1,26 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_sass_binary(
+    name = "data_table_styles",
+    src = "data_table_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_sass_deps"],
+)
+
+tf_ng_module(
+    name = "data_table",
+    srcs = [
+        "data_table_component.ts",
+        "data_table_module.ts",
+    ],
+    assets = [
+        "data_table_component.ng.html",
+        ":data_table_styles",
+    ],
+    deps = [
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -1,0 +1,17 @@
+<!--
+@license
+Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div>
+  <!-- TODO(JamesHollyer) implement data table -->
+</div>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -1,0 +1,14 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -1,0 +1,24 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+@Component({
+  selector: 'tb-data-table',
+  templateUrl: 'data_table_component.ng.html',
+  styleUrls: ['data_table_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DataTableComponent {}

--- a/tensorboard/webapp/widgets/data_table/data_table_module.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_module.ts
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/widgets/data_table/data_table_module.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_module.ts
@@ -1,0 +1,25 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {DataTableComponent} from './data_table_component';
+
+@NgModule({
+  declarations: [DataTableComponent],
+  exports: [DataTableComponent],
+  imports: [CommonModule],
+})
+export class DataTableModule {}


### PR DESCRIPTION
* Motivation for features / changes
This is the first change towards adding a dedicated table to hold the data for a selected time in the Scalar Card. This change simply adds the basic structure of the DataTable widget which will be a component which displays the data passed to it. For more context on where this is headed see https://github.com/tensorflow/tensorboard/pull/5719. 

* Technical description of changes
This just adds the structure to stand up a widget which will be implemented in later CLs.

* Screenshots of UI changes
This PR makes no UI changes but we eventually plan to add a table that will probably look something like this:
![Screen Shot 2022-05-23 at 4 29 28 PM](https://user-images.githubusercontent.com/8672809/169921803-e31d9999-0fce-41cb-80d1-318611b4bd25.png)

The look of that table is still subject to change.

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
I considered adding a ScalarCardDataTableContainer and component that sat beside the ScalarCardContainer. However, I decided the amount of work that the ScalarCardContainer does to consolidate and format the data from the ngrx state was too much to copy. I decided it was better to allow the ScalarCardContainer to continue maintaining that logic and passing the consolidated data down to a dumber component which is the widget.