### PR TITLE
Update affordance `enums` to use string values

### DIFF
--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -25,19 +25,19 @@ export interface TimeSelection {
  * Only used for internal analytics.
  */
 export enum TimeSelectionAffordance {
-  NONE,
+  NONE = 'NO_AFFORDANCE',
   // Dragging the extended line above a fob.
-  EXTENDED_LINE,
+  EXTENDED_LINE = 'EXTENDED_LINE',
   // Dragging the fob.
-  FOB,
+  FOB = 'FOB',
   // Clicking the deselect button.
-  FOB_REMOVED,
+  FOB_REMOVED = 'FOB_REMOVED',
   // Typing the step in fob.
-  FOB_TEXT,
+  FOB_TEXT = 'FOB_TEXT',
   // Typing the step in setting pane.
-  SETTINGS_TEXT,
+  SETTINGS_TEXT = 'SETTINGS_TEXT',
   // Dragging the slider in setting pane.
-  SETTINGS_SLIDER,
+  SETTINGS_SLIDER = 'SETTINGS_SLIDER',
 }
 
 /**
@@ -45,11 +45,11 @@ export enum TimeSelectionAffordance {
  * Only used for internal analytics.
  */
 export enum TimeSelectionToggleAffordance {
-  NONE,
+  NONE = 'NO_TOGGLE_AFFORDANCE',
   // Clicking cross sign in fob.
-  FOB_DESELECT,
+  FOB_DESELECT = 'FOB_DESELECT',
   // Clicking check box in settings pane.
-  CHECK_BOX,
+  CHECK_BOX = 'CHECK_BOX',
 }
 
 /**

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -25,19 +25,19 @@ export interface TimeSelection {
  * Only used for internal analytics.
  */
 export enum TimeSelectionAffordance {
-  NONE = 'NO_AFFORDANCE',
+  NONE = 'no affordance',
   // Dragging the extended line above a fob.
-  EXTENDED_LINE = 'EXTENDED_LINE',
+  EXTENDED_LINE = 'extendedLine',
   // Dragging the fob.
-  FOB = 'FOB',
+  FOB = 'fob',
   // Clicking the deselect button.
-  FOB_REMOVED = 'FOB_REMOVED',
+  FOB_REMOVED = 'fobRemoved',
   // Typing the step in fob.
-  FOB_TEXT = 'FOB_TEXT',
+  FOB_TEXT = 'fobText',
   // Typing the step in setting pane.
-  SETTINGS_TEXT = 'SETTINGS_TEXT',
+  SETTINGS_TEXT = 'settingsText',
   // Dragging the slider in setting pane.
-  SETTINGS_SLIDER = 'SETTINGS_SLIDER',
+  SETTINGS_SLIDER = 'settingsSlider',
 }
 
 /**
@@ -45,11 +45,11 @@ export enum TimeSelectionAffordance {
  * Only used for internal analytics.
  */
 export enum TimeSelectionToggleAffordance {
-  NONE = 'NO_TOGGLE_AFFORDANCE',
+  NONE = 'no toggle affordance',
   // Clicking cross sign in fob.
-  FOB_DESELECT = 'FOB_DESELECT',
+  FOB_DESELECT = 'fobDeselect',
   // Clicking check box in settings pane.
-  CHECK_BOX = 'CHECK_BOX',
+  CHECK_BOX = 'checkBox',
 }
 
 /**


### PR DESCRIPTION
* Motivation for features / changes
The existing enums using numeric values prevented them from being compared and made some internal logic much more complicated.

* Detailed steps to verify changes work correctly (as executed by you)
1) Use the change in internal tensorboard.
2) Perform actions to dispatch effected analytics events
3) Use the analytics dashboard to ensure the events are unchanged.

* Alternate designs / implementations considered
Using a `record` instead would potentially be more complicated but would also remove the need to map enums to strings.