### PR TITLE
step selector: renders data table element on feature enabled

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -364,6 +364,7 @@ tf_ts_library(
         "//tensorboard/webapp/widgets:resize_detector_testing",
         "//tensorboard/webapp/widgets/card_fob",
         "//tensorboard/webapp/widgets/card_fob:types",
+        "//tensorboard/webapp/widgets/data_table",
         "//tensorboard/webapp/widgets/experiment_alias",
         "//tensorboard/webapp/widgets/histogram:types",
         "//tensorboard/webapp/widgets/intersection_observer:intersection_observer_testing",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -168,7 +168,7 @@ limitations under the License.
     </table>
   </ng-template>
 </div>
-<ng-container *ngIf="selectedTime">
+<ng-container *ngIf="internalSelectedTime || selectedTime">
   <div>
     <tb-data-table
       [headers]="dataHeaders"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -214,9 +214,12 @@ export class ScalarCardComponent<Downloader> {
   }
 
   getSelectedTimeTableData(): SelectedStepRunData[] {
-    if (this.selectedTime === null) {
+    if (this.selectedTime === null && this.internalSelectedTime === null) {
       return [];
     }
+    const startStep = this.selectedTime
+      ? this.selectedTime.startStep
+      : this.internalSelectedTime.start.step;
     const dataTableData: SelectedStepRunData[] = this.dataSeries
       .filter((datum) => {
         const metadata = this.chartMetadataMap[datum.id];
@@ -225,9 +228,7 @@ export class ScalarCardComponent<Downloader> {
       .map((datum) => {
         const metadata = this.chartMetadataMap[datum.id];
         const closestStartPoint =
-          datum.points[
-            findClosestIndex(datum.points, this.selectedTime!.startStep)
-          ];
+          datum.points[findClosestIndex(datum.points, startStep)];
         const selectedStepData: SelectedStepRunData = {};
         selectedStepData.COLOR = metadata.color;
         for (const header of this.dataHeaders) {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -221,11 +221,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.fullHeightChanged.emit(this.showFullSize);
   }
 
-<<<<<<< HEAD
   getMinMaxStepInSeries(series: PartitionedSeries[]) {
-=======
-  getMinMaxStepInSerise(series: PartitionedSeries[]) {
->>>>>>> 0722d2093 (add internalSelectedTime)
     let minStep = Infinity;
     let maxStep = -Infinity;
     for (const {points} of series) {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -221,7 +221,11 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.fullHeightChanged.emit(this.showFullSize);
   }
 
+<<<<<<< HEAD
   getMinMaxStepInSeries(series: PartitionedSeries[]) {
+=======
+  getMinMaxStepInSerise(series: PartitionedSeries[]) {
+>>>>>>> 0722d2093 (add internalSelectedTime)
     let minStep = Infinity;
     let maxStep = -Infinity;
     for (const {points} of series) {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -51,6 +51,8 @@ import {
   Fob,
 } from '../../../widgets/card_fob/card_fob_controller_component';
 import {CardFobModule} from '../../../widgets/card_fob/card_fob_module';
+import {DataTableComponent} from '../../../widgets/data_table/data_table_component';
+import {DataTableModule} from '../../../widgets/data_table/data_table_module';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
 import {IntersectionObserverTestingModule} from '../../../widgets/intersection_observer/intersection_observer_testing_module';
 import {
@@ -266,6 +268,7 @@ describe('scalar card', () => {
         ExperimentAliasModule,
         IntersectionObserverTestingModule,
         CardFobModule,
+        DataTableModule,
         MatDialogModule,
         MatIconTestingModule,
         MatMenuModule,
@@ -2245,6 +2248,50 @@ describe('scalar card', () => {
         expect(dispatchedActions).toEqual([selectTimeEnableToggled()]);
       }));
     });
+
+    describe('scalar card data table', () => {
+      beforeEach(() => {
+        const runToSeries = {
+          run1: [buildScalarStepData({step: 10})],
+          run2: [buildScalarStepData({step: 20})],
+          run3: [buildScalarStepData({step: 30})],
+        };
+        provideMockCardRunToSeriesData(
+          selectSpy,
+          PluginType.SCALARS,
+          'card1',
+          null /* metadataOverride */,
+          runToSeries
+        );
+      });
+
+      it('renders table', fakeAsync(() => {
+        store.overrideSelector(getMetricsSelectedTime, {
+          start: {step: 20},
+          end: null,
+        });
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+
+        const dataTableComponentInstance = fixture.debugElement.query(
+          By.directive(DataTableComponent)
+        ).componentInstance;
+
+        expect(dataTableComponentInstance).toBeTruthy();
+      }));
+
+      it('does not render table when disabled', fakeAsync(() => {
+        store.overrideSelector(getMetricsSelectedTime, null);
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+
+        const dataTableComponent = fixture.debugElement.query(
+          By.directive(DataTableComponent)
+        );
+
+        expect(dataTableComponent).toBeFalsy();
+      }));
+    });
   });
 
   describe('getSelectedTimeTableData', () => {
@@ -2513,6 +2560,47 @@ describe('scalar card', () => {
           start: {step: 25},
           end: null,
         });
+      }));
+    });
+
+    describe('scalar card data table', () => {
+      beforeEach(() => {
+        const runToSeries = {
+          run1: [buildScalarStepData({step: 10})],
+          run2: [buildScalarStepData({step: 20})],
+          run3: [buildScalarStepData({step: 30})],
+        };
+        provideMockCardRunToSeriesData(
+          selectSpy,
+          PluginType.SCALARS,
+          'card1',
+          null /* metadataOverride */,
+          runToSeries
+        );
+      });
+
+      it('renders data table', fakeAsync(() => {
+        store.overrideSelector(selectors.getMetricsStepSelectorEnabled, true);
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+
+        const dataTableComponentInstance = fixture.debugElement.query(
+          By.directive(DataTableComponent)
+        ).componentInstance;
+
+        expect(dataTableComponentInstance).toBeTruthy();
+      }));
+
+      it('does not render table when disabled', fakeAsync(() => {
+        store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+
+        const dataTableComponent = fixture.debugElement.query(
+          By.directive(DataTableComponent)
+        );
+
+        expect(dataTableComponent).toBeFalsy();
       }));
     });
   });


### PR DESCRIPTION
* Motivation for features / changes
Currently the data table with selected step data when step (i.e.,`<tb-data-table>`) is rendered only when linkedTime is enabled (aka `selectTime!==null`). We want to render the table when step selector is enabled.

* Technical description of changes
This PR adds OR condition on `<tb-data-table>` rendering and the selected step fallback to `internalSelectedTime` if `selectTime` is null. 

* Screenshots of UI changes
`<tb-data-table>` is rendered when "Step Selector" is enabled but "Link visualization" is disabled 

![Screen Shot 2022-06-08 at 3 36 40 PM](https://user-images.githubusercontent.com/1131010/172728968-c1ca1bbe-a61c-48a2-935a-a590f49d257c.png)
