### PR TITLE
chore: Explicitly mark tensorboard/summary:repl.sh as executable.

### DIFF
--- a/tensorboard/defs/py_repl.bzl
+++ b/tensorboard/defs/py_repl.bzl
@@ -17,13 +17,14 @@
 # Minimal wrapper over ctx.actions.write to write a string to a file.
 # Simpler than the genrule equivalent since we don't need to escape.
 def _write_file_impl(ctx):
-    ctx.actions.write(ctx.outputs.out, ctx.attr.content)
+    ctx.actions.write(ctx.outputs.out, ctx.attr.content, ctx.attr.is_executable)
 
 _write_file = rule(
     implementation = _write_file_impl,
     attrs = {
         "out": attr.output(mandatory = True),
         "content": attr.string(),
+        "is_executable": attr.bool(default = False),
     },
 )
 
@@ -93,6 +94,7 @@ def py_repl(name, preamble = None, deps = None, **kwargs):
         name = name + "_sh_gen",
         out = name + ".sh",
         content = "PYTHONINSPECT=1 exec $1",
+        is_executable = True,
     )
 
     # Use `args` to pass the location of the data dep which is shorter


### PR DESCRIPTION
* Motivation for features / changes

  Building tensorboard/summary:repl in the internal Google repo does not succeed:
  
  ```
  $ blaze clean
  $ blaze build third_party/tensorboard/summary:repl
  <snip>
  ERROR: /google/src/cloud/bdubois/hgtb/google3/third_party/tensorboard/summary/BUILD:199:8: Symlinking //third_party/tensorboard/summary:repl failed: failed to create symbolic link 'blaze-out/k8-fastbuild/bin/third_party/tensorboard/summary/repl': file 'blaze-out/k8-fastbuild/bin/third_party/tensorboard/summary/repl.sh' is not executable
  Target //third_party/tensorboard/summary:repl failed to build
  ```
  
  Notably this means we cannot `blaze build third_party/tensorboard/...`

* Technical description of changes
  
  Explicitly set repl.sh to executable when creating the file. ctx.actions.write() already has a is_executable argument so we just make sure we pass that information to the call.
  
* Detailed steps to verify changes work correctly (as executed by you)
  
  Ensure the public repl target still builds and runs:
  
  ```
  $ bazel clean
  $ bazel run tensorboard/summary:repl
  <snip>
  INFO: Running command line: bazel-bin/tensorboard/summary/repl tensorboard/summary/replINFO: Build completed successfully, 353 total actions
  from tensorboard.summary import Writer
  w = Writer("/tmp/foo")
  <snip>
  >>> w
  <tensorboard.summary._writer.Writer object at 0x7fcb963b36d0>
  >>> ^D
  ```

  Also:
  ```
  $ bazel run tensorboard:repl
  <snip>
  >>> import tensorboard.version
  >>> tensorboard.version.VERSION
  '2.11.0a0'
  >>> ^D
  ```
  
  Ensure the internal repl target builds and runs (although it doesn't really run very well):
  ```
  $ blaze clean
  $ blaze run third_party/tensorboard/summary:repl
  <snip>
  INFO: Build completed successfully, 10794 total actions
  from tensorboard.summary import Writer
  Traceback (most recent call last):
    File "<embedded module '_launcher'>", line 161, in run_filename_as_main
    File "<embedded module '_launcher'>", line 34, in _run_code_in_main
    File "/google/obj/workspace/d158cd457c2f2d42871081a28ab8f0450727dfae657c8d81f94250519e7c2b33/aa8a6db3-9d3c-4311-9b48-2ebb00c7a968/blaze-out/k8-fastbuild/bin/third_party/tensorboard/summary/repl.runfiles/google3/third_party/tensorboard/summary/repl.py", line 2, in <module>
      exec("from tensorboard.summary import Writer")
    File "<string>", line 1, in <module>
  ModuleNotFoundError: No module named 'tensorboard'
  ```
