### PR TITLE
feature flags: Refresh page after feature flag modal closed.

### DIFF
--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container.ts
@@ -16,7 +16,7 @@ import {Component, OnInit} from '@angular/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {Store} from '@ngrx/store';
 import {State} from '../../app_state';
-import {featureFlagOverrideChanged} from '../actions/feature_flag_actions';
+import {featureFlagOverridesReset} from '../actions/feature_flag_actions';
 import {getShowFlagsEnabled} from '../store/feature_flag_selectors';
 import {FeatureFlagPageContainer} from './feature_flag_page_container';
 
@@ -39,13 +39,20 @@ export class FeatureFlagModalTriggerContainer implements OnInit {
       if (showFeatureFlags) {
         this.featureFlagsDialog = this.dialog.open(FeatureFlagPageContainer);
         this.featureFlagsDialog.afterClosed().subscribe(() => {
-          // Disable the flag when the dialog is closed to prevent it from
-          // appearing again after the page is refreshed.
+          // Reset the 'showFlags' flag when the dialog is closed to prevent the
+          // dialog from appearing again after the page is refreshed.
           this.store.dispatch(
-            featureFlagOverrideChanged({
-              flags: {enableShowFlags: false},
+            featureFlagOverridesReset({
+              flags: ['enableShowFlags'],
             })
           );
+          // Reload the page so that the application restarts with stable
+          // feature flag values.
+          // Wait one tick before reloading the page so the 'enableShowFlags'
+          // reset has a chance to be reflected in the URL before page reload.
+          setTimeout(() => {
+            window.location.reload();
+          }, 1);
         });
         return;
       }


### PR DESCRIPTION
When the feature flag modal is closed, the application is possibly in a state where it was loaded with one set of feature flags but now the feature flags have possibly changed.  This is undefined and unpredictable - functionality that is gated by feature flags generally haven't needed to consider this possibility and we really don't want to have to think about this possibility in the future.

The simple solution is to refresh the page as soon as the modal is closed. This means the application is reloaded with a stable set of feature flags.

I also change the logic that attempts to remove 'showFlags' from the URL after the modal is closed. Use featureFlagOverrideReset instead of featuerFlagOverridesChanged. The practical result for the user is effectively the same but it keeps their local storage clean of 'showFlags' setting so is a little more hygienic.

