### PR TITLE
linked time: updates linked time selection to latest step selector update

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -173,8 +173,8 @@ export const metricsShowAllPlugins = createAction(
   '[Metrics] Toggle Show All Plugins'
 );
 
-export const linkedTimeSelectionChanged = createAction(
-  '[Metrics] Linked Time Selection Changed',
+export const timeSelectionChanged = createAction(
+  '[Metrics] Time Selection Changed',
   props<{
     timeSelection: {
       startStep: number;
@@ -205,22 +205,5 @@ export const stepSelectorToggled = createAction(
     // Affordance for internal analytics purpose. When no affordance is specified or is
     // undefined we do not want to log an analytics event.
     affordance?: TimeSelectionToggleAffordance;
-  }>()
-);
-
-/**
- * Fired when step selector time selection is changed. This event is
- * used for internal analytics only and will not cause state changes.
- */
-export const stepSelectorTimeSelectionChanged = createAction(
-  '[Metrics] Ｓtep Selector Time Selection Changed',
-  props<{
-    timeSelection: {
-      startStep: number;
-      endStep: number | undefined;
-    };
-    // Affordance for internal analytics purpose. When no affordance is specified or is
-    // undefined we do not want to log an analytics event.
-    affordance?: TimeSelectionAffordance | undefined;
   }>()
 );

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -207,3 +207,6 @@ export const stepSelectorToggled = createAction(
     affordance?: TimeSelectionToggleAffordance;
   }>()
 );
+
+// TODO(jieweiwu): Delete after internal code is updated.
+export const stepSelectorTimeSelectionChanged = timeSelectionChanged;

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -978,7 +978,7 @@ const reducer = createReducer(
       stepSelectorEnabled: nextStepSelectorEnabled,
     };
   }),
