### PR TITLE
linked time: decouple fob from linked time: fix scalar scss file rename

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -247,8 +247,8 @@ tf_sass_binary(
 )
 
 tf_sass_binary(
-    name = "scalar_card_linked_time_fob_controller_styles",
-    src = "scalar_card_linked_time_fob_controller.scss",
+    name = "scalar_card_fob_controller_styles",
+    src = "scalar_card_fob_controller.scss",
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
     ],
@@ -264,7 +264,7 @@ tf_ng_module(
     ],
     assets = [
         ":scalar_card_styles",
-        ":scalar_card_linked_time_fob_controller_styles",
+        ":scalar_card_fob_controller_styles",
         "scalar_card_component.ng.html",
     ],
     deps = [

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.scss
@@ -11,6 +11,6 @@ limitations under the License.
 ==============================================================================*/
 
 // Creates height space for vertical lines
-::ng-deep scalar-card-linked-time-fob-controller .time-fob-wrapper {
+::ng-deep scalar-card-fob-controller .time-fob-wrapper {
   height: 100%;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -30,7 +30,7 @@ import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
       (onSelectTimeToggle)="onSelectTimeToggle.emit($event)"
     ></card-fob-controller>
   `,
-  styleUrls: ['scalar_card_linked_time_fob_controller.css'],
+  styleUrls: ['scalar_card_fob_controller.css'],
 })
 export class ScalarCardFobController implements CardFobAdapter {
   @Input() linkedTime!: LinkedTime;


### PR DESCRIPTION
* Motivation for features / changes
While renamign the linked time fob to be card fob (https://github.com/tensorflow/tensorboard/pull/5732), a scss file was overlooked. This PR rename `scalar_card_linked_time_fob_controller.scss` to `scalar_card_fob_controller.scss`.

Googlers, please see cl/438908607 for webtest

* Screenshots of UI changes
Before
![Screen Shot 2022-06-03 at 1 22 06 PM](https://user-images.githubusercontent.com/1131010/171947310-5b4ba6bb-8a9f-4f25-acac-9c6b989d1b99.png)

After
![Screen Shot 2022-06-03 at 1 25 37 PM](https://user-images.githubusercontent.com/1131010/171947330-ff09cdb0-ee59-420a-87ab-4ad9ab863125.png)

