### PR TITLE
Add summary source metadata to the TB summary writer output

### DIFF
--- a/tensorboard/summary/writer/event_file_writer.py
+++ b/tensorboard/summary/writer/event_file_writer.py
@@ -90,7 +90,11 @@ class EventFileWriter(object):
 
         # Initialize an event instance.
         _event = event_pb2.Event(
-            wall_time=time.time(), file_version="brain.Event:2"
+            wall_time=time.time(),
+            file_version="brain.Event:2",
+            source_metadata=event_pb2.SourceMetadata(
+                writer="tensorboard.summary.writer.event_file_writer"
+            ),
         )
         self.add_event(_event)
         self.flush()

--- a/tensorboard/summary/writer/event_file_writer_fsspec_test.py
+++ b/tensorboard/summary/writer/event_file_writer_fsspec_test.py
@@ -81,6 +81,10 @@ class EventFileWriterFSSpecTest(tb_test.TestCase):
         r.GetNext()
         s = event_pb2.Event.FromString(r.record())
         self.assertEqual(s.file_version, "brain.Event:2")
+        self.assertEqual(
+            s.source_metadata.writer,
+            "tensorboard.summary.writer.event_file_writer",
+        )
 
 
 if __name__ == "__main__":

--- a/tensorboard/summary/writer/event_file_writer_test.py
+++ b/tensorboard/summary/writer/event_file_writer_test.py
@@ -64,6 +64,10 @@ class EventFileWriterTest(tb_test.TestCase):
         r.GetNext()
         s = event_pb2.Event.FromString(r.record())
         self.assertEqual(s.file_version, "brain.Event:2")
+        self.assertEqual(
+            s.source_metadata.writer,
+            "tensorboard.summary.writer.event_file_writer",
+        )
 
 
 class AsyncWriterTest(tb_test.TestCase):


### PR DESCRIPTION
Specifies source metadata for event files as `tensorboard.summary.writer.event_file_writer` for the TB summary writer.