### PR TITLE
Remove extraneous check on encoded data length

### DIFF
--- a/tensorboard/util/encoder_test.py
+++ b/tensorboard/util/encoder_test.py
@@ -29,11 +29,9 @@ class TensorFlowPngEncoderTest(tf.test.TestCase):
         )
 
     def _check_png(self, data):
-        # If it has a valid PNG header and is of a reasonable size, we can
-        # assume it did the right thing. We trust the underlying
-        # `encode_png` op.
+        # If it has a valid PNG header, we can assume it did the right thing.
+        # We trust the underlying `encode_png` op.
         self.assertEqual(b"\x89PNG", data[:4])
-        self.assertGreater(len(data), 125)
 
     def test_invalid_non_numpy(self):
         with self.assertRaisesRegex(ValueError, "must be a numpy array"):


### PR DESCRIPTION
The encoded data length is something that can change over time with
improvements to the underlying compression. We trust the underlying
`encode_op`, so just checking that that we have a valid PNG header is
sufficient.
