### PR TITLE
Add completes for shells by shtab, fix #5886

### DIFF
--- a/tensorboard/_shtab.py
+++ b/tensorboard/_shtab.py
@@ -1,0 +1,8 @@
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(parser, *args, **kwargs):
+    from argparse import Action
+    Action.complete = None
+    return parser

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -63,6 +63,9 @@ setup(
         ],
     },
     install_requires=REQUIRED_PACKAGES,
+    extras_require={
+        "shtab": ["completion"],
+    },
     tests_require=REQUIRED_PACKAGES,
     python_requires=">=3.7",
     # PyPI package information.


### PR DESCRIPTION
* Motivation for features / changes

Fix #5886, Add completes for shell

* Technical description of changes

* Screenshots of UI changes

Take bash as an example:

```bash
[root@desktop Desktop]# tensorboard dev upload --<TAB>
--description  --dry_run      --help         --helpfull     --logdir       --name         --one_shot     --plugins      --verbose
```

* Detailed steps to verify changes work correctly (as executed by you)

```
tensorboard --print-completion bash | sudo tee /usr/share/bash-completion/completions/tensorboard
tensorboard --print-completion tcsh | sudo tee /etc/profile.d/tensorboard.completion.csh
# tensorboard --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_tensorboard
```

`tensorboard --print-completion zsh` has some bug which comes from shtab.

* Alternate designs / implementations considered

- Realizing a py script to do this work which is not dependent in shtab.
- click, etc, See <https://docs.iterative.ai/shtab/#alternatives>
