### PR TITLE
Linked Time: Use TimeSelectionWithAffordance for onLinkedTimeSelectionChanged event

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -21,6 +21,7 @@ import {
 } from '@angular/core';
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
+import {TimeSelectionWithAffordance} from '../../../widgets/card_fob/card_fob_types';
 import {
   HistogramDatum,
   HistogramMode,
@@ -53,7 +54,8 @@ export class HistogramCardComponent {
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
-  @Output() onLinkedTimeSelectionChanged = new EventEmitter<TimeSelection>();
+  @Output() onLinkedTimeSelectionChanged =
+    new EventEmitter<TimeSelectionWithAffordance>();
   @Output() onLinkedTimeToggled = new EventEmitter();
 
   timeProperty(xAxisType: XAxisType) {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -40,6 +40,8 @@ export enum TimeSelectionAffordance {
   SETTINGS_SLIDER = 'settingsSlider',
   // User changes from multi selection to single selection.
   CHANGE_TO_SINGLE = 'changeToSingle',
+  // User clicks on Histogram Chart to change to range selection.
+  HISTOGRAM_CLICK_TO_RANGE = 'histogramClickToRange',
 }
 
 /**

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -29,7 +29,11 @@ import {fromEvent, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import * as d3 from '../../third_party/d3';
 import {HCLColor} from '../../third_party/d3';
-import {TimeSelection} from '../card_fob/card_fob_types';
+import {
+  TimeSelection,
+  TimeSelectionAffordance,
+  TimeSelectionWithAffordance,
+} from '../card_fob/card_fob_types';
 import {formatTickNumber} from './formatter';
 import {
   Bin,
@@ -100,7 +104,8 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   @Input() timeSelection: TimeSelection | null = null;
 
-  @Output() onLinkedTimeSelectionChanged = new EventEmitter<TimeSelection>();
+  @Output() onLinkedTimeSelectionChanged =
+    new EventEmitter<TimeSelectionWithAffordance>();
   @Output() onLinkedTimeToggled = new EventEmitter();
 
   readonly HistogramMode = HistogramMode;
@@ -328,8 +333,11 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
       nextStartStep !== nextEndStep
     ) {
       this.onLinkedTimeSelectionChanged.emit({
-        start: {step: nextStartStep},
-        end: {step: nextEndStep},
+        timeSelection: {
+          start: {step: nextStartStep},
+          end: {step: nextEndStep},
+        },
+        affordance: TimeSelectionAffordance.HISTOGRAM_CLICK_TO_RANGE,
       });
     }
   }

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -1128,8 +1128,11 @@ describe('histogram test', () => {
         histograms[3].triggerEventHandler('click', null);
         fixture.detectChanges();
         expect(onLinkedTimeSelectionChangedSpy).toHaveBeenCalledWith({
-          start: {step: 5},
-          end: {step: 20},
+          timeSelection: {
+            start: {step: 5},
+            end: {step: 20},
+          },
+          affordance: TimeSelectionAffordance.HISTOGRAM_CLICK_TO_RANGE,
         });
       });
 
@@ -1144,8 +1147,11 @@ describe('histogram test', () => {
         histograms[0].triggerEventHandler('click', null);
         fixture.detectChanges();
         expect(onLinkedTimeSelectionChangedSpy).toHaveBeenCalledWith({
-          start: {step: 0},
-          end: {step: 5},
+          timeSelection: {
+            start: {step: 0},
+            end: {step: 5},
+          },
+          affordance: TimeSelectionAffordance.HISTOGRAM_CLICK_TO_RANGE,
         });
       });
 
@@ -1163,8 +1169,11 @@ describe('histogram test', () => {
         histograms[0].triggerEventHandler('click', null);
         fixture.detectChanges();
         expect(onLinkedTimeSelectionChangedSpy).toHaveBeenCalledWith({
-          start: {step: 0},
-          end: {step: 10},
+          timeSelection: {
+            start: {step: 0},
+            end: {step: 10},
+          },
+          affordance: TimeSelectionAffordance.HISTOGRAM_CLICK_TO_RANGE,
         });
       });
 
@@ -1182,8 +1191,11 @@ describe('histogram test', () => {
         histograms[3].triggerEventHandler('click', null);
         fixture.detectChanges();
         expect(onLinkedTimeSelectionChangedSpy).toHaveBeenCalledWith({
-          start: {step: 5},
-          end: {step: 20},
+          timeSelection: {
+            start: {step: 5},
+            end: {step: 20},
+          },
+          affordance: TimeSelectionAffordance.HISTOGRAM_CLICK_TO_RANGE,
         });
       });
 


### PR DESCRIPTION
* Motivation for features / changes
Recent changes broke a feature in Histogram Cards which allowed users to enable range selection by clicking on the chart. This fixes that breakage.

* Technical description of changes
The onLinkedTimeSelectionChanged event was still emitting a simple TimeSelection object. However, the function being called on that event was expecting a TimeSelectionWithAffordance object.  This changes the object to emit a TimeSelectionWithAffordance and created a new type of affordance to use in this event.