### PR TITLE
Bugfix: Fix zooming with linked time by changing the definition of "clipped"

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -387,7 +387,7 @@ describe('histogram card', () => {
         );
         expect(viz.componentInstance.timeSelection).toEqual({
           start: {step: 15},
-          end: null,
+          end: {step: 15},
         });
       });
 
@@ -415,7 +415,7 @@ describe('histogram card', () => {
         );
         expect(viz.componentInstance.timeSelection).toEqual({
           start: {step: 50},
-          end: null,
+          end: {step: 50},
         });
       });
 
@@ -456,7 +456,7 @@ describe('histogram card', () => {
             'vis-linked-time-selection-warning mat-icon[data-value="clipped"]'
           )
         );
-        expect(indicatorAfter).toBeNull();
+        expect(indicatorAfter).toBeTruthy();
       });
     });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -91,10 +91,7 @@ limitations under the License.
       [value]="stepIndex"
       (input)="onSliderInput($event)"
     ></mat-slider>
-    <div
-      class="linked-time-wrapper"
-      *ngIf="linkedTimeSelection"
-    >
+    <div class="linked-time-wrapper" *ngIf="linkedTimeSelection">
       <span *ngIf="linkedTimeSelection.endStep !== null">
         <span class="slider-track"></span>
         <span

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ng.html
@@ -82,7 +82,7 @@ limitations under the License.
     <mat-slider
       class="step-slider"
       color="primary"
-      [ngClass]="[linkedTimeSelection && !linkedTimeSelection.clipped && linkedTimeSelection.endStep !== null ? 'hide-slider' : '']"
+      [ngClass]="[linkedTimeSelection && linkedTimeSelection.endStep !== null ? 'hide-slider' : '']"
       [disabled]="steps.length <= 1"
       [min]="0"
       [max]="steps.length - 1"
@@ -93,7 +93,7 @@ limitations under the License.
     ></mat-slider>
     <div
       class="linked-time-wrapper"
-      *ngIf="linkedTimeSelection && !linkedTimeSelection.clipped"
+      *ngIf="linkedTimeSelection"
     >
       <span *ngIf="linkedTimeSelection.endStep !== null">
         <span class="slider-track"></span>

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.ts
@@ -94,11 +94,7 @@ export class ImageCardComponent {
   }
 
   renderRangeSlider() {
-    if (
-      !this.linkedTimeSelection ||
-      !this.linkedTimeSelection.endStep ||
-      this.linkedTimeSelection.clipped
-    ) {
+    if (!this.linkedTimeSelection || !this.linkedTimeSelection.endStep) {
       return;
     }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -263,12 +263,11 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
 
           const minStep = Math.min(...steps);
           const maxStep = Math.max(...steps);
-          const potentiallyClippedTimeSelection = maybeClipLinkedTimeSelection(
+          return maybeClipLinkedTimeSelection(
             linkedTimeSelection,
             minStep,
             maxStep
           );
-          return potentiallyClippedTimeSelection;
         })
       );
 

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -261,17 +261,14 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
         map(([linkedTimeSelection, steps]) => {
           if (!linkedTimeSelection) return null;
 
-          let minStep = Infinity;
-          let maxStep = -Infinity;
-          for (const step of steps) {
-            minStep = Math.min(step, minStep);
-            maxStep = Math.max(step, maxStep);
-          }
-          return maybeClipLinkedTimeSelection(
+          const minStep = Math.min(...steps);
+          const maxStep = Math.max(...steps);
+          const potentiallyClippedTimeSelection = maybeClipLinkedTimeSelection(
             linkedTimeSelection,
             minStep,
             maxStep
           );
+          return potentiallyClippedTimeSelection;
         })
       );
 
@@ -287,16 +284,11 @@ export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {
           return [];
         }
 
-        const selectedStepsInRange = [];
-        for (const step of steps) {
-          if (
+        return steps.filter(
+          (step) =>
             step >= linkedTimeSelection.startStep &&
-            step <= linkedTimeSelection.endStep
-          ) {
-            selectedStepsInRange.push(step);
-          }
-        }
-        return selectedStepsInRange;
+            step <= linkedTimeSelection.endStep!
+        );
       })
     );
 

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -564,28 +564,7 @@ describe('image card', () => {
         );
       });
 
