### PR TITLE
step selector: gather data to be passed to data table

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -300,6 +300,7 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2:line_chart_utils",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/sub_view",
         "//tensorboard/webapp/widgets/linked_time_fob",
         "//tensorboard/webapp/widgets/linked_time_fob:types",
         "//tensorboard/webapp/widgets/text:truncated_path",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -170,7 +170,10 @@ limitations under the License.
 </div>
 <ng-container *ngIf="isDataTableEnabled && selectedTime">
   <div>
-    <tb-data-table></tb-data-table>
+    <tb-data-table
+      [headers]="dataHeaders"
+      [data]="getSelectedTimeTableData()"
+    ></tb-data-table>
   </div>
 </ng-container>
 <ng-template

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -32,6 +32,7 @@ import {
   siNumberFormatter,
 } from '../../../widgets/line_chart_v2/lib/formatter';
 import {LineChartComponent} from '../../../widgets/line_chart_v2/line_chart_component';
+import {findClosestIndex} from '../../../widgets/line_chart_v2/sub_view/line_chart_interactive_utils';
 import {
   RendererType,
   ScaleType,
@@ -100,6 +101,8 @@ export class ScalarCardComponent<Downloader> {
 
   yScaleType = ScaleType.LINEAR;
   isViewBoxOverridden: boolean = false;
+  // array of columns that will be displayed in the Data Table when enabled. The
+  // order of this array will be the order displayed on the table.
   dataHeaders: ColumnHeaders[] = [
     ColumnHeaders.RUN,
     ColumnHeaders.VALUE,
@@ -199,20 +202,19 @@ export class ScalarCardComponent<Downloader> {
     const dataTableData = this.dataSeries
       .map((datum) => {
         const metadata = this.chartMetadataMap[datum.id];
-        const closestStartPoint = this.getClosestPoint(
-          datum.points,
-          this.selectedTime!.startStep
-        );
-        const closestEndPoint = null;
+        const closestStartPoint =
+          datum.points[
+            findClosestIndex(datum.points, this.selectedTime!.startStep)
+          ];
         return {
           metadata,
           closestStartPoint,
-          closestEndPoint,
         };
       })
       .filter(({metadata}) => {
         return metadata && metadata.visible && !Boolean(metadata.aux);
       });
+
     return dataTableData;
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2246,4 +2246,229 @@ describe('scalar card', () => {
       }));
     });
   });
