### PR TITLE
Adds client_feature_flags to DataProvider's RequestContext.

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -190,7 +190,7 @@ py_library(
     srcs_version = "PY3",
     deps = [
         "//tensorboard:context",
-    ]
+    ],
 )
 
 py_test(

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -53,6 +53,7 @@ py_library(
     srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
+        ":client_feature_flags",
         ":empty_path_redirect",
         ":experiment_id",
         ":experimental_plugin",
@@ -179,6 +180,28 @@ py_test(
         ":security_validator",
         "//tensorboard:test",
         "//tensorboard/util:tb_logging",
+        "@org_pocoo_werkzeug",
+    ],
+)
+
+py_library(
+    name = "client_feature_flags",
+    srcs = ["client_feature_flags.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorboard:context",
+    ]
+)
+
+py_test(
+    name = "client_feature_flags_test",
+    size = "small",
+    srcs = ["client_feature_flags_test.py"],
+    srcs_version = "PY3",
+    tags = ["support_notf"],
+    deps = [
+        ":client_feature_flags",
+        "//tensorboard:test",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -190,6 +190,7 @@ py_library(
     srcs_version = "PY3",
     deps = [
         "//tensorboard:context",
+        "//tensorboard:errors",
     ],
 )
 
@@ -201,6 +202,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":client_feature_flags",
+        "//tensorboard:errors",
         "//tensorboard:test",
         "@org_pocoo_werkzeug",
     ],

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -34,6 +34,7 @@ from tensorboard import errors
 from tensorboard import plugin_util
 from tensorboard import auth
 from tensorboard import context
+from tensorboard.backend import client_feature_flags
 from tensorboard.backend import empty_path_redirect
 from tensorboard.backend import experiment_id
 from tensorboard.backend import experimental_plugin
@@ -326,6 +327,7 @@ class TensorBoardWSGI(object):
         for middleware in self._extra_middlewares:
             app = middleware(app)
         app = _auth_context_middleware(app, self._auth_providers)
+        app = client_feature_flags.ClientFeatureFlagsMiddleware(app)
         app = empty_path_redirect.EmptyPathRedirectMiddleware(app)
         app = experiment_id.ExperimentIdMiddleware(app)
         app = path_prefix.PathPrefixMiddleware(app, self._path_prefix)

--- a/tensorboard/backend/client_feature_flags.py
+++ b/tensorboard/backend/client_feature_flags.py
@@ -42,7 +42,12 @@ class ClientFeatureFlagsMiddleware(object):
         if not possible_feature_flags:
             return self._application(environ, start_response)
 
-        client_feature_flags = json.loads(possible_feature_flags)
+        try:
+            client_feature_flags = json.loads(possible_feature_flags)
+        except json.JSONDecodeError:
+            start_response("400 Bad Request", [("Content-Type", "text/plain")])
+            return ["Invalid X-TensorBoard-Feature-Flags Header"]
+
         ctx = context.from_environ(environ).replace(
             client_feature_flags=client_feature_flags
         )

--- a/tensorboard/backend/client_feature_flags.py
+++ b/tensorboard/backend/client_feature_flags.py
@@ -17,6 +17,7 @@
 import json
 
 from tensorboard import context
+from tensorboard import errors
 
 
 class ClientFeatureFlagsMiddleware(object):
@@ -45,8 +46,9 @@ class ClientFeatureFlagsMiddleware(object):
         try:
             client_feature_flags = json.loads(possible_feature_flags)
         except json.JSONDecodeError:
-            start_response("400 Bad Request", [("Content-Type", "text/plain")])
-            return ["Invalid X-TensorBoard-Feature-Flags Header"]
+            raise errors.InvalidArgumentError(
+                "X-TensorBoard-Feature-Flags cannot be JSON decoded."
+            )
 
         ctx = context.from_environ(environ).replace(
             client_feature_flags=client_feature_flags

--- a/tensorboard/backend/client_feature_flags.py
+++ b/tensorboard/backend/client_feature_flags.py
@@ -1,0 +1,51 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Middleware for injecting client-side feature flags into the Context."""
+
+import json
+
+from tensorboard import context
+
+
+class ClientFeatureFlagsMiddleware(object):
+    """Middleware for injecting client-side feature flags into the Context.
+
+    The client webapp is expected to include a json-serialized version of its
+    FeatureFlags in the `X-TensorBoard-Feature-Flags` header. This middleware
+    extracts the header value and converts it into the client_feature_flags
+    property for the DataProvider's Context object, where client_feature_flags
+    is a Dict of string keys and arbitrary value types.
+    """
+
+    def __init__(self, application):
+        """Initializes this middleware.
+
+        Args:
+          application: The WSGI application to wrap (see PEP 3333).
+        """
+        self._application = application
+
+    def __call__(self, environ, start_response):
+        possible_feature_flags = environ.get("HTTP_X_TENSORBOARD_FEATURE_FLAGS")
+        if not possible_feature_flags:
+            return self._application(environ, start_response)
+
+        client_feature_flags = json.loads(possible_feature_flags)
+        ctx = context.from_environ(environ).replace(
+            client_feature_flags=client_feature_flags
+        )
+        context.set_in_environ(environ, ctx)
+
+        return self._application(environ, start_response)

--- a/tensorboard/backend/client_feature_flags_test.py
+++ b/tensorboard/backend/client_feature_flags_test.py
@@ -89,6 +89,25 @@ class ClientFeatureFlagsMiddlewareTest(tb_test.TestCase):
             },
         )
 
+    def test_header_with_invalid_json(self):
+        app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
+        server = werkzeug_test.Client(app, wrappers.Response)
+
+        response = server.get(
+            "",
+            headers=[
+                (
+                    "X-TensorBoard-Feature-Flags",
+                    "some_invalid_json {} {}",
+                )
+            ],
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_data().decode(),
+            "Invalid X-TensorBoard-Feature-Flags Header",
+        )
+
 
 if __name__ == "__main__":
     tb_test.main()

--- a/tensorboard/backend/client_feature_flags_test.py
+++ b/tensorboard/backend/client_feature_flags_test.py
@@ -1,0 +1,95 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `tensorboard.backend.client_feature_flags`."""
+
+
+import json
+import werkzeug
+from werkzeug import test as werkzeug_test
+from werkzeug import wrappers
+
+from tensorboard import context
+from tensorboard import test as tb_test
+from tensorboard.backend import client_feature_flags
+
+
+class ClientFeatureFlagsMiddlewareTest(tb_test.TestCase):
+    """Tests for `ClientFeatureFlagsMiddleware`."""
+
+    def _echo_app(self, environ, start_response):
+        # https://www.python.org/dev/peps/pep-0333/#environ-variables
+        data = {
+            "client_feature_flags": context.from_environ(
+                environ
+            ).client_feature_flags,
+        }
+        body = json.dumps(data)
+        start_response("200 OK", [("Content-Type", "application/json")])
+        return [body]
+
+    def _assert_ok(self, response, client_feature_flags):
+        self.assertEqual(response.status_code, 200)
+        actual = json.loads(response.get_data())
+        expected = dict(client_feature_flags=client_feature_flags)
+        self.assertEqual(actual, expected)
+
+    def test_no_header(self):
+        app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
+
+        response = server.get("")
+        self._assert_ok(response, {})
+
+    def test_header_with_no_value(self):
+        app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
+
+        response = server.get("", headers=[("X-TensorBoard-Feature-Flags", "")])
+        self._assert_ok(response, {})
+
+    def test_header_with_no_flags(self):
+        app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
+
+        response = server.get(
+            "", headers=[("X-TensorBoard-Feature-Flags", "{}")]
+        )
+        self._assert_ok(response, {})
+
+    def test_header_with_client_feature_flags(self):
+        app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
+
+        response = server.get(
+            "",
+            headers=[
+                (
+                    "X-TensorBoard-Feature-Flags",
+                    '{"str": "hi", "bool": true, "strArr": ["one", "two"]}',
+                )
+            ],
+        )
+        self._assert_ok(
+            response,
+            {
+                "str": "hi",
+                "bool": True,
+                "strArr": ["one", "two"],
+            },
+        )
+
+
+if __name__ == "__main__":
+    tb_test.main()

--- a/tensorboard/backend/client_feature_flags_test.py
+++ b/tensorboard/backend/client_feature_flags_test.py
@@ -16,7 +16,6 @@
 
 
 import json
-import werkzeug
 from werkzeug import test as werkzeug_test
 from werkzeug import wrappers
 
@@ -47,21 +46,21 @@ class ClientFeatureFlagsMiddlewareTest(tb_test.TestCase):
 
     def test_no_header(self):
         app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
-        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
+        server = werkzeug_test.Client(app, wrappers.Response)
 
         response = server.get("")
         self._assert_ok(response, {})
 
     def test_header_with_no_value(self):
         app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
-        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
+        server = werkzeug_test.Client(app, wrappers.Response)
 
         response = server.get("", headers=[("X-TensorBoard-Feature-Flags", "")])
         self._assert_ok(response, {})
 
     def test_header_with_no_flags(self):
         app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
-        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
+        server = werkzeug_test.Client(app, wrappers.Response)
 
         response = server.get(
             "", headers=[("X-TensorBoard-Feature-Flags", "{}")]
@@ -70,7 +69,7 @@ class ClientFeatureFlagsMiddlewareTest(tb_test.TestCase):
 
     def test_header_with_client_feature_flags(self):
         app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
-        server = werkzeug_test.Client(app, werkzeug.wrappers.Response)
+        server = werkzeug_test.Client(app, wrappers.Response)
 
         response = server.get(
             "",

--- a/tensorboard/context.py
+++ b/tensorboard/context.py
@@ -40,8 +40,7 @@ class RequestContext(object):
       client_feature_flags: A dict of string to arbitrary type. These represent
         feature flag key/value pairs sent by the client application. Usage of
         client_feature_flags should know the name of the feature flag key and
-        should know its value type (typically a boolean but sometimes an array
-        of strings).
+        should know and validate the type of the value.
     """
 
     def __init__(

--- a/tensorboard/context.py
+++ b/tensorboard/context.py
@@ -37,9 +37,20 @@ class RequestContext(object):
       x_forwarded_for: A tuple of `ipaddress.IPv4Address` or `ipaddress.IPv6Address`,
         which may be empty but is never None. This should be parsed value of X-Forwarded-For
         HTTP header from the request.
+      client_feature_flags: A dict of string to arbitrary type. These represent
+        feature flag key/value pairs sent by the client application. Usage of
+        client_feature_flags should know the name of the feature flag key and
+        should know its value type (typically a boolean but sometimes an array
+        of strings).
     """
 
-    def __init__(self, auth=None, remote_ip=None, x_forwarded_for=None):
+    def __init__(
+        self,
+        auth=None,
+        remote_ip=None,
+        x_forwarded_for=None,
+        client_feature_flags=None,
+    ):
         """Create a request context.
 
         The argument list is sorted and may be extended in the future;
@@ -53,6 +64,7 @@ class RequestContext(object):
         self._auth = auth if auth is not None else auth_lib.AuthContext.empty()
         self._remote_ip = remote_ip
         self._x_forwarded_for = x_forwarded_for or ()
+        self._client_feature_flags = client_feature_flags or {}
 
     @property
     def auth(self):
@@ -65,6 +77,10 @@ class RequestContext(object):
     @property
     def x_forwarded_for(self):
         return self._x_forwarded_for
+
+    @property
+    def client_feature_flags(self):
+        return self._client_feature_flags
 
     def replace(self, **kwargs):
         """Create a copy of this context with updated key-value pairs.
@@ -82,6 +98,7 @@ class RequestContext(object):
         kwargs.setdefault("auth", self.auth)
         kwargs.setdefault("remote_ip", self.remote_ip)
         kwargs.setdefault("x_forwarded_for", self.x_forwarded_for)
+        kwargs.setdefault("client_feature_flags", self.client_feature_flags)
         return type(self)(**kwargs)
 
 

--- a/tensorboard/context_test.py
+++ b/tensorboard/context_test.py
@@ -28,24 +28,33 @@ class RequestContextTest(tb_test.TestCase):
     def test_defaults(self):
         ctx = context.RequestContext()
         self.assertIsInstance(ctx.auth, auth_lib.AuthContext)
+        self.assertEqual(ctx.remote_ip, None)
         self.assertEqual(ctx.x_forwarded_for, ())
+        self.assertEqual(ctx.client_feature_flags, {})
 
     def test_args(self):
         auth = auth_lib.AuthContext({}, {"REQUEST_METHOD": "GET"})
+        client_feature_flags = {"someFlag": True}
         ctx = context.RequestContext(
-            auth=auth, remote_ip=REMOTE_IP, x_forwarded_for=X_FORWARDED_FOR_IPS
+            auth=auth,
+            remote_ip=REMOTE_IP,
+            x_forwarded_for=X_FORWARDED_FOR_IPS,
+            client_feature_flags=client_feature_flags,
         )
         self.assertEqual(ctx.auth, auth)
         self.assertEqual(ctx.remote_ip, REMOTE_IP)
         self.assertEqual(ctx.x_forwarded_for, X_FORWARDED_FOR_IPS)
+        self.assertEqual(ctx.client_feature_flags, client_feature_flags)
 
     def test_environ(self):
         environ = {"one": "two", "three": "four"}
         auth = auth_lib.AuthContext({}, environ)
+        client_feature_flags = {"someFlag": True}
         req_context = context.from_environ(environ)
         self.assertNotEqual(req_context.auth, auth)
-        self.assertNotEqual(req_context.remote_ip, REMOTE_IP)
-        self.assertNotEqual(req_context.x_forwarded_for, X_FORWARDED_FOR_IPS)
+        self.assertEqual(req_context.remote_ip, None)
+        self.assertEqual(req_context.x_forwarded_for, ())
+        self.assertEqual(req_context.client_feature_flags, {})
 
         context.set_in_environ(
             environ,
@@ -53,6 +62,7 @@ class RequestContextTest(tb_test.TestCase):
                 auth=auth,
                 remote_ip=REMOTE_IP,
                 x_forwarded_for=X_FORWARDED_FOR_IPS,
+                client_feature_flags=client_feature_flags,
             ),
         )
         self.assertEqual(environ["one"], "two")
@@ -61,6 +71,7 @@ class RequestContextTest(tb_test.TestCase):
         self.assertEqual(req_context.auth, auth)
         self.assertEqual(req_context.remote_ip, REMOTE_IP)
         self.assertEqual(req_context.x_forwarded_for, X_FORWARDED_FOR_IPS)
+        self.assertEqual(req_context.client_feature_flags, client_feature_flags)
 
     def test_replace(self):
         environ1 = {"one": "two", "three": "four"}
@@ -71,21 +82,31 @@ class RequestContextTest(tb_test.TestCase):
         remote_ip2 = ipaddress.ip_address("192.168.0.2")
         x_forwarded_for_ips1 = (remote_ip1, REMOTE_IP)
         x_forwarded_for_ips2 = (remote_ip2, REMOTE_IP)
+        client_feature_flags1 = {"oneFlag": True}
+        client_feature_flags2 = {"twoFlag": False}
 
         req_context = context.RequestContext(
             auth=auth1,
             remote_ip=remote_ip1,
             x_forwarded_for=x_forwarded_for_ips1,
+            client_feature_flags=client_feature_flags1,
         )
         self.assertEqual(req_context.auth, auth1)
         self.assertEqual(req_context.remote_ip, remote_ip1)
         self.assertEqual(req_context.x_forwarded_for, x_forwarded_for_ips1)
+        self.assertEqual(
+            req_context.client_feature_flags, client_feature_flags1
+        )
 
         req_context_new = req_context.replace(auth=auth2)
         self.assertEqual(req_context_new.auth, auth2)
         self.assertEqual(req_context_new.remote_ip, req_context.remote_ip)
         self.assertEqual(
             req_context_new.x_forwarded_for, req_context.x_forwarded_for
+        )
+        self.assertEqual(
+            req_context_new.client_feature_flags,
+            req_context.client_feature_flags,
         )
 
         req_context_new = req_context.replace(remote_ip=remote_ip2)
@@ -94,6 +115,10 @@ class RequestContextTest(tb_test.TestCase):
         self.assertEqual(
             req_context_new.x_forwarded_for, req_context.x_forwarded_for
         )
+        self.assertEqual(
+            req_context_new.client_feature_flags,
+            req_context.client_feature_flags,
+        )
 
         req_context_new = req_context.replace(
             x_forwarded_for=x_forwarded_for_ips2
@@ -101,6 +126,22 @@ class RequestContextTest(tb_test.TestCase):
         self.assertEqual(req_context_new.auth, req_context.auth)
         self.assertEqual(req_context_new.remote_ip, req_context.remote_ip)
         self.assertEqual(req_context_new.x_forwarded_for, x_forwarded_for_ips2)
+        self.assertEqual(
+            req_context_new.client_feature_flags,
+            req_context.client_feature_flags,
+        )
+
+        req_context_new = req_context.replace(
+            client_feature_flags=client_feature_flags2
+        )
+        self.assertEqual(req_context_new.auth, req_context.auth)
+        self.assertEqual(req_context_new.remote_ip, req_context.remote_ip)
+        self.assertEqual(
+            req_context_new.x_forwarded_for, req_context.x_forwarded_for
+        )
+        self.assertEqual(
+            req_context_new.client_feature_flags, client_feature_flags2
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a client_feature_flags property to the DataProvider's RequestContext object. Also add a middleware that extracts the feature flags from the HTTP request and sets them on the RequestContext.

client_feature_flags represents feature flags set in the TB webapp client. They will be injected into many HTTP requests originating from the webapp and will be of the form:
X-TensorBoard-Feature-Flags: JSON.stringify(currentFeatureFlags)

We expose these values as a Dict in the RequestContext object, with string keys and values of arbitrary types (but, in practice, mostly booleans and sometimes arrays of strings). Usage of client_feature_flags should be aware of the key names and the value types.

(Googlers, see: http://go/tb-client-feature-flags-in-data-provider for motivation, more details, and high level design.)

https://github.com/tensorflow/tensorboard/pull/5718 is a complimentary PR that sets the feature flags in requests originating from the Angular code base while the change for the Polymer code base is still pending.