### PR TITLE
Step Selector: Use intlNumberFormatter for step formatting

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -20,6 +20,7 @@ import {
 } from '../../metrics/views/card_renderer/scalar_card_types';
 import {
   numberFormatter,
+  intlNumberFormatter,
   relativeTimeFormatter,
 } from '../line_chart_v2/lib/formatter';
 
@@ -71,7 +72,9 @@ export class DataTableComponent {
         if (selectedStepRunData.STEP === undefined) {
           return '';
         }
-        return numberFormatter.formatShort(selectedStepRunData.STEP as number);
+        return intlNumberFormatter.formatShort(
+          selectedStepRunData.STEP as number
+        );
       case ColumnHeaders.TIME:
         if (selectedStepRunData.TIME === undefined) {
           return '';

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -19,8 +19,8 @@ import {
   SelectedStepRunData,
 } from '../../metrics/views/card_renderer/scalar_card_types';
 import {
-  numberFormatter,
   intlNumberFormatter,
+  numberFormatter,
   relativeTimeFormatter,
 } from '../line_chart_v2/lib/formatter';
 


### PR DESCRIPTION
* Motivation for features / changes
The number formatter being used to format the step number was converting it to scientific notation. This changes the formatter to the same one being used int he tooltip which will simply add commas.

googlers see b/238666738