### PR TITLE
step selector: extends the height of scalar card when step selector is enabled

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -160,5 +160,5 @@ $_title-to-heading-gap: 12px;
 .data-table-container {
   width: 100%;
   height: 100px;
-  overflow: scroll;
+  overflow: auto;
 }

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -23,6 +23,7 @@ limitations under the License.
   <div class="card-grid" [style.grid-template-columns]="gridTemplateColumn">
     <card-view
       *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
+      [ngClass]="isStepSelectorEnabled && item.plugin === PluginType.SCALARS ? 'height-with-table' : ''"
       [cardId]="item.cardId"
       [groupName]="groupName"
       [pluginType]="item.plugin"

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -46,6 +46,7 @@ export class CardGridComponent {
   @Input() cardMinWidth!: number | null;
   @Input() cardObserver!: CardObserver;
   @Input() showPaginationControls!: boolean;
+  @Input() isStepSelectorEnabled!: boolean;
 
   @Output() pageIndexChanged = new EventEmitter<number>();
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -27,6 +27,7 @@ import {State} from '../../../app_state';
 import {
   getEnabledCardWidthSetting,
   getMetricsCardMinWidth,
+  getMetricsStepSelectorEnabled,
   getMetricsTagGroupExpansionState,
 } from '../../../selectors';
 import {selectors as settingsSelectors} from '../../../settings';
@@ -44,6 +45,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
       [cardIdsWithMetadata]="pagedItems$ | async"
       [cardMinWidth]="cardMinWidth$ | async"
       [cardObserver]="cardObserver"
+      [isStepSelectorEnabled]="isStepSelectorEnabled$ | async"
       (pageIndexChanged)="onPageIndexChanged($event)"
     >
     </metrics-card-grid-component>
@@ -60,6 +62,10 @@ export class CardGridContainer implements OnChanges, OnDestroy {
   readonly pageIndex$ = new BehaviorSubject<number>(0);
   private readonly items$ = new BehaviorSubject<CardIdWithMetadata[]>([]);
   private readonly ngUnsubscribe = new Subject<void>();
+
+  readonly isStepSelectorEnabled$ = this.store.select(
+    getMetricsStepSelectorEnabled
+  );
 
   readonly numPages$ = combineLatest([
     this.items$,

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -91,6 +91,7 @@ describe('card grid', () => {
     store.overrideSelector(getEnabledCardWidthSetting, false);
     store.overrideSelector(getMetricsCardMinWidth, 30);
     store.overrideSelector(settingsSelectors.getPageSize, 10);
+    store.overrideSelector(getMetricsStepSelectorEnabled, false);
   });
 
   it('keeps pagination button position when page size changes', fakeAsync(() => {


### PR DESCRIPTION
* Motivation for features / changes
We have put a data table inside the scalar card but the table is squeezed in the original card space. We want to create extra height for the card when the table is rendered. Please see screenshots below 

* Technical description of changes
There is a pre-defined class `height-with-table` which increase the min height from the original card height (320px) to 100px more. This is not perfect in many scenarios but good enough for now. Also I guess for those not-so-good-looking scenarios it does not happen often. (for example, histogram card and scalar card under the same tag and placed in the same row)

* Screenshots of UI changes
Before 
<img width="562" alt="Screen Shot 2022-06-23 at 1 40 36 PM" src="https://user-images.githubusercontent.com/1131010/175398649-7bc27df2-39db-4a21-bb43-e2a6fb5ca792.png">

After 
![Screen Shot 2022-06-22 at 4 12 28 PM](https://user-images.githubusercontent.com/1131010/175399392-3869f140-db7a-4e07-9733-f72a324666ac.png)

![Screen Shot 2022-06-23 at 2 02 58 PM](https://user-images.githubusercontent.com/1131010/175399405-beca38f1-397c-44ca-ac2e-f6f57f9c9b97.png)


Known css flaw:
1. All cards on the same row will have the same height. Therefore if step selector is enabled and there is one scalar card in the row, it increases height for all other non-scalar cards. 
![Screen Shot 2022-06-22 at 4 19 45 PM](https://user-images.githubusercontent.com/1131010/175398664-61f6191a-2cfe-40c7-acbe-759d806deba2.png)

2. For fewer runs we do not lower the height (still 100px more) therefore there might be some weird blank space. Dynamically changing the height cause re-rendering that we don't really want
![Screen Shot 2022-06-23 at 2 05 46 PM](https://user-images.githubusercontent.com/1131010/175399740-4b2b60b4-7c95-4ed0-a669-0cf92797ed12.png)
