### PR TITLE
linked time: toggle relations between step selector and linked time

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -957,6 +957,7 @@ const reducer = createReducer(
     const nextLinkedTimeEnabled = !state.linkedTimeEnabled;
     let nextCardStepIndexMap = {...state.cardStepIndex};
     let nextLinkedTimeSelection = state.linkedTimeSelection;
+    let nextStepSelectorEnabled = state.stepSelectorEnabled;
 
     // Updates cardStepIndex only when toggle to enable linked time.
     if (nextLinkedTimeEnabled) {
@@ -972,6 +973,8 @@ const reducer = createReducer(
         state.timeSeriesData,
         nextLinkedTimeSelection
       );
+
+      nextStepSelectorEnabled = nextLinkedTimeEnabled;
     }
 
     return {
@@ -979,6 +982,7 @@ const reducer = createReducer(
       cardStepIndex: nextCardStepIndexMap,
       linkedTimeEnabled: nextLinkedTimeEnabled,
       linkedTimeSelection: nextLinkedTimeSelection,
+      stepSelectorEnabled: nextStepSelectorEnabled,
     };
   }),
   on(actions.linkedTimeSelectionChanged, (state, change) => {
@@ -1017,9 +1021,15 @@ const reducer = createReducer(
     };
   }),
   on(actions.stepSelectorToggled, (state) => {
+    const nextStepSelectorEnabled = !state.stepSelectorEnabled;
+    const nextLinkedTimeEnabled = nextStepSelectorEnabled
+      ? state.linkedTimeEnabled
+      : nextStepSelectorEnabled;
+
     return {
       ...state,
-      stepSelectorEnabled: !state.stepSelectorEnabled,
+      stepSelectorEnabled: nextStepSelectorEnabled,
+      linkedTimeEnabled: nextLinkedTimeEnabled,
     };
   }),
   on(actions.timeSelectionCleared, (state) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1028,8 +1028,8 @@ const reducer = createReducer(
 
     return {
       ...state,
-      stepSelectorEnabled: nextStepSelectorEnabled,
       linkedTimeEnabled: nextLinkedTimeEnabled,
+      stepSelectorEnabled: nextStepSelectorEnabled,
     };
   }),
   on(actions.timeSelectionCleared, (state) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2747,6 +2747,28 @@ describe('metrics reducers', () => {
         expect(state3.linkedTimeEnabled).toBe(false);
       });
 
+      it('enables stepSelector when linkedTime is enabled', () => {
+        const state1 = buildMetricsState({
+          stepSelectorEnabled: false,
+          linkedTimeEnabled: false,
+        });
+
+        const state2 = reducers(state1, actions.linkedTimeToggled({}));
+        expect(state2.stepSelectorEnabled).toBe(true);
+        expect(state2.linkedTimeEnabled).toBe(true);
+      });
+
+      it('keeps stepSelector enabled when linkedTime is disabled', () => {
+        const state1 = buildMetricsState({
+          stepSelectorEnabled: true,
+          linkedTimeEnabled: true,
+        });
+
+        const state2 = reducers(state1, actions.linkedTimeToggled({}));
+        expect(state2.stepSelectorEnabled).toBe(true);
+        expect(state2.linkedTimeEnabled).toBe(false);
+      });
+
       it('sets cardStepIndex to step 0 when linkedTimeSelection is null before toggling', () => {
         const state1 = buildMetricsState({
           linkedTimeEnabled: false,
@@ -2900,6 +2922,25 @@ describe('metrics reducers', () => {
 
       const state3 = reducers(state2, actions.stepSelectorToggled({}));
       expect(state3.stepSelectorEnabled).toBe(false);
+    });
+
+    it('disables linkedTime when stepSelector is disabled', () => {
+      const state1 = buildMetricsState({
+        stepSelectorEnabled: false,
+        linkedTimeEnabled: false,
+      });
+
+      const state2 = reducers(state1, actions.stepSelectorToggled({}));
+      expect(state2.stepSelectorEnabled).toBe(true);
+      expect(state2.linkedTimeEnabled).toBe(false);
+
+      const state3 = buildMetricsState({
+        stepSelectorEnabled: true,
+        linkedTimeEnabled: true,
+      });
+      const state4 = reducers(state3, actions.stepSelectorToggled({}));
+      expect(state4.stepSelectorEnabled).toBe(false);
+      expect(state2.linkedTimeEnabled).toBe(false);
     });
   });
 


### PR DESCRIPTION
* Motivation for features / changes
"Linked time" is considered a subset of "step selector". We want to 
1. Enable "Enable step selection and ..." while "Link by step" is toggled to enable
2. Disable "Link by step" when "Enable step selection and ..." is disabled
Please see demo video below

* Technical description of changes
Add extra handling on reducer for this two toggle actions. The reason is that we do not want to fire multiple actions on one  user toggle behavior.

* Screenshots of UI changes

https://user-images.githubusercontent.com/1131010/184249196-ff3bc223-8d98-4011-8075-4ea78396503a.mov
