### PR TITLE
Step Selector: Add action to sorting data table for metrics

### DIFF
--- a/tensorboard/webapp/metrics/actions/BUILD
+++ b/tensorboard/webapp/metrics/actions/BUILD
@@ -12,6 +12,7 @@ tf_ts_library(
     deps = [
         "//tensorboard/webapp/metrics:internal_types",
         "//tensorboard/webapp/metrics/data_source",
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/util:dom",
         "//tensorboard/webapp/widgets/card_fob:types",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -30,6 +30,7 @@ import {
   TooltipSort,
   XAxisType,
 } from '../internal_types';
+import {SortingInfo} from '../views/card_renderer/scalar_card_types';
 
 export const metricsSettingsPaneClosed = createAction(
   '[Metrics] Metrics Settings Pane Closed'
@@ -189,6 +190,11 @@ export const linkedTimeToggled = createAction(
     // undefined we do not want to log an analytics event.
     affordance?: TimeSelectionToggleAffordance;
   }>()
+);
+
+export const sortingDataTable = createAction(
+  '[Metrics] Sorting Data Table By Header',
+  props<SortingInfo>()
 );
 
 export const stepSelectorToggled = createAction(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -103,6 +103,7 @@ export class ScalarCardComponent<Downloader> {
   }>();
   @Output() onStepSelectorToggled =
     new EventEmitter<TimeSelectionToggleAffordance>();
+  @Output() onDataTableSorting = new EventEmitter<SortingInfo>();
 
   @Output() onLineChartZoom = new EventEmitter<Extent>();
 
@@ -126,6 +127,7 @@ export class ScalarCardComponent<Downloader> {
 
   sortDataBy(sortingInfo: SortingInfo) {
     this.sortingInfo = sortingInfo;
+    this.onDataTableSorting.emit(sortingInfo);
   }
 
   resetDomain() {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -66,7 +66,11 @@ import {
 import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer';
 import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
-import {stepSelectorToggled, timeSelectionChanged} from '../../actions';
+import {
+  sortingDataTable,
+  stepSelectorToggled,
+  timeSelectionChanged,
+} from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
   getCardLoadState,
@@ -92,6 +96,7 @@ import {
   ScalarCardPoint,
   ScalarCardSeriesMetadataMap,
   SeriesType,
+  SortingInfo,
 } from './scalar_card_types';
 import {
   maybeClipLinkedTimeSelection,
@@ -158,6 +163,7 @@ function areSeriesEqual(
       (onVisibilityChange)="onVisibilityChange($event)"
       (onTimeSelectionChanged)="onTimeSelectionChanged($event)"
       (onStepSelectorToggled)="onStepSelectorToggled($event)"
+      (onDataTableSorting)="onDataTableSorting($event)"
       (onLineChartZoom)="onLineChartZoom($event)"
     ></scalar-card-component>
   `,
@@ -607,6 +613,10 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         relativeTimeInMs: 0,
       };
     });
+  }
+
+  onDataTableSorting(sortingInfo: SortingInfo) {
+    this.store.dispatch(sortingDataTable(sortingInfo));
   }
 
   onTimeSelectionChanged(


### PR DESCRIPTION
* Motivation for features / changes
We want to track some metrics to see if users are utilizing the sort by feature in the data table. In order to do that we need to fire an action when sorting. This PR fires that action. Note: currently nothing happens on this action but, it sill get hooked into the metrics logging from the internal code for our hosted services.

* Detailed steps to verify changes work correctly (as executed by you)
I created a reducer which fired from that action and console logged the info just to ensure it fired. Then removed that reducer.