### PR TITLE
Reduce js bundle size by eliminating duplicate sass rules.

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -21,10 +21,6 @@ limitations under the License.
 
 // Angular Material theme definition.
 
-// Include non-theme styles for core.
-@include mat.all-component-typographies();
-@include mat.core();
-
 // Value for `app-bar` property in $tb-background. Can specify an override in
 // _variable.scss to specifically customize this value.
 $tb-app-bar-color: mat.get-color-from-palette($tb-primary, default) !default;
@@ -266,6 +262,8 @@ $tb-dark-theme: map_merge(
 
 // Apply themed style for the global stylesheet (styles.scss).
 @mixin tb-global-themed-styles() {
+  @include mat.core();
+  @include mat.all-component-typographies();
   // Include all theme-styles for the components based on the current theme.
   @include mat.all-component-themes($tb-theme);
 


### PR DESCRIPTION
Googlers, see [b/259074873](https://b.corp.google.com/issues/259074873).

http://go/tbpr/5951 increased the size of our Angular js bundle from 4,418,195 bytes to 5,440,612 bytes. The root cause was adding an @include statement to a sass "Partial" file (_tb_theme.template.scss) that is included by many many TensorBoard components. The contents of the @included sass file were therefore duplicated many many times and included many many times in our js bundle.

The Angular team advised us that "Partial" sass files should not contain @include statements at the top-level. These particular @include statements probably should really only be invoked once for the entire application so we add them to the `tb-global-themed-styles()` mixin, which is already included once in the project by `tensorboard/webapp/styles.scss` and by other `style.scss` files written internally at Google for other TensorBoard instances.

The impact on bundle size is impressive. The Angular js bundle (tb_webapp_binary.js) is reduced to 3,216,597 bytes -- a decrease of over 25% from the original size before http://go/tbpr/5951!