### PR TITLE
Linked Time: Stick the data table headers

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -19,6 +19,9 @@ limitations under the License.
 
   th {
     text-align: left;
+    position: sticky;
+    top: 0;
+    background-color: white;
   }
 
   .row {

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -18,10 +18,10 @@ limitations under the License.
   font-size: 13px;
 
   th {
-    text-align: left;
-    position: sticky;
-    top: 0;
     background-color: white;
+    position: sticky;
+    text-align: left;
+    top: 0;
   }
 
   .row {


### PR DESCRIPTION
* Motivation for features / changes
When scrolling through the data table it will be useful to continue seeing the headers. Also we plan to use these headers and controls for sorting. 

* Technical description of changes
Just a css change.

* Screenshots of UI changes

https://user-images.githubusercontent.com/8672809/184069538-238f1f35-bf7f-4a69-99bc-471746d0028f.mp4

