### PR TITLE
linked time: create listen area for fob and set step to null on mouseleave

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -41,6 +41,7 @@ import {MinMaxStep} from './scalar_card_types';
       [isProspectiveFobFeatureEnabled]="isProspectiveFobFeatureEnabled"
       [cardFobHelper]="cardFobHelper"
       [showExtendedLine]="true"
+      (onPrespectiveStepChanged)="onPrespectiveStepChanged($event)"
       (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
       (onTimeSelectionToggled)="onTimeSelectionToggled.emit($event)"
     ></card-fob-controller>
@@ -97,6 +98,10 @@ export class ScalarCardFobController {
       [0, this.axisSize],
       this.prospectiveStep
     );
+  }
+
+  onPrespectiveStepChanged(step: number | null) {
+    this.prospectiveStep = step;
   }
 
   getHighestStep(): number {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -28,6 +28,11 @@ limitations under the License.
     ></card-fob>
   </div>
   <div
+    class="prospective-fob-area"
+    [ngClass]="isVertical() ? 'vertical-prospective-area' : 'horizontal-prospective-area'"
+    (mouseleave)="onProspectiveAreaMouseLeave()"
+  ></div>
+  <div
     #startFobWrapper
     class="time-fob-wrapper"
     [style.transform]="getCssTranslatePxForStartFob()"

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
@@ -57,9 +57,11 @@ limitations under the License.
 }
 
 .horizontal-prospective-area {
-  height: 25px;
-  transform: translateY(225px);
-  width: 100%;
+  bottom: 0;
+  position: absolute;
+  // Height/Width to match x-axis
+  height: 30px;
+  width: calc(100% - 30px); // dot on the left takes up 30px
 }
 
 .prospective-area {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
@@ -19,6 +19,7 @@ limitations under the License.
 .time-fob-wrapper {
   display: inline-block;
   position: absolute;
+  top: 0;
   width: 0;
 }
 
@@ -53,4 +54,14 @@ limitations under the License.
 .prospectiveFob {
   opacity: 0.8;
   cursor: pointer;
+}
+
+.horizontal-prospective-area {
+  height: 25px;
+  transform: translateY(225px);
+  width: 100%;
+}
+
+.prospective-area {
+  display: block;
 }

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
@@ -61,7 +61,7 @@ limitations under the License.
   position: absolute;
   // Height/Width to match x-axis
   height: 30px;
-  width: calc(100% - 30px); // dot on the left takes up 30px
+  width: calc(100% - 50px); // dot on the left takes up 50px
 }
 
 .prospective-area {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -67,6 +67,7 @@ export class CardFobControllerComponent {
   @Output() onTimeSelectionChanged =
     new EventEmitter<TimeSelectionWithAffordance>();
   @Output() onTimeSelectionToggled = new EventEmitter();
+  @Output() onPrespectiveStepChanged = new EventEmitter<number | null>();
 
   private hasFobMoved: boolean = false;
   private currentDraggingFob: Fob = Fob.NONE;
@@ -345,5 +346,9 @@ export class CardFobControllerComponent {
     }
 
     this.onTimeSelectionToggled.emit();
+  }
+
+  onProspectiveAreaMouseLeave() {
+    this.onPrespectiveStepChanged.emit(null);
   }
 }

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -44,6 +44,7 @@ import {
       [prospectiveStep]="prospectiveStep"
       (onTimeSelectionChanged)="onTimeSelectionChanged($event)"
       (onTimeSelectionToggled)="onTimeSelectionToggled()"
+      (onPrespectiveStepChanged)="onPrespectiveStepChanged($event)"
     ></card-fob-controller>
   `,
 })
@@ -65,6 +66,7 @@ class TestableComponent {
 
   @Input() onTimeSelectionChanged!: (newTimeSelection: TimeSelection) => void;
   @Input() onTimeSelectionToggled!: () => void;
+  @Input() onPrespectiveStepChanged!: (step: number | null) => void;
 }
 
 describe('card_fob_controller', () => {
@@ -76,6 +78,8 @@ describe('card_fob_controller', () => {
   let getAxisPositionFromEndStepSpy: jasmine.Spy;
   let getAxisPositionFromProspectiveStepSpy: jasmine.Spy;
   let cardFobHelper: CardFobGetStepFromPositionHelper;
+  let onPrespectiveStepChangedSpy: jasmine.Spy;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [
@@ -165,6 +169,14 @@ describe('card_fob_controller', () => {
 
     onTimeSelectionToggled = jasmine.createSpy();
     fixture.componentInstance.onTimeSelectionToggled = onTimeSelectionToggled;
+
+    onPrespectiveStepChangedSpy = jasmine.createSpy();
+    fixture.componentInstance.onPrespectiveStepChanged =
+      onPrespectiveStepChangedSpy;
+    onPrespectiveStepChangedSpy.and.callFake((step: number | null) => {
+      fixture.componentInstance.prospectiveStep = step;
+    });
+
     return fixture;
   }
 
@@ -1364,6 +1376,26 @@ describe('card_fob_controller', () => {
           .top;
 
       expect(prospectiveFobTopPosition).toEqual(2);
+    });
+
+    describe('prospective area', () => {
+      it('emits null step on mouseleave', () => {
+        const fixture = createComponent({
+          timeSelection: {start: {step: 4}, end: null},
+          axisDirection: AxisDirection.HORIZONTAL,
+          isProspectiveFobFeatureEnabled: true,
+          prospectiveStep: 2,
+        });
+        fixture.detectChanges();
+
+        const hoverArea = fixture.debugElement.query(
+          By.css('.prospective-fob-area')
+        );
+        hoverArea.triggerEventHandler('mouseleave', {});
+        fixture.detectChanges();
+
+        expect(onPrespectiveStepChangedSpy).toHaveBeenCalledWith(null);
+      });
     });
   });
 });


### PR DESCRIPTION
* Motivation for features / changes
On mouse hovering the axis, we want to show the prospective fob. On mouse leaving, we want to remove the fob. This PR creates that element and implement the mouse leaving part.

* Technical description of changes
A new div element to take the mouse event for displaying the prospective fob.
The element is placed beneath start/end fob then those events will not be triggered when start/end fob hovered and ready to be dragged. 

The range of this area is subjected to change. I made something seems reasonable to me for now. We can also think of extending the area or do something else about it (might be similar to the dragging flow) but that will come later if we feel the need to improve the flow.

* Screenshots of UI changes
Not visible still, but the area in scalar card kind of covers axis:
![Screen Shot 2022-10-27 at 5 11 39 PM](https://user-images.githubusercontent.com/1131010/198420290-a338e967-c1a4-490e-a344-13c6891f3de8.png)
