### PR TITLE
Linked Time: Make Prospective Fob Interactive

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1018,6 +1018,7 @@ const reducer = createReducer(
     const {timeSelection} = change;
     const nextStartStep = timeSelection.start.step;
     const nextEndStep = timeSelection.end?.step;
+    const nextStepSelectorEnabled = Boolean(timeSelection);
     const end =
       nextEndStep === undefined
         ? null
@@ -1046,6 +1047,7 @@ const reducer = createReducer(
       linkedTimeSelection,
       cardStepIndex: nextCardStepIndexMap,
       rangeSelectionEnabled,
+      stepSelectorEnabled: nextStepSelectorEnabled,
     };
   }),
   on(actions.stepSelectorToggled, (state) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -23,6 +23,7 @@ import {DataLoadState} from '../../types/data';
 import {ElementId} from '../../util/dom';
 import {mapObjectValues} from '../../util/lang';
 import {composeReducers} from '../../util/ngrx';
+import {TimeSelectionAffordance} from '../../widgets/card_fob/card_fob_types';
 import * as actions from '../actions';
 import {
   isFailedTimeSeriesResponse,
@@ -1018,7 +1019,9 @@ const reducer = createReducer(
     const {timeSelection} = change;
     const nextStartStep = timeSelection.start.step;
     const nextEndStep = timeSelection.end?.step;
-    const nextStepSelectorEnabled = Boolean(timeSelection);
+    const nextStepSelectorEnabled =
+      change.affordance === TimeSelectionAffordance.FOB_ADDED ||
+      state.stepSelectorEnabled;
     const end =
       nextEndStep === undefined
         ? null

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -3420,6 +3420,66 @@ describe('scalar card', () => {
         ]);
       }));
 
