### PR TITLE
GitHub Actions: Cache output of `bazel fetch`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,20 @@ jobs:
             ;
       - name: 'Check Pip state'
         run: pip freeze --all
+      - name: 'Restore Bazel Cache'
+        uses: actions/cache@1a9e2138d905efd099035b49d8b7a3888c653ca8
+        with:
+          path: |
+            bazel-bin
+          key: bazel-fetch-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
       - name: 'Bazel: fetch'
         run: bazel fetch //tensorboard/...
+      - name: 'Update Bazel Cache'
+        uses: actions/cache@1a9e2138d905efd099035b49d8b7a3888c653ca8
+        with:
+          path: |
+            bazel-bin
+          key: bazel-fetch-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
       - name: 'Bazel: build'
         # Note we suppress a flood of warnings from the proto compiler.
         # Googlers see b/222706811 & b/182876485 discussion and preconditions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:latest
+
+# Install environment dependencies
+RUN apt update && apt install -y git wget unzip python3 python3-pip python3-dev python-is-python3 default-jdk
+RUN python3 -m pip install -U pip
+
+# Setup build environment
+ENV BAZEL_VERSION='4.0.0'
+ENV BAZEL_SHA256SUM='7bee349a626281fc8b8d04a7a0b0358492712377400ab12533aeb39c2eb2b901'
+ENV BUILDTOOLS_VERSION='3.0.0'
+ENV BUILDIFIER_SHA256SUM='e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
+ENV BUILDOZER_SHA256SUM='3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
+ENV TENSORFLOW_VERSION='tf-nightly'
+
+# Get the code
+RUN git clone https://github.com/tensorflow/tensorboard /tensorboard
+WORKDIR /tensorboard
+
+# Install python dependencies
+RUN pip install -r ./tensorboard/pip_package/requirements.txt -r ./tensorboard/pip_package/requirements_dev.txt && pip freeze --all
+
+# Setup Bazel
+RUN ci/download_bazel.sh "${BAZEL_VERSION}" "${BAZEL_SHA256SUM}" ~/bazel
+RUN mv ~/bazel /usr/local/bin/bazel && chmod +x /usr/local/bin/bazel && cp ./ci/bazelrc ~/.bazelrc
+
+# Configure build cache write credentials
+# RUN \
+#   if [ -z "${CREDS}" ]; then \
+#     printf 'Using read-only cache (no credentials)\n' \
+#     exit \
+#   fi \
+#   if [ "${EVENT_TYPE}" = pull_request ]; then \
+#     printf 'Using read-only cache (PR build)\n' \
+#     exit \
+#   fi \
+#   printf 'Using writable cache\n' \
+#   creds_file=/tmp/service_account_creds.json \
+#   printf '%s\n' "${CREDS}" >"${creds_file}" \
+#   printf '%s\n' >>~/.bazelrc \
+#     "common --google_credentials=${creds_file}" \
+#     "common --remote_upload_local_results=true" \
+#     ;
+
+# Install TensorFlow
+RUN pip install "${TENSORFLOW_VERSION}"
+
+# Fetch dependencies
+RUN bazel fetch //tensorboard/...

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -73,4 +73,6 @@ import {TensorBoardWrapperModule} from './tb_wrapper/tb_wrapper_module';
   ],
   bootstrap: [AppContainer],
 })
-export class AppModule {}
+export class AppModule {
+  // noop
+}


### PR DESCRIPTION
* Motivation for features / changes
Our builds are taking an extremely long time due to http request timeouts. Hopefully by caching the external `bazel` dependencies we should see build times drop dramatically.
![image](https://user-images.githubusercontent.com/78179109/187272742-c163c4ce-fd15-4df4-9d4f-4b2decbb3d48.png)

* Alternate designs / implementations considered
We could switch to using `docker` images in which we prefetch dependencies.
