### PR TITLE
🍒: Cherry-pick fix that elevates Time Series dashboard for image only events to 2.10 branch

### DIFF
--- a/tensorboard/plugins/metrics/metrics_plugin.py
+++ b/tensorboard/plugins/metrics/metrics_plugin.py
@@ -292,7 +292,11 @@ class MetricsPlugin(base_plugin.TBPlugin):
         }
 
     def data_plugin_names(self):
-        return (scalar_metadata.PLUGIN_NAME, histogram_metadata.PLUGIN_NAME)
+        return (
+            scalar_metadata.PLUGIN_NAME,
+            histogram_metadata.PLUGIN_NAME,
+            image_metadata.PLUGIN_NAME,
+        )
 
     def is_active(self):
         return False  # 'data_plugin_names' suffices.


### PR DESCRIPTION
Cherry-picks the fix in #5852.