### PR TITLE
Linked Time: Make `timeSelection` optional in fob controllers

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -49,7 +49,7 @@ import {MinMaxStep} from './scalar_card_types';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScalarCardFobController {
-  @Input() timeSelection!: TimeSelection;
+  @Input() timeSelection?: TimeSelection;
   @Input() scale!: Scale;
   @Input() minMaxHorizontalViewExtend!: [number, number];
   @Input() minMaxStep!: MinMaxStep;
@@ -74,18 +74,18 @@ export class ScalarCardFobController {
     return this.scale.forward(
       this.minMaxHorizontalViewExtend,
       [0, this.axisSize],
-      this.timeSelection.start.step
+      this.timeSelection?.start.step ?? this.minMaxStep.minStep
     );
   }
 
   getAxisPositionFromEndStep() {
-    if (this.timeSelection.end === null) {
+    if (!this.timeSelection?.end) {
       return null;
     }
     return this.scale.forward(
       this.minMaxHorizontalViewExtend,
       [0, this.axisSize],
-      this.timeSelection.end.step
+      this.timeSelection?.end.step ?? this.minMaxStep.maxStep
     );
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -71,10 +71,13 @@ export class ScalarCardFobController {
   prospectiveStep: number | null = null;
 
   getAxisPositionFromStartStep() {
+    if (!this.timeSelection) {
+      return '';
+    }
     return this.scale.forward(
       this.minMaxHorizontalViewExtend,
       [0, this.axisSize],
-      this.timeSelection?.start.step ?? this.minMaxStep.minStep
+      this.timeSelection.start.step
     );
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2376,6 +2376,24 @@ describe('scalar card', () => {
           }),
         ]);
       }));
+
+      it('does not render fobs when no timeSelection is provided', fakeAsync(() => {
+        store.overrideSelector(getMetricsLinkedTimeSelection, {
+          start: {step: 20},
+          end: null,
+        });
+        const fixture = createComponent('card1');
+        const scalarCardFobController = fixture.debugElement.query(
+          By.directive(ScalarCardFobController)
+        ).componentInstance;
+        delete scalarCardFobController.timeSelection;
+        fixture.detectChanges();
+        const fobController = fixture.debugElement.query(
+          By.directive(CardFobComponent)
+        ).componentInstance;
+        expect(fobController.startFobWrapper).not.toBeDefined();
+        expect(fobController.endFobWrapper).not.toBeDefined();
+      }));
     });
 
     describe('scalar card data table', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2391,8 +2391,9 @@ describe('scalar card', () => {
         const fobController = fixture.debugElement.query(
           By.directive(CardFobComponent)
         ).componentInstance;
-        expect(fobController.startFobWrapper).not.toBeDefined();
-        expect(fobController.endFobWrapper).not.toBeDefined();
+
+        expect(fobController.startFobWrapper).toBeUndefined();
+        expect(fobController.endFobWrapper).toBeUndefined();
       }));
     });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2377,6 +2377,7 @@ describe('scalar card', () => {
         ]);
       }));
 
+      // TODO(rileyajones) refactor this test with #6006
       it('does not render fobs when no timeSelection is provided', fakeAsync(() => {
         store.overrideSelector(getMetricsLinkedTimeSelection, {
           start: {step: 20},

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -31,6 +31,7 @@ limitations under the License.
     #startFobWrapper
     class="time-fob-wrapper"
     [style.transform]="getCssTranslatePxForStartFob()"
+    *ngIf="timeSelection"
   >
     <div
       *ngIf="showExtendedLine"
@@ -48,7 +49,7 @@ limitations under the License.
   </div>
   <div
     #endFobWrapper
-    *ngIf="timeSelection.end"
+    *ngIf="timeSelection && timeSelection.end"
     class="time-fob-wrapper"
     [style.transform]="getCssTranslatePxForEndFob()"
   >

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -269,12 +269,9 @@ export class CardFobControllerComponent {
   }
 
   getDraggingFobStep(): number {
-    if (!this.timeSelection) {
-      throw new Error('TimeSelection is not defined');
-    }
     return this.currentDraggingFob !== Fob.END
-      ? this.timeSelection.start.step
-      : this.timeSelection.end!.step;
+      ? this.timeSelection!.start.step
+      : this.timeSelection!.end!.step;
   }
 
   getMousePositionFromEvent(event: MouseEvent): number {
@@ -284,13 +281,10 @@ export class CardFobControllerComponent {
   }
 
   stepTyped(fob: Fob, step: number | null) {
-    if (!this.timeSelection) {
-      return;
-    }
     // Types empty string in fob.
     if (step === null) {
       // Removes fob on range selection and sets step to minimum on single selection.
-      if (this.timeSelection.end !== null) {
+      if (this.timeSelection!.end !== null) {
         this.onFobRemoved(fob);
       } else {
         // TODO(jieweiwu): sets start step to minum.
@@ -299,7 +293,7 @@ export class CardFobControllerComponent {
       return;
     }
 
-    let newTimeSelection = {...this.timeSelection};
+    let newTimeSelection = {...this.timeSelection!};
     if (fob === Fob.START) {
       newTimeSelection.start = {step};
     } else if (fob === Fob.END) {
@@ -334,22 +328,19 @@ export class CardFobControllerComponent {
    * fob toggles the feature entirely.
    */
   onFobRemoved(fob: Fob) {
-    if (!this.timeSelection) {
-      return;
-    }
     if (fob === Fob.END) {
       this.onTimeSelectionChanged.emit({
         affordance: TimeSelectionAffordance.FOB_REMOVED,
-        timeSelection: {...this.timeSelection, end: null},
+        timeSelection: {...this.timeSelection!, end: null},
       });
       return;
     }
 
-    if (this.timeSelection.end !== null) {
+    if (this.timeSelection!.end !== null) {
       this.onTimeSelectionChanged.emit({
         affordance: TimeSelectionAffordance.FOB_REMOVED,
         timeSelection: {
-          start: this.timeSelection.end,
+          start: this.timeSelection!.end,
           end: null,
         },
       });


### PR DESCRIPTION
* Motivation for features / changes
We would like to be able to enable step selection using a prospective fob. The prospective fob is currently implemented withing the fob_controller_component which has a required `timeSelection` parameter.

* Screenshots of UI changes
None

* Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Go to [http://localhost:6006?enableDataTable=true&enableProspectiveFob=true](http://localhost:6006?enableDataTable=true&enableProspectiveFob=true)
3) View a scalar card
4) Assert that no fobs are shown
5) Enable step selection
6) Assert that a single fob is shown