+
+  describe('getSelectedTimeTableData', () => {
+    it('Correctly builds data object', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 2},
+          {wallTime: 3, value: 20, step: 3},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 2},
+          {wallTime: 3, value: 20, step: 3},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsSelectedTime, {
+        start: {step: 2},
+        end: {step: 50},
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getSelectedTimeTableData();
+
+      expect(data).toEqual([
+        {
+          metadata: {
+            type: 0,
+            id: 'run1',
+            alias: null,
+            displayName: 'run1',
+            visible: true,
+            color: '#fff',
+            aux: false,
+            opacity: 1,
+          },
+          closestStartPoint: {
+            wallTime: 2000,
+            value: 10,
+            step: 2,
+            x: 2,
+            y: 10,
+            relativeTimeInMs: 1000,
+          },
+          closestEndPoint: null,
+        },
+        {
+          metadata: {
+            type: 0,
+            id: 'run2',
+            alias: null,
+            displayName: 'run2',
+            visible: true,
+            color: '#fff',
+            aux: false,
+            opacity: 1,
+          },
+          closestStartPoint: {
+            wallTime: 2000,
+            value: 10,
+            step: 2,
+            x: 2,
+            y: 10,
+            relativeTimeInMs: 1000,
+          },
+          closestEndPoint: null,
+        },
+      ]);
+    }));
+    it('Selects closest points to selectedTime', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 20},
+          {wallTime: 3, value: 20, step: 35},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 15},
+          {wallTime: 3, value: 20, step: 50},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsSelectedTime, {
+        start: {step: 18},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getSelectedTimeTableData();
+
+      expect(data[0].closestStartPoint.step).toEqual(20);
+      expect(data[1].closestStartPoint.step).toEqual(15);
+    }));
+    it('Selects largest points when selectedTime startStep is greater than any points step', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 20},
+          {wallTime: 3, value: 20, step: 35},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 15},
+          {wallTime: 3, value: 20, step: 50},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsSelectedTime, {
+        start: {step: 100},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getSelectedTimeTableData();
+
+      expect(data[0].closestStartPoint.step).toEqual(35);
+      expect(data[1].closestStartPoint.step).toEqual(50);
+    }));
+    it('Selects smallest points when selectedTime startStep is less than any points step', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 10},
+          {wallTime: 2, value: 10, step: 20},
+          {wallTime: 3, value: 20, step: 35},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 8},
+          {wallTime: 2, value: 10, step: 15},
+          {wallTime: 3, value: 20, step: 50},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsSelectedTime, {
+        start: {step: 1},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getSelectedTimeTableData();
+
+      expect(data[0].closestStartPoint.step).toEqual(10);
+      expect(data[1].closestStartPoint.step).toEqual(8);
+    }));
+  });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2248,7 +2248,7 @@ describe('scalar card', () => {
   });
 
   describe('getSelectedTimeTableData', () => {
-    it('Correctly builds data object', fakeAsync(() => {
+    it('builds data object', fakeAsync(() => {
       const runToSeries = {
         run1: [
           {wallTime: 1, value: 1, step: 1},
@@ -2310,7 +2310,6 @@ describe('scalar card', () => {
             y: 10,
             relativeTimeInMs: 1000,
           },
-          closestEndPoint: null,
         },
         {
           metadata: {
@@ -2331,10 +2330,10 @@ describe('scalar card', () => {
             y: 10,
             relativeTimeInMs: 1000,
           },
-          closestEndPoint: null,
         },
       ]);
     }));
+
     it('Selects closest points to selectedTime', fakeAsync(() => {
       const runToSeries = {
         run1: [
@@ -2380,6 +2379,7 @@ describe('scalar card', () => {
       expect(data[0].closestStartPoint.step).toEqual(20);
       expect(data[1].closestStartPoint.step).toEqual(15);
     }));
+
     it('Selects largest points when selectedTime startStep is greater than any points step', fakeAsync(() => {
       const runToSeries = {
         run1: [
@@ -2425,6 +2425,7 @@ describe('scalar card', () => {
       expect(data[0].closestStartPoint.step).toEqual(35);
       expect(data[1].closestStartPoint.step).toEqual(50);
     }));
+
     it('Selects smallest points when selectedTime startStep is less than any points step', fakeAsync(() => {
       const runToSeries = {
         run1: [

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -69,7 +69,6 @@ export type ScalarCardDataSeries = DataSeries<ScalarCardPoint>;
 export interface RunStepData {
   metadata: ScalarCardSeriesMetadata;
   closestStartPoint: ScalarCardPoint;
-  closestEndPoint: ScalarCardPoint | null;
 }
 
 export interface PartialSeries {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -26,6 +26,16 @@ export enum SeriesType {
   DERIVED,
 }
 
+// The types of data that can be displayed in the data table
+export enum ColumnHeaders {
+  RUN,
+  SMOOTHED,
+  VALUE,
+  STEP,
+  TIME,
+  RELATIVE_TIME,
+}
+
 // Smoothed series is derived from a data serie. The additional information on the
 // metadata allows us to render smoothed value and its original value in the tooltip.
 export interface SmoothedSeriesMetadata extends DataSeriesMetadata {
@@ -55,6 +65,12 @@ export interface ScalarCardPoint extends Point {
 }
 
 export type ScalarCardDataSeries = DataSeries<ScalarCardPoint>;
+
+export interface RunStepData {
+  metadata: ScalarCardSeriesMetadata;
+  closestStartPoint: ScalarCardPoint;
+  closestEndPoint: ScalarCardPoint | null;
+}
 
 export interface PartialSeries {
   runId: string;

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -19,6 +19,7 @@ tf_ng_module(
         ":data_table_styles",
     ],
     deps = [
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {
+  ColumnHeaders,
+  RunStepData,
+} from '../../metrics/views/card_renderer/scalar_card_types';
 
 @Component({
   selector: 'tb-data-table',
@@ -21,4 +25,7 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
   styleUrls: ['data_table_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DataTableComponent {}
+export class DataTableComponent {
+  @Input() headers!: ColumnHeaders[];
+  @Input() data!: RunStepData[];
+}


### PR DESCRIPTION
Motivation for features / changes

This is one pr in a chain intended to add a data table feature. This change gathers the data needed for the table. For more context on where this is headed see https://github.com/tensorflow/tensorboard/pull/5719.

Technical description of changes
The ScalarCard now decides which columns we will have on the table(currently this is hard coded but, we plan to allow for the user to select which columns they want so this is built with that in mind). It also uses the selectedTime to decide which points of data will be displayed.  Eventually we will replace selected time with a more narrow step selection that is specific for that card. 

Screenshots of UI changes
This PR makes no UI changes but we event
![Screen Shot 2022-05-23 at 4 29 28 PM](https://user-images.githubusercontent.com/8672809/171557504-e14b7543-188c-42da-abab-15e9825e1690.png)
ually plan to add a table that will probably look something like this:


The look of that table is still subject to change.
