### PR TITLE
Linked Time: Clean data table headers

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -360,6 +360,7 @@ tf_svg_bundle(
         "@com_google_material_design_icon//:brightness_6_24px.svg",
         "@com_google_material_design_icon//:bug_report_24px.svg",
         "@com_google_material_design_icon//:cancel_24px.svg",
+        "@com_google_material_design_icon//:change_history_24px.svg",
         "@com_google_material_design_icon//:chevron_left_24px.svg",
         "@com_google_material_design_icon//:chevron_right_24px.svg",
         "@com_google_material_design_icon//:clear_24px.svg",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -431,10 +431,10 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
           headers.push(ColumnHeaders.RUN);
           headers.push(ColumnHeaders.MIN_VALUE);
           headers.push(ColumnHeaders.MAX_VALUE);
-          headers.push(ColumnHeaders.VALUE_CHANGE);
-          headers.push(ColumnHeaders.PERCENTAGE_CHANGE);
           headers.push(ColumnHeaders.START_VALUE);
           headers.push(ColumnHeaders.END_VALUE);
+          headers.push(ColumnHeaders.VALUE_CHANGE);
+          headers.push(ColumnHeaders.PERCENTAGE_CHANGE);
           headers.push(ColumnHeaders.START_STEP);
           headers.push(ColumnHeaders.END_STEP);
         }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -20,23 +20,21 @@ limitations under the License.
           <!-- This header is intentionally left blank for the color column -->
         </th>
         <ng-container *ngFor="let header of headers;">
-          <th [ngSwitch]="header">
-            <div *ngSwitchCase="ColumnHeaders.VALUE_CHANGE" class="cell">
+          <th>
+            <div [ngSwitch]="header" class="cell">
               <mat-icon
+                *ngSwitchCase="ColumnHeaders.VALUE_CHANGE"
                 class="delta-arrow"
                 svgIcon="change_history_24px"
               ></mat-icon>
-              <div>{{ getHeaderTextColumn(header) }}</div>
-            </div>
-            <div *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE" class="cell">
               <mat-icon
+                *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE"
                 class="delta-arrow"
                 svgIcon="change_history_24px"
               ></mat-icon>
-              <div>{{ getHeaderTextColumn(header) }}</div>
-            </div>
-            <div *ngSwitchDefault class="cell extra-right-padding">
-              {{ getHeaderTextColumn(header) }}
+              <div *ngSwitchDefault class="extra-right-padding"></div>
+
+              <span>{{ getHeaderTextColumn(header) }}</span>
             </div>
           </th>
         </ng-container>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -20,7 +20,25 @@ limitations under the License.
           <!-- This header is intentionally left blank for the color column -->
         </th>
         <ng-container *ngFor="let header of headers;">
-          <th>{{ getHeaderTextColumn(header) }}</th>
+          <th [ngSwitch]="header">
+            <div *ngSwitchCase="ColumnHeaders.VALUE_CHANGE" class="cell">
+              <mat-icon
+                class="delta-arrow"
+                svgIcon="change_history_24px"
+              ></mat-icon>
+              <div>{{ getHeaderTextColumn(header) }}</div>
+            </div>
+            <div *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE" class="cell">
+              <mat-icon
+                class="delta-arrow"
+                svgIcon="change_history_24px"
+              ></mat-icon>
+              <div>{{ getHeaderTextColumn(header) }}</div>
+            </div>
+            <div *ngSwitchDefault class="cell without-icon">
+              {{ getHeaderTextColumn(header) }}
+            </div>
+          </th>
         </ng-container>
       </tr>
     </thead>
@@ -32,21 +50,21 @@ limitations under the License.
           </td>
           <ng-container *ngFor="let header of headers;">
             <td [ngSwitch]="header">
-              <span *ngSwitchCase="ColumnHeaders.VALUE_CHANGE">
+              <div *ngSwitchCase="ColumnHeaders.VALUE_CHANGE" class="cell">
                 <ng-container
                   *ngTemplateOutlet="arrow; context: {$implicit:runData.VALUE_CHANGE}"
                 ></ng-container>
                 {{ getFormattedDataForColumn(header, runData) }}
-              </span>
-              <span *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE">
+              </div>
+              <div *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE" class="cell">
                 <ng-container
                   *ngTemplateOutlet="arrow; context: {$implicit:runData.PERCENTAGE_CHANGE}"
                 ></ng-container>
                 {{ getFormattedDataForColumn(header, runData) }}
-              </span>
-              <span *ngSwitchDefault
-                >{{ getFormattedDataForColumn(header, runData) }}</span
-              >
+              </div>
+              <div *ngSwitchDefault class="cell without-icon">
+                {{ getFormattedDataForColumn(header, runData) }}
+              </div>
             </td>
           </ng-container>
         </tr>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -35,7 +35,7 @@ limitations under the License.
               ></mat-icon>
               <div>{{ getHeaderTextColumn(header) }}</div>
             </div>
