### PR TITLE
step selector: updates selected time to single selection only

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -256,7 +256,11 @@ export class ScalarCardComponent<Downloader> {
   }
 
   onFobSelectTimeChanged(newSelectedTime: LinkedTime) {
-    this.internalSelectedTime = newSelectedTime;
+    // Updates step selector to single selection.
+    this.internalSelectedTime = {
+      start: {step: newSelectedTime.start.step},
+      end: null,
+    };
 
     if (this.selectedTime !== null) {
       this.onSelectTimeChanged.emit(newSelectedTime);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2530,7 +2530,7 @@ describe('scalar card', () => {
 
         // Simulate dragging start fob to step 25
         testController.startDrag(Fob.START);
-        const fakeEvent = new MouseEvent('mousemove', {
+        let fakeEvent = new MouseEvent('mousemove', {
           clientX: 25 + controllerStartPosition,
           movementX: 1,
         });
@@ -2538,10 +2538,9 @@ describe('scalar card', () => {
         fixture.detectChanges();
 
         // Simulate dragging end fob to step 28
-        testControllerstopDrag();
-        testController.(Fob.END);
+        testController.stopDrag();
         testController.startDrag(Fob.END);
-        const fakeEvent = new MouseEvent('mousemove', {
+        fakeEvent = new MouseEvent('mousemove', {
           clientX: 28 + controllerStartPosition,
           movementX: 1,
         });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2514,6 +2514,51 @@ describe('scalar card', () => {
           end: null,
         });
       }));
+
+      it('sets internalSelectedTime to single selection', fakeAsync(() => {
+        store.overrideSelector(getMetricsSelectedTime, {
+          start: {step: 20},
+          end: {step: 40},
+        });
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+        const testController = fixture.debugElement.query(
+          By.directive(CardFobControllerComponent)
+        ).componentInstance;
+        const controllerStartPosition =
+          testController.root.nativeElement.getBoundingClientRect().left;
+
+        // Simulate dragging fob to step 25.
+        testController.startDrag(Fob.START);
+        const fakeEvent = new MouseEvent('mousemove', {
+          clientX: 25 + controllerStartPosition,
+          movementX: 1,
+        });
+        testController.mouseMove(fakeEvent);
+        fixture.detectChanges();
+
+        // Disable linked time
+        store.overrideSelector(getMetricsSelectedTime, null);
+        store.refreshState();
+        fixture.detectChanges();
+
+        const fobs = fixture.debugElement.queryAll(
+          By.directive(CardFobComponent)
+        );
+        expect(fobs.length).toBe(1);
+        expect(
+          fobs[0].query(By.css('span')).nativeElement.textContent.trim()
+        ).toEqual('25');
+        const scalarCardComponent = fixture.debugElement.query(
+          By.directive(ScalarCardComponent)
+        );
+        expect(
+          scalarCardComponent.componentInstance.internalSelectedTime
+        ).toEqual({
+          start: {step: 25},
+          end: null,
+        });
+      }));
     });
   });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2528,10 +2528,21 @@ describe('scalar card', () => {
         const controllerStartPosition =
           testController.root.nativeElement.getBoundingClientRect().left;
 
-        // Simulate dragging fob to step 25.
+        // Simulate dragging start fob to step 25
         testController.startDrag(Fob.START);
         const fakeEvent = new MouseEvent('mousemove', {
           clientX: 25 + controllerStartPosition,
+          movementX: 1,
+        });
+        testController.mouseMove(fakeEvent);
+        fixture.detectChanges();
+
+        // Simulate dragging end fob to step 28
+        testControllerstopDrag();
+        testController.(Fob.END);
+        testController.startDrag(Fob.END);
+        const fakeEvent = new MouseEvent('mousemove', {
+          clientX: 28 + controllerStartPosition,
           movementX: 1,
         });
         testController.mouseMove(fakeEvent);


### PR DESCRIPTION
* Motivation for features / changes
To cope with launch phases we only apply single selection to step selector for now. Therefore when dragging fob to new selected time, we update start step and sets end to null. This prevents having two fobs after linked time launch, which enables users to set range selection. The type of internalSelectedTime is still LinkedTime, which reserves future extension to range selection of step selector.

* Technical description of changes
On fob changed, we set the start step instead of LinkedTime object.

* Screenshots of UI changes


https://user-images.githubusercontent.com/1131010/172928846-f19ab1e5-0582-4526-8a57-e80a4ba7f43b.mov



