### PR TITLE
step selector: add control to settings panel behind feature flag

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -526,7 +526,7 @@ describe('metrics right_pane', () => {
       });
     });
 
-    describe('time selector feature enabled', () => {
+    describe('step selector feature enabled', () => {
       beforeEach(() => {
         store.overrideSelector(selectors.getIsDataTableEnabled, true);
       });
@@ -536,7 +536,7 @@ describe('metrics right_pane', () => {
         fixture.detectChanges();
 
         expect(
-          select(fixture, '.scalars-time-selector input').attributes[
+          select(fixture, '.scalars-step-selector input').attributes[
             'aria-checked'
           ]
         ).toBe('false');

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -88,6 +88,7 @@ describe('metrics right_pane', () => {
       store.overrideSelector(selectors.getIsFeatureFlagsLoaded, true);
       store.overrideSelector(selectors.getIsMetricsImageSupportEnabled, true);
       store.overrideSelector(selectors.getIsLinkedTimeEnabled, false);
+      store.overrideSelector(selectors.getIsDataTableEnabled, false);
       store.overrideSelector(selectors.getEnabledCardWidthSetting, false);
       store.overrideSelector(selectors.getMetricsCardMinWidth, null);
       store.overrideSelector(selectors.getMetricsSelectTimeEnabled, false);
@@ -522,6 +523,23 @@ describe('metrics right_pane', () => {
             })
           );
         });
+      });
+    });
+
+    describe('time selector feature enabled', () => {
+      beforeEach(() => {
+        store.overrideSelector(selectors.getIsDataTableEnabled, true);
+      });
+
+      it('renders', () => {
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        expect(
+          select(fixture, '.scalars-time-selector input').attributes[
+            'aria-checked'
+          ]
+        ).toBe('false');
       });
     });
   });

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -386,6 +386,15 @@ describe('metrics right_pane', () => {
       expect(el).toBeFalsy();
     });
 
