### PR TITLE
Bug: Initialize proper minMaxSteps when there are no points.

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -376,9 +376,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
           .map(({points}) => points.map(({x}) => x))
           .flat();
         const min =
-          allPoints.length == 0 ? DEFAULT_MIN : Math.min(...allPoints);
+          allPoints.length === 0 ? DEFAULT_MIN : Math.min(...allPoints);
         const max =
-          allPoints.length == 0 ? DEFAULT_MAX : Math.max(...allPoints);
+          allPoints.length === 0 ? DEFAULT_MAX : Math.max(...allPoints);
         const minStep = Math.max(min, viewPort.minStep);
         const maxStep = Math.min(max, viewPort.maxStep);
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -375,8 +375,10 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         const allPoints = series
           .map(({points}) => points.map(({x}) => x))
           .flat();
-        const min = Math.min(...allPoints);
-        const max = Math.max(...allPoints);
+        const min =
+          allPoints.length == 0 ? DEFAULT_MIN : Math.min(...allPoints);
+        const max =
+          allPoints.length == 0 ? DEFAULT_MAX : Math.max(...allPoints);
         const minStep = Math.max(min, viewPort.minStep);
         const maxStep = Math.min(max, viewPort.maxStep);
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2160,6 +2160,29 @@ describe('scalar card', () => {
         ).toEqual('30');
       }));
 
+      it('initializes minMaxSteps when there is no run data', fakeAsync(async () => {
+        const runToSeries = {
+          run1: [],
+        };
+        provideMockCardRunToSeriesData(
+          selectSpy,
+          PluginType.SCALARS,
+          'card1',
+          null /* metadataOverride */,
+          runToSeries
+        );
+        const fixture = createComponent('card1');
+        let newSteps: MinMaxStep | null = null;
+        fixture.componentInstance.minMaxSteps$?.subscribe((minMaxStep) => {
+          newSteps = minMaxStep;
+        });
+
+        expect(newSteps!).toEqual({
+          minStep: -Infinity,
+          maxStep: Infinity,
+        });
+      }));
+
       describe('stepSelectorTimeSelection', () => {
         beforeEach(() => {
           provideMockCardRunToSeriesData(


### PR DESCRIPTION
* Motivation for features / changes
This fixes a bug where the start step was sometimes initialized as INFINITY.  Math.min([]) returns INFINITY and Math.max([]) return -INFINITY. This makes sense for some applications but for us this was causing bugs. I went ahead and forced the value to be the other way around when the array was empty. This fixed the bug.