### PR TITLE
Linked Time: Disable Step Selection when dismissing single fob

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -32,7 +32,7 @@ import {
 } from '../../../widgets/card_fob/card_fob_types';
 import {HistogramDatum} from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
-import {linkedTimeToggled, timeSelectionChanged} from '../../actions';
+import {stepSelectorToggled, timeSelectionChanged} from '../../actions';
 import {HistogramStepDatum, PluginType} from '../../data_source';
 import {
   getCardLoadState,
@@ -237,7 +237,7 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
 
   onLinkedTimeToggled() {
     this.store.dispatch(
-      linkedTimeToggled({
+      stepSelectorToggled({
         affordance: TimeSelectionToggleAffordance.FOB_DESELECT,
       })
     );

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -38,7 +38,7 @@ import {
 } from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
-import {linkedTimeToggled, timeSelectionChanged} from '../../actions';
+import {stepSelectorToggled, timeSelectionChanged} from '../../actions';
 import {PluginType} from '../../data_source';
 import * as selectors from '../../store/metrics_selectors';
 import {
@@ -539,7 +539,7 @@ describe('histogram card', () => {
         expect(indicator).toBeFalsy();
       });
 
-      it('dispatches linkedTimeToggled when HistogramComponent emits the onLinkedTimeToggled event', () => {
+      it('dispatches stepSelectorToggled when HistogramComponent emits the onLinkedTimeToggled event', () => {
         provideMockCardSeriesData(selectSpy, PluginType.HISTOGRAMS, 'card1');
         store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
           start: {step: 5},
@@ -558,7 +558,7 @@ describe('histogram card', () => {
         histogramWidget.onLinkedTimeToggled.emit();
 
         expect(dispatchedActions).toEqual([
-          linkedTimeToggled({
+          stepSelectorToggled({
             affordance: TimeSelectionToggleAffordance.FOB_DESELECT,
           }),
         ]);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -97,8 +97,6 @@ export class ScalarCardComponent<Downloader> {
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
-  @Output() onLinkedTimeToggled =
-    new EventEmitter<TimeSelectionToggleAffordance>();
   @Output() onTimeSelectionChanged = new EventEmitter<{
     timeSelection: TimeSelection;
     affordance?: TimeSelectionAffordance;
@@ -256,13 +254,7 @@ export class ScalarCardComponent<Downloader> {
   }
 
   onFobRemoved() {
-    if (this.linkedTimeSelection !== null) {
-      this.onLinkedTimeToggled.emit(TimeSelectionToggleAffordance.FOB_DESELECT);
-    } else {
-      this.onStepSelectorToggled.emit(
-        TimeSelectionToggleAffordance.FOB_DESELECT
-      );
-    }
+    this.onStepSelectorToggled.emit(TimeSelectionToggleAffordance.FOB_DESELECT);
   }
 
   inTimeSelectionMode(): boolean {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -58,11 +58,7 @@ import {
 } from '../../../widgets/card_fob/card_fob_types';
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
-import {
-  linkedTimeToggled,
-  stepSelectorToggled,
-  timeSelectionChanged,
-} from '../../actions';
+import {stepSelectorToggled, timeSelectionChanged} from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
   getCardLoadState,
@@ -151,7 +147,6 @@ function areSeriesEqual(
       observeIntersection
       (onVisibilityChange)="onVisibilityChange($event)"
       (onTimeSelectionChanged)="onTimeSelectionChanged($event)"
-      (onLinkedTimeToggled)="onLinkedTimeToggled($event)"
       (onStepSelectorToggled)="onStepSelectorToggled($event)"
     ></scalar-card-component>
   `,
@@ -599,10 +594,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     newTimeSelectionWithAffordance: TimeSelectionWithAffordance
   ) {
     this.store.dispatch(timeSelectionChanged(newTimeSelectionWithAffordance));
-  }
-
-  onLinkedTimeToggled(affordance: TimeSelectionToggleAffordance) {
-    this.store.dispatch(linkedTimeToggled({affordance}));
   }
 
   onStepSelectorToggled(affordance: TimeSelectionToggleAffordance) {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -73,11 +73,7 @@ import {
 } from '../../../widgets/line_chart_v2/types';
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
-import {
-  linkedTimeToggled,
-  stepSelectorToggled,
-  timeSelectionChanged,
-} from '../../actions';
+import {stepSelectorToggled, timeSelectionChanged} from '../../actions';
 import {PluginType} from '../../data_source';
 import {
   getMetricsLinkedTimeEnabled,
@@ -2293,7 +2289,7 @@ describe('scalar card', () => {
         ]);
       }));
 
-      it('toggles linked time when single fob is deselected', fakeAsync(() => {
+      it('toggles step selection when single fob is deselected', fakeAsync(() => {
         store.overrideSelector(getMetricsLinkedTimeSelection, {
           start: {step: 20},
           end: null,
@@ -2306,7 +2302,7 @@ describe('scalar card', () => {
         fobComponent.fobRemoved.emit();
 
         expect(dispatchedActions).toEqual([
-          linkedTimeToggled({
+          stepSelectorToggled({
             affordance: TimeSelectionToggleAffordance.FOB_DESELECT,
           }),
         ]);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2289,7 +2289,7 @@ describe('scalar card', () => {
         ]);
       }));
 
-      it('toggles step selection when single fob is deselected', fakeAsync(() => {
+      it('toggles step selection when single fob is deselected even when linked time is enabled', fakeAsync(() => {
         store.overrideSelector(getMetricsLinkedTimeSelection, {
           start: {step: 20},
           end: null,


### PR DESCRIPTION
* Motivation for features / changes
When the fobs are dismissed you expect the fob to disappear. However, when "Link by step" is enabled it only goes into "step selection" mode which still has the fob in Scalar Cards. This change make the dismissal disable step selection so that the fob always disappears. For consistency this also disables step selection when dismissing For on Histogram Card.

* Screenshots of UI changes
Before this change
![2022-09-07_16-03-05 (1)](https://user-images.githubusercontent.com/8672809/188998272-2b92dc43-0d5d-4665-a9e0-d188c0073fe6.gif)

After this change
![2022-09-07_16-02-12 (1)](https://user-images.githubusercontent.com/8672809/188998377-428cbc7b-08be-4a82-b7e3-29c28347425a.gif)
