### PR TITLE
ci: update to macos 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-18.04', 'macos-10.15']
+        platform: ['ubuntu-18.04', 'macos-11']
         rust_version: ['1.58.1']
         include:
           - mode: 'universal'


### PR DESCRIPTION
According to https://github.com/actions/virtual-environments/issues/5583, macos-10.15 is no longer supported and fails our ci flow. Upgrade t o macos-11.