### PR TITLE
Revert "Linked Time: Render end fob based on the status of `rangeSelectionEnabled`"

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -194,7 +194,6 @@ limitations under the License.
       [minMaxHorizontalViewExtend]="viewExtent.x"
       [minMaxStep]="minMaxStep"
       [axisSize]="domDim.width"
-      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [isProspectiveFobFeatureEnabled]="isProspectiveFobFeatureEnabled"
       (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
       (onTimeSelectionToggled)="onFobRemoved()"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -92,7 +92,6 @@ export class ScalarCardComponent<Downloader> {
   @Input() forceSvg!: boolean;
   @Input() linkedTimeSelection!: TimeSelectionView | null;
   @Input() stepOrLinkedTimeSelection!: TimeSelection | null;
-  @Input() rangeSelectionEnabled: boolean = false;
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
   @Input() minMaxStep!: MinMaxStep;
   @Input() dataHeaders!: ColumnHeaders[];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -157,7 +157,6 @@ function areSeriesEqual(
       [useDarkMode]="useDarkMode$ | async"
       [linkedTimeSelection]="linkedTimeSelection$ | async"
       [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection$ | async"
-      [rangeSelectionEnabled]="rangeSelectionEnabled$ | async"
       [isProspectiveFobFeatureEnabled]="isProspectiveFobFeatureEnabled$ | async"
       [forceSvg]="forceSvg$ | async"
       [minMaxStep]="minMaxSteps$ | async"
@@ -224,9 +223,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   });
   readonly stepSelectorTimeSelection$ =
     new BehaviorSubject<TimeSelection | null>(null);
-  readonly rangeSelectionEnabled$ = this.store.select(
-    getMetricsRangeSelectionEnabled
-  );
   readonly useDarkMode$ = this.store.select(getDarkModeEnabled);
   readonly ignoreOutliers$ = this.store.select(getMetricsIgnoreOutliers);
   readonly tooltipSort$ = this.store.select(getMetricsTooltipSort);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -32,7 +32,6 @@ import {MinMaxStep} from './scalar_card_types';
     <card-fob-controller
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [prospectiveStepAxisPosition]="getAxisPositionFromProspectiveStep()"
@@ -56,7 +55,6 @@ export class ScalarCardFobController {
   @Input() minMaxHorizontalViewExtend!: [number, number];
   @Input() minMaxStep!: MinMaxStep;
   @Input() axisSize!: number;
-  @Input() rangeSelectionEnabled: boolean = false;
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
 
   @Output() onTimeSelectionChanged = new EventEmitter<{

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -3299,19 +3299,6 @@ describe('scalar card', () => {
         ).toBeFalsy();
       }));
 
-      it('Does not render end fob when range selection is disabled', fakeAsync(() => {
-        store.overrideSelector(
-          selectors.getMetricsRangeSelectionEnabled,
-          false
-        );
-        const fixture = createComponent('card1');
-        fixture.detectChanges();
-
-        expect(
-          fixture.debugElement.queryAll(By.directive(CardFobComponent)).length
-        ).toEqual(1);
-      }));
-
       it('dispatches timeSelectionChanged actions when fob is dragged while linked time is enabled', fakeAsync(() => {
         store.overrideSelector(getMetricsLinkedTimeEnabled, true);
         store.overrideSelector(getMetricsLinkedTimeSelection, {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -57,7 +57,7 @@ limitations under the License.
   </div>
   <div
     #endFobWrapper
-    *ngIf="timeSelection && timeSelection.end && rangeSelectionEnabled"
+    *ngIf="timeSelection && timeSelection.end"
     class="time-fob-wrapper"
     [style.transform]="getCssTranslatePxForEndFob()"
   >

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -55,7 +55,6 @@ export class CardFobControllerComponent {
   readonly prospectiveFobWrapper!: ElementRef;
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection?: TimeSelection;
-  @Input() rangeSelectionEnabled: boolean = false;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
   @Input() startStepAxisPosition!: number;
   @Input() endStepAxisPosition!: number | null;

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -33,7 +33,6 @@ import {
       #FobController
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [prospectiveStepAxisPosition]="getAxisPositionFromProspectiveStep()"
@@ -55,7 +54,6 @@ class TestableComponent {
 
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection!: TimeSelection;
-  @Input() rangeSelectionEnabled: boolean = false;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
   @Input() showExtendedLine?: Boolean;
   @Input() highestStep!: number;
@@ -96,7 +94,6 @@ describe('card_fob_controller', () => {
   function createComponent(input: {
     axisDirection?: AxisDirection;
     timeSelection: TimeSelection;
-    enableRangeSelection?: boolean;
     showExtendedLine?: Boolean;
     steps?: number[];
     isProspectiveFobFeatureEnabled?: Boolean;
@@ -153,9 +150,6 @@ describe('card_fob_controller', () => {
       input.axisDirection ?? AxisDirection.VERTICAL;
 
     fixture.componentInstance.timeSelection = input.timeSelection;
-    fixture.componentInstance.rangeSelectionEnabled = Boolean(
-      input.enableRangeSelection
-    );
 
     fixture.componentInstance.showExtendedLine =
       input.showExtendedLine ?? false;
@@ -189,7 +183,6 @@ describe('card_fob_controller', () => {
   it('sets fob position based on time selection', () => {
     const fixture = createComponent({
       timeSelection: {start: {step: 2}, end: {step: 5}},
-      enableRangeSelection: true,
       axisDirection: AxisDirection.HORIZONTAL,
     });
     fixture.detectChanges();
@@ -260,7 +253,6 @@ describe('card_fob_controller', () => {
     it('swaps fobs being dragged when start > end', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -294,7 +286,6 @@ describe('card_fob_controller', () => {
     it('swaps fobs being dragged when end < start', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -328,7 +319,6 @@ describe('card_fob_controller', () => {
     it('does not swaps fobs when start === end', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -363,7 +353,6 @@ describe('card_fob_controller', () => {
     it('does not fire event when time selection does not change', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -555,7 +544,6 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging up and mouse is above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 1}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -594,7 +582,6 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging down and mouse is below the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -632,7 +619,6 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging down but, mouse is above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -663,7 +649,6 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging up but, mouse is below the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -870,7 +855,6 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging left and mouse is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 1}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -910,7 +894,6 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging right and mouse is right of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -949,7 +932,6 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging right but, mouse is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -981,7 +963,6 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging left but, mouse is right of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -1027,7 +1008,6 @@ describe('card_fob_controller', () => {
     it('renders two lines on range selection', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
         showExtendedLine: true,
       });
       fixture.detectChanges();
@@ -1041,7 +1021,6 @@ describe('card_fob_controller', () => {
     it('clicks and drags the line to change selected step in horizontal axis', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
         showExtendedLine: true,
       });
@@ -1132,7 +1111,6 @@ describe('card_fob_controller', () => {
     it('range selection start fob step typed which is less than end fob step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1150,7 +1128,6 @@ describe('card_fob_controller', () => {
     it('range selection end fob step typed which is greater than start fob step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1168,7 +1145,6 @@ describe('card_fob_controller', () => {
     it('range selection swaps when start step is typed in which is greater than end step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1186,7 +1162,6 @@ describe('card_fob_controller', () => {
     it('range selection swaps when end step is typed in which is less than start step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 3}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1204,7 +1179,6 @@ describe('card_fob_controller', () => {
     it('properly handles a 0 step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 3}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1246,7 +1220,6 @@ describe('card_fob_controller', () => {
     it('changing end fob input modifies end step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1290,7 +1263,6 @@ describe('card_fob_controller', () => {
     it('fires onTimeSelectionChanged to remove end fob when end fob is deselected', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1312,7 +1284,6 @@ describe('card_fob_controller', () => {
     it('fires onTimeSelectionChanged to change the start fob step to the current end fob step and the end fob step to null when start fob is deselected in a range selection', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
 


### PR DESCRIPTION
Reverts tensorflow/tensorboard#6033

A endfob is not rendered on histogram. Googlers see internal bug number b/259092516
