### PR TITLE
step selector: gather data for data table

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -302,6 +302,7 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2:line_chart_utils",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/sub_view",
         "//tensorboard/webapp/widgets/text:truncated_path",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -170,7 +170,10 @@ limitations under the License.
 </div>
 <ng-container *ngIf="isDataTableEnabled && selectedTime">
   <div>
-    <tb-data-table></tb-data-table>
+    <tb-data-table
+      [headers]="dataHeaders"
+      [data]="getSelectedTimeTableData()"
+    ></tb-data-table>
   </div>
 </ng-container>
 <ng-template

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -227,9 +227,9 @@ export class ScalarCardComponent<Downloader> {
           datum.points[
             findClosestIndex(datum.points, this.selectedTime!.startStep)
           ];
-        let selectedStepData: SelectedStepRunData = {};
+        const selectedStepData: SelectedStepRunData = {};
         selectedStepData.COLOR = metadata.color;
-        for (let header of this.dataHeaders) {
+        for (const header of this.dataHeaders) {
           switch (header) {
             case ColumnHeaders.RUN:
               selectedStepData.RUN = metadata.displayName;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2246,4 +2246,202 @@ describe('scalar card', () => {
       }));
     });
   });
+  describe('getSelectedTimeTableData', () => {
+    it('builds data object', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 2},
+          {wallTime: 3, value: 20, step: 3},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 2},
+          {wallTime: 3, value: 20, step: 3},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsSelectedTime, {
+        start: {step: 2},
+        end: {step: 50},
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getSelectedTimeTableData();
+
+      expect(data).toEqual([
+        {
+          COLOR: '#fff',
+          RELATIVE_TIME: 1000,
+          RUN: 'run1',
+          STEP: 2,
+          VALUE: 10,
+        },
+        {
+          COLOR: '#fff',
+          RELATIVE_TIME: 1000,
+          RUN: 'run2',
+          STEP: 2,
+          VALUE: 10,
+        },
+      ]);
+    }));
+
+    it('Selects closest points to selectedTime', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 20},
+          {wallTime: 3, value: 20, step: 35},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 15},
+          {wallTime: 3, value: 20, step: 50},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsSelectedTime, {
+        start: {step: 18},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getSelectedTimeTableData();
+
+      expect(data[0].STEP).toEqual(20);
+      expect(data[1].STEP).toEqual(15);
+    }));
+
+    it('Selects largest points when selectedTime startStep is greater than any points step', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 20},
+          {wallTime: 3, value: 20, step: 35},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 15},
+          {wallTime: 3, value: 20, step: 50},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsSelectedTime, {
+        start: {step: 100},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getSelectedTimeTableData();
+
+      expect(data[0].STEP).toEqual(35);
+      expect(data[1].STEP).toEqual(50);
+    }));
+
+    it('Selects smallest points when selectedTime startStep is less than any points step', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 10},
+          {wallTime: 2, value: 10, step: 20},
+          {wallTime: 3, value: 20, step: 35},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 8},
+          {wallTime: 2, value: 10, step: 15},
+          {wallTime: 3, value: 20, step: 50},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+      store.overrideSelector(getMetricsSelectedTime, {
+        start: {step: 1},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getSelectedTimeTableData();
+
+      expect(data[0].STEP).toEqual(10);
+      expect(data[1].STEP).toEqual(8);
+    }));
+  });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2246,8 +2246,9 @@ describe('scalar card', () => {
       }));
     });
   });
