### PR TITLE
Fix "Card Width" property reset button.

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -712,7 +712,7 @@ const reducer = createReducer(
       settingOverrides: {
         ...state.settingOverrides,
         cardMinWidth: null,
-      }
+      },
     };
   }),
   on(

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -707,10 +707,12 @@ const reducer = createReducer(
     };
   }),
   on(actions.metricsResetCardWidth, (state) => {
-    const {cardMinWidth, ...nextOverride} = state.settingOverrides;
     return {
       ...state,
-      settingOverrides: nextOverride,
+      settingOverrides: {
+        ...state.settingOverrides,
+        cardMinWidth: null,
+      }
     };
   }),
   on(

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1201,9 +1201,7 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(prevState, actions.metricsResetCardWidth());
       expect(nextState.settings.cardMinWidth).toBe(400);
-      expect(nextState.settingOverrides.hasOwnProperty('cardMinWidth')).toBe(
-        false
-      );
+      expect(nextState.settingOverrides.cardMinWidth).toBeNull();
     });
   });
 


### PR DESCRIPTION
The reset button for "Card Width" does not effectively reset the property. Pressing it resets it to the value that it was set to when the page was loaded. (So, for example, if the value is 535px on page load, pressing reset will reset it to 535px and not reset the property entirely).

The reasoning is:
* Pressing the reset button will remove the property from state, effectively making it undefined:
  * https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/webapp/metrics/store/metrics_reducers.ts;l=709;drc=2059b53ef0f6875dbaa8bca4362653c07d0069fd
* The PersistentSettingsDataSource does not update the field in local storage if the value is undefined:
  * https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts;l=87;drc=54be1df836817d1a5a6378902eec23a9fe5cb40d
* And, so, the value will continue to be whatever was stored in local storage on page load. 

We fix the problem by setting the state value to null rather than removing it entirely. This means it will also be set to null in local storage and effectively reset the property.