### PR TITLE
[WIP] Step Selector: Move Step Selector State to Redux

### DIFF
--- a/tensorboard/webapp/metrics/actions/BUILD
+++ b/tensorboard/webapp/metrics/actions/BUILD
@@ -12,6 +12,7 @@ tf_ts_library(
     deps = [
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/metrics/data_source",
+        "//tensorboard/webapp/metrics/store:types",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/util:dom",
         "//tensorboard/webapp/widgets/card_fob:types",

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -23,6 +23,7 @@ import {
   TimeSeriesRequest,
   TimeSeriesResponse,
 } from '../data_source';
+import {MinMaxStep} from '../store/metrics_types';
 import {
   CardId,
   HistogramMode,
@@ -185,7 +186,12 @@ export const metricsShowAllPlugins = createAction(
 
 export const timeSelectionChanged = createAction(
   '[Metrics] Time Selection Changed',
-  props<TimeSelectionWithAffordance>()
+  props<{cardId?: CardId} & TimeSelectionWithAffordance>()
+);
+
+export const cardMinMaxChanged = createAction(
+  '[Metrics] Card Min Max Changed',
+  props<{cardId: CardId; minMax: MinMaxStep}>()
 );
 
 export const timeSelectionCleared = createAction(

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -23,6 +23,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
+        "//tensorboard/webapp/metrics/views/card_renderer:utils",
         "//tensorboard/webapp/persistent_settings",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/util:dom",

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -192,6 +192,26 @@ export const getCardStepIndexMetaData = createSelector(
 );
 
 /**
+ * Gets the time selection of a metrics card.
+ */
+export const getMetricsCardTimeSelection = createSelector(
+  selectMetricsState,
+  (state: MetricsState): Map<CardId, TimeSelection> => {
+    return state.cardToTimeSelection;
+  }
+);
+
+/**
+ * Gets the min and max step of a metrics card.
+ */
+export const getMetricsCardToMinMax = createSelector(
+  selectMetricsState,
+  (state: MetricsState) => {
+    return state.cardToMinMax;
+  }
+);
+
+/**
  * Returns step values of an image card.
  */
 export const getMetricsImageCardSteps = createSelector(

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -17,7 +17,14 @@ limitations under the License.
  */
 
 import {DataLoadState} from '../../types/data';
-import {isSampledPlugin, PluginType, SampledPluginType} from '../data_source';
+import {
+  HistogramStepDatum,
+  ImageStepDatum,
+  isSampledPlugin,
+  PluginType,
+  SampledPluginType,
+  ScalarStepDatum,
+} from '../data_source';
 import {
   CardId,
   CardMetadata,
@@ -30,9 +37,13 @@ import {
   CardStepIndexMap,
   CardStepIndexMetaData,
   CardToPinnedCard,
+  CardToTimeSelection,
   MetricsState,
+  MinMaxStep,
   PinnedCardToCard,
   RunToLoadState,
+  RunToSeries,
+  StepDatum,
   TagMetadata,
   TimeSeriesData,
   TimeSeriesLoadables,
@@ -45,6 +56,7 @@ type ResolvedPinPartialState = Pick<
   | 'cardToPinnedCopyCache'
   | 'pinnedCardToOriginal'
   | 'cardStepIndex'
+  | 'cardToTimeSelection'
 >;
 
 const DISTANCE_RATIO = 0.1;
@@ -206,7 +218,8 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
   cardToPinnedCopy: CardToPinnedCard,
   cardToPinnedCopyCache: CardToPinnedCard,
   pinnedCardToOriginal: PinnedCardToCard,
-  cardStepIndexMap: CardStepIndexMap
+  cardStepIndexMap: CardStepIndexMap,
+  cardToTimeSelection: CardToTimeSelection
 ): ResolvedPinPartialState & {unresolvedImportedPinnedCards: CardUniqueInfo[]} {
   const unresolvedPinSet = new Set(unresolvedImportedPinnedCards);
   const nonPinnedCardsWithMatch = [];
@@ -228,6 +241,7 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
       cardToPinnedCopy,
       cardToPinnedCopyCache,
       pinnedCardToOriginal,
+      cardToTimeSelection,
       cardStepIndex: cardStepIndexMap,
     };
   }
@@ -238,6 +252,7 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
     pinnedCardToOriginal,
     cardStepIndex: cardStepIndexMap,
     cardMetadataMap,
+    cardToTimeSelection,
   };
   for (const cardToPin of nonPinnedCardsWithMatch) {
     stateWithResolvedPins = buildOrReturnStateWithPinnedCopy(
@@ -246,7 +261,8 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
       stateWithResolvedPins.cardToPinnedCopyCache,
       stateWithResolvedPins.pinnedCardToOriginal,
       stateWithResolvedPins.cardStepIndex,
-      stateWithResolvedPins.cardMetadataMap
+      stateWithResolvedPins.cardMetadataMap,
+      stateWithResolvedPins.cardToTimeSelection
     );
   }
 
@@ -266,7 +282,8 @@ export function buildOrReturnStateWithPinnedCopy(
   cardToPinnedCopyCache: CardToPinnedCard,
   pinnedCardToOriginal: PinnedCardToCard,
   cardStepIndexMap: CardStepIndexMap,
-  cardMetadataMap: CardMetadataMap
+  cardMetadataMap: CardMetadataMap,
+  nextCardToTimeSelection: CardToTimeSelection
 ): ResolvedPinPartialState {
   // No-op if the card already has a pinned copy.
   if (cardToPinnedCopy.has(cardId)) {
@@ -276,6 +293,7 @@ export function buildOrReturnStateWithPinnedCopy(
       pinnedCardToOriginal,
       cardStepIndex: cardStepIndexMap,
       cardMetadataMap,
+      cardToTimeSelection: nextCardToTimeSelection,
     };
   }
 
@@ -290,6 +308,10 @@ export function buildOrReturnStateWithPinnedCopy(
   nextCardToPinnedCopy.set(cardId, pinnedCardId);
   nextCardToPinnedCopyCache.set(cardId, pinnedCardId);
   nextPinnedCardToOriginal.set(pinnedCardId, cardId);
+  const originalTimeSelection = nextCardToTimeSelection.get(cardId);
+  if (originalTimeSelection) {
+    nextCardToTimeSelection.set(pinnedCardId, {...originalTimeSelection});
+  }
   if (cardStepIndexMap.hasOwnProperty(cardId)) {
     nextCardStepIndexMap[pinnedCardId] = cardStepIndexMap[cardId];
   }
@@ -306,6 +328,7 @@ export function buildOrReturnStateWithPinnedCopy(
     pinnedCardToOriginal: nextPinnedCardToOriginal,
     cardStepIndex: nextCardStepIndexMap,
     cardMetadataMap: nextCardMetadataMap,
+    cardToTimeSelection: nextCardToTimeSelection,
   };
 }
 
@@ -363,6 +386,23 @@ export function generateNextCardStepIndex(
     }
   });
   return nextCardStepIndexMap;
+}
+
+export function generateCardMinMaxStep<T extends PluginType = PluginType>(
+  runsToSeries: RunToSeries<T>,
+  pluginType: PluginType
+): MinMaxStep {
+  const allData = Object.values(runsToSeries)
+    .flat()
+    .map((stepDatum) => stepDatum as StepDatum[T])
+    .flat()
+    .map((datum: ScalarStepDatum | HistogramStepDatum | ImageStepDatum) => {
+      return datum.step;
+    });
+  return {
+    minStep: Math.min(...allData),
+    maxStep: Math.max(...allData),
+  };
 }
 
 /**

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -21,6 +21,7 @@ import {
   buildTimeSeriesData,
   createCardMetadata,
 } from '../testing';
+import {NonPinnedCardId, TimeSelection} from '../types';
 import {
   buildOrReturnStateWithPinnedCopy,
   buildOrReturnStateWithUnresolvedImportedPins,
@@ -374,7 +375,8 @@ describe('metrics store utils', () => {
         new Map(),
         new Map(),
         new Map(),
-        {card1: buildStepIndexMetadata({index: 2})}
+        {card1: buildStepIndexMetadata({index: 2})},
+        new Map()
       );
 
       const pinnedCardId = getPinnedCardId('card1');
@@ -405,7 +407,8 @@ describe('metrics store utils', () => {
         new Map(),
         new Map(),
         {card1: buildStepIndexMetadata({index: 2})},
-        {card1: createCardMetadata()}
+        {card1: createCardMetadata()},
+        new Map()
       );
       const pinnedCardId = getPinnedCardId('card1');
 
@@ -430,7 +433,8 @@ describe('metrics store utils', () => {
           new Map(),
           new Map(),
           {},
-          {}
+          {},
+          new Map()
         );
       }).toThrow();
     });
@@ -448,6 +452,7 @@ describe('metrics store utils', () => {
         cardStepIndexMap: {...cardStepIndexMap},
         cardMetadataMap: {...cardMetadataMap},
       };
+      const cardToTimeSelection = new Map<NonPinnedCardId, TimeSelection>();
 
       const result = buildOrReturnStateWithPinnedCopy(
         'card1',
@@ -455,7 +460,8 @@ describe('metrics store utils', () => {
         cardToPinnedCopyCache,
         pinnedCardToOriginal,
         cardStepIndexMap,
-        cardMetadataMap
+        cardMetadataMap,
+        cardToTimeSelection
       );
 
       expect(result.cardToPinnedCopy).toEqual(originals.cardToPinnedCopy);

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -40,6 +40,15 @@ import {ColumnHeader} from '../views/card_renderer/scalar_card_types';
 
 export const METRICS_FEATURE_KEY = 'metrics';
 
+/**
+ * An object which is intended to hold the min and max step within each scalar
+ * card.
+ */
+export type MinMaxStep = {
+  minStep: number;
+  maxStep: number;
+};
+
 type RunId = string;
 
 type tagToRunIds = Record<string, RunId[]>;
@@ -150,6 +159,10 @@ export type CardToPinnedCard = Map<NonPinnedCardId, PinnedCardId>;
 
 export type PinnedCardToCard = Map<PinnedCardId, NonPinnedCardId>;
 
+export type CardToMinMax = Map<NonPinnedCardId, MinMaxStep>;
+
+export type CardToTimeSelection = Map<NonPinnedCardId, TimeSelection>;
+
 export interface MetricsNamespacedState {
   tagMetadataLoadState: LoadState;
   tagMetadata: TagMetadata;
@@ -159,6 +172,9 @@ export interface MetricsNamespacedState {
   // A map of card ids that previously pinned by the user.
   cardToPinnedCopyCache: CardToPinnedCard;
   pinnedCardToOriginal: PinnedCardToCard;
+  cardToMinMax: CardToMinMax;
+  // A record of card ids to the time selection of the card
+  cardToTimeSelection: CardToTimeSelection;
   /**
    * Pinned cards imported from storage that do not yet have a corresponding
    * card (e.g. tag metadata might not be loaded yet). Resolving an imported

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -92,6 +92,8 @@ function buildBlankState(): MetricsState {
     cardToPinnedCopy: new Map(),
     cardToPinnedCopyCache: new Map(),
     pinnedCardToOriginal: new Map(),
+    cardToMinMax: new Map(),
+    cardToTimeSelection: new Map(),
     unresolvedImportedPinnedCards: [],
     cardMetadataMap: {},
     cardStepIndex: {},

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -357,6 +357,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/store",
+        "//tensorboard/webapp/metrics/store:types",
         "//tensorboard/webapp/runs/store:testing",
         "//tensorboard/webapp/runs/store:types",
         "//tensorboard/webapp/testing:mat_icon",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -43,11 +43,11 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
+import {MinMaxStep} from '../../store';
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ColumnHeader,
   ColumnHeaderType,
-  MinMaxStep,
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
   ScalarCardSeriesMetadataMap,
@@ -241,6 +241,7 @@ export class ScalarCardComponent<Downloader> {
   showFobController() {
     return (
       this.xAxisType === XAxisType.STEP &&
+      this.minMaxStep &&
       (this.stepOrLinkedTimeSelection !== null ||
         this.isProspectiveFobFeatureEnabled)
     );

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -24,7 +24,7 @@ import {
   TimeSelectionAffordance,
 } from '../../../widgets/card_fob/card_fob_types';
 import {Scale} from '../../../widgets/line_chart_v2/lib/public_types';
-import {MinMaxStep} from './scalar_card_types';
+import {MinMaxStep} from '../../store';
 
 @Component({
   selector: 'scalar-card-fob-controller',

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_test.ts
@@ -15,8 +15,8 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {CardFobControllerComponent} from '../../../widgets/card_fob/card_fob_controller_component';
 import {TimeSelection} from '../../../widgets/card_fob/card_fob_types';
 import {LinearScale} from '../../../widgets/line_chart_v2/lib/scale';
+import {MinMaxStep} from '../../store/metrics_types';
 import {ScalarCardFobController} from './scalar_card_fob_controller';
-import {MinMaxStep} from './scalar_card_types';
 
 const SCALE_RATIO = 10;
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2662,6 +2662,7 @@ describe('scalar card', () => {
         //   maxStep: 50,
         // });
         store.overrideSelector(selectors.getMetricsStepSelectorEnabled, true);
+        store.overrideSelector(selectors.getMetricsRangeSelectionEnabled, true);
         store.overrideSelector(selectors.getMetricsLinkedTimeSelection, {
           start: {step: 0},
           end: {step: 50},

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -122,12 +122,3 @@ export interface SortingInfo {
 export type SelectedStepRunData = {
   [key in ColumnHeaderType]?: string | number;
 } & {id: string};
-
-/**
- * An object which is intended to hold the min and max step within each scalar
- * card.
- */
-export type MinMaxStep = {
-  minStep: number;
-  maxStep: number;
-};


### PR DESCRIPTION
## Motivation for features / changes
1) There is a bug which occurs when pinning a card with an updated step selector where the newly created card does not have the modified time selection.
2) The current design of the scalar card relies on passing data through the props of a very deep component tree.

## Technical description of changes

## Screenshots of UI changes
### Pinning a Card
**Before**
![8e98b295-2075-4007-9fdf-45c94e7dad15](https://user-images.githubusercontent.com/78179109/200374545-33507b30-5354-4fd1-8212-cda664f78185.gif)

**After**
![e6e0b522-0ae9-4d37-8bf8-ad1ec3a72cd8](https://user-images.githubusercontent.com/78179109/200373937-300bab56-3ad6-4e43-a4ae-5efb0971f5fd.gif)


## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered
1) Implement another means of data sharing
2) Render the SAME card in the pinned area rather than a copy
3) Require additional instantiation data when pinning a card
