### PR TITLE
Bug Fix: Fix centering of linked time fob dismiss button

### DIFF
--- a/tensorboard/webapp/widgets/card_fob/card_fob_component.scss
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_component.scss
@@ -49,6 +49,7 @@ button {
   padding: 0;
   border: 0;
   border-radius: 50%;
+  font-size: 11px;
   width: 11px;
   height: 11px;
   background-color: inherit;


### PR DESCRIPTION
* Motivation for features / changes
The dismiss button for the linked time fob was off center when the chrome font size was greater than medium.

* Technical description of changes
The reason it was off center was because the size of the container was hard coded to 11px and the font size property was not set.

* Screenshots of UI changes
Before
![Screen Shot 2022-08-16 at 1 31 50 PM](https://user-images.githubusercontent.com/78179109/184979686-0e448a69-e0b8-48a4-8a2f-8374453ff3ca.png)

After
![Screen Shot 2022-08-16 at 1 32 10 PM](https://user-images.githubusercontent.com/78179109/184979705-4c10319e-a134-4a9e-a0e5-85edc624d013.png)

* Detailed steps to verify changes work correctly (as executed by you)
1) go to Chrome settings(chrome://settings/)
2) select appearance on the left side menu
3) Change the "Font size" option to "large"
4) open tensorboard at http://localhost:6006/?enableLinkedTime=true&enableDataTable=true#timeseries
5) observe the fob

* Alternate designs / implementations considered
Allow the size of the fob to expand along with browser font size by replacing the hard coded pixel values.