### PR TITLE
projector: fix controls help dialog button

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector.html.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.html.ts
@@ -358,7 +358,7 @@ export const template = html`
           ></vz-projector-metadata-card>
           <paper-icon-button
             raised
-            onclick="help3dDialog.open()"
+            on-click="_toggleHelp3dDialog"
             icon="help-outline"
             id="help-3d-icon"
           ></paper-icon-button>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -701,4 +701,9 @@ class Projector
     }
     this.notifySelectionChanged(state.selectedPoints);
   }
+
+  _toggleHelp3dDialog(event: MouseEvent) {
+    event.preventDefault();
+    (this.$$('#help3dDialog') as any).open();
+  }
 }


### PR DESCRIPTION
## Motivation for features / changes

On the embeddings projector, on the top left corner of the scatter plot there's an help icon (with a question mark) that when clicked should open a dialog showing an help for the controls in 3D and 2D mode.
Currently the icon doesn't work and if clicked nothing happens.

## Technical description of changes

Set a custom function on the `on-click` event of the `paper-icon-button`.

## Detailed steps to verify changes work correctly (as executed by you)

- Open the embeddings projector
- Click on the help icon (question mark, tooltip "Help with interaction control")
- The help dialog should appear at the center of the page