### PR TITLE
Change color of warning message in feature flag modal

### DIFF
--- a/tensorboard/webapp/feature_flag/views/feature_flag_page_component.scss
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_page_component.scss
@@ -17,7 +17,7 @@ limitations under the License.
 
 .message {
   .warning {
-    color: mat.get-color-from-palette($tb-primary);
+    color: mat.get-color-from-palette($tb-warn);
   }
   margin-bottom: 16px;
 }


### PR DESCRIPTION
* Motivation for features / changes
While the modal coloring looks pretty good in OSS internal tensorboard uses a different color palette that does not look as good.
Honestly it should always have been this color anyway.

* Screenshots of UI changes
Before
![image](https://user-images.githubusercontent.com/78179109/187542657-cbc48b90-152a-454c-a2cd-40129eed3bed.png)
![image](https://user-images.githubusercontent.com/78179109/187542628-e344a425-e18a-417a-9c0c-0692fc758389.png)


After
![image](https://user-images.githubusercontent.com/78179109/187542353-60d7e382-ff7c-48fd-a9e2-697969021e99.png)
![image](https://user-images.githubusercontent.com/78179109/187542481-031c9f3a-85a1-4269-a254-5ec887a9224c.png)


* Detailed steps to verify changes work correctly (as executed by you)
1) Start start tensorboard
2) Navigate to localhost:6006/?showFlags
3) Assert that the modal colors have changed

* Alternate designs / implementations considered
