### PR TITLE
Fix tests to be compatible with numpy>=1.23.0 and python>=3.9.0.

### DIFF
--- a/tensorboard/plugins/metrics/metrics_plugin_test.py
+++ b/tensorboard/plugins/metrics/metrics_plugin_test.py
@@ -16,7 +16,7 @@
 
 
 import argparse
-import collections
+import collections.abc
 import os.path
 
 import tensorflow.compat.v1 as tf1
@@ -165,7 +165,7 @@ class MetricsPluginTest(tf.test.TestCase):
     def test_routes_provided(self):
         """Tests that the plugin offers the correct routes."""
         routes = self._plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/tags"], collections.Callable)
+        self.assertIsInstance(routes["/tags"], collections.abc.Callable)
 
     def test_tags_empty(self):
         response = self._plugin._tags_impl(context.RequestContext(), "eid")

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -149,7 +149,7 @@ def reduce_to_2d(arr):
         raise ValueError("reduce_to_2d requires an array of dimensionality >=2")
     # slice(None) is equivalent to `:`, so we take arr[0,0,...0,:,:]
     slices = ([0] * (ndims - 2)) + [slice(None), slice(None)]
-    return arr[slices]
+    return arr[tuple(slices)]
 
 
 def text_array_to_html(text_arr, enable_markdown):

--- a/tensorboard/plugins/text_v2/text_v2_plugin.py
+++ b/tensorboard/plugins/text_v2/text_v2_plugin.py
@@ -57,7 +57,7 @@ def reduce_to_2d(arr):
         raise ValueError("reduce_to_2d requires an array of dimensionality >=2")
     # slice(None) is equivalent to `:`, so we take arr[0,0,...0,:,:]
     slices = ([0] * (ndims - 2)) + [slice(None), slice(None)]
-    return arr[slices]
+    return arr[tuple(slices)]
 
 
 def reduce_and_jsonify(text_ndarr):


### PR DESCRIPTION
Fix tests to be compatible with numpy>=1.23.0 and python>=3.9.0.

It's possible nobody has run these tests locally in a while because I have numpy 1.23.1 and python 3.10.5 installed on my machine and these tests failed for me.

Note that the numpy changes, specifically, were originally proposed internall in cl/465149745, which states:

> NumPy 1.23 removes support for non-tuple indexing of NumPy arrays ([https://numpy.org/devdocs/release/1.23.0-notes.html#expired-deprecations](https://www.google.com/url?sa=D&q=https%3A%2F%2Fnumpy.org%2Fdevdocs%2Frelease%2F1.23.0-notes.html%23expired-deprecations)). The workaround is to convert multidimensional indices to a tuple.


Python 3.9.0 removes collections.Callable. We should now use collections.abc.Callable.

