### PR TITLE
chore: Port annotations for suppressing TS 4.8 type errors.

### DIFF
--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.ts
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.ts
@@ -28,6 +28,8 @@ import {
 import {TfDomRepeat} from './tf-dom-repeat';
 
 @customElement('tf-category-paginated-view')
+// @ts-ignore(go/ts48upgrade) Fix code and remove this comment. Error:
+// TS2344: Type 'CategoryItem' does not satisfy the constraint '{}'.
 class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
   static readonly template = html`
     <template is="dom-if" if="[[_paneRendered]]" id="ifRendered">

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -1271,6 +1271,8 @@ class TfGraphControls extends LegacyElementMixin(
   _deviceCheckboxClicked(event: Event) {
     // Update the device map.
     const input = event.target as HTMLInputElement;
+    // @ts-ignore(go/ts48upgrade) Fix code and remove this comment. Error:
+    // TS2322: Type 'object' is not assignable to type 'DeviceForStats'.
     const devicesForStats: DeviceForStats = Object.assign(
       {},
       this.devicesForStats

--- a/tensorboard/webapp/testing/lang.ts
+++ b/tensorboard/webapp/testing/lang.ts
@@ -17,6 +17,8 @@ limitations under the License.
  * assumed not to have reference loops.
  */
 export function deepFreeze<T>(obj: T): T {
+  // @ts-ignore(go/ts48upgrade) Fix code and remove this comment. Error:
+  // TS2769: No overload matches this call.
   for (const val of Object.values(obj)) {
     if (val && typeof val === 'object') {
       deepFreeze(val);


### PR DESCRIPTION
Googlers, see b/260116849 and cl/490119036. 

Google is internally upgrading to TS 4.8. We haven't yet upgraded so the internal language team has asked us to annotate some code to suppress some TS 4.8 type errors.