### PR TITLE
cleanup: Run force_svg_data_source_test only once.

### DIFF
--- a/tensorboard/webapp/feature_flag/BUILD
+++ b/tensorboard/webapp/feature_flag/BUILD
@@ -60,9 +60,9 @@ tf_ts_library(
         "force_svg_data_source_test.ts",
     ],
     deps = [
-      ":force_svg_data_source",
-      "//tensorboard/webapp/angular:expect_angular_core_testing",
-      "@npm//@types/jasmine",
+        ":force_svg_data_source",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "@npm//@types/jasmine",
     ],
 )
 

--- a/tensorboard/webapp/feature_flag/BUILD
+++ b/tensorboard/webapp/feature_flag/BUILD
@@ -45,22 +45,31 @@ tf_ts_library(
     name = "testing",
     testonly = True,
     srcs = [
-        "force_svg_data_source_test.ts",
         "testing.ts",
     ],
     deps = [
-        ":force_svg_data_source",
         ":types",
-        "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/feature_flag/store:feature_flag_metadata",
-        "//tensorboard/webapp/webapp_data_source:feature_flag_types",
-        "@npm//@types/jasmine",
+    ],
+)
+
+tf_ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = [
+        "force_svg_data_source_test.ts",
+    ],
+    deps = [
+      ":force_svg_data_source",
+      "//tensorboard/webapp/angular:expect_angular_core_testing",
+      "@npm//@types/jasmine",
     ],
 )
 
 tf_ng_web_test_suite(
     name = "karma_test",
     deps = [
+        ":test_lib",
         "//tensorboard/webapp/feature_flag/effects:effects_test_lib",
         "//tensorboard/webapp/feature_flag/http:http_test_lib",
         "//tensorboard/webapp/feature_flag/store:store_test_lib",


### PR DESCRIPTION
force_svg_data_source_test.ts is run multiple times in our test suite. We want to run it only one time.

It gets run multiple times because it is grouped with tensorboard/webapp/feature_flag/testing.ts in the same tf_ts_library and thus is accidentally depended on by multiple karma test suite targets.

This change refactors force_svg_data_source_test.ts into its own tf_ts_library and changes tensorboard/webapp/feature_flag:karma_test to explicitly depend on that library. Thus the force_svg_data_source_test.ts is run exactly once as part of feature flag tests.