### PR TITLE
Support protobuf 3.20

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -24,11 +24,11 @@ google-auth >= 1.6.3, < 3
 google-auth-oauthlib >= 0.4.1, < 0.5
 markdown >= 2.6.8
 numpy >= 1.12.0
-# Protobuf 4.0 is incompatible with TF. Force < 3.20 until they unblock upgrade.
+# Protobuf 4.0 is incompatible with TF. Force < 4 until they unblock upgrade.
 # See: http://b/182876485
 # See: https://github.com/protocolbuffers/protobuf/issues/9954#issuecomment-1128283911
 # See: https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/tools/pip_package/setup.py?q=protobuf
-protobuf >= 3.9.2, < 3.20
+protobuf >= 3.9.2, < 4
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
 tensorboard-data-server >= 0.6.0, < 0.7.0


### PR DESCRIPTION
* Motivation for features / changes

The conda-forge feedstock for tensorboard is attempting to move forward with protobuf support: https://github.com/conda-forge/tensorboard-feedstock/pull/64
@ngam @h-vetinari @hmaarrfk

* Technical description of changes

This PR bumps the upper bound on the protobuf dependency to `< 4`. According to https://github.com/protocolbuffers/protobuf/issues/10051, the only backwards incompatible change that was introduced was between 3.X and 4.X, not between 3.19 and 3.20, hence the change in major version number.

* Screenshots of UI changes

N/A

* Detailed steps to verify changes work correctly (as executed by you)

The conda-forge feedstock for tensorboard now uses protobuf 3.20 without issue, as far as I can tell.

* Alternate designs / implementations considered

In the long run, we'll eventually need to support protobuf 4.X, but that's a bigger change that is being tracked in #5708.
@nfelt