### PR TITLE
Step Selector: Move Step Selector to General section of Settings panel

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -59,8 +59,9 @@ limitations under the License.
     <mat-checkbox
       [checked]="isScalarStepSelectorEnabled"
       (change)="stepSelectorEnableToggled.emit()"
-      >Scalar Step Selector</mat-checkbox
-    >
+      >Enable step selection and data table
+    </mat-checkbox>
+    <span class="second-line-clarifier">(Scalar only)</span>
   </div>
 
   <div

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -61,7 +61,7 @@ limitations under the License.
       (change)="stepSelectorEnableToggled.emit()"
       >Enable step selection and data table
     </mat-checkbox>
-    <span class="second-line-clarifier">(Scalar only)</span>
+    <span class="second-line-clarifier">(Scalars only)</span>
   </div>
 
   <div

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -53,6 +53,17 @@ limitations under the License.
   </div>
 
   <div
+    class="control-row scalars-step-selector"
+    *ngIf="isScalarStepSelectorFeatureEnabled"
+  >
+    <mat-checkbox
+      [checked]="isScalarStepSelectorEnabled"
+      (change)="stepSelectorEnableToggled.emit()"
+      >Scalar Step Selector</mat-checkbox
+    >
+  </div>
+
+  <div
     class="control-row linked-time"
     *ngIf="isLinkedTimeFeatureEnabled && xAxisType == XAxisType.STEP"
   >
@@ -124,17 +135,6 @@ limitations under the License.
       [checked]="ignoreOutliers"
       (change)="ignoreOutliersChanged.emit($event.checked)"
       >Ignore outliers in chart scaling</mat-checkbox
-    >
-  </div>
-
-  <div
-    class="control-row scalars-step-selector"
-    *ngIf="isScalarStepSelectorFeatureEnabled"
-  >
-    <mat-checkbox
-      [checked]="isScalarStepSelectorEnabled"
-      (change)="stepSelectorEnableToggled.emit()"
-      >Step Selector</mat-checkbox
     >
   </div>
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -61,7 +61,7 @@ limitations under the License.
       (change)="stepSelectorEnableToggled.emit()"
       >Enable step selection and data table
     </mat-checkbox>
-    <span class="second-line-clarifier">(Scalars only)</span>
+    <span class="indent">(Scalars only)</span>
   </div>
 
   <div

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -109,3 +109,9 @@ tb-dropdown {
     padding: 5px;
   }
 }
+
+.control-row {
+  .second-line-clarifier {
+    margin-left: 25px;
+  }
+}

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -111,7 +111,7 @@ tb-dropdown {
 }
 
 .control-row {
-  .second-line-clarifier {
+  .indent {
     margin-left: 25px;
   }
 }


### PR DESCRIPTION
* Motivation for features / changes
In future changes the Step Selector Checkbox will be part of a larger feature which encompasses more than just scalar cards. We wanted to keep the checkbox in the same location to not confuse users so we are moving it out of Scalar Settings into General Settings now.

* Screenshots of UI changes
<img width="244" alt="Screen Shot 2022-07-07 at 10 57 27 AM" src="https://user-images.githubusercontent.com/8672809/177838817-6b28422c-90c3-47b4-82d5-3b4514d2368e.png">