-      it('renders ticks on selected steps are particially in range', () => {
-        store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
-          start: {step: 25},
-          end: {step: 350},
-        });
-
-        const fixture = createImageCardContainer('card1');
-        fixture.detectChanges();
-
-        const dots = fixture.debugElement.queryAll(
-          By.css('.linked-time-wrapper .linked-time-tick')
-        );
-        // The third and fourth ticks are selected.
-        expect(dots[0].nativeElement.getAttribute('style')).toBe(
-          TICKS_STYLE[2]
-        );
-        expect(dots[1].nativeElement.getAttribute('style')).toBe(
-          TICKS_STYLE[3]
-        );
-      });
-
-      it('does not render ticks on slected range wrapped between steps ', () => {
+      it('does not render ticks on selected range wrapped between steps ', () => {
         store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
           start: {step: 11},
           end: {step: 14},
@@ -723,42 +702,6 @@ describe('image card', () => {
         expect(sliderTrackFill).toBeTruthy();
         expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
           'left: 25%; width: 31.25%;'
-        );
-      });
-
-      it('renders range slider on selected steps which end step is out of range, ', () => {
-        store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
-          start: {step: 15},
-          end: {step: 55},
-        });
-
-        const fixture = createImageCardContainer('card1');
-        fixture.detectChanges();
-
-        const sliderTrackFill = fixture.debugElement.query(
-          By.css('.linked-time-wrapper .slider-track-fill')
-        );
-        expect(sliderTrackFill).toBeTruthy();
-        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
-          'left: 12.5%; width: 87.5%;'
-        );
-      });
-
-      it('renders range slider on selected steps which start step is out of range, ', () => {
-        store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
-          start: {step: 5},
-          end: {step: 35},
-        });
-
-        const fixture = createImageCardContainer('card1');
-        fixture.detectChanges();
-
-        const sliderTrackFill = fixture.debugElement.query(
-          By.css('.linked-time-wrapper .slider-track-fill')
-        );
-        expect(sliderTrackFill).toBeTruthy();
-        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
-          'left: 0%; width: 62.5%;'
         );
       });
 
@@ -969,7 +912,7 @@ describe('image card', () => {
 
         expect(timeSelectionChangeSpy).toHaveBeenCalledWith({
           startStep: 40,
-          endStep: null,
+          endStep: 40,
           clipped: true,
         });
       });
@@ -1002,7 +945,7 @@ describe('image card', () => {
 
         expect(timeSelectionChangeSpy).toHaveBeenCalledWith({
           startStep: 10,
-          endStep: null,
+          endStep: 10,
           clipped: true,
         });
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -564,10 +564,10 @@ describe('image card', () => {
         );
       });
 
-      it('does not render ticks on selected range wrapped between steps ', () => {
+      it('renders ticks on selected steps are particially in range', () => {
         store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
-          start: {step: 11},
-          end: {step: 14},
+          start: {step: 25},
+          end: {step: 350},
         });
 
         const fixture = createImageCardContainer('card1');
@@ -577,13 +577,18 @@ describe('image card', () => {
           By.css('.linked-time-wrapper .linked-time-tick')
         );
         // The third and fourth ticks are selected.
-        expect(dots.length).toBe(0);
+        expect(dots[0].nativeElement.getAttribute('style')).toBe(
+          TICKS_STYLE[2]
+        );
+        expect(dots[1].nativeElement.getAttribute('style')).toBe(
+          TICKS_STYLE[3]
+        );
       });
 
-      it('does not render ticks when the slected range is clipped', () => {
+      it('does not render ticks on selected range wrapped between steps ', () => {
         store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
-          start: {step: 45},
-          end: {step: 55},
+          start: {step: 11},
+          end: {step: 14},
         });
 
         const fixture = createImageCardContainer('card1');
@@ -705,6 +710,42 @@ describe('image card', () => {
         );
       });
 
+      it('renders range slider on selected steps which end step is out of range, ', () => {
+        store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
+          start: {step: 15},
+          end: {step: 55},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 12.5%; width: 87.5%;'
+        );
+      });
+
+      it('renders range slider on selected steps which start step is out of range, ', () => {
+        store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
+          start: {step: 5},
+          end: {step: 35},
+        });
+
+        const fixture = createImageCardContainer('card1');
+        fixture.detectChanges();
+
+        const sliderTrackFill = fixture.debugElement.query(
+          By.css('.linked-time-wrapper .slider-track-fill')
+        );
+        expect(sliderTrackFill).toBeTruthy();
+        expect(sliderTrackFill.nativeElement.getAttribute('style')).toBe(
+          'left: 0%; width: 62.5%;'
+        );
+      });
+
       it('renders range slider where range is between two steps, ', () => {
         store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
           start: {step: 12.5},
@@ -727,21 +768,6 @@ describe('image card', () => {
         store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
           start: {step: 15},
           end: null,
-        });
-
-        const fixture = createImageCardContainer('card1');
-        fixture.detectChanges();
-
-        const sliderTrackFill = fixture.debugElement.query(
-          By.css('.linked-time-wrapper .slider-track-fill')
-        );
-        expect(sliderTrackFill).toBeFalsy();
-      });
-
-      it('does not render range slider when the slected range is clipped', () => {
-        store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
-          start: {step: 55},
-          end: {step: 60},
         });
 
         const fixture = createImageCardContainer('card1');

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2098,50 +2098,6 @@ describe('scalar card', () => {
         ).toBeTruthy();
       }));
 
