### PR TITLE
Column Customization: Add feature flag

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -121,6 +121,11 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       queryParamOverride: 'enableProspectiveFob',
       parseValue: parseBoolean,
     },
+    enableScalarColumnCustomization: {
+      defaultValue: false,
+      queryParamOverride: 'enableScalarColumnCustomization',
+      parseValue: parseBoolean,
+    },
   };
 
 /**

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -170,3 +170,10 @@ export const getIsLinkedTimeProspectiveFobEnabled = createSelector(
     return flags.enabledProspectiveFob;
   }
 );
+
+export const getIsScalarColumnCustomizationEnabled = createSelector(
+  getFeatureFlags,
+  (flags: FeatureFlags): boolean => {
+    return flags.enableScalarColumnCustomization;
+  }
+);

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -51,4 +51,7 @@ export interface FeatureFlags {
   // In Linked Time, if enabled, show a prospective fob user to turn on the feature or select a step.
   // If this is removed update the `getCurrentFob` method of tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
   enabledProspectiveFob: boolean;
+  // Adds affordance for users to select and reorder the columns in the Scalar
+  // Card Data Table
+  enableScalarColumnCustomization: boolean;
 }


### PR DESCRIPTION
* Motivation for features / changes
There is a plan to add customization features to the new data table in Scalar cards. This prepares for those changes by adding a flag that these features can hide behind while in development.

* Technical description of changes
This simply follows the same pattern as other feature flags.