### PR TITLE
Linked Time: Sorting Header css cleanup and hover indication

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -37,15 +37,15 @@ limitations under the License.
 
               <div
                 class="sorting-icon-container"
-                [ngClass]="header === sortingInfo.header ? 'opaque' : 'show-on-hover'"
+                [ngClass]="header === sortingInfo.header ? 'show' : 'show-on-hover'"
               >
                 <mat-icon
                   *ngIf="sortingInfo.order === SortingOrder.ASCENDING || header !== sortingInfo.header"
-                  svgIcon="arrow_downward_24px"
+                  svgIcon="arrow_upward_24px"
                 ></mat-icon>
                 <mat-icon
                   *ngIf="sortingInfo.order === SortingOrder.DESCENDING && header === sortingInfo.header"
-                  svgIcon="arrow_upward_24px"
+                  svgIcon="arrow_downward_24px"
                 ></mat-icon>
               </div>
             </div>
@@ -84,14 +84,6 @@ limitations under the License.
   </table>
 </div>
 <ng-template #arrow let-value>
-  <mat-icon
-    *ngIf="value >= 0"
-    class="delta-arrow"
-    svgIcon="arrow_upward_24px"
-  ></mat-icon>
-  <mat-icon
-    *ngIf="value < 0"
-    class="delta-arrow"
-    svgIcon="arrow_downward_24px"
-  ></mat-icon>
+  <mat-icon *ngIf="value >= 0" svgIcon="arrow_upward_24px"></mat-icon>
+  <mat-icon *ngIf="value < 0" svgIcon="arrow_downward_24px"></mat-icon>
 </ng-template>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -25,28 +25,27 @@ limitations under the License.
               <!-- order icon -->
               <mat-icon
                 *ngSwitchCase="ColumnHeaders.VALUE_CHANGE"
-                class="delta-arrow"
                 svgIcon="change_history_24px"
               ></mat-icon>
               <mat-icon
                 *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE"
-                class="delta-arrow"
                 svgIcon="change_history_24px"
               ></mat-icon>
               <div *ngSwitchDefault class="extra-right-padding"></div>
 
               <span>{{ getHeaderTextColumn(header) }}</span>
 
-              <div *ngIf="header === sortingInfo.header">
+              <div
+                class="sorting-icon-container"
+                [ngClass]="header === sortingInfo.header ? 'opaque' : 'show-on-hover'"
+              >
                 <mat-icon
-                  *ngIf="sortingInfo.order === SortingOrder.ASCENDING"
-                  class="delta-arrow"
-                  svgIcon="expand_more_24px"
+                  *ngIf="sortingInfo.order === SortingOrder.ASCENDING || header !== sortingInfo.header"
+                  svgIcon="arrow_downward_24px"
                 ></mat-icon>
                 <mat-icon
-                  *ngIf="sortingInfo.order === SortingOrder.DESCENDING"
-                  class="delta-arrow"
-                  svgIcon="expand_less_24px"
+                  *ngIf="sortingInfo.order === SortingOrder.DESCENDING && header === sortingInfo.header"
+                  svgIcon="arrow_upward_24px"
                 ></mat-icon>
               </div>
             </div>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -29,6 +29,10 @@ limitations under the License.
     @include tb-dark-theme {
       background-color: map-get($tb-dark-background, background);
     }
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   .cell {
@@ -63,8 +67,25 @@ limitations under the License.
     width: $_circle-size - 2px;
   }
 
-  .delta-arrow {
+  mat-icon {
     height: 12px;
     width: 12px;
+  }
+
+  .sorting-icon-container {
+    width: 12px;
+    height: 12px;
+  }
+
+  .opaque {
+    opacity: 1;
+  }
+
+  .show-on-hover {
+    opacity: 0;
+  }
+
+  th:hover .show-on-hover {
+    opacity: 0.3;
   }
 }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -26,12 +26,12 @@ limitations under the License.
     top: 0;
     vertical-align: bottom;
 
-    @include tb-dark-theme {
-      background-color: map-get($tb-dark-background, background);
-    }
-
     &:hover {
       cursor: pointer;
+    }
+
+    @include tb-dark-theme {
+      background-color: map-get($tb-dark-background, background);
     }
   }
 
@@ -67,7 +67,7 @@ limitations under the License.
     width: $_circle-size - 2px;
   }
 
-  mat-icon {
+  .cell mat-icon {
     height: 12px;
     width: 12px;
   }
@@ -77,7 +77,7 @@ limitations under the License.
     height: 12px;
   }
 
