### PR TITLE
Linked Time: Render card fob controller when prospective fob feature is enabled

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -187,7 +187,7 @@ limitations under the License.
   let-domDim="domDimension"
   let-xScale="xScale"
 >
-  <ng-container *ngIf="inTimeSelectionMode()">
+  <ng-container *ngIf="inTimeSelectionMode() || isProspectiveFobFeatureEnabled">
     <scalar-card-fob-controller
       [timeSelection]="stepOrLinkedTimeSelection"
       [scale]="xScale"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2377,17 +2377,16 @@ describe('scalar card', () => {
         ]);
       }));
 
-      // TODO(rileyajones) refactor this test with #6006
       it('does not render fobs when no timeSelection is provided', fakeAsync(() => {
         store.overrideSelector(getMetricsLinkedTimeSelection, {
           start: {step: 20},
           end: null,
         });
+        store.overrideSelector(
+          selectors.getIsLinkedTimeProspectiveFobEnabled,
+          true
+        );
         const fixture = createComponent('card1');
-        const scalarCardFobController = fixture.debugElement.query(
-          By.directive(ScalarCardFobController)
-        ).componentInstance;
-        delete scalarCardFobController.timeSelection;
         fixture.detectChanges();
         const fobController = fixture.debugElement.query(
           By.directive(CardFobComponent)


### PR DESCRIPTION
~Blocked by #6005~

* Motivation for features / changes
We would like to be able to enable step selection using a prospective fob. Now that #6005 is merged, the fob controller can safely be rendered with an undefined `timeSelection`

* Screenshots of UI changes
None

* Alternate designs / implementations considered
