### PR TITLE
chore: Upgrade github actions to use Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
           nbfmt_version="174c9a5c1cc51a3af1de98d84824c811ecd49029"
           pip install black yamllint -c ./tensorboard/pip_package/requirements_dev.txt
           pip install -U git+https://github.com/tensorflow/docs@${nbfmt_version}
+          pip install -U "protobuf<3.20"
       - run: pip freeze --all
       - name: 'Lint Python code for style with Black'
         # You can run `black .` to fix all Black complaints.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: lint-python-flake8 # fail fast in case of "undefined variable" errors
     strategy:
       fail-fast: false
@@ -135,11 +135,11 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-18.04', 'macos-11']
+        platform: ['ubuntu-22.04', 'macos-11']
         rust_version: ['1.58.1']
         include:
           - mode: 'universal'
-            platform: 'ubuntu-18.04'
+            platform: 'ubuntu-22.04'
             rust_version: '1.58.1'
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -207,7 +207,7 @@ jobs:
           path: /tmp/pip_package/*
 
   lint-python-flake8:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -232,7 +232,7 @@ jobs:
         run: flake8 . --count --select=E9,F63,F7,F82,F401 --show-source --statistics
 
   lint-python-yaml-docs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
@@ -256,7 +256,7 @@ jobs:
         run: git ls-files -z '*.ipynb' | xargs -0 python3 -m tensorflow_docs.tools.nbfmt --test
 
   lint-rust:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rust_version: ['1.58.1']
@@ -300,7 +300,7 @@ jobs:
           git diff --staged --exit-code
 
   lint-frontend:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
@@ -331,7 +331,7 @@ jobs:
           ! git grep -E '@npm//numeric' 'tensorboard/*/BUILD' ':!tensorboard/webapp/third_party/**'
 
   lint-misc: # build, protos, etc.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - name: 'Set up Buildifier'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: 'Install black, yamllint, and the TensorFlow docs notebook tools'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  RUN_PLATFORM: ubuntu-20.04
   TENSORFLOW_VERSION: 'tf-nightly'
 
 jobs:
@@ -136,11 +135,11 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-20.04'', 'macos-11']
+        platform: ['ubuntu-20.04', 'macos-11']
         rust_version: ['1.58.1']
         include:
           - mode: 'universal'
-            platform: 'ubuntu-20.04''
+            platform: 'ubuntu-20.04'
             rust_version: '1.58.1'
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,11 @@ jobs:
           nbfmt_version="174c9a5c1cc51a3af1de98d84824c811ecd49029"
           pip install black yamllint -c ./tensorboard/pip_package/requirements_dev.txt
           pip install -U git+https://github.com/tensorflow/docs@${nbfmt_version}
-          pip install -U "protobuf<3.20"
+        # Workaround tensorflow incompatibility with protobuf>4.
+        # See: https://github.com/tensorflow/tensorboard/issues/5708.
+        # See: https://github.com/tensorflow/tensorflow/issues/53234.
+      - name: 'Downgrade to compatible protobuf version'
+        run: pip install -U "protobuf<3.20"
       - run: pip freeze --all
       - name: 'Lint Python code for style with Black'
         # You can run `black .` to fix all Black complaints.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ env.RUN_PLATFORM }}
+    runs-on: ubuntu-20.04
     needs: lint-python-flake8 # fail fast in case of "undefined variable" errors
     strategy:
       fail-fast: false
@@ -136,11 +136,11 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['${{ env.RUN_PLATFORM }}'', 'macos-11']
+        platform: ['ubuntu-20.04'', 'macos-11']
         rust_version: ['1.58.1']
         include:
           - mode: 'universal'
-            platform: '${{ env.RUN_PLATFORM }}''
+            platform: 'ubuntu-20.04''
             rust_version: '1.58.1'
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -208,7 +208,7 @@ jobs:
           path: /tmp/pip_package/*
 
   lint-python-flake8:
-    runs-on: ${{ env.RUN_PLATFORM }}
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -233,7 +233,7 @@ jobs:
         run: flake8 . --count --select=E9,F63,F7,F82,F401 --show-source --statistics
 
   lint-python-yaml-docs:
-    runs-on: ${{ env.RUN_PLATFORM }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
@@ -262,7 +262,7 @@ jobs:
         run: git ls-files -z '*.ipynb' | xargs -0 python3 -m tensorflow_docs.tools.nbfmt --test
 
   lint-rust:
-    runs-on: ${{ env.RUN_PLATFORM }}
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         rust_version: ['1.58.1']
@@ -306,7 +306,7 @@ jobs:
           git diff --staged --exit-code
 
   lint-frontend:
-    runs-on: ${{ env.RUN_PLATFORM }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
@@ -337,7 +337,7 @@ jobs:
           ! git grep -E '@npm//numeric' 'tensorboard/*/BUILD' ':!tensorboard/webapp/third_party/**'
 
   lint-misc: # build, protos, etc.
-    runs-on: ${{ env.RUN_PLATFORM }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - name: 'Set up Buildifier'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,12 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
+  RUN_PLATFORM: ubuntu-20.04
   TENSORFLOW_VERSION: 'tf-nightly'
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ env.RUN_PLATFORM }}
     needs: lint-python-flake8 # fail fast in case of "undefined variable" errors
     strategy:
       fail-fast: false
@@ -135,11 +136,11 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-22.04', 'macos-11']
+        platform: ['${{ env.RUN_PLATFORM }}'', 'macos-11']
         rust_version: ['1.58.1']
         include:
           - mode: 'universal'
-            platform: 'ubuntu-22.04'
+            platform: '${{ env.RUN_PLATFORM }}''
             rust_version: '1.58.1'
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -207,7 +208,7 @@ jobs:
           path: /tmp/pip_package/*
 
   lint-python-flake8:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ env.RUN_PLATFORM }}
     strategy:
       fail-fast: false
       matrix:
@@ -232,7 +233,7 @@ jobs:
         run: flake8 . --count --select=E9,F63,F7,F82,F401 --show-source --statistics
 
   lint-python-yaml-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ env.RUN_PLATFORM }}
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
@@ -261,7 +262,7 @@ jobs:
         run: git ls-files -z '*.ipynb' | xargs -0 python3 -m tensorflow_docs.tools.nbfmt --test
 
   lint-rust:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ env.RUN_PLATFORM }}
     strategy:
       matrix:
         rust_version: ['1.58.1']
@@ -305,7 +306,7 @@ jobs:
           git diff --staged --exit-code
 
   lint-frontend:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ env.RUN_PLATFORM }}
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
@@ -336,7 +337,7 @@ jobs:
           ! git grep -E '@npm//numeric' 'tensorboard/*/BUILD' ':!tensorboard/webapp/third_party/**'
 
   lint-misc: # build, protos, etc.
-    runs-on: ubuntu-22.04
+    runs-on: ${{ env.RUN_PLATFORM }}
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - name: 'Set up Buildifier'

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
 
   nightly-release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: ci
     if: github.repository == 'tensorflow/tensorboard'
     steps:


### PR DESCRIPTION
ubuntu-18.04 is deprecated and experiences periodic brownouts.
See: https://github.com/actions/runner-images/issues/6002