### PR TITLE
Change mimetype mapping of js files to 'text/javascript'.

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -63,6 +63,7 @@ _TEXTUAL_MIMETYPES = set(
         "text/css",
         "text/csv",
         "text/html",
+        "text/javascript",
         "text/plain",
         "text/tab-separated-values",
         "text/x-protobuf",

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
@@ -62,9 +62,7 @@ class ExamplePlugin(base_plugin.TBPlugin):
         filepath = os.path.join(os.path.dirname(__file__), "static", "index.js")
         with open(filepath) as infile:
             contents = infile.read()
-        return werkzeug.Response(
-            contents, content_type="text/javascript"
-        )
+        return werkzeug.Response(contents, content_type="text/javascript")
 
     @wrappers.Request.application
     def _serve_tags(self, request):

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
@@ -63,7 +63,7 @@ class ExamplePlugin(base_plugin.TBPlugin):
         with open(filepath) as infile:
             contents = infile.read()
         return werkzeug.Response(
-            contents, content_type="application/javascript"
+            contents, content_type="text/javascript"
         )
 
     @wrappers.Request.application

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -389,7 +389,7 @@ class TensorBoard(object):
         """
         # Known to be problematic when Visual Studio is installed:
         # <https://github.com/tensorflow/tensorboard/issues/3120>
-        mimetypes.add_type("application/javascript", ".js")
+        mimetypes.add_type("text/javascript", ".js")
         # Not known to be problematic, but used by TensorBoard:
         mimetypes.add_type("font/woff2", ".woff2")
         mimetypes.add_type("text/html", ".html")


### PR DESCRIPTION
While investigating the test failure that lead to #5746, we realized that RFC 9239 (https://www.rfc-editor.org/rfc/rfc9239) has changed the preferred js mimetype to 'text/javascript' from 'application/javascript'.

To be a good citizen of the internet, this change modifies the logic introduced in #3128 to force the mapping of js files to mimetype 'text/javascript'. We must also modify http_util.py to ensure that the proper charset is included in the Content-Type header. And, finally, we modify the example plugin to use 'text/javascript' as mimetype.

To Test:
* I ran local tensorboard and used the chrome developer tools to verify that the Content-Type for js files fetched by the browser was 'text/javascript; charset=utf-8'.  I did a basic sanity test ensuring both Angular and Polymer portions of the application are running.
* I ran a tensorboard with the example plugin installed and verified that index.js is returned with Content-Type 'text/javascript'.