### PR TITLE
Linked Time: Render end fob based on the status of `rangeSelectionEnabled`

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -194,6 +194,7 @@ limitations under the License.
       [minMaxHorizontalViewExtend]="viewExtent.x"
       [minMaxStep]="minMaxStep"
       [axisSize]="domDim.width"
+      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [isProspectiveFobFeatureEnabled]="isProspectiveFobFeatureEnabled"
       (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
       (onTimeSelectionToggled)="onFobRemoved()"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -92,6 +92,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() forceSvg!: boolean;
   @Input() linkedTimeSelection!: TimeSelectionView | null;
   @Input() stepOrLinkedTimeSelection!: TimeSelection | null;
+  @Input() rangeSelectionEnabled: boolean = false;
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
   @Input() minMaxStep!: MinMaxStep;
   @Input() dataHeaders!: ColumnHeaders[];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -157,6 +157,7 @@ function areSeriesEqual(
       [useDarkMode]="useDarkMode$ | async"
       [linkedTimeSelection]="linkedTimeSelection$ | async"
       [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection$ | async"
+      [rangeSelectionEnabled]="rangeSelectionEnabled$ | async"
       [isProspectiveFobFeatureEnabled]="isProspectiveFobFeatureEnabled$ | async"
       [forceSvg]="forceSvg$ | async"
       [minMaxStep]="minMaxSteps$ | async"
@@ -223,6 +224,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   });
   readonly stepSelectorTimeSelection$ =
     new BehaviorSubject<TimeSelection | null>(null);
+  readonly rangeSelectionEnabled$ = this.store.select(
+    getMetricsRangeSelectionEnabled
+  );
   readonly useDarkMode$ = this.store.select(getDarkModeEnabled);
   readonly ignoreOutliers$ = this.store.select(getMetricsIgnoreOutliers);
   readonly tooltipSort$ = this.store.select(getMetricsTooltipSort);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -32,6 +32,7 @@ import {MinMaxStep} from './scalar_card_types';
     <card-fob-controller
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
+      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [prospectiveStepAxisPosition]="getAxisPositionFromProspectiveStep()"
@@ -55,6 +56,7 @@ export class ScalarCardFobController {
   @Input() minMaxHorizontalViewExtend!: [number, number];
   @Input() minMaxStep!: MinMaxStep;
   @Input() axisSize!: number;
+  @Input() rangeSelectionEnabled: boolean = false;
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
 
   @Output() onTimeSelectionChanged = new EventEmitter<{

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -3270,6 +3270,19 @@ describe('scalar card', () => {
         ).toBeFalsy();
       }));
 
+      it('Does not render end fob when range selection is disabled', fakeAsync(() => {
+        store.overrideSelector(
+          selectors.getMetricsRangeSelectionEnabled,
+          false
+        );
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+
+        expect(
+          fixture.debugElement.queryAll(By.directive(CardFobComponent)).length
+        ).toEqual(1);
+      }));
+
       it('dispatches timeSelectionChanged actions when fob is dragged while linked time is enabled', fakeAsync(() => {
         store.overrideSelector(getMetricsLinkedTimeEnabled, true);
         store.overrideSelector(getMetricsLinkedTimeSelection, {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -54,7 +54,7 @@ limitations under the License.
   </div>
   <div
     #endFobWrapper
-    *ngIf="timeSelection && timeSelection.end"
+    *ngIf="timeSelection && timeSelection.end && rangeSelectionEnabled"
     class="time-fob-wrapper"
     [style.transform]="getCssTranslatePxForEndFob()"
   >

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -54,6 +54,7 @@ export class CardFobControllerComponent {
   readonly prospectiveFobWrapper!: ElementRef;
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection?: TimeSelection;
+  @Input() rangeSelectionEnabled: boolean = false;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
   @Input() startStepAxisPosition!: number;
   @Input() endStepAxisPosition!: number | null;

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -33,6 +33,7 @@ import {
       #FobController
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
+      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [prospectiveStepAxisPosition]="getAxisPositionFromProspectiveStep()"
@@ -54,6 +55,7 @@ class TestableComponent {
 
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection!: TimeSelection;
+  @Input() rangeSelectionEnabled: boolean = false;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
   @Input() showExtendedLine?: Boolean;
   @Input() highestStep!: number;
@@ -94,6 +96,7 @@ describe('card_fob_controller', () => {
   function createComponent(input: {
     axisDirection?: AxisDirection;
     timeSelection: TimeSelection;
+    enableRangeSelection: boolean;
     showExtendedLine?: Boolean;
     steps?: number[];
     isProspectiveFobFeatureEnabled?: Boolean;
@@ -150,6 +153,8 @@ describe('card_fob_controller', () => {
       input.axisDirection ?? AxisDirection.VERTICAL;
 
     fixture.componentInstance.timeSelection = input.timeSelection;
+    fixture.componentInstance.rangeSelectionEnabled =
+      input.enableRangeSelection;
 
     fixture.componentInstance.showExtendedLine =
       input.showExtendedLine ?? false;
@@ -183,6 +188,7 @@ describe('card_fob_controller', () => {
   it('sets fob position based on time selection', () => {
     const fixture = createComponent({
       timeSelection: {start: {step: 2}, end: {step: 5}},
+      enableRangeSelection: true,
       axisDirection: AxisDirection.HORIZONTAL,
     });
     fixture.detectChanges();
@@ -217,6 +223,7 @@ describe('card_fob_controller', () => {
     it('adds and removes event listener', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -253,6 +260,7 @@ describe('card_fob_controller', () => {
     it('swaps fobs being dragged when start > end', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -286,6 +294,7 @@ describe('card_fob_controller', () => {
     it('swaps fobs being dragged when end < start', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -319,6 +328,7 @@ describe('card_fob_controller', () => {
     it('does not swaps fobs when start === end', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -353,6 +363,7 @@ describe('card_fob_controller', () => {
     it('does not fire event when time selection does not change', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -383,6 +394,7 @@ describe('card_fob_controller', () => {
     it('moves the start fob based on adapter getStepHigherThanMousePosition when mouse is dragging down and is below fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -420,6 +432,7 @@ describe('card_fob_controller', () => {
     it('moves the start fob based on adapter getStepLowerThanMousePosition when mouse is dragging up and above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -457,6 +470,7 @@ describe('card_fob_controller', () => {
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging up but, is below the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -487,6 +501,7 @@ describe('card_fob_controller', () => {
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging down but, is above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -514,6 +529,7 @@ describe('card_fob_controller', () => {
     it('does not move the start fob or call call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging down but, the fob is already on the final step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -544,6 +560,7 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging up and mouse is above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 1}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -582,6 +599,7 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging down and mouse is below the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -619,6 +637,7 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging down but, mouse is above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -649,6 +668,7 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging up but, mouse is below the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -681,6 +701,7 @@ describe('card_fob_controller', () => {
     it('moves the start fob based on adapter getStepHigherThanMousePosition when mouse is dragging right and is to the right of fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -719,6 +740,7 @@ describe('card_fob_controller', () => {
     it('moves the start fob based on adapter getStepLowerThanMousePosition when mouse is dragging left and is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -757,6 +779,7 @@ describe('card_fob_controller', () => {
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging left but, is right of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: null},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -790,6 +813,7 @@ describe('card_fob_controller', () => {
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging right but, is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -823,6 +847,7 @@ describe('card_fob_controller', () => {
     it('does not move the start fob or call call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging right but, the fob is already on the final step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -855,6 +880,7 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging left and mouse is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 1}},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -894,6 +920,7 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging right and mouse is right of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -932,6 +959,7 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging right but, mouse is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -963,6 +991,7 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging left but, mouse is right of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -997,6 +1026,7 @@ describe('card_fob_controller', () => {
     it('renders single line on setting showExtendedLine true', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
+        enableRangeSelection: true,
         showExtendedLine: true,
       });
       fixture.detectChanges();
@@ -1008,6 +1038,7 @@ describe('card_fob_controller', () => {
     it('renders two lines on range selection', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
+        enableRangeSelection: true,
         showExtendedLine: true,
       });
       fixture.detectChanges();
@@ -1021,6 +1052,7 @@ describe('card_fob_controller', () => {
     it('clicks and drags the line to change selected step in horizontal axis', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
         showExtendedLine: true,
       });
@@ -1094,6 +1126,7 @@ describe('card_fob_controller', () => {
     it('single time selection changed with fob typing', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1111,6 +1144,7 @@ describe('card_fob_controller', () => {
     it('range selection start fob step typed which is less than end fob step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1128,6 +1162,7 @@ describe('card_fob_controller', () => {
     it('range selection end fob step typed which is greater than start fob step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1145,6 +1180,7 @@ describe('card_fob_controller', () => {
     it('range selection swaps when start step is typed in which is greater than end step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1162,6 +1198,7 @@ describe('card_fob_controller', () => {
     it('range selection swaps when end step is typed in which is less than start step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 3}, end: {step: 4}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1179,6 +1216,7 @@ describe('card_fob_controller', () => {
     it('properly handles a 0 step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 3}, end: {step: 4}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1196,6 +1234,7 @@ describe('card_fob_controller', () => {
     it('changing start input modifies start step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1220,6 +1259,7 @@ describe('card_fob_controller', () => {
     it('changing end fob input modifies end step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1248,6 +1288,7 @@ describe('card_fob_controller', () => {
     it('fires onTimeSelectionToggled when in single selection', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1263,6 +1304,7 @@ describe('card_fob_controller', () => {
     it('fires onTimeSelectionChanged to remove end fob when end fob is deselected', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1284,6 +1326,7 @@ describe('card_fob_controller', () => {
     it('fires onTimeSelectionChanged to change the start fob step to the current end fob step and the end fob step to null when start fob is deselected in a range selection', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
+        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1307,6 +1350,7 @@ describe('card_fob_controller', () => {
     it('renders when feature flag is enabled and the step is not null', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
         isProspectiveFobFeatureEnabled: true,
         prospectiveStep: 2,
       });
@@ -1321,6 +1365,7 @@ describe('card_fob_controller', () => {
     it('does not render when feature flag is disenabled', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
         isProspectiveFobFeatureEnabled: false,
         prospectiveStep: 2,
       });
@@ -1334,6 +1379,7 @@ describe('card_fob_controller', () => {
     it('does not render when step is null', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
         isProspectiveFobFeatureEnabled: true,
         prospectiveStep: null,
       });
@@ -1347,6 +1393,7 @@ describe('card_fob_controller', () => {
     it('sets horizontal position based on prospective step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
         isProspectiveFobFeatureEnabled: true,
         prospectiveStep: 2,
@@ -1364,6 +1411,7 @@ describe('card_fob_controller', () => {
     it('sets vertical position based on prospective step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
+        enableRangeSelection: true,
         axisDirection: AxisDirection.VERTICAL,
         isProspectiveFobFeatureEnabled: true,
         prospectiveStep: 2,
@@ -1382,6 +1430,7 @@ describe('card_fob_controller', () => {
       it('emits null step on mouseleave', () => {
         const fixture = createComponent({
           timeSelection: {start: {step: 4}, end: null},
+          enableRangeSelection: true,
           axisDirection: AxisDirection.HORIZONTAL,
           isProspectiveFobFeatureEnabled: true,
           prospectiveStep: 2,

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -96,7 +96,7 @@ describe('card_fob_controller', () => {
   function createComponent(input: {
     axisDirection?: AxisDirection;
     timeSelection: TimeSelection;
-    enableRangeSelection: boolean;
+    enableRangeSelection?: boolean;
     showExtendedLine?: Boolean;
     steps?: number[];
     isProspectiveFobFeatureEnabled?: Boolean;
@@ -223,7 +223,6 @@ describe('card_fob_controller', () => {
     it('adds and removes event listener', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -394,7 +393,6 @@ describe('card_fob_controller', () => {
     it('moves the start fob based on adapter getStepHigherThanMousePosition when mouse is dragging down and is below fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -432,7 +430,6 @@ describe('card_fob_controller', () => {
     it('moves the start fob based on adapter getStepLowerThanMousePosition when mouse is dragging up and above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -470,7 +467,6 @@ describe('card_fob_controller', () => {
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging up but, is below the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -501,7 +497,6 @@ describe('card_fob_controller', () => {
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging down but, is above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -529,7 +524,6 @@ describe('card_fob_controller', () => {
     it('does not move the start fob or call call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging down but, the fob is already on the final step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -701,7 +695,6 @@ describe('card_fob_controller', () => {
     it('moves the start fob based on adapter getStepHigherThanMousePosition when mouse is dragging right and is to the right of fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -740,7 +733,6 @@ describe('card_fob_controller', () => {
     it('moves the start fob based on adapter getStepLowerThanMousePosition when mouse is dragging left and is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -779,7 +771,6 @@ describe('card_fob_controller', () => {
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging left but, is right of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: null},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -813,7 +804,6 @@ describe('card_fob_controller', () => {
     it('does not call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging right but, is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -847,7 +837,6 @@ describe('card_fob_controller', () => {
     it('does not move the start fob or call call getStepLowerThanMousePosition or getStepHigherThanMousePosition when mouse is dragging right but, the fob is already on the final step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -1026,7 +1015,6 @@ describe('card_fob_controller', () => {
     it('renders single line on setting showExtendedLine true', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
-        enableRangeSelection: true,
         showExtendedLine: true,
       });
       fixture.detectChanges();
@@ -1126,7 +1114,6 @@ describe('card_fob_controller', () => {
     it('single time selection changed with fob typing', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1234,7 +1221,6 @@ describe('card_fob_controller', () => {
     it('changing start input modifies start step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1288,7 +1274,6 @@ describe('card_fob_controller', () => {
     it('fires onTimeSelectionToggled when in single selection', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: null},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1350,7 +1335,6 @@ describe('card_fob_controller', () => {
     it('renders when feature flag is enabled and the step is not null', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
         isProspectiveFobFeatureEnabled: true,
         prospectiveStep: 2,
       });
@@ -1365,7 +1349,6 @@ describe('card_fob_controller', () => {
     it('does not render when feature flag is disenabled', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
         isProspectiveFobFeatureEnabled: false,
         prospectiveStep: 2,
       });
@@ -1379,7 +1362,6 @@ describe('card_fob_controller', () => {
     it('does not render when step is null', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
         isProspectiveFobFeatureEnabled: true,
         prospectiveStep: null,
       });
@@ -1393,7 +1375,6 @@ describe('card_fob_controller', () => {
     it('sets horizontal position based on prospective step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
         isProspectiveFobFeatureEnabled: true,
         prospectiveStep: 2,
@@ -1411,7 +1392,6 @@ describe('card_fob_controller', () => {
     it('sets vertical position based on prospective step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 4}, end: null},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.VERTICAL,
         isProspectiveFobFeatureEnabled: true,
         prospectiveStep: 2,

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -153,8 +153,9 @@ describe('card_fob_controller', () => {
       input.axisDirection ?? AxisDirection.VERTICAL;
 
     fixture.componentInstance.timeSelection = input.timeSelection;
-    fixture.componentInstance.rangeSelectionEnabled =
-      input.enableRangeSelection;
+    fixture.componentInstance.rangeSelectionEnabled = Boolean(
+      input.enableRangeSelection
+    );
 
     fixture.componentInstance.showExtendedLine =
       input.showExtendedLine ?? false;

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -1411,7 +1411,6 @@ describe('card_fob_controller', () => {
       it('emits null step on mouseleave', () => {
         const fixture = createComponent({
           timeSelection: {start: {step: 4}, end: null},
-          enableRangeSelection: true,
           axisDirection: AxisDirection.HORIZONTAL,
           isProspectiveFobFeatureEnabled: true,
           prospectiveStep: 2,


### PR DESCRIPTION
## Motivation for features / changes
We currently have two sources of truth for determining if range selection is enabled, the existence of the timeSelection end step AND the state variable `rangeSelectionEnabled`. This means that when range selection is disabled we need to clear the end step.

In a future PR I will stop the end step from being removed when range selection is disabled.

## Screenshots of UI changes
None

* Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Go to http://localhost:6006?enableRangeSelection
3) Enable range selection
4) Ensure a second fob appears on the scalar card
5) Disable range selection
6) Assert the end fob is removed.
