### PR TITLE
step selector: add missing dep for @angular/core/testing

### DIFF
--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -34,6 +34,7 @@ tf_ts_library(
     ],
     deps = [
         ":data_table",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",


### PR DESCRIPTION
The file data_table_test.ts as added in https://github.com/tensorflow/tensorboard/pull/5767 uses `@angular/core/testing`, and for that import, we require this placeholder dep in order to sync properly internal to Google.