### PR TITLE
Linked Time: Clean up slider

### DIFF
--- a/tensorboard/webapp/widgets/range_input/range_input_component.scss
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.scss
@@ -96,6 +96,13 @@ input {
   transition: transform 0.3s ease;
   width: $_thumb-size;
   will-change: transform;
+
+  &:hover {
+    cursor: grab;
+  }
+  &:active {
+    cursor: grabbing;
+  }
 }
 
 .thumb.active {

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ts
@@ -215,6 +215,8 @@ export class RangeInputComponent implements OnInit, OnDestroy {
   }
 
   handleMouseDown(event: MouseEvent, position: Position) {
+    event.stopPropagation();
+    event.preventDefault();
     this.activeThumb = position;
     // Mouse event reports cursor position w.r.t the top left edge of the target
     // (in this case, a thumb) element.


### PR DESCRIPTION
* Motivation for features / changes
While messing around with the slider I found some issues. The propagation of the event caused some problems so I stoped that. Also, the change in [this PR](https://github.com/tensorflow/tensorboard/pull/5908) makes it unclear if you are dragging the thumb when there are few steps. Changing the cursor to a grabber helps give that indication and also helps range slider align with the single slider.

* Screenshots of UI changes
Before:
![2022-08-30_23-14-22 (1)](https://user-images.githubusercontent.com/8672809/187607008-e186f8a6-ff28-411f-a65c-92ad1431a84f.gif)

After:
![2022-08-30_23-25-56 (1)](https://user-images.githubusercontent.com/8672809/187608653-073a9a88-3b14-4318-9947-b81fac0620cb.gif)
