### PR TITLE
Bug Fix: Only override forceSvg from localStorage when the key is present

### DIFF
--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
@@ -47,8 +47,8 @@ export class FeatureFlagEffects {
 
         if (features.forceSvg != null) {
           this.forceSvgDataSource.updateForceSvgFlag(features.forceSvg);
-        } else {
-          features.forceSvg = this.forceSvgDataSource.getForceSvgFlag();
+        } else if (this.forceSvgDataSource.getForceSvgFlag()) {
+          features.forceSvg = true;
         }
 
         return partialFeatureFlagsLoaded({features});


### PR DESCRIPTION
* Motivation for features / changes
We always override the value of `forceSvg` regardless of whether a value is set in localStorage. This is an existing bug that is only coming to light now that we persist feature flags to the queryParams.
#5717 

* Detailed steps to verify changes work correctly (as executed by you)
1) Clear localStorage
2) Visit tensorboard and note that the `forceSVG` query parameter is not set.

