### PR TITLE
data table: Add data table feature flag

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -129,3 +129,10 @@ export const getForceSvgFeatureFlag = createSelector(
     return flags.forceSvg;
   }
 );
+
+export const getIsDataTableEnabled = createSelector(
+  getFeatureFlags,
+  (flags: FeatureFlags): boolean => {
+    return flags.enabledDataTable;
+  }
+);

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -133,6 +133,6 @@ export const getForceSvgFeatureFlag = createSelector(
 export const getIsDataTableEnabled = createSelector(
   getFeatureFlags,
   (flags: FeatureFlags): boolean => {
-    return flags.enabledDataTable;
+    return flags.enabledScalarDataTable;
   }
 );

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -340,4 +340,29 @@ describe('feature_flag_selectors', () => {
       expect(selectors.getEnabledCardWidthSetting(state)).toEqual(true);
     });
   });
+
+  describe('#getIsDataTableEnabled', () => {
+    it('returns the proper value', () => {
+      let state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            enabledDataTable: false,
+          }),
+        })
+      );
+      expect(selectors.getIsDataTableEnabled(state)).toEqual(false);
+
+      state = buildState(
+        buildFeatureFlagState({
+          defaultFlags: buildFeatureFlag({
+            enabledDataTable: false,
+          }),
+          flagOverrides: {
+            enabledDataTable: true,
+          },
+        })
+      );
+      expect(selectors.getIsDataTableEnabled(state)).toEqual(true);
+    });
+  });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -346,7 +346,7 @@ describe('feature_flag_selectors', () => {
       let state = buildState(
         buildFeatureFlagState({
           defaultFlags: buildFeatureFlag({
-            enabledDataTable: false,
+            enabledScalarDataTable: false,
           }),
         })
       );
@@ -355,10 +355,10 @@ describe('feature_flag_selectors', () => {
       state = buildState(
         buildFeatureFlagState({
           defaultFlags: buildFeatureFlag({
-            enabledDataTable: false,
+            enabledScalarDataTable: false,
           }),
           flagOverrides: {
-            enabledDataTable: true,
+            enabledScalarDataTable: true,
           },
         })
       );

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -32,6 +32,7 @@ export const initialState: FeatureFlagState = {
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: true,
     forceSvg: false,
+    enabledDataTable: false,
   },
   flagOverrides: {},
 };

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -32,7 +32,7 @@ export const initialState: FeatureFlagState = {
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: true,
     forceSvg: false,
-    enabledDataTable: false,
+    enabledScalarDataTable: false,
   },
   flagOverrides: {},
 };

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -32,6 +32,7 @@ export function buildFeatureFlag(
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: false,
     forceSvg: false,
+    enabledDataTable: false,
     ...override,
   };
 }

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -32,7 +32,7 @@ export function buildFeatureFlag(
     enableTimeSeriesPromotion: false,
     enabledCardWidthSetting: false,
     forceSvg: false,
-    enabledDataTable: false,
+    enabledScalarDataTable: false,
     ...override,
   };
 }

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -51,5 +51,5 @@ export interface FeatureFlags {
   // Scalar cards.
   forceSvg: boolean;
   // Whether to enable the "sticky" data table in scalar cards.
-  enabledDataTable: boolean;
+  enabledScalarDataTable: boolean;
 }

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -50,4 +50,6 @@ export interface FeatureFlags {
   // Flag for the escape hatch from WebGL. This only effects the TimeSeries
   // Scalar cards.
   forceSvg: boolean;
+  // Whether to enable the "sticky" data table in scalar cards.
+  enabledDataTable: boolean;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -168,7 +168,7 @@ limitations under the License.
     </table>
   </ng-template>
 </div>
-<ng-container *ngIf="selectedTime">
+<ng-container *ngIf="isDataTableEnabled && selectedTime">
   <div>
     <tb-data-table></tb-data-table>
   </div>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -81,6 +81,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() xScaleType!: ScaleType;
   @Input() useDarkMode!: boolean;
   @Input() forceSvg!: boolean;
+  @Input() isDataTableEnabled!: boolean;
   @Input() selectedTime!: ViewSelectedTime | null;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -37,7 +37,10 @@ import {
 } from 'rxjs/operators';
 import {State} from '../../../app_state';
 import {ExperimentAlias} from '../../../experiments/types';
-import {getForceSvgFeatureFlag} from '../../../feature_flag/store/feature_flag_selectors';
+import {
+  getForceSvgFeatureFlag,
+  getIsDataTableEnabled,
+} from '../../../feature_flag/store/feature_flag_selectors';
 import {
   getCardPinnedState,
   getCurrentRouteRunSelection,
@@ -131,6 +134,7 @@ function areSeriesEqual(
       [useDarkMode]="useDarkMode$ | async"
       [selectedTime]="selectedTime$ | async"
       [forceSvg]="forceSvg$ | async"
+      [isDataTableEnabled]="isDataTableEnabled$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       observeIntersection
@@ -181,6 +185,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   readonly tooltipSort$ = this.store.select(getMetricsTooltipSort);
   readonly xAxisType$ = this.store.select(getMetricsXAxisType);
   readonly forceSvg$ = this.store.select(getForceSvgFeatureFlag);
+  readonly isDataTableEnabled$ = this.store.select(getIsDataTableEnabled);
   readonly xScaleType$ = this.store.select(getMetricsXAxisType).pipe(
     map((xAxisType) => {
       switch (xAxisType) {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -316,6 +316,7 @@ describe('scalar card', () => {
     store.overrideSelector(selectors.getRunColorMap, {});
     store.overrideSelector(selectors.getDarkModeEnabled, false);
     store.overrideSelector(selectors.getForceSvgFeatureFlag, false);
+    store.overrideSelector(selectors.getIsDataTableEnabled, false);
   });
 
   describe('basic renders', () => {

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -20,6 +20,7 @@ import {
   ENABLE_COLOR_GROUP_BY_REGEX_QUERY_PARAM_KEY,
   ENABLE_COLOR_GROUP_QUERY_PARAM_KEY,
   ENABLE_DARK_MODE_QUERY_PARAM_KEY,
+  ENABLE_DATA_TABLE_PARAM_KEY,
   ENABLE_LINK_TIME_PARAM_KEY,
   EXPERIMENTAL_PLUGIN_QUERY_PARAM_KEY,
   FORCE_SVG_RENDERER,
@@ -87,6 +88,11 @@ export class QueryParamsFeatureFlagDataSource
 
     if (params.has(FORCE_SVG_RENDERER)) {
       featureFlags.forceSvg = params.get(FORCE_SVG_RENDERER) !== 'false';
+    }
+
+    if (params.has(ENABLE_DATA_TABLE_PARAM_KEY)) {
+      featureFlags.enabledDataTable =
+        params.get(ENABLE_DATA_TABLE_PARAM_KEY) !== 'false';
     }
 
     return featureFlags;

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -91,7 +91,7 @@ export class QueryParamsFeatureFlagDataSource
     }
 
     if (params.has(ENABLE_DATA_TABLE_PARAM_KEY)) {
-      featureFlags.enabledDataTable =
+      featureFlags.enabledScalarDataTable =
         params.get(ENABLE_DATA_TABLE_PARAM_KEY) !== 'false';
     }
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -183,6 +183,27 @@ describe('tb_feature_flag_data_source', () => {
         });
       });
 
+      it('returns enableDataTable from the query params', () => {
+        getParamsSpy.and.returnValues(
+          new URLSearchParams('enableDataTable=false'),
+          new URLSearchParams('enableDataTable='),
+          new URLSearchParams('enableDataTable=true'),
+          new URLSearchParams('enableDataTable=foo')
+        );
+        expect(dataSource.getFeatures()).toEqual({
+          enabledDataTable: false,
+        });
+        expect(dataSource.getFeatures()).toEqual({
+          enabledDataTable: true,
+        });
+        expect(dataSource.getFeatures()).toEqual({
+          enabledDataTable: true,
+        });
+        expect(dataSource.getFeatures()).toEqual({
+          enabledDataTable: true,
+        });
+      });
+
       it('returns all flag values when they are all set', () => {
         getParamsSpy.and.returnValue(
           new URLSearchParams(

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -191,16 +191,16 @@ describe('tb_feature_flag_data_source', () => {
           new URLSearchParams('enableDataTable=foo')
         );
         expect(dataSource.getFeatures()).toEqual({
-          enabledDataTable: false,
+          enabledScalarDataTable: false,
         });
         expect(dataSource.getFeatures()).toEqual({
-          enabledDataTable: true,
+          enabledScalarDataTable: true,
         });
         expect(dataSource.getFeatures()).toEqual({
-          enabledDataTable: true,
+          enabledScalarDataTable: true,
         });
         expect(dataSource.getFeatures()).toEqual({
-          enabledDataTable: true,
+          enabledScalarDataTable: true,
         });
       });
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -46,3 +46,5 @@ export const ENABLE_DARK_MODE_QUERY_PARAM_KEY = 'darkMode';
 export const ENABLE_LINK_TIME_PARAM_KEY = 'enableLinkTime';
 
 export const FORCE_SVG_RENDERER = 'forceSVG';
+
+export const ENABLE_DATA_TABLE_PARAM_KEY = 'enableDataTable';


### PR DESCRIPTION
* Motivation for features / changes
This adds a feature flag to allow for development of the Data Table behind this flag that is not seen by regular users. This will also allow us to launch the Data Table as a standalone feature.

* Screenshots of UI changes
This PR makes no UI changes. However to help give context to the Data Table feature here is a screen shot of what the feature may look like:
![Screen Shot 2022-05-23 at 4 29 28 PM](https://user-images.githubusercontent.com/8672809/170369528-6ee9b965-2027-41b0-b6d9-3bc4bf409a5b.png)


* Detailed steps to verify changes work correctly (as executed by you)
I just tested this with console logs.
