### PR TITLE
Stop removing empty aliases from experiment id to alias map

### DIFF
--- a/tensorboard/webapp/app_routing/store_only_utils.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils.ts
@@ -38,7 +38,7 @@ export function getCompareExperimentIdAliasWithNumberSpec(
   let aliasNumber = 0;
   for (const {id, name} of nameAndIds) {
     aliasNumber++;
-    if (idToDisplayName.has(id) || !name) {
+    if (idToDisplayName.has(id)) {
       continue;
     }
     idToDisplayName.set(id, {aliasText: name, aliasNumber: aliasNumber});

--- a/tensorboard/webapp/app_routing/store_only_utils_test.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils_test.ts
@@ -53,6 +53,28 @@ describe('app_routing store_only_utils test', () => {
       );
     });
 
+    it('includes empty aliases', () => {
+      let map = getCompareExperimentIdAliasWithNumberSpec({
+        experimentIds: 'a:123,:345',
+      });
+      expect(map).toEqual(
+        new Map([
+          ['123', {aliasText: 'a', aliasNumber: 1}],
+          ['345', {aliasText: '', aliasNumber: 2}],
+        ])
+      );
+      map = getCompareExperimentIdAliasWithNumberSpec({
+        experimentIds: 'a:123,:345,c:567',
+      });
+      expect(map).toEqual(
+        new Map([
+          ['123', {aliasText: 'a', aliasNumber: 1}],
+          ['345', {aliasText: '', aliasNumber: 2}],
+          ['567', {aliasText: 'c', aliasNumber: 3}],
+        ])
+      );
+    });
+
     it('throws when it is empty', () => {
       expect(() =>
         getCompareExperimentIdAliasWithNumberSpec({

--- a/tensorboard/webapp/app_routing/store_only_utils_test.ts
+++ b/tensorboard/webapp/app_routing/store_only_utils_test.ts
@@ -53,25 +53,6 @@ describe('app_routing store_only_utils test', () => {
       );
     });
 
-    it('does not include empty aliases', () => {
-      const map = getCompareExperimentIdAliasWithNumberSpec({
-        experimentIds: 'a:123,:345',
-      });
-      expect(map).toEqual(new Map([['123', {aliasText: 'a', aliasNumber: 1}]]));
-    });
-
-    it('does not include empty aliases', () => {
-      const map = getCompareExperimentIdAliasWithNumberSpec({
-        experimentIds: 'a:123,:345,c:567',
-      });
-      expect(map).toEqual(
-        new Map([
-          ['123', {aliasText: 'a', aliasNumber: 1}],
-          ['567', {aliasText: 'c', aliasNumber: 3}],
-        ])
-      );
-    });
-
     it('throws when it is empty', () => {
       expect(() =>
         getCompareExperimentIdAliasWithNumberSpec({


### PR DESCRIPTION
* Motivation for features / changes
`getCompareExperimentIdAliasWithNumberSpec` used to remove experiments with empty aliases from the map returned. This functionality was not being used anywhere and got in the way of detecting experiments with missing aliases.

* Screenshots of UI changes
None

* Detailed steps to verify changes work correctly (as executed by you)
I ran the app and didn't see any visible changes (or errors thrown in the console), the I ran the tests and they passed (after deleting two).

* Alternate designs / implementations considered
Create a new function doing the same thing as `getCompareExperimentIdAliasWithNumberSpec` but not removing experiments with empty aliases.

I could potentially have updated the deprecated function `getCompareExperimentIdAliasSpec` as well but I thought it was best to have the lowest possible impact.