### PR TITLE
Linked Time: Round to nearest integer when dragging range slider

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -56,6 +56,7 @@ limitations under the License.
           [lowerValue]="linkedTimeSelection?.start.step"
           [upperValue]="linkedTimeSelection?.end?.step"
           [enabled]="isLinkedTimeEnabled && isAxisTypeStep()"
+          [returnIntegers]="true"
           (singleValueChanged)="onSingleValueChanged($event)"
           (rangeValuesChanged)="onRangeValuesChanged($event)"
         ></tb-range-input>

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ts
@@ -135,6 +135,11 @@ export class RangeInputComponent implements OnInit, OnDestroy {
    */
   @Input() enabled: boolean = true;
 
+  /**
+   * Whether the slider returns discrete integers or allows for floating points.
+   */
+  @Input() returnIntegers: boolean = false;
+
   @Output()
   rangeValuesChanged = new EventEmitter<RangeValues>();
 
@@ -245,9 +250,13 @@ export class RangeInputComponent implements OnInit, OnDestroy {
       xPositionInPercent = compensatedRelativeXInPx / (right - left);
     }
 
-    const newValue = this.getClippedValue(
+    let newValue = this.getClippedValue(
       this.min + (this.max - this.min) * xPositionInPercent
     );
+
+    if (this.returnIntegers) {
+      newValue = Math.round(newValue);
+    }
 
     // Make sure floating point arithmatic does not pollute the number with
     // noise (e.g., 0.2 + 0.1 = 0.30000000000000004; we don't want 4e-17). Clip

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ts
@@ -250,12 +250,12 @@ export class RangeInputComponent implements OnInit, OnDestroy {
       xPositionInPercent = compensatedRelativeXInPx / (right - left);
     }
 
-    let newValue = this.getClippedValue(
+    const newValue = this.getClippedValue(
       this.min + (this.max - this.min) * xPositionInPercent
     );
 
     if (this.returnIntegers) {
-      newValue = Math.round(newValue);
+      return Math.round(newValue);
     }
 
     // Make sure floating point arithmatic does not pollute the number with

--- a/tensorboard/webapp/widgets/range_input/range_input_test.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_test.ts
@@ -30,6 +30,7 @@ import {RangeInputSource, RangeValues, SingleValue} from './types';
       [upperValue]="upperValue"
       [enabled]="enabled"
       [tickCount]="tickCount"
+      [returnIntegers]="returnIntegers"
       (rangeValuesChanged)="onRangeValuesChanged($event)"
       (singleValueChanged)="onSingleValueChanged($event)"
     ></tb-range-input>
@@ -59,6 +60,8 @@ class TestableComponent {
 
   @Input() tickCount!: number | null;
 
+  @Input() returnIntegers!: boolean;
+
   @Input()
   onRangeValuesChanged!: (event: RangeValues) => void;
 
@@ -74,6 +77,7 @@ describe('range input test', () => {
     lowerValue: number;
     upperValue?: number;
     useRange?: boolean;
+    returnIntegers?: boolean;
   }
 
   function createComponent(props: CreateComponentInput) {
@@ -82,6 +86,7 @@ describe('range input test', () => {
       max: 5,
       tickCount: 10,
       enabled: true,
+      returnIntegers: false,
       ...props,
     };
     const fixture = TestBed.createComponent(TestableComponent);
@@ -97,6 +102,7 @@ describe('range input test', () => {
     fixture.componentInstance.min = propsWithDefault.min;
     fixture.componentInstance.max = propsWithDefault.max;
     fixture.componentInstance.tickCount = propsWithDefault.tickCount;
+    fixture.componentInstance.returnIntegers = propsWithDefault.returnIntegers!;
     fixture.componentInstance.onRangeValuesChanged = onRangeValuesChanged;
     fixture.componentInstance.onSingleValueChanged = onSingleValueChanged;
     fixture.detectChanges();
@@ -268,6 +274,26 @@ describe('range input test', () => {
           lowerValue: 0.102,
           upperValue: 0.3,
           source: RangeInputSource.SLIDER,
+        });
+      });
+
+      it('rounds to integer when returnIntegers is set to true', () => {
+        const {fixture, onRangeValuesChanged} = createComponent({
+          min: 0,
+          max: 6,
+          lowerValue: 1,
+          upperValue: 5,
+          tickCount: 10,
+          returnIntegers: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+        moveThumb(leftThumb, 170);
+        // Without rounding, lowerValue would be 2.4.
+        expect(onRangeValuesChanged).toHaveBeenCalledWith({
+          lowerValue: 2,
+          upperValue: 5,
+          source: 'SLIDER',
         });
       });
 

--- a/tensorboard/webapp/widgets/range_input/range_input_test.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_test.ts
@@ -277,7 +277,7 @@ describe('range input test', () => {
         });
       });
 
-      it('rounds to integer when returnIntegers is set to true', () => {
+      it('rounds down to integer when returnIntegers is set to true', () => {
         const {fixture, onRangeValuesChanged} = createComponent({
           min: 0,
           max: 6,
@@ -292,6 +292,46 @@ describe('range input test', () => {
         // Without rounding, lowerValue would be 2.4.
         expect(onRangeValuesChanged).toHaveBeenCalledWith({
           lowerValue: 2,
+          upperValue: 5,
+          source: 'SLIDER',
+        });
+      });
+
+      it('rounds up to integer when returnIntegers is set to true', () => {
+        const {fixture, onRangeValuesChanged} = createComponent({
+          min: 0,
+          max: 6,
+          lowerValue: 1,
+          upperValue: 5,
+          tickCount: 20,
+          returnIntegers: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+        moveThumb(leftThumb, 190);
+        // Without rounding, lowerValue would be 2.7.
+        expect(onRangeValuesChanged).toHaveBeenCalledWith({
+          lowerValue: 3,
+          upperValue: 5,
+          source: 'SLIDER',
+        });
+      });
+
+      it('Keeps integer value if already an integer when returnIntegers is set to true', () => {
+        const {fixture, onRangeValuesChanged} = createComponent({
+          min: 0,
+          max: 6,
+          lowerValue: 1,
+          upperValue: 5,
+          tickCount: 10,
+          returnIntegers: true,
+        });
+        const [leftThumb] = getThumbsOnRange(fixture);
+        startMovingThumb(leftThumb);
+        moveThumb(leftThumb, 200);
+        // Without rounding, lowerValue is 3.
+        expect(onRangeValuesChanged).toHaveBeenCalledWith({
+          lowerValue: 3,
           upperValue: 5,
           source: 'SLIDER',
         });


### PR DESCRIPTION
* Motivation for features / changes
Steps are discrete. It does not make sense to have a slider which chooses steps to use floating point. This forces that slider to round to the nearest integer.

* Technical description of changes
Since the slider is a widget I wanted to allow the user of the widget to decide if floating point was something that they wanted. Therefore I made it an optional input.

* Screenshots of UI changes
![2022-08-30_16-30-19 (1)](https://user-images.githubusercontent.com/8672809/187561360-ae73a876-a4b8-48db-bc1b-e69cb6effca9.gif)

This is what is looks like in the edge case with only 2 steps.
![2022-08-30_16-28-59 (1)](https://user-images.githubusercontent.com/8672809/187561228-09c3e652-1f2b-4b21-a503-f8e269939911.gif)

