### PR TITLE
linked time: moves the position in settings panel to closer to "horizontal axis"

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -26,31 +26,6 @@ limitations under the License.
     >
     </tb-dropdown>
   </div>
-  <div class="control-row card-width">
-    <div class="control-name" id="card-width-label">Card Width</div>
-    <div class="slider-row">
-      <mat-slider
-        aria-labelledby="card-width-label"
-        color="primary"
-        [max]="MAX_CARD_WIDTH_SLIDER_VALUE"
-        [min]="MIN_CARD_WIDTH_SLIDER_VALUE"
-        [step]="50"
-        [value]="cardMinWidth"
-        [thumbLabel]="false"
-        (input)="cardWidthSliderChanged$.emit($event.value)"
-      ></mat-slider>
-      <button
-        class="reset-button"
-        mat-icon-button
-        i18n-aria-label="A button to reset the card width setting"
-        aria-label="Reset card width"
-        title="Reset card width"
-        (click)="cardWidthReset.emit()"
-      >
-        <mat-icon svgIcon="settings_backup_restore_24px"></mat-icon>
-      </button>
-    </div>
-  </div>
 
   <div
     class="control-row scalars-step-selector"
@@ -85,6 +60,32 @@ limitations under the License.
           (rangeValuesChanged)="onRangeValuesChanged($event)"
         ></tb-range-input>
       </div>
+    </div>
+  </div>
+
+  <div class="control-row card-width">
+    <div class="control-name" id="card-width-label">Card Width</div>
+    <div class="slider-row">
+      <mat-slider
+        aria-labelledby="card-width-label"
+        color="primary"
+        [max]="MAX_CARD_WIDTH_SLIDER_VALUE"
+        [min]="MIN_CARD_WIDTH_SLIDER_VALUE"
+        [step]="50"
+        [value]="cardMinWidth"
+        [thumbLabel]="false"
+        (input)="cardWidthSliderChanged$.emit($event.value)"
+      ></mat-slider>
+      <button
+        class="reset-button"
+        mat-icon-button
+        i18n-aria-label="A button to reset the card width setting"
+        aria-label="Reset card width"
+        title="Reset card width"
+        (click)="cardWidthReset.emit()"
+      >
+        <mat-icon svgIcon="settings_backup_restore_24px"></mat-icon>
+      </button>
     </div>
   </div>
 </section>


### PR DESCRIPTION
* Motivation for features / changes
Since step selector and linked time can only be used when axis is "step". We want to move them closer to communicate they're related for better user experiences.

* Technical description of changes
Simple switch the two div element. Will need to update internal webtests screenshots.

* Screenshots of UI changes
before
<img width="234" alt="Screen Shot 2022-08-22 at 5 24 43 PM" src="https://user-images.githubusercontent.com/1131010/186042278-2722c08e-d059-46a2-a0fc-e84ff88af3ed.png">


after
<img width="233" alt="Screen Shot 2022-08-22 at 5 21 45 PM" src="https://user-images.githubusercontent.com/1131010/186042243-37c6c787-612f-461b-b958-0a15dce0a47f.png">

