### PR TITLE
cherry-pick: Add 2.10.1 relnotes to RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,9 @@
+# Release 2.10.1
+
+## Bug Fixes
+
+- Fix embedding projector plugin. (#5944)
+
 # Release 2.10.0
 
 The 2.10 minor series tracks TensorFlow 2.10.


### PR DESCRIPTION
This change cherry-picks the 2.10.1 release notes into master. (Googlers, see step 8 in http://go/tensorboard-release).