### PR TITLE
step selector: add internalSelectedTime to scalar card

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -361,6 +361,13 @@ export const getMetricsSelectTimeEnabled = createSelector(
   }
 );
 
+export const getMetricsStepSelectorEnabled = createSelector(
+  selectMetricsState,
+  (state: MetricsState): boolean => {
+    return state.stepSelectorEnabled;
+  }
+);
+
 export const getMetricsUseRangeSelectTime = createSelector(
   selectMetricsState,
   (state: MetricsState): boolean => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -168,7 +168,7 @@ limitations under the License.
     </table>
   </ng-template>
 </div>
-<ng-container *ngIf="isDataTableEnabled && selectedTime">
+<ng-container *ngIf="selectedTime">
   <div>
     <tb-data-table
       [headers]="dataHeaders"
@@ -221,13 +221,13 @@ limitations under the License.
   let-domDim="domDimension"
   let-xScale="xScale"
 >
-  <ng-container *ngIf="selectedTime">
+  <ng-container *ngIf="internalSelectedTime || selectedTime">
     <scalar-card-fob-controller
       [linkedTime]="getLinkedTime()"
       [scale]="xScale"
       [minMax]="viewExtent.x"
       [axisSize]="domDim.width"
-      (onSelectTimeChanged)="onSelectTimeChanged.emit($event)"
+      (onSelectTimeChanged)="onFobSelectTimeChanged($event)"
       (onSelectTimeToggle)="onSelectTimeToggle.emit()"
     ></scalar-card-fob-controller>
   </ng-container>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -84,8 +84,8 @@ export class ScalarCardComponent<Downloader> {
   @Input() xScaleType!: ScaleType;
   @Input() useDarkMode!: boolean;
   @Input() forceSvg!: boolean;
-  @Input() isDataTableEnabled!: boolean;
   @Input() selectedTime!: ViewSelectedTime | null;
+  @Input() internalSelectedTime!: LinkedTime;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
@@ -200,8 +200,9 @@ export class ScalarCardComponent<Downloader> {
 
   getLinkedTime(): LinkedTime | null {
     if (this.selectedTime === null) {
-      return null;
+      return this.internalSelectedTime;
     }
+
     return {
       start: {
         step: this.selectedTime!.startStep,
@@ -252,5 +253,13 @@ export class ScalarCardComponent<Downloader> {
       });
 
     return dataTableData;
+  }
+
+  onFobSelectTimeChanged(newSelectedTime: LinkedTime) {
+    this.internalSelectedTime = newSelectedTime;
+
+    if (this.selectedTime !== null) {
+      this.onSelectTimeChanged.emit(newSelectedTime);
+    }
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -221,7 +221,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.fullHeightChanged.emit(this.showFullSize);
   }
 
-  getMinMaxStepInSerise(series: PartitionedSeries[]) {
+  getMinMaxStepInSeries(series: PartitionedSeries[]) {
     let minStep = Infinity;
     let maxStep = -Infinity;
     for (const {points} of series) {
@@ -376,7 +376,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
       map(([series, selectedTime, xAxisType]) => {
         if (xAxisType !== XAxisType.STEP || !selectedTime) return null;
 
-        const {minStep, maxStep} = this.getMinMaxStepInSerise(series);
+        const {minStep, maxStep} = this.getMinMaxStepInSeries(series);
 
         return maybeClipSelectedTime(selectedTime, minStep, maxStep);
       })
@@ -487,7 +487,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
       this.store.select(getMetricsStepSelectorEnabled),
     ]).pipe(
       map(([partitionedSeries, enableStepSelector]) => {
-        const {minStep} = this.getMinMaxStepInSerise(partitionedSeries);
+        const {minStep} = this.getMinMaxStepInSeries(partitionedSeries);
 
         return enableStepSelector ? {start: {step: minStep}, end: null} : null;
       })

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -316,7 +316,7 @@ describe('scalar card', () => {
     store.overrideSelector(selectors.getRunColorMap, {});
     store.overrideSelector(selectors.getDarkModeEnabled, false);
     store.overrideSelector(selectors.getForceSvgFeatureFlag, false);
-    store.overrideSelector(selectors.getIsDataTableEnabled, false);
+    store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
   });
 
   describe('basic renders', () => {
@@ -2444,5 +2444,67 @@ describe('scalar card', () => {
       expect(data[0].STEP).toEqual(10);
       expect(data[1].STEP).toEqual(8);
     }));
+  });
+
+  describe('step selector feature integration', () => {
+    describe('fob controls', () => {
+      let dispatchedActions: Action[] = [];
+      beforeEach(() => {
+        dispatchedActions = [];
+        const runToSeries = {
+          run1: [buildScalarStepData({step: 10})],
+          run2: [buildScalarStepData({step: 20})],
+          run3: [buildScalarStepData({step: 30})],
+        };
+        spyOn(store, 'dispatch').and.callFake((action: Action) => {
+          dispatchedActions.push(action);
+        });
+        provideMockCardRunToSeriesData(
+          selectSpy,
+          PluginType.SCALARS,
+          'card1',
+          null /* metadataOverride */,
+          runToSeries
+        );
+        store.overrideSelector(selectors.getMetricsStepSelectorEnabled, true);
+      });
+
+      it('renders fobs', fakeAsync(() => {
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+        const testController = fixture.debugElement.query(
+          By.directive(CardFobControllerComponent)
+        ).componentInstance;
+
+        expect(testController).toBeTruthy();
+      }));
+
+      it('dose not dispatch timeSelectionChanged action when fob is dragged', fakeAsync(() => {
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+        const testController = fixture.debugElement.query(
+          By.directive(CardFobControllerComponent)
+        ).componentInstance;
+        const controllerStartPosition =
+          testController.root.nativeElement.getBoundingClientRect().left;
+
+        // Simulate dragging fob to step 25.
+        testController.startDrag(Fob.START);
+        const fakeEvent = new MouseEvent('mousemove', {
+          clientX: 25 + controllerStartPosition,
+          movementX: 1,
+        });
+        testController.mouseMove(fakeEvent);
+        fixture.detectChanges();
+
+        const fobs = fixture.debugElement.queryAll(
+          By.directive(CardFobComponent)
+        );
+        expect(
+          fobs[0].query(By.css('span')).nativeElement.textContent.trim()
+        ).toEqual('25');
+        expect(dispatchedActions).toEqual([]);
+      }));
+    });
   });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2354,7 +2354,7 @@ describe('scalar card', () => {
       expect(data[1].STEP).toEqual(15);
     }));
 
-    it('Selects largest points when selectedTime startStep is greater than any points step', fakeAsync(() => {
+    it('selects largest points when selectedTime startStep is greater than any points step', fakeAsync(() => {
       const runToSeries = {
         run1: [
           {wallTime: 1, value: 1, step: 1},
@@ -2400,7 +2400,7 @@ describe('scalar card', () => {
       expect(data[1].STEP).toEqual(50);
     }));
 
-    it('Selects smallest points when selectedTime startStep is less than any points step', fakeAsync(() => {
+    it('selects smallest points when selectedTime startStep is less than any points step', fakeAsync(() => {
       const runToSeries = {
         run1: [
           {wallTime: 1, value: 1, step: 10},
@@ -2479,7 +2479,7 @@ describe('scalar card', () => {
         expect(testController).toBeTruthy();
       }));
 
-      it('dose not dispatch timeSelectionChanged action when fob is dragged', fakeAsync(() => {
+      it('does not dispatch timeSelectionChanged action when fob is dragged', fakeAsync(() => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
         const testController = fixture.debugElement.query(
@@ -2504,6 +2504,15 @@ describe('scalar card', () => {
           fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('25');
         expect(dispatchedActions).toEqual([]);
+        const scalarCardComponent = fixture.debugElement.query(
+          By.directive(ScalarCardComponent)
+        );
+        expect(
+          scalarCardComponent.componentInstance.internalSelectedTime
+        ).toEqual({
+          start: {step: 25},
+          end: null,
+        });
       }));
     });
   });


### PR DESCRIPTION
* Motivation for features / changes
This is part of the work to disconnect fob from linked time. When linked time is disabled, we want to updates the fob location (and corresponding data table) for this scalar card only. This PR adds a new attribute "internalSelectedTime" which exists in component only.

* Technical description of changes
   * We build "internalSelectedTime" inside scalar card. The initial value comes from the min step in this card.
   * We only dispatch timeSelectionChanged when "LinkedTime" is enabled. Whether linkedTime is enabled based on selectedTime inside scalar_card_component, aka `selectedTime===null` if linkedTime is not enabled.
   * Remove feature flag `isDataTableEnabled` and eventually replace with "internalSelectedTime" (The current data table still using linkedTime start step, you will need to enable linked time to see it, later "internalSelectedTime" should be added as OR condition with proper input handling.)

* This initial PR implementation has a couple of known TODOs:
  * render data table when internalSelectedTime is not null
  * consider move range input inside Step Selector
  * apply range visual effect (i.e., faded out out of range area) with internalSelectedTime
  * remember previous selected step after toggle off Step Selector

* Screenshots of UI changes


https://user-images.githubusercontent.com/1131010/172483602-752c836e-e750-4aeb-ba9b-8385482800e7.mov


* Alternate designs / implementations considered
Considered building "internalSelectedTime" in container as observable then using Subject to trigger this observable. Eventually abandon that direction cause it gets complicated to check if selectedTime$ observable has value (aka linked time is enabled)