### PR TITLE
Bug Fix: Prevent toggling range from resetting time selection

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -604,39 +604,30 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
       this.minMaxSteps$,
       this.store.select(getMetricsStepSelectorEnabled),
       this.store.select(getMetricsRangeSelectionEnabled),
-    ]).subscribe(([minMaxStep, enableStepSelector, rangeSelectionEnabled]) => {
-      this.stepSelectorTimeSelection$.next(
-        this.computeStepSelectorTimeSelection(
-          minMaxStep,
-          enableStepSelector,
-          rangeSelectionEnabled
-        )
-      );
-    });
+    ]).subscribe(
+      ([{minStep, maxStep}, enableStepSelector, rangeSelectionEnabled]) => {
+        this.stepSelectorTimeSelection$.next(
+          enableStepSelector
+            ? {
+                start: {
+                  step: clipStepWithinMinMax(
+                    this.stepSelectorTimeSelection$.getValue()?.start.step ??
+                      minStep,
+                    minStep,
+                    maxStep
+                  ),
+                },
+                end: rangeSelectionEnabled ? {step: maxStep} : null,
+              }
+            : null
+        );
+      }
+    );
   }
 
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
-  }
-
-  computeStepSelectorTimeSelection(
-    {minStep, maxStep}: MinMaxStep,
-    enableStepSelector: boolean,
-    rangeSelectionEnabled: boolean
-  ) {
-    return enableStepSelector
-      ? {
-          start: {
-            step: clipStepWithinMinMax(
-              this.stepSelectorTimeSelection$.getValue()?.start.step ?? minStep,
-              minStep,
-              maxStep
-            ),
-          },
-          end: rangeSelectionEnabled ? {step: maxStep} : null,
-        }
-      : null;
   }
 
   private getRunDisplayNameAndAlias(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2154,6 +2154,112 @@ describe('scalar card', () => {
           fobs[0].query(By.css('span')).nativeElement.textContent.trim()
         ).toEqual('30');
       }));
+
+      describe('computeStepSelectorTimeSelection', () => {
+        beforeEach(() => {
+          provideMockCardRunToSeriesData(
+            selectSpy,
+            PluginType.SCALARS,
+            'card1',
+            null /* metadataOverride */,
+            {}
+          );
+        });
+
+        it('returns null when step selection is disable', fakeAsync(() => {
+          const fixture = createComponent('card1');
+          const timeSelection =
+            fixture.componentInstance.computeStepSelectorTimeSelection(
+              {
+                minStep: 0,
+                maxStep: 50,
+              },
+              false,
+              false
+            );
+          expect(timeSelection).toBeNull();
+        }));
+
+        it('time selection defaults to min/max', fakeAsync(() => {
+          const fixture = createComponent('card1');
+          const timeSelection =
+            fixture.componentInstance.computeStepSelectorTimeSelection(
+              {
+                minStep: 0,
+                maxStep: 50,
+              },
+              true,
+              true
+            );
+          expect(timeSelection).toEqual({
+            start: {step: 0},
+            end: {step: 50},
+          });
+        }));
+
+        it('uses existing min step when defined', fakeAsync(() => {
+          const fixture = createComponent('card1');
+          fixture.componentInstance.stepSelectorTimeSelection$.next({
+            start: {step: 10},
+            end: {step: 50},
+          });
+          const timeSelection =
+            fixture.componentInstance.computeStepSelectorTimeSelection(
+              {
+                minStep: 0,
+                maxStep: 50,
+              },
+              true,
+              true
+            );
+          expect(timeSelection).toEqual({
+            start: {step: 10},
+            end: {step: 50},
+          });
+        }));
+
+        it('removes end step when range is disabled', fakeAsync(() => {
+          const fixture = createComponent('card1');
+          fixture.componentInstance.stepSelectorTimeSelection$.next({
+            start: {step: 10},
+            end: {step: 50},
+          });
+          const timeSelection =
+            fixture.componentInstance.computeStepSelectorTimeSelection(
+              {
+                minStep: 0,
+                maxStep: 50,
+              },
+              true,
+              false
+            );
+          expect(timeSelection).toEqual({
+            start: {step: 10},
+            end: null,
+          });
+        }));
+
+        it('cannot generate steps outside min/max', fakeAsync(() => {
+          const fixture = createComponent('card1');
+          fixture.componentInstance.stepSelectorTimeSelection$.next({
+            start: {step: 10},
+            end: {step: 50},
+          });
+          const timeSelection =
+            fixture.componentInstance.computeStepSelectorTimeSelection(
+              {
+                minStep: 20,
+                maxStep: 30,
+              },
+              true,
+              true
+            );
+          expect(timeSelection).toEqual({
+            start: {step: 20},
+            end: {step: 30},
+          });
+        }));
+      });
     });
 
     describe('fob controls', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -80,6 +80,7 @@ import {
   getMetricsLinkedTimeSelection,
   getMetricsRangeSelectionEnabled,
   getMetricsScalarSmoothing,
+  getMetricsStepSelectorEnabled,
 } from '../../store';
 import {
   appStateFromMetricsState,
@@ -2155,7 +2156,7 @@ describe('scalar card', () => {
         ).toEqual('30');
       }));
 
