### PR TITLE
Update generics in feature_flag_metadata and feature_flag_serializer

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -39,7 +39,7 @@ export type FeatureFlagMetadata<T> =
       parseValue: (str: string) => T;
     };
 
-export type FeatureFlagMetadataMapType<T extends FeatureFlags> = {
+export type FeatureFlagMetadataMapType<T> = {
   [FlagName in keyof T]: FeatureFlagMetadata<T[FlagName]>;
 };
 
@@ -127,12 +127,12 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
 /**
  * Gets gets just the default values of each feature flag from the provided metadata.
  */
-export function generateFeatureFlagDefaults<T extends FeatureFlags>(
+export function generateFeatureFlagDefaults<T>(
   featureFlagMetadataMap: FeatureFlagMetadataMapType<T>
 ): T {
   return Object.entries(featureFlagMetadataMap).reduce(
-    (map, [key, {defaultValue}]) => {
-      map[key] = defaultValue;
+    (map, [key, metadata]) => {
+      map[key] = (metadata as FeatureFlagMetadata<T>).defaultValue;
       return map;
     },
     {} as Record<string, any>

--- a/tensorboard/webapp/routes/feature_flag_serializer.ts
+++ b/tensorboard/webapp/routes/feature_flag_serializer.ts
@@ -18,10 +18,9 @@ import {
   FeatureFlagMetadataMapType,
   FeatureFlagType,
 } from '../feature_flag/store/feature_flag_metadata';
-import {FeatureFlags} from '../feature_flag/types';
 
-export function featureFlagsToSerializableQueryParams<T extends FeatureFlags>(
-  overriddenFeatureFlags: Partial<FeatureFlags>,
+export function featureFlagsToSerializableQueryParams<T>(
+  overriddenFeatureFlags: Partial<T>,
   featureFlagMetadataMap: FeatureFlagMetadataMapType<T>
 ): SerializableQueryParams {
   return Object.entries(overriddenFeatureFlags)
@@ -32,7 +31,7 @@ export function featureFlagsToSerializableQueryParams<T extends FeatureFlags>(
         return {};
       }
       const featureFlagMetadata: FeatureFlagMetadata<any> =
-        featureFlagMetadataMap[featureFlag as keyof FeatureFlags];
+        featureFlagMetadataMap[featureFlag as keyof T];
       if (!featureFlagMetadata || !featureFlagMetadata.queryParamOverride) {
         // No metadata for this feature flag or no query param support specified
         // by the metadata.
@@ -47,7 +46,7 @@ export function featureFlagsToSerializableQueryParams<T extends FeatureFlags>(
         // want. Mostly notably, string[].toString() effectively does join(',').
         // If this does hold when we add new types then consider adding support
         // for custom encoders.
-        value: featureValue?.toString(),
+        value: (featureValue as FeatureFlagType)?.toString(),
       };
     })
     .filter(
@@ -76,9 +75,7 @@ export function getFeatureFlagValueFromSearchParams<T extends FeatureFlagType>(
 /**
  * Parses all feature flags from the query params.
  */
-export function getOverriddenFeatureFlagValuesFromSearchParams<
-  T extends FeatureFlags
->(
+export function getOverriddenFeatureFlagValuesFromSearchParams<T>(
   featureFlagMetadataMap: FeatureFlagMetadataMapType<T>,
   params: URLSearchParams
 ) {
@@ -90,11 +87,11 @@ export function getOverriddenFeatureFlagValuesFromSearchParams<
       );
 
       if (featureValue !== null) {
-        const f = flagName as keyof FeatureFlags;
+        const f = flagName as keyof T;
         overrides[f] = featureValue;
       }
       return overrides;
     },
-    {} as Partial<Record<keyof FeatureFlags, FeatureFlagType>>
+    {} as Partial<T>
   );
 }


### PR DESCRIPTION
* Motivation for features / changes
In TBcorp and TBdev it is useful to build feature flag metadata maps based on unions of types. This typing was unnecessarily restrictive and prevented the creation of clean unions.

* Alternate designs / implementations considered
Make some ugly type casts in internal code?