### PR TITLE
Settings Link Converter: adding  first basic action in OSS

### DIFF
--- a/tensorboard/webapp/settings_link_converter/BUILD
+++ b/tensorboard/webapp/settings_link_converter/BUILD
@@ -1,0 +1,19 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])
+
+tf_ng_module(
+    name = "settings_link_converter",
+    srcs = [
+        "_settings_link_converter_module.ts",
+        "index.ts",
+    ],
+    deps = [
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+        "//tensorboard/webapp/settings_link_converter/_redux:actions",
+        "//tensorboard/webapp/settings_link_converter/_redux:types",
+    ],
+)

--- a/tensorboard/webapp/settings_link_converter/BUILD
+++ b/tensorboard/webapp/settings_link_converter/BUILD
@@ -11,9 +11,9 @@ tf_ng_module(
         "index.ts",
     ],
     deps = [
-        "@npm//@angular/core",
-        "@npm//@ngrx/store",
         "//tensorboard/webapp/settings_link_converter/_redux:actions",
         "//tensorboard/webapp/settings_link_converter/_redux:types",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/settings_link_converter/_redux/BUILD
+++ b/tensorboard/webapp/settings_link_converter/_redux/BUILD
@@ -1,9 +1,8 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard/webapp/settings_link_converter:__subpackages__"])
 
 licenses(["notice"])
-
 
 tf_ts_library(
     name = "actions",

--- a/tensorboard/webapp/settings_link_converter/_redux/BUILD
+++ b/tensorboard/webapp/settings_link_converter/_redux/BUILD
@@ -1,0 +1,25 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard/webapp/settings_link_converter:__subpackages__"])
+
+licenses(["notice"])
+
+
+tf_ts_library(
+    name = "actions",
+    srcs = [
+        "settings_link_converter_actions.ts",
+    ],
+    deps = [
+        ":types",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "types",
+    srcs = [
+        "settings_link_converter_types.ts",
+    ],
+    visibility = ["//tensorboard:internal"],
+)

--- a/tensorboard/webapp/settings_link_converter/_redux/settings_link_converter_actions.ts
+++ b/tensorboard/webapp/settings_link_converter/_redux/settings_link_converter_actions.ts
@@ -1,0 +1,18 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {createAction, props} from '@ngrx/store';
+import {ShareableSettingState} from './settings_link_converter_types';
+
+export const stateRehydrateFromSharing = createAction(
+  '[Settings Link Converter] State rehydrated from sharing',
+  props<{settings: ShareableSettingState}>()
+);

--- a/tensorboard/webapp/settings_link_converter/_redux/settings_link_converter_types.ts
+++ b/tensorboard/webapp/settings_link_converter/_redux/settings_link_converter_types.ts
@@ -1,0 +1,25 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+export const SETTINGS_LINK_CONVERTER_FEATURE_KEY = 'settingsLinkConverter';
+
+// TODO(jieweiwu): Update to a subset of RunsDataState and Metrics(None)NamespacedState,
+export type ShareableSettingState = null;
+export type SettingLinkConverterState = {
+  settings: ShareableSettingState;
+};
+
+export interface State {
+  [SETTINGS_LINK_CONVERTER_FEATURE_KEY]?: SettingLinkConverterState;
+}

--- a/tensorboard/webapp/settings_link_converter/_settings_link_converter_module.ts
+++ b/tensorboard/webapp/settings_link_converter/_settings_link_converter_module.ts
@@ -1,0 +1,20 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+
+@NgModule({
+  imports: [],
+})
+export class SettingsLinkConverterModule {}

--- a/tensorboard/webapp/settings_link_converter/index.ts
+++ b/tensorboard/webapp/settings_link_converter/index.ts
@@ -1,0 +1,15 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+export * as settingsLinkConverterActions from './_redux/settings_link_converter_actions';


### PR DESCRIPTION
* Motivation for features / changes
Start building "Settings Link Converter", the FE part of the Shareability project. While still deciding where we should cut the line between internal/external changes. This PR adds an action that will be put in OSS for sure.

* Technical description of changes
Create one action that is necessary for runs/metrics state change.

* Screenshots of UI changes
N/A

* Test
Add deps (`"//tensorboard/webapp/settings_link_converter"`) in `runs:store` and it compiles

* Notes
  - We might want to rename `SettingsLinkConverterModule` to add `OSS...` prefix to distinguish it from `Corp...` module, but let's leave it for now.
  - The props is only settings for now. We will consider adding other props for internal usages.
  - We expect settings to be a subset of other features' states. This is not included in this PR.

Googlers, please see internal design doc.