### PR TITLE
Step Selector: Stop unnecessarily rerendering data table.

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -72,6 +72,7 @@ export class ScalarCardComponent<Downloader> {
   readonly DataLoadState = DataLoadState;
   readonly RendererType = RendererType;
   readonly ScaleType = ScaleType;
+  table_data: SelectedStepRunData[] = [];
 
   @Input() cardId!: string;
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
@@ -308,6 +309,13 @@ export class ScalarCardComponent<Downloader> {
         return selectedStepData;
       });
 
+    // Send the same object as before is nothing has changed so the table does
+    // not re-render.
+    if (JSON.stringify(this.table_data) === JSON.stringify(dataTableData)) {
+      return this.table_data;
+    }
+
+    this.table_data = dataTableData;
     return dataTableData;
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2825,6 +2825,40 @@ describe('scalar card', () => {
         ColumnHeaders.SMOOTHED
       );
     }));
+
+    it('returns the same object when nothing has changed', fakeAsync(() => {
+      const runToSeries = {
+        run1: [{wallTime: 1, value: 1, step: 1}],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([['run1', true]])
+      );
+
+      store.overrideSelector(getMetricsLinkedTimeSelection, {
+        start: {step: 2},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardComponent = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardComponent.componentInstance.getTimeSelectionTableData();
+      const secondData =
+        scalarCardComponent.componentInstance.getTimeSelectionTableData();
+      expect(data).toBe(secondData);
+    }));
   });
 
   describe('step selector feature integration', () => {


### PR DESCRIPTION
* Motivation for features / changes
The launch of the data table caused a significant performance reduction when scrolling the mouse a crossed the scalar card. This is because we created a new object for the data being passed to the table. Therefore even if the information did not change(which is the case while mousing over the card) the table re-rendered.  This change ensures the same object is passed when nothing changes.

* Detailed steps to verify changes work correctly (as executed by you)
Using the "Paint flashing" option in Rendering in the chrome dev tools I proved that the re-rendering no longer occurs. Also, even without the tool you can tell the performance is much better.

googlers see b/242572017