### PR TITLE
step selector: add alias in run name if any

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -237,10 +237,14 @@ export class ScalarCardComponent<Downloader> {
           datum.points[findClosestIndex(datum.points, startStep)];
         const selectedStepData: SelectedStepRunData = {};
         selectedStepData.COLOR = metadata.color;
+        let alias = '';
+        if (metadata.alias) {
+          alias = `${metadata.alias.aliasNumber} ${metadata.alias.aliasText}/`;
+        }
         for (const header of this.dataHeaders) {
           switch (header) {
             case ColumnHeaders.RUN:
-              selectedStepData.RUN = metadata.displayName;
+              selectedStepData.RUN = `${alias}${metadata.displayName}`;
               continue;
             case ColumnHeaders.STEP:
               selectedStepData.STEP = closestStartPoint.step;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -237,13 +237,13 @@ export class ScalarCardComponent<Downloader> {
           datum.points[findClosestIndex(datum.points, startStep)];
         const selectedStepData: SelectedStepRunData = {};
         selectedStepData.COLOR = metadata.color;
-        let alias = '';
-        if (metadata.alias) {
-          alias = `${metadata.alias.aliasNumber} ${metadata.alias.aliasText}/`;
-        }
         for (const header of this.dataHeaders) {
           switch (header) {
             case ColumnHeaders.RUN:
+              let alias = '';
+              if (metadata.alias) {
+                alias = `${metadata.alias.aliasNumber} ${metadata.alias.aliasText}/`;
+              }
               selectedStepData.RUN = `${alias}${metadata.displayName}`;
               continue;
             case ColumnHeaders.STEP:

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2263,20 +2263,11 @@ describe('scalar card', () => {
           run2: [buildScalarStepData({step: 20})],
           run3: [buildScalarStepData({step: 30})],
         };
-        const cardMetadata = {
-          plugin: PluginType.SCALARS,
-          tag: 'tagA',
-          run: null,
-          alias: {
-            aliasNumber: 100,
-            aliastText: 'test alias',
-          },
-        };
         provideMockCardRunToSeriesData(
           selectSpy,
           PluginType.SCALARS,
           'card1',
-          cardMetadata /* metadataOverride */,
+          null /* metadataOverride */,
           runToSeries
         );
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2263,11 +2263,20 @@ describe('scalar card', () => {
           run2: [buildScalarStepData({step: 20})],
           run3: [buildScalarStepData({step: 30})],
         };
+        const cardMetadata = {
+          plugin: PluginType.SCALARS,
+          tag: 'tagA',
+          run: null,
+          alias: {
+            aliasNumber: 100,
+            aliastText: 'test alias',
+          },
+        };
         provideMockCardRunToSeriesData(
           selectSpy,
           PluginType.SCALARS,
           'card1',
-          null /* metadataOverride */,
+          cardMetadata /* metadataOverride */,
           runToSeries
         );
       });
@@ -2497,6 +2506,66 @@ describe('scalar card', () => {
 
       expect(data[0].STEP).toEqual(10);
       expect(data[1].STEP).toEqual(8);
+    }));
+
+    it('renders alias', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 10},
+          {wallTime: 2, value: 10, step: 20},
+          {wallTime: 3, value: 20, step: 35},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 8},
+          {wallTime: 2, value: 10, step: 15},
+          {wallTime: 3, value: 20, step: 50},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+      store.overrideSelector(selectors.getExperimentIdToExperimentAliasMap, {
+        eid1: {aliasText: 'test alias 1', aliasNumber: 100},
+        eid2: {aliasText: 'test alias 2', aliasNumber: 200},
+      });
+      store.overrideSelector(getMetricsLinkedTimeSelection, {
+        start: {step: 1},
+        end: null,
+      });
+      selectSpy
+        .withArgs(selectors.getExperimentIdForRunId, {runId: 'run1'})
+        .and.returnValue(of('eid1'));
+      selectSpy
+        .withArgs(selectors.getExperimentIdForRunId, {runId: 'run2'})
+        .and.returnValue(of('eid2'));
+      selectSpy
+        .withArgs(selectors.getRun, {runId: 'run1'})
+        .and.returnValue(of(buildRun({name: 'Run1 name'})));
+      selectSpy
+        .withArgs(selectors.getRun, {runId: 'run2'})
+        .and.returnValue(of(buildRun({name: 'Run2 name'})));
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getTimeSelectionTableData();
+      expect(data[0].RUN).toEqual('100 test alias 1/Run1 name');
+      expect(data[1].RUN).toEqual('200 test alias 2/Run2 name');
     }));
   });
 


### PR DESCRIPTION
* Motivation for features / changes
Previously when displaying the run column we display the run name. Yet when comparing multiple experiments we missed the alias number and text. This PR adds it to the table.

* Technical description of changes
Extract alias info from metadata and combine with Run name. A space is added between alias number and text. We do have alias component, however introducing the component adds too much unnecessary complexity (the data_table widget needs to treat it "special" as color run and also customize the background color of alias number). I decide to no involve this component and just simply add alias as part of RUN column.


* Screenshots of UI changes
Before 
![Screen Shot 2022-07-21 at 4 15 39 PM](https://user-images.githubusercontent.com/1131010/180330407-f468a03c-f23f-40c0-93cd-4331e56ba049.png)
After
![Screen Shot 2022-07-21 at 3 32 24 PM](https://user-images.githubusercontent.com/1131010/180329844-5d2112fb-4f6d-4855-8a78-6534c5af37ba.png)

![Screen Shot 2022-07-21 at 4 17 35 PM](https://user-images.githubusercontent.com/1131010/180330574-f28d1e29-1787-4349-9fbb-b3dd8f7e59d9.png)


