### PR TITLE
linked time: move "link step" into step selector in settings panel

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -399,6 +399,7 @@ describe('metrics right_pane', () => {
 
     describe('linked time feature enabled', () => {
       beforeEach(() => {
+        store.overrideSelector(selectors.getIsDataTableEnabled, true);
         store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
         store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
       });
@@ -408,7 +409,8 @@ describe('metrics right_pane', () => {
         const fixture = TestBed.createComponent(SettingsViewContainer);
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('.linked-time'))).toBeTruthy();
+        const el = fixture.debugElement.query(By.css('.linked-time mat-checkbox input'));
+        expect(el.properties['disabled']).toBe(false);
 
         store.overrideSelector(
           selectors.getMetricsXAxisType,
@@ -417,7 +419,7 @@ describe('metrics right_pane', () => {
         store.refreshState();
         fixture.detectChanges();
 
-        expect(fixture.debugElement.query(By.css('.linked-time'))).toBeFalsy();
+        expect(el.properties['disabled']).toBe(true);
       });
 
       describe('toggles', () => {

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -409,7 +409,9 @@ describe('metrics right_pane', () => {
         const fixture = TestBed.createComponent(SettingsViewContainer);
         fixture.detectChanges();
 
-        const el = fixture.debugElement.query(By.css('.linked-time mat-checkbox input'));
+        const el = fixture.debugElement.query(
+          By.css('.linked-time mat-checkbox input')
+        );
         expect(el.properties['disabled']).toBe(false);
 
         store.overrideSelector(

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -94,7 +94,6 @@ describe('metrics right_pane', () => {
       store.overrideSelector(selectors.getMetricsCardMinWidth, null);
       store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, false);
       store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
-      store.overrideSelector(selectors.getMetricsLinkedTimeRangeEnabled, false);
       store.overrideSelector(selectors.getMetricsLinkedTimeSelectionSetting, {
         start: {step: 0},
         end: {step: 1000},
@@ -401,7 +400,6 @@ describe('metrics right_pane', () => {
       beforeEach(() => {
         store.overrideSelector(selectors.getIsDataTableEnabled, true);
         store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
-        store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
       });
 
       it('enables the feature only when xAxisType=STEP', () => {
@@ -450,12 +448,19 @@ describe('metrics right_pane', () => {
       });
 
       describe('range input', () => {
-        it('displays tb-range-input on both single and range step selection mode', () => {
-          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
+        beforeEach(() => {
+          store.overrideSelector(selectors.getMetricsStepSelectorEnabled, true);
+          store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, true);
           store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
+        });
+
+        it('displays tb-range-input on both single and range step selection mode', () => {
           store.overrideSelector(
-            selectors.getMetricsLinkedTimeRangeEnabled,
-            false
+            selectors.getMetricsLinkedTimeSelectionSetting,
+            {
+              start: {step: 0},
+              end: null,
+            }
           );
           const fixture = TestBed.createComponent(SettingsViewContainer);
           fixture.detectChanges();
@@ -464,39 +469,29 @@ describe('metrics right_pane', () => {
           expect(el.query(By.css('tb-range-input'))).toBeTruthy();
 
           store.overrideSelector(
-            selectors.getMetricsLinkedTimeRangeEnabled,
-            true
+            selectors.getMetricsLinkedTimeSelectionSetting,
+            {
+              start: {step: 2},
+              end: {step: 5},
+            }
           );
           store.refreshState();
           fixture.detectChanges();
           expect(el.query(By.css('tb-range-input'))).toBeTruthy();
         });
 
-        it('disables tb-range-input on select time disabled', () => {
-          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
-          store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
+        it('does not render tb-range-input on linked time disabled', () => {
           store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, false);
-          store.overrideSelector(
-            selectors.getMetricsLinkedTimeRangeEnabled,
-            false
-          );
           const fixture = TestBed.createComponent(SettingsViewContainer);
           fixture.detectChanges();
 
-          const el = fixture.debugElement.query(
-            By.css('.linked-time tb-range-input')
-          );
-          expect(el.properties['enabled']).toBe(false);
+          expect(
+            fixture.debugElement.query(By.css('.linked-time tb-range-input'))
+          ).toBeNull();
         });
 
-        it('enables tb-range-input on select time enabled', () => {
-          store.overrideSelector(selectors.getIsLinkedTimeEnabled, true);
+        it('enable tb-range-input only when xAxisType=STEP', () => {
           store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
-          store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, true);
-          store.overrideSelector(
-            selectors.getMetricsLinkedTimeRangeEnabled,
-            false
-          );
           const fixture = TestBed.createComponent(SettingsViewContainer);
           fixture.detectChanges();
 
@@ -504,13 +499,17 @@ describe('metrics right_pane', () => {
             By.css('.linked-time tb-range-input')
           );
           expect(el.properties['enabled']).toBe(true);
+
+          store.overrideSelector(
+            selectors.getMetricsXAxisType,
+            XAxisType.RELATIVE
+          );
+          store.refreshState();
+          fixture.detectChanges();
+          expect(el.properties['enabled']).toBe(false);
         });
 
         it('dispatches actions when making range step change', () => {
-          store.overrideSelector(
-            selectors.getMetricsLinkedTimeRangeEnabled,
-            true
-          );
           store.overrideSelector(
             selectors.getMetricsLinkedTimeSelectionSetting,
             {
@@ -540,10 +539,6 @@ describe('metrics right_pane', () => {
         });
 
         it('dispatches actions when making single step change', () => {
-          store.overrideSelector(
-            selectors.getMetricsLinkedTimeRangeEnabled,
-            true
-          );
           store.overrideSelector(
             selectors.getMetricsLinkedTimeSelectionSetting,
             {

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -74,13 +74,13 @@ limitations under the License.
             >Link by step</mat-checkbox
           >
         </div>
-        <div class="indent">
+        <div class="indent" *ngIf="isLinkedTimeEnabled">
           <tb-range-input
             [min]="stepMinMax.min"
             [max]="stepMinMax.max"
             [lowerValue]="linkedTimeSelection?.start.step"
             [upperValue]="linkedTimeSelection?.end?.step"
-            [enabled]="isLinkedTimeEnabled"
+            [enabled]="isLinkedTimeEnabled && isAxisTypeStep()"
             (singleValueChanged)="onSingleValueChanged($event)"
             (rangeValuesChanged)="onRangeValuesChanged($event)"
           ></tb-range-input>

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -64,10 +64,7 @@ limitations under the License.
       >Enable step selection and data table
     </mat-checkbox>
     <span class="indent">(Scalars only)</span>
-    <div
-      class="control-row indent"
-      *ngIf="isLinkedTimeFeatureEnabled"
-    >
+    <div class="control-row indent" *ngIf="isLinkedTimeFeatureEnabled">
       <div class="linked-time">
         <div>
           <mat-checkbox

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -64,27 +64,28 @@ limitations under the License.
       >Enable step selection and data table
     </mat-checkbox>
     <span class="indent">(Scalars only)</span>
-    <div class="control-row indent" *ngIf="isLinkedTimeFeatureEnabled">
-      <div class="linked-time">
-        <div>
-          <mat-checkbox
-            [checked]="isLinkedTimeEnabled"
-            (change)="linkedTimeToggled.emit()"
-            [disabled]="!isAxisTypeStep()"
-            >Link by step</mat-checkbox
-          >
-        </div>
-        <div class="indent" *ngIf="isLinkedTimeEnabled">
-          <tb-range-input
-            [min]="stepMinMax.min"
-            [max]="stepMinMax.max"
-            [lowerValue]="linkedTimeSelection?.start.step"
-            [upperValue]="linkedTimeSelection?.end?.step"
-            [enabled]="isLinkedTimeEnabled && isAxisTypeStep()"
-            (singleValueChanged)="onSingleValueChanged($event)"
-            (rangeValuesChanged)="onRangeValuesChanged($event)"
-          ></tb-range-input>
-        </div>
+    <div
+      class="control-row linked-time indent"
+      *ngIf="isLinkedTimeFeatureEnabled"
+    >
+      <div>
+        <mat-checkbox
+          [checked]="isLinkedTimeEnabled"
+          (change)="linkedTimeToggled.emit()"
+          [disabled]="!isAxisTypeStep()"
+          >Link by step</mat-checkbox
+        >
+      </div>
+      <div class="indent" *ngIf="isLinkedTimeEnabled">
+        <tb-range-input
+          [min]="stepMinMax.min"
+          [max]="stepMinMax.max"
+          [lowerValue]="linkedTimeSelection?.start.step"
+          [upperValue]="linkedTimeSelection?.end?.step"
+          [enabled]="isLinkedTimeEnabled && isAxisTypeStep()"
+          (singleValueChanged)="onSingleValueChanged($event)"
+          (rangeValuesChanged)="onRangeValuesChanged($event)"
+        ></tb-range-input>
       </div>
     </div>
   </div>

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -68,14 +68,12 @@ limitations under the License.
       class="control-row linked-time indent"
       *ngIf="isLinkedTimeFeatureEnabled"
     >
-      <div>
-        <mat-checkbox
-          [checked]="isLinkedTimeEnabled"
-          (change)="linkedTimeToggled.emit()"
-          [disabled]="!isAxisTypeStep()"
-          >Link by step</mat-checkbox
-        >
-      </div>
+      <mat-checkbox
+        [checked]="isLinkedTimeEnabled"
+        (change)="linkedTimeToggled.emit()"
+        [disabled]="!isAxisTypeStep()"
+        >Link by step</mat-checkbox
+      >
       <div class="indent" *ngIf="isLinkedTimeEnabled">
         <tb-range-input
           [min]="stepMinMax.min"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -55,40 +55,39 @@ limitations under the License.
   <div
     class="control-row scalars-step-selector"
     *ngIf="isScalarStepSelectorFeatureEnabled"
+    [title]="!isAxisTypeStep()? 'Only available when Horizontal Axis is set to step': ''"
   >
     <mat-checkbox
       [checked]="isScalarStepSelectorEnabled"
       (change)="stepSelectorToggled.emit()"
       [disabled]="!isAxisTypeStep()"
-      [title]="!isAxisTypeStep()? 'Only available When Horizontal Axis is set to step': ''"
       >Enable step selection and data table
     </mat-checkbox>
     <span class="indent">(Scalars only)</span>
-  </div>
-
-  <div
-    class="control-row linked-time"
-    *ngIf="isLinkedTimeFeatureEnabled && xAxisType == XAxisType.STEP"
-  >
-    <label>Link visualization by step</label>
-    <div class="controls">
-      <div>
-        <mat-checkbox
-          [checked]="isLinkedTimeEnabled"
-          (change)="linkedTimeToggled.emit()"
-          >Enabled</mat-checkbox
-        >
-      </div>
-      <div class="step-selector">
-        <tb-range-input
-          [min]="stepMinMax.min"
-          [max]="stepMinMax.max"
-          [lowerValue]="linkedTimeSelection?.start.step"
-          [upperValue]="linkedTimeSelection?.end?.step"
-          [enabled]="isLinkedTimeEnabled"
-          (singleValueChanged)="onSingleValueChanged($event)"
-          (rangeValuesChanged)="onRangeValuesChanged($event)"
-        ></tb-range-input>
+    <div
+      class="control-row indent"
+      *ngIf="isLinkedTimeFeatureEnabled"
+    >
+      <div class="linked-time">
+        <div>
+          <mat-checkbox
+            [checked]="isLinkedTimeEnabled"
+            (change)="linkedTimeToggled.emit()"
+            [disabled]="!isAxisTypeStep()"
+            >Link by step</mat-checkbox
+          >
+        </div>
+        <div class="indent">
+          <tb-range-input
+            [min]="stepMinMax.min"
+            [max]="stepMinMax.max"
+            [lowerValue]="linkedTimeSelection?.start.step"
+            [upperValue]="linkedTimeSelection?.end?.step"
+            [enabled]="isLinkedTimeEnabled"
+            (singleValueChanged)="onSingleValueChanged($event)"
+            (rangeValuesChanged)="onRangeValuesChanged($event)"
+          ></tb-range-input>
+        </div>
       </div>
     </div>
   </div>

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -101,13 +101,7 @@ tb-dropdown {
 }
 
 .linked-time {
-  .step-selector {
-    padding: 0 10px;
-  }
-
-  .controls {
-    padding: 5px;
-  }
+  padding: 5px 0;
 }
 
 .control-row {


### PR DESCRIPTION
* Motivation for features / changes
  In settings panel we want to move "linked time" to be nested into our "step selector". These two features are related: using linked time means step selector is used. (while turning on step selector does not mean linked time is turned on too)
  This PR purely moves them together visually. The toggling connection will come afterward.

* Technical description of changes
    * step selector has been launched so the feature flag is set to true in testing
     * This PR also includes some right_panel test cleanup and refactoring, remove unused `selectors.getMetricsLinkedTimeRangeEnabled`.

* Screenshots of UI changes
<img width="235" alt="Screen Shot 2022-08-10 at 2 03 44 PM" src="https://user-images.githubusercontent.com/1131010/184020335-c69e728e-3b23-48e1-9112-66cfcf27a3d0.png">
<img width="234" alt="Screen Shot 2022-08-10 at 2 03 54 PM" src="https://user-images.githubusercontent.com/1131010/184020308-a1f53c6a-2df2-4785-b1b4-0310ba92ee1e.png">



Inactive when xAxis is not step

<img width="225" alt="Screen Shot 2022-08-10 at 2 08 46 PM" src="https://user-images.githubusercontent.com/1131010/184023807-70363e4b-b831-415d-9229-5322da4ed149.png">
<img width="234" alt="Screen Shot 2022-08-10 at 2 29 38 PM" src="https://user-images.githubusercontent.com/1131010/184023824-af5e1a01-5170-4334-a91f-e5ff8421027d.png">

