### PR TITLE
Bug Fix: Histogram fob fades when dragged to the bottom

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.scss
@@ -69,7 +69,6 @@ limitations under the License.
 .axis ::ng-deep {
   @include tb-theme-foreground-prop(color, secondary-text);
   position: relative;
-  overflow: hidden;
 
   .domain,
   .tick text {
@@ -108,20 +107,6 @@ svg {
 
 .y-axis {
   grid-area: y-axis;
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    #0000 0%,
-    #000 10%,
-    #000 90%,
-    #0000 100%
-  );
-  mask-image: linear-gradient(
-    to bottom,
-    #0000 0%,
-    #000 10%,
-    #000 90%,
-    #0000 100%
-  );
 
   .tooltip {
     dominant-baseline: middle;

--- a/tensorboard/webapp/widgets/histogram/histogram_component.scss
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.scss
@@ -69,6 +69,7 @@ limitations under the License.
 .axis ::ng-deep {
   @include tb-theme-foreground-prop(color, secondary-text);
   position: relative;
+  overflow: hidden;
 
   .domain,
   .tick text {
@@ -107,6 +108,7 @@ svg {
 
 .y-axis {
   grid-area: y-axis;
+  overflow: clip visible;
 
   .tooltip {
     dominant-baseline: middle;


### PR DESCRIPTION
* Motivation for features / changes
When the fob is dragged to the bottom of the histogram it is cut off and hidden behind a box shadow

* Technical description of changes
Remove the problematic box shadow and enable overflow.
Note: Overflow should be fine because the fob is bounded

* Screenshots of UI changes
Before
![c05094bc-adfd-463c-af48-e80a1a05973a](https://user-images.githubusercontent.com/78179109/192655501-be49a5f4-ef53-443b-a811-b291400a2864.gif)

After
![3cf9e831-ca93-4e6f-ac81-4022ba3b9427](https://user-images.githubusercontent.com/78179109/192655216-0e048b34-b1da-4897-b598-bf9cb80db77d.gif)

* Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Go to localhost:6006?enableLinkedTime
3) Enable linked time in the settings panel (the fob only appears on the histogram card when linked time is enabled)
4) On a histogram card drag the fob to the bottom and note the appearance does not change
5) Drag fobs around on a scalar card and note that it is unchanged.
