### PR TITLE
Bug Fix: Fix data table sorting of nans

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -196,25 +196,31 @@ export class ScalarCardDataTable {
         }
         return selectedStepData;
       });
-      dataTableData.sort(
-        (point1: SelectedStepRunData, point2: SelectedStepRunData) => {
-          const p1 = getSortableValue(point1[this.sortingInfo.header]);
-          const p2 = getSortableValue(point2[this.sortingInfo.header]);
-          if (p1 < p2) {
-            return this.sortingInfo.order === SortingOrder.ASCENDING ? -1 : 1;
-          }
-          if (p1 > p2) {
-            return this.sortingInfo.order === SortingOrder.ASCENDING ? 1 : -1;
-          }
+    dataTableData.sort(
+      (point1: SelectedStepRunData, point2: SelectedStepRunData) => {
+        const p1 = getSortableValue(point1[this.sortingInfo.header]);
+        const p2 = getSortableValue(point2[this.sortingInfo.header]);
+        if (p1 < p2) {
+          return this.sortingInfo.order === SortingOrder.ASCENDING ? -1 : 1;
+        }
+        if (p1 > p2) {
+          return this.sortingInfo.order === SortingOrder.ASCENDING ? 1 : -1;
+        }
 
-          return 0;
-        });
+        return 0;
+      }
+    );
     return dataTableData;
   }
 }
 
-function getSortableValue(value: number|string|undefined|null) {
-  if (Number.isNaN(value) || value === "NaN" || value === undefined || value === null) {
+function getSortableValue(value: number | string | undefined | null) {
+  if (
+    Number.isNaN(value) ||
+    value === 'NaN' ||
+    value === undefined ||
+    value === null
+  ) {
     return -Infinity;
   }
   return value;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -196,22 +196,26 @@ export class ScalarCardDataTable {
         }
         return selectedStepData;
       });
-    dataTableData.sort(
-      (point1: SelectedStepRunData, point2: SelectedStepRunData) => {
-        if (
-          point1[this.sortingInfo.header]! < point2[this.sortingInfo.header]!
-        ) {
-          return this.sortingInfo.order === SortingOrder.ASCENDING ? -1 : 1;
-        }
-        if (
-          point1[this.sortingInfo.header]! > point2[this.sortingInfo.header]!
-        ) {
-          return this.sortingInfo.order === SortingOrder.ASCENDING ? 1 : -1;
-        }
+      dataTableData.sort(
+        (point1: SelectedStepRunData, point2: SelectedStepRunData) => {
+          const p1 = getSortableValue(point1[this.sortingInfo.header]);
+          const p2 = getSortableValue(point2[this.sortingInfo.header]);
+          if (p1 < p2) {
+            return this.sortingInfo.order === SortingOrder.ASCENDING ? -1 : 1;
+          }
+          if (p1 > p2) {
+            return this.sortingInfo.order === SortingOrder.ASCENDING ? 1 : -1;
+          }
 
-        return 0;
-      }
-    );
+          return 0;
+        });
     return dataTableData;
   }
+}
+
+function getSortableValue(value: number|string|undefined|null) {
+  if (Number.isNaN(value) || value === "NaN" || value === undefined || value === null) {
+    return -Infinity;
+  }
+  return value;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2972,6 +2972,70 @@ describe('scalar card', () => {
       expect(data[1].RUN).toEqual('run1');
       expect(data[2].RUN).toEqual('run2');
     }));
+
+    it('Correctly orders NaNs', fakeAsync(() => {
+      const runToSeries = {
+        run1: [{wallTime: 1, value: 1, step: 1}],
+        run2: [{wallTime: 1, value: 2, step: 1}],
+        run3: [{wallTime: 1, value: 3, step: 1}],
+        run4: [{wallTime: 1, value: NaN, step: 1}],
+        run5: [{wallTime: 1, value: "NaN", step: 1}],
+        run6: [{wallTime: 1, value: null, step: 1}],
+        run7: [{wallTime: 1, value: undefined, step: 1}],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries as any
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+          ['run3', true],
+          ['run4', true],
+          ['run5', true],
+          ['run6', true],
+          ['run7', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsLinkedTimeSelection, {
+        start: {step: 1},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardDataTable = fixture.debugElement.query(
+        By.directive(ScalarCardDataTable)
+      );
+      scalarCardDataTable.componentInstance.sortingInfo = {
+        header: ColumnHeaders.VALUE,
+        order: SortingOrder.DESCENDING,
+      };
+      fixture.detectChanges();
+
+      const data =
+        scalarCardDataTable.componentInstance.getTimeSelectionTableData();
+
+      // expect(data[0].RUN).toEqual('run4');
+      // expect(data[1].RUN).toEqual('run5');
+      // expect(data[2].RUN).toEqual('run6');
+      // expect(data[3].RUN).toEqual('run7');
+      // expect(data[4].RUN).toEqual('run1');
+      // expect(data[5].RUN).toEqual('run2');
+      // expect(data[6].RUN).toEqual('run3');
+      expect(data[0].RUN).toEqual('run3');
+      expect(data[1].RUN).toEqual('run2');
+      expect(data[2].RUN).toEqual('run1');
+      expect(data[3].RUN).toEqual('run4');
+      expect(data[4].RUN).toEqual('run5');
+      expect(data[5].RUN).toEqual('run6');
+      expect(data[6].RUN).toEqual('run7');
+    }));
   });
 
   describe('step selector feature integration', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2979,7 +2979,7 @@ describe('scalar card', () => {
         run2: [{wallTime: 1, value: 2, step: 1}],
         run3: [{wallTime: 1, value: 3, step: 1}],
         run4: [{wallTime: 1, value: NaN, step: 1}],
-        run5: [{wallTime: 1, value: "NaN", step: 1}],
+        run5: [{wallTime: 1, value: 'NaN', step: 1}],
         run6: [{wallTime: 1, value: null, step: 1}],
         run7: [{wallTime: 1, value: undefined, step: 1}],
       };
@@ -3021,13 +3021,6 @@ describe('scalar card', () => {
       const data =
         scalarCardDataTable.componentInstance.getTimeSelectionTableData();
 
-      // expect(data[0].RUN).toEqual('run4');
-      // expect(data[1].RUN).toEqual('run5');
-      // expect(data[2].RUN).toEqual('run6');
-      // expect(data[3].RUN).toEqual('run7');
-      // expect(data[4].RUN).toEqual('run1');
-      // expect(data[5].RUN).toEqual('run2');
-      // expect(data[6].RUN).toEqual('run3');
       expect(data[0].RUN).toEqual('run3');
       expect(data[1].RUN).toEqual('run2');
       expect(data[2].RUN).toEqual('run1');


### PR DESCRIPTION
* Motivation for features / changes
Sorting in a column which contains `NaN` in the data table used to break the sorting.

* Technical description of changes
Sorting was broken because `NaN` values were actually being passed in as strings which lead to all the values in the column being sorted as though they were strings. To resolve this I translate all values into "sortable" versions which serves to additionally guard against other potentially problematic types.

* Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard with a logdir which contains runs with `NaN` values.
2) Go to localhost:6006?enableDataTable
3) Enable step selection and select a step in a scalar card where some but not all values are `NaN`
4) Sort the table by the `value` column and ensure that sorting makes sense.

* Alternate designs / implementations considered
We could run all incoming series data through a map and convert the string `"NaN"` to `NaN` so sorting would work. That solution seems a bit hackier though and doesn't do as much to guard against other sorting anomalies.