### PR TITLE
Validate that decoded client_feature_flags is a dict.

### DIFF
--- a/tensorboard/backend/client_feature_flags.py
+++ b/tensorboard/backend/client_feature_flags.py
@@ -55,7 +55,6 @@ class ClientFeatureFlagsMiddleware(object):
                 "X-TensorBoard-Feature-Flags cannot be decoded to a dict."
             )
 
-
         ctx = context.from_environ(environ).replace(
             client_feature_flags=client_feature_flags
         )

--- a/tensorboard/backend/client_feature_flags.py
+++ b/tensorboard/backend/client_feature_flags.py
@@ -50,6 +50,12 @@ class ClientFeatureFlagsMiddleware(object):
                 "X-TensorBoard-Feature-Flags cannot be JSON decoded."
             )
 
+        if not isinstance(client_feature_flags, dict):
+            raise errors.InvalidArgumentError(
+                "X-TensorBoard-Feature-Flags cannot be decoded to a dict."
+            )
+
+
         ctx = context.from_environ(environ).replace(
             client_feature_flags=client_feature_flags
         )

--- a/tensorboard/backend/client_feature_flags_test.py
+++ b/tensorboard/backend/client_feature_flags_test.py
@@ -95,7 +95,7 @@ class ClientFeatureFlagsMiddlewareTest(tb_test.TestCase):
         server = werkzeug_test.Client(app, wrappers.Response)
 
         with self.assertRaisesRegex(
-            errors.InvalidArgumentError, "X-TensorBoard-Feature-Flags"
+            errors.InvalidArgumentError, "cannot be JSON decoded."
         ):
             response = server.get(
                 "",
@@ -103,6 +103,23 @@ class ClientFeatureFlagsMiddlewareTest(tb_test.TestCase):
                     (
                         "X-TensorBoard-Feature-Flags",
                         "some_invalid_json {} {}",
+                    )
+                ],
+            )
+
+    def test_header_with_json_not_dict(self):
+        app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
+        server = werkzeug_test.Client(app, wrappers.Response)
+
+        with self.assertRaisesRegex(
+            errors.InvalidArgumentError, "cannot be decoded to a dict"
+        ):
+            response = server.get(
+                "",
+                headers=[
+                    (
+                        "X-TensorBoard-Feature-Flags",
+                        '["not", "a", "dict"]',
                     )
                 ],
             )


### PR DESCRIPTION
In https://github.com/tensorflow/tensorboard/pull/5721 we added ClientFeatureFlagsMiddleware. It decodes the feature flag payload from JSON into a dict.

Reviewer suggested we validate that the decoded result is indeed a dict and I claimed that this was not a valid scenario to worry about. I realized not long afterwards that I was wrong.

