### PR TITLE
Swap card fobs when one is dragged past another

### DIFF
--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -123,7 +123,7 @@ export class CardFobControllerComponent {
     return this.axisDirection === AxisDirection.VERTICAL;
   }
 
-  private moveCurrentFob(
+  private getNewTimeSelection(
     newStep: number,
     timeSelection: TimeSelection
   ): TimeSelection {
@@ -136,7 +136,7 @@ export class CardFobControllerComponent {
       if (newStep < this.timeSelection.start.step) {
         timeSelection.end!.step = this.timeSelection.start.step;
         this.currentDraggingFob = Fob.START;
-        return this.moveCurrentFob(newStep, timeSelection);
+        return this.getNewTimeSelection(newStep, timeSelection);
       }
       timeSelection.end!.step = newStep;
 
@@ -146,7 +146,7 @@ export class CardFobControllerComponent {
     if (this.timeSelection.end && newStep > this.timeSelection.end.step) {
       timeSelection.start.step = this.timeSelection.end.step;
       this.currentDraggingFob = Fob.END;
-      return this.moveCurrentFob(newStep, timeSelection);
+      return this.getNewTimeSelection(newStep, timeSelection);
     }
     timeSelection.start.step = newStep;
 
@@ -172,7 +172,10 @@ export class CardFobControllerComponent {
       return;
     }
 
-    const newTimeSelection = this.moveCurrentFob(newStep, this.timeSelection);
+    const newTimeSelection = this.getNewTimeSelection(
+      newStep,
+      this.timeSelection
+    );
     this.onTimeSelectionChanged.emit({
       timeSelection: newTimeSelection,
     });

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -36,6 +36,11 @@ export enum Fob {
   END,
 }
 
+const TIME_SELECTION_TO_FOB: Record<keyof TimeSelection, Fob> = {
+  start: Fob.START,
+  end: Fob.END,
+};
+
 @Component({
   selector: 'card-fob-controller',
   templateUrl: 'card_fob_controller_component.ng.html',
@@ -142,14 +147,14 @@ export class CardFobControllerComponent {
     // Range Selection
     // Swapping if fobs pass each other
     if (this.shouldSwapFobs(newStep)) {
-      const [oldDraggingFob, newDraggingFob] =
+      const [oldDraggingFob, newDraggingFob]: Array<keyof TimeSelection> =
         this.currentDraggingFob === Fob.END
-          ? [Fob.END, Fob.START]
-          : [Fob.START, Fob.END];
-      timeSelection[oldDraggingFob].step =
-        this.timeSelection[newDraggingFob].step;
-      this.currentDraggingFob = newDraggingFob;
-      timeSelection[newDraggingFob].step = newStep;
+          ? ['end', 'start']
+          : ['start', 'end'];
+      this.currentDraggingFob = TIME_SELECTION_TO_FOB[newDraggingFob];
+      timeSelection[oldDraggingFob]!.step =
+        this.timeSelection[newDraggingFob]!.step;
+      timeSelection[newDraggingFob]!.step = newStep;
       return timeSelection;
     }
 

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -129,9 +129,17 @@ export class CardFobControllerComponent {
   }
 
   private shouldSwapFobs(newStep: number) {
-    return this.currentDraggingFob === Fob.END
-      ? newStep < this.timeSelection.start.step
-      : this.timeSelection.end && newStep > this.timeSelection.end.step;
+    if (!this.timeSelection.end) {
+      return false;
+    }
+    if (this.currentDraggingFob === Fob.END) {
+      return newStep < this.timeSelection.start.step;
+    }
+    if (this.currentDraggingFob === Fob.START) {
+      return newStep > this.timeSelection.end.step;
+    }
+
+    return false;
   }
 
   private getNewTimeSelection(

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -207,6 +207,46 @@ describe('card_fob_controller', () => {
         mouseUpListener
       );
     });
+
+    it('swaps fobs being dragged when one fobs collide', () => {
+      const fixture = createComponent({
+        timeSelection: {start: {step: 1}, end: {step: 2}},
+      });
+      fixture.detectChanges();
+      const fobController = fixture.componentInstance.fobController;
+      expect(
+        fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
+      ).toEqual(1);
+
+      fobController.startDrag(
+        Fob.START,
+        TimeSelectionAffordance.FOB,
+        new MouseEvent('mouseDown')
+      );
+      expect((fobController as any).currentDraggingFob).toEqual(Fob.START);
+
+      const fakeEvent = new MouseEvent('mousemove', {
+        clientY: 3,
+        movementY: 2,
+      });
+      fobController.mouseMove(fakeEvent);
+      expect((fobController as any).currentDraggingFob).toEqual(Fob.END);
+
+      fobController.stopDrag();
+      fixture.detectChanges();
+
+      // expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3);
+      // expect(
+      //   fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
+      // ).toEqual(3);
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 2},
+          end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.FOB,
+      });
+    });
   });
 
   describe('vertical dragging', () => {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -208,15 +208,12 @@ describe('card_fob_controller', () => {
       );
     });
 
-    it('swaps fobs being dragged when one fobs collide', () => {
+    it('swaps fobs being dragged when start > end', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
-      expect(
-        fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
-      ).toEqual(1);
 
       fobController.startDrag(
         Fob.START,
@@ -235,14 +232,75 @@ describe('card_fob_controller', () => {
       fobController.stopDrag();
       fixture.detectChanges();
 
-      // expect(getStepHigherSpy).toHaveBeenCalledOnceWith(3);
-      // expect(
-      //   fobController.startFobWrapper.nativeElement.getBoundingClientRect().top
-      // ).toEqual(3);
       expect(onTimeSelectionChanged).toHaveBeenCalledWith({
         timeSelection: {
           start: {step: 2},
           end: {step: 3},
+        },
+        affordance: TimeSelectionAffordance.FOB,
+      });
+    });
+
+    it('swaps fobs being dragged when end < start', () => {
+      const fixture = createComponent({
+        timeSelection: {start: {step: 2}, end: {step: 3}},
+      });
+      fixture.detectChanges();
+      const fobController = fixture.componentInstance.fobController;
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        new MouseEvent('mouseDown')
+      );
+      expect((fobController as any).currentDraggingFob).toEqual(Fob.END);
+
+      const fakeEvent = new MouseEvent('mousemove', {
+        clientY: 1,
+        movementY: -3,
+      });
+      fobController.mouseMove(fakeEvent);
+      expect((fobController as any).currentDraggingFob).toEqual(Fob.START);
+
+      fobController.stopDrag();
+      fixture.detectChanges();
+
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 1},
+          end: {step: 2},
+        },
+        affordance: TimeSelectionAffordance.FOB,
+      });
+    });
+
+    it('does not swaps fobs when start === end', () => {
+      const fixture = createComponent({
+        timeSelection: {start: {step: 2}, end: {step: 3}},
+      });
+      fixture.detectChanges();
+      const fobController = fixture.componentInstance.fobController;
+
+      fobController.startDrag(
+        Fob.END,
+        TimeSelectionAffordance.FOB,
+        new MouseEvent('mouseDown')
+      );
+      expect((fobController as any).currentDraggingFob).toEqual(Fob.END);
+
+      const fakeEvent = new MouseEvent('mousemove', {
+        clientY: 2,
+        movementY: -1,
+      });
+      fobController.mouseMove(fakeEvent);
+      expect((fobController as any).currentDraggingFob).toEqual(Fob.END);
+
+      fobController.stopDrag();
+      fixture.detectChanges();
+
+      expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+        timeSelection: {
+          start: {step: 2},
+          end: {step: 2},
         },
         affordance: TimeSelectionAffordance.FOB,
       });


### PR DESCRIPTION
* Motivation for features / changes
This is how it behaves in the settings panel so it stands to reason that the fobs on the chart should behave the same.

* Technical description of changes
Change the fob currently being dragged when they collide

* Screenshots of UI changes
![e27da5a4-cac1-4c25-b400-3a3fccb10c46](https://user-images.githubusercontent.com/78179109/188794523-8040a520-5184-4ad6-8284-a8c6c8b5a207.gif)

* Detailed steps to verify changes work correctly (as executed by you)
1) Start TensorBoard
2) Navigate to [localhost:6006?enableLinkedTime&enableDataTable](http://localhost:6006?enableLinkedTime&enableDataTable)
3) Enable "Link by step" in the settings panel
4) Set a value for the end step
5) Validate you can drag the start fob past the end fob
6) Validate you can drag the end fob past the start fob


