### PR TITLE
Load Feature Flags from `localStorage`

### DIFF
--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -45,6 +45,7 @@ export class FeatureFlagOverrideDataSource implements TBFeatureFlagDataSource {
     );
     return {
       ...featuresFromMediaQuery,
+      ...this.getPersistentFeatureFlags(),
       ...overriddenFeatures,
     } as Partial<FeatureFlags>;
   }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -43,8 +43,12 @@ describe('tb_feature_flag_data_source', () => {
     });
 
     describe('getFeatures', () => {
-      function getFeatures(options?: {enableMediaQuery?: boolean, localStorageOverrides?: string|null}) {
-        const {enableMediaQuery = false, localStorageOverrides = null} = options || {};
+      function getFeatures(options?: {
+        enableMediaQuery?: boolean;
+        localStorageOverrides?: string | null;
+      }) {
+        const {enableMediaQuery = false, localStorageOverrides = null} =
+          options || {};
         spyOn(localStorage, 'getItem').and.returnValue(localStorageOverrides);
         return dataSource.getFeatures(enableMediaQuery, FeatureFlagMetadataMap);
       }
@@ -131,8 +135,10 @@ describe('tb_feature_flag_data_source', () => {
         );
 
         it('retrieves values from localStorage', () => {
-          expect(getFeatures({localStorageOverrides: '{"inColab": true}'})).toEqual({
-            inColab: true
+          expect(
+            getFeatures({localStorageOverrides: '{"inColab": true}'})
+          ).toEqual({
+            inColab: true,
           });
         });
       });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -43,7 +43,9 @@ describe('tb_feature_flag_data_source', () => {
     });
 
     describe('getFeatures', () => {
-      function getFeatures(enableMediaQuery: boolean = false) {
+      function getFeatures(options?: {enableMediaQuery?: boolean, localStorageOverrides?: string|null}) {
+        const {enableMediaQuery = false, localStorageOverrides = null} = options || {};
+        spyOn(localStorage, 'getItem').and.returnValue(localStorageOverrides);
         return dataSource.getFeatures(enableMediaQuery, FeatureFlagMetadataMap);
       }
 
@@ -114,7 +116,7 @@ describe('tb_feature_flag_data_source', () => {
 
         it('takes value from media query when `enableMediaQuery` is true', () => {
           fakeMediaQuery(true);
-          expect(getFeatures(true)).toEqual({
+          expect(getFeatures({enableMediaQuery: true})).toEqual({
             defaultEnableDarkMode: true,
           });
         });
@@ -124,9 +126,15 @@ describe('tb_feature_flag_data_source', () => {
             'dark mode',
           () => {
             fakeMediaQuery(false);
-            expect(getFeatures(true)).toEqual({});
+            expect(getFeatures({enableMediaQuery: true})).toEqual({});
           }
         );
+
+        it('retrieves values from localStorage', () => {
+          expect(getFeatures({localStorageOverrides: '{"inColab": true}'})).toEqual({
+            inColab: true
+          });
+        });
       });
     });
 


### PR DESCRIPTION
* Motivation for features / changes
This makes the feature flags modal much more useful

* Detailed steps to verify changes work correctly (as executed by you)
1) Prior to making the change open TensorBoard with the `?showFlags` query param.
2) Change a flag to a non default value.
3) Open a fresh tab and note that it no longer appears and overridden in the modal.
4) Apply the change and note that it now appears as overridden.
