### PR TITLE
Access colors through theme color config

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/vis_linked_time_selection_warning_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/vis_linked_time_selection_warning_component.scss
@@ -16,13 +16,19 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 
 :host {
-  color: mat.get-color-from-palette(map-get($tb-theme, warn), 700);
+  color: mat.get-color-from-palette(
+    map-get(mat.get-color-config($tb-theme), warn),
+    700
+  );
   height: 1em;
   line-height: 0;
   display: inline-flex;
 
   @include tb-dark-theme {
-    color: mat.get-color-from-palette(map-get($tb-dark-theme, warn), 700);
+    color: mat.get-color-from-palette(
+      map-get(mat.get-color-config($tb-dark-theme), warn),
+      700
+    );
   }
 
   mat-icon {

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -22,6 +22,7 @@ limitations under the License.
 // Angular Material theme definition.
 
 // Include non-theme styles for core.
+@include mat.all-component-typographies();
 @include mat.core();
 
 // Value for `app-bar` property in $tb-background. Can specify an override in
@@ -106,7 +107,7 @@ $tb-dark-theme: mat.define-dark-theme(
   )
 );
 $tb-dark-foreground: map_merge(
-  map-get($tb-dark-theme, foreground),
+  map-get(mat.get-color-config($tb-dark-theme), foreground),
   (
     border: #555,
     disabled-text: mat.get-color-from-palette(mat.$gray-palette, 700),
@@ -115,7 +116,7 @@ $tb-dark-foreground: map_merge(
   )
 );
 $tb-dark-background: map_merge(
-  map-get($tb-dark-theme, background),
+  map-get(mat.get-color-config($tb-dark-theme), background),
   (
     app-bar: $tb-dark-app-bar-color,
   )


### PR DESCRIPTION
Angular Material theme configs put color in a "color" map in the theme config. The colors stored on the first-level are deprecated and copies for backwards compatibility, and will soon be removed.

Also, explicitly include typography rather than including it via core. This exclusion will soon be required for all apps