### PR TITLE
linked time: displays expected step for link by step in settings

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -550,6 +550,53 @@ describe('metrics right_pane', () => {
             })
           );
         });
+
+        it('displays expected linked time start step when linked time is not enabled', () => {
+          store.overrideSelector(
+            selectors.getMetricsLinkedTimeSelectionSetting,
+            {
+              start: {step: 20},
+              end: null,
+            }
+          );
+          store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, false);
+          const fixture = TestBed.createComponent(SettingsViewContainer);
+          fixture.detectChanges();
+
+          const el = fixture.debugElement.query(
+            By.css('.linked-time mat-checkbox')
+          );
+          expect(el.nativeElement.textContent).toContain('20');
+
+          store.overrideSelector(
+            selectors.getMetricsLinkedTimeSelectionSetting,
+            {
+              start: {step: 40},
+              end: null,
+            }
+          );
+          store.refreshState();
+          fixture.detectChanges();
+          expect(el.nativeElement.textContent).toContain('40');
+        });
+
+        it('does not display expected linked time start step when linked time is enabled', () => {
+          store.overrideSelector(
+            selectors.getMetricsLinkedTimeSelectionSetting,
+            {
+              start: {step: 20},
+              end: null,
+            }
+          );
+          store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, true);
+          const fixture = TestBed.createComponent(SettingsViewContainer);
+          fixture.detectChanges();
+
+          const el = fixture.debugElement.query(
+            By.css('.linked-time mat-checkbox')
+          );
+          expect(el.nativeElement.textContent.trim()).toBe('Link by step');
+        });
       });
     });
 

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -566,7 +566,7 @@ describe('metrics right_pane', () => {
           const el = fixture.debugElement.query(
             By.css('.linked-time mat-checkbox')
           );
-          expect(el.nativeElement.textContent).toContain('20');
+          expect(el.nativeElement.textContent).toContain('Link by step 20');
 
           store.overrideSelector(
             selectors.getMetricsLinkedTimeSelectionSetting,
@@ -577,7 +577,7 @@ describe('metrics right_pane', () => {
           );
           store.refreshState();
           fixture.detectChanges();
-          expect(el.nativeElement.textContent).toContain('40');
+          expect(el.nativeElement.textContent).toContain('Link by step 40');
         });
 
         it('does not display expected linked time start step when linked time is enabled', () => {

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -47,8 +47,8 @@ limitations under the License.
         [checked]="isLinkedTimeEnabled"
         (change)="linkedTimeToggled.emit()"
         [disabled]="!isAxisTypeStep()"
-        >Link by step</mat-checkbox
-      >
+        >Link by step {{getLinkedTimeSelectionStartStep()}}
+      </mat-checkbox>
       <div class="indent" *ngIf="isLinkedTimeEnabled">
         <tb-range-input
           [min]="stepMinMax.min"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -174,6 +174,17 @@ export class SettingsViewComponent {
     );
   }
 
+  getLinkedTimeSelectionStartStep() {
+    if (
+      !this.isLinkedTimeEnabled &&
+      this.linkedTimeSelection !== null &&
+      this.linkedTimeSelection.end === null
+    ) {
+      return this.linkedTimeSelection.start.step;
+    }
+    return '';
+  }
+
   onSingleValueChanged(stepValue: number) {
     this.linkedTimeSelectionChanged.emit({
       start: {step: stepValue},


### PR DESCRIPTION
* Motivation for features / changes
Before user check "Link by step" we show them what is the step we are going to link across cards.


* Technical description of changes
This only works on 
  * single selection (we can think about extend to range selection later)
  * when linked time is disabled: we don't want to have two identical numbers shown up close and updated at the same time

* Screenshots of UI changes
https://user-images.githubusercontent.com/1131010/186510747-88776ec2-7d86-42f8-8011-9345658c519d.mov


