### PR TITLE
Update `DashboardDeeplinkProvider` to get feature flag metadata dynamically

### DIFF
--- a/tensorboard/webapp/routes/BUILD
+++ b/tensorboard/webapp/routes/BUILD
@@ -13,6 +13,7 @@ tf_ts_library(
         ":dashboard_deeplink_provider",
         "//tensorboard/webapp/app_routing:route_config",
         "//tensorboard/webapp/app_routing:types",
+        "//tensorboard/webapp/feature_flag/store:feature_flag_metadata",
         "//tensorboard/webapp/feature_flag/views",
         "//tensorboard/webapp/tb_wrapper",
         "@npm//@angular/core",

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
@@ -19,8 +19,9 @@ import {map} from 'rxjs/operators';
 import {DeepLinkProvider} from '../app_routing/deep_link_provider';
 import {SerializableQueryParams} from '../app_routing/types';
 import {State} from '../app_state';
-import {FeatureFlagMetadataMap} from '../feature_flag/store/feature_flag_metadata';
+import {FeatureFlagMetadataMapType} from '../feature_flag/store/feature_flag_metadata';
 import {getOverriddenFeatureFlags} from '../feature_flag/store/feature_flag_selectors';
+import {FeatureFlags} from '../feature_flag/types';
 import {
   isPluginType,
   isSampledPlugin,
@@ -45,7 +46,12 @@ const COLOR_GROUP_REGEX_VALUE_PREFIX = 'regex:';
  * Provides deeplinking for the core dashboards page.
  */
 @Injectable()
-export class DashboardDeepLinkProvider extends DeepLinkProvider {
+export class DashboardDeepLinkProvider<
+  T extends FeatureFlags = FeatureFlags
+> extends DeepLinkProvider {
+  constructor(readonly featureFlagMetadataMap: FeatureFlagMetadataMapType<T>) {
+    super();
+  }
   private getMetricsPinnedCards(
     store: Store<State>
   ): Observable<SerializableQueryParams> {
@@ -98,7 +104,7 @@ export class DashboardDeepLinkProvider extends DeepLinkProvider {
         map((featureFlags) => {
           return featureFlagsToSerializableQueryParams(
             featureFlags,
-            FeatureFlagMetadataMap
+            this.featureFlagMetadataMap
           );
         })
       ),

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
@@ -18,6 +18,7 @@ import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {skip} from 'rxjs/operators';
 import {SerializableQueryParams} from '../app_routing/types';
 import {State} from '../app_state';
+import {FeatureFlagMetadataMap} from '../feature_flag/store/feature_flag_metadata';
 import {PluginType} from '../metrics/data_source/types';
 import {appStateFromMetricsState, buildMetricsState} from '../metrics/testing';
 import {GroupBy, GroupByKey} from '../runs/types';
@@ -52,7 +53,7 @@ describe('core deeplink provider', () => {
 
     queryParamsSerialized = [];
 
-    provider = new DashboardDeepLinkProvider();
+    provider = new DashboardDeepLinkProvider(FeatureFlagMetadataMap);
     provider
       .serializeStateToQueryParams(store)
       .pipe(

--- a/tensorboard/webapp/routes/index.ts
+++ b/tensorboard/webapp/routes/index.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {Component, Type} from '@angular/core';
 import {RouteDef} from '../app_routing/route_config_types';
 import {RouteKind} from '../app_routing/types';
+import {FeatureFlagMetadataMap} from '../feature_flag/store/feature_flag_metadata';
 import {FeatureFlagPageContainer} from '../feature_flag/views/feature_flag_page_container';
 import {TensorBoardWrapperComponent} from '../tb_wrapper/tb_wrapper_component';
 import {DashboardDeepLinkProvider} from './dashboard_deeplink_provider';
@@ -26,7 +27,7 @@ export function routesFactory(): RouteDef[] {
       path: '/',
       ngComponent: TensorBoardWrapperComponent as Type<Component>,
       defaultRoute: true,
-      deepLinkProvider: new DashboardDeepLinkProvider(),
+      deepLinkProvider: new DashboardDeepLinkProvider(FeatureFlagMetadataMap),
     },
     {
       routeKind: RouteKind.FLAGS,


### PR DESCRIPTION
* Motivation for features / changes
This would make it easier to extend the set of feature flags in TBcorp.

* Technical description of changes

* Detailed steps to verify changes work correctly (as executed by you)
Go to tensorboard with a feature flag overridden by a query parameter.
Assert that the query parameter is not removed.

* Alternate designs / implementations considered
While changes to TBcorp would be possible without this (by extending and then deduplicating query parameters) this would be much cleaner.