-      describe('computeStepSelectorTimeSelection', () => {
+      describe('stepSelectorTimeSelection', () => {
         beforeEach(() => {
           provideMockCardRunToSeriesData(
             selectSpy,
@@ -2166,95 +2167,73 @@ describe('scalar card', () => {
           );
         });
 
-        it('returns null when step selection is disable', fakeAsync(() => {
-          const fixture = createComponent('card1');
-          const timeSelection =
-            fixture.componentInstance.computeStepSelectorTimeSelection(
-              {
-                minStep: 0,
-                maxStep: 50,
-              },
-              false,
-              false
-            );
-          expect(timeSelection).toBeNull();
-        }));
-
         it('defaults to min/max', fakeAsync(() => {
+          store.overrideSelector(getMetricsStepSelectorEnabled, true);
+          store.overrideSelector(getMetricsRangeSelectionEnabled, true);
           const fixture = createComponent('card1');
-          const timeSelection =
-            fixture.componentInstance.computeStepSelectorTimeSelection(
-              {
-                minStep: 0,
-                maxStep: 50,
-              },
-              true,
-              true
-            );
-          expect(timeSelection).toEqual({
+          fixture.componentInstance.minMaxSteps$.next({
+            minStep: 0,
+            maxStep: 50,
+          });
+          expect(
+            fixture.componentInstance.stepSelectorTimeSelection$.getValue()
+          ).toEqual({
             start: {step: 0},
             end: {step: 50},
           });
         }));
 
-        it('uses existing start step when defined', fakeAsync(() => {
+        it('sets end to null when range is disabled', fakeAsync(() => {
+          store.overrideSelector(getMetricsStepSelectorEnabled, true);
+          store.overrideSelector(getMetricsRangeSelectionEnabled, false);
           const fixture = createComponent('card1');
-          fixture.componentInstance.stepSelectorTimeSelection$.next({
-            start: {step: 10},
-            end: {step: 50},
+          fixture.componentInstance.minMaxSteps$.next({
+            minStep: 0,
+            maxStep: 50,
           });
-          const timeSelection =
-            fixture.componentInstance.computeStepSelectorTimeSelection(
-              {
-                minStep: 0,
-                maxStep: 50,
-              },
-              true,
-              true
-            );
-          expect(timeSelection).toEqual({
-            start: {step: 10},
-            end: {step: 50},
-          });
-        }));
-
-        it('removes end step when range is disabled', fakeAsync(() => {
-          const fixture = createComponent('card1');
-          fixture.componentInstance.stepSelectorTimeSelection$.next({
-            start: {step: 10},
-            end: {step: 50},
-          });
-          const timeSelection =
-            fixture.componentInstance.computeStepSelectorTimeSelection(
-              {
-                minStep: 0,
-                maxStep: 50,
-              },
-              true,
-              false
-            );
-          expect(timeSelection).toEqual({
-            start: {step: 10},
+          expect(
+            fixture.componentInstance.stepSelectorTimeSelection$.getValue()
+          ).toEqual({
+            start: {step: 0},
             end: null,
           });
         }));
 
-        it('cannot generate steps outside min/max', fakeAsync(() => {
+        it('uses existing start step when defined', fakeAsync(() => {
+          store.overrideSelector(getMetricsStepSelectorEnabled, true);
+          store.overrideSelector(getMetricsRangeSelectionEnabled, true);
           const fixture = createComponent('card1');
           fixture.componentInstance.stepSelectorTimeSelection$.next({
             start: {step: 10},
             end: {step: 50},
           });
-          const timeSelection =
-            fixture.componentInstance.computeStepSelectorTimeSelection(
-              {
-                minStep: 20,
-                maxStep: 30,
-              },
-              true,
-              true
-            );
-          expect(timeSelection).toEqual({
+          fixture.componentInstance.minMaxSteps$.next({
+            minStep: 0,
+            maxStep: 50,
+          });
+          expect(
+            fixture.componentInstance.stepSelectorTimeSelection$.getValue()
+          ).toEqual({
+            start: {step: 10},
+            end: {step: 50},
+          });
+        }));
+
+        it('cannot generate steps outside min/max', fakeAsync(() => {
+          store.overrideSelector(getMetricsStepSelectorEnabled, true);
+          store.overrideSelector(getMetricsRangeSelectionEnabled, true);
+          const fixture = createComponent('card1');
+          fixture.componentInstance.stepSelectorTimeSelection$.next({
+            start: {step: 10},
+            end: {step: 50},
+          });
+          fixture.componentInstance.minMaxSteps$.next({
+            minStep: 20,
+            maxStep: 30,
+          });
+          expect(
+            fixture.componentInstance.stepSelectorTimeSelection$.getValue()
+          ).toEqual({
             start: {step: 20},
             end: {step: 30},
           });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2180,7 +2180,7 @@ describe('scalar card', () => {
           expect(timeSelection).toBeNull();
         }));
 
-        it('time selection defaults to min/max', fakeAsync(() => {
+        it('defaults to min/max', fakeAsync(() => {
           const fixture = createComponent('card1');
           const timeSelection =
             fixture.componentInstance.computeStepSelectorTimeSelection(
@@ -2197,7 +2197,7 @@ describe('scalar card', () => {
           });
         }));
 
-        it('uses existing min step when defined', fakeAsync(() => {
+        it('uses existing start step when defined', fakeAsync(() => {
           const fixture = createComponent('card1');
           fixture.componentInstance.stepSelectorTimeSelection$.next({
             start: {step: 10},

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -91,7 +91,7 @@ export interface TimeSelectionView {
   clipped: boolean;
 }
 
-function clipStepWithinMinMax(value: number, min: number, max: number) {
+export function clipStepWithinMinMax(value: number, min: number, max: number) {
   if (value < min) {
     return min;
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {buildRun} from '../../../runs/store/testing';
 import {PartialSeries} from './scalar_card_types';
 import {
+  clipStepWithinMinMax,
   getClosestStep,
   getDisplayNameForRun,
   maybeClipLinkedTimeSelection,
@@ -309,6 +310,25 @@ describe('metrics card_renderer utils test', () => {
 
     it('gets closeset step equal to selected step', () => {
       expect(getClosestStep(10, [0, 10, 20])).toBe(10);
+    });
+  });
+
+  describe('#clipStepWithinMinMax', () => {
+    it('returns step if greater than min', () => {
+      expect(clipStepWithinMinMax(1, 0, 5)).toBe(1);
+    });
+
+    it('returns step if less than max', () => {
+      expect(clipStepWithinMinMax(1, 0, 5)).toBe(1);
+    });
+
+    it('returns min if greater than step', () => {
+      expect(clipStepWithinMinMax(1, 3, 5)).toBe(3);
+      expect(clipStepWithinMinMax(1, 5, 3)).toBe(5);
+    });
+
+    it('returns max if less than step', () => {
+      expect(clipStepWithinMinMax(6, 0, 5)).toBe(5);
     });
   });
 


### PR DESCRIPTION
* Motivation for features / changes
When toggling range selection the remaining fob was being set to the min value in the range.

* Screenshots of UI changes
Range Enabled:
![image](https://user-images.githubusercontent.com/78179109/195214454-bf2c3461-ea33-45b0-9210-8eb2171b6c8b.png)
Range Disabled:
![image](https://user-images.githubusercontent.com/78179109/195214485-64236a20-5967-4ddd-992a-7822e3506059.png)

See it in action
![69353c11-7537-4b81-9bf7-441c6b34fee1](https://user-images.githubusercontent.com/78179109/195214562-e1cf16f7-6960-4fa1-8314-c463c92cc525.gif)

Zooming Still Works:
![2ff41be9-598c-4bfb-8959-c4d7073b3870](https://user-images.githubusercontent.com/78179109/195214607-b057147c-bb20-411f-b9e6-89c211e61758.gif)

* Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Go to localhost:6006?enableRangeSelection
3) Enable range selection in the settings panel
4) Move both fobs on the scalar card
5) Disable range selection either via the checkbox or by removing a fob
6) Assert the remaining fob is not effected.
8) Renable range selection
7) Zoom in on the chart and assert both fobs are visible.

