### PR TITLE
Fix usage of deprecated jsoup constructors.

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -97,7 +97,7 @@ public final class Vulcanize {
     if (firstScript != null) {
       firstScript.before(
           new Element(Tag.valueOf("script"), firstScript.baseUri())
-              .appendChild(new DataNode("var CLOSURE_NO_DEPS = true;", firstScript.baseUri())));
+              .appendChild(new DataNode("var CLOSURE_NO_DEPS = true;")));
     }
     if (licenseComment != null) {
       licenseComment.attr("comment", String.format("\n%s\n", Joiner.on("\n\n").join(licenses)));
@@ -238,7 +238,7 @@ public final class Vulcanize {
         new Element(Tag.valueOf("style"), node.baseUri(), node.attributes())
             .appendChild(
                 new DataNode(
-                    new String(Files.readAllBytes(getWebfile(href)), UTF_8), node.baseUri()))
+                    new String(Files.readAllBytes(getWebfile(href)), UTF_8)))
             .removeAttr("rel")
             .removeAttr("href"));
   }
@@ -255,7 +255,7 @@ public final class Vulcanize {
       result = replaceNode(
           node,
           new Element(Tag.valueOf("script"), node.baseUri(), node.attributes())
-              .appendChild(new DataNode(code, node.baseUri()))
+              .appendChild(new DataNode(code))
               .removeAttr("src"));
     }
     if (firstScript == null) {
@@ -270,7 +270,7 @@ public final class Vulcanize {
   }
 
   private static Node removeNode(Node node) {
-    return replaceNode(node, new TextNode("", node.baseUri()));
+    return replaceNode(node, new TextNode(""));
   }
 
   private static Path getWebfile(Webpath path) {
@@ -450,7 +450,7 @@ public final class Vulcanize {
   private static Document getFlattenedHTML5Document(Document document) {
     Document flatDoc = new Document("/");
 
-    flatDoc.appendChild(new DocumentType("html", "", "", ""));
+    flatDoc.appendChild(new DocumentType("html", "", ""));
 
     // Transfer comment nodes from the `document` level. They are important
     // license comments


### PR DESCRIPTION
Googlers, see cl/474322268 for an internal request to stop using some deprecated constructors within the jsoup library. In all cases here we are unnecessarily passing some baseUri value to a tree node constructor.

They are all unused according to the documentation for older versions of jsoup: 
https://javadoc.io/doc/org.jsoup/jsoup/1.12.1/org/jsoup/nodes/DocumentType.html
https://javadoc.io/doc/org.jsoup/jsoup/1.12.1/org/jsoup/nodes/DataNode.html
https://javadoc.io/doc/org.jsoup/jsoup/1.12.1/org/jsoup/nodes/TreeNode.html

And the constructors are entirely removed in more recent versions of jsoup: For example: 
https://javadoc.io/doc/org.jsoup/jsoup/latest/org/jsoup/nodes/DataNode.html

I did some basic sanity: 
* Ensure generated tensorboard/webapp/index.html and index.js are unimpacted by the changes.
* Run TensorBoard and make sure it loads. Play with Time Series and Scalars plugins to ensure both Angular and Polymer are working.
