### PR TITLE
Step Selector: Enable Range Selection for Scalar Card

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -174,8 +174,7 @@ limitations under the License.
     <scalar-card-data-table
       [chartMetadataMap]="chartMetadataMap"
       [dataSeries]="dataSeries"
-      [linkedTimeSelection]="linkedTimeSelection"
-      [stepSelectorTimeSelection]="stepSelectorTimeSelection"
+      [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection"
       [dataHeaders]="dataHeaders"
       [sortingInfo]="sortingInfo"
       (sortDataBy)="sortDataBy($event)"
@@ -189,23 +188,23 @@ limitations under the License.
   let-domDim="domDimension"
   let-xScale="xScale"
 >
-  <ng-container *ngIf="linkedTimeSelection">
+  <ng-container *ngIf="stepOrLinkedTimeSelection">
     <div
       [ngClass]="{
         'out-of-selected-time': true,
         start: true,
-        range: !!linkedTimeSelection.endStep
+        range: !!stepOrLinkedTimeSelection.end?.step
       }"
       [style.right]="
         xScale.forward(
           viewExtent.x,
           [domDim.width, 0],
-          linkedTimeSelection.startStep
+          stepOrLinkedTimeSelection.start.step
         ) + 'px'
       "
     ></div>
     <div
-      *ngIf="linkedTimeSelection.endStep"
+      *ngIf="stepOrLinkedTimeSelection.end?.step"
       [ngClass]="{
         'out-of-selected-time': true,
         end: true,
@@ -215,7 +214,7 @@ limitations under the License.
         xScale.forward(
           viewExtent.x,
           [0, domDim.width],
-          linkedTimeSelection.endStep
+          stepOrLinkedTimeSelection.end?.step
         ) + 'px'
       "
     ></div>
@@ -230,7 +229,7 @@ limitations under the License.
 >
   <ng-container *ngIf="inTimeSelectionMode()">
     <scalar-card-fob-controller
-      [timeSelection]="getTimeSelection()"
+      [timeSelection]="stepOrLinkedTimeSelection"
       [scale]="xScale"
       [minMax]="viewExtent.x"
       [axisSize]="domDim.width"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -91,7 +91,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() useDarkMode!: boolean;
   @Input() forceSvg!: boolean;
   @Input() linkedTimeSelection!: TimeSelectionView | null;
-  @Input() stepSelectorTimeSelection!: TimeSelection;
+  @Input() stepOrLinkedTimeSelection!: TimeSelection | null;
   @Input() minMaxStep!: MinMaxStep;
   @Input() dataHeaders!: ColumnHeaders[];
 
@@ -216,21 +216,6 @@ export class ScalarCardComponent<Downloader> {
     });
   }
 
-  getTimeSelection(): TimeSelection | null {
-    if (this.linkedTimeSelection === null) {
-      return this.stepSelectorTimeSelection;
-    }
-
-    return {
-      start: {
-        step: this.linkedTimeSelection.startStep,
-      },
-      end: this.linkedTimeSelection.endStep
-        ? {step: this.linkedTimeSelection.endStep}
-        : null,
-    };
-  }
-
   onFobRemoved() {
     this.onStepSelectorToggled.emit(TimeSelectionToggleAffordance.FOB_DESELECT);
   }