-  .opaque {
+  .show {
     opacity: 1;
   }
 

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -111,7 +111,6 @@ describe('data table', () => {
     expect(headerElements[3].nativeElement.innerText).toBe('Step');
     expect(headerElements[4].nativeElement.innerText).toBe('Relative');
     expect(headerElements[5].nativeElement.innerText).toBe('Value');
-    expect(headerElements[5].queryAll(By.css('mat-icon')).length).toBe(1);
     expect(
       headerElements[5]
         .queryAll(By.css('mat-icon'))[0]
@@ -124,7 +123,6 @@ describe('data table', () => {
     expect(headerElements[10].nativeElement.innerText).toBe('Min');
     expect(headerElements[11].nativeElement.innerText).toBe('Max');
     expect(headerElements[12].nativeElement.innerText).toBe('%');
-    expect(headerElements[12].queryAll(By.css('mat-icon')).length).toBe(1);
     expect(
       headerElements[12]
         .queryAll(By.css('mat-icon'))[0]
@@ -254,5 +252,33 @@ describe('data table', () => {
       header: ColumnHeaders.STEP,
       order: SortingOrder.DESCENDING,
     });
+  });
+
+  it('keeps sorting arrow invisible unless sorting on that header', () => {
+    const fixture = createComponent({
+      headers: [ColumnHeaders.VALUE, ColumnHeaders.RUN, ColumnHeaders.STEP],
+      sortingInfo: {header: ColumnHeaders.VALUE, order: SortingOrder.ASCENDING},
+    });
+    fixture.detectChanges();
+    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+
+    expect(
+      window.getComputedStyle(
+        headerElements[1].queryAll(By.css('.sorting-icon-container'))[0]
+          .nativeElement
+      ).opacity
+    ).toBe('1');
+    expect(
+      window.getComputedStyle(
+        headerElements[2].queryAll(By.css('.sorting-icon-container'))[0]
+          .nativeElement
+      ).opacity
+    ).toBe('0');
+    expect(
+      window.getComputedStyle(
+        headerElements[3].queryAll(By.css('.sorting-icon-container'))[0]
+          .nativeElement
+      ).opacity
+    ).toBe('0');
   });
 });

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -263,28 +263,35 @@ describe('data table', () => {
     const headerElements = fixture.debugElement.queryAll(By.css('th'));
 
     expect(
-      window.getComputedStyle(
-        headerElements[1].queryAll(By.css('.sorting-icon-container'))[0]
-          .nativeElement
-      ).opacity
-    ).toBe('1');
+      headerElements[1]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show')
+    ).toBe(true);
     expect(
       headerElements[1]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.getAttribute('svgIcon')
     ).toBe('arrow_upward_24px');
     expect(
-      window.getComputedStyle(
-        headerElements[2].queryAll(By.css('.sorting-icon-container'))[0]
-          .nativeElement
-      ).opacity
-    ).toBe('0');
+      headerElements[2]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show')
+    ).toBe(false);
     expect(
-      window.getComputedStyle(
-        headerElements[3].queryAll(By.css('.sorting-icon-container'))[0]
-          .nativeElement
-      ).opacity
-    ).toBe('0');
+      headerElements[2]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show-on-hover')
+    ).toBe(true);
+    expect(
+      headerElements[3]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show')
+    ).toBe(false);
+    expect(
+      headerElements[3]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show-on-hover')
+    ).toBe(true);
   });
 
   it('shows downward arrow when order is DESCENDING', () => {
@@ -296,23 +303,30 @@ describe('data table', () => {
     const headerElements = fixture.debugElement.queryAll(By.css('th'));
 
     expect(
-      window.getComputedStyle(
-        headerElements[1].queryAll(By.css('.sorting-icon-container'))[0]
-          .nativeElement
-      ).opacity
-    ).toBe('0');
+      headerElements[1]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show')
+    ).toBe(false);
     expect(
-      window.getComputedStyle(
-        headerElements[2].queryAll(By.css('.sorting-icon-container'))[0]
-          .nativeElement
-      ).opacity
-    ).toBe('0');
+      headerElements[1]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show-on-hover')
+    ).toBe(true);
     expect(
-      window.getComputedStyle(
-        headerElements[3].queryAll(By.css('.sorting-icon-container'))[0]
-          .nativeElement
-      ).opacity
-    ).toBe('1');
+      headerElements[2]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show')
+    ).toBe(false);
+    expect(
+      headerElements[2]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show-on-hover')
+    ).toBe(true);
+    expect(
+      headerElements[3]
+        .queryAll(By.css('.sorting-icon-container'))[0]
+        .nativeElement.classList.contains('show')
+    ).toBe(true);
     expect(
       headerElements[3]
         .queryAll(By.css('mat-icon'))[0]

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -269,6 +269,11 @@ describe('data table', () => {
       ).opacity
     ).toBe('1');
     expect(
+      headerElements[1]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.getAttribute('svgIcon')
+    ).toBe('arrow_upward_24px');
+    expect(
       window.getComputedStyle(
         headerElements[2].queryAll(By.css('.sorting-icon-container'))[0]
           .nativeElement
@@ -280,5 +285,38 @@ describe('data table', () => {
           .nativeElement
       ).opacity
     ).toBe('0');
+  });
+
+  it('shows downward arrow when order is DESCENDING', () => {
+    const fixture = createComponent({
+      headers: [ColumnHeaders.VALUE, ColumnHeaders.RUN, ColumnHeaders.STEP],
+      sortingInfo: {header: ColumnHeaders.STEP, order: SortingOrder.DESCENDING},
+    });
+    fixture.detectChanges();
+    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+
+    expect(
+      window.getComputedStyle(
+        headerElements[1].queryAll(By.css('.sorting-icon-container'))[0]
+          .nativeElement
+      ).opacity
+    ).toBe('0');
+    expect(
+      window.getComputedStyle(
+        headerElements[2].queryAll(By.css('.sorting-icon-container'))[0]
+          .nativeElement
+      ).opacity
+    ).toBe('0');
+    expect(
+      window.getComputedStyle(
+        headerElements[3].queryAll(By.css('.sorting-icon-container'))[0]
+          .nativeElement
+      ).opacity
+    ).toBe('1');
+    expect(
+      headerElements[3]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.getAttribute('svgIcon')
+    ).toBe('arrow_downward_24px');
   });
 });


### PR DESCRIPTION
* Motivation for features / changes
This is a followup to PR #5911 which added the sorting functionality to the data table. This is purely a UI change to help indicate to users that you can click the header to sort and help make the feature look better.

* Screenshots of UI changes
![2022-09-06_15-46-17 (1)](https://user-images.githubusercontent.com/8672809/188753835-4f1ef7d7-51f2-4284-8dd5-64006684b196.gif)
