### PR TITLE
Stop event propagation when starting to drag step selector

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2235,7 +2235,11 @@ describe('scalar card', () => {
           testController.root.nativeElement.getBoundingClientRect().left;
 
         // Simulate dragging fob to step 25.
-        testController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+        testController.startDrag(
+          Fob.START,
+          TimeSelectionAffordance.FOB,
+          new MouseEvent('mouseDown')
+        );
         let fakeEvent = new MouseEvent('mousemove', {
           clientX: 25 + controllerStartPosition,
           movementX: 1,
@@ -2246,7 +2250,8 @@ describe('scalar card', () => {
 
         testController.startDrag(
           Fob.START,
-          TimeSelectionAffordance.EXTENDED_LINE
+          TimeSelectionAffordance.EXTENDED_LINE,
+          new MouseEvent('mouseDown')
         );
         fakeEvent = new MouseEvent('mousemove', {
           clientX: 30 + controllerStartPosition,
@@ -2779,7 +2784,11 @@ describe('scalar card', () => {
           testController.root.nativeElement.getBoundingClientRect().left;
 
         // Simulate dragging fob to step 25.
-        testController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+        testController.startDrag(
+          Fob.START,
+          TimeSelectionAffordance.FOB,
+          new MouseEvent('mouseDown')
+        );
         const fakeEvent = new MouseEvent('mousemove', {
           clientX: 25 + controllerStartPosition,
           movementX: 1,
@@ -2836,7 +2845,11 @@ describe('scalar card', () => {
           testController.root.nativeElement.getBoundingClientRect().left;
 
         // Simulates dragging start fob to step 25
-        testController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+        testController.startDrag(
+          Fob.START,
+          TimeSelectionAffordance.FOB,
+          new MouseEvent('mouseDown')
+        );
         let fakeEvent = new MouseEvent('mousemove', {
           clientX: 25 + controllerStartPosition,
           movementX: 1,
@@ -2874,7 +2887,11 @@ describe('scalar card', () => {
         testController = fixture.debugElement.query(
           By.directive(CardFobControllerComponent)
         ).componentInstance;
-        testController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+        testController.startDrag(
+          Fob.END,
+          TimeSelectionAffordance.FOB,
+          new MouseEvent('mouseDown')
+        );
         fakeEvent = new MouseEvent('mousemove', {
           clientX: 28 + controllerStartPosition,
           movementX: -1,

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -24,13 +24,13 @@ limitations under the License.
     <div
       *ngIf="showExtendedLine"
       class="extended-line"
-      (mousedown)="startDrag(Fob.START, TimeSelectionAffordance.EXTENDED_LINE)"
+      (mousedown)="startDrag(Fob.START, TimeSelectionAffordance.EXTENDED_LINE, $event)"
     ></div>
     <card-fob
       class="startFob"
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="timeSelection.start.step"
-      (mousedown)="startDrag(Fob.START, TimeSelectionAffordance.FOB)"
+      (mousedown)="startDrag(Fob.START, TimeSelectionAffordance.FOB, $event)"
       (stepChanged)="stepTyped(Fob.START, $event)"
       (fobRemoved)="onFobRemoved(Fob.START)"
     ></card-fob>

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -44,13 +44,13 @@ limitations under the License.
     <div
       *ngIf="showExtendedLine"
       class="extended-line"
-      (mousedown)="startDrag(Fob.END, TimeSelectionAffordance.EXTENDED_LINE)"
+      (mousedown)="startDrag(Fob.END, TimeSelectionAffordance.EXTENDED_LINE, $event)"
     ></div>
     <card-fob
       class="endFob"
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="timeSelection.end.step"
-      (mousedown)="startDrag(Fob.END, TimeSelectionAffordance.FOB)"
+      (mousedown)="startDrag(Fob.END, TimeSelectionAffordance.FOB, $event)"
       (stepChanged)="stepTyped(Fob.END, $event)"
       (fobRemoved)="onFobRemoved(Fob.END)"
     ></card-fob>

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -90,7 +90,14 @@ export class CardFobControllerComponent {
     return `translate(${this.endStepAxisPosition}px, 0px)`;
   }
 
-  startDrag(fob: Fob, affordance: TimeSelectionAffordance) {
+  stopEventPropagation(e: Event) {
+    if (e.stopPropagation) e.stopPropagation();
+    if (e.preventDefault) e.preventDefault();
+    e.cancelBubble = true;
+  }
+
+  startDrag(fob: Fob, affordance: TimeSelectionAffordance, event: MouseEvent) {
+    this.stopEventPropagation(event);
     document.addEventListener('mousemove', this.mouseListener);
     document.addEventListener('mouseup', this.stopListener);
     this.currentDraggingFob = fob;

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -179,11 +179,10 @@ describe('card_fob_controller', () => {
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       expect(document.addEventListener).toHaveBeenCalledWith(
         'mousemove',
@@ -221,11 +220,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(1);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 3,
@@ -258,11 +256,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2,
@@ -295,11 +292,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 4,
@@ -326,11 +322,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {clientY: 2, movementY: 1});
       fobController.mouseMove(fakeEvent);
@@ -354,11 +349,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 8,
@@ -385,11 +379,10 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(1);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.END,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       onTimeSelectionChanged.calls.reset();
       const fakeEvent = new MouseEvent('mousemove', {
@@ -423,11 +416,10 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.END,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2,
@@ -460,11 +452,10 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.END,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 3,
@@ -491,11 +482,10 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.END,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2,
@@ -525,11 +515,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(1);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 3,
@@ -563,11 +552,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
@@ -601,11 +589,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 4,
@@ -640,11 +627,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
@@ -680,11 +666,10 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.START,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 8,
@@ -712,11 +697,10 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(1);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.END,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       onTimeSelectionChanged.calls.reset();
       const fakeEvent = new MouseEvent('mousemove', {
@@ -751,11 +735,10 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.END,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
@@ -789,11 +772,10 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
 
-      const mouseDownEvent = new MouseEvent('mouseDown');
       fobController.startDrag(
         Fob.END,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 3,
@@ -821,11 +803,11 @@ describe('card_fob_controller', () => {
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(3);
-      const mouseDownEvent = new MouseEvent('mouseDown');
+
       fobController.startDrag(
         Fob.END,
         TimeSelectionAffordance.FOB,
-        mouseDownEvent
+        new MouseEvent('mouseDown')
       );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -179,7 +179,12 @@ describe('card_fob_controller', () => {
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       expect(document.addEventListener).toHaveBeenCalledWith(
         'mousemove',
         mouseMoveListener
@@ -216,7 +221,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(1);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 3,
         movementY: 1,
@@ -248,7 +258,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2,
         movementY: -1,
@@ -280,7 +295,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 4,
         movementY: -1,
@@ -306,7 +326,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {clientY: 2, movementY: 1});
       fobController.mouseMove(fakeEvent);
       fixture.detectChanges();
@@ -329,7 +354,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 8,
         movementY: 1,
@@ -355,7 +385,12 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(1);
 
-      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       onTimeSelectionChanged.calls.reset();
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 3,
@@ -388,7 +423,12 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(4);
 
-      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2,
         movementY: -1,
@@ -420,7 +460,12 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(2);
 
-      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 3,
         movementY: -1,
@@ -446,7 +491,12 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().top
       ).toEqual(3);
 
-      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientY: 2,
         movementY: 1,
@@ -475,7 +525,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(1);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 3,
         movementX: 1,
@@ -508,7 +563,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
         movementX: -1,
@@ -541,7 +601,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 4,
         movementX: -1,
@@ -575,7 +640,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
         movementX: 1,
@@ -610,7 +680,12 @@ describe('card_fob_controller', () => {
         fobController.startFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      fobController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 8,
         movementX: 1,
@@ -637,7 +712,12 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(1);
 
-      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       onTimeSelectionChanged.calls.reset();
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 3,
@@ -671,7 +751,12 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(4);
 
-      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
         movementX: -1,
@@ -704,7 +789,12 @@ describe('card_fob_controller', () => {
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(2);
 
-      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 3,
         movementX: -1,
@@ -731,7 +821,12 @@ describe('card_fob_controller', () => {
       expect(
         fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
       ).toEqual(3);
-      fobController.startDrag(Fob.END, TimeSelectionAffordance.FOB);
+      const mouseDownEvent = new MouseEvent('mouseDown');
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        mouseDownEvent
+      );
       const fakeEvent = new MouseEvent('mousemove', {
         clientX: 2,
         movementX: 1,

--- a/tensorboard/webapp/widgets/histogram/histogram_card_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_card_fob_test.ts
@@ -17,7 +17,10 @@ import {
   CardFobControllerComponent,
   Fob,
 } from '../card_fob/card_fob_controller_component';
-import {TimeSelection} from '../card_fob/card_fob_types';
+import {
+  TimeSelection,
+  TimeSelectionAffordance,
+} from '../card_fob/card_fob_types';
 import {HistogramCardFobController} from './histogram_card_fob_controller';
 import {TemporalScale} from './histogram_component';
 
@@ -157,7 +160,11 @@ describe('HistogramCardFobController', () => {
       let testController = fixture.debugElement.query(
         By.directive(CardFobControllerComponent)
       ).componentInstance;
-      testController.startDrag(Fob.START);
+      testController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.NONE,
+        new MouseEvent('mouseDown')
+      );
       // Starting step '300' renders the fob at 3000px. Mouse event at 3020px
       // mimics a drag down (towards higher steps).
       const fakeEvent = new MouseEvent('mousemove', {
@@ -180,7 +187,11 @@ describe('HistogramCardFobController', () => {
       let testController = fixture.debugElement.query(
         By.directive(CardFobControllerComponent)
       ).componentInstance;
-      testController.startDrag(Fob.START);
+      testController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.NONE,
+        new MouseEvent('mouseDown')
+      );
       // Starting step '300' renders the fob at 3000px. Mouse event at 2980px
       // mimics a drag up (towards lower steps).
       const fakeEvent = new MouseEvent('mousemove', {

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -1268,7 +1268,11 @@ describe('histogram test', () => {
           .getBoundingClientRect().top;
 
         // Simulate dragging fob to step 10.
-        testController.startDrag(Fob.START, TimeSelectionAffordance.FOB);
+        testController.startDrag(
+          Fob.START,
+          TimeSelectionAffordance.FOB,
+          new MouseEvent('mouseDown')
+        );
         const fakeEvent = new MouseEvent('mousemove', {
           clientY: 5 + fobStartPosition, // Add the difference between step 5 and 10, which is equal to 5.
           movementY: 1,


### PR DESCRIPTION
* Motivation for features / changes
Some strange behavior was observed when trying to drag the step selector. The root cause of this behavior was that when clicking and dragging in certain places the mouse was triggering other events(such as trying to move an entire graphic or highlighting text. This PR stops the propagation of those mouse clicks so that only the dragging that we want to occur occurs.

Googlers see b/241921321