+      it('dispatches timeSelectionChanged actions when fob is added by clicking prospective fob', fakeAsync(() => {
+        store.overrideSelector(
+          selectors.getIsLinkedTimeProspectiveFobEnabled,
+          true
+        );
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+
+        const testController = fixture.debugElement.query(
+          By.directive(CardFobControllerComponent)
+        ).componentInstance;
+        testController.timeSelection = null;
+        testController.prospectiveStep = 10;
+        fixture.detectChanges();
+
+        // One prospective fob
+        let fobs = fixture.debugElement.queryAll(
+          By.directive(CardFobComponent)
+        );
+        expect(fobs.length).toEqual(1);
+
+        // Click the prospective fob to set the start time
+        fixture.debugElement
+          .query(By.css('.prospective-fob-area'))
+          .nativeElement.click();
+        fixture.detectChanges();
+
+        // One start fob + 1 prospective fob
+        fobs = fixture.debugElement.queryAll(By.directive(CardFobComponent));
+        expect(fobs.length).toEqual(2);
+
+        // Click the prospective fob to set the end time
+        testController.prospectiveStep = 25;
+        fixture.debugElement
+          .query(By.css('.prospective-fob-area'))
+          .nativeElement.click();
+        fixture.detectChanges();
+
+        // One start fob, one end fob, and one prospective fob
+        fobs = fixture.debugElement.queryAll(By.directive(CardFobComponent));
+        expect(fobs.length).toEqual(3);
+
+        expect(dispatchedActions).toEqual([
+          timeSelectionChanged({
+            timeSelection: {
+              start: {step: 10},
+              end: null,
+            },
+            affordance: TimeSelectionAffordance.FOB_ADDED,
+          }),
+          timeSelectionChanged({
+            timeSelection: {
+              start: {step: 10},
+              end: {step: 25},
+            },
+            affordance: TimeSelectionAffordance.FOB_ADDED,
+          }),
+        ]);
+      }));
+
       it('toggles when single fob is deselected', fakeAsync(() => {
         const fixture = createComponent('card1');
         fixture.detectChanges();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -3458,9 +3458,9 @@ describe('scalar card', () => {
           .nativeElement.click();
         fixture.detectChanges();
 
-        // One start fob, one end fob, and one prospective fob
+        // One start fob, one end fob
         fobs = fixture.debugElement.queryAll(By.directive(CardFobComponent));
-        expect(fobs.length).toEqual(3);
+        expect(fobs.length).toEqual(2);
 
         expect(dispatchedActions).toEqual([
           timeSelectionChanged({

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -23,7 +23,6 @@ limitations under the License.
     [style.transform]="getCssTranslatePxForProspectiveFob()"
   >
     <div *ngIf="showExtendedLine" class="extended-line"></div>
-
     <card-fob
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [allowRemoval]="false"

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -16,26 +16,30 @@ limitations under the License.
 -->
 
 <div>
-  <div
-    #prospectiveFobWrapper
-    class="time-fob-wrapper prospectiveFob"
-    *ngIf="prospectiveStep !== null && isProspectiveFobFeatureEnabled"
-    [style.transform]="getCssTranslatePxForProspectiveFob()"
+  <ng-container
+    *ngIf="isProspectiveFobFeatureEnabled && !rangeSelectionEnabled"
   >
-    <div *ngIf="showExtendedLine" class="extended-line"></div>
-    <card-fob
-      [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
-      [allowRemoval]="false"
-      [step]="prospectiveStep"
-    ></card-fob>
-  </div>
-  <div
-    class="prospective-fob-area"
-    [ngClass]="isVertical() ? 'vertical-prospective-area' : 'horizontal-prospective-area'"
-    (mousemove)="mouseOver($event)"
-    (mouseleave)="onProspectiveAreaMouseLeave()"
-    (click)="prospectiveFobClicked($event)"
-  ></div>
+    <div
+      #prospectiveFobWrapper
+      *ngIf="prospectiveStep !== null"
+      class="time-fob-wrapper prospectiveFob"
+      [style.transform]="getCssTranslatePxForProspectiveFob()"
+    >
+      <div *ngIf="showExtendedLine" class="extended-line"></div>
+      <card-fob
+        [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
+        [allowRemoval]="false"
+        [step]="prospectiveStep"
+      ></card-fob>
+    </div>
+    <div
+      class="prospective-fob-area"
+      [ngClass]="isVertical() ? 'vertical-prospective-area' : 'horizontal-prospective-area'"
+      (mousemove)="mouseOver($event)"
+      (mouseleave)="onProspectiveAreaMouseLeave()"
+      (click)="prospectiveFobClicked($event)"
+    ></div>
+  </ng-container>
   <div
     #startFobWrapper
     class="time-fob-wrapper"

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -23,6 +23,7 @@ limitations under the License.
     [style.transform]="getCssTranslatePxForProspectiveFob()"
   >
     <div *ngIf="showExtendedLine" class="extended-line"></div>
+
     <card-fob
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [allowRemoval]="false"
@@ -34,6 +35,7 @@ limitations under the License.
     [ngClass]="isVertical() ? 'vertical-prospective-area' : 'horizontal-prospective-area'"
     (mousemove)="mouseOver($event)"
     (mouseleave)="onProspectiveAreaMouseLeave()"
+    (click)="prospectiveFobClicked($event)"
   ></div>
   <div
     #startFobWrapper

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -343,14 +343,10 @@ export class CardFobControllerComponent {
   }
 
   stepTyped(fob: Fob, step: number | null) {
-    if (!this.timeSelection) {
-      return;
-    }
-
     // Types empty string in fob.
     if (step === null) {
       // Removes fob on range selection and sets step to minimum on single selection.
-      if (this.timeSelection.end !== null) {
+      if (this.timeSelection!.end !== null) {
         this.onFobRemoved(fob);
       } else {
         // TODO(jieweiwu): sets start step to minum.
@@ -359,7 +355,7 @@ export class CardFobControllerComponent {
       return;
     }
 
-    let newTimeSelection = {...this.timeSelection};
+    let newTimeSelection = {...this.timeSelection!};
     if (fob === Fob.START) {
       newTimeSelection.start = {step};
     } else if (fob === Fob.END) {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -381,9 +381,6 @@ export class CardFobControllerComponent {
   }
 
   prospectiveFobClicked(event: Event) {
-    if (!this.isProspectiveFobFeatureEnabled) {
-      return;
-    }
     event.stopPropagation();
     if (this.prospectiveStep === null) {
       return;

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -343,10 +343,14 @@ export class CardFobControllerComponent {
   }
 
   stepTyped(fob: Fob, step: number | null) {
+    if (!this.timeSelection) {
+      return;
+    }
+
     // Types empty string in fob.
     if (step === null) {
       // Removes fob on range selection and sets step to minimum on single selection.
-      if (this.timeSelection!.end !== null) {
+      if (this.timeSelection.end !== null) {
         this.onFobRemoved(fob);
       } else {
         // TODO(jieweiwu): sets start step to minum.
@@ -355,7 +359,7 @@ export class CardFobControllerComponent {
       return;
     }
 
-    let newTimeSelection = {...this.timeSelection!};
+    let newTimeSelection = {...this.timeSelection};
     if (fob === Fob.START) {
       newTimeSelection.start = {step};
     } else if (fob === Fob.END) {
@@ -377,6 +381,32 @@ export class CardFobControllerComponent {
     this.onTimeSelectionChanged.emit({
       timeSelection: newTimeSelection,
       affordance: TimeSelectionAffordance.FOB_TEXT,
+    });
+  }
+
+  prospectiveFobClicked(event: Event) {
+    if (!this.isProspectiveFobFeatureEnabled) {
+      return;
+    }
+    event.stopPropagation();
+    if (this.prospectiveStep === null) {
+      return;
+    }
+    const newTimeSelection = this.timeSelection
+      ? {
+          ...this.timeSelection,
+          end: {
+            step: this.prospectiveStep,
+          },
+        }
+      : {
+          start: {step: this.prospectiveStep},
+          end: null,
+        };
+
+    this.onTimeSelectionChanged.emit({
+      affordance: TimeSelectionAffordance.FOB_ADDED,
+      timeSelection: newTimeSelection,
     });
   }
 

--- a/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_types.ts
@@ -42,6 +42,8 @@ export enum TimeSelectionAffordance {
   CHANGE_TO_SINGLE = 'changeToSingle',
   // User clicks on Histogram Chart to change to range selection.
   HISTOGRAM_CLICK_TO_RANGE = 'histogramClickToRange',
+  // Adding a new fob
+  FOB_ADDED = 'fobAdded',
 }
 
 /**


### PR DESCRIPTION
Blocked by #6006 and #6016

## Motivation for features / changes
We believe the many check boxes in the settings panel to not be very discoverable and a generally poor user experience.
![image](https://user-images.githubusercontent.com/78179109/199616005-4fbe6df0-ebe8-462e-b684-cf883e6675cb.png)

To remedy this we would like to shown a "Prospective Fob" when the user hovers over the scalar card chart. When the user clicks on this "prospective fob", a fob will be placed at the corresponding location and step selection / range selection will be enabled as appropriate.

## Technical description of changes

## Screenshots of UI changes
Step Selection Disabled
![f469e422-ad1e-4c33-a329-4d60c3ba437f](https://user-images.githubusercontent.com/78179109/199615269-39b9305d-3922-4608-ad57-f122ebdff542.gif)

Step Selection Enabled
![761fb76e-b4ff-43be-bfe8-cf9410752c81](https://user-images.githubusercontent.com/78179109/199615324-5f48779f-b880-4121-a71c-50ad2cf34920.gif)

## Detailed steps to verify changes work correctly (as executed by you)
### Enabling Step Selection
1) Start tensorboard
2) Navigate to http://localhost:6006?enableDataTable=true&allowRangeSelection=true&enableProspectiveFob=true
3) Hover over the X Axis of a scalar card chart
4) Assert a prospective fob is shown and has no deselect button
5) Click on the prospective fob
6) Assert step selection is enabled and the data table is shown

### Enabling Range Selection
With Step Selection Enabled
1) Hovering the X Axis of the scalar card
2) Assert a prospective fob is shown
3) Click the prospective fob
4) Assert range selection is now enabled
5) Continue hovering the X Axis of the scalar card
6) Assert no prospective fob is shown
7) Remove a fob
8) Hover the X Axis of the scalar card
9) Assert a prospective fob is shown

* Alternate designs / implementations considered
