### PR TITLE
Limit feature flags sent to server.

### DIFF
--- a/tensorboard/components/tf_backend/requestManager.ts
+++ b/tensorboard/components/tf_backend/requestManager.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {FEATURE_FLAGS_HEADER_NAME} from '../../webapp/feature_flag/http/const';
-import {getFeatureFlags} from '../tf_feature_flags/feature-flags';
+import {getFeatureFlagsToSendToServer} from '../tf_feature_flags/feature-flags';
 
 interface ResolveReject {
   resolve: (x: unknown) => void;
@@ -245,7 +245,7 @@ export class RequestManager {
       );
       req.setRequestHeader(
         FEATURE_FLAGS_HEADER_NAME,
-        JSON.stringify(getFeatureFlags())
+        JSON.stringify(getFeatureFlagsToSendToServer())
       );
       req.onload = function () {
         if (req.status === 200) {

--- a/tensorboard/components/tf_feature_flags/feature-flags-test.ts
+++ b/tensorboard/components/tf_feature_flags/feature-flags-test.ts
@@ -21,15 +21,26 @@ describe('feature-flags', () => {
     feature_flags.initializeFeatureFlags();
   });
 
-  it('sets and gets FeatureFlags', () => {
-    feature_flags.setFeatureFlags(buildFeatureFlag({inColab: true}));
+  it('sets and gets FeatureFlags and getFeatureFlagsToSendToServer', () => {
+    feature_flags.setFeatureFlags(buildFeatureFlag({inColab: true}), {
+      scalarsBatchSize: 10,
+    });
     expect(feature_flags.getFeatureFlags()).toEqual(
       buildFeatureFlag({inColab: true})
     );
+    expect(feature_flags.getFeatureFlagsToSendToServer()).toEqual({
+      scalarsBatchSize: 10,
+    });
   });
 
   it('throws Error if getFeatureFlags is called before setFeatureFlags', () => {
     expect(() => feature_flags.getFeatureFlags()).toThrow(
+      new Error('FeatureFlags have not yet been determined by TensorBoard.')
+    );
+  });
+
+  it('throws Error if getFeatureFlagsToSendToServer is called before setFeatureFlags', () => {
+    expect(() => feature_flags.getFeatureFlagsToSendToServer()).toThrow(
       new Error('FeatureFlags have not yet been determined by TensorBoard.')
     );
   });

--- a/tensorboard/components/tf_feature_flags/feature-flags.ts
+++ b/tensorboard/components/tf_feature_flags/feature-flags.ts
@@ -19,20 +19,27 @@ import {FeatureFlags} from '../../webapp/feature_flag/types';
 // base. In practice they are set one time soon after application load and never
 // again for the lifetime of the application.
 let _featureFlags: FeatureFlags | null;
+let _featureFlagsToSendToServer: Partial<FeatureFlags> | null;
 initializeFeatureFlags();
 
 export function initializeFeatureFlags(): void {
   _featureFlags = null;
+  _featureFlagsToSendToServer = null;
 }
 
 /**
- * Sets the FeatureFlags for use in the Polymer portion of the TB code base.
+ * Sets FeatureFlags-related properties for use in the Polymer portion of the TB
+ * code base.
  *
  * In practice this should only be called by the Angular portion of the TB code
  * base immediately after it determines the final set of FeatureFlags.
  */
-export function setFeatureFlags(featureFlags: FeatureFlags): void {
+export function setFeatureFlags(
+  featureFlags: FeatureFlags,
+  featureFlagsToSendToServer: Partial<FeatureFlags>
+): void {
   _featureFlags = featureFlags;
+  _featureFlagsToSendToServer = featureFlagsToSendToServer;
 }
 
 /**
@@ -47,4 +54,18 @@ export function getFeatureFlags(): FeatureFlags {
     throw Error('FeatureFlags have not yet been determined by TensorBoard.');
   }
   return _featureFlags;
+}
+
+/**
+ * Retrieves the set of FeatureFlags that should be sent to the server.
+ *
+ * @throws Error if FeatureFlags have not yet been set. In practice they should
+ *     be set soon after application load before any Polymer code is invoked.
+ *     This runtime check acts as a sanity check to enforce that assumption.
+ */
+export function getFeatureFlagsToSendToServer(): Partial<FeatureFlags> {
+  if (_featureFlagsToSendToServer === null) {
+    throw Error('FeatureFlags have not yet been determined by TensorBoard.');
+  }
+  return _featureFlagsToSendToServer;
 }

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
@@ -26,6 +26,7 @@ import {
 import {ForceSvgDataSource} from '../force_svg_data_source';
 import {
   getFeatureFlags,
+  getFeatureFlagsToSendToServer,
   getIsAutoDarkModeAllowed,
 } from '../store/feature_flag_selectors';
 import {State} from '../store/feature_flag_types';
@@ -72,9 +73,15 @@ export class FeatureFlagEffects {
         // feature flag values used are from the Store, given that it contains
         // the finalized merged feature flags.
         ofType(partialFeatureFlagsLoaded),
-        withLatestFrom(this.store.select(getFeatureFlags)),
-        tap(([, featureFlags]) => {
-          this.tfFeatureFlags.ref.setFeatureFlags(featureFlags);
+        withLatestFrom(
+          this.store.select(getFeatureFlags),
+          this.store.select(getFeatureFlagsToSendToServer)
+        ),
+        tap(([, featureFlags, featureFlagsToSendToServer]) => {
+          this.tfFeatureFlags.ref.setFeatureFlags(
+            featureFlags,
+            featureFlagsToSendToServer
+          );
         })
       ),
     {dispatch: false}

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -30,6 +30,7 @@ import {ForceSvgDataSource} from '../force_svg_data_source';
 import {ForceSvgDataSourceModule} from '../force_svg_data_source_module';
 import {
   getFeatureFlags,
+  getFeatureFlagsToSendToServer,
   getIsAutoDarkModeAllowed,
 } from '../store/feature_flag_selectors';
 import {State} from '../store/feature_flag_types';
@@ -161,6 +162,9 @@ describe('feature_flag_effects', () => {
         getFeatureFlags,
         buildFeatureFlag({inColab: true})
       );
+      store.overrideSelector(getFeatureFlagsToSendToServer, {
+        scalarsBatchSize: 10,
+      });
       store.refreshState();
 
       effects.updatePolymerFeatureFlags$.subscribe();
@@ -173,10 +177,10 @@ describe('feature_flag_effects', () => {
         })
       );
 
-      // Expect tf_feature_flags.setFeatureFlags() to be called using the
-      // FeatureFlags object from the Store (and not from the action).
       expect(setPolymerFeatureFlagsSpy).toHaveBeenCalledOnceWith(
-        buildFeatureFlag({inColab: true})
+        // Uses the FeatureFlags object from the Store and not from the action.
+        buildFeatureFlag({inColab: true}),
+        {scalarsBatchSize: 10}
       );
     });
   });

--- a/tensorboard/webapp/feature_flag/http/BUILD
+++ b/tensorboard/webapp/feature_flag/http/BUILD
@@ -17,6 +17,7 @@ tf_ng_module(
     deps = [
         ":const",
         "//tensorboard/webapp/angular:expect_angular_common_http",
+        "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/feature_flag/store:types",
         "@npm//@angular/core",

--- a/tensorboard/webapp/feature_flag/http/feature_flag_http_interceptor.ts
+++ b/tensorboard/webapp/feature_flag/http/feature_flag_http_interceptor.ts
@@ -22,7 +22,7 @@ import {Injectable} from '@angular/core';
 import {select, Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {first, switchMap} from 'rxjs/operators';
-import {getFeatureFlags} from '../store/feature_flag_selectors';
+import {getFeatureFlagsToSendToServer} from '../store/feature_flag_selectors';
 import {State as FeatureFlagState} from '../store/feature_flag_types';
 import {FEATURE_FLAGS_HEADER_NAME} from './const';
 
@@ -39,7 +39,7 @@ export class FeatureFlagHttpInterceptor implements HttpInterceptor {
     next: HttpHandler
   ): Observable<HttpEvent<unknown>> {
     return this.store.pipe(
-      select(getFeatureFlags),
+      select(getFeatureFlagsToSendToServer),
       first(),
       switchMap((featureFlags) => {
         // Add feature flags to the headers.

--- a/tensorboard/webapp/feature_flag/http/feature_flag_http_interceptor_test.ts
+++ b/tensorboard/webapp/feature_flag/http/feature_flag_http_interceptor_test.ts
@@ -23,7 +23,7 @@ import {provideMockActions} from '@ngrx/effects/testing';
 import {Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {of} from 'rxjs';
-import {getFeatureFlags} from '../store/feature_flag_selectors';
+import {getFeatureFlagsToSendToServer} from '../store/feature_flag_selectors';
 import {State as FeatureFlagState} from '../store/feature_flag_types';
 import {buildFeatureFlag} from '../testing';
 import {FEATURE_FLAGS_HEADER_NAME} from './const';
@@ -50,7 +50,7 @@ describe('FeatureFlagHttpInterceptor', () => {
     store = TestBed.inject<Store<FeatureFlagState>>(
       Store
     ) as MockStore<FeatureFlagState>;
-    store.overrideSelector(getFeatureFlags, buildFeatureFlag());
+    store.overrideSelector(getFeatureFlagsToSendToServer, {});
 
     // Note that we do not test FeatureFlagHttpInterceptor directly. We instead
     // test it indirectly by firing Http requests and examining the final
@@ -59,7 +59,10 @@ describe('FeatureFlagHttpInterceptor', () => {
   });
 
   it('injects feature flags into the HTTP request', () => {
-    store.overrideSelector(getFeatureFlags, buildFeatureFlag({inColab: true}));
+    store.overrideSelector(
+      getFeatureFlagsToSendToServer,
+      {inColab: true, scalarsBatchSize: 5}
+    );
     httpClient.get('/data/hello').subscribe();
     const request = TestBed.inject(HttpTestingController).expectOne(
       '/data/hello'
@@ -67,7 +70,23 @@ describe('FeatureFlagHttpInterceptor', () => {
     expect(request.request.headers).toEqual(
       new HttpHeaders().set(
         FEATURE_FLAGS_HEADER_NAME,
-        JSON.stringify(buildFeatureFlag({inColab: true}))
+        JSON.stringify({inColab: true, scalarsBatchSize: 5})
+      )
+    );
+  });
+
+  it('injects empty feature flags into the HTTP request', () => {
+    store.overrideSelector(
+      getFeatureFlagsToSendToServer, {}
+    );
+    httpClient.get('/data/hello').subscribe();
+    const request = TestBed.inject(HttpTestingController).expectOne(
+      '/data/hello'
+    );
+    expect(request.request.headers).toEqual(
+      new HttpHeaders().set(
+        FEATURE_FLAGS_HEADER_NAME,
+        "{}"
       )
     );
   });

--- a/tensorboard/webapp/feature_flag/http/feature_flag_http_interceptor_test.ts
+++ b/tensorboard/webapp/feature_flag/http/feature_flag_http_interceptor_test.ts
@@ -25,7 +25,6 @@ import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {of} from 'rxjs';
 import {getFeatureFlagsToSendToServer} from '../store/feature_flag_selectors';
 import {State as FeatureFlagState} from '../store/feature_flag_types';
-import {buildFeatureFlag} from '../testing';
 import {FEATURE_FLAGS_HEADER_NAME} from './const';
 import {FeatureFlagHttpInterceptor} from './feature_flag_http_interceptor';
 
@@ -59,10 +58,10 @@ describe('FeatureFlagHttpInterceptor', () => {
   });
 
   it('injects feature flags into the HTTP request', () => {
-    store.overrideSelector(
-      getFeatureFlagsToSendToServer,
-      {inColab: true, scalarsBatchSize: 5}
-    );
+    store.overrideSelector(getFeatureFlagsToSendToServer, {
+      inColab: true,
+      scalarsBatchSize: 5,
+    });
     httpClient.get('/data/hello').subscribe();
     const request = TestBed.inject(HttpTestingController).expectOne(
       '/data/hello'
@@ -76,18 +75,13 @@ describe('FeatureFlagHttpInterceptor', () => {
   });
 
   it('injects empty feature flags into the HTTP request', () => {
-    store.overrideSelector(
-      getFeatureFlagsToSendToServer, {}
-    );
+    store.overrideSelector(getFeatureFlagsToSendToServer, {});
     httpClient.get('/data/hello').subscribe();
     const request = TestBed.inject(HttpTestingController).expectOne(
       '/data/hello'
     );
     expect(request.request.headers).toEqual(
-      new HttpHeaders().set(
-        FEATURE_FLAGS_HEADER_NAME,
-        "{}"
-      )
+      new HttpHeaders().set(FEATURE_FLAGS_HEADER_NAME, '{}')
     );
   });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -37,6 +37,9 @@ export type FeatureFlagMetadata<T> =
       // Additionally they should specify a way to parse the query param string
       // values into the feature flag value.
       parseValue: (str: string) => T;
+      // Some overridable feature flags should be sent to the server if the user
+      // has specified an override value.
+      sendToServer?: boolean;
     };
 
 export type FeatureFlagMetadataMapType<T> = {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -37,9 +37,9 @@ export type FeatureFlagMetadata<T> =
       // Additionally they should specify a way to parse the query param string
       // values into the feature flag value.
       parseValue: (str: string) => T;
-      // Some overridable feature flags should be sent to the server if the user
-      // has specified an override value.
-      sendToServer?: boolean;
+      // Indicates that the feature flag and value should be sent to the server
+      // if the user has specified an override value.
+      sendToServerWhenOverridden?: boolean;
     };
 
 export type FeatureFlagMetadataMapType<T> = {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -58,6 +58,24 @@ export const getFeatureFlagsMetadata = createSelector(
   }
 );
 
+export const getFeatureFlagsToSendToServer = createSelector(
+  selectFeatureFlagState,
+  (state: FeatureFlagState): Partial<FeatureFlags> => {
+    let featureFlagsToSendToServer: Partial<FeatureFlags> = {};
+    for (const entry in state.flagOverrides) {
+      const entryMetadata = state.metadata[entry as keyof FeatureFlags];
+      if (!entryMetadata.queryParamOverride || !entryMetadata.sendToServer) {
+        continue;
+      }
+      featureFlagsToSendToServer = {
+        ...featureFlagsToSendToServer,
+        [entry]: state.flagOverrides[entry as keyof FeatureFlags],
+      };
+    }
+    return featureFlagsToSendToServer;
+  }
+);
+
 export const getIsAutoDarkModeAllowed = createSelector(
   getFeatureFlags,
   (flags): boolean => {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -61,18 +61,18 @@ export const getFeatureFlagsMetadata = createSelector(
 export const getFeatureFlagsToSendToServer = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): Partial<FeatureFlags> => {
-    let featureFlagsToSendToServer: Partial<FeatureFlags> = {};
+    let featureFlagsToSendToServer: any = {};
     for (const entry in state.flagOverrides) {
       const entryMetadata = state.metadata[entry as keyof FeatureFlags];
-      if (!entryMetadata.queryParamOverride || !entryMetadata.sendToServer) {
-        continue;
+      if (
+        entryMetadata.queryParamOverride &&
+        entryMetadata.sendToServerWhenOverridden
+      ) {
+        featureFlagsToSendToServer[entry] =
+          state.flagOverrides[entry as keyof FeatureFlags];
       }
-      featureFlagsToSendToServer = {
-        ...featureFlagsToSendToServer,
-        [entry]: state.flagOverrides[entry as keyof FeatureFlags],
-      };
     }
-    return featureFlagsToSendToServer;
+    return featureFlagsToSendToServer as Partial<FeatureFlags>;
   }
 );
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -15,7 +15,10 @@ limitations under the License.
 
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {FeatureFlags} from '../types';
-import {FeatureFlagMetadataMapType} from './feature_flag_metadata';
+import {
+  FeatureFlagMetadataMapType,
+  FeatureFlagType,
+} from './feature_flag_metadata';
 import {
   FeatureFlagState,
   FEATURE_FLAG_FEATURE_KEY,
@@ -61,14 +64,16 @@ export const getFeatureFlagsMetadata = createSelector(
 export const getFeatureFlagsToSendToServer = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): Partial<FeatureFlags> => {
-    let featureFlagsToSendToServer: any = {};
+    const featureFlagsToSendToServer: Partial<
+      Record<keyof FeatureFlags, FeatureFlagType>
+    > = {};
     for (const entry in state.flagOverrides) {
       const entryMetadata = state.metadata[entry as keyof FeatureFlags];
       if (
         entryMetadata.queryParamOverride &&
         entryMetadata.sendToServerWhenOverridden
       ) {
-        featureFlagsToSendToServer[entry] =
+        featureFlagsToSendToServer[entry as keyof FeatureFlags] =
           state.flagOverrides[entry as keyof FeatureFlags];
       }
     }

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -105,12 +105,12 @@ describe('feature_flag_selectors', () => {
         inColab: {
           ...FeatureFlagMetadataMap.inColab,
           defaultValue: true,
-          sendToServer: true,
+          sendToServerWhenOverridden: true,
         },
         scalarsBatchSize: {
           ...FeatureFlagMetadataMap.scalarsBatchSize,
           defaultValue: 5,
-          sendToServer: true,
+          sendToServerWhenOverridden: true,
         },
       };
       const state = buildState(
@@ -132,7 +132,7 @@ describe('feature_flag_selectors', () => {
         inColab: {
           ...FeatureFlagMetadataMap.inColab,
           defaultValue: true,
-          sendToServer: true,
+          sendToServerWhenOverridden: true,
         },
       };
       const state = buildState(
@@ -150,12 +150,12 @@ describe('feature_flag_selectors', () => {
         inColab: {
           ...FeatureFlagMetadataMap.inColab,
           defaultValue: true,
-          sendToServer: true,
+          sendToServerWhenOverridden: true,
         },
         scalarsBatchSize: {
           ...FeatureFlagMetadataMap.scalarsBatchSize,
           defaultValue: 5,
-          sendToServer: false,
+          sendToServerWhenOverridden: false,
         },
         // Omit sendToServer property to show that unset is equivalent to false.
         forceSvg: {...FeatureFlagMetadataMap.forceSvg, defaultValue: true},
@@ -183,12 +183,12 @@ describe('feature_flag_selectors', () => {
         inColab: {
           ...FeatureFlagMetadataMap.inColab,
           defaultValue: true,
-          sendToServer: true,
+          sendToServerWhenOverridden: true,
         },
         scalarsBatchSize: {
           ...FeatureFlagMetadataMap.scalarsBatchSize,
           defaultValue: 5,
-          sendToServer: true,
+          sendToServerWhenOverridden: true,
         },
       };
       const state = buildState(

--- a/tensorboard/webapp/tb_polymer_interop_types.ts
+++ b/tensorboard/webapp/tb_polymer_interop_types.ts
@@ -44,7 +44,10 @@ export declare interface SetStringOption {
 }
 
 export declare interface TfFeatureFlags {
-  setFeatureFlags(featureFlags: FeatureFlags): void;
+  setFeatureFlags(
+    featureFlags: FeatureFlags,
+    featureFlagsToSendToServer: Partial<FeatureFlags>
+  ): void;
 }
 
 export declare interface TfFeatureFlagsElement extends HTMLElement {


### PR DESCRIPTION
In all requests from the TensorBoard application to the HTTP server we currently populate the "X-TensorBoard-Feature-Flags" header with the entire set of feature flags and values. We decided we only want to send the set of feature flags that are relevant to the HTTP Server and whichever DataProvider implementation backs it.

This change limits the feature flags in two ways:
* Introduce the "sendToServerWhenOverridden" metadata field. Only flags that are marked as "sendToServerWhenOverridden" can be sent to the HTTP Server.
* Only send flags which have been overriden by the user.

So for a flag value to be included in "X-TensorBoard-Feature-Flags" it must both have "sendToServerWhenOverridden" set to true and it must be overridden by the user.

Note that none of the flags in Standalone TensorBoard are marked as sendToServerWhenOverridden - the use case is currently internal.