### PR TITLE
Revert "cleanup: replace namedtuple with dataclass - part 1"

### DIFF
--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -15,10 +15,7 @@
 """Takes a generator of values, and accumulates them for a frontend."""
 
 import collections
-import dataclasses
 import threading
-
-from typing import Sequence, Tuple
 
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import event_file_loader
@@ -30,137 +27,47 @@ from tensorboard.compat.proto import config_pb2
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import graph_pb2
 from tensorboard.compat.proto import meta_graph_pb2
-from tensorboard.compat.proto import tensor_pb2
 from tensorboard.plugins.distribution import compressor
 from tensorboard.util import tb_logging
 
 
 logger = tb_logging.get_logger()
 
+namedtuple = collections.namedtuple
+ScalarEvent = namedtuple("ScalarEvent", ["wall_time", "step", "value"])
 
-@dataclasses.dataclass(frozen=True)
-class ScalarEvent:
-    """Contains information of a scalar event.
+CompressedHistogramEvent = namedtuple(
+    "CompressedHistogramEvent",
+    ["wall_time", "step", "compressed_histogram_values"],
+)
 
-    Attributes:
-      wall_time: Timestamp of the event in seconds.
-      step: Global step of the event.
-      value: A float or int value of the scalar.
-    """
+HistogramEvent = namedtuple(
+    "HistogramEvent", ["wall_time", "step", "histogram_value"]
+)
 
-    wall_time: float
-    step: int
-    value: float
+HistogramValue = namedtuple(
+    "HistogramValue",
+    ["min", "max", "num", "sum", "sum_squares", "bucket_limit", "bucket"],
+)
 
+ImageEvent = namedtuple(
+    "ImageEvent",
+    ["wall_time", "step", "encoded_image_string", "width", "height"],
+)
 
