### PR TITLE
Serve TensorBoard at /flags

### DIFF
--- a/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
@@ -40,10 +40,17 @@ export interface NavigateToExperiments {
   resetNamespacedState?: boolean;
 }
 
+export interface NavigateToFlags {
+  routeKind: RouteKind.FLAGS;
+  routeParams: {},
+  resetNamespacedState?: boolean;
+}
+
 export type ProgrammaticalNavigation =
   | NavigateToExperiment
   | NavigateToCompare
-  | NavigateToExperiments;
+  | NavigateToExperiments
+  | NavigateToFlags;
 
 export interface NavigationLambda {
   actionCreator: ActionCreator<string, Creator>;


### PR DESCRIPTION
* Motivation for features / changes
There is an existing page available at the route "/flags" on the frontend, however, the backend does support this route so it is functionally inaccessible.

* Technical description of changes
Rather than just serving that app at "/" I added a list of routes for the app to be served at.
The meta tag content attribute is now generated using parameter which is closured during app startup.
get_resource_apps now generates resource paths for ALL supported routes.
Because of the logic in the `clean_path` function found in `application.py` which prevents paths from ending in "/" it is necessary to support routes which DO and DO NOT end with "/" slightly convoluting the logic.

* Screenshots of UI changes 
![image](https://user-images.githubusercontent.com/78179109/177881936-2633fcd3-8743-41d9-9d85-234f62bb5382.png)

* Detailed steps to verify changes work correctly (as executed by you)
Start the application and manually navigate to the "/flags" route. Assert that the page is rendered.

* Alternate designs / implementations considered
