### PR TITLE
Use FeatureFlagMetadata from state in DeepLinkProviders.

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -15,6 +15,7 @@ limitations under the License.
 
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {FeatureFlags} from '../types';
+import {FeatureFlagMetadataMapType} from './feature_flag_metadata';
 import {
   FeatureFlagState,
   FEATURE_FLAG_FEATURE_KEY,
@@ -47,6 +48,13 @@ export const getOverriddenFeatureFlags = createSelector(
   (state: FeatureFlagState): Partial<FeatureFlags> => {
     // Temporarily assume state.flagOverrides can be undefined for sync purposes.
     return state.flagOverrides || {};
+  }
+);
+
+export const getFeatureFlagsMetadata = createSelector(
+  selectFeatureFlagState,
+  (state: FeatureFlagState): FeatureFlagMetadataMapType<FeatureFlags> => {
+    return state.metadata;
   }
 );
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {buildFeatureFlag} from '../testing';
-import {FeatureFlagMetadataMap, FeatureFlagMetadataMapType} from './feature_flag_metadata';
+import {FeatureFlagMetadataMap} from './feature_flag_metadata';
 import * as selectors from './feature_flag_selectors';
 import {buildFeatureFlagState, buildState} from './testing';
 
@@ -85,7 +85,10 @@ describe('feature_flag_selectors', () => {
     it('returns metadata', () => {
       // Modify the default value for one of the properties. inColab is a good
       // one because the defaultValue is unlikely to ever change.
-      const metadata = {...FeatureFlagMetadataMap, inColab: {...FeatureFlagMetadataMap.inColab, defaultValue: true}};
+      const metadata = {
+        ...FeatureFlagMetadataMap,
+        inColab: {...FeatureFlagMetadataMap.inColab, defaultValue: true},
+      };
       const state = buildState(buildFeatureFlagState({metadata}));
       const actual = selectors.getFeatureFlagsMetadata(state);
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {buildFeatureFlag} from '../testing';
+import {FeatureFlagMetadataMap, FeatureFlagMetadataMapType} from './feature_flag_metadata';
 import * as selectors from './feature_flag_selectors';
 import {buildFeatureFlagState, buildState} from './testing';
 
@@ -77,6 +78,18 @@ describe('feature_flag_selectors', () => {
       const actual = selectors.getOverriddenFeatureFlags(state);
 
       expect(actual).toEqual({enabledExperimentalPlugins: ['foo']});
+    });
+  });
+
+  describe('#getFeatureFlagsMetadata', () => {
+    it('returns metadata', () => {
+      // Modify the default value for one of the properties. inColab is a good
+      // one because the defaultValue is unlikely to ever change.
+      const metadata = {...FeatureFlagMetadataMap, inColab: {...FeatureFlagMetadataMap.inColab, defaultValue: true}};
+      const state = buildState(buildFeatureFlagState({metadata}));
+      const actual = selectors.getFeatureFlagsMetadata(state);
+
+      expect(actual).toEqual(metadata);
     });
   });
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -21,12 +21,7 @@ export const FEATURE_FLAG_FEATURE_KEY = 'feature';
 export interface FeatureFlagState {
   isFeatureFlagsLoaded: boolean;
   defaultFlags: FeatureFlags;
-  // TODO(bmd3k@): `metadata` is temporarily an optional property of
-  //   `FeatureFlagState`.
-  //
-  //   The property will become required once all internal code is updated to
-  //   specify `metadata` as part of `FeatureFlagState`.
-  metadata?: FeatureFlagMetadataMapType<FeatureFlags>;
+  metadata: FeatureFlagMetadataMapType<FeatureFlags>;
   flagOverrides?: Partial<FeatureFlags>;
 }
 export interface State {

--- a/tensorboard/webapp/routes/BUILD
+++ b/tensorboard/webapp/routes/BUILD
@@ -13,7 +13,6 @@ tf_ts_library(
         ":dashboard_deeplink_provider",
         "//tensorboard/webapp/app_routing:route_config",
         "//tensorboard/webapp/app_routing:types",
-        "//tensorboard/webapp/feature_flag/store:feature_flag_metadata",
         "//tensorboard/webapp/feature_flag/views",
         "//tensorboard/webapp/tb_wrapper",
         "@npm//@angular/core",

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
@@ -20,7 +20,7 @@ import {DeepLinkProvider} from '../app_routing/deep_link_provider';
 import {SerializableQueryParams} from '../app_routing/types';
 import {State} from '../app_state';
 import {FeatureFlagMetadataMapType} from '../feature_flag/store/feature_flag_metadata';
-import {getOverriddenFeatureFlags} from '../feature_flag/store/feature_flag_selectors';
+import {getFeatureFlagsMetadata, getOverriddenFeatureFlags} from '../feature_flag/store/feature_flag_selectors';
 import {FeatureFlags} from '../feature_flag/types';
 import {
   isPluginType,
@@ -49,9 +49,13 @@ const COLOR_GROUP_REGEX_VALUE_PREFIX = 'regex:';
 export class DashboardDeepLinkProvider<
   T extends FeatureFlags = FeatureFlags
 > extends DeepLinkProvider {
-  constructor(readonly featureFlagMetadataMap: FeatureFlagMetadataMapType<T>) {
+
+  // TODO(bmd3k@): Remove featureFlagMetadataMap as a constructor argument when
+  //   all internal code has been updated to no longer pass it.
+  constructor(readonly featureFlagMetadataMap?: FeatureFlagMetadataMapType<T>) {
     super();
   }
+
   private getMetricsPinnedCards(
     store: Store<State>
   ): Observable<SerializableQueryParams> {
@@ -100,13 +104,15 @@ export class DashboardDeepLinkProvider<
           return [{key: TAG_FILTER_KEY, value: filterText}];
         })
       ),
-      store.select(getOverriddenFeatureFlags).pipe(
-        map((featureFlags) => {
-          return featureFlagsToSerializableQueryParams(
-            featureFlags,
-            this.featureFlagMetadataMap
-          );
-        })
+      combineLatest([
+        store.select(getOverriddenFeatureFlags),
+        store.select(getFeatureFlagsMetadata)]).pipe(
+          map(([overriddenFeatureFlags, featureFlagsMetadata]) => {
+            return featureFlagsToSerializableQueryParams(
+              overriddenFeatureFlags,
+              featureFlagsMetadata
+            );
+          })
       ),
       store.select(selectors.getMetricsSettingOverrides).pipe(
         map((settingOverrides) => {

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider.ts
@@ -20,7 +20,10 @@ import {DeepLinkProvider} from '../app_routing/deep_link_provider';
 import {SerializableQueryParams} from '../app_routing/types';
 import {State} from '../app_state';
 import {FeatureFlagMetadataMapType} from '../feature_flag/store/feature_flag_metadata';
-import {getFeatureFlagsMetadata, getOverriddenFeatureFlags} from '../feature_flag/store/feature_flag_selectors';
+import {
+  getFeatureFlagsMetadata,
+  getOverriddenFeatureFlags,
+} from '../feature_flag/store/feature_flag_selectors';
 import {FeatureFlags} from '../feature_flag/types';
 import {
   isPluginType,
@@ -49,7 +52,6 @@ const COLOR_GROUP_REGEX_VALUE_PREFIX = 'regex:';
 export class DashboardDeepLinkProvider<
   T extends FeatureFlags = FeatureFlags
 > extends DeepLinkProvider {
-
   // TODO(bmd3k@): Remove featureFlagMetadataMap as a constructor argument when
   //   all internal code has been updated to no longer pass it.
   constructor(readonly featureFlagMetadataMap?: FeatureFlagMetadataMapType<T>) {
@@ -106,13 +108,14 @@ export class DashboardDeepLinkProvider<
       ),
       combineLatest([
         store.select(getOverriddenFeatureFlags),
-        store.select(getFeatureFlagsMetadata)]).pipe(
-          map(([overriddenFeatureFlags, featureFlagsMetadata]) => {
-            return featureFlagsToSerializableQueryParams(
-              overriddenFeatureFlags,
-              featureFlagsMetadata
-            );
-          })
+        store.select(getFeatureFlagsMetadata),
+      ]).pipe(
+        map(([overriddenFeatureFlags, featureFlagsMetadata]) => {
+          return featureFlagsToSerializableQueryParams(
+            overriddenFeatureFlags,
+            featureFlagsMetadata
+          );
+        })
       ),
       store.select(selectors.getMetricsSettingOverrides).pipe(
         map((settingOverrides) => {

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
@@ -50,7 +50,10 @@ describe('core deeplink provider', () => {
     store.overrideSelector(selectors.getMetricsSettingOverrides, {});
     store.overrideSelector(selectors.getRunUserSetGroupBy, null);
     store.overrideSelector(selectors.getRunSelectorRegexFilter, '');
-    store.overrideSelector(selectors.getFeatureFlagsMetadata, FeatureFlagMetadataMap);
+    store.overrideSelector(
+      selectors.getFeatureFlagsMetadata,
+      FeatureFlagMetadataMap
+    );
 
     queryParamsSerialized = [];
 
@@ -404,7 +407,7 @@ describe('core deeplink provider', () => {
 
       store.overrideSelector(selectors.getOverriddenFeatureFlags, {
         enabledColorGroupByRegex: false,
-    });
+      });
       store.refreshState();
 
       expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
@@ -50,10 +50,11 @@ describe('core deeplink provider', () => {
     store.overrideSelector(selectors.getMetricsSettingOverrides, {});
     store.overrideSelector(selectors.getRunUserSetGroupBy, null);
     store.overrideSelector(selectors.getRunSelectorRegexFilter, '');
+    store.overrideSelector(selectors.getFeatureFlagsMetadata, FeatureFlagMetadataMap);
 
     queryParamsSerialized = [];
 
-    provider = new DashboardDeepLinkProvider(FeatureFlagMetadataMap);
+    provider = new DashboardDeepLinkProvider();
     provider
       .serializeStateToQueryParams(store)
       .pipe(
@@ -403,7 +404,7 @@ describe('core deeplink provider', () => {
 
       store.overrideSelector(selectors.getOverriddenFeatureFlags, {
         enabledColorGroupByRegex: false,
-      });
+    });
       store.refreshState();
 
       expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([

--- a/tensorboard/webapp/routes/index.ts
+++ b/tensorboard/webapp/routes/index.ts
@@ -15,7 +15,6 @@ limitations under the License.
 import {Component, Type} from '@angular/core';
 import {RouteDef} from '../app_routing/route_config_types';
 import {RouteKind} from '../app_routing/types';
-import {FeatureFlagMetadataMap} from '../feature_flag/store/feature_flag_metadata';
 import {FeatureFlagPageContainer} from '../feature_flag/views/feature_flag_page_container';
 import {TensorBoardWrapperComponent} from '../tb_wrapper/tb_wrapper_component';
 import {DashboardDeepLinkProvider} from './dashboard_deeplink_provider';
@@ -27,7 +26,7 @@ export function routesFactory(): RouteDef[] {
       path: '/',
       ngComponent: TensorBoardWrapperComponent as Type<Component>,
       defaultRoute: true,
-      deepLinkProvider: new DashboardDeepLinkProvider(FeatureFlagMetadataMap),
+      deepLinkProvider: new DashboardDeepLinkProvider(),
     },
     {
       routeKind: RouteKind.FLAGS,


### PR DESCRIPTION
We can now consume metadata field from FeatureFlagState. In #5876 we added the metadata field to FeatureFlagState optional and are in the process of updating internal Google code to specify this field universally (Googlers, see cl/467745607).

We update DashboardDeeplinkProvider to use metadata from FeatureFlagState instead of via constructor. The constructor argument is left optional for the time being, until we can update internal code to remove usage.

We also make the metadata field mandatory now that it is specified universally.