### PR TITLE
Step Selector: Fix fob position rendering bug and remove CardFobAdaptor

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prettier-plugin-organize-imports": "2.3.4",
     "requirejs": "^2.3.6",
     "rollup": "^2.56.2",
-    "terser": "^5.7.1",
+    "terser": "^5.14.2",
     "tslib": "^2.3.0",
     "typescript": "4.5.4",
     "yarn-deduplicate": "^5.0.0"

--- a/tensorboard/pip_package/setup.cfg
+++ b/tensorboard/pip_package/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
 description-file = README.rst
-license_file = LICENSE
+license_files = LICENSE

--- a/tensorboard/webapp/metrics/actions/BUILD
+++ b/tensorboard/webapp/metrics/actions/BUILD
@@ -13,6 +13,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics:internal_types",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/util:dom",
+        "//tensorboard/webapp/widgets/card_fob:types",
         "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {createAction, props} from '@ngrx/store';
 import {ElementId} from '../../util/dom';
+import {TimeSelectionAffordance} from '../../widgets/card_fob/card_fob_types';
 import {
   TagMetadata,
   TimeSeriesRequest,
@@ -172,8 +173,13 @@ export const metricsShowAllPlugins = createAction(
 export const linkedTimeSelectionChanged = createAction(
   '[Metrics] Linked Time Selection Changed',
   props<{
-    startStep: number;
-    endStep: number | undefined;
+    timeSelection: {
+      startStep: number;
+      endStep: number | undefined;
+    };
+    // Affordance for analytics purpose. When no affordance is specified or is
+    // undefined we do not want to log an analytics event.
+    affordance?: TimeSelectionAffordance | undefined;
   }>()
 );
 

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -28,6 +28,7 @@ tf_ts_library(
         "//tensorboard/webapp/util:lang",
         "//tensorboard/webapp/util:ngrx",
         "//tensorboard/webapp/util:types",
+        "//tensorboard/webapp/widgets/card_fob:types",
         "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -978,8 +978,9 @@ const reducer = createReducer(
     };
   }),
   on(actions.linkedTimeSelectionChanged, (state, change) => {
-    const nextStartStep = change.startStep;
-    const nextEndStep = change.endStep;
+    const {timeSelection} = change;
+    const nextStartStep = timeSelection.startStep;
+    const nextEndStep = timeSelection.endStep;
     const end =
       nextEndStep === undefined
         ? null

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2431,8 +2431,10 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.linkedTimeSelectionChanged({
-            startStep: 2,
-            endStep: 5,
+            timeSelection: {
+              startStep: 2,
+              endStep: 5,
+            },
           })
         );
 
@@ -2450,7 +2452,9 @@ describe('metrics reducers', () => {
 
         const after = reducers(
           before,
-          actions.linkedTimeSelectionChanged({startStep: 2, endStep: undefined})
+          actions.linkedTimeSelectionChanged({
+            timeSelection: {startStep: 2, endStep: undefined},
+          })
         );
 
         expect(after.linkedTimeSelection).toEqual({
@@ -2468,8 +2472,10 @@ describe('metrics reducers', () => {
         const after = reducers(
           before,
           actions.linkedTimeSelectionChanged({
-            startStep: 2,
-            endStep: 50,
+            timeSelection: {
+              startStep: 2,
+              endStep: 50,
+            },
           })
         );
 
@@ -2486,7 +2492,9 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({startStep: 2, endStep: undefined})
+          actions.linkedTimeSelectionChanged({
+            timeSelection: {startStep: 2, endStep: undefined},
+          })
         );
 
         expect(nextState.linkedTimeEnabled).toBe(true);
@@ -2501,8 +2509,10 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.linkedTimeSelectionChanged({
-            startStep: 150,
-            endStep: 0,
+            timeSelection: {
+              startStep: 150,
+              endStep: 0,
+            },
           })
         );
 
@@ -2521,8 +2531,10 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.linkedTimeSelectionChanged({
-            startStep: 2,
-            endStep: 5,
+            timeSelection: {
+              startStep: 2,
+              endStep: 5,
+            },
           })
         );
 
@@ -2544,8 +2556,10 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.linkedTimeSelectionChanged({
-            startStep: 2,
-            endStep: 5,
+            timeSelection: {
+              startStep: 2,
+              endStep: 5,
+            },
           })
         );
 
@@ -2564,8 +2578,10 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.linkedTimeSelectionChanged({
-            startStep: 2,
-            endStep: 0,
+            timeSelection: {
+              startStep: 2,
+              endStep: 0,
+            },
           })
         );
 
@@ -2581,8 +2597,10 @@ describe('metrics reducers', () => {
         const nextState1 = reducers(
           beforeState1,
           actions.linkedTimeSelectionChanged({
-            startStep: 2,
-            endStep: undefined,
+            timeSelection: {
+              startStep: 2,
+              endStep: undefined,
+            },
           })
         );
 
@@ -2616,8 +2634,10 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.linkedTimeSelectionChanged({
-            startStep: 10,
-            endStep: undefined,
+            timeSelection: {
+              startStep: 10,
+              endStep: undefined,
+            },
           })
         );
 
@@ -2654,8 +2674,10 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.linkedTimeSelectionChanged({
-            startStep: 15,
-            endStep: undefined,
+            timeSelection: {
+              startStep: 15,
+              endStep: undefined,
+            },
           })
         );
 
@@ -2677,8 +2699,10 @@ describe('metrics reducers', () => {
       const nextState = reducers(
         beforeState,
         actions.linkedTimeSelectionChanged({
-          startStep: 3,
-          endStep: undefined,
+          timeSelection: {
+            startStep: 3,
+            endStep: undefined,
+          },
         })
       );
 

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -108,6 +108,7 @@ tf_ng_module(
         "//tensorboard/webapp/metrics/views:utils",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/types:ui",
+        "//tensorboard/webapp/widgets/card_fob:types",
         "//tensorboard/webapp/widgets/histogram",
         "//tensorboard/webapp/widgets/histogram:types",
         "//tensorboard/webapp/widgets/text:truncated_path",

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -26,6 +26,7 @@ import {filter, map} from 'rxjs/operators';
 import {State} from '../../../app_state';
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
+import {TimeSelectionAffordance} from '../../../widgets/card_fob/card_fob_types';
 import {HistogramDatum} from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
 import {linkedTimeSelectionChanged, linkedTimeToggled} from '../../actions';
@@ -223,13 +224,18 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
     this.isPinned$ = this.store.select(getCardPinnedState, this.cardId);
   }
 
-  onLinkedTimeSelectionChanged(newLinkedTimeSelection: TimeSelection) {
+  onLinkedTimeSelectionChanged(newLinkedTimeSelectionWithAffordance: {
+    timeSelection: TimeSelection;
+    affordance: TimeSelectionAffordance;
+  }) {
+    const {timeSelection, affordance} = newLinkedTimeSelectionWithAffordance;
     this.store.dispatch(
       linkedTimeSelectionChanged({
-        startStep: newLinkedTimeSelection.start.step,
-        endStep: newLinkedTimeSelection.end
-          ? newLinkedTimeSelection.end.step
-          : undefined,
+        timeSelection: {
+          startStep: timeSelection.start.step,
+          endStep: timeSelection.end ? timeSelection.end.step : undefined,
+        },
+        affordance,
       })
     );
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -240,7 +240,11 @@ export class ScalarCardComponent<Downloader> {
         for (const header of this.dataHeaders) {
           switch (header) {
             case ColumnHeaders.RUN:
-              selectedStepData.RUN = metadata.displayName;
+              let alias = '';
+              if (metadata.alias) {
+                alias = `${metadata.alias.aliasNumber} ${metadata.alias.aliasText}/`;
+              }
+              selectedStepData.RUN = `${alias}${metadata.displayName}`;
               continue;
             case ColumnHeaders.STEP:
               selectedStepData.STEP = closestStartPoint.step;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -24,7 +24,10 @@ import {
 } from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {DataLoadState} from '../../../types/data';
-import {TimeSelection} from '../../../widgets/card_fob/card_fob_types';
+import {
+  TimeSelection,
+  TimeSelectionAffordance,
+} from '../../../widgets/card_fob/card_fob_types';
 import {
   Formatter,
   intlNumberFormatter,
@@ -91,7 +94,10 @@ export class ScalarCardComponent<Downloader> {
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
-  @Output() onLinkedTimeSelectionChanged = new EventEmitter<TimeSelection>();
+  @Output() onLinkedTimeSelectionChanged = new EventEmitter<{
+    timeSelection: TimeSelection;
+    affordance: TimeSelectionAffordance;
+  }>();
   @Output() onLinkedTimeToggled = new EventEmitter();
   @Output() onStepSelectorToggled = new EventEmitter();
 
@@ -266,24 +272,31 @@ export class ScalarCardComponent<Downloader> {
     return dataTableData;
   }
 
-  onFobTimeSelectionChanged(newTimeSelection: TimeSelection) {
+  onFobTimeSelectionChanged(newTimeSelectionWithAffordance: {
+    timeSelection: TimeSelection;
+    affordance: TimeSelectionAffordance;
+  }) {
     // Updates step selector to single selection.
-    const givenStartStep = newTimeSelection.start.step;
-    const newStartStep =
-      givenStartStep < this.minMaxStep.minStep
+    const {timeSelection, affordance} = newTimeSelectionWithAffordance;
+    const newStartStep = timeSelection.start.step;
+    const nextStartStep =
+      newStartStep < this.minMaxStep.minStep
         ? this.minMaxStep.minStep
-        : givenStartStep > this.minMaxStep.maxStep
+        : newStartStep > this.minMaxStep.maxStep
         ? this.minMaxStep.maxStep
-        : givenStartStep;
+        : newStartStep;
 
     // Updates step selector to single selection.
     this.stepSelectorTimeSelection = {
-      start: {step: newStartStep},
+      start: {step: nextStartStep},
       end: null,
     };
 
     if (this.linkedTimeSelection !== null) {
-      this.onLinkedTimeSelectionChanged.emit(newTimeSelection);
+      this.onLinkedTimeSelectionChanged.emit({
+        timeSelection,
+        affordance,
+      });
     }
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -50,7 +50,10 @@ import {
   getRunColorMap,
 } from '../../../selectors';
 import {DataLoadState} from '../../../types/data';
-import {TimeSelection} from '../../../widgets/card_fob/card_fob_types';
+import {
+  TimeSelection,
+  TimeSelectionAffordance,
+} from '../../../widgets/card_fob/card_fob_types';
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {
@@ -555,11 +558,18 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     });
   }
 
-  onLinkedTimeSelectionChanged(newLinkedTime: TimeSelection) {
+  onLinkedTimeSelectionChanged(newTimeSelectionWithAffordance: {
+    timeSelection: TimeSelection;
+    affordance: TimeSelectionAffordance;
+  }) {
+    const {timeSelection, affordance} = newTimeSelectionWithAffordance;
     this.store.dispatch(
       linkedTimeSelectionChanged({
-        startStep: newLinkedTime.start.step,
-        endStep: newLinkedTime.end ? newLinkedTime.end.step : undefined,
+        timeSelection: {
+          startStep: timeSelection.start.step,
+          endStep: timeSelection.end ? timeSelection.end.step : undefined,
+        },
+        affordance,
       })
     );
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -15,6 +15,7 @@ import {
   AxisDirection,
   CardFobAdapter,
   TimeSelection,
+  TimeSelectionAffordance,
 } from '../../../widgets/card_fob/card_fob_types';
 import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
 
@@ -38,7 +39,10 @@ export class ScalarCardFobController implements CardFobAdapter {
   @Input() minMax!: [number, number];
   @Input() axisSize!: number;
 
-  @Output() onTimeSelectionChanged = new EventEmitter<TimeSelection>();
+  @Output() onTimeSelectionChanged = new EventEmitter<{
+    timeSelection: TimeSelection;
+    affordance?: TimeSelectionAffordance;
+  }>();
   @Output() onTimeSelectionToggled = new EventEmitter();
 
   readonly axisDirection = AxisDirection.HORIZONTAL;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -31,8 +31,8 @@ import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
     <card-fob-controller
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [axisPositionFromStartStep]="getAxisPositionFromStartStep()"
-      [axisPositionFromEndStep]="getAxisPositionFromEndStep()"
+      [startStepAxisPosition]="getAxisPositionFromStartStep()"
+      [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [highestStep]="getHighestStep()"
       [lowestStep]="getLowestStep()"
       [cardFobHelper]="cardFobHelper"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -11,17 +11,17 @@ limitations under the License.
 ==============================================================================*/
 
 import {
-  Component,
   ChangeDetectionStrategy,
+  Component,
   EventEmitter,
   Input,
   Output,
 } from '@angular/core';
 import {
-  CardFobGetStepHelper,
+  AxisDirection,
+  CardFobGetStepFromPositionHelper,
   TimeSelection,
   TimeSelectionAffordance,
-  AxisDirection,
 } from '../../../widgets/card_fob/card_fob_types';
 import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
 
@@ -31,8 +31,10 @@ import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
     <card-fob-controller
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [getAxisPositionFromStartStep]="getAxisPositionFromStartStep()"
-      [getAxisPositionFromEndStep]="getAxisPositionFromEndStep()"
+      [axisPositionFromStartStep]="getAxisPositionFromStartStep()"
+      [axisPositionFromEndStep]="getAxisPositionFromEndStep()"
+      [highestStep]="getHighestStep()"
+      [lowestStep]="getLowestStep()"
       [cardFobHelper]="cardFobHelper"
       [showExtendedLine]="true"
       (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
@@ -55,9 +57,7 @@ export class ScalarCardFobController {
   @Output() onTimeSelectionToggled = new EventEmitter();
 
   readonly axisDirection = AxisDirection.HORIZONTAL;
-  readonly cardFobHelper: CardFobGetStepHelper = {
-    getHighestStep: this.getHighestStep.bind(this),
-    getLowestStep: this.getLowestStep.bind(this),
+  readonly cardFobHelper: CardFobGetStepFromPositionHelper = {
     getStepHigherThanAxisPosition:
       this.getStepHigherThanAxisPosition.bind(this),
     getStepLowerThanAxisPosition: this.getStepLowerThanAxisPosition.bind(this),
@@ -82,7 +82,6 @@ export class ScalarCardFobController {
     );
   }
 
-  // CardFobGetStepHelper
   getHighestStep(): number {
     const minMax = this.minMax;
     return minMax[0] < minMax[1] ? minMax[1] : minMax[0];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_test.ts
@@ -67,20 +67,25 @@ describe('ScalarFobController', () => {
     return fixture;
   }
 
-  describe('getAxisPositionFromStep', () => {
+  describe('getAxisPositionFromStartStep/EndStep', () => {
     it('calls the scale function', () => {
       const minMax: [number, number] = [0, 2];
       const axisSize = 20;
-      const fixture = createComponent({minMax, axisSize});
-
-      const position = fixture.componentInstance.getAxisPositionFromStep(1);
-
-      expect(position).toBe(1 * SCALE_RATIO);
-      expect(forwardScaleSpy).toHaveBeenCalledOnceWith(
+      const fixture = createComponent({
         minMax,
-        [0, axisSize],
-        1
-      );
+        axisSize,
+        timeSelection: {start: {step: 1}, end: {step: 3}},
+      });
+
+      const startPosition =
+        fixture.componentInstance.getAxisPositionFromStartStep();
+      const endPosition =
+        fixture.componentInstance.getAxisPositionFromEndStep();
+
+      expect(startPosition).toBe(1 * SCALE_RATIO);
+      expect(endPosition).toBe(3 * SCALE_RATIO);
+      expect(forwardScaleSpy).toHaveBeenCalledWith(minMax, [0, axisSize], 1);
+      expect(forwardScaleSpy).toHaveBeenCalledWith(minMax, [0, axisSize], 3);
     });
   });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -51,6 +51,7 @@ import {
   Fob,
 } from '../../../widgets/card_fob/card_fob_controller_component';
 import {CardFobModule} from '../../../widgets/card_fob/card_fob_module';
+import {TimeSelectionAffordance} from '../../../widgets/card_fob/card_fob_types';
 import {DataTableComponent} from '../../../widgets/data_table/data_table_component';
 import {DataTableModule} from '../../../widgets/data_table/data_table_module';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
@@ -2224,18 +2225,55 @@ describe('scalar card', () => {
           testController.root.nativeElement.getBoundingClientRect().left;
 
         // Simulate dragging fob to step 25.
-        testController.startDrag(Fob.START);
-        const fakeEvent = new MouseEvent('mousemove', {
+        testController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+        let fakeEvent = new MouseEvent('mousemove', {
           clientX: 25 + controllerStartPosition,
           movementX: 1,
         });
         testController.mouseMove(fakeEvent);
+        testController.stopDrag();
+        fixture.detectChanges();
+
+        testController.startDrag(
+          Fob.START,
+          TimeSelectionAffordance.EXTENDED_LINE
+        );
+        fakeEvent = new MouseEvent('mousemove', {
+          clientX: 30 + controllerStartPosition,
+          movementX: 1,
+        });
+        testController.mouseMove(fakeEvent);
+        testController.stopDrag();
         fixture.detectChanges();
 
         expect(dispatchedActions).toEqual([
           linkedTimeSelectionChanged({
-            startStep: 25,
-            endStep: undefined,
+            timeSelection: {
+              startStep: 25,
+              endStep: undefined,
+            },
+            affordance: undefined,
+          }),
+          linkedTimeSelectionChanged({
+            timeSelection: {
+              startStep: 25,
+              endStep: undefined,
+            },
+            affordance: TimeSelectionAffordance.FOB,
+          }),
+          linkedTimeSelectionChanged({
+            timeSelection: {
+              startStep: 30,
+              endStep: undefined,
+            },
+            affordance: undefined,
+          }),
+          linkedTimeSelectionChanged({
+            timeSelection: {
+              startStep: 30,
+              endStep: undefined,
+            },
+            affordance: TimeSelectionAffordance.EXTENDED_LINE,
           }),
         ]);
       }));
@@ -2603,7 +2641,7 @@ describe('scalar card', () => {
           testController.root.nativeElement.getBoundingClientRect().left;
 
         // Simulate dragging fob to step 25.
-        testController.startDrag(Fob.START);
+        testController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
         const fakeEvent = new MouseEvent('mousemove', {
           clientX: 25 + controllerStartPosition,
           movementX: 1,
@@ -2617,7 +2655,6 @@ describe('scalar card', () => {
         expect(
           fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('25');
-        expect(dispatchedActions).toEqual([]);
         const scalarCardComponent = fixture.debugElement.query(
           By.directive(ScalarCardComponent)
         );
@@ -2636,29 +2673,58 @@ describe('scalar card', () => {
         });
         const fixture = createComponent('card1');
         fixture.detectChanges();
-        const testController = fixture.debugElement.query(
+        let testController = fixture.debugElement.query(
           By.directive(CardFobControllerComponent)
         ).componentInstance;
         const controllerStartPosition =
           testController.root.nativeElement.getBoundingClientRect().left;
 
-        // Simulate dragging start fob to step 25
-        testController.startDrag(Fob.START);
+        // Simulates dragging start fob to step 25
+        testController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
         let fakeEvent = new MouseEvent('mousemove', {
           clientX: 25 + controllerStartPosition,
           movementX: 1,
         });
         testController.mouseMove(fakeEvent);
+        testController.stopDrag();
+        fixture.detectChanges();
+
+        expect(dispatchedActions).toEqual([
+          linkedTimeSelectionChanged({
+            timeSelection: {
+              startStep: 25,
+              endStep: 40,
+            },
+            affordance: undefined,
+          }),
+          linkedTimeSelectionChanged({
+            timeSelection: {
+              startStep: 25,
+              endStep: 40,
+            },
+            affordance: TimeSelectionAffordance.FOB,
+          }),
+        ]);
+
+        // Reflects linked time selection changes above.
+        store.overrideSelector(getMetricsLinkedTimeSelection, {
+          start: {step: 25},
+          end: {step: 40},
+        });
+        store.refreshState();
         fixture.detectChanges();
 
         // Simulate dragging end fob to step 28
-        testController.stopDrag();
-        testController.startDrag(Fob.END);
+        testController = fixture.debugElement.query(
+          By.directive(CardFobControllerComponent)
+        ).componentInstance;
+        testController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
         fakeEvent = new MouseEvent('mousemove', {
           clientX: 28 + controllerStartPosition,
-          movementX: 1,
+          movementX: -1,
         });
         testController.mouseMove(fakeEvent);
+        testController.stopDrag();
         fixture.detectChanges();
 
         // Disable linked time

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -524,8 +524,10 @@ describe('metrics right_pane', () => {
 
           expect(dispatchSpy).toHaveBeenCalledOnceWith(
             actions.linkedTimeSelectionChanged({
-              startStep: 10,
-              endStep: 200,
+              timeSelection: {
+                startStep: 10,
+                endStep: 200,
+              },
             })
           );
         });
@@ -552,8 +554,10 @@ describe('metrics right_pane', () => {
 
           expect(dispatchSpy).toHaveBeenCalledOnceWith(
             actions.linkedTimeSelectionChanged({
-              startStep: 10,
-              endStep: undefined,
+              timeSelection: {
+                startStep: 10,
+                endStep: undefined,
+              },
             })
           );
         });

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -210,8 +210,10 @@ export class SettingsViewContainer {
   onLinkedTimeSelectionChanged(newValue: TimeSelection) {
     this.store.dispatch(
       linkedTimeSelectionChanged({
-        startStep: newValue.start.step,
-        endStep: newValue.end?.step,
+        timeSelection: {
+          startStep: newValue.start.step,
+          endStep: newValue.end?.step,
+        },
       })
     );
   }

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -28,15 +28,15 @@ limitations under the License.
     <div
       *ngIf="showExtendedLine"
       class="extended-line"
-      (mousedown)="startDrag(FobType().START)"
+      (mousedown)="startDrag(Fob.START, TimeSelectionAffordance.EXTENDED_LINE)"
     ></div>
     <card-fob
       class="startFob"
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="timeSelection.start.step"
-      (mousedown)="startDrag(FobType().START)"
-      (stepChanged)="stepTyped(FobType().START, $event)"
-      (fobRemoved)="onFobRemoved(FobType().START)"
+      (mousedown)="startDrag(Fob.START, TimeSelectionAffordance.FOB)"
+      (stepChanged)="stepTyped(Fob.START, $event)"
+      (fobRemoved)="onFobRemoved(Fob.START)"
     ></card-fob>
   </div>
   <div
@@ -48,15 +48,15 @@ limitations under the License.
     <div
       *ngIf="showExtendedLine"
       class="extended-line"
-      (mousedown)="startDrag(FobType().END)"
+      (mousedown)="startDrag(Fob.END, TimeSelectionAffordance.EXTENDED_LINE)"
     ></div>
     <card-fob
       class="endFob"
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="timeSelection.end.step"
-      (mousedown)="startDrag(FobType().END)"
-      (stepChanged)="stepTyped(FobType().END, $event)"
-      (fobRemoved)="onFobRemoved(FobType().END)"
+      (mousedown)="startDrag(Fob.END, TimeSelectionAffordance.FOB)"
+      (stepChanged)="stepTyped(Fob.END, $event)"
+      (fobRemoved)="onFobRemoved(Fob.END)"
     ></card-fob>
   </div>
 </div>

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -23,7 +23,7 @@ limitations under the License.
   <div
     #startFobWrapper
     class="time-fob-wrapper"
-    [style.transform]="getCssTranslatePx(timeSelection.start.step)"
+    [style.transform]="getCssTranslatePxForStartFob()"
   >
     <div
       *ngIf="showExtendedLine"
@@ -43,7 +43,7 @@ limitations under the License.
     #endFobWrapper
     *ngIf="timeSelection.end"
     class="time-fob-wrapper"
-    [style.transform]="getCssTranslatePx(timeSelection.end.step)"
+    [style.transform]="getCssTranslatePxForEndFob()"
   >
     <div
       *ngIf="showExtendedLine"

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -47,8 +47,8 @@ export class CardFobControllerComponent {
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection!: TimeSelection;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
-  @Input() axisPositionFromStartStep!: number;
-  @Input() axisPositionFromEndStep!: number;
+  @Input() startStepAxisPosition!: number;
+  @Input() endStepAxisPosition!: number | null;
   @Input() highestStep!: number;
   @Input() lowestStep!: number;
   @Input() showExtendedLine?: Boolean = false;
@@ -69,16 +69,19 @@ export class CardFobControllerComponent {
 
   getCssTranslatePxForStartFob() {
     if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.axisPositionFromStartStep}px)`;
+      return `translate(0px, ${this.startStepAxisPosition}px)`;
     }
-    return `translate(${this.axisPositionFromStartStep}px, 0px)`;
+    return `translate(${this.startStepAxisPosition}px, 0px)`;
   }
 
   getCssTranslatePxForEndFob() {
-    if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.axisPositionFromEndStep}px)`;
+    if (this.endStepAxisPosition === null) {
+      return '';
     }
-    return `translate(${this.axisPositionFromEndStep}px, 0px)`;
+    if (this.axisDirection === AxisDirection.VERTICAL) {
+      return `translate(0px, ${this.endStepAxisPosition}px)`;
+    }
+    return `translate(${this.endStepAxisPosition}px, 0px)`;
   }
 
   startDrag(fob: Fob, affordance: TimeSelectionAffordance) {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -15,18 +15,16 @@ limitations under the License.
 
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   Output,
-  SimpleChanges,
   ViewChild,
 } from '@angular/core';
 import {
   AxisDirection,
-  CardFobAdapter,
+  CardFobGetStepFromPositionHelper,
   TimeSelection,
   TimeSelectionAffordance,
 } from './card_fob_types';
@@ -48,9 +46,11 @@ export class CardFobControllerComponent {
   @ViewChild('endFobWrapper') readonly endFobWrapper!: ElementRef;
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection!: TimeSelection;
-  @Input() cardFobHelper!: CardFobGetStepHelper;
-  @Input() getAxisPositionFromStartStep!: number;
-  @Input() getAxisPositionFromEndStep!: number;
+  @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
+  @Input() axisPositionFromStartStep!: number;
+  @Input() axisPositionFromEndStep!: number;
+  @Input() highestStep!: number;
+  @Input() lowestStep!: number;
   @Input() showExtendedLine?: Boolean = false;
 
   @Output() onTimeSelectionChanged = new EventEmitter<{
@@ -69,16 +69,16 @@ export class CardFobControllerComponent {
 
   getCssTranslatePxForStartFob() {
     if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.getAxisPositionFromStartStep}px)`;
+      return `translate(0px, ${this.axisPositionFromStartStep}px)`;
     }
-    return `translate(${this.getAxisPositionFromStartStep}px, 0px)`;
+    return `translate(${this.axisPositionFromStartStep}px, 0px)`;
   }
 
   getCssTranslatePxForEndFob() {
     if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.getAxisPositionFromEndStep}px)`;
+      return `translate(0px, ${this.axisPositionFromEndStep}px)`;
     }
-    return `translate(${this.getAxisPositionFromEndStep}px, 0px)`;
+    return `translate(${this.axisPositionFromEndStep}px, 0px)`;
   }
 
   startDrag(fob: Fob, affordance: TimeSelectionAffordance) {
@@ -150,7 +150,7 @@ export class CardFobControllerComponent {
     return (
       position < this.getDraggingFobCenter() &&
       movement < 0 &&
-      this.getDraggingFobStep() > this.cardFobHelper.getLowestStep()
+      this.getDraggingFobStep() > this.lowestStep
     );
   }
 
@@ -158,7 +158,7 @@ export class CardFobControllerComponent {
     return (
       position > this.getDraggingFobCenter() &&
       movement > 0 &&
-      this.getDraggingFobStep() < this.cardFobHelper.getHighestStep()
+      this.getDraggingFobStep() < this.highestStep
     );
   }
 

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -15,11 +15,13 @@ limitations under the License.
 
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   Output,
+  SimpleChanges,
   ViewChild,
 } from '@angular/core';
 import {
@@ -46,7 +48,9 @@ export class CardFobControllerComponent {
   @ViewChild('endFobWrapper') readonly endFobWrapper!: ElementRef;
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection!: TimeSelection;
-  @Input() cardAdapter!: CardFobAdapter;
+  @Input() cardFobHelper!: CardFobGetStepHelper;
+  @Input() getAxisPositionFromStartStep!: number;
+  @Input() getAxisPositionFromEndStep!: number;
   @Input() showExtendedLine?: Boolean = false;
 
   @Output() onTimeSelectionChanged = new EventEmitter<{
@@ -63,16 +67,18 @@ export class CardFobControllerComponent {
   readonly Fob = Fob;
   readonly TimeSelectionAffordance = TimeSelectionAffordance;
 
-  getCssTranslatePx(step: number): string {
+  getCssTranslatePxForStartFob() {
     if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.cardAdapter.getAxisPositionFromStep(
-        step
-      )}px)`;
+      return `translate(0px, ${this.getAxisPositionFromStartStep}px)`;
     }
+    return `translate(${this.getAxisPositionFromStartStep}px, 0px)`;
+  }
 
-    return `translate(${this.cardAdapter.getAxisPositionFromStep(
-      step
-    )}px, 0px)`;
+  getCssTranslatePxForEndFob() {
+    if (this.axisDirection === AxisDirection.VERTICAL) {
+      return `translate(0px, ${this.getAxisPositionFromEndStep}px)`;
+    }
+    return `translate(${this.getAxisPositionFromEndStep}px, 0px)`;
   }
 
   startDrag(fob: Fob, affordance: TimeSelectionAffordance) {
@@ -113,9 +119,9 @@ export class CardFobControllerComponent {
         ? event.movementY
         : event.movementX;
     if (this.isDraggingHigher(mousePosition, movement)) {
-      newStep = this.cardAdapter.getStepHigherThanAxisPosition(mousePosition);
+      newStep = this.cardFobHelper.getStepHigherThanAxisPosition(mousePosition);
     } else if (this.isDraggingLower(mousePosition, movement)) {
-      newStep = this.cardAdapter.getStepLowerThanAxisPosition(mousePosition);
+      newStep = this.cardFobHelper.getStepLowerThanAxisPosition(mousePosition);
     }
 
     if (newStep === null) {
@@ -144,7 +150,7 @@ export class CardFobControllerComponent {
     return (
       position < this.getDraggingFobCenter() &&
       movement < 0 &&
-      this.getDraggingFobStep() > this.cardAdapter.getLowestStep()
+      this.getDraggingFobStep() > this.cardFobHelper.getLowestStep()
     );
   }
 
@@ -152,7 +158,7 @@ export class CardFobControllerComponent {
     return (
       position > this.getDraggingFobCenter() &&
       movement > 0 &&
-      this.getDraggingFobStep() < this.cardAdapter.getHighestStep()
+      this.getDraggingFobStep() < this.cardFobHelper.getHighestStep()
     );
   }
 

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -22,7 +22,12 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import {AxisDirection, CardFobAdapter, TimeSelection} from './card_fob_types';
+import {
+  AxisDirection,
+  CardFobAdapter,
+  TimeSelection,
+  TimeSelectionAffordance,
+} from './card_fob_types';
 
 export enum Fob {
   NONE,
@@ -44,17 +49,19 @@ export class CardFobControllerComponent {
   @Input() cardAdapter!: CardFobAdapter;
   @Input() showExtendedLine?: Boolean = false;
 
-  @Output() onTimeSelectionChanged = new EventEmitter<TimeSelection>();
+  @Output() onTimeSelectionChanged = new EventEmitter<{
+    timeSelection: TimeSelection;
+    affordance?: TimeSelectionAffordance;
+  }>();
   @Output() onTimeSelectionToggled = new EventEmitter();
 
   private currentDraggingFob: Fob = Fob.NONE;
+  private affordance: TimeSelectionAffordance = TimeSelectionAffordance.NONE;
 
   constructor(private readonly root: ElementRef) {}
 
-  // Helper function to check enum in template.
-  public FobType(): typeof Fob {
-    return Fob;
-  }
+  readonly Fob = Fob;
+  readonly TimeSelectionAffordance = TimeSelectionAffordance;
 
   getCssTranslatePx(step: number): string {
     if (this.axisDirection === AxisDirection.VERTICAL) {
@@ -68,12 +75,27 @@ export class CardFobControllerComponent {
     )}px, 0px)`;
   }
 
-  startDrag(fob: Fob) {
+  startDrag(fob: Fob, affordance: TimeSelectionAffordance) {
     this.currentDraggingFob = fob;
+    this.affordance = affordance;
   }
 
   stopDrag() {
+    // This function might be overtrigged by both mouseup and mouseleave.
+    // We only want to fire one onTimeSelectionChanged event.
+    if (
+      this.currentDraggingFob === Fob.NONE ||
+      this.affordance === TimeSelectionAffordance.NONE
+    ) {
+      return;
+    }
+
     this.currentDraggingFob = Fob.NONE;
+    this.onTimeSelectionChanged.emit({
+      timeSelection: this.timeSelection,
+      affordance: this.affordance,
+    });
+    this.affordance = TimeSelectionAffordance.NONE;
   }
 
   isVertical() {
@@ -83,7 +105,7 @@ export class CardFobControllerComponent {
   mouseMove(event: MouseEvent) {
     if (this.currentDraggingFob === Fob.NONE) return;
 
-    const newLinkedTimeSelection = this.timeSelection;
+    const newTimeSelection = this.timeSelection;
     let newStep: number | null = null;
     const mousePosition = this.getMousePositionFromEvent(event);
     const movement =
@@ -106,16 +128,16 @@ export class CardFobControllerComponent {
       if (newStep <= this.timeSelection.start.step) {
         newStep = this.timeSelection.start.step;
       }
-      newLinkedTimeSelection.end!.step = newStep;
+      newTimeSelection.end!.step = newStep;
     } else {
       // Do not let the start fob pass the end fob.
       // TODO: add swapping logic here to allow continued dragging
       if (this.timeSelection.end && newStep >= this.timeSelection.end.step) {
         newStep = this.timeSelection.end.step;
       }
-      newLinkedTimeSelection.start.step = newStep;
+      newTimeSelection.start.step = newStep;
     }
-    this.onTimeSelectionChanged.emit(newLinkedTimeSelection);
+    this.onTimeSelectionChanged.emit({timeSelection: newTimeSelection});
   }
 
   isDraggingLower(position: number, movement: number): boolean {
@@ -201,8 +223,11 @@ export class CardFobControllerComponent {
       };
     }
 
-    // TODO(jieweiwu): Only emits action when selected time is changed.
-    this.onTimeSelectionChanged.emit(newTimeSelection);
+    // TODO(jieweiwu): Only emits action when time selection is changed.
+    this.onTimeSelectionChanged.emit({
+      timeSelection: newTimeSelection,
+      affordance: TimeSelectionAffordance.FOB_TEXT,
+    });
   }
 
   /**
@@ -216,14 +241,20 @@ export class CardFobControllerComponent {
    */
   onFobRemoved(fob: Fob) {
     if (fob === Fob.END) {
-      this.onTimeSelectionChanged.emit({...this.timeSelection, end: null});
+      this.onTimeSelectionChanged.emit({
+        timeSelection: {...this.timeSelection, end: null},
+        affordance: TimeSelectionAffordance.FOB_REMOVED,
+      });
       return;
     }
 
     if (this.timeSelection.end !== null) {
       this.onTimeSelectionChanged.emit({
-        start: this.timeSelection.end,
-        end: null,
+        timeSelection: {
+          start: this.timeSelection.end,
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB_REMOVED,
       });
       return;
     }

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -84,16 +84,6 @@ export class CardFobControllerComponent {
     return `translate(${this.endStepAxisPosition}px, 0px)`;
   }
 
-  getCssTranslatePxForEndFob() {
-    if (this.endStepAxisPosition === null) {
-      return '';
-    }
-    if (this.axisDirection === AxisDirection.VERTICAL) {
-      return `translate(0px, ${this.endStepAxisPosition}px)`;
-    }
-    return `translate(${this.endStepAxisPosition}px, 0px)`;
-  }
-
   startDrag(fob: Fob, affordance: TimeSelectionAffordance) {
     this.currentDraggingFob = fob;
     this.affordance = affordance;

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -32,8 +32,8 @@ import {
       #FobController
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [axisPositionFromStartStep]="getAxisPositionFromStartStep()"
-      [axisPositionFromEndStep]="getAxisPositionFromEndStep()"
+      [startStepAxisPosition]="getAxisPositionFromStartStep()"
+      [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [highestStep]="getHighestStep()"
       [lowestStep]="getLowestStep()"
       [cardFobHelper]="cardFobHelper"
@@ -145,13 +145,22 @@ describe('card_fob_controller', () => {
     return fixture;
   }
 
-  it('sets fob position based on time selection and getAxisPositionFromStartStep/EndStep call', () => {
+  fit('sets fob position based on time selection and getAxisPositionFromStartStep/EndStep call', () => {
     const fixture = createComponent({
       timeSelection: {start: {step: 2}, end: {step: 5}},
+      axisDirection: AxisDirection.HORIZONTAL,
     });
     fixture.detectChanges();
+
     expect(getAxisPositionFromStartStepSpy).toHaveBeenCalled();
     expect(getAxisPositionFromEndStepSpy).toHaveBeenCalled();
+    const fobController = fixture.componentInstance.fobController;
+    expect(
+      fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
+    ).toEqual(2);
+    expect(
+      fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
+    ).toEqual(5);
   });
 
   describe('vertical dragging', () => {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -145,7 +145,7 @@ describe('card_fob_controller', () => {
     return fixture;
   }
 
-  fit('sets fob position based on time selection and getAxisPositionFromStartStep/EndStep call', () => {
+  it('sets fob position based on time selection', () => {
     const fixture = createComponent({
       timeSelection: {start: {step: 2}, end: {step: 5}},
       axisDirection: AxisDirection.HORIZONTAL,

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -49,10 +49,6 @@ class TestableComponent {
 
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection!: TimeSelection;
-  @Input() axisPositionFromStartStep!: number;
-  @Input() axisPositionFromEndStep!: number;
-  @Input() highestStep!: number;
-  @Input() lowestStep!: number;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
   @Input() showExtendedLine?: Boolean;
 

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -34,8 +34,8 @@ import {
       [timeSelection]="timeSelection"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
-      [highestStep]="getHighestStep()"
-      [lowestStep]="getLowestStep()"
+      [highestStep]="highestStep"
+      [lowestStep]="lowestStep"
       [cardFobHelper]="cardFobHelper"
       [showExtendedLine]="showExtendedLine"
       (onTimeSelectionChanged)="onTimeSelectionChanged($event)"
@@ -51,24 +51,22 @@ class TestableComponent {
   @Input() timeSelection!: TimeSelection;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
   @Input() showExtendedLine?: Boolean;
+  @Input() highestStep!: number;
+  @Input() lowestStep!: number;
+  @Input() getAxisPositionFromStartStep!: () => number;
+  @Input() getAxisPositionFromEndStep!: () => number;
 
   @Input() onTimeSelectionChanged!: (newTimeSelection: TimeSelection) => void;
   @Input() onTimeSelectionToggled!: () => void;
-  @Input() getAxisPositionFromStartStep!: () => number;
-  @Input() getAxisPositionFromEndStep!: () => number;
-  @Input() getHighestStep!: () => number;
-  @Input() getLowestStep!: () => number;
 }
 
 describe('card_fob_controller', () => {
   let onTimeSelectionChanged: jasmine.Spy;
   let onTimeSelectionToggled: jasmine.Spy;
-  let getHighestStepSpy: jasmine.Spy;
-  let getLowestStepSpy;
-  let getAxisPositionFromStartStepSpy: jasmine.Spy;
-  let getAxisPositionFromEndStepSpy: jasmine.Spy;
   let getStepHigherSpy: jasmine.Spy;
   let getStepLowerSpy: jasmine.Spy;
+  let getAxisPositionFromStartStepSpy: jasmine.Spy;
+  let getAxisPositionFromEndStepSpy: jasmine.Spy;
   let cardFobHelper: CardFobGetStepFromPositionHelper;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -95,38 +93,33 @@ describe('card_fob_controller', () => {
     fixture.debugElement.nativeElement.style.left = '0';
     fixture.debugElement.nativeElement.style.top = '0';
 
-    getHighestStepSpy = jasmine.createSpy();
-    getLowestStepSpy = jasmine.createSpy();
-    getAxisPositionFromStartStepSpy = jasmine.createSpy();
-    getAxisPositionFromEndStepSpy = jasmine.createSpy();
     getStepHigherSpy = jasmine.createSpy();
     getStepLowerSpy = jasmine.createSpy();
-    cardFobHelper = {
-      getStepHigherThanAxisPosition: getStepHigherSpy,
-      getStepLowerThanAxisPosition: getStepLowerSpy,
-    };
-
-    getHighestStepSpy.and.callFake(() => 4);
-    getLowestStepSpy.and.callFake(() => 0);
-    getAxisPositionFromStartStepSpy.and.callFake(() => {
-      return input.timeSelection.start.step;
-    });
-    getAxisPositionFromEndStepSpy.and.callFake(() => {
-      return input.timeSelection.end ? input.timeSelection.end.step : null;
-    });
+    getAxisPositionFromStartStepSpy = jasmine.createSpy();
+    getAxisPositionFromEndStepSpy = jasmine.createSpy();
     getStepHigherSpy.and.callFake((step: number) => {
       return step;
     });
     getStepLowerSpy.and.callFake((step: number) => {
       return step;
     });
-    fixture.componentInstance.cardFobHelper = cardFobHelper;
+    getAxisPositionFromStartStepSpy.and.callFake(() => {
+      return input.timeSelection.start.step;
+    });
+    getAxisPositionFromEndStepSpy.and.callFake(() => {
+      return input.timeSelection.end ? input.timeSelection.end.step : null;
+    });
+    cardFobHelper = {
+      getStepHigherThanAxisPosition: getStepHigherSpy,
+      getStepLowerThanAxisPosition: getStepLowerSpy,
+    };
+
     fixture.componentInstance.getAxisPositionFromStartStep =
       getAxisPositionFromStartStepSpy;
     fixture.componentInstance.getAxisPositionFromEndStep =
       getAxisPositionFromEndStepSpy;
-    fixture.componentInstance.getHighestStep = getHighestStepSpy;
-    fixture.componentInstance.getLowestStep = getLowestStepSpy;
+    fixture.componentInstance.highestStep = 4;
+    fixture.componentInstance.lowestStep = 0;
     fixture.componentInstance.cardFobHelper = cardFobHelper;
 
     fixture.componentInstance.axisDirection =
@@ -152,8 +145,6 @@ describe('card_fob_controller', () => {
     });
     fixture.detectChanges();
 
-    expect(getAxisPositionFromStartStepSpy).toHaveBeenCalled();
-    expect(getAxisPositionFromEndStepSpy).toHaveBeenCalled();
     const fobController = fixture.componentInstance.fobController;
     expect(
       fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
@@ -278,7 +269,6 @@ describe('card_fob_controller', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
       });
-      getHighestStepSpy.and.callFake(() => 4);
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
       expect(
@@ -544,7 +534,6 @@ describe('card_fob_controller', () => {
         timeSelection: {start: {step: 4}, end: null},
         axisDirection: AxisDirection.HORIZONTAL,
       });
-      getHighestStepSpy.and.callFake(() => 4);
       fixture.detectChanges();
 
       const fobController = fixture.componentInstance.fobController;

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -18,7 +18,12 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CardFobComponent} from './card_fob_component';
 import {CardFobControllerComponent, Fob} from './card_fob_controller_component';
-import {AxisDirection, CardFobAdapter, TimeSelection} from './card_fob_types';
+import {
+  AxisDirection,
+  CardFobAdapter,
+  TimeSelection,
+  TimeSelectionAffordance,
+} from './card_fob_types';
 
 @Component({
   selector: 'testable-comp',
@@ -143,18 +148,22 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(1);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {clientY: 3, movementY: 1});
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 3},
-        end: null,
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 3},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB,
       });
     });
 
@@ -168,21 +177,25 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2,
         movementY: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepLowerSpy).toHaveBeenCalledOnceWith(2);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 2},
-        end: null,
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 2},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB,
       });
     });
 
@@ -196,7 +209,7 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 4,
         movementY: -1,
@@ -222,7 +235,7 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {clientY: 2, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
@@ -246,7 +259,7 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {clientY: 8, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
@@ -269,19 +282,23 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(1);
 
-      fobController.startDrag(Fob.END);
+      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
       onTimeSelectionChanged.calls.reset();
       const fakeEvent = new MouseEvent('mousemove', {clientY: 3, movementY: 1});
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 1},
-        end: {step: 3},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 1},
+          end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.FOB,
       });
     });
 
@@ -295,21 +312,25 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      fobController.startDrag(Fob.END);
+      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2,
         movementY: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepLowerSpy).toHaveBeenCalledOnceWith(2);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 1},
-        end: {step: 2},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 1},
+          end: {step: 2},
+        },
+        affordance: TimeSelectionAffordance.FOB,
       });
     });
 
@@ -323,7 +344,7 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
 
-      fobController.startDrag(Fob.END);
+      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 3,
         movementY: -1,
@@ -349,7 +370,7 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
 
-      fobController.startDrag(Fob.END);
+      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {clientY: 2, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
@@ -375,18 +396,22 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(1);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {clientX: 3, movementX: 1});
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(3);
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 3},
-        end: null,
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 3},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB,
       });
     });
 
@@ -401,21 +426,25 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
         movementX: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepLowerSpy).toHaveBeenCalledOnceWith(2);
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 2},
-        end: null,
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 2},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB,
       });
     });
 
@@ -430,12 +459,13 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 4,
         movementX: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
@@ -443,7 +473,13 @@ describe('card_fob_controller', () => {
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
-      expect(onTimeSelectionChanged).toHaveBeenCalledTimes(0);
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 2},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB,
+      });
     });
 
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging right but, is left of the fob', () => {
@@ -457,9 +493,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {clientX: 2, movementX: 1});
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepLowerSpy).toHaveBeenCalledTimes(0);
@@ -467,7 +504,13 @@ describe('card_fob_controller', () => {
       expect(
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
-      expect(onTimeSelectionChanged).toHaveBeenCalledTimes(0);
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 4},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB,
+      });
     });
 
     it('does not move the start fob or call call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging right but, the fob is already on the final step', () => {
@@ -483,7 +526,7 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START);
+      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {clientX: 8, movementX: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
@@ -507,19 +550,23 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(1);
 
-      fobController.startDrag(Fob.END);
+      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
       onTimeSelectionChanged.calls.reset();
       const fakeEvent = new MouseEvent('mousemove', {clientX: 3, movementX: 1});
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(3);
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 1},
-        end: {step: 3},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 1},
+          end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.FOB,
       });
     });
 
@@ -534,21 +581,25 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      fobController.startDrag(Fob.END);
+      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
         movementX: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepLowerSpy).toHaveBeenCalledOnceWith(2);
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 1},
-        end: {step: 2},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 1},
+          end: {step: 2},
+        },
+        affordance: TimeSelectionAffordance.FOB,
       });
     });
 
@@ -563,7 +614,7 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
 
-      fobController.startDrag(Fob.END);
+      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 3,
         movementX: -1,
@@ -590,7 +641,7 @@ describe('card_fob_controller', () => {
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(3);
-      fobController.startDrag(Fob.END);
+      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
       const fakeEvent = new MouseEvent('mousemove', {clientX: 2, movementX: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
@@ -657,6 +708,7 @@ describe('card_fob_controller', () => {
       fobController.mouseMove(
         new MouseEvent('mousemove', {clientX: 3, movementX: 1})
       );
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepHigherSpy).toHaveBeenCalledWith(3);
@@ -664,8 +716,11 @@ describe('card_fob_controller', () => {
         startFobExtendedLine.nativeElement.getBoundingClientRect().left
       ).toEqual(3);
       expect(onTimeSelectionChanged).toHaveBeenCalledWith({
-        start: {step: 3},
-        end: {step: 3},
+        timeSelection: {
+          start: {step: 3},
+          end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.EXTENDED_LINE,
       });
 
       // Clicks and drags extended line from end fob
@@ -678,15 +733,19 @@ describe('card_fob_controller', () => {
       fobController.mouseMove(
         new MouseEvent('mousemove', {clientX: 5, movementX: 1})
       );
+      fobController.stopDrag();
       fixture.detectChanges();
 
       expect(getStepHigherSpy).toHaveBeenCalledWith(5);
       expect(
         endFobExtendedLine.nativeElement.getBoundingClientRect().left
-      ).toEqual(5);
+      ).toBe(5);
       expect(onTimeSelectionChanged).toHaveBeenCalledWith({
-        start: {step: 3},
-        end: {step: 5},
+        timeSelection: {
+          start: {step: 3},
+          end: {step: 5},
+        },
+        affordance: TimeSelectionAffordance.EXTENDED_LINE,
       });
     });
   });
@@ -700,9 +759,12 @@ describe('card_fob_controller', () => {
       const fobController = fixture.componentInstance.fobController;
       fobController.stepTyped(Fob.START, 3);
       fixture.detectChanges();
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 3},
-        end: null,
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 3},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB_TEXT,
       });
     });
 
@@ -714,9 +776,12 @@ describe('card_fob_controller', () => {
       const fobController = fixture.componentInstance.fobController;
       fobController.stepTyped(Fob.START, 3);
       fixture.detectChanges();
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 3},
-        end: {step: 4},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 3},
+          end: {step: 4},
+        },
+        affordance: TimeSelectionAffordance.FOB_TEXT,
       });
     });
 
