### PR TITLE
Bug Fix: Update Histogram YAxis Values to match those shown in the chart

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -469,17 +469,28 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
     }
   }
 
+  private getMaxTicks() {
+    const {height} = this.layout.contentClientRect;
+    const maxPerHeight = height / 15;
+
+    if (this.timeProperty === TimeProperty.STEP) {
+      return Math.min(this.data.length, maxPerHeight);
+    }
+
+    return maxPerHeight;
+  }
+
   private renderYAxis() {
     if (!this.scales) return;
     const yScale =
       this.mode === HistogramMode.OVERLAY
         ? this.scales.countScale
         : this.scales.temporalScale;
-    const {height} = this.layout.contentClientRect;
-    const yAxis = d3.axisRight(yScale).ticks(Math.max(2, height / 15));
-    // d3 on DefinitelyTyped is typed incorrectly and it does not allow function
-    // that takes (d: Data) => string to be specified in the parameter unlike
-    // the real d3.
+    const maxTicks = this.getMaxTicks();
+    const yAxis = d3.axisRight(yScale).ticks(Math.max(2, maxTicks));
+    // d3 on DefinitelyTyped is typed incorrectly and it does not allow
+    // function that takes (d: Data) => string to be specified in the
+    // parameter unlike the real d3.
     const anyYAxis = yAxis as any;
     anyYAxis.tickFormat(this.getYAxisFormatter());
     yAxis(d3.select(this.yAxis.nativeElement));

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -469,12 +469,13 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
     }
   }
 
-  private getMaxTicks() {
+  private getMaxTicks(yScale: Scales[keyof Scales]) {
     const {height} = this.layout.contentClientRect;
     const maxPerHeight = height / 15;
-
     if (this.timeProperty === TimeProperty.STEP) {
-      return Math.min(this.data.length, maxPerHeight);
+      const [min, max] = yScale.domain() as [number, number];
+      const numberOfSteps = Math.max(max - min + 1, 1);
+      return Math.min(numberOfSteps, maxPerHeight);
     }
 
     return maxPerHeight;
@@ -486,7 +487,7 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
       this.mode === HistogramMode.OVERLAY
         ? this.scales.countScale
         : this.scales.temporalScale;
-    const maxTicks = this.getMaxTicks();
+    const maxTicks = this.getMaxTicks(yScale);
     const yAxis = d3.axisRight(yScale).ticks(Math.max(2, maxTicks));
     // d3 on DefinitelyTyped is typed incorrectly and it does not allow
     // function that takes (d: Data) => string to be specified in the

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -301,6 +301,43 @@ describe('histogram test', () => {
         ).toEqual(['0', '20', '40', '60', '80', '100']);
       });
 
+      it('cannot have fractional steps in STEP mode', () => {
+        const fixture = createComponent('foo', [
+          buildHistogramDatum({
+            step: 0,
+          }),
+          buildHistogramDatum({
+            step: 1,
+          }),
+          buildHistogramDatum({
+            step: 2,
+          }),
+          buildHistogramDatum({
+            step: 3,
+          }),
+          buildHistogramDatum({
+            step: 4,
+          }),
+          buildHistogramDatum({
+            step: 5,
+          }),
+          buildHistogramDatum({
+            step: 6,
+          }),
+          buildHistogramDatum({
+            step: 7,
+          }),
+        ]);
+        fixture.componentInstance.mode = HistogramMode.OFFSET;
+        fixture.componentInstance.timeProperty = TimeProperty.STEP;
+        fixture.detectChanges();
+        intersectionObserver.simulateVisibilityChange(fixture, true);
+
+        expect(
+          getAxisLabelText(fixture.debugElement.query(byCss.Y_AXIS))
+        ).toEqual(['0', '2', '4', '6']);
+      });
+
       it('renders wallTime in WALL_TIME mode', () => {
         const fixture = createComponent('foo', [
           buildHistogramDatum({


### PR DESCRIPTION
* Motivation for features / changes
There is a bug where the lines on the histogram chart do not align with the ticks in the YAxis. This because of some fault logic around the maximum number ticks to be shown there. The issue will occur when the number of lines (steps) is fewer than the height of the chart / 15 (a seemingly arbitrary value).

* Technical description of changes
I updated the logic surrounding the number of ticks to be shown so that the number of ticks <= number steps.

* Screenshots of UI changes
Before
![image](https://user-images.githubusercontent.com/78179109/190025105-d737faa7-e2a2-46bf-8121-87628ec905bc.png)
![image](https://user-images.githubusercontent.com/78179109/190025132-5359a01b-3426-4b40-89a6-4cffabca8515.png)

After
![image](https://user-images.githubusercontent.com/78179109/190024929-1d7f8c35-051f-470f-8dc1-49f1bd8b1b75.png)
![image](https://user-images.githubusercontent.com/78179109/190024958-cbc24cc3-4a0a-44db-835c-491453c6b88a.png)


* Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard with a log directory containing histogram data. Below is some python code. which should generate valid logs.
2) Navigate to [localhost:6006?enableDataTable&enableLinkedTime](http://localhost:6006?enableDataTable&enableLinkedTime)
3) Note that the histogram chart has the same number of YAxis ticks as lines on the chart.
4) Enable linked time and set a value for the upper value to enable range selection.
![Screen Shot 2022-09-13 at 4 36 40 PM](https://user-images.githubusercontent.com/78179109/190027886-7c1a23ab-adfa-4f4b-9135-030146883987.png)
5) Note that the upper fob is placed correctly on the chart.


```
# https://www.tensorflow.org/tensorboard/get_started
import tensorflow as tf
import datetime
mnist = tf.keras.datasets.mnist

(x_train, y_train),(x_test, y_test) = mnist.load_data()
x_train, x_test = x_train / 255.0, x_test / 255.0

def create_model():
  return tf.keras.models.Sequential([
    tf.keras.layers.Flatten(input_shape=(28, 28)),
    tf.keras.layers.Dense(512, activation='relu'),
    tf.keras.layers.Dropout(0.2),
    tf.keras.layers.Dense(10, activation='softmax')
  ])

model = create_model()
model.compile(optimizer='adam',
              loss='sparse_categorical_crossentropy',
              metrics=['accuracy'])

log_dir = "logs/fit/" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=log_dir, histogram_freq=1)

model.fit(x=x_train, 
          y=y_train, 
          epochs=5, 
          validation_data=(x_test, y_test), 
          callbacks=[tensorboard_callback])

```

* Alternate designs / implementations considered
