### PR TITLE
Improve FeatureFlagMetadata type so parse only specified when required.

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -22,14 +22,22 @@ export type FeatureFlagType =
   | null
   | undefined;
 
-export type FeatureFlagMetadata<T> = {
-  defaultValue: T;
-  // The name of the query param users can use to override the feature flag
-  // value. If unspecified then users cannot override the feature flag value.
-  queryParamOverride?: string;
-  // Function that translates a query param value into the feature flag value.
-  parseValue: (str: string) => T;
-};
+export type FeatureFlagMetadata<T> =
+  | {
+      defaultValue: T;
+      // Some feature flags cannot be overridden by query params in the URL. They
+      // should specify null here.
+      queryParamOverride: null;
+    }
+  | {
+      defaultValue: T;
+      // Some feature flags can be overridden by query params in the URL. They
+      // should specify the name of the query param here.
+      queryParamOverride: string;
+      // Additionally they should specify a way to parse the query param string
+      // values into the feature flag value.
+      parseValue: (str: string) => T;
+    };
 
 export type FeatureFlagMetadataMapType<T extends FeatureFlags> = {
   [FlagName in keyof T]: FeatureFlagMetadata<T[FlagName]>;
@@ -37,13 +45,6 @@ export type FeatureFlagMetadataMapType<T extends FeatureFlags> = {
 
 export function parseBoolean(str: string): boolean {
   return str !== 'false';
-}
-
-export function parseBooleanOrNull(str: string): boolean | null {
-  if (str === 'null') {
-    return null;
-  }
-  return parseBoolean(str);
 }
 
 export function parseStringArray(str: string): string[] {
@@ -97,7 +98,7 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
     },
     enableDarkModeOverride: {
       defaultValue: null,
-      parseValue: parseBooleanOrNull,
+      queryParamOverride: null,
     },
     defaultEnableDarkMode: {
       defaultValue: false,
@@ -106,7 +107,7 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
     },
     isAutoDarkModeAllowed: {
       defaultValue: true,
-      parseValue: parseBoolean,
+      queryParamOverride: null,
     },
     inColab: {
       defaultValue: false,
@@ -115,11 +116,11 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
     },
     metricsImageSupportEnabled: {
       defaultValue: true,
-      parseValue: parseBoolean,
+      queryParamOverride: null,
     },
     enableTimeSeriesPromotion: {
       defaultValue: false,
-      parseValue: parseBoolean,
+      queryParamOverride: null,
     },
   };
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata_test.ts
@@ -12,11 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {
-  parseBoolean,
-  parseBooleanOrNull,
-  parseStringArray,
-} from './feature_flag_metadata';
+import {parseBoolean, parseStringArray} from './feature_flag_metadata';
 
 describe('feature flag query parameters', () => {
   describe('parseBoolean', () => {
@@ -28,22 +24,6 @@ describe('feature flag query parameters', () => {
       expect(parseBoolean('true')).toBeTrue();
       expect(parseBoolean('foo bar')).toBeTrue();
       expect(parseBoolean('')).toBeTrue();
-    });
-  });
-
-  describe('parseBooleanOrNull', () => {
-    it('"null" should return null', () => {
-      expect(parseBooleanOrNull('null')).toBeNull();
-    });
-
-    it('"false" should evaluate to false', () => {
-      expect(parseBooleanOrNull('false')).toBeFalse();
-    });
-
-    it('values other than "false" should evaluate to true', () => {
-      expect(parseBooleanOrNull('true')).toBeTrue();
-      expect(parseBooleanOrNull('foo bar')).toBeTrue();
-      expect(parseBooleanOrNull('')).toBeTrue();
     });
   });
 

--- a/tensorboard/webapp/routes/feature_flag_serializer.ts
+++ b/tensorboard/webapp/routes/feature_flag_serializer.ts
@@ -26,23 +26,22 @@ export function featureFlagsToSerializableQueryParams<T extends FeatureFlags>(
 ): SerializableQueryParams {
   return Object.entries(overriddenFeatureFlags)
     .map(([featureFlag, featureValue]) => {
+      if (featureValue === undefined) {
+        // Feature flag has no overriden value specified.
+        // Return empty item. Will be filtered out.
+        return {};
+      }
       const featureFlagMetadata: FeatureFlagMetadata<any> =
         featureFlagMetadataMap[featureFlag as keyof FeatureFlags];
-      if (!featureFlagMetadata) {
-        // No metadata for this feature flag. Shouldn't happen but we must
-        // include the check for the compiler.
+      if (!featureFlagMetadata || !featureFlagMetadata.queryParamOverride) {
+        // No metadata for this feature flag or no query param support specified
+        // by the metadata.
         // Return empty item. Will be filtered out.
         return {};
       }
-      const key = featureFlagMetadata.queryParamOverride;
-      if (!key || featureValue === undefined) {
-        // Feature flag has no query param or there was no overriden value
-        // specified.
-        // Return empty item. Will be filtered out.
-        return {};
-      }
+
       return {
-        key,
+        key: featureFlagMetadata.queryParamOverride,
         // Note that all FeatureFlagType (string | number | boolean | string[])
         // support toString() and toString() happens to output the format we
         // want. Mostly notably, string[].toString() effectively does join(',').


### PR DESCRIPTION
In the newly-added FeatureFlagMetadataMap, we are specifying parseValue functions for a number of feature flags that don't need them.

This change improves the typing of FeatureFlagMetadata so we only specify parseValue functions when they are required - that is, when the metadata includes a queryParamOverride value.

This makes the type a bit more strict. This allows us to get rid of the parseBooleanOrNull parser.
