### PR TITLE
Linked Time: Add Range Checkbox behind new flag

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -113,7 +113,7 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
     },
     allowRangeSelection: {
       defaultValue: false,
-      queryParamOverride: 'allowRange',
+      queryParamOverride: 'allowRangeSelection',
       parseValue: parseBoolean,
     },
   };

--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -111,6 +111,11 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       queryParamOverride: 'showFlags',
       parseValue: parseBoolean,
     },
+    allowRangeSelection: {
+      defaultValue: false,
+      queryParamOverride: 'allowRange',
+      parseValue: parseBoolean,
+    },
   };
 
 /**

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -156,3 +156,10 @@ export const getShowFlagsEnabled = createSelector(
     return flags.enableShowFlags;
   }
 );
+
+export const getAllowRangeSelection = createSelector(
+  getFeatureFlags,
+  (flags: FeatureFlags): boolean => {
+    return flags.allowRangeSelection;
+  }
+);

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -46,4 +46,6 @@ export interface FeatureFlags {
   enabledScalarDataTable: boolean;
   // If enabled causes the feature flags modal to appear.
   enableShowFlags: boolean;
+  // Adds check box in settings which allows users to enter step selection range.
+  allowRangeSelection: boolean;
 }

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -97,6 +97,7 @@ describe('metrics right_pane', () => {
       store.overrideSelector(selectors.getMetricsCardMinWidth, null);
       store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, false);
       store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
+      store.overrideSelector(selectors.getAllowRangeSelection, false);
       store.overrideSelector(selectors.getMetricsLinkedTimeSelectionSetting, {
         start: {step: 0},
         end: {step: 1000},
@@ -649,6 +650,21 @@ describe('metrics right_pane', () => {
             affordance: TimeSelectionToggleAffordance.CHECK_BOX,
           })
         );
+      });
+
+      describe('range selection', () => {
+        beforeEach(() => {
+          store.overrideSelector(selectors.getAllowRangeSelection, true);
+        });
+
+        it('renders the Range Selection checkbox', () => {
+          const fixture = TestBed.createComponent(SettingsViewContainer);
+          fixture.detectChanges();
+
+          expect(
+            fixture.debugElement.query(By.css('.range-selection mat-checkbox'))
+          ).toBeTruthy();
+        });
       });
     });
   });

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -39,6 +39,11 @@ limitations under the License.
       >Enable step selection and data table
     </mat-checkbox>
     <span class="indent">(Scalars only)</span>
+    <div class="indent range-selection" *ngIf="isRangeSelectionAllowed">
+      <mat-checkbox [disabled]="!isAxisTypeStep()"
+        >Enable Range Selection
+      </mat-checkbox>
+    </div>
     <div
       class="control-row linked-time indent"
       *ngIf="isLinkedTimeFeatureEnabled"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -66,6 +66,7 @@ export class SettingsViewComponent {
   constructor(@Inject(LOCALE_ID) private readonly locale: string) {}
 
   @Input() isLinkedTimeFeatureEnabled!: boolean;
+  @Input() isRangeSelectionAllowed!: boolean;
   @Input() isLinkedTimeEnabled!: boolean;
   @Input() isScalarStepSelectorFeatureEnabled!: boolean;
   @Input() isScalarStepSelectorEnabled!: boolean;

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -82,6 +82,7 @@ const RANGE_INPUT_SOURCE_TO_AFFORDANCE: Record<
       [imageShowActualSize]="imageShowActualSize$ | async"
       (imageShowActualSizeChanged)="onImageShowActualSizeChanged()"
       [isLinkedTimeFeatureEnabled]="isLinkedTimeFeatureEnabled$ | async"
+      [isRangeSelectionAllowed]="isRangeSelectionAllowed$ | async"
       [isScalarStepSelectorFeatureEnabled]="
         isScalarStepSelectorFeatureEnabled$ | async
       "
@@ -102,6 +103,9 @@ export class SettingsViewContainer {
 
   readonly isLinkedTimeFeatureEnabled$: Observable<boolean> = this.store.select(
     selectors.getIsLinkedTimeEnabled
+  );
+  readonly isRangeSelectionAllowed$: Observable<boolean> = this.store.select(
+    selectors.getAllowRangeSelection
   );
   readonly isScalarStepSelectorFeatureEnabled$: Observable<boolean> =
     this.store.select(selectors.getIsDataTableEnabled);


### PR DESCRIPTION
* Motivation for features / changes
We plan to launch a new feature which allows users to enable a range instead of a single for scalar cards. This is the first PR towards that goal.

* Technical description of changes
This PR adds a feature flag and then uses that flag to enable or disable a checkbox in the settings panel. The checkbox currently has no functionality. That will come in later PRs.

* Screenshots of UI changes
<img width="255" alt="Screen Shot 2022-09-08 at 5 09 07 PM" src="https://user-images.githubusercontent.com/8672809/189246772-5b946813-6f9b-4664-8513-239d82cadc60.png">
