### PR TITLE
Allow event propogation on Fob clicks

### DIFF
--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -95,6 +95,9 @@ export class CardFobControllerComponent {
   }
 
   startDrag(fob: Fob, affordance: TimeSelectionAffordance, event: MouseEvent) {
+    // The Fob has the contenteditable attribute. This needs the event to
+    // propagate. The contenteditable attribute also stops MouseEvent from
+    // causing the strange behavior we are avoiding by stopping propagation.
     if (affordance !== TimeSelectionAffordance.FOB) {
       this.stopEventPropagation(event);
     }

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -95,9 +95,10 @@ export class CardFobControllerComponent {
   }
 
   startDrag(fob: Fob, affordance: TimeSelectionAffordance, event: MouseEvent) {
-    // The Fob has the contenteditable attribute. This needs the event to
-    // propagate. The contenteditable attribute also stops MouseEvent from
-    // causing the strange behavior we are avoiding by stopping propagation.
+    // When clicking on the fob, we needs to allow MouseEvent propagate to the
+    // text span in the fob for editing. The contenteditable attribute also
+    // stops the event from propagating which satisfies our need to call
+    // stopEventPropagation regardless of affordance.
     if (affordance !== TimeSelectionAffordance.FOB) {
       this.stopEventPropagation(event);
     }

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -95,7 +95,9 @@ export class CardFobControllerComponent {
   }
 
   startDrag(fob: Fob, affordance: TimeSelectionAffordance, event: MouseEvent) {
-    this.stopEventPropagation(event);
+    if (affordance !== TimeSelectionAffordance.FOB) {
+      this.stopEventPropagation(event);
+    }
     document.addEventListener('mousemove', this.mouseListener);
     document.addEventListener('mouseup', this.stopListener);
     this.currentDraggingFob = fob;


### PR DESCRIPTION
* Motivation for features / changes
Event propagation was causing some when dragging the line above the fob. This prompted us to stop propagation for startDrag events. However, that propagation is needed on the fob to allow users to type in the step. This change adds logic to allow propagation of mouse events on fob clicks.

* Screenshots of UI changes
Before change:
![2022-08-30_15-18-06 (1)](https://user-images.githubusercontent.com/8672809/187553597-81d7e3c5-1c61-4584-9195-364df7ee7271.gif)

After change:
![2022-08-30_15-16-32 (1)](https://user-images.githubusercontent.com/8672809/187553392-55320c50-d1cf-452c-ba4e-9ea90bd945ca.gif)
