### PR TITLE
linked time: set prospective fob position from prospective step

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -34,6 +34,7 @@ import {MinMaxStep} from './scalar_card_types';
       [timeSelection]="timeSelection"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
+      [prospectiveStepAxisPosition]="getAxisPositionFromProspectiveStep()"
       [highestStep]="getHighestStep()"
       [lowestStep]="getLowestStep()"
       [prospectiveStep]="prospectiveStep"
@@ -85,6 +86,16 @@ export class ScalarCardFobController {
       this.minMaxHorizontalViewExtend,
       [0, this.axisSize],
       this.timeSelection.end.step
+    );
+  }
+
+  getAxisPositionFromProspectiveStep() {
+    if (this.prospectiveStep === null) return null;
+
+    return this.scale.forward(
+      this.minMaxHorizontalViewExtend,
+      [0, this.axisSize],
+      this.prospectiveStep
     );
   }
 

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -18,12 +18,14 @@ limitations under the License.
 <div>
   <div
     #prospectiveFobWrapper
-    class="time-fob-wrapper"
+    class="time-fob-wrapper prospectiveFob"
     *ngIf="prospectiveStep !== null && isProspectiveFobFeatureEnabled"
+    [style.transform]="getCssTranslatePxForProspectiveFob()"
   >
     <div *ngIf="showExtendedLine" class="extended-line"></div>
     <card-fob
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
+      [step]="prospectiveStep"
     ></card-fob>
   </div>
   <div

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -25,7 +25,6 @@ limitations under the License.
     <div *ngIf="showExtendedLine" class="extended-line"></div>
     <card-fob
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
-      [step]="prospectiveStep"
     ></card-fob>
   </div>
   <div

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -65,4 +65,14 @@ limitations under the License.
       (fobRemoved)="onFobRemoved(Fob.END)"
     ></card-fob>
   </div>
+  <div
+    #prospectiveFobWrapper
+    class="time-fob-wrapper"
+    *ngIf="prospectiveStep !== null && isProspectiveFobFeatureEnabled"
+  >
+    <div *ngIf="showExtendedLine" class="extended-line"></div>
+    <card-fob
+      [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
+    ></card-fob>
+  </div>
 </div>

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -65,14 +65,4 @@ limitations under the License.
       (fobRemoved)="onFobRemoved(Fob.END)"
     ></card-fob>
   </div>
-  <div
-    #prospectiveFobWrapper
-    class="time-fob-wrapper"
-    *ngIf="prospectiveStep !== null && isProspectiveFobFeatureEnabled"
-  >
-    <div *ngIf="showExtendedLine" class="extended-line"></div>
-    <card-fob
-      [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
-    ></card-fob>
-  </div>
 </div>

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
@@ -49,3 +49,8 @@ limitations under the License.
     padding: 0 20px;
   }
 }
