### PR TITLE
Enable Time Series dashboard when only image events are available.

### DIFF
--- a/tensorboard/plugins/metrics/metrics_plugin.py
+++ b/tensorboard/plugins/metrics/metrics_plugin.py
@@ -292,7 +292,11 @@ class MetricsPlugin(base_plugin.TBPlugin):
         }
 
     def data_plugin_names(self):
-        return (scalar_metadata.PLUGIN_NAME, histogram_metadata.PLUGIN_NAME)
+        return (
+            scalar_metadata.PLUGIN_NAME,
+            histogram_metadata.PLUGIN_NAME,
+            image_metadata.PLUGIN_NAME,
+        )
 
     def is_active(self):
         return False  # 'data_plugin_names' suffices.


### PR DESCRIPTION
I noticed that for TensorBoards with only image events that the Time Series dashboard does not appear.

I suspect this was just an oversight when Images were added to the Time Series dashboard. There is a function in the Metrics (aka "Time Series") plugin, `data_plugin_names()` which lists all data types for which the plugin should be enabled. It currently lists scalars and histograms but does not list images. This change just adds images to that list.