### PR TITLE
[WIP]Step Selector: store card time selections in ngrx state

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {createAction, props} from '@ngrx/store';
 import {ElementId} from '../../util/dom';
 import {
+  TimeSelection,
   TimeSelectionToggleAffordance,
   TimeSelectionWithAffordance,
 } from '../../widgets/card_fob/card_fob_types';
@@ -176,6 +177,16 @@ export const metricsShowAllPlugins = createAction(
 export const timeSelectionChanged = createAction(
   '[Metrics] Time Selection Changed',
   props<TimeSelectionWithAffordance>()
+);
+
+export const cardTimeSelectionChanged = createAction(
+  '[Metrics] Time Selection of individual card updated',
+  props<{
+    // Affordance for internal analytics purpose. When no affordance is specified or is
+    // undefined we do not want to log an analytics event.
+    cardId: CardId;
+    timeSelection: TimeSelection;
+  }>()
 );
 
 export const timeSelectionCleared = createAction(

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -368,6 +368,13 @@ export const getMetricsStepSelectorEnabled = createSelector(
   }
 );
 
+export const getMetricsCardStepSelections = createSelector(
+  selectMetricsState,
+  (state: MetricsState): Map<CardId, TimeSelection> => {
+    return state.cardTimeSelections;
+  }
+);
+
 export const getMetricsLinkedTimeRangeEnabled = createSelector(
   selectMetricsState,
   (state: MetricsState): boolean => {

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -166,6 +166,7 @@ export interface MetricsNamespacedState {
   linkedTimeSelection: TimeSelection | null;
   linkedTimeEnabled: boolean;
   stepSelectorEnabled: boolean;
+  cardTimeSelections: Map<CardId, TimeSelection>;
   linkedTimeRangeEnabled: boolean;
   // Empty Set would signify "show all". `filteredPluginTypes` will never have
   // all pluginTypes in the Set.

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -234,22 +234,28 @@ export class ScalarCardComponent<Downloader> {
   ) {
     // Updates step selector to single selection.
     const {timeSelection, affordance} = newTimeSelectionWithAffordance;
-    const newStartStep = timeSelection.start.step;
-    const nextStartStep =
-      newStartStep < this.minMaxStep.minStep
-        ? this.minMaxStep.minStep
-        : newStartStep > this.minMaxStep.maxStep
-        ? this.minMaxStep.maxStep
-        : newStartStep;
 
-    // Updates step selector to single selection.
-    this.stepSelectorTimeSelection = {
-      start: {step: nextStartStep},
-      end: null,
-    };
+    let newStart: {step: number} = {step: timeSelection.start.step};
+    newStart.step =
+      timeSelection.start.step < this.minMaxStep.minStep
+        ? this.minMaxStep.minStep
+        : timeSelection.start.step > this.minMaxStep.maxStep
+        ? this.minMaxStep.maxStep
+        : timeSelection.start.step;
+
+    let newEnd: null | {step: number} = null;
+    if (timeSelection.end) {
+      newEnd = timeSelection.end;
+      newEnd.step =
+        timeSelection.end.step < this.minMaxStep.minStep
+          ? this.minMaxStep.minStep
+          : timeSelection.end.step > this.minMaxStep.maxStep
+          ? this.minMaxStep.maxStep
+          : timeSelection.end.step;
+    }
 
     this.onTimeSelectionChanged.emit({
-      timeSelection,
+      timeSelection: {start: newStart, end: newEnd},
       // Only sets affordance when it's not undefined.
       ...(affordance && {affordance}),
     });

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -146,10 +146,11 @@ export class CardFobControllerComponent {
     newStep: number,
     timeSelection: TimeSelection
   ): TimeSelection {
+    let newTimeSelection = {start: {step: timeSelection.start.step}, end: null};
     // Single Selection
     if (!this.timeSelection.end) {
-      timeSelection.start.step = newStep;
-      return timeSelection;
+      newTimeSelection.start.step = newStep;
+      return newTimeSelection;
     }
 
     // Range Selection


### PR DESCRIPTION
* Motivation for features / changes
Currently there is some strange behavior in the ScalarCardComponent where we update the timeSelection(which is an Input) directly in the component. This is because it cannot be updated in the ScalarCardContainer since it is only an Observable object. This strangeness is due to the fact that we strayed away from out typical pattern when deciding to store the timeSelection for each card in the ScalarCardComponent instead of in the NGRX state. This change remedies the situation by following the prescribed pattern of keeping all state in NGRX.

* Technical description of changes
There are multiple place in the code where we change the timeSelection Input object. There are a couple extra changes in here to ensure that object never changes in the component.
