### PR TITLE
Remove transitive dep from tensorboard polymer on Angular.

### DIFF
--- a/tensorboard/webapp/feature_flag/http/BUILD
+++ b/tensorboard/webapp/feature_flag/http/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_ng_module(
+tf_ts_library(
     name = "const",
     srcs = [
         "const.ts",


### PR DESCRIPTION
Change `tensorboard/webapp/feature_flag/http:const` target to use `tf_ts_library` instead of `tf_ng_module`. const.ts does not have any dependency on Angular so using `tf_ng_module` was unnecessary and created a transitive dependency from our polymer codebase to Angular, which we don't like (this was caught by internal tests).