### PR TITLE
Avoid parsing Text Plugin metadata b"{}"

### DIFF
--- a/tensorboard/plugins/text/metadata.py
+++ b/tensorboard/plugins/text/metadata.py
@@ -15,8 +15,6 @@
 """Internal information about the text plugin."""
 
 
-import werkzeug
-from google.protobuf import message
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.text import plugin_data_pb2
 

--- a/tensorboard/plugins/text/metadata.py
+++ b/tensorboard/plugins/text/metadata.py
@@ -58,12 +58,6 @@ def parse_plugin_metadata(content):
     if content == b"{}":
         # Old-style JSON format. Equivalent to an all-default proto.
         return plugin_data_pb2.TextPluginData()
-    try:
-        result = plugin_data_pb2.TextPluginData.FromString(content)
-    except (message.DecodeError, TypeError) as e:
-        raise werkzeug.exceptions.InternalServerError(
-            "Failed to parse plugin metadata {}: {}".format(content, str(e))
-        )
     result = plugin_data_pb2.TextPluginData.FromString(content)
     if result.version == 0:
         return result


### PR DESCRIPTION
## Motivation for features / changes
There is a library that emits b"{}" as the plugin's metadata, which triggers 500 errors in the Text Plugin server code ([b/250789176](https://b.corp.google.com/issues/250789176)):

```
google3.net.proto2.python.public.message.DecodeError: Error parsing message with type 'tensorboard.TextPluginData'
```

## Technical description of changes
This commit handles the edge case by returning a TextPluginData default proto without parsing the metadata. 

## Screenshots of UI changes
- For the edge case that feeds in b"{}", users will see something like <img width="1213" alt="image" src="https://user-images.githubusercontent.com/88216042/195389659-a75660ce-01e4-4ecd-ace3-19b11cadfa07.png"> rather than an "Internal server error" page. 

## Detailed steps to verify changes work correctly (as executed by you)
Open the browser and enter the TextPlugin metadata endpoint of an experiment that generates the invalid metadata, e.g. `experiment/4725997998739972179/data/plugin/text/tags` and you should see the resulting valid metadata. 