### PR TITLE
Linked Time: Fix histogram range selection bug

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -65,6 +65,7 @@ limitations under the License.
   [timeProperty]="timeProperty(xAxisType)"
   [color]="runColorScale(runId)"
   [timeSelection]="convertToTimeSelection(linkedTimeSelection)"
+  [rangeSelectionEnabled]="rangeSelectionEnabled"
   (onLinkedTimeSelectionChanged)="onLinkedTimeSelectionChanged.emit($event)"
   (onLinkedTimeToggled)="onLinkedTimeToggled.emit()"
 ></tb-histogram>

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -50,6 +50,7 @@ export class HistogramCardComponent {
   @Input() showFullSize!: boolean;
   @Input() isPinned!: boolean;
   @Input() linkedTimeSelection!: TimeSelectionView | null;
+  @Input() rangeSelectionEnabled?: boolean;
   @Input() isClosestStepHighlighted!: boolean | null;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -41,6 +41,7 @@ import {
   getCardTimeSeries,
   getMetricsHistogramMode,
   getMetricsLinkedTimeSelection,
+  getMetricsRangeSelectionEnabled,
   getMetricsXAxisType,
 } from '../../store';
 import {CardId, CardMetadata} from '../../types';
@@ -73,6 +74,7 @@ type HistogramCardMetadata = CardMetadata & {
       [isPinned]="isPinned$ | async"
       [isClosestStepHighlighted]="isClosestStepHighlighted$ | async"
       [linkedTimeSelection]="linkedTimeSelection$ | async"
+      [rangeSelectionEnabled]="rangeSelectionEnabled$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       (onLinkedTimeSelectionChanged)="onLinkedTimeSelectionChanged($event)"
@@ -106,6 +108,7 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   data$?: Observable<HistogramDatum[]>;
   mode$ = this.store.select(getMetricsHistogramMode);
   xAxisType$ = this.store.select(getMetricsXAxisType);
+  rangeSelectionEnabled$ = this.store.select(getMetricsRangeSelectionEnabled);
   showFullSize = false;
   isPinned$?: Observable<boolean>;
   linkedTimeSelection$?: Observable<TimeSelectionView | null>;

--- a/tensorboard/webapp/widgets/histogram/histogram_card_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_card_fob_controller.ts
@@ -30,6 +30,7 @@ import {TemporalScale} from './histogram_component';
     <card-fob-controller
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
+      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [highestStep]="getHighestStep()"
@@ -44,6 +45,7 @@ import {TemporalScale} from './histogram_component';
 export class HistogramCardFobController {
   @Input() steps!: number[];
   @Input() timeSelection!: TimeSelection;
+  @Input() rangeSelectionEnabled?: boolean;
   @Input() temporalScale!: TemporalScale;
   @Output() onTimeSelectionChanged = new EventEmitter<TimeSelection>();
   @Output() onTimeSelectionToggled = new EventEmitter();

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -54,6 +54,7 @@ limitations under the License.
       <histogram-card-fob-controller
         class="histogram-card-fob"
         [timeSelection]="timeSelection"
+        [rangeSelectionEnabled]="rangeSelectionEnabled"
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"
         (onTimeSelectionChanged)="onLinkedTimeSelectionChanged.emit($event)"

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -104,6 +104,8 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   @Input() timeSelection: TimeSelection | null = null;
 
+  @Input() rangeSelectionEnabled: boolean = false;
+
   @Output() onLinkedTimeSelectionChanged =
     new EventEmitter<TimeSelectionWithAffordance>();
   @Output() onLinkedTimeToggled = new EventEmitter();


### PR DESCRIPTION
## Motivation for features / changes
For googlers b/259092516
When linked time is enabled fobs are shown on the histogram card. There is currently a bug where the end fob is now shown on the histogram card. This is because of a #6033 changing the circumstances under which the end fob is shown.

## Technical description of changes
After #6033 the end fob is only rendered when the `CardFobControllers` `rangeSelectionEnabled` prop is set. I missed setting it from the Histogram Card and thus it does not appear.

## Screenshots of UI changes
Before:
![image](https://user-images.githubusercontent.com/78179109/201790205-26834029-52c7-4cf9-ae36-8dde743bb4d7.png)

After:
![image](https://user-images.githubusercontent.com/78179109/201790023-f3b84e1d-1347-41c7-99c4-cbabe71f655d.png)


## Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Nagivate to http://localhost:6006?enableDataTable=true&enableLinkedTime=true&allowRangeSelection=true
3) Enable range selection and linked time in the settings panel
4) Ensure two fobs are shown on the histogram card

