### PR TITLE
fix flaky test

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1664,7 +1664,7 @@ describe('metrics main view', () => {
         expect(indicator).toBeTruthy();
       });
 
-      it('shows the indicator when the same card gets pinned toggled', async () => {
+      it('shows the indicator when the same card gets pinned toggled', fakeAsync(() => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -1682,8 +1682,9 @@ describe('metrics main view', () => {
         updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        // Wait for the indicator to fade completely before repinning card2.
-        await fixture.whenStable();
+        // Wait for 3s + 100ms for the new card indicator animation to complete:
+        // https://github.com/tensorflow/tensorboard/blob/master/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss#L48
+        tick(3100);
         updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
@@ -1696,7 +1697,7 @@ describe('metrics main view', () => {
         expect(card2IndicatorBefore.attributes['data-id']).not.toBe(
           card2IndicatorAfter.attributes['data-id']
         );
-      });
+      }));
 
       it('does not show indicator when you remove a pin', () => {
         const fixture = TestBed.createComponent(MainViewContainer);

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1682,15 +1682,15 @@ describe('metrics main view', () => {
         updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        // Wait for 3s + 100ms for the new card indicator animation to complete:
-        // https://github.com/tensorflow/tensorboard/blob/master/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss#L48
-        tick(3100);
+        // Wait for 100ms before repinning to avoid flakiness.
+        tick(100);
         updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
         const card2IndicatorAfter = fixture.debugElement.query(byCss.INDICATOR);
 
+        // It should be a different new-card-pinned indicator instance.
         expect(card2IndicatorBefore.nativeElement).not.toBe(
           card2IndicatorAfter.nativeElement
         );

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1625,7 +1625,7 @@ describe('metrics main view', () => {
         INDICATOR: By.css('.new-card-pinned'),
       };
 
-      function updatePinnedCards(
+      async function updatePinnedCards(
         fixture: ComponentFixture<MainViewContainer>,
         pinnedCardMetadata: CardIdWithMetadata[]
       ) {
@@ -1635,27 +1635,28 @@ describe('metrics main view', () => {
         );
         store.refreshState();
         fixture.detectChanges();
+        await fixture.whenStable();
       }
 
-      it('does not show any indicator initially', () => {
+      it('does not show any indicator initially', async () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
         const indicator = fixture.debugElement.query(byCss.INDICATOR);
         expect(indicator).toBeNull();
       });
 
-      it('shows an indication when pin a new card', () => {
+      it('shows an indication when pin a new card', async () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
@@ -1664,24 +1665,24 @@ describe('metrics main view', () => {
         expect(indicator).toBeTruthy();
       });
 
-      it('shows the indicator when the same card gets pinned toggled', () => {
+      it('shows the indicator when the same card gets pinned toggled', async () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
         const card2IndicatorBefore = fixture.debugElement.query(
           byCss.INDICATOR
         );
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
@@ -1695,15 +1696,15 @@ describe('metrics main view', () => {
         );
       });
 
-      it('does not show indicator when you remove a pin', () => {
+      it('does not show indicator when you remove a pin', async () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
 
@@ -1711,15 +1712,15 @@ describe('metrics main view', () => {
         expect(indicator).toBeNull();
       });
 
-      it('shows an indicator a change contains both removal and addition', () => {
+      it('shows an indicator a change contains both removal and addition', async () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        updatePinnedCards(fixture, [
+        await updatePinnedCards(fixture, [
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card3', ...createCardMetadata(PluginType.SCALARS)},
         ]);

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1664,7 +1664,7 @@ describe('metrics main view', () => {
         expect(indicator).toBeTruthy();
       });
 
-      it('shows the indicator when the same card gets pinned toggled', () => {
+      it('shows the indicator when the same card gets pinned toggled', async () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
@@ -1678,9 +1678,12 @@ describe('metrics main view', () => {
         const card2IndicatorBefore = fixture.debugElement.query(
           byCss.INDICATOR
         );
+        // Unpin card2.
         updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
+        // Wait for the indicator to fade completely before repinning card2.
+        await fixture.whenStable();
         updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1625,7 +1625,7 @@ describe('metrics main view', () => {
         INDICATOR: By.css('.new-card-pinned'),
       };
 
-      async function updatePinnedCards(
+      function updatePinnedCards(
         fixture: ComponentFixture<MainViewContainer>,
         pinnedCardMetadata: CardIdWithMetadata[]
       ) {
@@ -1635,28 +1635,27 @@ describe('metrics main view', () => {
         );
         store.refreshState();
         fixture.detectChanges();
-        await fixture.whenStable();
       }
 
-      it('does not show any indicator initially', async () => {
+      it('does not show any indicator initially', () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
         const indicator = fixture.debugElement.query(byCss.INDICATOR);
         expect(indicator).toBeNull();
       });
 
-      it('shows an indication when pin a new card', async () => {
+      it('shows an indication when pin a new card', () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
@@ -1665,24 +1664,24 @@ describe('metrics main view', () => {
         expect(indicator).toBeTruthy();
       });
 
-      it('shows the indicator when the same card gets pinned toggled', async () => {
+      it('shows the indicator when the same card gets pinned toggled', () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
         const card2IndicatorBefore = fixture.debugElement.query(
           byCss.INDICATOR
         );
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
@@ -1696,15 +1695,15 @@ describe('metrics main view', () => {
         );
       });
 
-      it('does not show indicator when you remove a pin', async () => {
+      it('does not show indicator when you remove a pin', () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
 
@@ -1712,15 +1711,15 @@ describe('metrics main view', () => {
         expect(indicator).toBeNull();
       });
 
-      it('shows an indicator a change contains both removal and addition', async () => {
+      it('shows an indicator a change contains both removal and addition', () => {
         const fixture = TestBed.createComponent(MainViewContainer);
         fixture.detectChanges();
 
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card1', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
         ]);
-        await updatePinnedCards(fixture, [
+        updatePinnedCards(fixture, [
           {cardId: 'card2', ...createCardMetadata(PluginType.SCALARS)},
           {cardId: 'card3', ...createCardMetadata(PluginType.SCALARS)},
         ]);


### PR DESCRIPTION
Wait 100ms before repinning the card and checking the indicator, to avoid the following flakiness:
```
Chrome Headless 84.0.4147.0 (Linux x86_64) metrics main view pinned view new pinned indicator shows the indicator when the same card gets pinned toggled FAILED
        Error: Expected <span _ngcontent-a-c329 class="new-card-pinned" data-id="1000">...</span> not to be <span _ngcontent-a-c329 class="new-card-pinned" data-id="1000">...</span>. Tip: To check for deep equality, use .toEqual() instead of .toBe().
            at <Jasmine>
            at UserContext.<anonymous> (tensorboard/webapp/metrics/views/main_view/main_view_test.ts:1690:56 <- org_tensorflow_tensorboard/tensorboard/webapp/metrics/views/main_view/main_view_test.js:1228:68)
            at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-testing-bundle.js:407:30)
            at ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing-bundle.js:3765:43)

        Error: Expected '1000' not to be '1000'.
            at <Jasmine>
            at UserContext.<anonymous> (tensorboard/webapp/metrics/views/main_view/main_view_test.ts:1693:64 <- org_tensorflow_tensorboard/tensorboard/webapp/metrics/views/main_view/main_view_test.js:1229:76)
            at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-testing-bundle.js:407:30)
            at ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing-bundle.js:3765:43)
```

Tested locally for flakiness with `--runs_per_test=1000 --runs_per_test_detects_flakes=true`, the error above didn't occur once in the 1000 runs.

Googlers, see b/235125954 for full details.

#refactor #jubilee