@@ -728,9 +793,12 @@ describe('card_fob_controller', () => {
       const fobController = fixture.componentInstance.fobController;
       fobController.stepTyped(Fob.END, 3);
       fixture.detectChanges();
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 1},
-        end: {step: 3},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 1},
+          end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.FOB_TEXT,
       });
     });
 
@@ -742,9 +810,12 @@ describe('card_fob_controller', () => {
       const fobController = fixture.componentInstance.fobController;
       fobController.stepTyped(Fob.START, 3);
       fixture.detectChanges();
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 2},
-        end: {step: 3},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 2},
+          end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.FOB_TEXT,
       });
     });
 
@@ -756,9 +827,12 @@ describe('card_fob_controller', () => {
       const fobController = fixture.componentInstance.fobController;
       fobController.stepTyped(Fob.END, 2);
       fixture.detectChanges();
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 2},
-        end: {step: 3},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 2},
+          end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.FOB_TEXT,
       });
     });
 
@@ -770,9 +844,12 @@ describe('card_fob_controller', () => {
       const fobController = fixture.componentInstance.fobController;
       fobController.stepTyped(Fob.END, 0);
       fixture.detectChanges();
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 0},
-        end: {step: 3},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 0},
+          end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.FOB_TEXT,
       });
     });
 
