### PR TITLE
Fix most tests that break with es2020 output.

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import {Rect, Scale, ScaleType} from './internal_types';
 import {createScale} from './scale';
-import {convertRectToExtent} from './utils';
+import {ChartUtils} from './utils';
 
 /**
  * A stateful convenient utility around scale for converting coordinate systems.
@@ -109,7 +109,7 @@ export class Coordinator {
     dataCoordinate: [number, number]
   ): [number, number] {
     const rect = rectInUiCoordinate;
-    const domain = convertRectToExtent(this.currentViewBoxRect);
+    const domain = ChartUtils.convertRectToExtent(this.currentViewBoxRect);
     return [
       this.xScale.forward(
         domain.x,

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/renderer_test.ts
@@ -17,7 +17,7 @@ import {Polyline} from '../internal_types';
 import {assertSvgPathD} from '../testing';
 import {ThreeCoordinator} from '../threejs_coordinator';
 import {SvgRenderer} from './svg_renderer';
-import {ThreeRenderer} from './threejs_renderer';
+import {TEST_ONLY, ThreeRenderer} from './threejs_renderer';
 
 describe('line_chart_v2/lib/renderer test', () => {
   const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -326,7 +326,7 @@ describe('line_chart_v2/lib/renderer test', () => {
 
     beforeEach(() => {
       scene = new THREE.Scene();
-      spyOn(THREE, 'Scene').and.returnValue(scene);
+      spyOn(TEST_ONLY.ThreeWrapper, 'createScene').and.returnValue(scene);
 
       const canvas = document.createElement('canvas');
       const coordinator = new ThreeCoordinator();

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/svg_renderer.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {Point, Polyline, Rect} from '../internal_types';
-import {arePolylinesEqual} from '../utils';
+import {ChartUtils} from '../utils';
 import {
   CirclePaintOption,
   LinePaintOption,
@@ -110,7 +110,7 @@ export class SvgRenderer implements ObjectRenderer<CacheValue> {
       (dom) => {
         if (
           !cachedLine?.data ||
-          !arePolylinesEqual(polyline, cachedLine?.data)
+          !ChartUtils.arePolylinesEqual(polyline, cachedLine?.data)
         ) {
           const data = this.createPathDString(polyline);
           dom.setAttribute('d', data);

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/renderer/threejs_renderer.ts
@@ -17,7 +17,7 @@ import * as THREE from 'three';
 import {hsl, interpolateHsl} from '../../../../third_party/d3';
 import {Point, Polyline, Rect} from '../internal_types';
 import {ThreeCoordinator} from '../threejs_coordinator';
-import {arePolylinesEqual, isOffscreenCanvasSupported} from '../utils';
+import {ChartUtils} from '../utils';
 import {
   CirclePaintOption,
   LinePaintOption,
@@ -260,9 +260,15 @@ function updateObject(
   return true;
 }
 
+const ThreeWrapper = {
+  createScene: () => {
+    return new THREE.Scene();
+  },
+};
+
 export class ThreeRenderer implements ObjectRenderer<CacheValue> {
   private readonly renderer: THREE.WebGLRenderer;
-  private readonly scene = new THREE.Scene();
+  private readonly scene = ThreeWrapper.createScene();
   private backgroundColor: string = '#fff';
 
   constructor(
@@ -271,7 +277,10 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
     devicePixelRatio: number,
     onContextLost?: EventListener
   ) {
-    if (isOffscreenCanvasSupported() && canvas instanceof OffscreenCanvas) {
+    if (
+      ChartUtils.isOffscreenCanvasSupported() &&
+      canvas instanceof OffscreenCanvas
+    ) {
       // THREE.js require the style object which Offscreen canvas lacks.
       (canvas as any).style = (canvas as any).style || {};
     }
@@ -347,7 +356,7 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
         if (
           width !== prevWidth ||
           !prevPolyline ||
-          !arePolylinesEqual(prevPolyline, polyline)
+          !ChartUtils.arePolylinesEqual(prevPolyline, polyline)
         ) {
           updateThickPolylineGeometry(geometry, polyline, width);
         }
@@ -497,3 +506,7 @@ export class ThreeRenderer implements ObjectRenderer<CacheValue> {
     this.renderer.dispose();
   }
 }
+
+export const TEST_ONLY = {
+  ThreeWrapper,
+};

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/utils.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import {Extent, Polyline, Rect} from './internal_types';
 
-export function convertRectToExtent(rect: Rect): Extent {
+function convertRectToExtent(rect: Rect): Extent {
   return {
     x: [rect.x, rect.x + rect.width],
     y: [rect.y, rect.y + rect.height],
@@ -39,15 +39,15 @@ let cachedIsWebGl2Supported = false;
   }
 }
 
-export function isWebGl2Supported(): boolean {
+function isWebGl2Supported(): boolean {
   return cachedIsWebGl2Supported;
 }
 
-export function isOffscreenCanvasSupported(): boolean {
+function isOffscreenCanvasSupported(): boolean {
   return self.hasOwnProperty('OffscreenCanvas');
 }
 
-export function arePolylinesEqual(lineA: Polyline, lineB: Polyline) {
+function arePolylinesEqual(lineA: Polyline, lineB: Polyline) {
   if (lineA.length !== lineB.length) {
     return false;
   }
@@ -60,7 +60,7 @@ export function arePolylinesEqual(lineA: Polyline, lineB: Polyline) {
   return true;
 }
 
-export function areExtentsEqual(extentA: Extent, extentB: Extent): boolean {
+function areExtentsEqual(extentA: Extent, extentB: Extent): boolean {
   return (
     extentA.x[0] === extentB.x[0] &&
     extentA.x[1] === extentB.x[1] &&
@@ -68,3 +68,11 @@ export function areExtentsEqual(extentA: Extent, extentB: Extent): boolean {
     extentA.y[1] === extentB.y[1]
   );
 }
+
+export const ChartUtils = {
+  convertRectToExtent,
+  isWebGl2Supported,
+  isOffscreenCanvasSupported,
+  arePolylinesEqual,
+  areExtentsEqual,
+};

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -43,7 +43,7 @@ import {
   ScaleType,
 } from './lib/public_types';
 import {createScale} from './lib/scale';
-import {isOffscreenCanvasSupported} from './lib/utils';
+import {ChartUtils} from './lib/utils';
 import {WorkerChart} from './lib/worker/worker_chart';
 import {
   computeDataSeriesExtent,
@@ -393,7 +393,8 @@ export class LineChartComponent
     }
 
     const useWorker =
-      rendererType !== RendererType.SVG && isOffscreenCanvasSupported();
+      rendererType !== RendererType.SVG &&
+      ChartUtils.isOffscreenCanvasSupported();
     const klass = useWorker ? WorkerChart : ChartImpl;
     this.lineChart = new klass(params);
   }

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils.ts
@@ -18,7 +18,7 @@ import {
   DataSeriesMetadataMap,
   RendererType,
 } from './lib/public_types';
-import {isWebGl2Supported} from './lib/utils';
+import {ChartUtils} from './lib/utils';
 
 /**
  * Returns extent, min and max values of each dimensions, of all data series points.
@@ -79,7 +79,9 @@ export function getRendererType(
     case RendererType.SVG:
       return RendererType.SVG;
     case RendererType.WEBGL:
-      return isWebGl2Supported() ? RendererType.WEBGL : RendererType.SVG;
+      return ChartUtils.isWebGl2Supported()
+        ? RendererType.WEBGL
+        : RendererType.SVG;
     default:
       const _ = preferredRendererType as never;
       throw new Error(`Unknown rendererType: ${preferredRendererType}`);

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_internal_utils_test.ts
@@ -16,7 +16,7 @@ limitations under the License.
 import {RendererType, ScaleType} from './lib/public_types';
 import {createScale} from './lib/scale';
 import {buildMetadata, buildSeries} from './lib/testing';
-import * as libUtils from './lib/utils';
+import {ChartUtils} from './lib/utils';
 import {
   computeDataSeriesExtent,
   getRendererType,
@@ -465,12 +465,12 @@ describe('line_chart_v2/line_chart_internal_utils test', () => {
     });
 
     it('returns webgl if webgl2 is supported', () => {
-      spyOn(libUtils, 'isWebGl2Supported').and.returnValue(true);
+      spyOn(ChartUtils, 'isWebGl2Supported').and.returnValue(true);
       expect(getRendererType(RendererType.WEBGL)).toBe(RendererType.WEBGL);
     });
 
     it('returns svg if webgl2 is not supported', () => {
-      spyOn(libUtils, 'isWebGl2Supported').and.returnValue(false);
+      spyOn(ChartUtils, 'isWebGl2Supported').and.returnValue(false);
       expect(getRendererType(RendererType.WEBGL)).toBe(RendererType.SVG);
     });
   });

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils.ts
@@ -39,7 +39,7 @@ function getNumLeadingZerosInFractional(value: number): number {
   return 0;
 }
 
-export function getStandardTicks(
+function getStandardTicks(
   scale: Scale,
   formatter: Formatter,
   maxMinorTickCount: number,
@@ -57,7 +57,7 @@ export function getStandardTicks(
   };
 }
 
-export function getTicksForTemporalScale(
+function getTicksForTemporalScale(
   scale: Scale,
   formatter: Formatter,
   maxMinorTickCount: number,
@@ -87,7 +87,7 @@ export function getTicksForTemporalScale(
   };
 }
 
-export function getTicksForLinearScale(
+function getTicksForLinearScale(
   scale: LinearScale,
   formatter: Formatter,
   maxMinorTickCount: number,
@@ -181,7 +181,7 @@ const canvasForMeasure = document.createElement('canvas').getContext('2d');
  * @param marginBetweenAxis Optional required spacing between labels.
  * @returns Filtered minor ticks based on their visibilities.
  */
