### PR TITLE
Do not update internalSelectedTime outside card range

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -107,6 +107,8 @@ export class ScalarCardComponent<Downloader> {
     ColumnHeaders.STEP,
     ColumnHeaders.RELATIVE_TIME,
   ];
+  minStep: number | null = null;
+  maxStep: number | null = null;
 
   toggleYScaleType() {
     this.yScaleType =
@@ -260,18 +262,50 @@ export class ScalarCardComponent<Downloader> {
     return dataTableData;
   }
 
+<<<<<<< HEAD
   onFobTimeSelectionChanged(newTimeSelection: TimeSelection) {
     // Updates step selector to single selection.
     const {minStep, maxStep} = this.getMinMaxStepInSeries();
     const givenStartStep = newTimeSelection.start.step;
+=======
+  getMinMaxStepInSeries() {
+    let minStep = Infinity;
+    let maxStep = -Infinity;
+    for (const {points} of this.dataSeries) {
+      for (const point of points) {
+        minStep = minStep > point.x ? point.x : minStep;
+        maxStep = maxStep < point.x ? point.x : maxStep;
+      }
+    }
+    return {minStep, maxStep};
+  }
+
+  onFobSelectTimeChanged(newSelectedTime: LinkedTime) {
+    // Lazy load minStep and maxStep
+    if (this.minStep == null || this.maxStep == null) {
+      const {minStep, maxStep} = this.getMinMaxStepInSeries();
+      this.minStep = minStep;
+      this.maxStep = maxStep;
+    }
+
+    // Get the closes step to the provided start step within the min and max
+    // steps.
+    const givenStartStep = newSelectedTime.start.step;
+>>>>>>> f34595594 (Lazy load min and max steps)
     const newStartStep =
-      givenStartStep < minStep
-        ? minStep
-        : givenStartStep > maxStep
-        ? maxStep
+      givenStartStep < this.minStep
+        ? this.minStep
+        : givenStartStep > this.maxStep
+        ? this.maxStep
         : givenStartStep;
+<<<<<<< HEAD
     // Updates step selector to single selection.
     this.stepSelectorTimeSelection = {
+=======
+
+    // Updates step selector to single selection.
+    this.internalSelectedTime = {
+>>>>>>> f34595594 (Lazy load min and max steps)
       start: {step: newStartStep},
       end: null,
     };

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -109,8 +109,6 @@ export class ScalarCardComponent<Downloader> {
     ColumnHeaders.STEP,
     ColumnHeaders.RELATIVE_TIME,
   ];
-  minStep: number | null = null;
-  maxStep: number | null = null;
 
   toggleYScaleType() {
     this.yScaleType =

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -271,6 +271,7 @@ export class ScalarCardComponent<Downloader> {
         : givenStartStep > this.minMaxStep.maxStep
         ? this.minMaxStep.maxStep
         : givenStartStep;
+
     // Updates step selector to single selection.
     this.stepSelectorTimeSelection = {
       start: {step: newStartStep},

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -42,6 +42,7 @@ import {
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ColumnHeaders,
+  MinMaxStep,
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
   ScalarCardSeriesMetadataMap,
@@ -86,6 +87,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() forceSvg!: boolean;
   @Input() linkedTimeSelection!: TimeSelectionView | null;
   @Input() stepSelectorTimeSelection!: TimeSelection;
+  @Input() minMaxStep!: MinMaxStep;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
@@ -266,10 +268,10 @@ export class ScalarCardComponent<Downloader> {
     // Updates step selector to single selection.
     const givenStartStep = newTimeSelection.start.step;
     const newStartStep =
-      givenStartStep < this.minStep
-        ? this.minStep
-        : givenStartStep > this.maxStep
-        ? this.maxStep
+      givenStartStep < this.minMaxStep.minStep
+        ? this.minMaxStep.minStep
+        : givenStartStep > this.minMaxStep.maxStep
+        ? this.minMaxStep.maxStep
         : givenStartStep;
     // Updates step selector to single selection.
     this.stepSelectorTimeSelection = {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -262,50 +262,17 @@ export class ScalarCardComponent<Downloader> {
     return dataTableData;
   }
 
-<<<<<<< HEAD
   onFobTimeSelectionChanged(newTimeSelection: TimeSelection) {
     // Updates step selector to single selection.
-    const {minStep, maxStep} = this.getMinMaxStepInSeries();
     const givenStartStep = newTimeSelection.start.step;
-=======
-  getMinMaxStepInSeries() {
-    let minStep = Infinity;
-    let maxStep = -Infinity;
-    for (const {points} of this.dataSeries) {
-      for (const point of points) {
-        minStep = minStep > point.x ? point.x : minStep;
-        maxStep = maxStep < point.x ? point.x : maxStep;
-      }
-    }
-    return {minStep, maxStep};
-  }
-
-  onFobSelectTimeChanged(newSelectedTime: LinkedTime) {
-    // Lazy load minStep and maxStep
-    if (this.minStep == null || this.maxStep == null) {
-      const {minStep, maxStep} = this.getMinMaxStepInSeries();
-      this.minStep = minStep;
-      this.maxStep = maxStep;
-    }
-
-    // Get the closes step to the provided start step within the min and max
-    // steps.
-    const givenStartStep = newSelectedTime.start.step;
->>>>>>> f34595594 (Lazy load min and max steps)
     const newStartStep =
       givenStartStep < this.minStep
         ? this.minStep
         : givenStartStep > this.maxStep
         ? this.maxStep
         : givenStartStep;
-<<<<<<< HEAD
     // Updates step selector to single selection.
     this.stepSelectorTimeSelection = {
-=======
-
-    // Updates step selector to single selection.
-    this.internalSelectedTime = {
->>>>>>> f34595594 (Lazy load min and max steps)
       start: {step: newStartStep},
       end: null,
     };

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -262,8 +262,17 @@ export class ScalarCardComponent<Downloader> {
 
   onFobTimeSelectionChanged(newTimeSelection: TimeSelection) {
     // Updates step selector to single selection.
+    const {minStep, maxStep} = this.getMinMaxStepInSeries();
+    const givenStartStep = newTimeSelection.start.step;
+    const newStartStep =
+      givenStartStep < minStep
+        ? minStep
+        : givenStartStep > maxStep
+        ? maxStep
+        : givenStartStep;
+    // Updates step selector to single selection.
     this.stepSelectorTimeSelection = {
-      start: {step: newTimeSelection.start.step},
+      start: {step: newStartStep},
       end: null,
     };
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -75,6 +75,7 @@ import {CardRenderer} from '../metrics_view_types';
 import {getTagDisplayName} from '../utils';
 import {DataDownloadDialogContainer} from './data_download_dialog_container';
 import {
+  MinMaxStep,
   PartialSeries,
   PartitionedSeries,
   ScalarCardDataSeries,
@@ -137,6 +138,7 @@ function areSeriesEqual(
       [linkedTimeSelection]="linkedTimeSelection$ | async"
       [stepSelectorTimeSelection]="stepSelectorTimeSelection$ | async"
       [forceSvg]="forceSvg$ | async"
+      [minMaxStep]="minMaxSteps$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       observeIntersection
@@ -179,6 +181,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   chartMetadataMap$?: Observable<ScalarCardSeriesMetadataMap>;
   linkedTimeSelection$?: Observable<TimeSelectionView | null>;
   stepSelectorTimeSelection$?: Observable<TimeSelection | null>;
+  minMaxSteps$?: Observable<MinMaxStep | null>;
 
   onVisibilityChange({visible}: {visible: boolean}) {
     this.isVisible = visible;
@@ -226,7 +229,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.fullHeightChanged.emit(this.showFullSize);
   }
 
-  getMinMaxStepInSeries(series: PartitionedSeries[]) {
+  getMinMaxStepInSeries(series: PartitionedSeries[]): MinMaxStep {
     let minStep = Infinity;
     let maxStep = -Infinity;
     for (const {points} of series) {
@@ -337,6 +340,12 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         });
       }),
       shareReplay(1)
+    );
+
+    this.minMaxSteps$ = partitionedSeries$.pipe(
+      map((partialSeries) => {
+        return this.getMinMaxStepInSeries(partialSeries);
+      })
     );
 
     this.dataSeries$ = partitionedSeries$.pipe(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -94,6 +94,10 @@ export type SelectedStepRunData = {
   [key in ColumnHeaders]?: string | number;
 };
 
+/**
+ * An object which is intended to hold the min and max step within each scalar
+ * card.
+ */
 export type MinMaxStep = {
   minStep: number;
   maxStep: number;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -93,3 +93,8 @@ export enum ColumnHeaders {
 export type SelectedStepRunData = {
   [key in ColumnHeaders]?: string | number;
 };
+
+export type MinMaxStep = {
+  minStep: number;
+  maxStep: number;
+};


### PR DESCRIPTION
* Motivation for features / changes
This fixes a bug where the fob disappears when the user types in a step larger than the max step or smaller than the min step.

Googlers see: b/238666726

* Technical description of changes
I added a lazy load of the min and max steps to avoid unnecessary calculations.

* Alternate designs / implementations considered
Considered moving this logic to the ScalarCardContainer but the changing of the value in the observable and emitting the change to all subscribers became a hacky mess so I kept this in the component.
