### PR TITLE
Step Selector: add step selector selection change action

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -195,6 +195,21 @@ export const stepSelectorToggled = createAction(
   '[Metrics] Time Selector Enable Toggle'
 );
 
+/**
+ * Fired when step selector time selection is changed. This event is
+ * used for internal analytics only and will not cause state changes.
+ */
+export const stepSelectorTimeSelectionChanged = createAction(
+  '[Metrics] Ｓtep Selector Time Selection Changed',
+  props<{
+    timeSelection: {
+      startStep: number;
+      endStep: number | undefined;
+    };
+    affordance?: TimeSelectionAffordance | undefined;
+  }>()
+);
+
 export const metricsPromoDismissed = createAction(
   '[Metrics] Metrics Promo Dismissed'
 );

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -206,6 +206,8 @@ export const stepSelectorTimeSelectionChanged = createAction(
       startStep: number;
       endStep: number | undefined;
     };
+    // Affordance for internal analytics purpose. When no affordance is specified or is
+    // undefined we do not want to log an analytics event.
     affordance?: TimeSelectionAffordance | undefined;
   }>()
 );

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -94,12 +94,16 @@ export class ScalarCardComponent<Downloader> {
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
+  @Output() onLinkedTimeToggled = new EventEmitter();
   @Output() onLinkedTimeSelectionChanged = new EventEmitter<{
     timeSelection: TimeSelection;
     affordance: TimeSelectionAffordance;
   }>();
-  @Output() onLinkedTimeToggled = new EventEmitter();
   @Output() onStepSelectorToggled = new EventEmitter();
+  @Output() onStepSelectorTimeSelectionChanged = new EventEmitter<{
+    timeSelection: TimeSelection;
+    affordance: TimeSelectionAffordance;
+  }>();
 
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)
@@ -297,6 +301,8 @@ export class ScalarCardComponent<Downloader> {
         timeSelection,
         affordance,
       });
+    } else {
+      this.onStepSelectorTimeSelectionChanged.emit({timeSelection, affordance});
     }
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -398,9 +398,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     ]).pipe(
       map(([series, linkedTimeEnabled, timeSelection, xAxisType]) => {
         if (
+          !linkedTimeEnabled ||
           xAxisType !== XAxisType.STEP ||
-          !timeSelection ||
-          !linkedTimeEnabled
+          !timeSelection
         )
           return null;
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -73,10 +73,12 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
   linkedTimeSelectionChanged,
   linkedTimeToggled,
+  stepSelectorTimeSelectionChanged,
   stepSelectorToggled,
 } from '../../actions';
 import {PluginType} from '../../data_source';
 import {
+  getMetricsLinkedTimeEnabled,
   getMetricsLinkedTimeSelection,
   getMetricsScalarSmoothing,
 } from '../../store';
@@ -2063,6 +2065,10 @@ describe('scalar card', () => {
   });
 
   describe('linked time feature integration', () => {
+    beforeEach(() => {
+      store.overrideSelector(getMetricsLinkedTimeEnabled, true);
+    });
+
     describe('time selection and dataset', () => {
       it('shows clipped warning when time selection is outside the extent of dataset', fakeAsync(() => {
         const runToSeries = {
@@ -2340,6 +2346,10 @@ describe('scalar card', () => {
   });
 
   describe('getTimeSelectionTableData', () => {
+    beforeEach(() => {
+      store.overrideSelector(getMetricsLinkedTimeEnabled, true);
+    });
+
     it('builds single selected step data object', fakeAsync(() => {
       const runToSeries = {
         run1: [
@@ -2631,7 +2641,7 @@ describe('scalar card', () => {
         expect(testController).toBeTruthy();
       }));
 
-      it('does not dispatch linkedTimeSelectionChanged action when fob is dragged', fakeAsync(() => {
+      it('dispatches stepSelectorTimeSelectionChanged action when fob is dragged', fakeAsync(() => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
         const testController = fixture.debugElement.query(
@@ -2647,6 +2657,7 @@ describe('scalar card', () => {
           movementX: 1,
         });
         testController.mouseMove(fakeEvent);
+        testController.stopDrag();
         fixture.detectChanges();
 
         const fobs = fixture.debugElement.queryAll(
@@ -2655,6 +2666,22 @@ describe('scalar card', () => {
         expect(
           fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('25');
+        expect(dispatchedActions).toEqual([
+          stepSelectorTimeSelectionChanged({
+            timeSelection: {
+              startStep: 25,
+              endStep: undefined,
+            },
+            affordance: undefined,
+          }),
+          stepSelectorTimeSelectionChanged({
+            timeSelection: {
+              startStep: 25,
+              endStep: undefined,
+            },
+            affordance: TimeSelectionAffordance.FOB,
+          }),
+        ]);
         const scalarCardComponent = fixture.debugElement.query(
           By.directive(ScalarCardComponent)
         );
@@ -2671,6 +2698,7 @@ describe('scalar card', () => {
           start: {step: 20},
           end: {step: 40},
         });
+        store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, true);
         const fixture = createComponent('card1');
         fixture.detectChanges();
         let testController = fixture.debugElement.query(
@@ -2728,7 +2756,7 @@ describe('scalar card', () => {
         fixture.detectChanges();
 
         // Disable linked time
-        store.overrideSelector(getMetricsLinkedTimeSelection, null);
+        store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, false);
         store.refreshState();
         fixture.detectChanges();
 


### PR DESCRIPTION
* Motivation for features / changes
For now we only emit actions on linked time time selection changes but not step selector changes. The reason is that only linked time changes update ngrx state. However, we need the action for step selector to perform internal analysis. This PR creates a new step selector time selection action and fires when linked time is disabled.

* Technical description of changes
The most noticeable change is adding linkedTimeEnabled on scalar card container level. Previously we do not need this because we will update the linked time selection even it is not enabled. This does not make sense now. Linked time selection should not be updated when it is disabled. Please see below demo for flow details.

* Demo
Updates linked time also updates step selector (within the same card) 
Updates step selector will _not_ update linked time (the source of truth is shown on the settings pane)

https://user-images.githubusercontent.com/1131010/180872923-b6b7eca1-328d-47d0-93c9-46c058bb8239.mov


Note: In the demo video, the appearance of linked time and step selector on the settings pane is temporary. They should be rearranged later.

* Detailed steps to verify changes work correctly (as executed by you)
Check developer console when dragging fob
![Screen Shot 2022-07-25 at 10 54 22 AM](https://user-images.githubusercontent.com/1131010/180869282-4d863e85-319b-4013-ba8c-67db2e527223.png)

