### PR TITLE
Update tests in preparation for Angular 13 upgrade.

### DIFF
--- a/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
+++ b/tensorboard/components/experimental/plugin_util/plugin_api_host_test.ts
@@ -61,6 +61,10 @@ describe('plugin_api_host test', () => {
     runApi = TestBed.inject(PluginRunsApiHostImpl);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('runs apis', () => {
     describe('#experimental.RunsChanged', () => {
       it('broadcasts runs when runs change', () => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -395,6 +395,10 @@ describe('Debugger effects', () => {
     store.overrideSelector(getActivePlugin, '');
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function createAndSubscribeToDebuggerEffectsWithEmptyRepeater() {
     spyOn(TEST_ONLY, 'createTimedRepeater').and.callFake(
       (stream: Observable<any>) => stream

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
@@ -56,6 +56,10 @@ describe('Graph Container', () => {
     dispatchSpy = spyOn(store, 'dispatch');
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders no-op-selected element and nothing else when no op is selected', () => {
     const fixture = TestBed.createComponent(GraphContainer);
     store.overrideSelector(getFocusedGraphOpInfo, null);

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -87,6 +87,10 @@ describe('Graph Executions Container', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('does not render execs viewport if # execs = 0', fakeAsync(() => {
     const fixture = TestBed.createComponent(GraphExecutionsContainer);
     store.overrideSelector(getNumGraphExecutions, 0);

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
@@ -75,6 +75,7 @@ describe('Source Files Container', () => {
 
   afterEach(() => {
     tearDownMonacoFakes();
+    store?.resetSelectors();
   });
 
   it('renders no file selected when no source line is focused on', () => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container_test.ts
@@ -58,6 +58,10 @@ describe('Stack Trace container', () => {
     dispatchSpy = spyOn(store, 'dispatch');
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   for (const stickToBottommostFrame of [false, true]) {
     it(
       `shows non-empty eager stack frames; highlights focused frame: ` +

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
@@ -91,6 +91,10 @@ describe('Timeline Container', () => {
     dispatchSpy = spyOn(store, 'dispatch');
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('shows total number of executions', () => {
     const fixture = TestBed.createComponent(TimelineContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/alert/views/alert_snackbar_test.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_test.ts
@@ -66,6 +66,7 @@ describe('alert snackbar', () => {
 
   afterEach(() => {
     snackbar.dismiss();
+    store?.resetSelectors();
   });
 
   it('opens the snackbar on each alert', () => {

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -250,6 +250,10 @@ describe('app_routing_effects', () => {
     );
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('bootstrapReducers$', () => {
     beforeEach(() => {
       effects = TestBed.inject(AppRoutingEffects);

--- a/tensorboard/webapp/app_routing/views/router_outlet_test.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_test.ts
@@ -74,6 +74,10 @@ describe('router_outlet', () => {
     getNgComponentByRouteKindSpy = spyOn(registry, 'getNgComponentByRouteKind');
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function setActiveRoute(routeKind: RouteKind) {
     store.overrideSelector(
       getActiveRoute,

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -133,6 +133,7 @@ describe('core_effects', () => {
 
   afterEach(() => {
     httpMock.verify();
+    store?.resetSelectors();
   });
 
   [

--- a/tensorboard/webapp/core/views/dark_mode_supporter_test.ts
+++ b/tensorboard/webapp/core/views/dark_mode_supporter_test.ts
@@ -35,6 +35,7 @@ describe('dark mode supporter test', () => {
 
   afterEach(() => {
     document.body.classList.remove('dark-mode');
+    store?.resetSelectors();
   });
 
   it('sets class name on body when dark mode is enabled', () => {

--- a/tensorboard/webapp/core/views/hash_storage_test.ts
+++ b/tensorboard/webapp/core/views/hash_storage_test.ts
@@ -60,6 +60,10 @@ describe('hash storage test', () => {
     getPluginIdSpy = spyOn(deepLinker, 'getPluginId');
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('sets hash to plugin id when plugin id changes from null to value', () => {
     const setPluginIdCalls: Array<{
       id: string | null;

--- a/tensorboard/webapp/core/views/layout_test.ts
+++ b/tensorboard/webapp/core/views/layout_test.ts
@@ -84,6 +84,10 @@ describe('layout test', () => {
     store.overrideSelector(getSideBarWidthInPercent, 10);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders sidebar and main content', () => {
     const fixture = TestBed.createComponent(TestableComponent);
     fixture.detectChanges();

--- a/tensorboard/webapp/core/views/page_title_test.ts
+++ b/tensorboard/webapp/core/views/page_title_test.ts
@@ -50,6 +50,10 @@ describe('page title test', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('uses window_title as page title if given', () => {
     const spy = spyOn(TEST_ONLY.utils, 'setDocumentTitle');
     store.overrideSelector(getRouteKind, RouteKind.EXPERIMENT);
@@ -139,6 +143,10 @@ describe('page title test with custom brand names', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('uses TensorBoard brand name as page title as default', () => {
     const spy = spyOn(TEST_ONLY.utils, 'setDocumentTitle');
     const fixture = TestBed.createComponent(TestingComponent);
@@ -211,6 +219,10 @@ describe('page title test for OSS TensorBoard', () => {
       data_location: 'my-location',
       window_title: '',
     });
+  });
+
+  afterEach(() => {
+    store?.resetSelectors();
   });
 
   it('uses `TensorBoard` for experiment page title', () => {

--- a/tensorboard/webapp/deeplink/hash_test.ts
+++ b/tensorboard/webapp/deeplink/hash_test.ts
@@ -52,6 +52,10 @@ describe('hash storage test', () => {
     createElement.and.callThrough();
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('sets the hash to plugin id by replacing on first load', () => {
     store.overrideSelector(getActivePlugin, 'foo');
     const fixture = TestBed.createComponent(HashStorageContainer);

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -78,6 +78,10 @@ describe('feature_flag_effects', () => {
     store.overrideSelector(getFeatureFlagsMetadata, FeatureFlagMetadataMap);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('getFeatureFlags$', () => {
     let recordedActions: Action[];
 

--- a/tensorboard/webapp/feature_flag/http/feature_flag_http_interceptor_test.ts
+++ b/tensorboard/webapp/feature_flag/http/feature_flag_http_interceptor_test.ts
@@ -57,6 +57,10 @@ describe('FeatureFlagHttpInterceptor', () => {
     httpClient = TestBed.inject(HttpClient);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('injects feature flags into the HTTP request', () => {
     store.overrideSelector(getFeatureFlagsToSendToServer, {
       inColab: true,

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container.ts
@@ -20,6 +20,12 @@ import {featureFlagOverridesReset} from '../actions/feature_flag_actions';
 import {getShowFlagsEnabled} from '../store/feature_flag_selectors';
 import {FeatureFlagPageContainer} from './feature_flag_page_container';
 
+const util = {
+  reloadWindow: () => {
+    window.location.reload();
+  }
+};
+
 @Component({
   selector: 'feature-flag-modal-trigger',
   template: ``,
@@ -51,11 +57,15 @@ export class FeatureFlagModalTriggerContainer implements OnInit {
           // Wait one tick before reloading the page so the 'enableShowFlags'
           // reset has a chance to be reflected in the URL before page reload.
           setTimeout(() => {
-            window.location.reload();
+            util.reloadWindow();
           }, 1);
         });
         return;
       }
     });
   }
+}
+
+export const TEST_ONLY = {
+  util,
 }

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container.ts
@@ -23,7 +23,7 @@ import {FeatureFlagPageContainer} from './feature_flag_page_container';
 const util = {
   reloadWindow: () => {
     window.location.reload();
-  }
+  },
 };
 
 @Component({
@@ -68,4 +68,4 @@ export class FeatureFlagModalTriggerContainer implements OnInit {
 
 export const TEST_ONLY = {
   util,
-}
+};

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
@@ -33,7 +33,7 @@ import {
   getShowFlagsEnabled,
 } from '../store/feature_flag_selectors';
 import {FeatureFlags} from '../types';
-import {FeatureFlagModalTriggerContainer} from './feature_flag_modal_trigger_container';
+import {FeatureFlagModalTriggerContainer, TEST_ONLY} from './feature_flag_modal_trigger_container';
 import {FeatureFlagPageContainer} from './feature_flag_page_container';
 
 describe('feature_flag_modal_trigger_container', () => {
@@ -58,6 +58,13 @@ describe('feature_flag_modal_trigger_container', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 
     spyOn(store, 'dispatch').and.stub();
+
+    // Fake out window.location.reload so it doesn't do anything.
+    TEST_ONLY.util.reloadWindow = () => {};
+  });
+
+  afterEach(() => {
+    store?.resetSelectors();
   });
 
   function createComponent() {

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
@@ -33,7 +33,10 @@ import {
   getShowFlagsEnabled,
 } from '../store/feature_flag_selectors';
 import {FeatureFlags} from '../types';
-import {FeatureFlagModalTriggerContainer, TEST_ONLY} from './feature_flag_modal_trigger_container';
+import {
+  FeatureFlagModalTriggerContainer,
+  TEST_ONLY,
+} from './feature_flag_modal_trigger_container';
 import {FeatureFlagPageContainer} from './feature_flag_page_container';
 
 describe('feature_flag_modal_trigger_container', () => {

--- a/tensorboard/webapp/feature_flag/views/feature_flag_page_test.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_page_test.ts
@@ -64,6 +64,10 @@ describe('feature_flag_page_container', () => {
     dispatchSpy = spyOn(store, 'dispatch');
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function createComponent() {
     fixture = TestBed.createComponent(FeatureFlagPageContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/header/dark_mode_toggle_test.ts
+++ b/tensorboard/webapp/header/dark_mode_toggle_test.ts
@@ -56,6 +56,10 @@ describe('dark mode toggle test', () => {
     overlayContainer = TestBed.inject(OverlayContainer);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function getMenuButtons(fixture: ComponentFixture<DarkModeToggleContainer>) {
     const els = fixture.debugElement.queryAll(By.css('button'));
     expect(els.length).toBe(1);

--- a/tensorboard/webapp/header/header_test.ts
+++ b/tensorboard/webapp/header/header_test.ts
@@ -88,6 +88,10 @@ describe('header test', () => {
     store.overrideSelector(getCoreDataLoadedState, DataLoadState.NOT_LOADED);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function assertDebugElementText(el: DebugElement, text: string) {
     expect(el.nativeElement.innerText.trim().toUpperCase()).toBe(text);
   }

--- a/tensorboard/webapp/metrics/data_source/metrics_data_source_test.ts
+++ b/tensorboard/webapp/metrics/data_source/metrics_data_source_test.ts
@@ -53,6 +53,7 @@ describe('TBMetricsDataSource test', () => {
 
   afterEach(() => {
     httpMock.verify();
+    store?.resetSelectors();
   });
 
   describe('fetchTagMetadata', () => {

--- a/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
+++ b/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
@@ -91,6 +91,10 @@ describe('metrics effects', () => {
     );
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('#dataEffects', () => {
     beforeEach(() => {
       effects.dataEffects$.subscribe();

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -71,6 +71,10 @@ describe('card view test', () => {
     intersectionObserver = TestBed.inject(IntersectionObserverTestingModule);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('stamps DOM only when it is first visible', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_test.ts
@@ -71,6 +71,10 @@ describe('metrics/views/data_download_dialog', () => {
     return fixture;
   }
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders', async () => {
     const fixture = await createComponent('card1');
     store.overrideSelector(getCardMetadata, {

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -120,6 +120,10 @@ describe('histogram card', () => {
     store.overrideSelector(selectors.getMetricsLinkedTimeSelection, null);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders empty message when there is no data', () => {
     const cardMetadata = {
       plugin: PluginType.HISTOGRAMS,

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -115,6 +115,10 @@ describe('image card', () => {
     store.overrideSelector(getRun, null);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function expectImageSliderUI(
     fixture: ComponentFixture<ImageCardContainer>,
     imageId: string,

--- a/tensorboard/webapp/metrics/views/card_renderer/run_name_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/run_name_test.ts
@@ -43,6 +43,10 @@ describe('card run name', () => {
     store.overrideSelector(getRun, null);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders exp display name and run name', () => {
     store.overrideSelector(getExperimentIdForRunId, 'eid');
     store.overrideSelector(getExperimentIdToExperimentAliasMap, {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -341,6 +341,10 @@ describe('scalar card', () => {
     );
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('basic renders', () => {
     it('renders empty chart when there is no data', fakeAsync(() => {
       const cardMetadata = {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -95,6 +95,10 @@ describe('card grid', () => {
     store.overrideSelector(getMetricsXAxisType, XAxisType.STEP);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('keeps pagination button position when page size changes', fakeAsync(() => {
     store.overrideSelector(settingsSelectors.getPageSize, 2);
     let scrollOffset = 30;

--- a/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_test.ts
@@ -93,6 +93,10 @@ describe('metrics filter input', () => {
     );
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('input interaction', () => {
     it('dispatches metricsTagFilterChanged when typing on input', () => {
       const fixture = TestBed.createComponent(MetricsFilterInputContainer);

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -205,6 +205,10 @@ describe('metrics main view', () => {
     store.overrideSelector(selectors.isMetricsSettingsPaneOpen, false);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('toolbar', () => {
     it('displays visible plugin type in the button toggle', () => {
       store.overrideSelector(

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -66,6 +66,10 @@ describe('metrics right_pane', () => {
     dispatchSpy = spyOn(store, 'dispatch');
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('settings pane', () => {
     beforeEach(() => {
       store.overrideSelector(

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -19,7 +19,7 @@ import {MatButtonModule} from '@angular/material/button';
 import {MatMenuModule} from '@angular/material/menu';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {Action, createAction, Store} from '@ngrx/store';
+import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {State} from '../../app_state';
 import {MatIconTestingModule} from '../../testing/mat_icon_module';

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -28,7 +28,6 @@ import * as selectors from '../_redux/notification_center_selectors';
 import {CategoryEnum} from '../_redux/notification_center_types';
 import {NotificationCenterComponent} from './notification_center_component';
 import {NotificationCenterContainer} from './notification_center_container';
-const testAction = createAction('[Notification] Notification Bell Clicked');
 
 describe('notification center', () => {
   let store: MockStore<State>;
@@ -58,6 +57,10 @@ describe('notification center', () => {
     });
     store.overrideSelector(selectors.getNotifications, []);
     store.overrideSelector(selectors.getLastReadTime, 0);
+  });
+
+  afterEach(() => {
+    store?.resetSelectors();
   });
 
   it('loads notification module', () => {

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
@@ -85,6 +85,7 @@ describe('persistent_settings effects test', () => {
 
   afterEach(fakeAsync(() => {
     discardPeriodicTasks();
+    store?.resetSelectors();
   }));
 
   describe('#initializeAndUpdateSettings$', () => {

--- a/tensorboard/webapp/plugins/npmi/effects/npmi_effects_test.ts
+++ b/tensorboard/webapp/plugins/npmi/effects/npmi_effects_test.ts
@@ -68,6 +68,10 @@ describe('npmi effects', () => {
     effects.loadData$.subscribe();
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('load Plugin Data', () => {
     let fetchDataSpy: jasmine.Spy;
     let fetchDataSubject: Subject<{

--- a/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
@@ -53,6 +53,10 @@ describe('Npmi Container', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi component initially with inactive component', () => {
     store.overrideSelector(
       getCurrentRouteRunSelection,

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_test.ts
@@ -111,6 +111,10 @@ describe('Npmi Annotations List Row', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders annotation', () => {
     store.overrideSelector(selectors.getRunColorMap, {
       run_1: '#000',

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
@@ -55,6 +55,10 @@ describe('Npmi Annotations List Container', () => {
     );
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders expanded annotations list', () => {
     const fixture = TestBed.createComponent(AnnotationsListContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_test.ts
@@ -57,6 +57,10 @@ describe('Npmi Annotations List Toolbar Container', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders toolbar in non-expanded state', () => {
     const fixture = TestBed.createComponent(AnnotationsListToolbarContainer);
     fixture.componentInstance.numAnnotations = 3;

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_test.ts
@@ -58,6 +58,10 @@ describe('Npmi Annotations Search Container', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi annotations search component', () => {
     const fixture = TestBed.createComponent(AnnotationsSearchContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_test.ts
@@ -86,6 +86,10 @@ describe('Npmi Annotations List Header Container', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders checkbox and container', () => {
     const checkboxContainer = fixture.debugElement.query(
       css.CHECKBOX_CONTAINER

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_test.ts
@@ -79,6 +79,10 @@ describe('Npmi Metric Arithmetic Element Container', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi metric arithmetic element component', () => {
     const fixture = TestBed.createComponent(MetricArithmeticElementContainer);
     fixture.componentInstance.metric = 'npmi@test';

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_test.ts
@@ -47,6 +47,10 @@ describe('Npmi Metric Arithmetic Container', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders no metrics when none active', () => {
     const fixture = TestBed.createComponent(MetricArithmeticContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
@@ -84,6 +84,10 @@ describe('Npmi Metric Search Container', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi metrics search component', () => {
     const fixture = TestBed.createComponent(MetricSearchContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
@@ -55,6 +55,10 @@ describe('Npmi Results Download', () => {
     );
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders disabled button when no annotations are flagged', () => {
     const fixture = TestBed.createComponent(ResultsDownloadContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/plugins/npmi/views/embedding_projection/embedding_projection_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/embedding_projection/embedding_projection_test.ts
@@ -62,6 +62,10 @@ describe('Npmi Embedding Projection Container', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi embedding projection component', () => {
     const fixture = TestBed.createComponent(EmbeddingProjectionContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/embeddings/embeddings_test.ts
@@ -68,6 +68,10 @@ describe('Npmi Embeddings Container', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi embeddings component without runs', () => {
     store.overrideSelector(
       getCurrentRouteRunSelection,

--- a/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
@@ -68,6 +68,10 @@ describe('Npmi Main Container', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi main component without runs', () => {
     store.overrideSelector(
       getCurrentRouteRunSelection,

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_test.ts
@@ -117,6 +117,10 @@ describe('Npmi Parallel Coordinates Container', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders parallel coordinates without selected annoations', () => {
     store.overrideSelector(
       getCurrentRouteRunSelection,

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_test.ts
@@ -61,6 +61,10 @@ describe('Npmi Selected Annotations', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders selected annotations component expanded', () => {
     const fixture = TestBed.createComponent(SelectedAnnotationsContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
@@ -134,6 +134,10 @@ describe('Npmi Violin Filter Container', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi violin filter component', () => {
     const chartContainer = fixture.debugElement.query(css.CHART_CONTAINER);
     expect(chartContainer).toBeTruthy();

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_test.ts
@@ -61,6 +61,10 @@ describe('Npmi Violin Filters Container', () => {
     });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('renders npmi violin filters component without filters', () => {
     store.overrideSelector(getMetricFilters, {});
     const fixture = TestBed.createComponent(ViolinFiltersContainer);

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -140,6 +140,10 @@ describe('plugins_component', () => {
     },
   };
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function setActivePlugin(plugin: PluginId) {
     store.overrideSelector(getActivePlugin, plugin);
     store.refreshState();

--- a/tensorboard/webapp/plugins/text_v2/effects/text_effects_test.ts
+++ b/tensorboard/webapp/plugins/text_v2/effects/text_effects_test.ts
@@ -88,6 +88,10 @@ describe('text_effects', () => {
     textEffects.loadData$.subscribe(() => {});
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('fetches run to tags on plugins loaded', () => {
     action.next(textPluginLoaded());
 

--- a/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/dashboard_deeplink_provider_test.ts
@@ -69,6 +69,10 @@ describe('core deeplink provider', () => {
       });
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('time series', () => {
     describe('smoothing state', () => {
       it('serializes the smoothing state to the URL', () => {

--- a/tensorboard/webapp/runs/effects/runs_effects_test.ts
+++ b/tensorboard/webapp/runs/effects/runs_effects_test.ts
@@ -125,6 +125,10 @@ describe('runs_effects', () => {
     store.overrideSelector(getActiveRoute, buildRoute());
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('loadRunsOnRunTableShown', () => {
     beforeEach(() => {
       // Subscribes to effects.loadRunsOnRunTableShown$ change. Must subscribe

--- a/tensorboard/webapp/runs/views/runs_selector/runs_selector_test.ts
+++ b/tensorboard/webapp/runs/views/runs_selector/runs_selector_test.ts
@@ -40,6 +40,10 @@ describe('runs selector test', () => {
     selectSpy = spyOn(store, 'select').and.callThrough();
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   describe('runs table', () => {
     it('renders no exp name when only one exp is being viewed', () => {
       store.overrideSelector(getExperimentIdsFromRoute, ['123']);

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -72,6 +72,10 @@ describe('regex_edit_dialog', () => {
     }).compileComponents();
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function createComponent(experimentIds: string[]) {
     TestBed.overrideProvider(MAT_DIALOG_DATA, {useValue: {experimentIds}});
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -157,6 +157,10 @@ describe('runs_table', () => {
   let overlayContainer: OverlayContainer;
   let actualActions: Action[];
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   function createComponent(
     experimentIds: string[],
     columns?: RunsTableColumn[],

--- a/tensorboard/webapp/settings/_views/polymer_interop_test.ts
+++ b/tensorboard/webapp/settings/_views/polymer_interop_test.ts
@@ -43,6 +43,10 @@ describe('settings polymer_interop', () => {
     } as unknown as HTMLElement);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('sets pagination limit when pageSize changes', () => {
     store.overrideSelector(getPageSize, 5);
     const fixture = TestBed.createComponent(SettingsPolymerInteropContainer);

--- a/tensorboard/webapp/settings/_views/settings_test.ts
+++ b/tensorboard/webapp/settings/_views/settings_test.ts
@@ -84,6 +84,10 @@ describe('settings test', () => {
     overlayContainer = TestBed.inject(OverlayContainer);
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('opens a dialog when clicking on the button', async () => {
     const fixture = TestBed.createComponent(SettingsButtonContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
@@ -55,6 +55,10 @@ describe('TBHttpClient', () => {
     ) as TestableAppRootProvider;
   });
 
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
   it('waits for feature flags before making POST request', () => {
     const body = new FormData();
     body.append('formKey', 'value');


### PR DESCRIPTION
The upcoming upgrade to Angular 13 (and related libraries) requires some modifications to tests that we can make pre-upgrade.

1. ngrx can no longer automatically reset selectors that have been modified with overrideSelector() call. We must now call store.resetSelectors() after each test.
  * See: https://github.com/ngrx/platform/issues/3264#issuecomment-996863478
2. The upgrade has exposed a latent test bug. In one of the tests there is the potential to refresh the window with a call to `window.location.refresh()`. After the Angular 13 upgrade the refresh actually happens and the test karma runner fails and complains "Some of your tests did a full page reload!". The fix is to mock out the call to `window.location.refresh()`.