### PR TITLE
Fix brittle Zlib-dependent test

### DIFF
--- a/tensorboard/util/encoder_test.py
+++ b/tensorboard/util/encoder_test.py
@@ -33,7 +33,7 @@ class TensorFlowPngEncoderTest(tf.test.TestCase):
         # assume it did the right thing. We trust the underlying
         # `encode_png` op.
         self.assertEqual(b"\x89PNG", data[:4])
-        self.assertGreater(len(data), 128)
+        self.assertGreater(len(data), 125)
 
     def test_invalid_non_numpy(self):
         with self.assertRaisesRegex(ValueError, "must be a numpy array"):


### PR DESCRIPTION
Tests that expect zlib to produce a particular bitstream for some input
data are brittle, because the output of zlib is variable for different
implementations and different tunings.

We trust the underlying zlib `encode_png` op does the right thing if it
has a valid PNG header and is of a reasonable size.