### PR TITLE
Migrate bazel cfg from "host" to "exec"

### DIFF
--- a/tensorboard/defs/internal/html.bzl
+++ b/tensorboard/defs/internal/html.bzl
@@ -138,7 +138,7 @@ tb_combine_html = rule(
         "_Vulcanize": attr.label(
             default = Label("//tensorboard/java/org/tensorflow/tensorboard/vulcanize:Vulcanize"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     outputs = {

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -266,7 +266,7 @@ tf_web_library = rule(
         "_WebfilesServer": attr.label(
             default=Label("@io_bazel_rules_closure//java/io/bazel/rules/closure/webfiles/server:WebfilesServer"),
             executable=True,
-            cfg="host"),
+            cfg="exec"),
         "_ClosureWorker": CLOSURE_WORKER_ATTR,
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
     },

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -53,7 +53,7 @@ tensorboard_zip_file = rule(
         "_Zipper": attr.label(
             default=Label("//tensorboard/java/org/tensorflow/tensorboard/vulcanize:Zipper"),
             executable=True,
-            cfg="host"),
+            cfg="exec"),
     },
     outputs={
         "zip": "%{name}.zip",


### PR DESCRIPTION
https://bazel.build/extending/rules#configurations

Googlers, see b/258839383 and cl/487924665.