### PR TITLE
Added support for pathlib paths as a logdir using the recommended os.PathLike class.

### DIFF
--- a/tensorboard/plugins/hparams/_keras.py
+++ b/tensorboard/plugins/hparams/_keras.py
@@ -17,7 +17,7 @@
 Use `tensorboard.plugins.hparams.api` to access this module's contents.
 """
 
-
+import os 
 import tensorflow as tf
 
 from tensorboard.plugins.hparams import api_pb2
@@ -39,7 +39,7 @@ class Callback(tf.keras.callbacks.Callback):
 
         Args:
           writer: The `SummaryWriter` object to which hparams should be
-            written, or a logdir (as a `str`) to be passed to
+            written, or a logdir (as a `str` or `PathLike`) to be passed to
             `tf.summary.create_file_writer` to create such a writer.
           hparams: A `dict` mapping hyperparameters to the values used in
             this session. Keys should be the names of `HParam` objects used
@@ -62,10 +62,12 @@ class Callback(tf.keras.callbacks.Callback):
         summary_v2.hparams_pb(self._hparams, trial_id=self._trial_id)
         if writer is None:
             raise TypeError(
-                "writer must be a `SummaryWriter` or `str`, not None"
+                "writer must be a `SummaryWriter`, `str` or `PathLike`, not None"
             )
         elif isinstance(writer, str):
             self._writer = tf.compat.v2.summary.create_file_writer(writer)
+        elif isinstance(writer, os.PathLike):
+            self._writer = tf.compat.v2.summary.create_file_writer(os.fsdecode(writer))
         else:
             self._writer = writer
 


### PR DESCRIPTION
* Motivation for features / changes
Most other Tensorflow functions accept Paths in other form than strings. 
This small change makes the plugin more consistent and users do not need to cast their Path objects to string manually.

* Technical description of changes
- Imported os
- added another elif case for the type of writer:
elif isinstance(writer, os.PathLike):
            self._writer = tf.compat.v2.summary.create_file_writer(os.fsdecode(writer))
- Changed the documentation to fit this

* Detailed steps to verify changes work correctly (as executed by you)
Barely tested to be honest. Just ran the tutorial code here: https://www.tensorflow.org/tensorboard/hyperparameter_tuning_with_hparams
with my version

* Alternate designs / implementations considered
Once all Tensorflow functions accept pathlikes instead of just strings the distinction between str and PathLike will be unnecessary.
