### PR TITLE
TensorBoard 2.9.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,10 @@
+# Release 2.9.1
+
+## Bug fixes
+
+- Force protobuf dependency < 3.20 to workaround incompatibilities with newer protobuf versions (#5726)
+- Recognize text/javascript as valid js mimetype for caching purposes (#5746)
+
 # Release 2.9.0
 
 The 2.9 minor series tracks TensorFlow 2.9.

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -24,7 +24,11 @@ google-auth >= 1.6.3, < 3
 google-auth-oauthlib >= 0.4.1, < 0.5
 markdown >= 2.6.8
 numpy >= 1.12.0
-protobuf >= 3.9.2
+# Protobuf 4.0 is incompatible with TF. Force < 3.20 until they unblock upgrade.
+# See: http://b/182876485
+# See: https://github.com/protocolbuffers/protobuf/issues/9954#issuecomment-1128283911
+# See: https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/tools/pip_package/setup.py?q=protobuf
+protobuf >= 3.9.2, < 3.20
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
 tensorboard-data-server >= 0.6.0, < 0.7.0

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -39,6 +39,11 @@ logger = tb_logging.get_logger()
 # If no port is specified, try to bind to this port. See help for --port
 # for more details.
 DEFAULT_PORT = 6006
+# Valid javascript mimetypes that we have seen configured, in practice.
+# Historically (~2020-2022) we saw "application/javascript" exclusively but with
+# RFC 9239 (https://www.rfc-editor.org/rfc/rfc9239) we saw some systems quickly
+# transition to 'text/javascript'.
+JS_MIMETYPES = ["text/javascript", "application/javascript"]
 JS_CACHE_EXPIRATION_IN_SECS = 86400
 
 
@@ -133,8 +138,7 @@ class CorePlugin(base_plugin.TBPlugin):
         # Cache JS resources while keep others do not cache.
         expires = (
             JS_CACHE_EXPIRATION_IN_SECS
-            if request.args.get("_file_hash")
-            and mimetype == "application/javascript"
+            if request.args.get("_file_hash") and mimetype in JS_MIMETYPES
             else 0
         )
 

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -19,6 +19,7 @@ import collections.abc
 import contextlib
 import io
 import json
+import mimetypes
 import os
 from unittest import mock
 import zipfile
@@ -150,6 +151,9 @@ class CorePluginTest(tf.test.TestCase):
         app = application.TensorBoardWSGI([self.plugin])
         self.server = werkzeug_test.Client(app, wrappers.Response)
 
+    def tearDown(self):
+        mimetypes.init()
+
     def _add_run(self, run_name):
         run_path = os.path.join(self.logdir, run_name)
         with test_util.FileWriter(run_path) as writer:
@@ -191,6 +195,34 @@ class CorePluginTest(tf.test.TestCase):
         )
 
     def test_js_cache(self):
+        """Tests cache header for js files marked for caching.
+
+        The test relies on local system's defaults for the javascript mimetype
+        which, in practice, should be one of 'text/javascript' or
+        'application/javascript'. It could be either, depending on the system.
+
+        See test_js_cache_with_text_javascript() and
+        test_js_cache_with_application_javascript() for test cases where
+        the javascript mimetype have been explicitly configured.
+        """
+        response = self.server.get("/index.js?_file_hash=meow")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            ONE_DAY_CACHE_CONTROL_VALUE, response.headers.get("Cache-Control")
+        )
+
+    def test_js_cache_with_text_javascript(self):
+        """Tests cache header when js mimetype is 'text/javascript'."""
+        mimetypes.add_type("text/javascript", ".js")
+        response = self.server.get("/index.js?_file_hash=meow")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            ONE_DAY_CACHE_CONTROL_VALUE, response.headers.get("Cache-Control")
+        )
+
+    def test_js_cache_with_application_javascript(self):
+        """Tests cache header when js mimetype is 'application/javascript'."""
+        mimetypes.add_type("application/javascript", ".js")
         response = self.server.get("/index.js?_file_hash=meow")
         self.assertEqual(200, response.status_code)
         self.assertEqual(

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = "2.9.0"
+VERSION = "2.9.1"


### PR DESCRIPTION
Cherrypicks:
* 174d8a6d35d Force protobuf dependency < 3.20.
* 28201b437ef Recognize text/javascript as valid js mimetype for caching purposes