### PR TITLE
Linked Time: Remove prospective fob when it is clicked

### DIFF
--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -401,6 +401,7 @@ export class CardFobControllerComponent {
       affordance: TimeSelectionAffordance.FOB_ADDED,
       timeSelection: newTimeSelection,
     });
+    this.onPrespectiveStepChanged.emit(null);
   }
 
   /**


### PR DESCRIPTION
* Motivation for features / changes
Enabling range selection by clicking a prospective fob then disabling range selection via the checkbox (or another card) resulted in the prospective fob being shown.

* Technical description of changes
The prospective fob appears based on the value of the prospectiveStep. When the prospective fob is clicked setting the step to null ensures that disabling range selection cannot trigger it to reappear.

* Screenshots of UI changes
Look ma, it's gone
![1dffea73-2d85-4dc5-8984-95889211f9f5](https://user-images.githubusercontent.com/78179109/201761724-45e9c49d-1419-46dd-89b0-33969489e15a.gif)


* Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Navigate to http://localhost:6006/?enableDataTable=true&enableLinkedTime=true&allowRangeSelection=true&enableProspectiveFob=true#timeseries
3) View a scalar card and click on the xaxis to add a start fob
4) Click somewhere else to add a second fob
5) Disable range selection in the settings panel
6) Ensure the prospective fob is not shown
