### PR TITLE
Change data table header background based on theme

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -24,6 +24,7 @@ limitations under the License.
     position: sticky;
     text-align: left;
     top: 0;
+
     @include tb-dark-theme {
       background-color: map-get($tb-dark-background, background);
     }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -12,16 +12,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
+@import 'tensorboard/webapp/theme/tb_theme';
 
 .data-table {
   border-spacing: 4px;
   font-size: 13px;
 
   th {
-    background-color: white;
+    background-color: mat.get-color-from-palette($tb-background, background);
     position: sticky;
     text-align: left;
     top: 0;
+    @include tb-dark-theme {
+      background-color: map-get($tb-dark-background, background);
+    }
   }
 
   .row {


### PR DESCRIPTION
* Motivation for features / changes
Currently the background color of the header is hard coded to white. This is a problem when users are in dark mode. This PR sets the background the the correct theme color based and changes it for dark mode.

Before:
<img width="489" alt="Screen Shot 2022-08-22 at 11 36 08 AM" src="https://user-images.githubusercontent.com/8672809/185998089-a339a018-9d64-42db-b335-306466effcfb.png">

After:
<img width="459" alt="Screen Shot 2022-08-22 at 11 58 49 AM" src="https://user-images.githubusercontent.com/8672809/185998107-e26e1255-aed5-4d44-837f-432050af2093.png">

