### PR TITLE
Add tooltip to run selection to hint about double click.

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -239,6 +239,7 @@ limitations under the License.
             [checked]="item.selected"
             (change)="onSelectionToggle.emit(item)"
             (dblclick)="onSelectionDblClick.emit(item)"
+            title="Click to toggle run selection or double click to select only this run."
           ></mat-checkbox>
         </span>
         <tb-experiment-alias


### PR DESCRIPTION
We recently added the ability to double click a run checkbox to select it only and deselect the other runs.

User feedback (googlers, see b/238365158#comment9) said it was not discoverable. 

This change adds a tooltip to the checkbox, which includes a hint about double click.

![image](https://user-images.githubusercontent.com/17152369/182915650-a07a60cb-06bd-4d41-b523-95e4c2068a48.png)

I use "title" instead of "matTooltip" just because we have many icon buttons that also use this and the behavior is more consistent with those buttons.