-export function filterTicksByVisibility(
+function filterTicksByVisibility(
   minorTicks: MinorTick[],
   getDomPos: (tick: MinorTick) => number,
   axis: 'x' | 'y',
@@ -223,3 +223,10 @@ export function filterTicksByVisibility(
     return true;
   });
 }
+
+export const AxisUtils = {
+  getStandardTicks,
+  getTicksForTemporalScale,
+  getTicksForLinearScale,
+  filterTicksByVisibility,
+};

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_utils_test.ts
@@ -14,19 +14,14 @@ limitations under the License.
 ==============================================================================*/
 
 import {createScale, LinearScale, ScaleType, TemporalScale} from '../lib/scale';
-import {
-  filterTicksByVisibility,
-  getStandardTicks,
-  getTicksForLinearScale,
-  getTicksForTemporalScale,
-} from './line_chart_axis_utils';
+import {AxisUtils} from './line_chart_axis_utils';
 
 describe('line_chart_v2/sub_view/axis_utils test', () => {
   describe('#getStandardTicks', () => {
     const scale = createScale(ScaleType.LOG10);
 
     it('returns no major ticks', () => {
-      const {major, minor} = getStandardTicks(
+      const {major, minor} = AxisUtils.getStandardTicks(
         scale,
         scale.defaultFormatter,
         5,
@@ -53,7 +48,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
     const scale = new TemporalScale();
 
     it('returns temporal ticks', () => {
-      const {major, minor} = getTicksForTemporalScale(
+      const {major, minor} = AxisUtils.getTicksForTemporalScale(
         scale,
         scale.defaultFormatter,
         5,
@@ -102,7 +97,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
     });
 
     it('returns only minor when d3 ticks return less than 2 major axes', () => {
-      const {major, minor} = getTicksForTemporalScale(
+      const {major, minor} = AxisUtils.getTicksForTemporalScale(
         scale,
         scale.defaultFormatter,
         5,
@@ -137,7 +132,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
     });
 
     it('does not return major when diff in time is greater than or equal to 1d', () => {
-      const {major, minor} = getTicksForTemporalScale(
+      const {major, minor} = AxisUtils.getTicksForTemporalScale(
         scale,
         scale.defaultFormatter,
         5,
@@ -177,7 +172,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
     const scale = new LinearScale();
 
     it('returns no major ticks for extents in integers', () => {
-      const {major, minor} = getTicksForLinearScale(
+      const {major, minor} = AxisUtils.getTicksForLinearScale(
         scale,
         scale.defaultFormatter,
         5,
@@ -195,7 +190,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
     });
 
     it('returns no major ticks for numbers with less than three decimal digits', () => {
-      const {major, minor} = getTicksForLinearScale(
+      const {major, minor} = AxisUtils.getTicksForLinearScale(
         scale,
         scale.defaultFormatter,
         2,
@@ -210,7 +205,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
     });
 
     it('handles extents with 0 and larger number', () => {
-      const {major, minor} = getTicksForLinearScale(
+      const {major, minor} = AxisUtils.getTicksForLinearScale(
         scale,
         scale.defaultFormatter,
         2,
@@ -225,7 +220,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
 
     describe('very small differences', () => {
       it('creates a major tick since very long minor tick labels are not legible', () => {
-        const {major, minor} = getTicksForLinearScale(
+        const {major, minor} = AxisUtils.getTicksForLinearScale(
           scale,
           scale.defaultFormatter,
           2,
@@ -246,7 +241,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('handles very minute differences in extent', () => {
-        const {major, minor} = getTicksForLinearScale(
+        const {major, minor} = AxisUtils.getTicksForLinearScale(
           scale,
           scale.defaultFormatter,
           2,
@@ -264,7 +259,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('breaks out to major axis when difference is small, not number', () => {
-        const {major, minor} = getTicksForLinearScale(
+        const {major, minor} = AxisUtils.getTicksForLinearScale(
           scale,
           scale.defaultFormatter,
           2,
@@ -285,7 +280,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('handles flipped axis', () => {
-        const {major, minor} = getTicksForLinearScale(
+        const {major, minor} = AxisUtils.getTicksForLinearScale(
           scale,
           scale.defaultFormatter,
           2,
@@ -305,7 +300,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('handles 0 and small number close to 0 well', () => {
-        const {major, minor} = getTicksForLinearScale(
+        const {major, minor} = AxisUtils.getTicksForLinearScale(
           scale,
           scale.defaultFormatter,
           2,
@@ -322,7 +317,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('handles 0 and small number close to 0 well (more minor ticks)', () => {
-        const {major, minor} = getTicksForLinearScale(
+        const {major, minor} = AxisUtils.getTicksForLinearScale(
           scale,
           scale.defaultFormatter,
           4,
@@ -341,7 +336,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('handles extent close to 0s well', () => {
-        const {major, minor} = getTicksForLinearScale(
+        const {major, minor} = AxisUtils.getTicksForLinearScale(
           scale,
           scale.defaultFormatter,
           2,
@@ -352,7 +347,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('handles negative extent close to 0s well', () => {
-        const {major, minor} = getTicksForLinearScale(
+        const {major, minor} = AxisUtils.getTicksForLinearScale(
           scale,
           scale.defaultFormatter,
           2,
@@ -378,7 +373,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
 
     describe('x axis', () => {
       it('filters ticks if it overlaps', () => {
-        const ticks = filterTicksByVisibility(
+        const ticks = AxisUtils.filterTicksByVisibility(
           [
             {value: 0, tickFormattedString: 'ABC'},
             {value: 0, tickFormattedString: 'XYZ'},
@@ -400,7 +395,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('filters everything out of nothing is visible', () => {
-        const ticks = filterTicksByVisibility(
+        const ticks = AxisUtils.filterTicksByVisibility(
           [
             {value: -100, tickFormattedString: 'A'},
             {value: -50, tickFormattedString: 'B'},
@@ -415,7 +410,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('honors the padding', () => {
-        const ticks = filterTicksByVisibility(
+        const ticks = AxisUtils.filterTicksByVisibility(
           [
             {value: 0, tickFormattedString: 'ABC'},
             {value: CHAR_WIDTH * 3, tickFormattedString: 'B'},
@@ -436,7 +431,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
 
     describe('y axis', () => {
       it('filters ticks if it overlaps', () => {
-        const ticks = filterTicksByVisibility(
+        const ticks = AxisUtils.filterTicksByVisibility(
           [
             {value: 200, tickFormattedString: 'A'},
             {value: 200, tickFormattedString: 'B'},
@@ -458,7 +453,7 @@ describe('line_chart_v2/sub_view/axis_utils test', () => {
       });
 
       it('honors the padding', () => {
-        const ticks = filterTicksByVisibility(
+        const ticks = AxisUtils.filterTicksByVisibility(
           [
             {value: 200, tickFormattedString: 'A'},
             {value: 200 - CHAR_HEIGHT, tickFormattedString: 'B'},

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -25,14 +25,7 @@ import {
   getDomSizeInformedTickCount,
   getScaleRangeFromDomDim,
 } from './chart_view_utils';
-import {
-  filterTicksByVisibility,
-  getStandardTicks,
-  getTicksForLinearScale,
-  getTicksForTemporalScale,
-  MajorTick,
-  MinorTick,
-} from './line_chart_axis_utils';
+import {AxisUtils, MajorTick, MinorTick} from './line_chart_axis_utils';
 
 const AXIS_FONT = '11px Roboto, sans-serif';
 
@@ -75,21 +68,21 @@ export class LineChartAxisComponent {
     const maxTickSize = getDomSizeInformedTickCount(domSize, this.gridCount);
 
     if (this.scale instanceof LinearScale) {
-      ticks = getTicksForLinearScale(
+      ticks = AxisUtils.getTicksForLinearScale(
         this.scale,
         this.getFormatter(),
         maxTickSize,
         this.axisExtent
       );
     } else if (this.scale instanceof TemporalScale) {
-      ticks = getTicksForTemporalScale(
+      ticks = AxisUtils.getTicksForTemporalScale(
         this.scale,
         this.getFormatter(),
         maxTickSize,
         this.axisExtent
       );
     } else {
-      ticks = getStandardTicks(
+      ticks = AxisUtils.getStandardTicks(
         this.scale,
         this.getFormatter(),
         maxTickSize,
@@ -98,7 +91,7 @@ export class LineChartAxisComponent {
     }
 
     this.majorTicks = ticks.major;
-    this.minorTicks = filterTicksByVisibility(
+    this.minorTicks = AxisUtils.filterTicksByVisibility(
       ticks.minor,
       (tick) => this.getDomPos(tick.value),
       this.axis,

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
@@ -26,7 +26,7 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {MatIconTestingModule} from '../../../testing/mat_icon_module';
 import {Extent, Scale, ScaleType} from '../lib/public_types';
 import {createScale} from '../lib/scale';
-import * as utils from './line_chart_axis_utils';
+import {AxisUtils} from './line_chart_axis_utils';
 import {LineChartAxisComponent} from './line_chart_axis_view';
 
 @Component({
@@ -98,7 +98,7 @@ describe('line_chart_v2/sub_view/axis test', () => {
 
     overlayContainer = TestBed.inject(OverlayContainer);
     // `filterTicksByVisibility` is tested separately.
-    spyOn(utils, 'filterTicksByVisibility').and.callFake((ticks) => ticks);
+    spyOn(AxisUtils, 'filterTicksByVisibility').and.callFake((ticks) => ticks);
   });
 
   function assertLabels(debugElements: DebugElement[], axisLabels: string[]) {

--- a/tensorboard/webapp/widgets/source_code/load_monaco_shim.ts
+++ b/tensorboard/webapp/widgets/source_code/load_monaco_shim.ts
@@ -55,7 +55,7 @@ function requireAsPromise(paths: string[]): Promise<void> {
  * global path dynamically using require.js. If `window.monaco` is already
  * defined, this function is a no-op.
  */
-export async function loadMonaco(): Promise<void> {
+async function loadMonaco(): Promise<void> {
   const window = utils.getWindow();
   if (window.monaco !== undefined) {
     return;
@@ -78,6 +78,10 @@ export async function loadMonaco(): Promise<void> {
     );
   }
 }
+
+export const MonacoShim = {
+  loadMonaco,
+};
 
 export const TEST_ONLY = {
   utils,

--- a/tensorboard/webapp/widgets/source_code/load_monaco_shim_test.ts
+++ b/tensorboard/webapp/widgets/source_code/load_monaco_shim_test.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {
-  loadMonaco,
+  MonacoShim,
   TEST_ONLY,
   WindowWithRequireAndMonaco,
 } from './load_monaco_shim';
@@ -65,19 +65,19 @@ describe('loadMonaco shim', () => {
   });
 
   it('async function returns without error', async () => {
-    await loadMonaco();
+    await MonacoShim.loadMonaco();
     expect(requireSpy).toHaveBeenCalled();
   });
 
   it('does not reload monaco module if already loaded', async () => {
     windowWithRequireAndMonaco.monaco = createFakeMonaco();
-    await loadMonaco();
+    await MonacoShim.loadMonaco();
     expect(requireSpy).not.toHaveBeenCalled();
   });
 
   it('rejects if require.js is unavailable', async () => {
     delete windowWithRequireAndMonaco.require;
 
-    await expectAsync(loadMonaco()).toBeRejected();
+    await expectAsync(MonacoShim.loadMonaco()).toBeRejected();
   });
 });

--- a/tensorboard/webapp/widgets/source_code/source_code_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {Component, Input, OnInit} from '@angular/core';
 import {from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
-import {loadMonaco} from './load_monaco_shim';
+import {MonacoShim} from './load_monaco_shim';
 
 /**
  * SourceCodeContainer displays the content of a source-code file.
@@ -55,7 +55,7 @@ export class SourceCodeContainer implements OnInit {
   monaco$: Observable<typeof monaco> | null = null;
 
   ngOnInit(): void {
-    this.monaco$ = from(loadMonaco()).pipe(map(() => window.monaco));
+    this.monaco$ = from(MonacoShim.loadMonaco()).pipe(map(() => window.monaco));
   }
 
   constructor() {}

--- a/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
@@ -17,7 +17,7 @@ limitations under the License.
  */
 import {Component, Input, NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import * as loadMonacoShim from './load_monaco_shim';
+import {MonacoShim} from './load_monaco_shim';
 import {SourceCodeComponent} from './source_code_component';
 import {SourceCodeContainer} from './source_code_container';
 import {fakes, setUpMonacoFakes, spies, tearDownMonacoFakes} from './testing';
@@ -74,7 +74,7 @@ describe('Source Code Component', () => {
     component.useDarkMode = true;
     fixture.detectChanges();
     // Simlulate loading monaco and setting the `monaco` input after loading.
-    await loadMonacoShim.loadMonaco();
+    await MonacoShim.loadMonaco();
     fixture.detectChanges();
 
     expect(fakes.fakeMonaco.editor.create).toHaveBeenCalledOnceWith(
@@ -103,7 +103,7 @@ describe('Source Code Component', () => {
     fixture.detectChanges();
 
     // Simlulate loading monaco and setting the `monaco` input after loading.
-    await loadMonacoShim.loadMonaco();
+    await MonacoShim.loadMonaco();
     fixture.detectChanges();
 
     // Initial rendering of code uses monaco editor's constructor instead of
@@ -139,7 +139,7 @@ describe('Source Code Component', () => {
       fixture = TestBed.createComponent(TestableComponent);
       fixture.componentInstance.lines = lines1;
       fixture.detectChanges();
-      await loadMonacoShim.loadMonaco();
+      await MonacoShim.loadMonaco();
       fixture.detectChanges();
     });
 

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
 import {from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
-import {loadMonaco} from './load_monaco_shim';
+import {MonacoShim} from './load_monaco_shim';
 
 /**
  * A component that renders a diff of 2 separate text contents. Diffs can be
@@ -60,6 +60,6 @@ export class SourceCodeDiffContainer implements OnInit {
   monaco$: Observable<typeof monaco> | null = null;
 
   ngOnInit(): void {
-    this.monaco$ = from(loadMonaco()).pipe(map(() => window.monaco));
+    this.monaco$ = from(MonacoShim.loadMonaco()).pipe(map(() => window.monaco));
   }
 }

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
@@ -19,7 +19,7 @@ import {
   NO_ERRORS_SCHEMA,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import * as loadMonacoShim from './load_monaco_shim';
+import {MonacoShim} from './load_monaco_shim';
 import {SourceCodeDiffComponent} from './source_code_diff_component';
 import {SourceCodeDiffContainer} from './source_code_diff_container';
 import {fakes, setUpMonacoFakes, spies, tearDownMonacoFakes} from './testing';
@@ -62,7 +62,7 @@ describe('Source Code Diff', () => {
     fixture.detectChanges();
 
     // Simlulate loading monaco.
-    await loadMonacoShim.loadMonaco();
+    await MonacoShim.loadMonaco();
     fixture.detectChanges();
 
     expect(spies.createDiffEditorSpy).toHaveBeenCalledTimes(1);
@@ -81,7 +81,7 @@ describe('Source Code Diff', () => {
     fixture.detectChanges();
 
     // Simlulate loading monaco.
-    await loadMonacoShim.loadMonaco();
+    await MonacoShim.loadMonaco();
     fixture.detectChanges();
 
     expect(spies.createDiffEditorSpy).toHaveBeenCalledTimes(1);
@@ -101,7 +101,7 @@ describe('Source Code Diff', () => {
     fixture.detectChanges();
 
     // Simlulate loading monaco.
-    await loadMonacoShim.loadMonaco();
+    await MonacoShim.loadMonaco();
     changeDetector.detectChanges();
 
     expect(spies.diffEditorSpy.updateOptions).not.toHaveBeenCalled();
@@ -134,7 +134,7 @@ describe('Source Code Diff', () => {
       const component = fixture.componentInstance;
       fixture.detectChanges();
 
-      await loadMonacoShim.loadMonaco();
+      await MonacoShim.loadMonaco();
       fixture.detectChanges();
 
       component.useDarkMode = true;

--- a/tensorboard/webapp/widgets/source_code/testing.ts
+++ b/tensorboard/webapp/widgets/source_code/testing.ts
@@ -18,7 +18,7 @@ limitations under the License.
  * code components.
  */
 
-import * as loadMonacoShim from './load_monaco_shim';
+import {MonacoShim} from './load_monaco_shim';
 
 export class FakeRange {
   constructor(
@@ -86,7 +86,7 @@ export function setUpMonacoFakes() {
     ).and.callThrough();
     windowWithRequireAndMonaco.monaco = fakes.fakeMonaco;
   }
-  spies.loadMonacoSpy = spyOn(loadMonacoShim, 'loadMonaco').and.callFake(
+  spies.loadMonacoSpy = spyOn(MonacoShim, 'loadMonaco').and.callFake(
     fakeLoadMonaco
   );
 }


### PR DESCRIPTION
The migration to spec_bundle() will require we configure the TypeScript compiler to output to JavaScript 'es2020'. For the most part, this will require very little changes to our test code. There is one glaring exception, though, that we mostly address in this PR.

The following pattern will break:

in my_utilities.ts:
```
export function myFuncToSpyOn() {
  // Some code.
}
```

in my_test.ts:
```
import * as my_utilities from './my_utilities'

spyOn(my_utilities, 'myFuncToSpyOn').and.returnValue(1);
```

The Jasmine library will complain: 
`Error: <spyOn> : myFuncToSpyOn is not declared writable or has no setter`

Jasmine is aware of the issue but can't provide a fix:
* https://github.com/jasmine/jasmine/issues/1942
* https://jasmine.github.io/pages/faq.html#module-spy

Instead they suggest we refactor our code so that the functions being spied on are wrapped in some Class or other Object.

This PR does exactly that, for the most part doing the most simple of wrapping:

now in my_utilities.ts:
```
// No longer exported.
function myFuncToSpyOn() {
  // Some code.
}

export const MyUtilities = {
  myFuncToSpyOn
}
```

now in my_test.ts:
```
import {MyUtilities} from './my_utilities'

spyOn(MyUtilities, 'myFuncToSpyOn').and.returnValue(1);
```

The change has a bit of bigger blast radius because not only do the tests need to be changed but so does every other file (test or not) that are using the utility functions.