### PR TITLE
Force protobuf dependency < 3.20.

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -24,7 +24,10 @@ google-auth >= 1.6.3, < 3
 google-auth-oauthlib >= 0.4.1, < 0.5
 markdown >= 2.6.8
 numpy >= 1.12.0
-protobuf >= 3.9.2
+# Protobuf 4.0 is incompatible with TF. Force < 3.20 until they upgrade.
+# See: https://github.com/protocolbuffers/protobuf/issues/9954#issuecomment-1128283911
+# See: https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/tools/pip_package/setup.py?q=protobuf
+protobuf >= 3.9.2, < 3.20
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
 tensorboard-data-server >= 0.6.0, < 0.7.0


### PR DESCRIPTION
The latest protobuf release is not backwards compatible with TensorFlow's protos and our copies of those protos in tensorboard/compat/proto . We knew this change was coming so, fortunately, TF had already fixed their dependencies to force a compatible version of protobuf. However, we also have to update our own requirements.txt to force the same version of protobuf, to unbreak the build when TensorFlow is not installed.

Googlers, see: http://b/182876485.
See: https://github.com/protocolbuffers/protobuf/issues/9954#issuecomment-1128283911
See: https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/tools/pip_package/setup.py?q=protobuf