### PR TITLE
Linked Time: Add Start and End Step values to data table

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -281,19 +281,16 @@ export class ScalarCardComponent<Downloader> {
                 continue;
               }
               selectedStepData.VALUE_CHANGE =
-                closestEndPoint!.value - closestStartPoint.value;
+                closestEndPoint.value - closestStartPoint.value;
               continue;
             case ColumnHeaders.START_STEP:
-              if (!closestEndPoint) {
-                continue;
-              }
               selectedStepData.START_STEP = closestStartPoint.step;
               continue;
             case ColumnHeaders.END_STEP:
               if (!closestEndPoint) {
                 continue;
               }
-              selectedStepData.END_STEP = closestEndPoint?.step;
+              selectedStepData.END_STEP = closestEndPoint.step;
               continue;
             default:
               continue;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -283,6 +283,18 @@ export class ScalarCardComponent<Downloader> {
               selectedStepData.VALUE_CHANGE =
                 closestEndPoint!.value - closestStartPoint.value;
               continue;
+            case ColumnHeaders.START_STEP:
+              if (!closestEndPoint) {
+                continue;
+              }
+              selectedStepData.START_STEP = closestStartPoint.step;
+              continue;
+            case ColumnHeaders.END_STEP:
+              if (!closestEndPoint) {
+                continue;
+              }
+              selectedStepData.END_STEP = closestEndPoint?.step;
+              continue;
             default:
               continue;
           }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -429,7 +429,8 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         } else {
           headers.push(ColumnHeaders.RUN);
           headers.push(ColumnHeaders.VALUE_CHANGE);
-          headers.push(ColumnHeaders.STEP);
+          headers.push(ColumnHeaders.START_STEP);
+          headers.push(ColumnHeaders.END_STEP);
         }
         return headers;
       })

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2502,14 +2502,16 @@ describe('scalar card', () => {
         {
           COLOR: '#fff',
           RUN: 'run1',
-          STEP: 1,
           VALUE_CHANGE: 19,
+          START_STEP: 1,
+          END_STEP: 3,
         },
         {
           COLOR: '#fff',
           RUN: 'run2',
-          STEP: 1,
           VALUE_CHANGE: 24,
+          START_STEP: 1,
+          END_STEP: 3,
         },
       ]);
     }));
@@ -2558,6 +2560,54 @@ describe('scalar card', () => {
 
       expect(data[0].STEP).toEqual(20);
       expect(data[1].STEP).toEqual(15);
+    }));
+
+    it('selects closest start and end points to ranged time selection', fakeAsync(() => {
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 20},
+          {wallTime: 3, value: 20, step: 35},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 3},
+          {wallTime: 2, value: 10, step: 5},
+          {wallTime: 3, value: 20, step: 25},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsLinkedTimeSelection, {
+        start: {step: 2},
+        end: {step: 18},
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getTimeSelectionTableData();
+
+      expect(data[0].START_STEP).toEqual(1);
+      expect(data[1].START_STEP).toEqual(3);
+      expect(data[0].END_STEP).toEqual(20);
+      expect(data[1].END_STEP).toEqual(25);
     }));
 
     it('selects largest points when time selection startStep is greater than any points step', fakeAsync(() => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -85,6 +85,8 @@ export enum ColumnHeaders {
   VALUE = 'VALUE',
   SMOOTHED = 'SMOOTHED',
   VALUE_CHANGE = 'VALUE_CHANGE',
+  START_STEP = 'START_STEP',
+  END_STEP = 'END_STEP',
 }
 
 /**

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -54,6 +54,10 @@ export class DataTableComponent {
         return 'Smoothed';
       case ColumnHeaders.VALUE_CHANGE:
         return 'Value Change';
+      case ColumnHeaders.START_STEP:
+        return 'Start Step';
+      case ColumnHeaders.END_STEP:
+        return 'End Step';
       default:
         return '';
     }
@@ -107,6 +111,20 @@ export class DataTableComponent {
         }
         return numberFormatter.formatShort(
           Math.abs(selectedStepRunData.VALUE_CHANGE as number)
+        );
+      case ColumnHeaders.START_STEP:
+        if (selectedStepRunData.START_STEP === undefined) {
+          return '';
+        }
+        return intlNumberFormatter.formatShort(
+          selectedStepRunData.START_STEP as number
+        );
+      case ColumnHeaders.END_STEP:
+        if (selectedStepRunData.END_STEP === undefined) {
+          return '';
+        }
+        return intlNumberFormatter.formatShort(
+          selectedStepRunData.END_STEP as number
         );
       default:
         return '';

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -72,6 +72,8 @@ describe('data table', () => {
         ColumnHeaders.STEP,
         ColumnHeaders.RELATIVE_TIME,
         ColumnHeaders.VALUE_CHANGE,
+        ColumnHeaders.START_STEP,
+        ColumnHeaders.END_STEP,
       ],
     });
     fixture.detectChanges();
@@ -84,6 +86,8 @@ describe('data table', () => {
     expect(headerElements[3].nativeElement.innerText).toBe('Step');
     expect(headerElements[4].nativeElement.innerText).toBe('Relative');
     expect(headerElements[5].nativeElement.innerText).toBe('Value Change');
+    expect(headerElements[6].nativeElement.innerText).toBe('Start Step');
+    expect(headerElements[7].nativeElement.innerText).toBe('End Step');
   });
 
   it('displays data in order', () => {
@@ -94,6 +98,8 @@ describe('data table', () => {
         ColumnHeaders.STEP,
         ColumnHeaders.RELATIVE_TIME,
         ColumnHeaders.VALUE_CHANGE,
+        ColumnHeaders.START_STEP,
+        ColumnHeaders.END_STEP,
       ],
       data: [
         {
@@ -102,6 +108,8 @@ describe('data table', () => {
           STEP: 1,
           RELATIVE_TIME: 123,
           VALUE_CHANGE: 20,
+          START_STEP: 5,
+          END_STEP: 30,
         },
       ],
     });
@@ -115,6 +123,8 @@ describe('data table', () => {
     expect(dataElements[3].nativeElement.innerText).toBe('1');
     expect(dataElements[4].nativeElement.innerText).toBe('123 ms');
     expect(dataElements[5].nativeElement.innerText).toBe(' 20'); // space before the value is kept for down or up arrow
+    expect(dataElements[6].nativeElement.innerText).toBe('5');
+    expect(dataElements[7].nativeElement.innerText).toBe('30');
   });
 
   it('displays nothing when no data is available', () => {


### PR DESCRIPTION
* Motivation for features / changes
When we launch linked time we will be allowing a range selection. The data table needs to be able to handle range values when in that mode. This change adds the Start Step and End Step columns so the user knows which step is selected for each run.

* Screenshots of UI changes
<img width="453" alt="Screen Shot 2022-08-10 at 4 18 13 PM" src="https://user-images.githubusercontent.com/8672809/184039208-1036fd8a-70bc-49e6-b2a1-9fca2dc48422.png">