-            <div *ngSwitchDefault class="cell without-icon">
+            <div *ngSwitchDefault class="cell extra-right-padding">
               {{ getHeaderTextColumn(header) }}
             </div>
           </th>
@@ -62,7 +62,7 @@ limitations under the License.
                 ></ng-container>
                 {{ getFormattedDataForColumn(header, runData) }}
               </div>
-              <div *ngSwitchDefault class="cell without-icon">
+              <div *ngSwitchDefault class="cell extra-right-padding">
                 {{ getFormattedDataForColumn(header, runData) }}
               </div>
             </td>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -24,10 +24,21 @@ limitations under the License.
     position: sticky;
     text-align: left;
     top: 0;
+    vertical-align: bottom;
 
     @include tb-dark-theme {
       background-color: map-get($tb-dark-background, background);
     }
+  }
+
+  .cell {
+    display: flex;
+    align-items: center;
+  }
+
+  .without-icon {
+    // Add artificial padding to keep consistent with icons which have whitespace
+    padding-right: 1px;
   }
 
   .row {

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -32,11 +32,11 @@ limitations under the License.
   }
 
   .cell {
-    display: flex;
     align-items: center;
+    display: flex;
   }
 
-  .without-icon {
+  .extra-right-padding {
     // Add artificial padding to keep consistent with icons which have whitespace
     padding-right: 1px;
   }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -53,21 +53,21 @@ export class DataTableComponent {
       case ColumnHeaders.SMOOTHED:
         return 'Smoothed';
       case ColumnHeaders.VALUE_CHANGE:
-        return 'Value Change';
+        return 'Value';
       case ColumnHeaders.START_STEP:
         return 'Start Step';
       case ColumnHeaders.END_STEP:
         return 'End Step';
       case ColumnHeaders.START_VALUE:
-        return 'Start';
+        return 'Start Value';
       case ColumnHeaders.END_VALUE:
-        return 'End';
+        return 'End Value';
       case ColumnHeaders.MIN_VALUE:
         return 'Min';
       case ColumnHeaders.MAX_VALUE:
         return 'Max';
       case ColumnHeaders.PERCENTAGE_CHANGE:
-        return 'Percentage Change';
+        return '%';
       default:
         return '';
     }

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -90,16 +90,16 @@ describe('data table', () => {
     expect(headerElements[2].nativeElement.innerText).toBe('Run');
     expect(headerElements[3].nativeElement.innerText).toBe('Step');
     expect(headerElements[4].nativeElement.innerText).toBe('Relative');
-    expect(headerElements[5].nativeElement.innerText).toBe('Value Change');
+    expect(headerElements[5].nativeElement.innerText).toBe('Value');
+    expect(headerElements[5].queryAll(By.css('mat-icon')).length).toBe(1);
     expect(headerElements[6].nativeElement.innerText).toBe('Start Step');
     expect(headerElements[7].nativeElement.innerText).toBe('End Step');
-    expect(headerElements[8].nativeElement.innerText).toBe('Start');
-    expect(headerElements[9].nativeElement.innerText).toBe('End');
+    expect(headerElements[8].nativeElement.innerText).toBe('Start Value');
+    expect(headerElements[9].nativeElement.innerText).toBe('End Value');
     expect(headerElements[10].nativeElement.innerText).toBe('Min');
     expect(headerElements[11].nativeElement.innerText).toBe('Max');
-    expect(headerElements[12].nativeElement.innerText).toBe(
-      'Percentage Change'
-    );
+    expect(headerElements[12].nativeElement.innerText).toBe('%');
+    expect(headerElements[12].queryAll(By.css('mat-icon')).length).toBe(1);
   });
 
   it('displays data in order', () => {
@@ -144,14 +144,16 @@ describe('data table', () => {
     expect(dataElements[2].nativeElement.innerText).toBe('run name');
     expect(dataElements[3].nativeElement.innerText).toBe('1');
     expect(dataElements[4].nativeElement.innerText).toBe('123 ms');
-    expect(dataElements[5].nativeElement.innerText).toBe(' 20'); // space before the value is kept for down or up arrow
+    expect(dataElements[5].nativeElement.innerText).toBe('20');
+    expect(dataElements[5].queryAll(By.css('mat-icon')).length).toBe(1);
     expect(dataElements[6].nativeElement.innerText).toBe('5');
     expect(dataElements[7].nativeElement.innerText).toBe('30');
     expect(dataElements[8].nativeElement.innerText).toBe('13');
     expect(dataElements[9].nativeElement.innerText).toBe('23');
     expect(dataElements[10].nativeElement.innerText).toBe('1');
     expect(dataElements[11].nativeElement.innerText).toBe('500');
-    expect(dataElements[12].nativeElement.innerText).toBe(' 30%'); // space before the percentage is kept for down or up arrow
+    expect(dataElements[12].nativeElement.innerText).toBe('30%');
+    expect(dataElements[12].queryAll(By.css('mat-icon')).length).toBe(1);
     expect;
   });
 

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -92,6 +92,11 @@ describe('data table', () => {
     expect(headerElements[4].nativeElement.innerText).toBe('Relative');
     expect(headerElements[5].nativeElement.innerText).toBe('Value');
     expect(headerElements[5].queryAll(By.css('mat-icon')).length).toBe(1);
+    expect(
+      headerElements[5]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.getAttribute('svgIcon')
+    ).toBe('change_history_24px');
     expect(headerElements[6].nativeElement.innerText).toBe('Start Step');
     expect(headerElements[7].nativeElement.innerText).toBe('End Step');
     expect(headerElements[8].nativeElement.innerText).toBe('Start Value');
@@ -100,6 +105,11 @@ describe('data table', () => {
     expect(headerElements[11].nativeElement.innerText).toBe('Max');
     expect(headerElements[12].nativeElement.innerText).toBe('%');
     expect(headerElements[12].queryAll(By.css('mat-icon')).length).toBe(1);
+    expect(
+      headerElements[12]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.getAttribute('svgIcon')
+    ).toBe('change_history_24px');
   });
 
   it('displays data in order', () => {
@@ -124,7 +134,7 @@ describe('data table', () => {
           VALUE: 3,
           STEP: 1,
           RELATIVE_TIME: 123,
-          VALUE_CHANGE: 20,
+          VALUE_CHANGE: -20,
           START_STEP: 5,
           END_STEP: 30,
           START_VALUE: 13,
@@ -146,6 +156,11 @@ describe('data table', () => {
     expect(dataElements[4].nativeElement.innerText).toBe('123 ms');
     expect(dataElements[5].nativeElement.innerText).toBe('20');
     expect(dataElements[5].queryAll(By.css('mat-icon')).length).toBe(1);
+    expect(
+      dataElements[5]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.getAttribute('svgIcon')
+    ).toBe('arrow_downward_24px');
     expect(dataElements[6].nativeElement.innerText).toBe('5');
     expect(dataElements[7].nativeElement.innerText).toBe('30');
     expect(dataElements[8].nativeElement.innerText).toBe('13');
@@ -154,7 +169,11 @@ describe('data table', () => {
     expect(dataElements[11].nativeElement.innerText).toBe('500');
     expect(dataElements[12].nativeElement.innerText).toBe('30%');
     expect(dataElements[12].queryAll(By.css('mat-icon')).length).toBe(1);
-    expect;
+    expect(
+      dataElements[12]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.getAttribute('svgIcon')
+    ).toBe('arrow_upward_24px');
   });
 
   it('displays nothing when no data is available', () => {

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -198,11 +198,16 @@ def tensorboard_js_workspace():
                 "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/d3d4aca5a7cf50bc68bbd401cefa708e364194e8/src/action/drag_indicator/materialicons/24px.svg",
                 "https://raw.githubusercontent.com/google/material-design-icons/d3d4aca5a7cf50bc68bbd401cefa708e364194e8/src/action/drag_indicator/materialicons/24px.svg",
             ],
+            "93a10e36c7550ecd220d36c33ad822f2d31e520ee9fba0c9cb6c1eb44042e9f0": [
+                "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_change_history_24px.svg",
+                "https://raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_change_history_24px.svg",
+            ],
         },
         rename = {
             "ic_arrow_downward_24px.svg": "arrow_downward_24px.svg",
             "ic_arrow_upward_24px.svg": "arrow_upward_24px.svg",
             "ic_cancel_24px.svg": "cancel_24px.svg",
+            "ic_change_history_24px.svg": "change_history_24px.svg",
             "ic_chevron_left_24px.svg": "chevron_left_24px.svg",
             "ic_chevron_right_24px.svg": "chevron_right_24px.svg",
             "ic_clear_24px.svg": "clear_24px.svg",


### PR DESCRIPTION
* Motivation for features / changes
In our next phase of launching linked time we introduce the range selection. This has a whole new set of columns in the data table. These new columns have already been added however, after discussions with the team and with users we want to change the ordering and text in the headers. This PR makes those changes to the headers.

* Technical description of changes
This change is mostly text changes and some css. The only real logic added was to add an ngswitch inside the data_table_component.ng.html file which adds the triangle mat-icon(which is called "change_history" for some reason).  This is also the first time we added that icon so I had to add it to our build in the js.bzl file.

* Screenshots of UI changes
<img width="456" alt="Screen Shot 2022-08-25 at 2 17 55 PM" src="https://user-images.githubusercontent.com/8672809/186770659-3c48d62c-8659-4728-99a3-c9f72553cd3f.png">