-      it('does not show clipped warning if there is an overlap', fakeAsync(() => {
-        const runToSeries = {
-          run1: [buildScalarStepData({step: 10})],
-          run2: [buildScalarStepData({step: 20})],
-          run3: [buildScalarStepData({step: 30})],
-        };
-        provideMockCardRunToSeriesData(
-          selectSpy,
-          PluginType.SCALARS,
-          'card1',
-          null /* metadataOverride */,
-          runToSeries
-        );
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
-          start: {step: 25},
-          end: {step: 50},
-        });
-        const fixture = createComponent('card1');
-        fixture.detectChanges();
-        expect(
-          fixture.debugElement.query(Selector.HEADER_WARNING_CLIPPED)
-        ).toBeNull();
-
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
-          start: {step: -10},
-          end: {step: 15},
-        });
-        store.refreshState();
-        fixture.detectChanges();
-        expect(
-          fixture.debugElement.query(Selector.HEADER_WARNING_CLIPPED)
-        ).toBeNull();
-
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
-          start: {step: -1000},
-          end: {step: 1000},
-        });
-        store.refreshState();
-        fixture.detectChanges();
-        expect(
-          fixture.debugElement.query(Selector.HEADER_WARNING_CLIPPED)
-        ).toBeNull();
-      }));
-
       it('selects time selection to min extent when global setting is too small', fakeAsync(() => {
         const runToSeries = {
           run1: [buildScalarStepData({step: 10})],

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -96,9 +96,9 @@ export function maybeClipLinkedTimeSelection(
   minStep: number,
   maxStep: number
 ): TimeSelectionView {
-  const startStep = Math.max(minStep, timeSelection.start.step);
+  const startStep = Math.min(Math.max(minStep, timeSelection.start.step), maxStep);
   const endStep = timeSelection.end
-    ? Math.min(maxStep, timeSelection.end.step)
+    ? Math.max(Math.min(maxStep, timeSelection.end.step), minStep)
     : null;
   if (
     startStep !== timeSelection.start.step ||

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -91,7 +91,7 @@ export interface TimeSelectionView {
   clipped: boolean;
 }
 
-function boundNumber(value: number, min: number, max: number) {
+function clipStepWithinMinMax(value: number, min: number, max: number) {
   if (value < min) {
     return min;
   }
@@ -106,16 +106,20 @@ export function maybeClipLinkedTimeSelection(
   minStep: number,
   maxStep: number
 ): TimeSelectionView {
-  const startStep = boundNumber(timeSelection.start.step, minStep, maxStep);
-  const endStep = timeSelection.end
-    ? boundNumber(timeSelection.end.step, minStep, maxStep)
+  const maybeClippedStartStep = clipStepWithinMinMax(
+    timeSelection.start.step,
+    minStep,
+    maxStep
+  );
+  const maybeClippedEndStep = timeSelection.end
+    ? clipStepWithinMinMax(timeSelection.end.step, minStep, maxStep)
     : null;
   const clipped =
-    startStep !== timeSelection.start.step ||
-    endStep !== (timeSelection.end?.step ?? null);
+    maybeClippedStartStep !== timeSelection.start.step ||
+    maybeClippedEndStep !== (timeSelection.end?.step ?? null);
   return {
-    startStep,
-    endStep,
+    startStep: maybeClippedStartStep,
+    endStep: maybeClippedEndStep,
     clipped,
   };
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -96,45 +96,24 @@ export function maybeClipLinkedTimeSelection(
   minStep: number,
   maxStep: number
 ): TimeSelectionView {
+  const startStep = Math.max(minStep, timeSelection.start.step);
+  const endStep = timeSelection.end
+    ? Math.min(maxStep, timeSelection.end.step)
+    : null;
   if (
-    // Case when timeSelection contains extents.
-    (timeSelection.start.step <= minStep &&
-      timeSelection.end &&
-      maxStep <= timeSelection.end.step) ||
-    // Case when start of timeSelection is within extent.
-    (minStep <= timeSelection.start.step &&
-      timeSelection.start.step <= maxStep) ||
-    // Case when end of timeSelection is within extent.
-    (timeSelection.end &&
-      minStep <= timeSelection.end?.step &&
-      timeSelection.end?.step <= maxStep)
+    startStep !== timeSelection.start.step ||
+    endStep !== (timeSelection.end?.step ?? null)
   ) {
     return {
-      startStep: timeSelection.start.step,
-      endStep: timeSelection.end?.step ?? null,
-      clipped: false,
-    };
-  }
-
-  // When time selection and data extent (in step axis) do not overlap,
-  // default single select min or max data extent depending on which side
-  // the time selection is at.
-
-  // Case when time selection is on the right of the maximum of the
-  // time series.
-  if (maxStep <= timeSelection.start.step) {
-    return {
-      startStep: maxStep,
-      endStep: null,
+      startStep,
+      endStep,
       clipped: true,
     };
   }
-  // Case when time selection is on the left of the minimum of the time
-  // series.
   return {
-    startStep: minStep,
-    endStep: null,
-    clipped: true,
+    startStep,
+    endStep,
+    clipped: false,
   };
 }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -91,29 +91,24 @@ export interface TimeSelectionView {
   clipped: boolean;
 }
 
+function boundNumber(value: number, min: number, max: number) {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
 export function maybeClipLinkedTimeSelection(
   timeSelection: TimeSelection,
   minStep: number,
   maxStep: number
 ): TimeSelectionView {
-  /**
-   * 1) Take greatest between the minStep and the current step.
-   *      This ensures that the current step is >= minStep
-   * 2) Take the minimum between the output of step 1 and the maxStep.
-   *      This ensures the result is <= maxStep.
-   */
-  const startStep = Math.min(
-    Math.max(minStep, timeSelection.start.step),
-    maxStep
-  );
-  /**
-   * 1) Take smallest between the maxStep and the current step.
-   *      This ensures that the current step is <= maxStep
-   * 2) Take the greatest between the output of step 1 and the minStep.
-   *      This ensures the result is >= minStep.
-   */
+  const startStep = boundNumber(timeSelection.start.step, minStep, maxStep);
   const endStep = timeSelection.end
-    ? Math.max(Math.min(maxStep, timeSelection.end.step), minStep)
+    ? boundNumber(timeSelection.end.step, minStep, maxStep)
     : null;
   const clipped =
     startStep !== timeSelection.start.step ||

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -96,27 +96,32 @@ export function maybeClipLinkedTimeSelection(
   minStep: number,
   maxStep: number
 ): TimeSelectionView {
+  /**
+   * 1) Take greatest between the minStep and the current step.
+   *      This ensures that the current step is >= minStep
+   * 2) Take the minimum between the output of step 1 and the maxStep.
+   *      This ensures the result is <= maxStep.
+   */
   const startStep = Math.min(
     Math.max(minStep, timeSelection.start.step),
     maxStep
   );
+  /**
+   * 1) Take smallest between the maxStep and the current step.
+   *      This ensures that the current step is <= maxStep
+   * 2) Take the greatest between the output of step 1 and the minStep.
+   *      This ensures the result is >= minStep.
+   */
   const endStep = timeSelection.end
     ? Math.max(Math.min(maxStep, timeSelection.end.step), minStep)
     : null;
-  if (
+  const clipped =
     startStep !== timeSelection.start.step ||
-    endStep !== (timeSelection.end?.step ?? null)
-  ) {
-    return {
-      startStep,
-      endStep,
-      clipped: true,
-    };
-  }
+    endStep !== (timeSelection.end?.step ?? null);
   return {
     startStep,
     endStep,
-    clipped: false,
+    clipped,
   };
 }
 
@@ -153,7 +158,7 @@ export function getClosestStep(
   steps: number[]
 ): number | null {
   let minDistance = Infinity;
-  let closestStep = null;
+  let closestStep: number | null = null;
   for (const step of steps) {
     const distance = Math.abs(selectedStep - step);
     // With the same distance between two steps, this method favors smaller step than larger

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -96,7 +96,10 @@ export function maybeClipLinkedTimeSelection(
   minStep: number,
   maxStep: number
 ): TimeSelectionView {
-  const startStep = Math.min(Math.max(minStep, timeSelection.start.step), maxStep);
+  const startStep = Math.min(
+    Math.max(minStep, timeSelection.start.step),
+    maxStep
+  );
   const endStep = timeSelection.end
     ? Math.max(Math.min(maxStep, timeSelection.end.step), minStep)
     : null;

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -17,6 +17,7 @@ import {PartialSeries} from './scalar_card_types';
 import {
   getClosestStep,
   getDisplayNameForRun,
+  maybeClipLinkedTimeSelection,
   maybeSetClosestStartStep,
   partitionSeries,
 } from './utils';
@@ -308,6 +309,74 @@ describe('metrics card_renderer utils test', () => {
 
     it('gets closeset step equal to selected step', () => {
       expect(getClosestStep(10, [0, 10, 20])).toBe(10);
+    });
+  });
+
+  describe('#maybeClipLinkedTimeSelection', () => {
+    it('changes start when start.step < minStep', () => {
+      expect(
+        maybeClipLinkedTimeSelection(
+          {
+            start: {step: 0},
+            end: null,
+          },
+          1,
+          4
+        )
+      ).toEqual({
+        startStep: 1,
+        endStep: null,
+        clipped: true,
+      });
+    });
+
+    it('changes end when end.step < maxStep', () => {
+      expect(
+        maybeClipLinkedTimeSelection(
+          {
+            start: {step: 0},
+            end: {step: 4},
+          },
+          0,
+          3
+        )
+      ).toEqual({
+        startStep: 0,
+        endStep: 3,
+        clipped: true,
+      });
+    });
+
+    it('returns clipped === false when provided timeSelection is a subspace of minStep, maxStep', () => {
+      expect(
+        maybeClipLinkedTimeSelection(
+          {
+            start: {step: 0},
+            end: {step: 4},
+          },
+          0,
+          4
+        )
+      ).toEqual({
+        startStep: 0,
+        endStep: 4,
+        clipped: false,
+      });
+
+      expect(
+        maybeClipLinkedTimeSelection(
+          {
+            start: {step: 1},
+            end: {step: 3},
+          },
+          0,
+          4
+        )
+      ).toEqual({
+        startStep: 1,
+        endStep: 3,
+        clipped: false,
+      });
     });
   });
 });

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -313,7 +313,7 @@ describe('metrics card_renderer utils test', () => {
   });
 
   describe('#maybeClipLinkedTimeSelection', () => {
-    it('changes start when start.step < minStep', () => {
+    it('clips to the minStep when time selection start step is smaller than the view extend', () => {
       expect(
         maybeClipLinkedTimeSelection(
           {
@@ -330,7 +330,7 @@ describe('metrics card_renderer utils test', () => {
       });
     });
 
-    it('changes end when end.step < maxStep', () => {
+    it('clips to maxStep when time selection end step is greater than view extend', () => {
       expect(
         maybeClipLinkedTimeSelection(
           {
@@ -347,7 +347,7 @@ describe('metrics card_renderer utils test', () => {
       });
     });
 
-    it('does not create an endstep when timeSelection does not contain one', () => {
+    it('does not clip when time selection falls into the view extend', () => {
       expect(
         maybeClipLinkedTimeSelection(
           {
@@ -381,7 +381,7 @@ describe('metrics card_renderer utils test', () => {
       });
     });
 
-    it('returns startStep === endStep === maxStep when timeSelection is above maxStep', () => {
+    it('clips both fobs to maxStep when timeSelection is greater than maxStep', () => {
       expect(
         maybeClipLinkedTimeSelection(
           {
@@ -415,7 +415,7 @@ describe('metrics card_renderer utils test', () => {
       });
     });
 
-    it('returns clipped === false when provided timeSelection is a subspace of minStep - maxStep', () => {
+    it('does not clip when time selection falls within the view extent', () => {
       expect(
         maybeClipLinkedTimeSelection(
           {

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -347,7 +347,58 @@ describe('metrics card_renderer utils test', () => {
       });
     });
 
-    it('returns clipped === false when provided timeSelection is a subspace of minStep, maxStep', () => {
+    it('returns minStep and maxStep when the timeselection is a superset of the min/maxstep', () => {
+      expect(
+        maybeClipLinkedTimeSelection(
+          {
+            start: {step: 0},
+            end: {step: 100},
+          },
+          30,
+          50,
+        )
+      ).toEqual({
+        startStep: 30,
+        endStep: 50,
+        clipped: true,
+      });
+    });
+
+    it('returns startStep === endStep === maxStep when timeSelection is above maxStep', () => {
+        expect(
+          maybeClipLinkedTimeSelection(
+            {
+              start: {step: 50},
+              end: {step: 100},
+            },
+            10,
+            20
+          )
+        ).toEqual({
+          startStep: 20,
+          endStep: 20,
+          clipped: true,
+        });
+    });
+
+    it('returns startStep === endStep === minStep when timeSelection is below minStep', () => {
+      expect(
+        maybeClipLinkedTimeSelection(
+          {
+            start: {step: 0},
+            end: {step: 10},
+          },
+          20,
+          30
+        )
+      ).toEqual({
+        startStep: 20,
+        endStep: 20,
+        clipped: true,
+      });
+    });
+
+    it('returns clipped === false when provided timeSelection is a subspace of minStep - maxStep', () => {
       expect(
         maybeClipLinkedTimeSelection(
           {

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -347,6 +347,23 @@ describe('metrics card_renderer utils test', () => {
       });
     });
 
+    it('does not create an endstep when timeSelection does not contain one', () => {
+      expect(
+        maybeClipLinkedTimeSelection(
+          {
+            start: {step: 10},
+            end: null,
+          },
+          0,
+          20
+        )
+      ).toEqual({
+        startStep: 10,
+        endStep: null,
+        clipped: false,
+      });
+    });
+
     it('returns minStep and maxStep when the timeselection is a superset of the min/maxstep', () => {
       expect(
         maybeClipLinkedTimeSelection(
@@ -355,7 +372,7 @@ describe('metrics card_renderer utils test', () => {
             end: {step: 100},
           },
           30,
-          50,
+          50
         )
       ).toEqual({
         startStep: 30,
@@ -365,20 +382,20 @@ describe('metrics card_renderer utils test', () => {
     });
 
     it('returns startStep === endStep === maxStep when timeSelection is above maxStep', () => {
-        expect(
-          maybeClipLinkedTimeSelection(
-            {
-              start: {step: 50},
-              end: {step: 100},
-            },
-            10,
-            20
-          )
-        ).toEqual({
-          startStep: 20,
-          endStep: 20,
-          clipped: true,
-        });
+      expect(
+        maybeClipLinkedTimeSelection(
+          {
+            start: {step: 50},
+            end: {step: 100},
+          },
+          10,
+          20
+        )
+      ).toEqual({
+        startStep: 20,
+        endStep: 20,
+        clipped: true,
+      });
     });
 
     it('returns startStep === endStep === minStep when timeSelection is below minStep', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_linked_time_selection_warning_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_linked_time_selection_warning_component.ts
@@ -24,7 +24,7 @@ export type TimeSelectionWithClipped = TimeSelection & {clipped: boolean};
       *ngIf="isClipped"
       data-value="clipped"
       svgIcon="info_outline_24px"
-      title="Linked step is not found in this visualization. We highlighted the closest step for you."
+      title="A portion of the time selection cannot be shown. We highlighted the closest step for you."
     ></mat-icon>
     <mat-icon
       *ngIf="isClosestStepHighlighted"

--- a/tensorboard/webapp/metrics/views/card_renderer/vis_linked_time_selection_warning_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_linked_time_selection_warning_component.ts
@@ -24,7 +24,7 @@ export type TimeSelectionWithClipped = TimeSelection & {clipped: boolean};
       *ngIf="isClipped"
       data-value="clipped"
       svgIcon="info_outline_24px"
-      title="A portion of the time selection cannot be shown. We highlighted the closest step for you."
+      title="Linked step is not found in this visualization. We highlighted the closest step for you."
     ></mat-icon>
     <mat-icon
       *ngIf="isClosestStepHighlighted"


### PR DESCRIPTION
Change the definition of "clipped" to "A portion of the time selection cannot be shown"

## Motivation for features / changes
Currently when a the entirety of the time selection is outside of a chart it is determined to be "clipped" and a section is chosen to be shown.

When a card is "clipped" an icon is shown
![Screenshot from 2022-09-21 14-09-49](https://user-images.githubusercontent.com/78179109/191611033-34011978-c4d6-4fe4-88bf-417de62ada95.png)

The current behavior is somewhat confusing as it can lead to states where the card does not show all the content but still does not register as "clipped"
![Screenshot from 2022-09-21 14-15-28](https://user-images.githubusercontent.com/78179109/191611870-af2981fc-8097-437e-9b42-fdcda501b6fa.png)

The issue is then further compounded by "zooming"
![Screenshot from 2022-09-21 14-15-59](https://user-images.githubusercontent.com/78179109/191611977-685938b2-cb25-4d51-8fbf-b8c4e9c0df0a.png)

## Technical description of changes
I updated the `maybeClipTimeSelection` method to always return the maximum time selection available within the bounds of the `minStep` and `maxStep` provided and setting `clipped` to `true` if the `timeSelection` has been changed.

## Screenshots of UI changes
Zooming with linked time enabled without range to include current step
![4c9091a2-ee78-4646-9266-548b67f9e6d1](https://user-images.githubusercontent.com/78179109/191847611-e676c47f-e1b8-477e-851d-df98b998ae5b.gif)

Zooming with linked time enabled to not include current step
![71900b0e-78ac-4f79-8a57-8d88d0b67134 (1)](https://user-images.githubusercontent.com/78179109/191847739-ae5d08b4-0257-4026-92d0-e71301803e09.gif)

Zooming to a subset of the time selection
![b2196686-1ab9-4ae9-9307-3865a89bdb74](https://user-images.githubusercontent.com/78179109/191846599-6732e602-b83f-4cdb-b188-42b3e9f59fd3.gif)

Zooming to a partial subset of the time selection
![8a8afbf5-b221-4bed-91ca-0dc5ffacf638](https://user-images.githubusercontent.com/78179109/191847133-3ae6e2e3-4e1c-4eb7-b034-eebf2da15a48.gif)

Zooming to a range including only a single whole number
![0f188df0-e82e-4c60-aae8-e1ad2716443c](https://user-images.githubusercontent.com/78179109/191847226-018e87af-c332-4f0b-b381-274a757e8c00.gif)

Zooming to a range including zero whole numbers
![f57f3f41-3f1b-4db5-82f5-01e86aba3928](https://user-images.githubusercontent.com/78179109/191847297-482e661d-1064-4303-a0d3-429568f74703.gif)

## Detailed steps to verify changes work correctly (as executed by you)
See gifs above

## Alternate designs / implementations considered
Not allowing zoom to effect the clipped status of a card.
I found the existing definition of clipped to be confusing and unintuitive and zooming compounded that. Additionally it would have been harder to maintain it working that way. For reference see [this commit](https://github.com/rileyajones/tensorboard/commit/3b27f4e9803a3d1c5eceb0f65264118a9987d5da) implementing it this way.