### PR TITLE
Support selecting single run using double click.

### DIFF
--- a/tensorboard/webapp/runs/actions/runs_actions.ts
+++ b/tensorboard/webapp/runs/actions/runs_actions.ts
@@ -53,6 +53,11 @@ export const runSelectionToggled = createAction(
   props<{runId: string}>()
 );
 
+export const runSelectionToggledOnly = createAction(
+  '[Runs] Run Selection Toggled to be Only',
+  props<{runId: string}>()
+);
+
 export const runPageSelectionToggled = createAction(
   '[Runs] Run Page Selection Toggled',
   props<{runIds: string[]}>()

--- a/tensorboard/webapp/runs/actions/runs_actions.ts
+++ b/tensorboard/webapp/runs/actions/runs_actions.ts
@@ -53,8 +53,12 @@ export const runSelectionToggled = createAction(
   props<{runId: string}>()
 );
 
-export const runSelectionToggledOnly = createAction(
-  '[Runs] Run Selection Toggled to be Only',
+/**
+ * An action to indicate a single run being selected while all other runs are to
+ * be deselected.
+ */
+export const singleRunSelected = createAction(
+  '[Runs] Single Run Selected',
   props<{runId: string}>()
 );
 

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -380,13 +380,13 @@ const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(
       selectionState: nextSelectionState,
     };
   }),