-@dataclasses.dataclass(frozen=True)
-class CompressedHistogramEvent:
-    """Contains information of a compressed histogram event.
+AudioEvent = namedtuple(
+    "AudioEvent",
+    [
+        "wall_time",
+        "step",
+        "encoded_audio_string",
+        "content_type",
+        "sample_rate",
+        "length_frames",
+    ],
+)
 
-    Attributes:
-      wall_time: Timestamp of the event in seconds.
-      step: Global step of the event.
-      compressed_histogram_values: A sequence of tuples of basis points and
-        associated values in a compressed histogram.
-    """
-
-    wall_time: float
-    step: int
-    compressed_histogram_values: Sequence[Tuple[float, float]]
-
-
-@dataclasses.dataclass(frozen=True)
-class HistogramValue:
-    """Holds the information of the histogram values.
-
-    Attributes:
-      min: A float or int min value.
-      max: A float or int max value.
-      num: Total number of values.
-      sum: Sum of all values.
-      sum_squares: Sum of squares for all values.
-      bucket_limit: Upper values per bucket.
-      bucket: Numbers of values per bucket.
-    """
-
-    min: float
-    max: float
-    num: int
-    sum: float
-    sum_squares: float
-    bucket_limit: Sequence[float]
-    bucket: Sequence[int]
-
-
-@dataclasses.dataclass(frozen=True)
-class HistogramEvent:
-    """Contains information of a histogram event.
-
-    Attributes:
-      wall_time: Timestamp of the event in seconds.
-      step: Global step of the event.
-      histogram_value: Information of the histogram values.
-    """
-
-    wall_time: float
-    step: int
-    histogram_value: HistogramValue
-
-
-@dataclasses.dataclass(frozen=True)
-class ImageEvent:
-    """Contains information of an image event.
-
-    Attributes:
-      wall_time: Timestamp of the event in seconds.
-      step: Global step of the event.
-      encoded_image_string: Image content encoded in bytes.
-      width: Width of the image.
-      height: Height of the image.
-    """
-
-    wall_time: float
-    step: int
-    encoded_image_string: bytes
-    width: int
-    height: int
-
-
-@dataclasses.dataclass(frozen=True)
-class AudioEvent:
-    """Contains information of an audio event.
-
-    Attributes:
-      wall_time: Timestamp of the event in seconds.
-      step: Global step of the event.
-      encoded_audio_string: Audio content encoded in bytes.
-      content_type: A string describes the type of the audio content.
-      sample_rate: Sample rate of the audio in Hz. Must be positive.
-      length_frames: Length of the audio in frames (samples per channel).
-    """
-
-    wall_time: float
-    step: int
-    encoded_audio_string: bytes
-    content_type: str
-    sample_rate: float
-    length_frames: int
-
-
-@dataclasses.dataclass(frozen=True)
-class TensorEvent:
-    """A tensor event.
-
-    Attributes:
-      wall_time: Timestamp of the event in seconds.
-      step: Global step of the event.
-      tensor_proto: A `TensorProto`.
-    """
-
-    wall_time: float
-    step: int
-    tensor_proto: tensor_pb2.TensorProto
-
+TensorEvent = namedtuple("TensorEvent", ["wall_time", "step", "tensor_proto"])
 
 ## Different types of summary events handled by the event_accumulator
 SUMMARY_TYPES = {
@@ -757,8 +664,7 @@ class EventAccumulator(object):
             self.most_recent_step = event.step
             self.most_recent_wall_time = event.wall_time
 
-    def _ConvertHistogramProtoToPopo(self, histo):
-        """Converts histogram proto to Python object."""
+    def _ConvertHistogramProtoToTuple(self, histo):
         return HistogramValue(
             min=histo.min,
             max=histo.max,
@@ -771,7 +677,7 @@ class EventAccumulator(object):
 
     def _ProcessHistogram(self, tag, wall_time, step, histo):
         """Processes a proto histogram by adding it to accumulated state."""
-        histo = self._ConvertHistogramProtoToPopo(histo)
+        histo = self._ConvertHistogramProtoToTuple(histo)
         histo_ev = HistogramEvent(wall_time, step, histo)
         self.histograms.AddItem(tag, histo_ev)
         self.compressed_histograms.AddItem(

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -374,7 +374,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
 
         # Create the expected values after compressing hst1
         expected_vals1 = [
-            compressor.CompressedHistogramValue(bp, val).as_tuple()
+            compressor.CompressedHistogramValue(bp, val)
             for bp, val in [
                 (0, 1.0),
                 (2500, 1.25),
@@ -390,7 +390,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
 
         # Create the expected values after compressing hst2
         expected_vals2 = [
-            compressor.CompressedHistogramValue(bp, val).as_tuple()
+            compressor.CompressedHistogramValue(bp, val)
             for bp, val in [
                 (0, -2),
                 (2500, 2),

--- a/tensorboard/backend/event_processing/event_file_inspector.py
+++ b/tensorboard/backend/event_processing/event_file_inspector.py
@@ -109,11 +109,9 @@ histograms
 """
 
 
-import dataclasses
+import collections
 import itertools
 import os
-
-from typing import Any, Generator, Mapping
 
 from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.backend.event_processing import event_file_loader
@@ -147,44 +145,25 @@ SHORT_FIELDS = ["graph", "sessionlog:checkpoint"] + TAG_FIELDS
 # All summary types that we can inspect.
 TRACKED_FIELDS = SHORT_FIELDS + LONG_FIELDS
 
+# An `Observation` contains the data within each Event file that the inspector
+# cares about. The inspector accumulates Observations as it processes events.
+Observation = collections.namedtuple(
+    "Observation", ["step", "wall_time", "tag"]
+)
+
+# An InspectionUnit is created for each organizational structure in the event
+# files visible in the final terminal output. For instance, one InspectionUnit
+# is created for each subdirectory in logdir. When asked to inspect a single
+# event file, there may only be one InspectionUnit.
+
+# The InspectionUnit contains the `name` of the organizational unit that will be
+# printed to console, a `generator` that yields `Event` protos, and a mapping
+# from string fields to `Observations` that the inspector creates.
+InspectionUnit = collections.namedtuple(
+    "InspectionUnit", ["name", "generator", "field_to_obs"]
+)
+
 PRINT_SEPARATOR = "=" * 70 + "\n"
-
-
-@dataclasses.dataclass(frozen=True)
-class Observation:
-    """Contains the data within each Event file that the inspector cares about.
-
-    The inspector accumulates Observations as it processes events.
-
-    Attributes:
-      step: Global step of the event.
-      wall_time: Timestamp of the event in seconds.
-      tag: Tag name associated with the event.
-    """
-
-    step: int
-    wall_time: float
-    tag: str
-
-
-@dataclasses.dataclass(frozen=True)
-class InspectionUnit:
-    """Created for each organizational structure in the event files.
-
-    An InspectionUnit is visible in the final terminal output. For instance, one
-    InspectionUnit is created for each subdirectory in logdir. When asked to inspect
-    a single event file, there may only be one InspectionUnit.
-
-    Attributes:
-      name: Name of the organizational unit that will be printed to console.
-      generator: A generator that yields `Event` protos.
-      field_to_obs: A mapping from string fields to `Observations` that the inspector
-        creates.
-    """
-
-    name: str
-    generator: Generator[event_pb2.Event, Any, Any]
-    field_to_obs: Mapping[str, Observation]
 
 
 def get_field_to_observations_map(generator, query_for_tag=""):
@@ -202,9 +181,9 @@ def get_field_to_observations_map(generator, query_for_tag=""):
     def increment(stat, event, tag=""):
         assert stat in TRACKED_FIELDS
         field_to_obs[stat].append(
-            dataclasses.asdict(
-                Observation(step=event.step, wall_time=event.wall_time, tag=tag)
-            )
+            Observation(
+                step=event.step, wall_time=event.wall_time, tag=tag
+            )._asdict()
         )
 
     field_to_obs = dict([(t, []) for t in TRACKED_FIELDS])

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -15,8 +15,8 @@
 """Takes a generator of values, and accumulates them for a frontend."""
 
 import collections
-import dataclasses
 import threading
+
 
 from tensorboard.backend.event_processing import directory_loader
 from tensorboard.backend.event_processing import directory_watcher
@@ -29,12 +29,14 @@ from tensorboard.compat.proto import config_pb2
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import graph_pb2
 from tensorboard.compat.proto import meta_graph_pb2
-from tensorboard.compat.proto import tensor_pb2
 from tensorboard.util import tb_logging
 
 
 logger = tb_logging.get_logger()
 
+namedtuple = collections.namedtuple
+
+TensorEvent = namedtuple("TensorEvent", ["wall_time", "step", "tensor_proto"])
 
 # Legacy aliases
 TENSORS = tag_types.TENSORS
@@ -51,21 +53,6 @@ STORE_EVERYTHING_SIZE_GUIDANCE = {
 }
 
 _TENSOR_RESERVOIR_KEY = "."  # arbitrary
-
-
-@dataclasses.dataclass(frozen=True)
-class TensorEvent:
-    """A tensor event.
-
-    Attributes:
-      wall_time: Timestamp of the event in seconds.
-      step: Global step of the event.
-      tensor_proto: A `TensorProto`.
-    """
-
-    wall_time: float
-    step: int
-    tensor_proto: tensor_pb2.TensorProto
 
 
 class EventAccumulator(object):

--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -15,14 +15,15 @@
 """Validates responses and their security features."""
 
 
-import dataclasses
-
-from typing import Collection
+import collections
 
 from werkzeug.datastructures import Headers
 from werkzeug import http
 
 from tensorboard.util import tb_logging
+
+# Loosely follow vocabulary from https://www.w3.org/TR/CSP/#framework-directives.
+Directive = collections.namedtuple("Directive", ["name", "value"])
 
 logger = tb_logging.get_logger()
 
@@ -39,21 +40,6 @@ _CSP_IGNORE = {
     "script-src": ["'unsafe-eval'"],
     "font-src": ["data:"],
 }
-
-
-@dataclasses.dataclass(frozen=True)
-class Directive:
-    """Content security policy directive.
-
-    Loosely follow vocabulary from https://www.w3.org/TR/CSP/#framework-directives.
-
-    Attributes:
-      name: A non-empty string.
-      value: A collection of non-empty strings.
-    """
-
-    name: str
-    value: Collection[str]
 
 
 def _maybe_raise_value_error(error_msg):

--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -20,7 +20,7 @@ TensorBoard.  This allows running TensorBoard without depending on
 TensorFlow for file operations.
 """
 
-import dataclasses
+from collections import namedtuple
 import glob as py_glob
 import io
 import os
@@ -84,15 +84,8 @@ def get_filesystem(filename):
     return fs
 
 
-@dataclasses.dataclass(frozen=True)
-class StatData:
-    """Data returned from the Stat call.
-
-    Attributes:
-      length: Length of the data content.
-    """
-
-    length: int
+# Data returned from the Stat call.
+StatData = namedtuple("StatData", ["length"])
 
 
 class LocalFileSystem(object):

--- a/tensorboard/plugins/distribution/compressor_test.py
+++ b/tensorboard/plugins/distribution/compressor_test.py
@@ -20,10 +20,7 @@ from tensorboard.plugins.distribution import compressor
 
 
 def _make_expected_value(*values):
-    return [
-        compressor.CompressedHistogramValue(bp, val).as_tuple()
-        for bp, val in values
-    ]
+    return [compressor.CompressedHistogramValue(bp, val) for bp, val in values]
 
 
 class CompressorTest(tf.test.TestCase):
@@ -70,7 +67,7 @@ class CompressorTest(tf.test.TestCase):
         )
 
     def test_ugly(self):
-        input_bps = (0, 668, 1587, 3085, 5000, 6915, 8413, 9332, 10000)
+        bps = (0, 668, 1587, 3085, 5000, 6915, 8413, 9332, 10000)
         bucket_limits = [
             -1.0,
             0.0,
@@ -83,18 +80,17 @@ class CompressorTest(tf.test.TestCase):
         buckets = list(
             zip(*[bucket_limits[:-1], bucket_limits[1:], bucket_counts])
         )
-        vals = compressor.compress_histogram(buckets, input_bps)
-        (bps, values) = zip(*vals)
-        self.assertSequenceEqual(bps, input_bps)
-        self.assertAlmostEqual(values[0], -1.0)
-        self.assertAlmostEqual(values[1], -0.86277993701301037)
-        self.assertAlmostEqual(values[2], -0.67399964077791519)
-        self.assertAlmostEqual(values[3], -0.36628159533703131)
-        self.assertAlmostEqual(values[4], 0.027096279842737214)
-        self.assertAlmostEqual(values[5], 0.42047415502250551)
-        self.assertAlmostEqual(values[6], 0.72819220046338917)
-        self.assertAlmostEqual(values[7], 0.91697249669848446)
-        self.assertAlmostEqual(values[8], 1.7976931348623157e308)
+        vals = compressor.compress_histogram(buckets, bps)
+        self.assertEqual(tuple(v.basis_point for v in vals), bps)
+        self.assertAlmostEqual(vals[0].value, -1.0)
+        self.assertAlmostEqual(vals[1].value, -0.86277993701301037)
+        self.assertAlmostEqual(vals[2].value, -0.67399964077791519)
+        self.assertAlmostEqual(vals[3].value, -0.36628159533703131)
+        self.assertAlmostEqual(vals[4].value, 0.027096279842737214)
+        self.assertAlmostEqual(vals[5].value, 0.42047415502250551)
+        self.assertAlmostEqual(vals[6].value, 0.72819220046338917)
+        self.assertAlmostEqual(vals[7].value, 0.91697249669848446)
+        self.assertAlmostEqual(vals[8].value, 1.7976931348623157e308)
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -16,10 +16,8 @@
 
 
 import collections
-import dataclasses
 import operator
 import re
-from typing import Optional
 
 from google.protobuf import struct_pb2
 
@@ -555,21 +553,13 @@ def _value_to_python(value):
         raise ValueError("Unknown struct_pb2.Value oneof field set: %s" % field)
 
 
-@dataclasses.dataclass(frozen=True)
-class _MetricIdentifier:
-    """An identifier for a metric.
-
-    As protobuffers are mutable we can't use MetricName directly as a dict's key.
-    Instead, we represent MetricName protocol buffer as an immutable dataclass.
-
-    Attributes:
-      group: Metric group corresponding to the dataset on which the model was
-        evaluated.
-      tag: String tag assoicated with the metric.
-    """
-
-    group: str
-    tag: str
+# As protobuffers are mutable we can't use MetricName directly as a dict's key.
+# Instead, we duplicate MetricName as a collections.namedtuple. Another
+# alternative would be to wrap the MetricName protocol buffer class in an
+# immutable class that defines equality and __hash__ methods based on the text
+# representation of the protocol buffer. This is more complex, but won't
+# require modification if we ever add fields to MetricName.
+_MetricIdentifier = collections.namedtuple("_MetricIdentifier", "group tag")
 
 
 class _MetricStats(object):
@@ -643,17 +633,11 @@ def _set_avg_session_metrics(session_group):
         )
 
 
-@dataclasses.dataclass(frozen=True)
-class _Measurement:
-    """Holds a session's metric value.
-
-    Attributes:
-      metric_value: Metric value of the session.
-      session_index: Index of the session in its group.
-    """
-
-    metric_value: Optional[api_pb2.MetricValue]
-    session_index: int
+# A namedtuple to hold a session's metric value.
+# 'session_index' is the index of the session in its group.
+_Measurement = collections.namedtuple(
+    "_Measurement", ["metric_value", "session_index"]
+)
 
 
 def _set_median_session_metrics(session_group, aggregation_metric):

--- a/tensorboard/plugins/mesh/metadata.py
+++ b/tensorboard/plugins/mesh/metadata.py
@@ -14,37 +14,20 @@
 # ==============================================================================
 """Internal information about the mesh plugin."""
 
-import dataclasses
 
-from typing import Any
-
+import collections
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.mesh import plugin_data_pb2
 
+
+MeshTensor = collections.namedtuple(
+    "MeshTensor", ("data", "content_type", "data_type")
+)
 PLUGIN_NAME = "mesh"
 
 # The most recent value for the `version` field of the
 # `MeshPluginData` proto.
 _PROTO_VERSION = 0
-
-
-@dataclasses.dataclass(frozen=True)
-class MeshTensor:
-    """A mesh tensor.
-
-    Attributes:
-      data: Tensor of shape `[dim_1, ..., dim_n, 3]` representing the mesh data
-        of one of the following:
-          - 3D coordinates of vertices
-          - Indices of vertices within each triangle
-          - Colors for each vertex
-      content_type: Type of the mesh plugin data content.
-      data_type: Data type of the elements in the tensor.
-    """
-
-    data: Any  # Expects type `tf.Tensor`, not specified here to avoid heavy TF dep.
-    content_type: plugin_data_pb2.MeshPluginData.ContentType
-    data_type: Any  # Expects type `tf.DType`, not specified here to avoid heavy TF dep.
 
 
 def get_components_bitmask(content_types):

--- a/tensorboard/plugins/mesh/test_utils.py
+++ b/tensorboard/plugins/mesh/test_utils.py
@@ -14,29 +14,15 @@
 # ==============================================================================
 """Test utils for mesh plugin tests."""
 
-import dataclasses
+import collections
 import json
 
 import numpy as np
 
 from tensorboard.util import tb_logging
 
+Mesh = collections.namedtuple("Mesh", ("vertices", "faces", "colors"))
 logger = tb_logging.get_logger()
-
-
-@dataclasses.dataclass(frozen=True)
-class Mesh:
-    """A mesh dataclass.
-
-    Attributes:
-      vertices: A numpy array containing 3D coordinates of vertices.
-      faces: A numpy array containing indices of vertices within each triangle
-      colors: A numpy array containing colors for each vertex.
-    """
-
-    vertices: np.ndarray
-    faces: np.ndarray
-    colors: np.ndarray
 
 
 def get_random_mesh(
@@ -52,7 +38,7 @@ def get_random_mesh(
       batch_size: Size of batch dimension in output array.
 
     Returns:
-      Mesh dataclass with vertices and optionally with faces and/or colors.
+      Mesh namedtuple with vertices and optionally with faces and/or colors.
     """
     vertices = np.random.random([num_vertices, 3]) * 1000
     # Add batch dimension.

--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -22,7 +22,7 @@ run TensorBoard. Read the output and follow the directions.
 
 # This script may only depend on the Python standard library. It is not
 # built with Bazel and should not assume any third-party dependencies.
-import dataclasses
+import collections
 import errno
 import functools
 import hashlib
@@ -45,20 +45,14 @@ import traceback
 CHECKS = []
 
 
-@dataclasses.dataclass(frozen=True)
-class Suggestion:
-    """A suggestion to the end user.
-
-    Attributes:
-      headline: A short description, like "Turn it off and on again". Should be
-        imperative with no trailing punctuation. May contain inline Markdown.
-      description: A full enumeration of the steps that the user should take to
-        accept the suggestion. Within this string, prose should be formatted
-        with `reflow`. May contain Markdown.
-    """
-
-    headline: str
-    description: str
+# A suggestion to the end user.
+#   headline (str): A short description, like "Turn it off and on
+#     again". Should be imperative with no trailing punctuation. May
+#     contain inline Markdown.
+#   description (str): A full enumeration of the steps that the user
+#     should take to accept the suggestion. Within this string, prose
+#     should be formatted with `reflow`. May contain Markdown.
+Suggestion = collections.namedtuple("Suggestion", ("headline", "description"))
 
 
 def check(fn):

--- a/tensorboard/tools/mat_bundle_icon_svg_test.py
+++ b/tensorboard/tools/mat_bundle_icon_svg_test.py
@@ -15,21 +15,21 @@
 
 """Tests for our composable SVG bundler."""
 
-import dataclasses
+import collections
 import os
 
 from tensorboard import test
 from tensorboard.tools import mat_bundle_icon_svg
 
 
-@dataclasses.dataclass(frozen=True)
-class _TestableSvg:
-    """Holds the information of a test SVG."""
-
-    basename: str
-    svg_content: str
-    expected_content: str
-
+_TestableSvg = collections.namedtuple(
+    "_TestableSvg",
+    (
+        "basename",
+        "svg_content",
+        "expected_content",
+    ),
+)
 
 TEST_SVG_A = _TestableSvg(
     "a.svg",

--- a/tensorboard/tools/whitespace_hygiene_test.py
+++ b/tensorboard/tools/whitespace_hygiene_test.py
@@ -19,7 +19,7 @@
 Keeps diffs clean and persnickety developers happy.
 """
 
-import dataclasses
+import collections
 import os
 import subprocess
 import sys
@@ -28,19 +28,7 @@ import sys
 exceptions = frozenset([])
 
 
-@dataclasses.dataclass(frozen=True)
-class Match:
-    """Information of the match for superfluous trailing whitespaces.
-
-    Attributes:
-      filename: Name of file containing the match.
-      line_number: Line number of the match.
-      line: Content of the line containing the match.
-    """
-
-    filename: str
-    line_number: int
-    line: str
+Match = collections.namedtuple("Match", ("filename", "line_number", "line"))
 
 
 def main():


### PR DESCRIPTION
Reverts tensorflow/tensorboard#5998, this caused internal breakage, the plugin event dataclasses need to be converted to tuples in `EventAccumulator`.