### PR TITLE
Rearrange NavigateToCompare, NavigateToExperiments for consistency.

### DIFF
--- a/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
+++ b/tensorboard/webapp/app_routing/programmatical_navigation_types.ts
@@ -28,19 +28,19 @@ export interface NavigateToExperiment {
 }
 
 export interface NavigateToCompare {
-  replaceState?: boolean;
   routeKind: RouteKind.COMPARE_EXPERIMENT;
   routeParams: {
     aliasAndExperimentIds: Array<{alias: string; id: string}>;
   };
   resetNamespacedState?: boolean;
+  replaceState?: boolean;
 }
 
 export interface NavigateToExperiments {
-  replaceState?: boolean;
   routeKind: RouteKind.EXPERIMENTS;
   routeParams: {};
   resetNamespacedState?: boolean;
+  replaceState?: boolean;
 }
 
 export type ProgrammaticalNavigation =


### PR DESCRIPTION
Followup to https://github.com/tensorflow/tensorboard/pull/5832, rearrange the replaceState property in NavigateToCompare and NavigateToExperiments to keep its place consistent.