### PR TITLE
Scalar Card Fob: Move fob when zoom changes

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -112,7 +112,7 @@ limitations under the License.
     [tooltipTemplate]="tooltip"
     [useDarkMode]="useDarkMode"
     (onViewBoxOverridden)="isViewBoxOverridden = $event"
-    (onViewBoxChanged)="onLineChartZoom.emit($event)"
+    (viewBoxChanged)="onLineChartZoom.emit($event)"
     [customVisTemplate]="lineChartCustomVis"
     [customChartOverlayTemplate]="lineChartCustomXAxisVis"
   ></line-chart>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -112,6 +112,7 @@ limitations under the License.
     [tooltipTemplate]="tooltip"
     [useDarkMode]="useDarkMode"
     (onViewBoxOverridden)="isViewBoxOverridden = $event"
+    (onViewBoxChanged)="onLineChartZoom.emit($event)"
     [customVisTemplate]="lineChartCustomVis"
     [customChartOverlayTemplate]="lineChartCustomXAxisVis"
   ></line-chart>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -37,6 +37,7 @@ import {
   relativeTimeFormatter,
   siNumberFormatter,
 } from '../../../widgets/line_chart_v2/lib/formatter';
+import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {LineChartComponent} from '../../../widgets/line_chart_v2/line_chart_component';
 import {
   RendererType,
@@ -105,6 +106,8 @@ export class ScalarCardComponent<Downloader> {
   }>();
   @Output() onStepSelectorToggled =
     new EventEmitter<TimeSelectionToggleAffordance>();
+
+  @Output() onLineChartZoom = new EventEmitter<Extent>();
 
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -97,6 +97,7 @@ import {ScalarCardDataTable} from './scalar_card_data_table';
 import {ScalarCardFobController} from './scalar_card_fob_controller';
 import {
   ColumnHeaders,
+  MinMaxStep,
   ScalarCardPoint,
   ScalarCardSeriesMetadata,
   SeriesType,
@@ -2392,6 +2393,41 @@ describe('scalar card', () => {
         );
 
         expect(dataTableComponent).toBeFalsy();
+      }));
+    });
+
+    describe('line chart integration', () => {
+      it('updates minMax value when line chart is zoomed', fakeAsync(async () => {
+        const runToSeries = {
+          run1: [buildScalarStepData({step: 10})],
+          run2: [buildScalarStepData({step: 20})],
+          run3: [buildScalarStepData({step: 30})],
+        };
+        provideMockCardRunToSeriesData(
+          selectSpy,
+          PluginType.SCALARS,
+          'card1',
+          null /* metadataOverride */,
+          runToSeries
+        );
+        store.overrideSelector(getMetricsLinkedTimeSelection, {
+          start: {step: 0},
+          end: {step: 50},
+        });
+        const fixture = createComponent('card1');
+
+        let newSteps: MinMaxStep | null = null;
+        fixture.componentInstance.minMaxSteps$?.subscribe((minMaxStep) => {
+          newSteps = minMaxStep;
+        });
+        fixture.componentInstance.onLineChartZoom({
+          x: [9.235, 30.4],
+          y: [0, 100],
+        });
+        expect(newSteps!).toEqual({
+          minStep: 10,
+          maxStep: 30,
+        });
       }));
     });
   });

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -18,10 +18,12 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
+  Output,
   SimpleChanges,
   TemplateRef,
   ViewChild,
@@ -136,6 +138,9 @@ export class LineChartComponent
 
   @Input()
   lineOnly?: boolean = false;
+
+  @Output()
+  viewBoxChanged = new EventEmitter<Extent>();
 
   private onViewBoxOverridden = new ReplaySubject<boolean>(1);
 
@@ -482,6 +487,7 @@ export class LineChartComponent
     this.isViewBoxChanged = true;
     this.viewBox = dataExtent;
     this.updateLineChart();