+
+.prospectiveFob {
+  opacity: 0.8;
+  cursor: pointer;
+}

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -62,6 +62,7 @@ export class CardFobControllerComponent {
   @Input() showExtendedLine?: Boolean = false;
   @Input() isProspectiveFobFeatureEnabled?: Boolean = false;
   @Input() prospectiveStep?: number | null = null;
+  @Input() prospectiveStepAxisPosition?: number | null = null;
 
   @Output() onTimeSelectionChanged =
     new EventEmitter<TimeSelectionWithAffordance>();
@@ -97,6 +98,17 @@ export class CardFobControllerComponent {
       return `translate(0px, ${this.endStepAxisPosition}px)`;
     }
     return `translate(${this.endStepAxisPosition}px, 0px)`;
+  }
+
+  getCssTranslatePxForProspectiveFob() {
+    if (this.prospectiveStep === null) {
+      return '';
+    }
+
+    if (this.axisDirection === AxisDirection.VERTICAL) {
+      return `translate(0px, ${this.prospectiveStepAxisPosition}px)`;
+    }
+    return `translate(${this.prospectiveStepAxisPosition}px, 0px)`;
   }
 
   stopEventPropagation(e: Event) {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -1359,11 +1359,11 @@ describe('card_fob_controller', () => {
       fixture.detectChanges();
 
       const fobController = fixture.componentInstance.fobController;
-      const prospectiveFobLeftPosition =
+      const prospectiveFobTopPosition =
         fobController.prospectiveFobWrapper.nativeElement.getBoundingClientRect()
           .top;
 
-      expect(prospectiveFobLeftPosition).toEqual(2);
+      expect(prospectiveFobTopPosition).toEqual(2);
     });
   });
 });

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -35,6 +35,7 @@ import {
       [timeSelection]="timeSelection"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
+      [prospectiveStepAxisPosition]="getAxisPositionFromProspectiveStep()"
       [highestStep]="highestStep"
       [lowestStep]="lowestStep"
       [cardFobHelper]="cardFobHelper"
@@ -58,6 +59,7 @@ class TestableComponent {
   @Input() lowestStep!: number;
   @Input() getAxisPositionFromStartStep!: () => number;
   @Input() getAxisPositionFromEndStep!: () => number;
+  @Input() getAxisPositionFromProspectiveStep!: () => number;
   @Input() isProspectiveFobFeatureEnabled!: Boolean;
   @Input() prospectiveStep!: number | null;
 
@@ -72,6 +74,7 @@ describe('card_fob_controller', () => {
   let getStepLowerSpy: jasmine.Spy;
   let getAxisPositionFromStartStepSpy: jasmine.Spy;
   let getAxisPositionFromEndStepSpy: jasmine.Spy;
+  let getAxisPositionFromProspectiveStepSpy: jasmine.Spy;
   let cardFobHelper: CardFobGetStepFromPositionHelper;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -104,6 +107,7 @@ describe('card_fob_controller', () => {
     getStepLowerSpy = jasmine.createSpy();
     getAxisPositionFromStartStepSpy = jasmine.createSpy();
     getAxisPositionFromEndStepSpy = jasmine.createSpy();
+    getAxisPositionFromProspectiveStepSpy = jasmine.createSpy();
     getStepHigherSpy.and.callFake((step: number) => {
       return step;
     });
@@ -118,6 +122,11 @@ describe('card_fob_controller', () => {
         ? fixture.componentInstance.timeSelection.end.step
         : null;
     });
+    getAxisPositionFromProspectiveStepSpy.and.callFake(() => {
+      return fixture.componentInstance.prospectiveStep
+        ? fixture.componentInstance.prospectiveStep
+        : null;
+    });
     cardFobHelper = {
       getStepHigherThanAxisPosition: getStepHigherSpy,
       getStepLowerThanAxisPosition: getStepLowerSpy,
@@ -127,6 +136,8 @@ describe('card_fob_controller', () => {
       getAxisPositionFromStartStepSpy;
     fixture.componentInstance.getAxisPositionFromEndStep =
       getAxisPositionFromEndStepSpy;
+    fixture.componentInstance.getAxisPositionFromProspectiveStep =
+      getAxisPositionFromProspectiveStepSpy;
     fixture.componentInstance.highestStep = 4;
     fixture.componentInstance.lowestStep = 0;
     fixture.componentInstance.cardFobHelper = cardFobHelper;
@@ -1319,6 +1330,40 @@ describe('card_fob_controller', () => {
       expect(
         fixture.componentInstance.fobController.prospectiveFobWrapper
       ).toBeUndefined();
+    });
+
+    it('sets horizontal position based on prospective step', () => {
+      const fixture = createComponent({
+        timeSelection: {start: {step: 4}, end: null},
+        axisDirection: AxisDirection.HORIZONTAL,
+        isProspectiveFobFeatureEnabled: true,
+        prospectiveStep: 2,
+      });
+      fixture.detectChanges();
+
+      const fobController = fixture.componentInstance.fobController;
+      const prospectiveFobLeftPosition =
+        fobController.prospectiveFobWrapper.nativeElement.getBoundingClientRect()
+          .left;
+
+      expect(prospectiveFobLeftPosition).toEqual(2);
+    });
+
+    it('sets vertical position based on prospective step', () => {
+      const fixture = createComponent({
+        timeSelection: {start: {step: 4}, end: null},
+        axisDirection: AxisDirection.VERTICAL,
+        isProspectiveFobFeatureEnabled: true,
+        prospectiveStep: 2,
+      });
+      fixture.detectChanges();
+
+      const fobController = fixture.componentInstance.fobController;
+      const prospectiveFobLeftPosition =
+        fobController.prospectiveFobWrapper.nativeElement.getBoundingClientRect()
+          .top;
+
+      expect(prospectiveFobLeftPosition).toEqual(2);
     });
   });
 });


### PR DESCRIPTION
* Motivation for features / changes
This is pre-work of placing prospective fob at the mouse position. First we want to get the position which reflects the prospective step.

* Technical description of changes
Same structure as how we get start/end fob position, just create another one for prospective fob.
Small styling (opacity and cursor)

* Screenshots of UI changes
Not visible yet. Sets step directly for unit test only.