+    it('does not display step selector setting on step selector disabled', () => {
+      store.overrideSelector(selectors.getIsDataTableEnabled, false);
+      const fixture = TestBed.createComponent(SettingsViewContainer);
+      fixture.detectChanges();
+
+      const el = fixture.debugElement.query(By.css('.scalars-step-selector'));
+      expect(el).toBeFalsy();
+    });
+
     describe('linked time feature enabled', () => {
       beforeEach(() => {
         store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -128,13 +128,13 @@ limitations under the License.
   </div>
 
   <div
-    class="control-row scalars-time-selector"
-    *ngIf="isScalarTimeSelectorEnabled"
+    class="control-row scalars-step-selector"
+    *ngIf="isScalarStepSelectorEnabled"
   >
     <mat-checkbox
-      [checked]="timeSelectorEnabled"
-      (change)="timeSelectorEnableToggled.emit()"
-      >Time Selector</mat-checkbox
+      [checked]="stepSelectorEnabled"
+      (change)="stepSelectorEnableToggled.emit()"
+      >Step Selector</mat-checkbox
     >
   </div>
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -127,6 +127,17 @@ limitations under the License.
     >
   </div>
 
+  <div
+    class="control-row scalars-time-selector"
+    *ngIf="isScalarTimeSelectorEnabled"
+  >
+    <mat-checkbox
+      [checked]="timeSelectorEnabled"
+      (change)="timeSelectorEnableToggled.emit()"
+      >Time Selector</mat-checkbox
+    >
+  </div>
+
   <div class="control-row scalars-partition-x">
     <mat-checkbox
       [checked]="scalarPartitionX"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -65,7 +65,7 @@ export class SettingsViewComponent {
 
   @Input() isCardWidthSettingEnabled!: boolean;
   @Input() isLinkedTimeFeatureEnabled!: boolean;
-  @Input() isScalarTimeSelectorEnabled!: boolean;
+  @Input() isScalarStepSelectorEnabled!: boolean;
   @Input() selectTimeEnabled!: boolean;
   @Input() useRangeSelectTime!: boolean;
   @Input() selectedTime!: LinkedTime | null;
@@ -74,7 +74,7 @@ export class SettingsViewComponent {
   @Output() selectTimeEnableToggled = new EventEmitter<void>();
   @Output() selectTimeChanged = new EventEmitter<LinkedTime>();
 
-  @Output() timeSelectorEnableToggled = new EventEmitter<void>();
+  @Output() stepSelectorEnableToggled = new EventEmitter<void>();
 
   @Input() isImageSupportEnabled!: boolean;
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -65,6 +65,7 @@ export class SettingsViewComponent {
 
   @Input() isCardWidthSettingEnabled!: boolean;
   @Input() isLinkedTimeFeatureEnabled!: boolean;
+  @Input() isScalarTimeSelectorEnabled!: boolean;
   @Input() selectTimeEnabled!: boolean;
   @Input() useRangeSelectTime!: boolean;
   @Input() selectedTime!: LinkedTime | null;
@@ -72,6 +73,8 @@ export class SettingsViewComponent {
 
   @Output() selectTimeEnableToggled = new EventEmitter<void>();
   @Output() selectTimeChanged = new EventEmitter<LinkedTime>();
+
+  @Output() timeSelectorEnableToggled = new EventEmitter<void>();
 
   @Input() isImageSupportEnabled!: boolean;
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -67,14 +67,14 @@ import {HistogramMode, LinkedTime, TooltipSort, XAxisType} from '../../types';
       [imageShowActualSize]="imageShowActualSize$ | async"
       (imageShowActualSizeChanged)="onImageShowActualSizeChanged()"
       [isLinkedTimeFeatureEnabled]="isLinkedTimeFeatureEnabled$ | async"
-      [isScalarTimeSelectorEnabled]="isScalarTimeSelectorEnabled$ | async"
+      [isScalarStepSelectorEnabled]="isScalarStepSelectorEnabled$ | async"
       [selectTimeEnabled]="selectTimeEnabled$ | async"
       [selectedTime]="selectedTime$ | async"
       [useRangeSelectTime]="useRangeSelectTime$ | async"
       [stepMinMax]="stepMinMax$ | async"
       (selectTimeEnableToggled)="onSelectTimeEnableToggled()"
       (selectTimeChanged)="onSelectTimeChanged($event)"
-      (timeSelectorEnableToggled)="onTimeSelectorEnableToggled()"
+      (stepSelectorEnableToggled)="onStepSelectorEnableToggled()"
     >
     </metrics-dashboard-settings-component>
   `,
@@ -89,7 +89,7 @@ export class SettingsViewContainer {
   readonly isLinkedTimeFeatureEnabled$: Observable<boolean> = this.store.select(
     selectors.getIsLinkedTimeEnabled
   );
-  readonly isScalarTimeSelectorEnabled$: Observable<boolean> =
+  readonly isScalarStepSelectorEnabled$: Observable<boolean> =
     this.store.select(selectors.getIsDataTableEnabled);
   readonly selectTimeEnabled$: Observable<boolean> = this.store.select(
     selectors.getMetricsSelectTimeEnabled
@@ -196,7 +196,7 @@ export class SettingsViewContainer {
     this.store.dispatch(selectTimeEnableToggled());
   }
 
-  onTimeSelectorEnableToggled() {
+  onStepSelectorEnableToggled() {
     // TODO(japie1235813): Dispatch toggled event to update ngrx state.
   }
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -67,12 +67,14 @@ import {HistogramMode, LinkedTime, TooltipSort, XAxisType} from '../../types';
       [imageShowActualSize]="imageShowActualSize$ | async"
       (imageShowActualSizeChanged)="onImageShowActualSizeChanged()"
       [isLinkedTimeFeatureEnabled]="isLinkedTimeFeatureEnabled$ | async"
+      [isScalarTimeSelectorEnabled]="isScalarTimeSelectorEnabled$ | async"
       [selectTimeEnabled]="selectTimeEnabled$ | async"
       [selectedTime]="selectedTime$ | async"
       [useRangeSelectTime]="useRangeSelectTime$ | async"
       [stepMinMax]="stepMinMax$ | async"
       (selectTimeEnableToggled)="onSelectTimeEnableToggled()"
       (selectTimeChanged)="onSelectTimeChanged($event)"
+      (timeSelectorEnableToggled)="onTimeSelectorEnableToggled()"
     >
     </metrics-dashboard-settings-component>
   `,
@@ -87,6 +89,8 @@ export class SettingsViewContainer {
   readonly isLinkedTimeFeatureEnabled$: Observable<boolean> = this.store.select(
     selectors.getIsLinkedTimeEnabled
   );
+  readonly isScalarTimeSelectorEnabled$: Observable<boolean> =
+    this.store.select(selectors.getIsDataTableEnabled);
   readonly selectTimeEnabled$: Observable<boolean> = this.store.select(
     selectors.getMetricsSelectTimeEnabled
   );
@@ -190,6 +194,10 @@ export class SettingsViewContainer {
 
   onSelectTimeEnableToggled() {
     this.store.dispatch(selectTimeEnableToggled());
+  }
+
+  onTimeSelectorEnableToggled() {
+    // TODO(japie1235813): Dispatch toggled event to update ngrx state.
   }
 
   onSelectTimeChanged(newValue: LinkedTime) {


### PR DESCRIPTION
* Motivation for features / changes
This is part of the work to separate the "sticky data table" (aka step selector) to its own feature. This PR adds the checkbox to enable/disable step selector. The checkbox is hided behind feature flag (enableScalarDataTable).

* Technical description of changes
Add visual component to settings panel and wiring toggle action. (no dispatch action yet)

TODO: add ngrx state to control enabling time selector and plump them together
TODO: consider renaming feature flag

* Screenshots of UI changes
![Screen Shot 2022-06-02 at 2 03 51 PM](https://user-images.githubusercontent.com/1131010/171737950-93ba96aa-f9f4-4a37-a0f0-53b08070ead6.png)

