### PR TITLE
Recognize text/javascript as valid js mimetype for caching purposes

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -138,8 +138,7 @@ class CorePlugin(base_plugin.TBPlugin):
         # Cache JS resources while keep others do not cache.
         expires = (
             JS_CACHE_EXPIRATION_IN_SECS
-            if request.args.get("_file_hash")
-            and mimetype in JS_MIMETYPES
+            if request.args.get("_file_hash") and mimetype in JS_MIMETYPES
             else 0
         )
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -39,6 +39,11 @@ logger = tb_logging.get_logger()
 # If no port is specified, try to bind to this port. See help for --port
 # for more details.
 DEFAULT_PORT = 6006
+# Valid javascript mimetypes that we have seen configured, in practice.
+# Historically (~2020-2022) we saw "application/javascript" exclusively but with
+# RFC 9239 (https://www.rfc-editor.org/rfc/rfc9239) we saw some systems quickly
+# transition to 'text/javascript'.
+JS_MIMETYPES = ["text/javascript", "application/javascript"]
 JS_CACHE_EXPIRATION_IN_SECS = 86400
 
 
@@ -134,7 +139,7 @@ class CorePlugin(base_plugin.TBPlugin):
         expires = (
             JS_CACHE_EXPIRATION_IN_SECS
             if request.args.get("_file_hash")
-            and mimetype == "application/javascript"
+            and mimetype in JS_MIMETYPES
             else 0
         )
 

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -152,7 +152,7 @@ class CorePluginTest(tf.test.TestCase):
         self.server = werkzeug_test.Client(app, wrappers.Response)
 
     def tearDown(self):
-      mimetypes.init()
+        mimetypes.init()
 
     def _add_run(self, run_name):
         run_path = os.path.join(self.logdir, run_name)

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -389,7 +389,7 @@ class TensorBoard(object):
         """
         # Known to be problematic when Visual Studio is installed:
         # <https://github.com/tensorflow/tensorboard/issues/3120>
-        mimetypes.add_type("text/javascript", ".js")
+        mimetypes.add_type("application/javascript", ".js")
         # Not known to be problematic, but used by TensorBoard:
         mimetypes.add_type("font/woff2", ".woff2")
         mimetypes.add_type("text/html", ".html")

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -389,7 +389,7 @@ class TensorBoard(object):
         """
         # Known to be problematic when Visual Studio is installed:
         # <https://github.com/tensorflow/tensorboard/issues/3120>
-        mimetypes.add_type("application/javascript", ".js")
+        mimetypes.add_type("text/javascript", ".js")
         # Not known to be problematic, but used by TensorBoard:
         mimetypes.add_type("font/woff2", ".woff2")
         mimetypes.add_type("text/html", ".html")


### PR DESCRIPTION
Recently the test core_plugin_test.py::test_js_cache began to fail in some environments with the following error:

```
... core_plugin_test.py", line 196, in test_js_cache
self.assertEqual(
AssertionError: 
- private, max-age=86400
+ no-cache, must-revalidate
```

The root cause is that these systems have now been configured to return 'text/javascript' as the mimetype for js files, where they were previously returning 'application/javascript'. This means the 'Cache-Control' header was not set by this line:

https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/plugins/core/core_plugin.py;l=137;drc=c061b659f50cde9dd9da5aa906ecb682ecdc68d4

```
        expires = (
            JS_CACHE_EXPIRATION_IN_SECS
            if request.args.get("_file_hash")
            and mimetype == "application/javascript"
            else 0
        )
```

After further investigation (thanks @nfelt!) we determined that the change in mimetype is likely intentional after the recent publishing of RFC 9239 (https://www.rfc-editor.org/rfc/rfc9239), where 'text/javascript' becomes the standard mimetype for js files.

We decided, therefore, to change the Cache-Control-setting logic to also recognize 'text/javascript'.

Note, in practice, the change in mimetype had no impact on running tensorboards thanks to the logic added in #3128, which always ensures ".js" is mapped to mimetype "application/javascript" but does it at a higher level (ie outside either core plugin or the http utils). 