### PR TITLE
Scalar Card Fob: Update time selection when zoom changes

### DIFF
--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -84,6 +84,8 @@ describe('card_fob_controller', () => {
     timeSelection: TimeSelection;
     showExtendedLine?: Boolean;
     steps?: number[];
+    lowestStep?: number;
+    highestStep?: number;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
 
@@ -118,8 +120,8 @@ describe('card_fob_controller', () => {
       getAxisPositionFromStartStepSpy;
     fixture.componentInstance.getAxisPositionFromEndStep =
       getAxisPositionFromEndStepSpy;
-    fixture.componentInstance.highestStep = 4;
-    fixture.componentInstance.lowestStep = 0;
+    fixture.componentInstance.highestStep = input.highestStep ?? 4;
+    fixture.componentInstance.lowestStep = input.lowestStep ?? 0;
     fixture.componentInstance.cardFobHelper = cardFobHelper;
 
     fixture.componentInstance.axisDirection =
@@ -152,6 +154,26 @@ describe('card_fob_controller', () => {
     expect(
       fobController.endFobWrapper.nativeElement.getBoundingClientRect().left
     ).toEqual(5);
+  });
+
+  it('updates time selection when lowest or hightest step changes', () => {
+    const fixture = createComponent({
+      timeSelection: {start: {step: 1}, end: null},
+      lowestStep: 0,
+      highestStep: 4,
+    });
+    fixture.detectChanges();
+
+    fixture.componentInstance.lowestStep = 2;
+
+    fixture.detectChanges();
+    expect(onTimeSelectionChanged).toHaveBeenCalledWith({
+      timeSelection: {
+        start: {step: 2},
+        end: null,
+      },
+      affordance: TimeSelectionAffordance.SCALAR_CARD_ZOOM,
+    });
   });
 
   describe('dragging', () => {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -42,6 +42,8 @@ export enum TimeSelectionAffordance {
   CHANGE_TO_SINGLE = 'changeToSingle',
   // User clicks on Histogram Chart to change to range selection.
   HISTOGRAM_CLICK_TO_RANGE = 'histogramClickToRange',
+  // User has changed the zoom on the scalar card.
+  SCALAR_CARD_ZOOM = 'scalarCardZoom',
 }
 
 /**

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -90,6 +90,7 @@ limitations under the License.
     ></line-chart-axis>
   </div>
   <div class="dot" *ngIf="!lineOnly"><span class="rect"></span></div>
+  {{isViewBoxInitialized()}}
   <div
     *ngIf="customChartOverlayTemplate && isViewBoxInitialized()"
     class="custom-vis custom-chart-overlay-vis"

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -91,7 +91,7 @@ limitations under the License.
   </div>
   <div class="dot" *ngIf="!lineOnly"><span class="rect"></span></div>
   <div
-    *ngIf="customChartOverlayTemplate"
+    *ngIf="customChartOverlayTemplate && isViewBoxInitialized()"
     class="custom-vis custom-chart-overlay-vis"
     #customChartOverlay
   >

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -51,7 +51,12 @@ import {TooltipTemplate} from './sub_view/line_chart_interactive_view';
 
 export {TooltipTemplate} from './sub_view/line_chart_interactive_view';
 
-const DEFAULT_EXTENT: Extent = {x: [0, 0], y: [0, 0]};
+// The default extent should be functionally invalid for easy detection.
+// If you need to unfreeze this object update isViewBoxInitialized.
+const DEFAULT_EXTENT: Readonly<Extent> = Object.freeze({
+  x: [0, 0],
+  y: [0, 0],
+} as Extent);
 
 interface DomDimensions {
   main: {width: number; height: number};
@@ -240,8 +245,7 @@ export class LineChartComponent
   }
 
   isViewBoxInitialized() {
-    // DO_NOT_SUBMIT add a really good test for this.
-    // Comparing by reference is fine here.
+    // Comparing by reference is fine here because DEFAULT_EXTENT is frozen.
     return this.viewBox !== DEFAULT_EXTENT;
   }
 
@@ -516,3 +520,7 @@ export class LineChartComponent
     this.onViewBoxChanged({dataExtent: nextDataExtent});
   }
 }
+
+export const TEST_ONLY = {
+  DEFAULT_EXTENT,
+};

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -51,7 +51,7 @@ import {TooltipTemplate} from './sub_view/line_chart_interactive_view';
 
 export {TooltipTemplate} from './sub_view/line_chart_interactive_view';
 
-const DEFAULT_EXTENT: Extent = {x: [0, 1], y: [0, 1]};
+const DEFAULT_EXTENT: Extent = {x: [0, 0], y: [0, 0]};
 
 interface DomDimensions {
   main: {width: number; height: number};
@@ -237,6 +237,12 @@ export class LineChartComponent
     // After view is initialized, if we ever change the Angular prop that should propagate
     // to children, we need to retrigger the Angular change.
     this.changeDetector.detectChanges();
+  }
+
+  isViewBoxInitialized() {
+    // DO_NOT_SUBMIT add a really good test for this.
+    // Comparing by reference is fine here.
+    return this.viewBox !== DEFAULT_EXTENT;
   }
 
   /**


### PR DESCRIPTION
## Motivation for features / changes
After zooming on the scalar card with step selection enabled the fob(s) are not guaranteed to be visible. This is because their position is dependent on the derived `timeSelection` property of the `card_fob_controller_component`.

## Technical description of changes
I changed the `card_fob_controller_component` to modify its' `timeSelection` property (and thus fob positions) whenever a change to its `lowestStep` or `highestStep` is detected.

This was more complicated than expected as the component is rendered as a child of the `line_chart_component` which will always render the component at least twice due to the way it derives its `viewBox` property.

To get around duplicate logging I updated the `line_chart` to use a more identifiable default value for its `viewBox` property. This enabled me to detect whether the viewBox is in its default state and only render the child component once the chart is fully initialized.

## Screenshots of UI changes
### One Fob
![e074ea87-29e1-49e8-a313-cfb4470199f5](https://user-images.githubusercontent.com/78179109/189445628-0dcd1420-1834-405e-914d-2214ae99e111.gif)

### Two Fobs
![a9c28d5b-e311-450e-8fa7-b680feb8b370](https://user-images.githubusercontent.com/78179109/189445948-a4d1f7ce-ef90-4c0f-bfca-8352dd1d1394.gif)

### Zooming With No Effect
![89664387-969d-4615-88b8-09a2c554f643](https://user-images.githubusercontent.com/78179109/189446056-57365e46-344e-486f-b97a-cffe413c9821.gif)


## Detailed steps to verify changes work correctly (as executed by you)
1) Start TensorBoard.
2) Navigate to `localhost:6006?enableLinkedTime&enableDataTable#timeseries`.
3) Enable linked time in the side bar.
4) Zoom into the chart in a way the fob(s) are still within the range.
5) Assert the timeSelection is unchanged.
6) Zoom the chart to a section where the fob is outside the range.
7) Assert the fob is moved within the range.
8) Enable linked time in the side bar.
9) Repeat the steps 6-7 ensuring both fobs respond accordingly.

Going deeper and using developer console
1) Start TensorBoard.
2) Navigate to `localhost:6006?enableLinkedTime&enableDataTable#timeseries`.
3) Enable linked time in the side bar.
4) Open the developer console and clear the logs.
5) Collapse and then expand a section with a scalar card
6) Assert that no `Time Selection Changed` events were logged.

## Alternate designs / implementations considered
### 1) Update the line chart to use props directly rather than deriving the `viewBox` component.
I attempted to do this but quickly realized that it would be a significant refactor that is beyond the scope of this task. It might be worth looking into in the future as it would make the component more consistent with the rest of the code base and likely bring a decent performance boost.

### 2) Update the `card_fob_controller` to stop deriving its `timeSelected` property
This seems like a pretty strange thing to do as it he property originally received as an `Input` and the parent is not necessarily notified of changes.
This also turns out to be a pretty significant refactor as the `card_fob_controller` has a bunch of mouse tracking logic that relies on the object.

### 3) Update the `scalar_card_fob_controller` instead of the `card_fob_controller`
Despite the `timeSelection` originating in the `scalar_card_fob_controller` it is actually modified by the `card_fob_controller` (see option 2).

### 4) Change the line chart to use redux
I did a bunch of the work trying to get this to work but eventually came to the conclusion that the nonstandard way the components here are written makes this quite difficult. If the line chart were to be refactored to be more inline with the rest of the codebase this would become more viable.