### PR TITLE
Linked Time: Sort Data Table based on header clicks

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -176,6 +176,8 @@ limitations under the License.
       [linkedTimeSelection]="linkedTimeSelection"
       [stepSelectorTimeSelection]="stepSelectorTimeSelection"
       [dataHeaders]="dataHeaders"
+      [sortingInfo]="sortingInfo"
+      (sortDataBy)="sortDataBy($event)"
     >
     </scalar-card-data-table>
   </div>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -50,6 +50,8 @@ import {
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
   ScalarCardSeriesMetadataMap,
+  SortingInfo,
+  SortingOrder,
 } from './scalar_card_types';
 import {TimeSelectionView} from './utils';
 
@@ -107,6 +109,10 @@ export class ScalarCardComponent<Downloader> {
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)
   lineChart?: LineChartComponent;
+  sortingInfo: SortingInfo = {
+    header: ColumnHeaders.RUN,
+    order: SortingOrder.ASCENDING,
+  };
 
   constructor(private readonly ref: ElementRef, private dialog: MatDialog) {}
 
@@ -116,6 +122,10 @@ export class ScalarCardComponent<Downloader> {
   toggleYScaleType() {
     this.yScaleType =
       this.yScaleType === ScaleType.LINEAR ? ScaleType.LOG10 : ScaleType.LINEAR;
+  }
+
+  sortDataBy(sortingInfo: SortingInfo) {
+    this.sortingInfo = sortingInfo;
   }
 
   resetDomain() {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {TimeSelection} from '../../../widgets/card_fob/card_fob_types';
 import {findClosestIndex} from '../../../widgets/line_chart_v2/sub_view/line_chart_interactive_utils';
 import {
@@ -21,6 +27,8 @@ import {
   ScalarCardPoint,
   ScalarCardSeriesMetadataMap,
   SelectedStepRunData,
+  SortingInfo,
+  SortingOrder,
 } from './scalar_card_types';
 import {TimeSelectionView} from './utils';
 
@@ -30,6 +38,8 @@ import {TimeSelectionView} from './utils';
     <tb-data-table
       [headers]="dataHeaders"
       [data]="getTimeSelectionTableData()"
+      [sortingInfo]="sortingInfo"
+      (sortDataBy)="sortDataBy.emit($event)"
     ></tb-data-table>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -40,6 +50,9 @@ export class ScalarCardDataTable {
   @Input() linkedTimeSelection!: TimeSelectionView | null;
   @Input() stepSelectorTimeSelection!: TimeSelection;
   @Input() dataHeaders!: ColumnHeaders[];
+  @Input() sortingInfo!: SortingInfo;
+
+  @Output() sortDataBy = new EventEmitter<SortingInfo>();
 
   getMinValueInRange(
     points: ScalarCardPoint[],
@@ -183,7 +196,22 @@ export class ScalarCardDataTable {
         }
         return selectedStepData;
       });
+    dataTableData.sort(
+      (point1: SelectedStepRunData, point2: SelectedStepRunData) => {
+        if (
+          point1[this.sortingInfo.header]! < point2[this.sortingInfo.header]!
+        ) {
+          return this.sortingInfo.order === SortingOrder.ASCENDING ? -1 : 1;
+        }
+        if (
+          point1[this.sortingInfo.header]! > point2[this.sortingInfo.header]!
+        ) {
+          return this.sortingInfo.order === SortingOrder.ASCENDING ? 1 : -1;
+        }
 
+        return 0;
+      }
+    );
     return dataTableData;
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -100,6 +100,7 @@ import {
   ScalarCardPoint,
   ScalarCardSeriesMetadata,
   SeriesType,
+  SortingOrder,
 } from './scalar_card_types';
 import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_warning_module';
 
@@ -2848,6 +2849,96 @@ describe('scalar card', () => {
       expect(scalarCardDataTable.componentInstance.dataHeaders).not.toContain(
         ColumnHeaders.SMOOTHED
       );
+    }));
+
+    it('orders data ascending', fakeAsync(() => {
+      const runToSeries = {
+        run1: [{wallTime: 1, value: 2, step: 1}],
+        run2: [{wallTime: 1, value: 1, step: 1}],
+        run3: [{wallTime: 1, value: 3, step: 1}],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+          ['run3', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsLinkedTimeSelection, {
+        start: {step: 1},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardDataTable = fixture.debugElement.query(
+        By.directive(ScalarCardDataTable)
+      );
+      scalarCardDataTable.componentInstance.sortingInfo = {
+        header: ColumnHeaders.VALUE,
+        order: SortingOrder.ASCENDING,
+      };
+      fixture.detectChanges();
+
+      const data =
+        scalarCardDataTable.componentInstance.getTimeSelectionTableData();
+
+      expect(data[0].RUN).toEqual('run2');
+      expect(data[1].RUN).toEqual('run1');
+      expect(data[2].RUN).toEqual('run3');
+    }));
+
+    it('orders data descending', fakeAsync(() => {
+      const runToSeries = {
+        run1: [{wallTime: 1, value: 2, step: 1}],
+        run2: [{wallTime: 1, value: 1, step: 1}],
+        run3: [{wallTime: 1, value: 3, step: 1}],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+          ['run3', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsLinkedTimeSelection, {
+        start: {step: 1},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardDataTable = fixture.debugElement.query(
+        By.directive(ScalarCardDataTable)
+      );
+      scalarCardDataTable.componentInstance.sortingInfo = {
+        header: ColumnHeaders.VALUE,
+        order: SortingOrder.DESCENDING,
+      };
+      fixture.detectChanges();
+
+      const data =
+        scalarCardDataTable.componentInstance.getTimeSelectionTableData();
+
+      expect(data[0].RUN).toEqual('run3');
+      expect(data[1].RUN).toEqual('run1');
+      expect(data[2].RUN).toEqual('run2');
     }));
   });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -94,6 +94,16 @@ export enum ColumnHeaders {
   PERCENTAGE_CHANGE = 'PERCENTAGE_CHANGE',
 }
 
+export enum SortingOrder {
+  ASCENDING,
+  DESCENDING,
+}
+
+export interface SortingInfo {
+  header: ColumnHeaders;
+  order: SortingOrder;
+}
+
 /**
  * An object which essentially contains the data for an entire row in the
  * DataTable. It will have a value for each required ColumnHeader for a given

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -20,8 +20,9 @@ limitations under the License.
           <!-- This header is intentionally left blank for the color column -->
         </th>
         <ng-container *ngFor="let header of headers;">
-          <th>
+          <th (click)="headerClicked(header)">
             <div [ngSwitch]="header" class="cell">
+              <!-- order icon -->
               <mat-icon
                 *ngSwitchCase="ColumnHeaders.VALUE_CHANGE"
                 class="delta-arrow"
@@ -35,6 +36,19 @@ limitations under the License.
               <div *ngSwitchDefault class="extra-right-padding"></div>
 
               <span>{{ getHeaderTextColumn(header) }}</span>
+
+              <div *ngIf="header === sortingInfo.header">
+                <mat-icon
+                  *ngIf="sortingInfo.order === SortingOrder.ASCENDING"
+                  class="delta-arrow"
+                  svgIcon="expand_more_24px"
+                ></mat-icon>
+                <mat-icon
+                  *ngIf="sortingInfo.order === SortingOrder.DESCENDING"
+                  class="delta-arrow"
+                  svgIcon="expand_less_24px"
+                ></mat-icon>
+              </div>
             </div>
           </th>
         </ng-container>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -13,10 +13,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {
   ColumnHeaders,
   SelectedStepRunData,
+  SortingInfo,
+  SortingOrder,
 } from '../../metrics/views/card_renderer/scalar_card_types';
 import {
   intlNumberFormatter,
@@ -35,8 +43,12 @@ export class DataTableComponent {
   // displayed in the table.
   @Input() headers!: ColumnHeaders[];
   @Input() data!: SelectedStepRunData[];
+  @Input() sortingInfo!: SortingInfo;
+
+  @Output() sortDataBy = new EventEmitter<SortingInfo>();
 
   readonly ColumnHeaders = ColumnHeaders;
+  readonly SortingOrder = SortingOrder;
 
   getHeaderTextColumn(columnHeader: ColumnHeaders): string {
     switch (columnHeader) {
@@ -176,5 +188,16 @@ export class DataTableComponent {
       default:
         return '';
     }
+  }
+
+  headerClicked(header: ColumnHeaders) {
+    let sortingOrder = SortingOrder.ASCENDING;
+    if (
+      this.sortingInfo.header === header &&
+      this.sortingInfo.order === SortingOrder.ASCENDING
+    ) {
+      sortingOrder = SortingOrder.DESCENDING;
+    }
+    this.sortDataBy.emit({header, order: sortingOrder});
   }
 }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -191,13 +191,13 @@ export class DataTableComponent {
   }
 
   headerClicked(header: ColumnHeaders) {
-    let sortingOrder = SortingOrder.ASCENDING;
     if (
       this.sortingInfo.header === header &&
       this.sortingInfo.order === SortingOrder.ASCENDING
     ) {
-      sortingOrder = SortingOrder.DESCENDING;
+      this.sortDataBy.emit({header, order: SortingOrder.DESCENDING});
+      return;
     }
-    this.sortDataBy.emit({header, order: sortingOrder});
+    this.sortDataBy.emit({header, order: SortingOrder.ASCENDING});
   }
 }


### PR DESCRIPTION
* Motivation for features / changes
With the introduction of the data table in Scalar Cards many more useful features become available. One of these features is sorting that data table. This change adds the ability for users to sort by any column by clicking on the header to that column.

* Technical description of changes
The sortingInfo object, which holds the information about which column and what order we are sorting, is stored in the ScalarCardComponent. It is currently not put into the ngrx state. It is piped through the ScalarCardDataTable and into the DataTableComponent. The ScalarCardDataTable uses this information to sort the data passed to the DataTableComponent and the DataTableComponent itself uses the information to update the header UI and inform the information emitted when the header is clicked.

* Screenshots of UI changes
![2022-09-01_12-30-46 (1)](https://user-images.githubusercontent.com/8672809/187997089-b7903510-7e29-43c8-946e-9de91cfeac62.gif)

