### PR TITLE
Get FeatureFlagsMetadata via state in FeatureFlagOverrideDataSource.

### DIFF
--- a/tensorboard/webapp/feature_flag/effects/BUILD
+++ b/tensorboard/webapp/feature_flag/effects/BUILD
@@ -38,6 +38,7 @@ tf_ng_module(
         "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/actions",
         "//tensorboard/webapp/feature_flag/store",
+        "//tensorboard/webapp/feature_flag/store:feature_flag_metadata",
         "//tensorboard/webapp/feature_flag/store:types",
         "//tensorboard/webapp/webapp_data_source:feature_flag_testing",
         "@npm//@ngrx/effects",

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
@@ -28,6 +28,7 @@ import {
 import {ForceSvgDataSource} from '../force_svg_data_source';
 import {
   getFeatureFlags,
+  getFeatureFlagsMetadata,
   getFeatureFlagsToSendToServer,
   getIsAutoDarkModeAllowed,
 } from '../store/feature_flag_selectors';
@@ -47,9 +48,15 @@ export class FeatureFlagEffects {
   readonly getFeatureFlags$ = createEffect(() =>
     this.actions$.pipe(
       ofType(effectsInitialized),
-      combineLatestWith(this.store.select(getIsAutoDarkModeAllowed)),
-      map(([, isDarkModeAllowed]) => {
-        const features = this.dataSource.getFeatures(isDarkModeAllowed);
+      combineLatestWith(
+        this.store.select(getIsAutoDarkModeAllowed),
+        this.store.select(getFeatureFlagsMetadata)
+      ),
+      map(([, isDarkModeAllowed, featureFlagsMetadata]) => {
+        const features = this.dataSource.getFeatures(
+          isDarkModeAllowed,
+          featureFlagsMetadata
+        );
 
         if (features.forceSvg != null) {
           this.forceSvgDataSource.updateForceSvgFlag(features.forceSvg);

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -30,8 +30,10 @@ import {
 } from '../actions/feature_flag_actions';
 import {ForceSvgDataSource} from '../force_svg_data_source';
 import {ForceSvgDataSourceModule} from '../force_svg_data_source_module';
+import {FeatureFlagMetadataMap} from '../store/feature_flag_metadata';
 import {
   getFeatureFlags,
+  getFeatureFlagsMetadata,
   getFeatureFlagsToSendToServer,
   getIsAutoDarkModeAllowed,
 } from '../store/feature_flag_selectors';
@@ -73,6 +75,7 @@ describe('feature_flag_effects', () => {
     dataSource = TestBed.inject(TestingTBFeatureFlagDataSource);
     forceSvgDataSource = TestBed.inject(ForceSvgDataSource);
     store.overrideSelector(getIsAutoDarkModeAllowed, false);
+    store.overrideSelector(getFeatureFlagsMetadata, FeatureFlagMetadataMap);
   });
 
   describe('getFeatureFlags$', () => {

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -84,6 +84,7 @@ tf_ng_module(
     ],
     deps = [
         "//tensorboard/webapp/feature_flag:types",
+        "//tensorboard/webapp/feature_flag/store:feature_flag_metadata",
         "@npm//@angular/core",
     ],
 )
@@ -130,6 +131,7 @@ tf_ng_module(
     deps = [
         ":feature_flag",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/store:feature_flag_metadata",
         "@npm//@angular/core",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
 import {
-  FeatureFlagMetadataMap,
+  FeatureFlagMetadataMapType,
   FeatureFlagType,
 } from '../feature_flag/store/feature_flag_metadata';
 import {FeatureFlags} from '../feature_flag/types';
@@ -29,7 +29,10 @@ const FEATURE_FLAG_STORAGE_KEY = 'tb_feature_flag_storage_key';
 export class FeatureFlagOverrideDataSource implements TBFeatureFlagDataSource {
   constructor(readonly queryParams: QueryParams) {}
 
-  getFeatures(enableMediaQuery: boolean = false) {
+  getFeatures(
+    enableMediaQuery: boolean,
+    featureFlagsMetadata: FeatureFlagMetadataMapType<FeatureFlags>
+  ) {
     // Set feature flag value for query parameters that are explicitly
     // specified. Feature flags for unspecified query parameters remain unset so
     // their values in the underlying state are not inadvertently changed.
@@ -37,7 +40,7 @@ export class FeatureFlagOverrideDataSource implements TBFeatureFlagDataSource {
       Record<keyof FeatureFlags, FeatureFlagType>
     > = enableMediaQuery ? this.getPartialFeaturesFromMediaQuery() : {};
     const overriddenFeatures = getOverriddenFeatureFlagValuesFromSearchParams(
-      FeatureFlagMetadataMap,
+      featureFlagsMetadata,
       this.queryParams.getParams()
     );
     return {

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {TestBed} from '@angular/core/testing';
+import {FeatureFlagMetadataMap} from '../feature_flag/store/feature_flag_metadata';
 import {QueryParams} from './query_params';
 import {
   FeatureFlagOverrideDataSource,
@@ -42,155 +43,68 @@ describe('tb_feature_flag_data_source', () => {
     });
 
     describe('getFeatures', () => {
+      function getFeatures(enableMediaQuery: boolean = false) {
+        return dataSource.getFeatures(enableMediaQuery, FeatureFlagMetadataMap);
+      }
+
       it('returns empty values when params are empty', () => {
         getParamsSpy.and.returnValue(new URLSearchParams(''));
-        expect(dataSource.getFeatures()).toEqual({});
+        expect(getFeatures()).toEqual({});
       });
 
       it('returns enabledExperimentalPlugins from the query params', () => {
         getParamsSpy.and.returnValue(
           new URLSearchParams('experimentalPlugin=a,b')
         );
-        expect(dataSource.getFeatures()).toEqual({
+        expect(getFeatures()).toEqual({
           enabledExperimentalPlugins: ['a', 'b'],
         });
       });
 
-      it('returns inColab=false when `tensorboardColab` is empty', () => {
+      it('returns inColab=true when `tensorboardColab` is empty', () => {
         getParamsSpy.and.returnValue(new URLSearchParams('tensorboardColab'));
-        expect(dataSource.getFeatures()).toEqual({inColab: true});
+        expect(getFeatures()).toEqual({inColab: true});
       });
 
       it('returns inColab=true when `tensorboardColab` is`true`', () => {
         getParamsSpy.and.returnValue(
           new URLSearchParams('tensorboardColab=true')
         );
-        expect(dataSource.getFeatures()).toEqual({inColab: true});
+        expect(getFeatures()).toEqual({inColab: true});
       });
 
       it('returns inColab=false when `tensorboardColab` is `false`', () => {
         getParamsSpy.and.returnValue(
           new URLSearchParams('tensorboardColab=false')
         );
-        expect(dataSource.getFeatures()).toEqual({inColab: false});
+        expect(getFeatures()).toEqual({inColab: false});
       });
 
       it('returns scalarsBatchSize from the query params', () => {
         getParamsSpy.and.returnValue(
           new URLSearchParams('scalarsBatchSize=12')
         );
-        expect(dataSource.getFeatures()).toEqual({
+        expect(getFeatures()).toEqual({
           scalarsBatchSize: 12,
         });
       });
 
-      describe('returns enabledLinkedTime from the query params', () => {
-        it('when set to false', () => {
-          getParamsSpy.and.returnValue(
-            new URLSearchParams('enableLinkedTime=false')
-          );
-          expect(dataSource.getFeatures()).toEqual({enabledLinkedTime: false});
-        });
-
-        it('when set to empty string', () => {
-          getParamsSpy.and.returnValue(
-            new URLSearchParams('enableLinkedTime=')
-          );
-          expect(dataSource.getFeatures()).toEqual({enabledLinkedTime: true});
-        });
-
-        it('when set to true', () => {
-          getParamsSpy.and.returnValue(
-            new URLSearchParams('enableLinkedTime=true')
-          );
-          expect(dataSource.getFeatures()).toEqual({enabledLinkedTime: true});
-        });
-
-        it('when set to an arbitrary string', () => {
-          getParamsSpy.and.returnValue(
-            new URLSearchParams('enableLinkedTime=foo')
-          );
-          expect(dataSource.getFeatures()).toEqual({enabledLinkedTime: true});
-        });
-      });
-
-      describe('returns forceSvg from the query params', () => {
-        it('when set to false', () => {
-          getParamsSpy.and.returnValue(new URLSearchParams('forceSVG=false'));
-          expect(dataSource.getFeatures()).toEqual({forceSvg: false});
-        });
-
-        it('when set to empty string', () => {
-          getParamsSpy.and.returnValue(new URLSearchParams('forceSVG='));
-          expect(dataSource.getFeatures()).toEqual({forceSvg: true});
-        });
-
-        it('when set to true', () => {
-          getParamsSpy.and.returnValue(new URLSearchParams('forceSVG=true'));
-          expect(dataSource.getFeatures()).toEqual({forceSvg: true});
-        });
-
-        it('when set to an arbitrary string', () => {
-          getParamsSpy.and.returnValue(new URLSearchParams('forceSVG=foo'));
-          expect(dataSource.getFeatures()).toEqual({forceSvg: true});
-        });
-      });
-
-      describe('returns enabledDataTable from the query params', () => {
-        it('when set to false', () => {
-          getParamsSpy.and.returnValue(
-            new URLSearchParams('enableDataTable=false')
-          );
-          expect(dataSource.getFeatures()).toEqual({
-            enabledScalarDataTable: false,
-          });
-        });
-
-        it('when set to empty string', () => {
-          getParamsSpy.and.returnValue(new URLSearchParams('enableDataTable='));
-          expect(dataSource.getFeatures()).toEqual({
-            enabledScalarDataTable: true,
-          });
-        });
-
-        it('when set to true', () => {
-          getParamsSpy.and.returnValue(
-            new URLSearchParams('enableDataTable=true')
-          );
-          expect(dataSource.getFeatures()).toEqual({
-            enabledScalarDataTable: true,
-          });
-        });
-
-        it('when set to an arbitrary string', () => {
-          getParamsSpy.and.returnValue(
-            new URLSearchParams('enableDataTable=foo')
-          );
-          expect(dataSource.getFeatures()).toEqual({
-            enabledScalarDataTable: true,
-          });
-        });
-      });
-
-      it('returns all flag values when they are all set', () => {
+      it('returns multiple flag values when they are all set', () => {
         getParamsSpy.and.returnValue(
           new URLSearchParams(
             'experimentalPlugin=a' +
               '&tensorboardColab' +
-              '&fastChart=true' +
               '&scalarsBatchSize=16'
           )
         );
-        expect(dataSource.getFeatures()).toEqual({
+        expect(getFeatures()).toEqual({
           enabledExperimentalPlugins: ['a'],
           inColab: true,
           scalarsBatchSize: 16,
         });
       });
-    });
 
-    describe('media query feature flag', () => {
-      describe('getFeatures', () => {
+      describe('media query feature flag', () => {
         function fakeMediaQuery(matchDarkMode: boolean) {
           matchMediaSpy
             .withArgs(TEST_ONLY.DARK_MODE_MEDIA_QUERY)
@@ -200,7 +114,7 @@ describe('tb_feature_flag_data_source', () => {
 
         it('takes value from media query when `enableMediaQuery` is true', () => {
           fakeMediaQuery(true);
-          expect(dataSource.getFeatures(true)).toEqual({
+          expect(getFeatures(true)).toEqual({
             defaultEnableDarkMode: true,
           });
         });
@@ -210,7 +124,7 @@ describe('tb_feature_flag_data_source', () => {
             'dark mode',
           () => {
             fakeMediaQuery(false);
-            expect(dataSource.getFeatures(true)).toEqual({});
+            expect(getFeatures(true)).toEqual({});
           }
         );
       });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
+import {FeatureFlagMetadataMapType} from '../feature_flag/store/feature_flag_metadata';
 import {FeatureFlags} from '../feature_flag/types';
 
 @Injectable()
@@ -27,7 +28,10 @@ export abstract class TBFeatureFlagDataSource {
    * The data source may leave some or all feature flags unspecified if it does
    * not have enough information to provide values.
    */
-  abstract getFeatures(enableMediaQuery?: boolean): Partial<FeatureFlags>;
+  abstract getFeatures(
+    enableMediaQuery: boolean,
+    featureFlagsMetadata: FeatureFlagMetadataMapType<FeatureFlags>
+  ): Partial<FeatureFlags>;
 
   /**
    * Stores the given feature flag values in localStorage to allow for more


### PR DESCRIPTION
Now that we can use feature flag metadata from state (https://github.com/tensorflow/tensorboard/pull/5876) we use it in FeatureFlagOverrideDataSource instead of hardcoding the FeatureFlagMetadataMap value.

This will actually allow us to delete all internal implementations of TBFeatureFlagDataSource (googlers, see cl/469204869) since all feature flag parsing logic is now controllable via metadata.