### PR TITLE
Step Selector: Stop modifying timeSelection Input

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -234,7 +234,7 @@ limitations under the License.
       [scale]="xScale"
       [minMax]="viewExtent.x"
       [axisSize]="domDim.width"
-      (onTimeSelectionChanged)="onFobTimeSelectionChanged($event)"
+      (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
       (onTimeSelectionToggled)="onFobRemoved()"
     ></scalar-card-fob-controller>
   </ng-container>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -28,7 +28,6 @@ import {
   TimeSelection,
   TimeSelectionAffordance,
   TimeSelectionToggleAffordance,
-  TimeSelectionWithAffordance,
 } from '../../../widgets/card_fob/card_fob_types';
 import {
   Formatter,
@@ -228,32 +227,6 @@ export class ScalarCardComponent<Downloader> {
         ? {step: this.linkedTimeSelection.endStep}
         : null,
     };
-  }
-
-  onFobTimeSelectionChanged(
-    newTimeSelectionWithAffordance: TimeSelectionWithAffordance
-  ) {
-    // Updates step selector to single selection.
-    const {timeSelection, affordance} = newTimeSelectionWithAffordance;
-    const newStartStep = timeSelection.start.step;
-    const nextStartStep =
-      newStartStep < this.minMaxStep.minStep
-        ? this.minMaxStep.minStep
-        : newStartStep > this.minMaxStep.maxStep
-        ? this.minMaxStep.maxStep
-        : newStartStep;
-
-    // Updates step selector to single selection.
-    this.stepSelectorTimeSelection = {
-      start: {step: nextStartStep},
-      end: null,
-    };
-
-    this.onTimeSelectionChanged.emit({
-      timeSelection,
-      // Only sets affordance when it's not undefined.
-      ...(affordance && {affordance}),
-    });
   }
 
   onFobRemoved() {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -146,10 +146,12 @@ export class CardFobControllerComponent {
     newStep: number,
     timeSelection: TimeSelection
   ): TimeSelection {
+    const newTimeSelection = {...timeSelection};
+
     // Single Selection
     if (!this.timeSelection.end) {
-      timeSelection.start.step = newStep;
-      return timeSelection;
+      newTimeSelection.start = {step: newStep};
+      return newTimeSelection;
     }
 
     // Range Selection
@@ -160,19 +162,18 @@ export class CardFobControllerComponent {
           ? ['end', 'start']
           : ['start', 'end'];
       this.currentDraggingFob = TIME_SELECTION_TO_FOB[newDraggingFob];
-      timeSelection[oldDraggingFob]!.step =
-        this.timeSelection[newDraggingFob]!.step;
-      timeSelection[newDraggingFob]!.step = newStep;
-      return timeSelection;
+      newTimeSelection[oldDraggingFob]! = this.timeSelection[newDraggingFob]!;
+      newTimeSelection[newDraggingFob]! = {step: newStep};
+      return newTimeSelection;
     }
 
     if (this.currentDraggingFob === Fob.END) {
-      timeSelection.end = {step: newStep};
-      return timeSelection;
+      newTimeSelection.end = {step: newStep};
+      return newTimeSelection;
     }
 
-    timeSelection.start.step = newStep;
-    return timeSelection;
+    newTimeSelection.start = {step: newStep};
+    return newTimeSelection;
   }
 
   mouseMove(event: MouseEvent) {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -23,6 +23,7 @@ import {
   CardFobGetStepFromPositionHelper,
   TimeSelection,
   TimeSelectionAffordance,
+  TimeSelectionWithAffordance,
 } from './card_fob_types';
 
 @Component({
@@ -104,10 +105,12 @@ describe('card_fob_controller', () => {
       return step;
     });
     getAxisPositionFromStartStepSpy.and.callFake(() => {
-      return input.timeSelection.start.step;
+      return fixture.componentInstance.timeSelection.start.step;
     });
     getAxisPositionFromEndStepSpy.and.callFake(() => {
-      return input.timeSelection.end ? input.timeSelection.end.step : null;
+      return fixture.componentInstance.timeSelection.end
+        ? fixture.componentInstance.timeSelection.end.step
+        : null;
     });
     cardFobHelper = {
       getStepHigherThanAxisPosition: getStepHigherSpy,
@@ -132,6 +135,12 @@ describe('card_fob_controller', () => {
 
     onTimeSelectionChanged = jasmine.createSpy();
     fixture.componentInstance.onTimeSelectionChanged = onTimeSelectionChanged;
+    onTimeSelectionChanged.and.callFake(
+      (newSelectionWithAffordance: TimeSelectionWithAffordance) => {
+        fixture.componentInstance.timeSelection =
+          newSelectionWithAffordance.timeSelection;
+      }
+    );
 
     onTimeSelectionToggled = jasmine.createSpy();
     fixture.componentInstance.onTimeSelectionToggled = onTimeSelectionToggled;
@@ -228,7 +237,7 @@ describe('card_fob_controller', () => {
       });
       fobController.mouseMove(fakeEvent);
       expect((fobController as any).currentDraggingFob).toEqual(Fob.END);
-
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -261,6 +270,7 @@ describe('card_fob_controller', () => {
       fobController.mouseMove(fakeEvent);
       expect((fobController as any).currentDraggingFob).toEqual(Fob.START);
 
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -294,6 +304,7 @@ describe('card_fob_controller', () => {
       fobController.mouseMove(fakeEvent);
       expect((fobController as any).currentDraggingFob).toEqual(Fob.END);
 
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -328,6 +339,7 @@ describe('card_fob_controller', () => {
         movementY: 1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -364,6 +376,7 @@ describe('card_fob_controller', () => {
         movementY: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -488,6 +501,7 @@ describe('card_fob_controller', () => {
         movementY: 1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -524,6 +538,7 @@ describe('card_fob_controller', () => {
         movementY: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -623,6 +638,7 @@ describe('card_fob_controller', () => {
         movementX: 1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -660,6 +676,7 @@ describe('card_fob_controller', () => {
         movementX: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -697,6 +714,7 @@ describe('card_fob_controller', () => {
         movementX: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -735,6 +753,7 @@ describe('card_fob_controller', () => {
         movementX: 1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -806,6 +825,7 @@ describe('card_fob_controller', () => {
         movementX: 1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -843,6 +863,7 @@ describe('card_fob_controller', () => {
         movementX: -1,
       });
       fobController.mouseMove(fakeEvent);
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -976,6 +997,7 @@ describe('card_fob_controller', () => {
       fobController.mouseMove(
         new MouseEvent('mousemove', {clientX: 3, movementX: 1})
       );
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 
@@ -1001,6 +1023,7 @@ describe('card_fob_controller', () => {
       fobController.mouseMove(
         new MouseEvent('mousemove', {clientX: 5, movementX: 1})
       );
+      fixture.detectChanges();
       fobController.stopDrag();
       fixture.detectChanges();
 

--- a/tensorboard/webapp/widgets/histogram/histogram_card_fob_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_card_fob_test.ts
@@ -20,6 +20,7 @@ import {
 import {
   TimeSelection,
   TimeSelectionAffordance,
+  TimeSelectionWithAffordance,
 } from '../card_fob/card_fob_types';
 import {HistogramCardFobController} from './histogram_card_fob_controller';
 import {TemporalScale} from './histogram_component';
@@ -57,6 +58,16 @@ describe('HistogramCardFobController', () => {
       // Imitate a 10 to 1 scale.
       return step * 10;
     });
+    const onTimeSelectionChangedSpy = jasmine.createSpy();
+    fixture.componentInstance.onTimeSelectionChanged.emit =
+      onTimeSelectionChangedSpy;
+    onTimeSelectionChangedSpy.and.callFake(
+      (timeSelectionWithAffordance: TimeSelectionWithAffordance) => {
+        fixture.componentInstance.timeSelection =
+          timeSelectionWithAffordance.timeSelection;
+      }
+    );
+
     return fixture;
   }
 

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -30,6 +30,7 @@ import {
 import {
   TimeSelection,
   TimeSelectionAffordance,
+  TimeSelectionWithAffordance,
 } from '../card_fob/card_fob_types';
 import {IntersectionObserverTestingModule} from '../intersection_observer/intersection_observer_testing_module';
 import {HistogramCardFobController} from './histogram_card_fob_controller';
@@ -1307,6 +1308,12 @@ describe('histogram test', () => {
         };
         fixture.componentInstance.onLinkedTimeSelectionChanged =
           onLinkedTimeSelectionChangedSpy;
+        onLinkedTimeSelectionChangedSpy.and.callFake(
+          (timeSelectionWithAffordance: TimeSelectionWithAffordance) => {
+            fixture.componentInstance.timeSelection =
+              timeSelectionWithAffordance.timeSelection;
+          }
+        );
         fixture.detectChanges();
         intersectionObserver.simulateVisibilityChange(fixture, true);
         const testController = fixture.debugElement.query(
@@ -1327,6 +1334,7 @@ describe('histogram test', () => {
           movementY: 1,
         });
         testController.mouseMove(fakeEvent);
+        fixture.detectChanges();
         testController.stopDrag();
         fixture.detectChanges();
 


### PR DESCRIPTION
* Motivation for features / changes
We used to modify the timeSelection Input object in the ScalarCardComponent. Since #5941 This object is now updated in the ScalarCardContainer as it should be. However, the modifications in lower level components are still there. This change removes those modifications and completely relies on the container changes. 

* Technical description of changes
I also took the opportunity to do some cleanup that I thought was nice. I moved the lineChartZoom$ declaration down to the other BehaviorSubject definitions and defined it as readonly. I also made the minMaxStep Observable a BehaviorSubject so that I can use the value to check the new timeSelections before modifying it. This check was previously done in the ScalarCardComponent since we did not have access to the minMaxStep values in the container. The logic makes more sense in the Container and allows us to remove that function entirely and just emit the event directly.