### PR TITLE
Source Metadata: cleanup

### DIFF
--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -308,8 +308,7 @@ class EventAccumulator(object):
             except StopIteration:
                 raise ValueError("No event timestamp could be found")
 
-    @property
-    def SourceWriter(self) -> Optional[str]:
+    def GetSourceWriter(self) -> Optional[str]:
         """Returns the name of the event writer."""
         if self._source_writer is not None:
             return self._source_writer
@@ -366,7 +365,7 @@ class EventAccumulator(object):
             )
             if self._source_writer and self._source_writer != new_source_writer:
                 # This should not happen.
-                logger.warning(
+                logger.info(
                     (
                         "Found new source writer for event.proto. "
                         "Old: {0}, New: {1}"

--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -364,7 +364,6 @@ class EventAccumulator(object):
                 event.source_metadata
             )
             if self._source_writer and self._source_writer != new_source_writer:
-                # This should not happen.
                 logger.info(
                     (
                         "Found new source writer for event.proto. "

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -713,7 +713,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         acc.Reload()
         self.assertEqual(acc.file_version, 2.0)
 
-    def testSourceWriter(self):
+    def testGetSourceWriter(self):
         gen = _EventGenerator(self)
         acc = ea.EventAccumulator(gen)
         gen.AddEvent(
@@ -726,10 +726,10 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
             )
         )
         gen.AddScalar("s1", wall_time=30, step=40, value=20)
-        self.assertEqual(acc.SourceWriter, "custom_writer")
+        self.assertEqual(acc.GetSourceWriter(), "custom_writer")
 
     def testReloadPopulatesSourceWriter(self):
-        """Test that Reload() means SourceWriter won't load events."""
+        """Test that Reload() means GetSourceWriter() won't load events."""
         gen = _EventGenerator(self)
         acc = ea.EventAccumulator(gen)
         gen.AddEvent(
@@ -747,10 +747,10 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
             raise RuntimeError("Load() should not be called")
 
         self.stubs.Set(gen, "Load", _Die)
-        self.assertEqual(acc.SourceWriter, "custom_writer")
+        self.assertEqual(acc.GetSourceWriter(), "custom_writer")
 
-    def testSourceWriterLoadsEvent(self):
-        """Test that SourceWriter doesn't discard the loaded event."""
+    def testGetSourceWriterLoadsEvent(self):
+        """Test that GetSourceWriter() doesn't discard the loaded event."""
         gen = _EventGenerator(self)
         acc = ea.EventAccumulator(gen)
         gen.AddEvent(
@@ -764,7 +764,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
             )
         )
 
-        self.assertEqual(acc.SourceWriter, "custom_writer")
+        self.assertEqual(acc.GetSourceWriter(), "custom_writer")
         acc.Reload()
         self.assertEqual(acc.file_version, 2.0)
 

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -272,7 +272,7 @@ class EventMultiplexer(object):
           Name of the writer that wrote the events in the run.
         """
         accumulator = self.GetAccumulator(run)
-        return accumulator.SourceWriter
+        return accumulator.GetSourceWriter()
 
     def Scalars(self, run, tag):
         """Retrieve the scalar events associated with a run and tag.

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -67,8 +67,7 @@ class _FakeAccumulator(object):
     def FirstEventTimestamp(self):
         return 0
 
-    @property
-    def SourceWriter(self):
+    def GetSourceWriter(self):
         return "%s_writer" % self._path
 
     def _TagHelper(self, tag_name, enum):

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -335,7 +335,6 @@ class EventAccumulator(object):
                 event.source_metadata
             )
             if self._source_writer and self._source_writer != new_source_writer:
-                # This should not happen.
                 logger.info(
                     (
                         "Found new source writer for event.proto. "

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -258,8 +258,7 @@ class EventAccumulator(object):
             except StopIteration:
                 raise ValueError("No event timestamp could be found")
 
-    @property
-    def SourceWriter(self) -> Optional[str]:
+    def GetSourceWriter(self) -> Optional[str]:
         """Returns the name of the event writer."""
         if self._source_writer is not None:
             return self._source_writer
@@ -337,7 +336,7 @@ class EventAccumulator(object):
             )
             if self._source_writer and self._source_writer != new_source_writer:
                 # This should not happen.
-                logger.warning(
+                logger.info(
                     (
                         "Found new source writer for event.proto. "
                         "Old: {0}, New: {1}"

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -381,7 +381,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         acc.Reload()
         self.assertEqual(acc.file_version, 2.0)
 
-    def testSourceWriter(self):
+    def testGetSourceWriter(self):
         gen = _EventGenerator(self)
         acc = self._make_accumulator(gen)
         gen.AddEvent(
@@ -394,10 +394,10 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
             )
         )
         gen.AddScalarTensor("s1", wall_time=30, step=40, value=20)
-        self.assertEqual(acc.SourceWriter, "custom_writer")
+        self.assertEqual(acc.GetSourceWriter(), "custom_writer")
 
     def testReloadPopulatesSourceWriter(self):
-        """Test that Reload() means SourceWriter won't load events."""
+        """Test that Reload() means GetSourceWriter() won't load events."""
         gen = _EventGenerator(self)
         acc = self._make_accumulator(gen)
         gen.AddEvent(
@@ -415,10 +415,10 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
             raise RuntimeError("Load() should not be called")
 
         self.stubs.Set(gen, "Load", _Die)
-        self.assertEqual(acc.SourceWriter, "custom_writer")
+        self.assertEqual(acc.GetSourceWriter(), "custom_writer")
 
-    def testSourceWriterLoadsEvent(self):
-        """Test that SourceWriter doesn't discard the loaded event."""
+    def testGetSourceWriterLoadsEvent(self):
+        """Test that GetSourceWriter() doesn't discard the loaded event."""
         gen = _EventGenerator(self)
         acc = self._make_accumulator(gen)
         gen.AddEvent(
@@ -431,7 +431,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
                 ),
             )
         )
-        self.assertEqual(acc.SourceWriter, "custom_writer")
+        self.assertEqual(acc.GetSourceWriter(), "custom_writer")
         acc.Reload()
         self.assertEqual(acc.file_version, 2.0)
 

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -334,7 +334,7 @@ class EventMultiplexer(object):
           Name of the writer that wrote the events in the run.
         """
         accumulator = self.GetAccumulator(run)
-        return accumulator.SourceWriter
+        return accumulator.GetSourceWriter()
 
     def Graph(self, run):
         """Retrieve the graph associated with the provided run.

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
@@ -67,8 +67,7 @@ class _FakeAccumulator(object):
     def FirstEventTimestamp(self):
         return 0
 
-    @property
-    def SourceWriter(self):
+    def GetSourceWriter(self):
         return "%s_writer" % self._path
 
     def _TagHelper(self, tag_name, enum):


### PR DESCRIPTION
To resolve the latest comments in https://github.com/tensorflow/tensorboard/pull/6014:
- Replace `SourceMetadata` property with `GetSourceWriter()`
- Log at `info` instead of `warning` when multiple source writers are found for the same run.

#source_metadata