### PR TITLE
projector: Fix standalone vz_projector server.

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -99,7 +99,7 @@ def _tf_web_library(ctx):
     )
   params = struct(
       label=str(ctx.label),
-      bind="localhost:0",
+      bind="localhost:6006",
       manifest=[long_path(ctx, man) for man in devserver_manifests.to_list()],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])

--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -22,7 +22,7 @@ tb_combine_html(
     output_path = "/tf-projector/projector_binary.html",
     deps = [
         ":tf_projector_plugin",
-        "//tensorboard/plugins/projector/vz_projector:standalone_lib",
+        "//tensorboard/plugins/projector/vz_projector:standalone",
     ],
 )
 
@@ -34,6 +34,6 @@ tf_web_library(
     path = "/tf-projector",
     deps = [
         "//tensorboard/components/tf_imports:roboto",
-        "//tensorboard/plugins/projector/vz_projector:standalone_lib",
+        "//tensorboard/plugins/projector/vz_projector:standalone",
     ],
 )

--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -112,25 +112,15 @@ genrule(
 )
 
 tf_web_library(
-    name = "standalone_lib",
+    name = "standalone",
     srcs = [
-        "standalone_lib.html",
+        "standalone.html",
         "standalone_projector_config.json",
         ":standalone_bundle.js",
     ],
     path = "/",
     deps = [
         "//tensorboard/components/tf_imports:roboto",
-    ],
-)
-
-tb_combine_html(
-    name = "standalone",
-    input_path = "/standalone_lib.html",
-    js_path = "/standalone.js",
-    output_path = "/standalone.html",
-    deps = [
-        ":standalone_lib",
     ],
 )
 

--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -1,5 +1,5 @@
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_web_test_suite", "tf_ts_library")
-load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard/plugins/projector:__subpackages__"])
 

--- a/tensorboard/plugins/projector/vz_projector/standalone.html
+++ b/tensorboard/plugins/projector/vz_projector/standalone.html
@@ -31,7 +31,6 @@ limitations under the License.
 
     <link rel="import" href="../tf-imports/roboto.html" />
 
-    <script jscomp-ignore src="standalone_bundle.js"></script>
     <script>
       (function (i, s, o, g, r, a, m) {
         i['GoogleAnalyticsObject'] = r;
@@ -72,6 +71,7 @@ limitations under the License.
     </style>
   </head>
   <body>
+    <script jscomp-ignore src="standalone_bundle.js"></script>
     <vz-projector-app
       documentation-link="https://www.tensorflow.org/get_started/embedding_viz"
       bug-report-link="https://github.com/tensorflow/tensorboard/issues"


### PR DESCRIPTION
See: https://github.com/tensorflow/tensorboard/issues/6065 

We document the ability to run the projector plugin in standalone mode:
https://github.com/tensorflow/tensorboard/blob/master/tensorboard/plugins/projector/README.md

But it doesn't work.

The first thing to fix is to get the ":standalone" target to be executable and bring up a working server:
  * Hard to know exactly where things went wrong. I have found evidence that this worked as late as [September 2020](https://github.com/tensorflow/tensorboard/issues/4158). I suspect things went wrong in [April 2021](https://github.com/tensorflow/tensorboard/pull/4906/files), when tensorboard_html_binary() was replaced by tb_combine_html().
  * In the case of vz_projector it seems we can just delete the current ":standalone" target and rename the ":standalone_lib" target to ":standalone". tb_combine_html() doesn't seem to be necessary for any part of the build. tf_web_library() produces an executable web server (Amazing! Who knew?).

The second thing to fix is to get it to render a working page.
  * As is, the page would wail with the error message "Cannot read properties of null (reading 'appendChild')". In this case, the null property is `document.body`.
  * Again, not really sure where things went wrong but this is probably also related to the changes in April 2021.
  * The fix here is to load the js binary in the `body` tag (much like we do for `//tensorboard` target).

The third thing to fix is to get a constant port of "6006".
  * As is, the web server would start up with random ports.
  * The relevant change here is https://github.com/tensorflow/tensorboard/pull/3047, where port is set to '0'. But the reason for that change is no longer relevant - the test infrastructure the change was supporting has all been deleted.
  * The fix is to change the port for the web server back to '6006'.