### PR TITLE
Post-release 2.11.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,18 @@
+# Release 2.11.0
+
+The 2.11 minor series tracks TensorFlow 2.11.
+
+## Bug Fixes
+
+- Fixed HParams plugin sorting bugs (#5971)
+- Fix color by menu drop down bug in projector plugin (#5974)
+- Fix bug with histogram axis being off due to rounding (#5925)
+
+## Breaking Changes
+
+- TensorBoard now only supports Python 3.7 and above (#5878)
+  Python 3.6 is past its End of Life: https://peps.python.org/pep-0494/#lifespan
+
 # Release 2.10.1
 
 ## Bug Fixes

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = "2.11.0a0"
+VERSION = "2.12.0a0"


### PR DESCRIPTION
Two commits to round out the 2.11.0 release process:

Bump tb-nightly version to 2.12.0a0
Cherrypick of 2.11.0 relnotes added to RELEASE.md( #6034 )