### PR TITLE
Revert "linked time: displays expected step for link by step in settings"

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -550,53 +550,6 @@ describe('metrics right_pane', () => {
             })
           );
         });
-
-        it('displays expected linked time start step when linked time is not enabled', () => {
-          store.overrideSelector(
-            selectors.getMetricsLinkedTimeSelectionSetting,
-            {
-              start: {step: 20},
-              end: null,
-            }
-          );
-          store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, false);
-          const fixture = TestBed.createComponent(SettingsViewContainer);
-          fixture.detectChanges();
-
-          const el = fixture.debugElement.query(
-            By.css('.linked-time mat-checkbox')
-          );
-          expect(el.nativeElement.textContent).toContain('Link by step 20');
-
-          store.overrideSelector(
-            selectors.getMetricsLinkedTimeSelectionSetting,
-            {
-              start: {step: 40},
-              end: null,
-            }
-          );
-          store.refreshState();
-          fixture.detectChanges();
-          expect(el.nativeElement.textContent).toContain('Link by step 40');
-        });
-
-        it('does not display expected linked time start step when linked time is enabled', () => {
-          store.overrideSelector(
-            selectors.getMetricsLinkedTimeSelectionSetting,
-            {
-              start: {step: 20},
-              end: null,
-            }
-          );
-          store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, true);
-          const fixture = TestBed.createComponent(SettingsViewContainer);
-          fixture.detectChanges();
-
-          const el = fixture.debugElement.query(
-            By.css('.linked-time mat-checkbox')
-          );
-          expect(el.nativeElement.textContent.trim()).toBe('Link by step');
-        });
       });
     });
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -47,8 +47,8 @@ limitations under the License.
         [checked]="isLinkedTimeEnabled"
         (change)="linkedTimeToggled.emit()"
         [disabled]="!isAxisTypeStep()"
-        >Link by step {{getLinkedTimeSelectionStartStep()}}
-      </mat-checkbox>
+        >Link by step</mat-checkbox
+      >
       <div class="indent" *ngIf="isLinkedTimeEnabled">
         <tb-range-input
           [min]="stepMinMax.min"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -174,17 +174,6 @@ export class SettingsViewComponent {
     );
   }
 
-  getLinkedTimeSelectionStartStep() {
-    if (
-      !this.isLinkedTimeEnabled &&
-      this.linkedTimeSelection !== null &&
-      this.linkedTimeSelection.end === null
-    ) {
-      return this.linkedTimeSelection.start.step;
-    }
-    return '';
-  }
-
   onSingleValueChanged(stepValue: number) {
     this.linkedTimeSelectionChanged.emit({
       start: {step: stepValue},


### PR DESCRIPTION
Reverts tensorflow/tensorboard#5898

Thanks for @rileyajones 's findings. The original PR will ruin our internal analysis.
We will end up in a case that the affordance check does not pass when catching stepSelectorTimeSelectionChange. I will investigate what's the cause.
To prevent this being released next Tue and to not block the release. Revert this PR until the analysis is handled.

Update: I cannot reproduce the bug