+
   describe('getSelectedTimeTableData', () => {
-    it('builds data object', fakeAsync(() => {
+    it('builds single selected step data object', fakeAsync(() => {
       const runToSeries = {
         run1: [
           {wallTime: 1, value: 1, step: 1},
@@ -2307,7 +2308,7 @@ describe('scalar card', () => {
       ]);
     }));
 
-    it('Selects closest points to selectedTime', fakeAsync(() => {
+    it('selects closest points to selectedTime', fakeAsync(() => {
       const runToSeries = {
         run1: [
           {wallTime: 1, value: 1, step: 1},

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -26,6 +26,20 @@ export enum SeriesType {
   DERIVED,
 }
 
+export enum ColumnHeaders {
+  COLOR = 'COLOR',
+  RUN = 'RUN',
+  VALUE = 'VALUE',
+  STEP = 'STEP',
+  START_STEP = 'START_STEP',
+  END_STEP = 'END_STEP',
+  START_VALUE = 'START_VALUE',
+  END_VALUE = 'END_VALUE',
+  SMOOTHED = 'SMOOTHED',
+  TIME = 'TIME',
+  RELATIVE_TIME = 'RELATIVE_TIME',
+}
+
 // Smoothed series is derived from a data serie. The additional information on the
 // metadata allows us to render smoothed value and its original value in the tooltip.
 export interface SmoothedSeriesMetadata extends DataSeriesMetadata {
@@ -70,3 +84,7 @@ export interface PartitionedSeries {
   runId: string;
   points: ScalarCardPoint[];
 }
+
+export type SelectedStepRunData = {
+  [key in ColumnHeaders]?: string | number;
+};

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -26,20 +26,6 @@ export enum SeriesType {
   DERIVED,
 }
 
-export enum ColumnHeaders {
-  COLOR = 'COLOR',
-  RUN = 'RUN',
-  VALUE = 'VALUE',
-  STEP = 'STEP',
-  START_STEP = 'START_STEP',
-  END_STEP = 'END_STEP',
-  START_VALUE = 'START_VALUE',
-  END_VALUE = 'END_VALUE',
-  SMOOTHED = 'SMOOTHED',
-  TIME = 'TIME',
-  RELATIVE_TIME = 'RELATIVE_TIME',
-}
-
 // Smoothed series is derived from a data serie. The additional information on the
 // metadata allows us to render smoothed value and its original value in the tooltip.
 export interface SmoothedSeriesMetadata extends DataSeriesMetadata {
@@ -85,6 +71,25 @@ export interface PartitionedSeries {
   points: ScalarCardPoint[];
 }
 
+/**
+ * This enum defines the columns available in the data table. The
+ * ScalarCardComponent must know which piece of data is associated with each
+ * value and the DataTable widget must know how to display each value.
+ */
+export enum ColumnHeaders {
+  COLOR = 'COLOR',
+  RELATIVE_TIME = 'RELATIVE_TIME',
+  RUN = 'RUN',
+  STEP = 'STEP',
+  TIME = 'TIME',
+  VALUE = 'VALUE',
+}
+
+/**
+ * An object which essentially contains the data for an entire row in the
+ * DataTable. It will have a value for each required ColumnHeader for a given
+ * run.
+ */
 export type SelectedStepRunData = {
   [key in ColumnHeaders]?: string | number;
 };

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -20,6 +20,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -19,8 +19,8 @@ tf_ng_module(
         ":data_table_styles",
     ],
     deps = [
-        "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {
+  ColumnHeaders,
+  SelectedStepRunData,
+} from '../../metrics/views/card_renderer/scalar_card_types';
 
 @Component({
   selector: 'tb-data-table',
@@ -21,4 +25,7 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
   styleUrls: ['data_table_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DataTableComponent {}
+export class DataTableComponent {
+  @Input() headers!: ColumnHeaders[];
+  @Input() data!: SelectedStepRunData[];
+}

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -26,6 +26,8 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataTableComponent {
+  // The order of this array of headers determines the order which they are
+  // displayed in the table.
   @Input() headers!: ColumnHeaders[];
   @Input() data!: SelectedStepRunData[];
 }


### PR DESCRIPTION
* Motivation for features / changes
This is one pr in a chain intended to add a data table feature. This change adds data types and gathers the data needed for the table. For more context on where this is headed see https://github.com/tensorflow/tensorboard/pull/5743

* Technical description of changes
The ScalarCard now decides which columns we will have on the table(currently this is hard coded but, we plan to allow for the user to select which columns they want so this is built with that in mind). It also uses the selectedTime to decide which points of data will be displayed.  Eventually we will replace selected time with a more narrow step selection that is specific for that card. 

* Screenshots of UI changes
This PR makes no UI changes but, for reference we are aiming to make a table like this:
![Screen Shot 2022-05-23 at 4 29 28 PM](https://user-images.githubusercontent.com/8672809/171557504-e14b7543-188c-42da-abab-15e9825e1690.png)

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
There was another design to pass the point data and run metadata down to the table and have that table understand how to get the correct data per column. We plan to one day allow for ranges of data and there are some calculations that would prove very difficult in the data table(for instance the average of all values within the range) so we went with this solution where the values are "calculated" in the ScalarCardComponent and then passed to the data table.