### PR TITLE
Update Github CI MacOS version from 10.15 to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-18.04', 'macos-10.15']
+        platform: ['ubuntu-18.04', 'macos-11']
         rust_version: ['1.58.1']
         include:
           - mode: 'universal'


### PR DESCRIPTION
* Motivation for features / change
Support for MacOS 10.15 being removed on Aug 30 https://github.com/actions/virtual-environments/issues/5583

* Technical description of changes
Minimum upgrade, from MacOS 10.15 to MacOS 11

* Tested:
Wait for CI to go.