### PR TITLE
Add optional `metadata` field to FeatureFlagState.

### DIFF
--- a/tensorboard/webapp/feature_flag/BUILD
+++ b/tensorboard/webapp/feature_flag/BUILD
@@ -52,6 +52,7 @@ tf_ts_library(
         ":force_svg_data_source",
         ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/feature_flag/store:feature_flag_metadata",
         "//tensorboard/webapp/webapp_data_source:feature_flag_types",
         "@npm//@types/jasmine",
     ],

--- a/tensorboard/webapp/feature_flag/store/BUILD
+++ b/tensorboard/webapp/feature_flag/store/BUILD
@@ -39,6 +39,7 @@ tf_ng_module(
         "feature_flag_types.ts",
     ],
     deps = [
+        ":feature_flag_metadata",
         "//tensorboard/webapp/feature_flag:types",
     ],
 )
@@ -48,6 +49,7 @@ tf_ts_library(
     testonly = True,
     srcs = ["testing.ts"],
     deps = [
+        ":feature_flag_metadata",
         ":types",
         "//tensorboard/webapp/feature_flag:testing",
     ],

--- a/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_store_config_provider.ts
@@ -23,6 +23,7 @@ import {FeatureFlagState} from './feature_flag_types';
 export const initialState: FeatureFlagState = {
   isFeatureFlagsLoaded: false,
   defaultFlags: generateFeatureFlagDefaults(FeatureFlagMetadataMap),
+  metadata: FeatureFlagMetadataMap,
   flagOverrides: {},
 };
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -14,12 +14,19 @@ limitations under the License.
 ==============================================================================*/
 
 import {FeatureFlags} from '../types';
+import {FeatureFlagMetadataMapType} from './feature_flag_metadata';
 
 export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 
 export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;
   defaultFlags: FeatureFlags;
+  // TODO(bmd3k@): `metadata` is temporarily an optional property of
+  //   `FeatureFlagState`.
+  //
+  //   The property will become required once all internal code is updated to
+  //   specify `metadata` as part of `FeatureFlagState`.
+  metadata?: FeatureFlagMetadataMapType<FeatureFlags>;
   flagOverrides?: Partial<FeatureFlags>;
 }
 export interface State {

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {buildFeatureFlag} from '../testing';
+import {FeatureFlagMetadataMap} from './feature_flag_metadata';
 import {FeatureFlagState, FEATURE_FLAG_FEATURE_KEY} from './feature_flag_types';
 
 export {buildFeatureFlag} from '../testing';
@@ -24,6 +25,7 @@ export function buildFeatureFlagState(
   return {
     isFeatureFlagsLoaded: true,
     defaultFlags: buildFeatureFlag(),
+    metadata: FeatureFlagMetadataMap,
     ...override,
     flagOverrides: override.flagOverrides ?? {},
   };

--- a/tensorboard/webapp/feature_flag/testing.ts
+++ b/tensorboard/webapp/feature_flag/testing.ts
@@ -13,26 +13,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {
+  FeatureFlagMetadataMap,
+  generateFeatureFlagDefaults,
+} from './store/feature_flag_metadata';
 import {FeatureFlags} from './types';
 
 export function buildFeatureFlag(
   override: Partial<FeatureFlags> = {}
 ): FeatureFlags {
   return {
-    isAutoDarkModeAllowed: false,
-    defaultEnableDarkMode: false,
-    enableDarkModeOverride: null,
-    enabledColorGroup: false,
-    enabledColorGroupByRegex: false,
-    enabledExperimentalPlugins: [],
-    inColab: false,
-    scalarsBatchSize: undefined,
-    metricsImageSupportEnabled: true,
-    enabledLinkedTime: false,
-    enableTimeSeriesPromotion: false,
-    enabledCardWidthSetting: false,
-    forceSvg: false,
-    enabledScalarDataTable: false,
+    ...generateFeatureFlagDefaults(FeatureFlagMetadataMap),
     ...override,
   };
 }


### PR DESCRIPTION
Add `metadata?: FeatureFlagMetadataMapType` field to FeatureFlagState and populate it in OSS TensorBoard.

We have use cases for accessing the Metadata through NgRx state and this is the first step to safely integrating that metadata into state for all TensorBoard instances, internal and external.

The optionality of the field will be removed when internal TensorBoards are updated to also populate the metadata field.