### PR TITLE
Data Table: Sort Run Names Without Id and Alias

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -104,11 +104,7 @@ export class ScalarCardDataTable {
           closestEndPointIndex = findClosestIndex(datum.points, endStep);
           closestEndPoint = datum.points[closestEndPointIndex];
         }
-        const alias = metadata.alias
-          ? `${metadata.alias.aliasNumber} ${metadata.alias.aliasText}/`
-          : '';
         const selectedStepData: SelectedStepRunData = {};
-        selectedStepData.ALIAS = alias;
         selectedStepData.COLOR = metadata.color;
         selectedStepData.DISPLAY_NAME = metadata.displayName;
         for (const header of this.dataHeaders) {
@@ -224,6 +220,8 @@ function makeValueSortable(value: number | string | null | undefined) {
 
 function getSortableValue(point: SelectedStepRunData, header: ColumnHeaders) {
   switch (header) {
+    // The value shown in the "RUN" column is a string concatenation of Alias Id + Alias + Run Name
+    // but we would actually prefer to sort by just the run name.
     case ColumnHeaders.RUN:
       return makeValueSortable(point[ColumnHeaders.DISPLAY_NAME]);
     default:

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -189,8 +189,8 @@ export class ScalarCardDataTable {
       });
     dataTableData.sort(
       (point1: SelectedStepRunData, point2: SelectedStepRunData) => {
-        const p1 = getSortableValue(point1[this.sortingInfo.header]);
-        const p2 = getSortableValue(point2[this.sortingInfo.header]);
+        const p1 = getSortableValue(point1, this.sortingInfo.header);
+        const p2 = getSortableValue(point2, this.sortingInfo.header);
         if (p1 < p2) {
           return this.sortingInfo.order === SortingOrder.ASCENDING ? -1 : 1;
         }
@@ -205,7 +205,7 @@ export class ScalarCardDataTable {
   }
 }
 
-function getSortableValue(value: number | string | undefined | null) {
+function makeValueSortable(value: number | string | null | undefined) {
   if (
     Number.isNaN(value) ||
     value === 'NaN' ||
@@ -215,4 +215,13 @@ function getSortableValue(value: number | string | undefined | null) {
     return -Infinity;
   }
   return value;
+}
+
+function getSortableValue(point: SelectedStepRunData, header: ColumnHeaders) {
+  switch (header) {
+    case ColumnHeaders.RUN:
+      return makeValueSortable(point[ColumnHeaders.DISPLAY_NAME]);
+    default:
+      return makeValueSortable(point[header]);
+  }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -104,9 +104,10 @@ export class ScalarCardDataTable {
           closestEndPointIndex = findClosestIndex(datum.points, endStep);
           closestEndPoint = datum.points[closestEndPointIndex];
         }
-        const selectedStepData: SelectedStepRunData = {};
+        const selectedStepData: SelectedStepRunData = {
+          id: datum.id,
+        };
         selectedStepData.COLOR = metadata.color;
-        selectedStepData.DISPLAY_NAME = metadata.displayName;
         for (const header of this.dataHeaders) {
           switch (header) {
             case ColumnHeaders.RUN:
@@ -190,8 +191,8 @@ export class ScalarCardDataTable {
       });
     dataTableData.sort(
       (point1: SelectedStepRunData, point2: SelectedStepRunData) => {
-        const p1 = getSortableValue(point1, this.sortingInfo.header);
-        const p2 = getSortableValue(point2, this.sortingInfo.header);
+        const p1 = this.getSortableValue(point1, this.sortingInfo.header);
+        const p2 = this.getSortableValue(point2, this.sortingInfo.header);
         if (p1 < p2) {
           return this.sortingInfo.order === SortingOrder.ASCENDING ? -1 : 1;
         }
@@ -203,6 +204,17 @@ export class ScalarCardDataTable {
       }
     );
     return dataTableData;
+  }
+
+  private getSortableValue(point: SelectedStepRunData, header: ColumnHeaders) {
+    switch (header) {
+      // The value shown in the "RUN" column is a string concatenation of Alias Id + Alias + Run Name
+      // but we would actually prefer to sort by just the run name.
+      case ColumnHeaders.RUN:
+        return makeValueSortable(this.chartMetadataMap[point.id].displayName);
+      default:
+        return makeValueSortable(point[header]);
+    }
   }
 }
 
@@ -216,15 +228,4 @@ function makeValueSortable(value: number | string | null | undefined) {
     return -Infinity;
   }
   return value;
-}
-
-function getSortableValue(point: SelectedStepRunData, header: ColumnHeaders) {
-  switch (header) {
-    // The value shown in the "RUN" column is a string concatenation of Alias Id + Alias + Run Name
-    // but we would actually prefer to sort by just the run name.
-    case ColumnHeaders.RUN:
-      return makeValueSortable(point[ColumnHeaders.DISPLAY_NAME]);
-    default:
-      return makeValueSortable(point[header]);
-  }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -104,8 +104,13 @@ export class ScalarCardDataTable {
           closestEndPointIndex = findClosestIndex(datum.points, endStep);
           closestEndPoint = datum.points[closestEndPointIndex];
         }
+        const alias = metadata.alias
+          ? `${metadata.alias.aliasNumber} ${metadata.alias.aliasText}/`
+          : '';
         const selectedStepData: SelectedStepRunData = {};
+        selectedStepData.ALIAS = alias;
         selectedStepData.COLOR = metadata.color;
+        selectedStepData.DISPLAY_NAME = metadata.displayName;
         for (const header of this.dataHeaders) {
           switch (header) {
             case ColumnHeaders.RUN:

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -3143,7 +3143,7 @@ describe('scalar card', () => {
       };
       scalarCardDataTable.componentInstance.chartMetadataMap.run1.alias = {
         aliasText: 'g',
-        aliasNumber: 7,
+        aliasNumber: 5,
       };
       scalarCardDataTable.componentInstance.chartMetadataMap.run2.alias = {
         aliasText: 'f',
@@ -3151,19 +3151,19 @@ describe('scalar card', () => {
       };
       scalarCardDataTable.componentInstance.chartMetadataMap.run3.alias = {
         aliasText: 'e',
-        aliasNumber: 5,
+        aliasNumber: 7,
       };
       scalarCardDataTable.componentInstance.chartMetadataMap.run4.alias = {
         aliasText: 'd',
         aliasNumber: 4,
       };
       scalarCardDataTable.componentInstance.chartMetadataMap.run5.alias = {
-        aliasText: 'c',
-        aliasNumber: 3,
-      };
-      scalarCardDataTable.componentInstance.chartMetadataMap.run6.alias = {
         aliasText: 'b',
         aliasNumber: 2,
+      };
+      scalarCardDataTable.componentInstance.chartMetadataMap.run6.alias = {
+        aliasText: 'c',
+        aliasNumber: 3,
       };
       scalarCardDataTable.componentInstance.chartMetadataMap.run7.alias = {
         aliasText: 'a',
@@ -3178,12 +3178,12 @@ describe('scalar card', () => {
       const data =
         scalarCardDataTable.componentInstance.getTimeSelectionTableData();
 
-      expect(data[0].RUN).toEqual('7 g/run1');
+      expect(data[0].RUN).toEqual('5 g/run1');
       expect(data[1].RUN).toEqual('6 f/run2');
-      expect(data[2].RUN).toEqual('5 e/run3');
+      expect(data[2].RUN).toEqual('7 e/run3');
       expect(data[3].RUN).toEqual('4 d/run4');
-      expect(data[4].RUN).toEqual('3 c/run5');
-      expect(data[5].RUN).toEqual('2 b/run6');
+      expect(data[4].RUN).toEqual('2 b/run5');
+      expect(data[5].RUN).toEqual('3 c/run6');
       expect(data[6].RUN).toEqual('1 a/run7');
     }));
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2541,6 +2541,7 @@ describe('scalar card', () => {
 
       expect(data).toEqual([
         {
+          id: 'run1',
           COLOR: '#fff',
           RELATIVE_TIME: 1000,
           RUN: 'run1',
@@ -2548,6 +2549,7 @@ describe('scalar card', () => {
           VALUE: 10,
         },
         {
+          id: 'run2',
           COLOR: '#fff',
           RELATIVE_TIME: 1000,
           RUN: 'run2',
@@ -2601,6 +2603,7 @@ describe('scalar card', () => {
 
       expect(data).toEqual([
         {
+          id: 'run1',
           COLOR: '#fff',
           RUN: 'run1',
           VALUE_CHANGE: 19,
@@ -2613,6 +2616,7 @@ describe('scalar card', () => {
           PERCENTAGE_CHANGE: 19, // percentage change from 1 to 20 is 1900%
         },
         {
+          id: 'run2',
           COLOR: '#fff',
           RUN: 'run2',
           VALUE_CHANGE: 24,
@@ -3092,6 +3096,95 @@ describe('scalar card', () => {
       expect(data[4].RUN).toEqual('run5');
       expect(data[5].RUN).toEqual('run6');
       expect(data[6].RUN).toEqual('run7');
+    }));
+
+    it('Sorts RUNS column by displayName', fakeAsync(() => {
+      const runToSeries = {
+        run1: [{wallTime: 1, value: 1, step: 1}],
+        run2: [{wallTime: 1, value: 2, step: 1}],
+        run3: [{wallTime: 1, value: 3, step: 1}],
+        run4: [{wallTime: 1, value: NaN, step: 1}],
+        run5: [{wallTime: 1, value: 'NaN', step: 1}],
+        run6: [{wallTime: 1, value: null, step: 1}],
+        run7: [{wallTime: 1, value: undefined, step: 1}],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries as any
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+          ['run3', true],
+          ['run4', true],
+          ['run5', true],
+          ['run6', true],
+          ['run7', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsLinkedTimeSelection, {
+        start: {step: 1},
+        end: null,
+      });
+
+      const fixture = createComponent('card1');
+      const scalarCardDataTable = fixture.debugElement.query(
+        By.directive(ScalarCardDataTable)
+      );
+      scalarCardDataTable.componentInstance.sortingInfo = {
+        header: ColumnHeaders.RUN,
+        order: SortingOrder.ASCENDING,
+      };
+      scalarCardDataTable.componentInstance.chartMetadataMap.run1.alias = {
+        aliasText: 'g',
+        aliasNumber: 7,
+      };
+      scalarCardDataTable.componentInstance.chartMetadataMap.run2.alias = {
+        aliasText: 'f',
+        aliasNumber: 6,
+      };
+      scalarCardDataTable.componentInstance.chartMetadataMap.run3.alias = {
+        aliasText: 'e',
+        aliasNumber: 5,
+      };
+      scalarCardDataTable.componentInstance.chartMetadataMap.run4.alias = {
+        aliasText: 'd',
+        aliasNumber: 4,
+      };
+      scalarCardDataTable.componentInstance.chartMetadataMap.run5.alias = {
+        aliasText: 'c',
+        aliasNumber: 3,
+      };
+      scalarCardDataTable.componentInstance.chartMetadataMap.run6.alias = {
+        aliasText: 'b',
+        aliasNumber: 2,
+      };
+      scalarCardDataTable.componentInstance.chartMetadataMap.run7.alias = {
+        aliasText: 'a',
+        aliasNumber: 1,
+      };
+      console.log(
+        'ChartMetadatMap: ',
+        scalarCardDataTable.componentInstance.chartMetadataMap
+      );
+      fixture.detectChanges();
+
+      const data =
+        scalarCardDataTable.componentInstance.getTimeSelectionTableData();
+
+      expect(data[0].RUN).toEqual('7 g/run1');
+      expect(data[1].RUN).toEqual('6 f/run2');
+      expect(data[2].RUN).toEqual('5 e/run3');
+      expect(data[3].RUN).toEqual('4 d/run4');
+      expect(data[4].RUN).toEqual('3 c/run5');
+      expect(data[5].RUN).toEqual('2 b/run6');
+      expect(data[6].RUN).toEqual('1 a/run7');
     }));
   });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -77,7 +77,6 @@ export interface PartitionedSeries {
  * value and the DataTable widget must know how to display each value.
  */
 export enum ColumnHeaders {
-  ALIAS = 'ALIAS',
   COLOR = 'COLOR',
   DISPLAY_NAME = 'DISPLAY_NAME',
   RELATIVE_TIME = 'RELATIVE_TIME',

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -78,7 +78,6 @@ export interface PartitionedSeries {
  */
 export enum ColumnHeaders {
   COLOR = 'COLOR',
-  DISPLAY_NAME = 'DISPLAY_NAME',
   RELATIVE_TIME = 'RELATIVE_TIME',
   RUN = 'RUN',
   STEP = 'STEP',
@@ -112,7 +111,7 @@ export interface SortingInfo {
  */
 export type SelectedStepRunData = {
   [key in ColumnHeaders]?: string | number;
-};
+} & {id: string};
 
 /**
  * An object which is intended to hold the min and max step within each scalar

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -77,7 +77,9 @@ export interface PartitionedSeries {
  * value and the DataTable widget must know how to display each value.
  */
 export enum ColumnHeaders {
+  ALIAS = 'ALIAS',
   COLOR = 'COLOR',
+  DISPLAY_NAME = 'DISPLAY_NAME',
   RELATIVE_TIME = 'RELATIVE_TIME',
   RUN = 'RUN',
   STEP = 'STEP',

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -52,6 +52,10 @@ export class DataTableComponent {
 
   getHeaderTextColumn(columnHeader: ColumnHeaders): string {
     switch (columnHeader) {
+      case ColumnHeaders.ALIAS:
+        return 'Alias';
+      case ColumnHeaders.DISPLAY_NAME:
+        return 'Display Name';
       case ColumnHeaders.RUN:
         return 'Run';
       case ColumnHeaders.VALUE:
@@ -90,6 +94,10 @@ export class DataTableComponent {
     selectedStepRunData: SelectedStepRunData
   ): string {
     switch (columnHeader) {
+      case ColumnHeaders.ALIAS:
+        return (selectedStepRunData.ALIAS || '').toString();
+      case ColumnHeaders.DISPLAY_NAME:
+        return (selectedStepRunData.DISPLAY_NAME || '').toString();
       case ColumnHeaders.RUN:
         if (selectedStepRunData.RUN === undefined) {
           return '';

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -52,8 +52,6 @@ export class DataTableComponent {
 
   getHeaderTextColumn(columnHeader: ColumnHeaders): string {
     switch (columnHeader) {
-      case ColumnHeaders.DISPLAY_NAME:
-        return 'Display Name';
       case ColumnHeaders.RUN:
         return 'Run';
       case ColumnHeaders.VALUE:
@@ -92,8 +90,6 @@ export class DataTableComponent {
     selectedStepRunData: SelectedStepRunData
   ): string {
     switch (columnHeader) {
-      case ColumnHeaders.DISPLAY_NAME:
-        return (selectedStepRunData.DISPLAY_NAME || '').toString();
       case ColumnHeaders.RUN:
         if (selectedStepRunData.RUN === undefined) {
           return '';

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -52,8 +52,6 @@ export class DataTableComponent {
 
   getHeaderTextColumn(columnHeader: ColumnHeaders): string {
     switch (columnHeader) {
-      case ColumnHeaders.ALIAS:
-        return 'Alias';
       case ColumnHeaders.DISPLAY_NAME:
         return 'Display Name';
       case ColumnHeaders.RUN:
@@ -94,8 +92,6 @@ export class DataTableComponent {
     selectedStepRunData: SelectedStepRunData
   ): string {
     switch (columnHeader) {
-      case ColumnHeaders.ALIAS:
-        return (selectedStepRunData.ALIAS || '').toString();
       case ColumnHeaders.DISPLAY_NAME:
         return (selectedStepRunData.DISPLAY_NAME || '').toString();
       case ColumnHeaders.RUN:

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -99,7 +99,6 @@ describe('data table', () => {
         ColumnHeaders.MIN_VALUE,
         ColumnHeaders.MAX_VALUE,
         ColumnHeaders.PERCENTAGE_CHANGE,
-        ColumnHeaders.DISPLAY_NAME,
       ],
     });
     fixture.detectChanges();
@@ -112,7 +111,6 @@ describe('data table', () => {
     expect(headerElements[3].nativeElement.innerText).toBe('Step');
     expect(headerElements[4].nativeElement.innerText).toBe('Relative');
     expect(headerElements[5].nativeElement.innerText).toBe('Value');
-    expect(headerElements[6].nativeElement.innerText).toBe('Run');
     expect(
       headerElements[5]
         .queryAll(By.css('mat-icon'))[0]
@@ -150,6 +148,7 @@ describe('data table', () => {
       ],
       data: [
         {
+          id: 'someid',
           RUN: 'run name',
           VALUE: 3,
           STEP: 1,
@@ -204,7 +203,7 @@ describe('data table', () => {
         ColumnHeaders.STEP,
         ColumnHeaders.RELATIVE_TIME,
       ],
-      data: [{}],
+      data: [{id: 'someid'}],
     });
     fixture.detectChanges();
     const dataElements = fixture.debugElement.queryAll(By.css('td'));

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -99,6 +99,7 @@ describe('data table', () => {
         ColumnHeaders.MIN_VALUE,
         ColumnHeaders.MAX_VALUE,
         ColumnHeaders.PERCENTAGE_CHANGE,
+        ColumnHeaders.DISPLAY_NAME,
       ],
     });
     fixture.detectChanges();
@@ -111,6 +112,7 @@ describe('data table', () => {
     expect(headerElements[3].nativeElement.innerText).toBe('Step');
     expect(headerElements[4].nativeElement.innerText).toBe('Relative');
     expect(headerElements[5].nativeElement.innerText).toBe('Value');
+    expect(headerElements[6].nativeElement.innerText).toBe('Run');
     expect(
       headerElements[5]
         .queryAll(By.css('mat-icon'))[0]


### PR DESCRIPTION
* Motivation for features / changes
For Googlers [b/254089050](b/254089050)
Run names are currently sorted differently in the data table than in the tool tip. I'm changing the sorting to be consistent with the tooltips alphabetical sort.

* Screenshots of UI changes
![51842c87-6bf0-4492-8c93-34535f845943](https://user-images.githubusercontent.com/78179109/196759166-be218ef4-1aaf-4383-9d61-fc6395a3db9a.gif)

* Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Visit localhost:6006?enableDataTable&enableRangeSelection
3) Click the "Enable Range Selection" checkbox in the settings panel
4) Sort the scalar card data table
5) Assert that the table is sorted by the run name only (not the alias or alias id)

* Alternate designs / implementations considered
I considered creating a column alias map but this approach seemed more flexible.