### PR TITLE
step selector: deselect fob in step selector

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -228,7 +228,7 @@ limitations under the License.
       [minMax]="viewExtent.x"
       [axisSize]="domDim.width"
       (onSelectTimeChanged)="onFobSelectTimeChanged($event)"
-      (onSelectTimeToggle)="onSelectTimeToggle.emit()"
+      (onSelectTimeToggle)="onFobRemoved()"
     ></scalar-card-fob-controller>
   </ng-container>
 </ng-template>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -91,6 +91,7 @@ export class ScalarCardComponent<Downloader> {
   @Output() onPinClicked = new EventEmitter<boolean>();
   @Output() onSelectTimeChanged = new EventEmitter<LinkedTime>();
   @Output() onSelectTimeToggle = new EventEmitter();
+  @Output() onStepSelectorToggle = new EventEmitter();
 
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)
@@ -265,6 +266,14 @@ export class ScalarCardComponent<Downloader> {
 
     if (this.selectedTime !== null) {
       this.onSelectTimeChanged.emit(newSelectedTime);
+    }
+  }
+
+  onFobRemoved() {
+    if (this.selectedTime !== null) {
+      this.onSelectTimeToggle.emit();
+    } else {
+      this.onStepSelectorToggle.emit();
     }
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -53,7 +53,11 @@ import {DataLoadState} from '../../../types/data';
 import {LinkedTime} from '../../../widgets/card_fob/card_fob_types';
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
-import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
+import {
+  selectTimeEnableToggled,
+  stepSelectorEnableToggled,
+  timeSelectionChanged,
+} from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
   getCardLoadState,
@@ -139,6 +143,7 @@ function areSeriesEqual(
       (onVisibilityChange)="onVisibilityChange($event)"
       (onSelectTimeChanged)="onSelectTimeChanged($event)"
       (onSelectTimeToggle)="onSelectTimeToggle()"
+      (onStepSelectorToggle)="onStepSelectorToggle()"
     ></scalar-card-component>
   `,
   styles: [
@@ -552,5 +557,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   onSelectTimeToggle() {
     this.store.dispatch(selectTimeEnableToggled());
+  }
+
+  onStepSelectorToggle() {
+    this.store.dispatch(stepSelectorEnableToggled());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2621,7 +2621,7 @@ describe('scalar card', () => {
         });
       }));
 
-      it('toggles selected time when single fob is deselected in step selector', fakeAsync(() => {
+      it('toggles when single fob is deselected', fakeAsync(() => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
         const fobComponent = fixture.debugElement.query(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -69,7 +69,11 @@ import {
 } from '../../../widgets/line_chart_v2/types';
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
-import {selectTimeEnableToggled, timeSelectionChanged} from '../../actions';
+import {
+  selectTimeEnableToggled,
+  stepSelectorEnableToggled,
+  timeSelectionChanged,
+} from '../../actions';
 import {PluginType} from '../../data_source';
 import {getMetricsScalarSmoothing, getMetricsSelectedTime} from '../../store';
 import {
@@ -2615,6 +2619,17 @@ describe('scalar card', () => {
           start: {step: 25},
           end: null,
         });
+      }));
+
+      it('toggles selected time when single fob is deselected in step selector', fakeAsync(() => {
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+        const fobComponent = fixture.debugElement.query(
+          By.directive(CardFobComponent)
+        ).componentInstance;
+        fobComponent.fobRemoved.emit();
+
+        expect(dispatchedActions).toEqual([stepSelectorEnableToggled()]);
       }));
     });
 

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -92,6 +92,7 @@ describe('metrics right_pane', () => {
       store.overrideSelector(selectors.getEnabledCardWidthSetting, false);
       store.overrideSelector(selectors.getMetricsCardMinWidth, null);
       store.overrideSelector(selectors.getMetricsSelectTimeEnabled, false);
+      store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
       store.overrideSelector(selectors.getMetricsUseRangeSelectTime, false);
       store.overrideSelector(selectors.getMetricsSelectedTimeSetting, {
         start: {step: 0},
@@ -441,7 +442,7 @@ describe('metrics right_pane', () => {
         });
       });
 
-      describe('step selector', () => {
+      describe('range input', () => {
         it('displays tb-range-input on both single and range step selection mode', () => {
           store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
           store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
@@ -549,6 +550,18 @@ describe('metrics right_pane', () => {
             'aria-checked'
           ]
         ).toBe('false');
+      });
+
+      it('renders checked feature', () => {
+        store.overrideSelector(selectors.getMetricsStepSelectorEnabled, true);
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        expect(
+          select(fixture, '.scalars-step-selector input').attributes[
+            'aria-checked'
+          ]
+        ).toBe('true');
       });
 
       it('dispatches stepSelectorEnableToggled on toggle', () => {

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -129,10 +129,10 @@ limitations under the License.
 
   <div
     class="control-row scalars-step-selector"
-    *ngIf="isScalarStepSelectorEnabled"
+    *ngIf="isScalarStepSelectorFeatureEnabled"
   >
     <mat-checkbox
-      [checked]="stepSelectorEnabled"
+      [checked]="isScalarStepSelectorEnabled"
       (change)="stepSelectorEnableToggled.emit()"
       >Step Selector</mat-checkbox
     >

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -65,6 +65,7 @@ export class SettingsViewComponent {
 
   @Input() isCardWidthSettingEnabled!: boolean;
   @Input() isLinkedTimeFeatureEnabled!: boolean;
+  @Input() isScalarStepSelectorFeatureEnabled!: boolean;
   @Input() isScalarStepSelectorEnabled!: boolean;
   @Input() selectTimeEnabled!: boolean;
   @Input() useRangeSelectTime!: boolean;

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -68,6 +68,9 @@ import {HistogramMode, LinkedTime, TooltipSort, XAxisType} from '../../types';
       [imageShowActualSize]="imageShowActualSize$ | async"
       (imageShowActualSizeChanged)="onImageShowActualSizeChanged()"
       [isLinkedTimeFeatureEnabled]="isLinkedTimeFeatureEnabled$ | async"
+      [isScalarStepSelectorFeatureEnabled]="
+        isScalarStepSelectorFeatureEnabled$ | async
+      "
       [isScalarStepSelectorEnabled]="isScalarStepSelectorEnabled$ | async"
       [selectTimeEnabled]="selectTimeEnabled$ | async"
       [selectedTime]="selectedTime$ | async"
@@ -90,8 +93,10 @@ export class SettingsViewContainer {
   readonly isLinkedTimeFeatureEnabled$: Observable<boolean> = this.store.select(
     selectors.getIsLinkedTimeEnabled
   );
-  readonly isScalarStepSelectorEnabled$: Observable<boolean> =
+  readonly isScalarStepSelectorFeatureEnabled$: Observable<boolean> =
     this.store.select(selectors.getIsDataTableEnabled);
+  readonly isScalarStepSelectorEnabled$: Observable<boolean> =
+    this.store.select(selectors.getMetricsStepSelectorEnabled);
   readonly selectTimeEnabled$: Observable<boolean> = this.store.select(
     selectors.getMetricsSelectTimeEnabled
   );


### PR DESCRIPTION
* Motivation for features / changes
The behavior of deselect fob still connects to linked time behavior (update "selectTimeEnableToggled", which is for linked time). We want to make the fob disappear when we deselect it in step selector single selection. This PR checks whether linked time is enabled and fires `stepSelectorEnableToggled` or `selectTimeEnableToggled` actions accordingly.

* Technical description of changes
1. fire `stepSelectorEnableToggled` action when linked time is not enabled. The "onSelectTimeToggle" is for linked time change selected time in ngrx state. When it's step selector, we do not have selected step in state (storing in each card level)
2. fix step selector checking bug: it's probably misunderstanding and misuse. `isScalarStepSelectorFeatureEnabled` is about wheteh the feature flag is turned on. `isScalarStepSelectorEnabled` is when users check/uncheck step selector.

* Demo


https://user-images.githubusercontent.com/1131010/176325540-24f330b2-37fa-4f57-9c55-4a5445940d14.mov


