### PR TITLE
projector: fix label/color legend

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html.ts
@@ -347,7 +347,7 @@ export const template = html`
           coloring by a given metadata field.
         </paper-tooltip>
       </div>
-      <template dom-if="[[colorLegendRenderInfo]]">
+      <template is="dom-if" if="[[colorLegendRenderInfo]]">
         <vz-projector-legend
           render-info="[[colorLegendRenderInfo]]"
         ></vz-projector-legend>


### PR DESCRIPTION
## Motivation for features / changes

Inside the projector plugin, a legend for labels/colors should appear when selecting a field from the "Color by" drop-down menu yet is not displayed.

## Technical description of changes

The `dom-if` property is misconfigured for the `vz-projector-legend` template.

## Screenshots of UI changes
Before: 
<img width="301" alt="before" src="https://user-images.githubusercontent.com/41620979/195603764-443cf730-2541-4827-b6c7-bd3348618e97.png">

After: 
<img width="298" alt="after" src="https://user-images.githubusercontent.com/41620979/195603792-5b780db5-56a0-4bc5-b3bc-45b544f6e6c3.png">

## Detailed steps to verify changes work correctly (as executed by you)

- Run the vz-projector in standalone mode
- Use the default [`standalone_projector_config.json`](tensorboard/plugins/projector/vz_projector/standalone_projector_config.json) as config file (if run locally you need a simple webserver to serve the file via http)
- Select the *Iris* tensor, then select "Class" under the "Color by" drop-down menu.
- See the label/color legend appear just below
