### PR TITLE
doc: replace the compatibility badge with pypi package badge in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TensorBoard [![GitHub Actions CI](https://github.com/tensorflow/tensorboard/workflows/CI/badge.svg)](https://github.com/tensorflow/tensorboard/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush) [![Compat check PyPI](https://python-compatibility-tools.appspot.com/one_badge_image?package=tensorboard)](https://python-compatibility-tools.appspot.com/one_badge_target?package=tensorboard)
+# TensorBoard [![GitHub Actions CI](https://github.com/tensorflow/tensorboard/workflows/CI/badge.svg)](https://github.com/tensorflow/tensorboard/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush) [![PyPI](https://badge.fury.io/py/tensorboard.svg)](https://badge.fury.io/py/tensorboard)
 
 TensorBoard is a suite of web applications for inspecting and understanding your
 TensorFlow runs and graphs.


### PR DESCRIPTION
The links to the compatibility badge and page do not exist any more (added at https://github.com/tensorflow/tensorboard/pull/2328). Also checked a few other repos under TensorFlow, none of them have compatibility badge.

Preview:
![image](https://user-images.githubusercontent.com/15273931/198138791-aca32e7d-3c9c-4e2d-a607-732d70f4e5d0.png)

#oncall