### PR TITLE
Feature: Add route specific configuration for replaceState

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -308,11 +308,11 @@ export class AppRoutingEffects {
     }),
     map((programmaticalNavigation) => {
       const nav = programmaticalNavigation!;
-      const routeKind = nav.routeKind;
-      const resetNamespacedState = nav.resetNamespacedState;
+      const {replaceState = false, resetNamespacedState, routeKind} = nav;
 
-      // TODO(stephanwlee): currently, the RouteParams is ill-typed and you can
-      // currently add any property without any type error. Better type it.
+      // TODO(stephanwlee): currently, the RouteParams is ill-typed and you
+      // can currently add any property without any type error. Better type
+      // it.
       let routeParams: RouteParams;
       switch (nav.routeKind) {
         case RouteKind.COMPARE_EXPERIMENT:
@@ -325,16 +325,16 @@ export class AppRoutingEffects {
         default:
           routeParams = nav.routeParams;
       }
-      return {routeKind, routeParams, resetNamespacedState};
+      return {replaceState, routeKind, routeParams, resetNamespacedState};
     }),
-    map(({routeKind, routeParams, resetNamespacedState}) => {
+    map(({replaceState, routeKind, routeParams, resetNamespacedState}) => {
       const routeMatch = this.routeConfigs
         ? this.routeConfigs.matchByRouteKind(routeKind, routeParams)
         : null;
       return {
         routeMatch,
         options: {
-          replaceState: false,
+          replaceState,
           browserInitiated: false,
           namespaceUpdate: {
             option: resetNamespacedState

--- a/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
@@ -24,9 +24,11 @@ export interface NavigateToExperiment {
   routeKind: RouteKind.EXPERIMENT;
   routeParams: ExperimentRouteParams;
   resetNamespacedState?: boolean;
+  replaceState?: boolean;
 }
 
 export interface NavigateToCompare {
+  replaceState?: boolean;
   routeKind: RouteKind.COMPARE_EXPERIMENT;
   routeParams: {
     aliasAndExperimentIds: Array<{alias: string; id: string}>;
@@ -35,6 +37,7 @@ export interface NavigateToCompare {
 }
 
 export interface NavigateToExperiments {
+  replaceState?: boolean;
   routeKind: RouteKind.EXPERIMENTS;
   routeParams: {};
   resetNamespacedState?: boolean;


### PR DESCRIPTION
Programatic routing should be able to amend the route rather than redirect the user. This comes up in situations like updating route params.