@@ -791,9 +868,12 @@ describe('card_fob_controller', () => {
         preventDefault: () => {},
       });
 
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 8},
-        end: null,
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 8},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB_TEXT,
       });
     });
 
@@ -813,9 +893,12 @@ describe('card_fob_controller', () => {
         preventDefault: preventDefaultSpy,
       });
 
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 1},
-        end: {step: 8},
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 1},
+          end: {step: 8},
+        },
+        affordance: TimeSelectionAffordance.FOB_TEXT,
       });
       expect(preventDefaultSpy).toHaveBeenCalled();
     });
@@ -849,9 +932,12 @@ describe('card_fob_controller', () => {
       deselectButton.triggerEventHandler('click', {});
       fixture.detectChanges();
 
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 1},
-        end: null,
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 1},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB_REMOVED,
       });
     });
 
@@ -867,9 +953,12 @@ describe('card_fob_controller', () => {
       deselectButton.triggerEventHandler('click', {});
       fixture.detectChanges();
 
-      expect(onTimeSelectionChanged).toHaveBeenCalledOnceWith({
-        start: {step: 3},
-        end: null,
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 3},
+          end: null,
+        },
+        affordance: TimeSelectionAffordance.FOB_REMOVED,
       });
     });
   });

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -45,7 +45,7 @@ class TestableComponent {
 
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection!: TimeSelection;
-  @Input() cardFobAdapter!: CardFobAdapter;
+  @Input() cardFobAdapter!: CardFobGetStepHelper;
   @Input() showExtendedLine?: Boolean;
 
   @Input() onTimeSelectionChanged!: (newTimeSelection: TimeSelection) => void;
@@ -56,11 +56,11 @@ describe('card_fob_controller', () => {
   let onTimeSelectionChanged: jasmine.Spy;
   let onTimeSelectionToggled: jasmine.Spy;
   let getHighestStepSpy: jasmine.Spy;
-  let getLowestStepSpy: jasmine.Spy;
+  let getLowestStepSpyCardFobGetStepHelper;
   let getAxisPositionFromStepSpy: jasmine.Spy;
   let getStepHigherSpy: jasmine.Spy;
   let getStepLowerSpy: jasmine.Spy;
-  let cardFobAdapter: CardFobAdapter;
+  let cardFobAdapter: CardFobGetStepHelper;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -48,17 +48,12 @@ export enum AxisDirection {
 }
 
 /**
- * These helper functions are intended to be used in the card that has a
- * CardFobControllerComponent.
+ * These helper functions are intended to be defined by the card that is a parent
+ * of CardFobControllerComponent.
  *
  * Each helper function will have some sort of Scale that is used to convert from
  * pixel to step so that the fob lines up with the axis properly. In future
  * comments this scale will be refered to as ImplementerScale.
- *
- * These helper functions use ImplementerScale, minMax, and axisSize from the card to
- * determine the step. The changes of minMax and axisSize will not be reflected as changes
- * of functions. (Functions are like pointers and as far as Angular concerns, it does not
- * get changed even thought the return values might be cahnged based on minMax, and axisSize.)
  *
  * It also allows cards to implement the dragging functionality in different
  * ways. By deciding which step to return in the getStepHigherThanMousePosition

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -55,8 +55,10 @@ export enum AxisDirection {
  * pixel to step so that the fob lines up with the axis properly. In future
  * comments this scale will be refered to as ImplementerScale.
  *
- * These helper functions use minMax and axisSize from the card to determine the step.
- * The changes of minMax and axisSize will not be reflected on the functions changes.
+ * These helper functions use ImplementerScale, minMax, and axisSize from the card to
+ * determine the step. The changes of minMax and axisSize will not be reflected as changes
+ * of functions. (Functions are like pointers and as far as Angular concerns, it does not
+ * get changed even thought the return values might be cahnged based on minMax, and axisSize.)
  *
  * It also allows cards to implement the dragging functionality in different
  * ways. By deciding which step to return in the getStepHigherThanMousePosition

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -48,11 +48,11 @@ export enum AxisDirection {
 }
 
 /**
- * These helper functions are intended to be implemented by the card that has a
+ * These helper functions are intended to be used in the card that has a
  * CardFobControllerComponent.
  *
- * Each helper function will have some sort of Scale that is used to convert between
- * step and pixel so that the fob lines up with the axis properly. In future
+ * Each helper function will have some sort of Scale that is used to convert from
+ * pixel to step so that the fob lines up with the axis properly. In future
  * comments this scale will be refered to as ImplementerScale.
  *
  * These helper functions use minMax and axisSize from the card to determine the step.
@@ -63,17 +63,7 @@ export enum AxisDirection {
  * and getStepLowerThanMousePosition functions the implementer can decide if the
  * fob "snaps" to certain steps or drags in in a smooth continuous way.
  */
-export interface CardFobGetStepHelper {
-  /**
-   * Gets the highest step for this card.
-   */
-  getHighestStep(): number;
-
-  /**
-   * Gets the lowest step for this card.
-   */
-  getLowestStep(): number;
-
+export interface CardFobGetStepFromPositionHelper {
   /**
    * Uses ImplementerScale to determine the step that is at the current mouse
    * position or the closest step that is higher than the current mouse position.

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -21,6 +21,25 @@ export interface TimeSelection {
 }
 
 /**
+ * The affordance supported to update the time selection.
+ */
+export enum TimeSelectionAffordance {
+  NONE,
+  // Dragging the extended line above a fob.
+  EXTENDED_LINE,
+  // Dragging the fob.
+  FOB,
+  // Clicking the deselect button.
+  FOB_REMOVED,
+  // Typing the step in fob.
+  FOB_TEXT,
+  // Typing the step in setting pane.
+  SETTINGS_TEXT,
+  // Dragging the slider in setting pane.
+  SETTINGS_SLIDER,
+}
+
+/**
  * The direction of the axis used to control the fob movements.
  */
 export enum AxisDirection {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -48,19 +48,22 @@ export enum AxisDirection {
 }
 
 /**
- * This class is intended to be implemented by the card that has a
+ * These helper functions are intended to be implemented by the card that has a
  * CardFobControllerComponent.
  *
- * Each implementer will have some sort of Scale that is used to convert between
+ * Each helper function will have some sort of Scale that is used to convert between
  * step and pixel so that the fob lines up with the axis properly. In future
  * comments this scale will be refered to as ImplementerScale.
+ *
+ * These helper functions use minMax and axisSize from the card to determine the step.
+ * The changes of minMax and axisSize will not be reflected on the functions changes.
  *
  * It also allows cards to implement the dragging functionality in different
  * ways. By deciding which step to return in the getStepHigherThanMousePosition
  * and getStepLowerThanMousePosition functions the implementer can decide if the
  * fob "snaps" to certain steps or drags in in a smooth continuous way.
  */
-export interface CardFobAdapter {
+export interface CardFobGetStepHelper {
   /**
    * Gets the highest step for this card.
    */
@@ -70,12 +73,6 @@ export interface CardFobAdapter {
    * Gets the lowest step for this card.
    */
   getLowestStep(): number;
-
-  /**
-   * Uses ImplementerScale to translate the proper pixel offset.
-   * @param step the step which needs to be translated.
-   */
-  getAxisPositionFromStep(step: number): number;
 
   /**
    * Uses ImplementerScale to determine the step that is at the current mouse

--- a/tensorboard/webapp/widgets/histogram/histogram_card_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_card_fob_controller.ts
@@ -19,8 +19,8 @@ import {
 } from '@angular/core';
 import {
   AxisDirection,
+  CardFobGetStepFromPositionHelper,
   TimeSelection,
-  CardFobGetStepHelper,
 } from '../card_fob/card_fob_types';
 import {TemporalScale} from './histogram_component';
 
@@ -30,8 +30,10 @@ import {TemporalScale} from './histogram_component';
     <card-fob-controller
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [getAxisPositionFromStartStep]="getAxisPositionFromStartStep()"
-      [getAxisPositionFromEndStep]="getAxisPositionFromEndStep()"
+      [axisPositionFromStartStep]="getAxisPositionFromStartStep()"
+      [axisPositionFromEndStep]="getAxisPositionFromEndStep()"
+      [highestStep]="getHighestStep()"
+      [lowestStep]="getLowestStep()"
       [cardFobHelper]="cardFobHelper"
       (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
       (onTimeSelectionToggled)="onTimeSelectionToggled.emit()"
@@ -47,9 +49,7 @@ export class HistogramCardFobController {
   @Output() onTimeSelectionToggled = new EventEmitter();
 
   readonly axisDirection = AxisDirection.VERTICAL;
-  readonly cardFobHelper: CardFobGetStepHelper = {
-    getHighestStep: this.getHighestStep.bind(this),
-    getLowestStep: this.getLowestStep.bind(this),
+  readonly cardFobHelper: CardFobGetStepFromPositionHelper = {
     getStepHigherThanAxisPosition:
       this.getStepHigherThanAxisPosition.bind(this),
     getStepLowerThanAxisPosition: this.getStepLowerThanAxisPosition.bind(this),

--- a/tensorboard/webapp/widgets/histogram/histogram_card_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_card_fob_controller.ts
@@ -30,8 +30,8 @@ import {TemporalScale} from './histogram_component';
     <card-fob-controller
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [axisPositionFromStartStep]="getAxisPositionFromStartStep()"
-      [axisPositionFromEndStep]="getAxisPositionFromEndStep()"
+      [startStepAxisPosition]="getAxisPositionFromStartStep()"
+      [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [highestStep]="getHighestStep()"
       [lowestStep]="getLowestStep()"
       [cardFobHelper]="cardFobHelper"
@@ -55,11 +55,11 @@ export class HistogramCardFobController {
     getStepLowerThanAxisPosition: this.getStepLowerThanAxisPosition.bind(this),
   };
 
-  getAxisPositionFromStartStep() {
+  getAxisPositionFromStartStep(): number {
     return this.temporalScale(this.timeSelection.start.step);
   }
 
-  getAxisPositionFromEndStep() {
+  getAxisPositionFromEndStep(): number | null {
     if (this.timeSelection.end === null) {
       return null;
     }

--- a/tensorboard/webapp/widgets/histogram/histogram_card_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_card_fob_test.ts
@@ -121,11 +121,17 @@ describe('HistogramCardFobController', () => {
     });
   });
 
-  describe('getAxisPositionFromStep', () => {
+  describe('getAxisPositionFromStartStep/EndStep', () => {
     it('calls the scale function', () => {
-      let fixture = createComponent({});
-      expect(fixture.componentInstance.getAxisPositionFromStep(150)).toBe(1500);
-      expect(temporalScaleSpy).toHaveBeenCalledOnceWith(150);
+      let fixture = createComponent({
+        timeSelection: {start: {step: 150}, end: {step: 300}},
+      });
+      expect(fixture.componentInstance.getAxisPositionFromStartStep()).toBe(
+        1500
+      );
+      expect(fixture.componentInstance.getAxisPositionFromEndStep()).toBe(3000);
+      expect(temporalScaleSpy).toHaveBeenCalledWith(150);
+      expect(temporalScaleSpy).toHaveBeenCalledWith(300);
     });
   });
 

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -473,6 +473,8 @@ export class LineChartComponent
       this.isViewBoxChanged = false;
       this.lineChart.setViewBox(this.viewBox);
     }
+
+    this.changeDetector.detectChanges();
   }
 
   onViewBoxChanged({dataExtent}: {dataExtent: Extent}) {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -472,9 +472,9 @@ export class LineChartComponent
       this.isFixedViewBoxUpdated = false;
       this.isViewBoxChanged = false;
       this.lineChart.setViewBox(this.viewBox);
+      // When viewBox is updated, we should also detect changes in child components.
+      this.changeDetector.detectChanges();
     }
-
-    this.changeDetector.detectChanges();
   }
 
   onViewBoxChanged({dataExtent}: {dataExtent: Extent}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,6 +453,14 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
+"@jridgewell/source-map@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
+  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
@@ -1744,6 +1752,11 @@ accepts@~1.3.4:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
+
+acorn@^8.5.0:
+  version "8.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
+  integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -4418,15 +4431,15 @@ source-map-support@0.5.9:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@~0.5.19:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@0.7.3, source-map@^0.7.3, source-map@~0.7.2:
+source-map@0.7.3, source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -4531,14 +4544,15 @@ tar@^6.0.2, tar@^6.1.0, tar@^6.1.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-terser@^5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.7.1.tgz#2dc7a61009b66bb638305cb2a824763b116bf784"
-  integrity sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==
+terser@^5.14.2:
+  version "5.14.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
+  integrity sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==
   dependencies:
+    "@jridgewell/source-map" "^0.3.2"
+    acorn "^8.5.0"
     commander "^2.20.0"
-    source-map "~0.7.2"
-    source-map-support "~0.5.19"
+    source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
* Motivation for features / changes
Current we define a `CardFobController` and implements the methods at CardFobController level (e.g. `ScalarCardFobController`) and pass "this" to child component. However,  Angular will not detech the data changes within `ScalarCardFobController` (in our case, minMax and axisSize) because as far as it concerns, "this" does not change.
This causes the bug when minMax and axisSize are updated (changing window size, expand card group..) it does not cause card_fob_component to be re-rendered and the fob position is off.

* Technical description of changes
To handle this, we need to modify the method `getAxisPositionFromStep` which transform step to position, to two separate methods, getAxisPositionFromStartStep and getAxisPositionFromEndStep, and execute these two methods on `ScalarCardFobController` level, and feed the result to CardFobController. This way we are sure the input data is changed and Angular will detect the changes then re-render the CardFobController.

For the rest of CardFobAdaptor methods, they are used to get step and involving mouse movements. They are either do not have the same re-render requirements or the changes will cause timeSelection changes, which for sure will trigger child component re-rendering.
Therefore, I preserve this four methods and rename it to CardFobGetStepHelper and pass it to child component.
This PR does not include test changes and is used for discussion.

Update: we only keep getStepHigherThanPosition and getStepLowerThanPosition in a helper object and pass it as functions. The other 4 methods are used as passing values.