### PR TITLE
Step Selector: Persist step selection settings.

### DIFF
--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -27,7 +27,10 @@ import {MetricsEffects} from './effects';
 import {
   getMetricsCardMinWidth,
   getMetricsIgnoreOutliers,
+  getMetricsLinkedTimeEnabled,
+  getMetricsRangeSelectionEnabled,
   getMetricsScalarSmoothing,
+  getMetricsStepSelectorEnabled,
   getMetricsTooltipSort,
   isMetricsSettingsPaneOpen,
   METRICS_FEATURE_KEY,
@@ -95,6 +98,22 @@ export function getMetricsTimeSeriesCardMinWidth() {
     return {timeSeriesCardMinWidth: cardMinWidth};
   });
 }
+export function getMetricsTimeSeriesStepSelectorEnabled() {
+  return createSelector(getMetricsStepSelectorEnabled, (isEnabled) => {
+    return {stepSelectorEnabled: isEnabled};
+  });
+}
+
+export function getMetricsTimeSeriesRangeSelectionEnabled() {
+  return createSelector(getMetricsRangeSelectionEnabled, (isEnabled) => {
+    return {rangeSelectionEnabled: isEnabled};
+  });
+}
+export function getMetricsTimeSeriesLinkedTimeEnabled() {
+  return createSelector(getMetricsLinkedTimeEnabled, (isEnabled) => {
+    return {linkedTimeEnabled: isEnabled};
+  });
+}
 
 @NgModule({
   imports: [
@@ -128,6 +147,15 @@ export function getMetricsTimeSeriesCardMinWidth() {
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
       getMetricsTimeSeriesCardMinWidth
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsTimeSeriesStepSelectorEnabled
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsTimeSeriesRangeSelectionEnabled
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsTimeSeriesLinkedTimeEnabled
     ),
   ],
   providers: [

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -436,10 +436,19 @@ const reducer = createReducer(
 
     const isSettingsPaneOpen =
       partialSettings.timeSeriesSettingsPaneOpened ?? state.isSettingsPaneOpen;
+    const stepSelectorEnabled =
+      partialSettings.stepSelectorEnabled ?? state.stepSelectorEnabled;
+    const rangeSelectionEnabled =
+      partialSettings.rangeSelectionEnabled ?? state.rangeSelectionEnabled;
+    const linkedTimeEnabled =
+      partialSettings.linkedTimeEnabled ?? state.linkedTimeEnabled;
 
     return {
       ...state,
       isSettingsPaneOpen,
+      stepSelectorEnabled,
+      rangeSelectionEnabled,
+      linkedTimeEnabled,
       settings: {
         ...state.settings,
         ...metricsSettings,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2414,6 +2414,29 @@ describe('metrics reducers', () => {
     });
   });
 
+  it('loads Step Selector Setting into the next state', () => {
+    const beforeState = buildMetricsState({
+      stepSelectorEnabled: false,
+      rangeSelectionEnabled: false,
+      linkedTimeEnabled: false,
+    });
+
+    const nextState = reducers(
+      beforeState,
+      globalSettingsLoaded({
+        partialSettings: {
+          stepSelectorEnabled: true,
+          rangeSelectionEnabled: true,
+          linkedTimeEnabled: true,
+        },
+      })
+    );
+
+    expect(nextState.stepSelectorEnabled).toBe(true);
+    expect(nextState.rangeSelectionEnabled).toBe(true);
+    expect(nextState.linkedTimeEnabled).toBe(true);
+  });
+
   describe('linked time features', () => {
     describe('#timeSelectionChanged', () => {
       const imageCardId = 'test image card id "plugin":"images"';

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2426,14 +2426,54 @@ describe('metrics reducers', () => {
       globalSettingsLoaded({
         partialSettings: {
           stepSelectorEnabled: true,
-          rangeSelectionEnabled: true,
-          linkedTimeEnabled: true,
         },
       })
     );
 
     expect(nextState.stepSelectorEnabled).toBe(true);
+    expect(nextState.rangeSelectionEnabled).toBe(false);
+    expect(nextState.linkedTimeEnabled).toBe(false);
+  });
+
+  it('loads Step Selector Setting into the next state', () => {
+    const beforeState = buildMetricsState({
+      stepSelectorEnabled: false,
+      rangeSelectionEnabled: false,
+      linkedTimeEnabled: false,
+    });
+
+    const nextState = reducers(
+      beforeState,
+      globalSettingsLoaded({
+        partialSettings: {
+          rangeSelectionEnabled: true,
+        },
+      })
+    );
+
+    expect(nextState.stepSelectorEnabled).toBe(false);
     expect(nextState.rangeSelectionEnabled).toBe(true);
+    expect(nextState.linkedTimeEnabled).toBe(false);
+  });
+
+  it('loads Step Selector Setting into the next state', () => {
+    const beforeState = buildMetricsState({
+      stepSelectorEnabled: false,
+      rangeSelectionEnabled: false,
+      linkedTimeEnabled: false,
+    });
+
+    const nextState = reducers(
+      beforeState,
+      globalSettingsLoaded({
+        partialSettings: {
+          linkedTimeEnabled: true,
+        },
+      })
+    );
+
+    expect(nextState.stepSelectorEnabled).toBe(false);
+    expect(nextState.rangeSelectionEnabled).toBe(false);
     expect(nextState.linkedTimeEnabled).toBe(true);
   });
 

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -84,6 +84,16 @@ export class OSSSettingsConverter extends SettingsConverter<
       serializableSettings.timeSeriesCardMinWidth =
         settings.timeSeriesCardMinWidth;
     }
+    if (settings.stepSelectorEnabled !== undefined) {
+      serializableSettings.stepSelectorEnabled = settings.stepSelectorEnabled;
+    }
+    if (settings.rangeSelectionEnabled !== undefined) {
+      serializableSettings.rangeSelectionEnabled =
+        settings.rangeSelectionEnabled;
+    }
+    if (settings.linkedTimeEnabled !== undefined) {
+      serializableSettings.linkedTimeEnabled = settings.linkedTimeEnabled;
+    }
     return serializableSettings;
   }
 
@@ -167,6 +177,27 @@ export class OSSSettingsConverter extends SettingsConverter<
       typeof backendSettings.timeSeriesCardMinWidth === 'number'
     ) {
       settings.timeSeriesCardMinWidth = backendSettings.timeSeriesCardMinWidth;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('stepSelectorEnabled') &&
+      typeof backendSettings.stepSelectorEnabled === 'boolean'
+    ) {
+      settings.stepSelectorEnabled = backendSettings.stepSelectorEnabled;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('rangeSelectionEnabled') &&
+      typeof backendSettings.rangeSelectionEnabled === 'boolean'
+    ) {
+      settings.rangeSelectionEnabled = backendSettings.rangeSelectionEnabled;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('linkedTimeEnabled') &&
+      typeof backendSettings.linkedTimeEnabled === 'boolean'
+    ) {
+      settings.linkedTimeEnabled = backendSettings.linkedTimeEnabled;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -141,6 +141,46 @@ describe('persistent_settings data_source test', () => {
           themeOverride: ThemeValue.DARK,
         });
       });
+
+      it('properly converts stepSelectorEnabled', async () => {
+        getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
+          JSON.stringify({
+            stepSelectorEnabled: true,
+          })
+        );
+
+        const actual = await firstValueFrom(dataSource.getSettings());
+
+        expect(actual).toEqual({
+          stepSelectorEnabled: true,
+        });
+      });
+      it('properly converts rangeSelectionEnabled', async () => {
+        getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
+          JSON.stringify({
+            rangeSelectionEnabled: true,
+          })
+        );
+
+        const actual = await firstValueFrom(dataSource.getSettings());
+
+        expect(actual).toEqual({
+          rangeSelectionEnabled: true,
+        });
+      });
+      it('properly converts linkedTimeEnabled', async () => {
+        getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
+          JSON.stringify({
+            linkedTimeEnabled: true,
+          })
+        );
+
+        const actual = await firstValueFrom(dataSource.getSettings());
+
+        expect(actual).toEqual({
+          linkedTimeEnabled: true,
+        });
+      });
     });
 
     describe('#setSettings', () => {
@@ -164,6 +204,63 @@ describe('persistent_settings data_source test', () => {
             ignoreOutliers: false,
             scalarSmoothing: 0.5,
             timeSeriesCardMinWidth: 360,
+          })
+        );
+      });
+
+      it('properly converts stepSelectorEnabled', async () => {
+        getItemSpy
+          .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
+          .and.returnValue(null);
+
+        await firstValueFrom(
+          dataSource.setSettings({
+            stepSelectorEnabled: true,
+          })
+        );
+
+        expect(setItemSpy).toHaveBeenCalledOnceWith(
+          TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
+          JSON.stringify({
+            stepSelectorEnabled: true,
+          })
+        );
+      });
+
+      it('properly converts rangeSelectionEnabled', async () => {
+        getItemSpy
+          .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
+          .and.returnValue(null);
+
+        await firstValueFrom(
+          dataSource.setSettings({
+            rangeSelectionEnabled: true,
+          })
+        );
+
+        expect(setItemSpy).toHaveBeenCalledOnceWith(
+          TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
+          JSON.stringify({
+            rangeSelectionEnabled: true,
+          })
+        );
+      });
+
+      it('properly converts linkedTimeEnabled', async () => {
+        getItemSpy
+          .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
+          .and.returnValue(null);
+
+        await firstValueFrom(
+          dataSource.setSettings({
+            linkedTimeEnabled: true,
+          })
+        );
+
+        expect(setItemSpy).toHaveBeenCalledOnceWith(
+          TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
+          JSON.stringify({
+            linkedTimeEnabled: true,
           })
         );
       });

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -38,6 +38,9 @@ export declare interface BackendSettings {
   sideBarWidthInPercent?: number;
   timeSeriesSettingsPaneOpened?: boolean;
   timeSeriesCardMinWidth?: number;
+  stepSelectorEnabled?: boolean;
+  rangeSelectionEnabled?: boolean;
+  linkedTimeEnabled?: boolean;
 }
 
 /**
@@ -57,4 +60,7 @@ export interface PersistableSettings {
   sideBarWidthInPercent?: number;
   timeSeriesSettingsPaneOpened?: boolean;
   timeSeriesCardMinWidth?: number;
+  stepSelectorEnabled?: boolean;
+  rangeSelectionEnabled?: boolean;
+  linkedTimeEnabled?: boolean;
 }


### PR DESCRIPTION
* Motivation for features / changes
The new step selection feature currently must be enabled every time you load Tensorboard. This is annoying for users who like this feature and have to turn it on constantly. This change persists the settings in LocalStorage so it can stay enabled on that machine until it is disabled.

* Technical description of changes
Just followed the pattern of settings that are already persisted.