### PR TITLE
Linked Time: Round to next step in fob controller

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -84,12 +84,12 @@ export class ScalarCardFobController {
 
   getHighestStep(): number {
     const minMax = this.minMax;
-    return minMax[0] < minMax[1] ? minMax[1] : minMax[0];
+    return Math.floor(minMax[0] < minMax[1] ? minMax[1] : minMax[0]);
   }
 
   getLowestStep(): number {
     const minMax = this.minMax;
-    return minMax[0] < minMax[1] ? minMax[0] : minMax[1];
+    return Math.ceil(minMax[0] < minMax[1] ? minMax[0] : minMax[1]);
   }
 
   getStepHigherThanAxisPosition(position: number): number {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_test.ts
@@ -105,6 +105,14 @@ describe('ScalarFobController', () => {
 
       expect(highestStep).toBe(2);
     });
+
+    it('returns the next lowest step when max is a floating point.', () => {
+      const fixture = createComponent({minMax: [4.5, 1]});
+
+      const lowestStep = fixture.componentInstance.getHighestStep();
+
+      expect(lowestStep).toBe(4);
+    });
   });
 
   describe('getLowestStep', () => {
@@ -122,6 +130,14 @@ describe('ScalarFobController', () => {
       const lowestStep = fixture.componentInstance.getLowestStep();
 
       expect(lowestStep).toBe(0);
+    });
+
+    it('returns the next highest step when min is a floating point.', () => {
+      const fixture = createComponent({minMax: [4, 1.5]});
+
+      const lowestStep = fixture.componentInstance.getLowestStep();
+
+      expect(lowestStep).toBe(2);
     });
   });
 


### PR DESCRIPTION
* Motivation for features / changes
When zooming on the scalar card the min and max values become floating points. Then when you drag the fob passed these values it sets those fobs to floating point steps. Since steps are discrete this is unwanted behavior. This change ensure that we show the min or max step instead of the value(often floating point) at the edge of the chart.

* Screenshots of UI changes

Before
![2022-09-07_16-28-44 (1)](https://user-images.githubusercontent.com/8672809/189000486-29d73592-4e3a-4fdc-8159-44f6db9099a2.gif)

After
![2022-09-07_16-13-27 (1)](https://user-images.githubusercontent.com/8672809/189000517-3d8af73d-e7fb-43df-8383-04d8ae43a271.gif)