@@ -238,8 +223,7 @@ export class ScalarCardComponent<Downloader> {
   inTimeSelectionMode(): boolean {
     return (
       this.xAxisType === XAxisType.STEP &&
-      (this.stepSelectorTimeSelection !== null ||
-        this.linkedTimeSelection !== null)
+      this.stepOrLinkedTimeSelection !== null
     );
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -30,7 +30,6 @@ import {
   SortingInfo,
   SortingOrder,
 } from './scalar_card_types';
-import {TimeSelectionView} from './utils';
 
 @Component({
   selector: 'scalar-card-data-table',
@@ -47,8 +46,7 @@ import {TimeSelectionView} from './utils';
 export class ScalarCardDataTable {
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
   @Input() dataSeries!: ScalarCardDataSeries[];
-  @Input() linkedTimeSelection!: TimeSelectionView | null;
-  @Input() stepSelectorTimeSelection!: TimeSelection;
+  @Input() stepOrLinkedTimeSelection!: TimeSelection;
   @Input() dataHeaders!: ColumnHeaders[];
   @Input() sortingInfo!: SortingInfo;
 
@@ -83,18 +81,11 @@ export class ScalarCardDataTable {
   }
 
   getTimeSelectionTableData(): SelectedStepRunData[] {
-    if (
-      this.linkedTimeSelection === null &&
-      this.stepSelectorTimeSelection === null
-    ) {
+    if (this.stepOrLinkedTimeSelection === null) {
       return [];
     }
-    const startStep = this.linkedTimeSelection
-      ? this.linkedTimeSelection.startStep
-      : this.stepSelectorTimeSelection.start.step;
-    const endStep = this.linkedTimeSelection
-      ? this.linkedTimeSelection.endStep
-      : this.stepSelectorTimeSelection.end?.step;
+    const startStep = this.stepOrLinkedTimeSelection.start.step;
+    const endStep = this.stepOrLinkedTimeSelection.end?.step;
     const dataTableData: SelectedStepRunData[] = this.dataSeries
       .filter((datum) => {
         const metadata = this.chartMetadataMap[datum.id];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -78,6 +78,7 @@ import {PluginType} from '../../data_source';
 import {
   getMetricsLinkedTimeEnabled,
   getMetricsLinkedTimeSelection,
+  getMetricsRangeSelectionEnabled,
   getMetricsScalarSmoothing,
 } from '../../store';
 import {
@@ -3074,6 +3075,7 @@ describe('scalar card', () => {
           start: {step: 20},
           end: null,
         });
+        store.overrideSelector(getMetricsRangeSelectionEnabled, false);
         const fixture = createComponent('card1');
         fixture.detectChanges();
         const testController = fixture.debugElement.query(
@@ -3124,7 +3126,7 @@ describe('scalar card', () => {
           By.directive(ScalarCardComponent)
         );
         expect(
-          scalarCardComponent.componentInstance.stepSelectorTimeSelection
+          scalarCardComponent.componentInstance.stepOrLinkedTimeSelection
         ).toEqual({
           start: {step: 25},
           end: null,


### PR DESCRIPTION
~Blocked by #5962~
~Blocked by #5965~

# Motivation for features / changes
We would like the feature to view data related to a range of steps.

# Technical description of changes
Now that both step selection and linked time selection both support range selection I am merging the object used to pass their values down through the scalar card component tree. This provides an opaque interface for the sub-components to utilize without needing to care about whether linked time is enabled.

# Screenshots of UI changes
## Enabling Range Selection
![771710fb-bbcd-4914-ab26-7b8dd8a2af8f](https://user-images.githubusercontent.com/78179109/194162018-0cc9b60b-b365-4a28-8fd7-5353bb67e9c8.gif)

## Disabling Range Selection
![49ff19c9-915d-40fe-a4db-c1d71343d6d9](https://user-images.githubusercontent.com/78179109/194162122-fde53b52-c9e5-4e8d-a8e4-5602b262b9d9.gif)
![33b28465-0f0f-414a-8743-a69cf135916e](https://user-images.githubusercontent.com/78179109/194162206-938a8731-75c9-44df-8d28-12d70c92fdf7.gif)
![b98ac7bd-a8e5-4300-823e-3f1599cf5644](https://user-images.githubusercontent.com/78179109/194162261-0de4c4f9-434d-41ac-950f-58249013b3ae.gif)

## Enabling Linked Time With Range Selection
![eb6150e1-117c-4adc-b766-5f1f7cb5deee](https://user-images.githubusercontent.com/78179109/194176186-e729cb78-cb70-44ad-8450-1637bfe2b0fe.gif)

## Enabling Range Selection With Linked Time
![e7162159-9f4d-4ca3-ba7c-57d101c9664d](https://user-images.githubusercontent.com/78179109/194176308-7d2ca623-b494-4abe-af93-42391fdfa4d7.gif)


# Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard with an experiment containing a scalar and histogram card
2) Navigate to http://localhost:6006?enableLinkedTime&enableRangeSelection&enableDataTable
3) Click the "Enable Range Selection" checkbox
![image](https://user-images.githubusercontent.com/78179109/194176417-4234490e-a5bf-496d-9f32-443a2baa053c.png)
4) Assert the the scalar card has two fobs
![image](https://user-images.githubusercontent.com/78179109/194176543-c718e2ae-324a-49ab-b139-d99cdfb85884.png)
5) Assert the scalar card data table is in range mode
![image](https://user-images.githubusercontent.com/78179109/194176783-bd380688-0fe3-4af8-b6cc-e186089ae71c.png)
![image](https://user-images.githubusercontent.com/78179109/194176874-5f9326b0-a90b-4be2-b077-42d943b9539e.png)
6) Disable "Enable Range Selection
7) Assert the second fob disappears from the scalar card
8) Enable "Link By Step"
9) Enable "Enable Range Selection"
10) Assert the fob reappears in the correct position.

