### PR TITLE
Remediate setup-node GH Action warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
         with:
           # default on setup-node@1 is v10.24.1.
-          version: '12.21.0'
+          node-version: '12.21.0'
       - run: yarn install --ignore-engines
         # You can run `yarn fix-lint` to fix all Prettier complaints.
       - run: yarn lint


### PR DESCRIPTION
The `setup-node` GH Action currently specifies `version` (which has been
deprecated since October 1, 2019) instead of `node-version`.

Current action output:
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/13921855/175368640-541479f0-ef98-4a6b-a45a-ba2cca9661a2.png">

After this change:
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/13921855/175368721-c11b4921-f0a4-45b7-bd3a-77c5a5ddddc3.png">