+    this.viewBoxChanged.emit(dataExtent);
   }
 
   viewBoxReset() {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -494,6 +494,7 @@ export class LineChartComponent
     this.setIsViewBoxOverridden(false);
     this.isViewBoxChanged = true;
     this.updateLineChart();
+    this.viewBoxChanged.emit(this.viewBox);
   }
 
   private setIsViewBoxOverridden(newValue: boolean): void {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -15,7 +15,14 @@ limitations under the License.
 
 import {OverlayModule} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
-import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  NO_ERRORS_SCHEMA,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ChartImpl} from './lib/chart';
@@ -55,6 +62,7 @@ class FakeGridComponent {
       [yScaleType]="yScaleType"
       [fixedViewBox]="fixedViewBox"
       [useDarkMode]="useDarkMode"
+      (viewBoxChanged)="viewBoxChanged.emit($event)"
     ></line-chart>
   `,
   styles: [
@@ -91,6 +99,9 @@ class TestableComponent {
 
   @Input()
   lineOnly: boolean = false;
+
+  @Output()
+  viewBoxChanged = new EventEmitter();
 
   // WebGL one is harder to test.
   preferredRendererType = RendererType.SVG;
@@ -383,6 +394,42 @@ describe('line_chart_v2/line_chart test', () => {
     expect(updateViewBoxSpy.calls.argsFor(3)).toEqual([
       {x: [-0.5, 4.5], y: [-2, 2]},
     ]);
+  });
+
+  it('emits viewBoxChanged event when viewbox is changed or reset', () => {
+    const fixture = createComponent({
+      seriesData: [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -1},
+            {x: 2, y: 1},
+          ],
+        }),
+      ],
+      seriesMetadataMap: {foo: buildMetadata({id: 'foo', visible: true})},
+      yScaleType: ScaleType.LINEAR,
+    });
+    spyOn(fixture.componentInstance.viewBoxChanged, 'emit');
+    fixture.detectChanges();
+    expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
+    expect(updateViewBoxSpy.calls.argsFor(0)).toEqual([
+      {x: [-0.2, 2.2], y: [-1.2, 1.2]},
+    ]);
+
+    fixture.componentInstance.triggerViewBoxChange({
+      x: [-5, 5],
+      y: [0, 10],
+    });
+
+    expect(fixture.componentInstance.viewBoxChanged.emit).toHaveBeenCalledTimes(
+      1
+    );
+    fixture.componentInstance.chart.viewBoxReset();
+    expect(fixture.componentInstance.viewBoxChanged.emit).toHaveBeenCalledTimes(
+      2
+    );
   });
 
   it('sets correct domDim and viewBox on initial render', () => {

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -413,10 +413,10 @@ describe('line_chart_v2/line_chart test', () => {
     });
     spyOn(fixture.componentInstance.viewBoxChanged, 'emit');
     fixture.detectChanges();
-    expect(updateViewBoxSpy).toHaveBeenCalledTimes(1);
-    expect(updateViewBoxSpy.calls.argsFor(0)).toEqual([
-      {x: [-0.2, 2.2], y: [-1.2, 1.2]},
-    ]);
+    expect(updateViewBoxSpy).toHaveBeenCalledOnceWith({
+      x: [-0.2, 2.2],
+      y: [-1.2, 1.2],
+    });
 
     fixture.componentInstance.triggerViewBoxChange({
       x: [-5, 5],


### PR DESCRIPTION
Tests will be added once the open question is answered

## Motivation for features / changes
After zooming on the scalar card with step selection enabled the fob(s) are not guaranteed to be visible.

~### Open Questions:~
#### ~Because steps must be whole numbers it is quite easy for a user to get themselves into an invalid situation where no valid steps exist. What should we do in this situation?~
![405ff102-f8a4-444a-8c53-c91f274b123b](https://user-images.githubusercontent.com/78179109/191137166-0a607604-f68c-4c3e-b7e6-9a5dcc82cfab.gif)

While this is an awkward user experience the user will have to get themselves into this situation so we are electing to leave this as is.

## Technical description of changes
* Updated the `line_chart_component` to emit an event when the zoom level is changed.
* This event is then bubbled up to the `scalar_card_container` which is responsible for deriving the `TimeSelectionView` (i.e. the clipped `MinMaxStep` used to to determine the fob position).
* Created an `observable` around this event which is then combined with the existing `observable` listening to the series data change to ensure the `TimeSelectionView` is always recomputed

## Screenshots of UI changes
Zooming on a valid range with a single fob
![9e539d8b-c225-4f9c-aa25-c7fe89c79913](https://user-images.githubusercontent.com/78179109/191619237-63b1e48f-fc33-4b22-a79e-771c2593d9fd.gif)


Resetting view box with a single fob
![3d5d15d9-91bb-4a1e-9dae-7e41816fd715](https://user-images.githubusercontent.com/78179109/191619499-7a256f89-2870-4cbc-9c5f-9408713f99fb.gif)

#5938 will be required to fix this issue when range selection is enabled.

## Detailed steps to verify changes work correctly (as executed by you)
