### PR TITLE
linked time: tslint: remove escalation 

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -208,10 +208,10 @@ export class ScalarCardComponent<Downloader> {
 
     return {
       start: {
-        step: this.linkedTimeSelection!.startStep,
+        step: this.linkedTimeSelection.startStep,
       },
-      end: this.linkedTimeSelection!.endStep
-        ? {step: this.linkedTimeSelection!.endStep}
+      end: this.linkedTimeSelection.endStep
+        ? {step: this.linkedTimeSelection.endStep}
         : null,
     };
   }


### PR DESCRIPTION
Removed unnecessary escalation syntax. Googlers please see [cl/460351035](https://critique.corp.google.com/cl/460351035/depot/google3/third_party/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts)