### PR TITLE
Use all theme configuration keys

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -45,6 +45,8 @@ $tb-theme: mat.define-light-theme(
       accent: $tb-accent,
       warn: $tb-warn,
     ),
+    typography: null,
+    density: 0,
   )
 );
 
@@ -99,6 +101,8 @@ $tb-dark-theme: mat.define-dark-theme(
       accent: $tb-dark-accent,
       warn: $tb-dark-warn,
     ),
+    typography: null,
+    density: 0,
   )
 );
 $tb-dark-foreground: map_merge(


### PR DESCRIPTION
Theme configurations used internal to Google will soon be required to define all three keys of the theme config: "color", "typography", and "density".

Setting `typography: null` and `density: 0` is a no-op that has no affect