-  on(actions.linkedTimeSelectionChanged, (state, change) => {
+  on(actions.timeSelectionChanged, (state, change) => {
     const {timeSelection} = change;
     const nextStartStep = timeSelection.startStep;
     const nextEndStep = timeSelection.endStep;

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1007,7 +1007,6 @@ const reducer = createReducer(
 
     return {
       ...state,
-      linkedTimeEnabled: true,
       linkedTimeSelection,
       cardStepIndex: nextCardStepIndexMap,
       linkedTimeRangeEnabled,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2488,7 +2488,7 @@ describe('metrics reducers', () => {
         });
       });
 
-      it('enables linkedTimeEnabled if previously disabled', () => {
+      it('keeps linkedTimeEnabled disabled if previously disabled', () => {
         const beforeState = buildMetricsState({
           linkedTimeEnabled: false,
         });
@@ -2500,7 +2500,7 @@ describe('metrics reducers', () => {
           })
         );
 
-        expect(nextState.linkedTimeEnabled).toBe(true);
+        expect(nextState.linkedTimeEnabled).toBe(false);
       });
 
       it('flips `end` to `start` if new start is greater than new end', () => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2433,7 +2433,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 2,
               endStep: 5,
@@ -2455,7 +2455,7 @@ describe('metrics reducers', () => {
 
         const after = reducers(
           before,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {startStep: 2, endStep: undefined},
           })
         );
@@ -2474,7 +2474,7 @@ describe('metrics reducers', () => {
 
         const after = reducers(
           before,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 2,
               endStep: 50,
@@ -2495,7 +2495,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {startStep: 2, endStep: undefined},
           })
         );
@@ -2511,7 +2511,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 150,
               endStep: 0,
@@ -2533,7 +2533,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 2,
               endStep: 5,
@@ -2558,7 +2558,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 2,
               endStep: 5,
@@ -2580,7 +2580,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 2,
               endStep: 0,
@@ -2599,7 +2599,7 @@ describe('metrics reducers', () => {
 
         const nextState1 = reducers(
           beforeState1,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 2,
               endStep: undefined,
@@ -2636,7 +2636,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 10,
               endStep: undefined,
@@ -2676,7 +2676,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          actions.linkedTimeSelectionChanged({
+          actions.timeSelectionChanged({
             timeSelection: {
               startStep: 15,
               endStep: undefined,
@@ -2701,7 +2701,7 @@ describe('metrics reducers', () => {
 
       const nextState = reducers(
         beforeState,
-        actions.linkedTimeSelectionChanged({
+        actions.timeSelectionChanged({
           timeSelection: {
             startStep: 3,
             endStep: undefined,

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -32,7 +32,7 @@ import {
 } from '../../../widgets/card_fob/card_fob_types';
 import {HistogramDatum} from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
-import {linkedTimeSelectionChanged, linkedTimeToggled} from '../../actions';
+import {linkedTimeToggled, timeSelectionChanged} from '../../actions';
 import {HistogramStepDatum, PluginType} from '../../data_source';
 import {
   getCardLoadState,
@@ -233,7 +233,7 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   }) {
     const {timeSelection, affordance} = newLinkedTimeSelectionWithAffordance;
     this.store.dispatch(
-      linkedTimeSelectionChanged({
+      timeSelectionChanged({
         timeSelection: {
           startStep: timeSelection.start.step,
           endStep: timeSelection.end ? timeSelection.end.step : undefined,

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -38,7 +38,7 @@ import {
 } from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
-import {linkedTimeSelectionChanged, linkedTimeToggled} from '../../actions';
+import {linkedTimeToggled, timeSelectionChanged} from '../../actions';
 import {PluginType} from '../../data_source';
 import * as selectors from '../../store/metrics_selectors';
 import {
@@ -281,7 +281,7 @@ describe('histogram card', () => {
   });
 
   describe('linked time', () => {
-    it('dispatches linkedTimeSelectionChanged when HistogramComponent emits onLinkedTimeSelectionChanged event', () => {
+    it('dispatches timeSelectionChanged when HistogramComponent emits onLinkedTimeSelectionChanged event', () => {
       provideMockCardSeriesData(selectSpy, PluginType.HISTOGRAMS, 'card1');
       store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
         start: {step: 5},
@@ -303,7 +303,7 @@ describe('histogram card', () => {
       });
 
       expect(dispatchedActions).toEqual([
-        linkedTimeSelectionChanged({
+        timeSelectionChanged({
           timeSelection: {
             startStep: 5,
             endStep: undefined,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -96,16 +96,12 @@ export class ScalarCardComponent<Downloader> {
   @Output() onPinClicked = new EventEmitter<boolean>();
   @Output() onLinkedTimeToggled =
     new EventEmitter<TimeSelectionToggleAffordance>();
-  @Output() onLinkedTimeSelectionChanged = new EventEmitter<{
+  @Output() onTimeSelectionChanged = new EventEmitter<{
     timeSelection: TimeSelection;
     affordance?: TimeSelectionAffordance;
   }>();
   @Output() onStepSelectorToggled =
     new EventEmitter<TimeSelectionToggleAffordance>();
-  @Output() onStepSelectorTimeSelectionChanged = new EventEmitter<{
-    timeSelection: TimeSelection;
-    affordance?: TimeSelectionAffordance;
-  }>();
 
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)
@@ -242,21 +238,11 @@ export class ScalarCardComponent<Downloader> {
       end: null,
     };
 
-    // Updates linked time selection regardless of linked time enableness.
-    // This enables the app to use the lastest step selector update as linked time selection
-    this.onLinkedTimeSelectionChanged.emit({
+    this.onTimeSelectionChanged.emit({
       timeSelection,
-      // When linkedTime is not enabled, we only update time selection state.
-      ...(this.linkedTimeSelection !== null && {affordance}),
+      // Only sets affordance when it's not undefined.
+      ...(affordance && {affordance}),
     });
-
-    // Fires onStepSelectorTimeSelectionChanged for internal analysis
-    if (this.linkedTimeSelection === null) {
-      this.onStepSelectorTimeSelectionChanged.emit({
-        timeSelection,
-        ...(affordance !== null && {affordance}),
-      });
-    }
   }
 
   onFobRemoved() {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -98,13 +98,13 @@ export class ScalarCardComponent<Downloader> {
     new EventEmitter<TimeSelectionToggleAffordance>();
   @Output() onLinkedTimeSelectionChanged = new EventEmitter<{
     timeSelection: TimeSelection;
-    affordance: TimeSelectionAffordance;
+    affordance?: TimeSelectionAffordance;
   }>();
   @Output() onStepSelectorToggled =
     new EventEmitter<TimeSelectionToggleAffordance>();
   @Output() onStepSelectorTimeSelectionChanged = new EventEmitter<{
     timeSelection: TimeSelection;
-    affordance: TimeSelectionAffordance;
+    affordance?: TimeSelectionAffordance;
   }>();
 
   // Line chart may not exist when was never visible (*ngIf).
@@ -224,7 +224,7 @@ export class ScalarCardComponent<Downloader> {
 
   onFobTimeSelectionChanged(newTimeSelectionWithAffordance: {
     timeSelection: TimeSelection;
-    affordance: TimeSelectionAffordance;
+    affordance?: TimeSelectionAffordance;
   }) {
     // Updates step selector to single selection.
     const {timeSelection, affordance} = newTimeSelectionWithAffordance;
@@ -242,13 +242,20 @@ export class ScalarCardComponent<Downloader> {
       end: null,
     };
 
-    if (this.linkedTimeSelection !== null) {
-      this.onLinkedTimeSelectionChanged.emit({
+    // Updates linked time selection regardless of linked time enableness.
+    // This enables the app to use the lastest step selector update as linked time selection
+    this.onLinkedTimeSelectionChanged.emit({
+      timeSelection,
+      // When linkedTime is not enabled, we only update time selection state.
+      ...(this.linkedTimeSelection !== null && {affordance}),
+    });
+
+    // Fires onStepSelectorTimeSelectionChanged for internal analysis
+    if (this.linkedTimeSelection === null) {
+      this.onStepSelectorTimeSelectionChanged.emit({
         timeSelection,
-        affordance,
+        ...(affordance !== null && {affordance}),
       });
-    } else {
-      this.onStepSelectorTimeSelectionChanged.emit({timeSelection, affordance});
     }
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -601,7 +601,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   onLinkedTimeSelectionChanged(newTimeSelectionWithAffordance: {
     timeSelection: TimeSelection;
-    affordance: TimeSelectionAffordance;
+    affordance?: TimeSelectionAffordance;
   }) {
     const {timeSelection, affordance} = newTimeSelectionWithAffordance;
     this.store.dispatch(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -59,10 +59,9 @@ import {
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {
-  linkedTimeSelectionChanged,
   linkedTimeToggled,
-  stepSelectorTimeSelectionChanged,
   stepSelectorToggled,
+  timeSelectionChanged,
 } from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
@@ -151,10 +150,7 @@ function areSeriesEqual(
       (onPinClicked)="pinStateChanged.emit($event)"
       observeIntersection
       (onVisibilityChange)="onVisibilityChange($event)"
-      (onLinkedTimeSelectionChanged)="onLinkedTimeSelectionChanged($event)"
-      (onStepSelectorTimeSelectionChanged)="
-        onStepSelectorTimeSelectionChanged($event)
-      "
+      (onTimeSelectionChanged)="onTimeSelectionChanged($event)"
       (onLinkedTimeToggled)="onLinkedTimeToggled($event)"
       (onStepSelectorToggled)="onStepSelectorToggled($event)"
     ></scalar-card-component>
@@ -599,30 +595,13 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     });
   }
 
-  onLinkedTimeSelectionChanged(newTimeSelectionWithAffordance: {
+  onTimeSelectionChanged(newTimeSelectionWithAffordance: {
     timeSelection: TimeSelection;
     affordance?: TimeSelectionAffordance;
   }) {
     const {timeSelection, affordance} = newTimeSelectionWithAffordance;
     this.store.dispatch(
-      linkedTimeSelectionChanged({
-        timeSelection: {
-          startStep: timeSelection.start.step,
-          endStep: timeSelection.end ? timeSelection.end.step : undefined,
-        },
-        affordance,
-      })
-    );
-  }
-
-  onStepSelectorTimeSelectionChanged(newStepSelectorTimeSelectionWthAffordance: {
-    timeSelection: TimeSelection;
-    affordance: TimeSelectionAffordance;
-  }) {
-    const {timeSelection, affordance} =
-      newStepSelectorTimeSelectionWthAffordance;
-    this.store.dispatch(
-      stepSelectorTimeSelectionChanged({
+      timeSelectionChanged({
         timeSelection: {
           startStep: timeSelection.start.step,
           endStep: timeSelection.end ? timeSelection.end.step : undefined,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2913,7 +2913,7 @@ describe('scalar card', () => {
         ).toBeFalsy();
       }));
 
-      it('dispatches stepSelectorTimeSelectionChanged action when fob is dragged', fakeAsync(() => {
+      it('dispatches stepSelectorTimeSelectionChanged actions when fob is dragged', fakeAsync(() => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
         const testController = fixture.debugElement.query(
@@ -2942,22 +2942,15 @@ describe('scalar card', () => {
         expect(
           fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('25');
-        expect(dispatchedActions).toEqual([
-          stepSelectorTimeSelectionChanged({
-            timeSelection: {
-              startStep: 25,
-              endStep: undefined,
-            },
-            affordance: undefined,
-          }),
+        expect(dispatchedActions).toContain(
           stepSelectorTimeSelectionChanged({
             timeSelection: {
               startStep: 25,
               endStep: undefined,
             },
             affordance: TimeSelectionAffordance.FOB,
-          }),
-        ]);
+          })
+        );
         const scalarCardComponent = fixture.debugElement.query(
           By.directive(ScalarCardComponent)
         );
@@ -2967,6 +2960,45 @@ describe('scalar card', () => {
           start: {step: 25},
           end: null,
         });
+      }));
+
+      it('dispatches linkedTimeSelectionChanged actions when fob is dragged under linkedTime disabled', fakeAsync(() => {
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+        const testController = fixture.debugElement.query(
+          By.directive(CardFobControllerComponent)
+        ).componentInstance;
+        const controllerStartPosition =
+          testController.root.nativeElement.getBoundingClientRect().left;
+
+        // Simulate dragging fob to step 25.
+        testController.startDrag(
+          Fob.START,
+          TimeSelectionAffordance.FOB,
+          new MouseEvent('mouseDown')
+        );
+        const fakeEvent = new MouseEvent('mousemove', {
+          clientX: 25 + controllerStartPosition,
+          movementX: 1,
+        });
+        testController.mouseMove(fakeEvent);
+        testController.stopDrag();
+        fixture.detectChanges();
+
+        const fobs = fixture.debugElement.queryAll(
+          By.directive(CardFobComponent)
+        );
+        expect(dispatchedActions).toContain(
+          linkedTimeSelectionChanged({
+            timeSelection: {
+              startStep: 25,
+              endStep: undefined,
+            },
+            // linkedTime is disabled, therefore there should be no affordance
+            // and this is not logged in internal analytics
+            affordance: undefined,
+          })
+        );
       }));
 
       it('sets stepSelectorTimeSelection to single selection', fakeAsync(() => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -74,10 +74,9 @@ import {
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
-  linkedTimeSelectionChanged,
   linkedTimeToggled,
-  stepSelectorTimeSelectionChanged,
   stepSelectorToggled,
+  timeSelectionChanged,
 } from '../../actions';
 import {PluginType} from '../../data_source';
 import {
@@ -2223,7 +2222,7 @@ describe('scalar card', () => {
         );
       });
 
-      it('dispatches linkedTimeSelectionChanged action when fob is dragged', fakeAsync(() => {
+      it('dispatches timeSelectionChanged action when fob is dragged', fakeAsync(() => {
         store.overrideSelector(getMetricsLinkedTimeSelection, {
           start: {step: 20},
           end: null,
@@ -2264,28 +2263,28 @@ describe('scalar card', () => {
         fixture.detectChanges();
 
         expect(dispatchedActions).toEqual([
-          linkedTimeSelectionChanged({
+          timeSelectionChanged({
             timeSelection: {
               startStep: 25,
               endStep: undefined,
             },
             affordance: undefined,
           }),
-          linkedTimeSelectionChanged({
+          timeSelectionChanged({
             timeSelection: {
               startStep: 25,
               endStep: undefined,
             },
             affordance: TimeSelectionAffordance.FOB,
           }),
-          linkedTimeSelectionChanged({
+          timeSelectionChanged({
             timeSelection: {
               startStep: 30,
               endStep: undefined,
             },
             affordance: undefined,
           }),
-          linkedTimeSelectionChanged({
+          timeSelectionChanged({
             timeSelection: {
               startStep: 30,
               endStep: undefined,
@@ -2913,7 +2912,7 @@ describe('scalar card', () => {
         ).toBeFalsy();
       }));
 
-      it('dispatches stepSelectorTimeSelectionChanged actions when fob is dragged', fakeAsync(() => {
+      it('dispatches timeSelectionChanged actions when fob is dragged', fakeAsync(() => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
         const testController = fixture.debugElement.query(
@@ -2943,7 +2942,7 @@ describe('scalar card', () => {
           fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('25');
         expect(dispatchedActions).toContain(
-          stepSelectorTimeSelectionChanged({
+          timeSelectionChanged({
             timeSelection: {
               startStep: 25,
               endStep: undefined,
@@ -2962,7 +2961,7 @@ describe('scalar card', () => {
         });
       }));
 
-      it('dispatches linkedTimeSelectionChanged actions when fob is dragged under linkedTime disabled', fakeAsync(() => {
+      it('dispatches timeSelectionChanged actions when fob is dragged under linkedTime disabled', fakeAsync(() => {
         const fixture = createComponent('card1');
         fixture.detectChanges();
         const testController = fixture.debugElement.query(
@@ -2989,7 +2988,7 @@ describe('scalar card', () => {
           By.directive(CardFobComponent)
         );
         expect(dispatchedActions).toContain(
-          linkedTimeSelectionChanged({
+          timeSelectionChanged({
             timeSelection: {
               startStep: 25,
               endStep: undefined,
@@ -3030,14 +3029,14 @@ describe('scalar card', () => {
         fixture.detectChanges();
 
         expect(dispatchedActions).toEqual([
-          linkedTimeSelectionChanged({
+          timeSelectionChanged({
             timeSelection: {
               startStep: 25,
               endStep: 40,
             },
             affordance: undefined,
           }),
-          linkedTimeSelectionChanged({
+          timeSelectionChanged({
             timeSelection: {
               startStep: 25,
               endStep: 40,

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -516,7 +516,7 @@ describe('metrics right_pane', () => {
           });
 
           expect(dispatchSpy).toHaveBeenCalledOnceWith(
-            actions.linkedTimeSelectionChanged({
+            actions.timeSelectionChanged({
               timeSelection: {
                 startStep: 10,
                 endStep: 200,
@@ -542,7 +542,7 @@ describe('metrics right_pane', () => {
           rangeInput.triggerEventHandler('singleValueChanged', 10);
 
           expect(dispatchSpy).toHaveBeenCalledOnceWith(
-            actions.linkedTimeSelectionChanged({
+            actions.timeSelectionChanged({
               timeSelection: {
                 startStep: 10,
                 endStep: undefined,

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -20,7 +20,6 @@ import {State} from '../../../app_state';
 import * as selectors from '../../../selectors';
 import {TimeSelectionToggleAffordance} from '../../../widgets/card_fob/card_fob_types';
 import {
-  linkedTimeSelectionChanged,
   linkedTimeToggled,
   metricsChangeCardWidth,
   metricsChangeHistogramMode,
@@ -36,6 +35,7 @@ import {
   metricsToggleIgnoreOutliers,
   metricsToggleImageShowActualSize,
   stepSelectorToggled,
+  timeSelectionChanged,
 } from '../../actions';
 import {
   HistogramMode,
@@ -210,7 +210,7 @@ export class SettingsViewContainer {
 
   onLinkedTimeSelectionChanged(newValue: TimeSelection) {
     this.store.dispatch(
-      linkedTimeSelectionChanged({
+      timeSelectionChanged({
         timeSelection: {
           startStep: newValue.start.step,
           endStep: newValue.end?.step,


### PR DESCRIPTION
* Motivation for features / changes
The values update between step selector and linked time have been an hidden and ambiguous part. They are largely undependable prior to this PR: (1)updates on step selector will not reflect on linked time (2)updates to linked time will only update to a single step selector only when users dragging on _that_ fob. 
In FE team we made a preliminary decision to change case (1): the latest update on step selector will be _remembered_ and set as the linked time selection (as opposed to always set to min value in the dashboard).  case (2) is still true.

* Technical description of changes
   * The `affordance` attribute on firing linkedTimeSelectionChanged was designed as optional. i.e., it's already possible that we fire this action without providing affordance (during dragging). This PR I further sets the it as optional across scalar_card_fob_controller and scalar_card_fob_component/container.
   * Remove the linkedTimeEnabled when time selection actions fired. The attribute was set when users dragging the sliders in range selection when linked time is not enabled. However, this scenario will no longer happen because we hide the range input slider unless linked time is enabled.
   * Remove stepSelectorTimeSelectionChange action: now both old stepSelectorTimeSelectionChange and linkedTimeSelectionChange actions will update linkedTimeSelection in state. The caveat is when doing internal analytics, we still want to identify which feature is enabled. We will need to pull out state value to check that. 

* Screenshots of UI changes
drag step selection --> enable linked time --> it shows the latest step selection update

https://user-images.githubusercontent.com/1131010/186279433-8610d99a-adea-497c-a4fa-3976e7ed351f.mov



* Alternatives
What was wrong: fire ssTC _and_ ltTC at component level.
(1) fire ssTC --> handle in metrics_reducer to also update ltTC (might end up duplicate logics has been handled in L981-1015)
[not good, composite actions](2) fire ssTC --> effect (set affordance to undefined if linkedTime is not enabled) --> fire ltTC
(3) Get ride of ssTC
      TC --(metric_reducer)--> 100% linkedTime state change 
        |----(analytics_effect)--> if (linkedTime disabled) log ssTC related event
ssTC: stepSelectionTimeSelectionChange
ltTC: linkedTimeSelectionChange

We decide to go to (3) in this PR.