-  on(runsActions.runSelectionToggledOnly, (state, {runId}) => {
+  on(runsActions.singleRunSelected, (state, {runId}) => {
     const nextSelectionState = new Map<string, boolean>();
 
-    for (const runId of state.selectionState.keys()) {
-      nextSelectionState.set(runId, false);
+    // Select the specified run and deselect the others.
+    for (const stateRunId of state.selectionState.keys()) {
+      nextSelectionState.set(stateRunId, runId === stateRunId);
     }
-    nextSelectionState.set(runId, true);
 
     return {
       ...state,

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -380,6 +380,19 @@ const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(
       selectionState: nextSelectionState,
     };
   }),
+  on(runsActions.runSelectionToggledOnly, (state, {runId}) => {
+    const nextSelectionState = new Map<string, boolean>();
+
+    for (const runId of state.selectionState.keys()) {
+      nextSelectionState.set(runId, false);
+    }
+    nextSelectionState.set(runId, true);
+
+    return {
+      ...state,
+      selectionState: nextSelectionState,
+    };
+  }),
   on(runsActions.runPageSelectionToggled, (state, {runIds}) => {
     const nextSelectionState = new Map(state.selectionState);
 

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -479,6 +479,106 @@ describe('runs_reducers', () => {
     });
   });
 
+  describe('singleRunSelected', () => {
+    it('selects run when it is only run', () => {
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([['run1', false]]),
+        }
+      );
+      const nextState = runsReducers.reducers(
+        state,
+        actions.singleRunSelected({
+          runId: 'run1',
+        })
+      );
+      expect(nextState.ui.selectionState).toEqual(new Map([['run1', true]]));
+    });
+
+    it('selects run and deselects others', () => {
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([
+            ['run1', true],
+            ['run2', true],
+            ['run3', false],
+            ['run4', false],
+            ['run5', true],
+          ]),
+        }
+      );
+      const nextState = runsReducers.reducers(
+        state,
+        actions.singleRunSelected({
+          runId: 'run4',
+        })
+      );
+      expect(nextState.ui.selectionState).toEqual(
+        new Map([
+          ['run1', false],
+          ['run2', false],
+          ['run3', false],
+          ['run4', true],
+          ['run5', false],
+        ])
+      );
+    });
+
+    it('keeps run selected if already selected', () => {
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([
+            ['run1', true],
+            ['run2', true],
+            ['run3', true],
+          ]),
+        }
+      );
+      const nextState = runsReducers.reducers(
+        state,
+        actions.singleRunSelected({
+          runId: 'run2',
+        })
+      );
+      expect(nextState.ui.selectionState).toEqual(
+        new Map([
+          ['run1', false],
+          ['run2', true],
+          ['run3', false],
+        ])
+      );
+    });
+
+    it('keeps run selected if only already selected', () => {
+      const state = buildRunsState(
+        {},
+        {
+          selectionState: new Map([
+            ['run1', false],
+            ['run2', true],
+            ['run3', false],
+          ]),
+        }
+      );
+      const nextState = runsReducers.reducers(
+        state,
+        actions.singleRunSelected({
+          runId: 'run2',
+        })
+      );
+      expect(nextState.ui.selectionState).toEqual(
+        new Map([
+          ['run1', false],
+          ['run2', true],
+          ['run3', false],
+        ])
+      );
+    });
+  });
+
   describe('runPageSelectionToggled', () => {
     it('toggles all items to on when they were all previously off', () => {
       const state = buildRunsState(

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -233,6 +233,7 @@ limitations under the License.
           <mat-checkbox
             [checked]="item.selected"
             (change)="onSelectionToggle.emit(item)"
+            (dblclick)="onSelectionDblClick.emit(item)"
           ></mat-checkbox>
         </span>
         <tb-experiment-alias

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
@@ -105,6 +105,7 @@ export class RunsTableComponent implements OnChanges {
 
   @Output() onRegexFilterChange = new EventEmitter<string>();
   @Output() onSelectionToggle = new EventEmitter<RunTableItem>();
+  @Output() onSelectionDblClick = new EventEmitter<RunTableItem>();
   @Output() onPageSelectionToggle = new EventEmitter<{items: RunTableItem[]}>();
   @Output()
   onPaginationChange = new EventEmitter<{

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -66,6 +66,7 @@ import {
   runColorChanged,
   runPageSelectionToggled,
   runSelectionToggled,
+  runSelectionToggledOnly,
   runSelectorPaginationOptionChanged,
   runSelectorRegexFilterChanged,
   runSelectorSortChanged,
@@ -205,6 +206,7 @@ function matchFilter(
       [sortOption]="sortOption$ | async"
       [usePagination]="usePagination"
       (onSelectionToggle)="onRunSelectionToggle($event)"
+      (onSelectionDblClick)="onRunSelectionDblClick($event)"
       (onPageSelectionToggle)="onPageSelectionToggle($event)"
       (onPaginationChange)="onPaginationChange($event)"
       (onRegexFilterChange)="onRegexFilterChange($event)"
@@ -559,6 +561,20 @@ export class RunsTableContainer implements OnInit, OnDestroy {
   onRunSelectionToggle(item: RunTableItem) {
     this.store.dispatch(
       runSelectionToggled({
+        runId: item.run.id,
+      })
+    );
+  }
+
+  // BDTODO: Fill out the doc.
+  // We are relying on the change event consistently being fired before the
+  // dblclick event. We know the click event is fired before the dblclick event
+  // (see https://www.quirksmode.org/dom/events/click.html) so we presume we
+  // can also rely on the change event being fired before the dblclick event.
+  onRunSelectionDblClick(item: RunTableItem) {
+    this.store.dispatch(
+      // BDTODO: Rename this action.
+      runSelectionToggledOnly({
         runId: item.run.id,
       })
     );

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -66,11 +66,11 @@ import {
   runColorChanged,
   runPageSelectionToggled,
   runSelectionToggled,
-  runSelectionToggledOnly,
   runSelectorPaginationOptionChanged,
   runSelectorRegexFilterChanged,
   runSelectorSortChanged,
   runTableShown,
+  singleRunSelected,
 } from '../../actions';
 import {MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT} from '../../store/runs_types';
 import {SortKey, SortType} from '../../types';
@@ -566,15 +566,21 @@ export class RunsTableContainer implements OnInit, OnDestroy {
     );
   }
 
-  // BDTODO: Fill out the doc.
-  // We are relying on the change event consistently being fired before the
-  // dblclick event. We know the click event is fired before the dblclick event
-  // (see https://www.quirksmode.org/dom/events/click.html) so we presume we
-  // can also rely on the change event being fired before the dblclick event.
   onRunSelectionDblClick(item: RunTableItem) {
+    // Note that a user's double click will trigger both 'change' and 'dblclick'
+    // events so onRunSelectionToggle() will also be called and we will fire
+    // two somewhat conflicting actions: runSelectionToggled and
+    // singleRunSelected. This is ok as long as singleRunSelected is fired last.
+    //
+    // We are therefore relying on the mat-checkbox 'change' event consistently
+    // being fired before the 'dblclick' event. Although we don't have any
+    // documentation that guarantees this order, we do have documentation that
+    // states that 'click' is guaranteed to occur before 'dblclick'
+    // (see https://www.quirksmode.org/dom/events/click.html). We presume, then,
+    // that we can rely on the 'change' event being fired before the 'dblclick'
+    // event.
     this.store.dispatch(
-      // BDTODO: Rename this action.
-      runSelectionToggledOnly({
+      singleRunSelected({
         runId: item.run.id,
       })
     );

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -92,6 +92,7 @@ import {
   runSelectorRegexFilterChanged,
   runSelectorSortChanged,
   runTableShown,
+  singleRunSelected,
 } from '../../actions';
 import {DomainType} from '../../data_source/runs_data_source_types';
 import {MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT, Run} from '../../store/runs_types';
@@ -1824,6 +1825,32 @@ describe('runs_table', () => {
       expect(dispatchSpy).toHaveBeenCalledWith(
         runSelectionToggled({
           runId: 'book1',
+        })
+      );
+    });
+
+    it('dispatches singleRunSelected on checkbox double click', async () => {
+      store.overrideSelector(getRuns, [
+        buildRun({id: 'book1', name: "The Philosopher's Stone"}),
+        buildRun({id: 'book2', name: 'The Chamber Of Secrets'}),
+        buildRun({id: 'book3', name: 'The Prisoner of Azkaban'}),
+      ]);
+
+      const fixture = createComponent(
+        ['rowling'],
+        [RunsTableColumn.CHECKBOX, RunsTableColumn.RUN_NAME],
+        true /* usePagination */
+      );
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW);
+      const book2 = rows[1].querySelector('mat-checkbox');
+      book2.dispatchEvent(new MouseEvent('dblclick', {relatedTarget: book2}));
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        singleRunSelected({
+          runId: 'book2',
         })
       );
     });


### PR DESCRIPTION
* Motivation for features / changes

  Users have asked for a way to select one and only one item in the Runs list in the Time Series dashboard. That is, select one run while deselecting all the others. This is supported in Scalars dashboad with a radio button but was not ported to Time Series.

  We decided to support this differently in Time Series -- with a double click. Double clicking on the checkbox for any run will select that run while deselecting the remaining runs.

* Technical description of changes

  We listen for dblclick events on the mat-checkbox. Events and actions are triggered up to the reducer layer where just the one run is selected while the other runs are deselected.

  We recognize that this might be a bit difficult to discover and some might consider it an anti-pattern but we think it is the best option for our situation. Some users might even try this out, having learned the pattern from other products.