### PR TITLE
Revert "Linked Time: Removed old customVisTemplate that is no longer used"

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -113,6 +113,7 @@ limitations under the License.
     [useDarkMode]="useDarkMode"
     (onViewBoxOverridden)="isViewBoxOverridden = $event"
     (viewBoxChanged)="onLineChartZoom.emit($event)"
+    [customVisTemplate]="lineChartCustomVis"
     [customChartOverlayTemplate]="lineChartCustomXAxisVis"
   ></line-chart>
   <ng-template
@@ -181,6 +182,45 @@ limitations under the License.
     </scalar-card-data-table>
   </div>
 </ng-container>
+<ng-template
+  #lineChartCustomVis
+  let-viewExtent="viewExtent"
+  let-domDim="domDimension"
+  let-xScale="xScale"
+>
+  <ng-container *ngIf="stepOrLinkedTimeSelection">
+    <div
+      [ngClass]="{
+        'out-of-selected-time': true,
+        start: true,
+        range: !!stepOrLinkedTimeSelection.end?.step
+      }"
+      [style.right]="
+        xScale.forward(
+          viewExtent.x,
+          [domDim.width, 0],
+          stepOrLinkedTimeSelection.start.step
+        ) + 'px'
+      "
+    ></div>
+    <div
+      *ngIf="stepOrLinkedTimeSelection.end?.step"
+      [ngClass]="{
+        'out-of-selected-time': true,
+        end: true,
+        range: true
+      }"
+      [style.left]="
+        xScale.forward(
+          viewExtent.x,
+          [0, domDim.width],
+          stepOrLinkedTimeSelection.end?.step
+        ) + 'px'
+      "
+    ></div>
+  </ng-container>
+</ng-template>
+
 <ng-template
   #lineChartCustomXAxisVis
   let-viewExtent="viewExtent"

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -54,6 +54,17 @@ limitations under the License.
       (onViewExtentReset)="viewBoxReset()"
       (onInteractionStateChange)="onInteractionStateChange($event)"
     ></line-chart-interactive-view>
+    <div *ngIf="customVisTemplate" class="custom-vis">
+      <ng-container
+        [ngTemplateOutlet]="customVisTemplate"
+        [ngTemplateOutletContext]="{
+          xScale: xScale,
+          yScale: yScale,
+          domDimension: domDimensions.main,
+          viewExtent: viewBox
+        }"
+      ></ng-container>
+    </div>
   </div>
   <div class="y-axis" #yAxis>
     <line-chart-axis

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -92,6 +92,14 @@ export class LineChartComponent
   @ViewChild('chartEl', {static: false, read: ElementRef})
   private chartEl?: ElementRef<HTMLCanvasElement | SVGElement>;
 
+  /**
+   * Optional ngTemplate that renders on top of line chart (not axis). This
+   * template is rendered on top of interactive layer and can mask other
+   * contents. Do note that this component may not intercept pointer-events.
+   */
+  @Input()
+  customVisTemplate?: TemplateRef<TemplateContext>;
+
   @Input()
   customChartOverlayTemplate?: TemplateRef<
     TemplateContext & {formatter: Formatter}


### PR DESCRIPTION
This reverts commit b08e2f8e907b10932fb707b30ab87eac7db85f3b.

* Motivation for features / changes
I was wrong. This template is still used to shade out the area outside of a range selection.
