### PR TITLE
build: export histogram proto declaration in summary proto

### DIFF
--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -237,10 +237,10 @@ tb_proto_library(
 tb_proto_library(
     name = "summary",
     srcs = ["summary.proto"],
-    exports = ["//tensorboard/compat/proto:histogram"],
+    exports = [":histogram"],
     deps = [
+        ":histogram",
         ":tensor",
-        "//tensorboard/compat/proto:histogram",
     ],
 )
 

--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -237,9 +237,10 @@ tb_proto_library(
 tb_proto_library(
     name = "summary",
     srcs = ["summary.proto"],
+    exports = ["//tensorboard/compat/proto:histogram"],
     deps = [
-        ":histogram",
         ":tensor",
+        "//tensorboard/compat/proto:histogram",
     ],
 )
 

--- a/tensorboard/defs/protos.bzl
+++ b/tensorboard/defs/protos.bzl
@@ -21,6 +21,7 @@ def tb_proto_library(
         visibility = None,
         testonly = None,
         has_services = False,
+        # The `exports` arg is unused here, but required internally for compatibility.
         exports = []):
     outs_proto = _PyOuts(srcs, grpc = False)
     outs_grpc = _PyOuts(srcs, grpc = True) if has_services else []

--- a/tensorboard/defs/protos.bzl
+++ b/tensorboard/defs/protos.bzl
@@ -20,7 +20,8 @@ def tb_proto_library(
         deps = [],
         visibility = None,
         testonly = None,
-        has_services = False):
+        has_services = False,
+        exports = []):
     outs_proto = _PyOuts(srcs, grpc = False)
     outs_grpc = _PyOuts(srcs, grpc = True) if has_services else []
     outs_all = outs_proto + outs_grpc


### PR DESCRIPTION
This is needed to fix internal build after the `HistogramProto` location change in https://github.com/tensorflow/tensorboard/pull/6010. In OSS we don't need the `tb_proto_library` to actually use the `exports` arg since we could use the `public` symbol (https://developers.google.com/protocol-buffers/docs/proto3#importing_definitions) without additional changes. The signature change for `tb_proto_library` is required internally.

Corresponding internal change: cl/485927103 (see cl description for full details).

Tested internally at cl/485864749.