### PR TITLE
fix argument type error and tslint

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -831,7 +831,7 @@ describe('runs_table', () => {
           })
         );
 
-        const dialogInputDebugElement: DebugElement = new DebugElement(
+        const dialogInputDebugElement = new DebugElement(
           overlayContainer
             .getContainerElement()
             .querySelector('mat-dialog-container input')!
@@ -864,7 +864,7 @@ describe('runs_table', () => {
         const [cancelButton, saveButton] =
           dialogContainer!.querySelectorAll('button');
 
-        const dialogInputDebugElement: DebugElement = new DebugElement(
+        const dialogInputDebugElement = new DebugElement(
           overlayContainer
             .getContainerElement()
             .querySelector('mat-dialog-container input')!

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -834,7 +834,7 @@ describe('runs_table', () => {
         const dialogInputDebugElement: DebugElement = new DebugElement(
           overlayContainer
             .getContainerElement()
-            .querySelector('mat-dialog-container input')
+            .querySelector('mat-dialog-container input')!
         );
         sendKeys(fixture, dialogInputDebugElement, 'foo(\\d+)');
 
@@ -867,7 +867,7 @@ describe('runs_table', () => {
         const dialogInputDebugElement: DebugElement = new DebugElement(
           overlayContainer
             .getContainerElement()
-            .querySelector('mat-dialog-container input')
+            .querySelector('mat-dialog-container input')!
         );
         sendKeys(fixture, dialogInputDebugElement, 'foo(\\d+)');
 


### PR DESCRIPTION
Fixing the following error when running internally:
```
error TS2345: Argument of type 'Element | null' is not assignable to parameter of type 'Element'.
  Type 'null' is not assignable to type 'Element'.
```
Also fixed tslint (redundant type annotation).

#refactor