### PR TITLE
Bug Fix: Use TypeScript to make axis edit button appear

### DIFF
--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.scss
@@ -57,7 +57,9 @@ limitations under the License.
   position: absolute;
   // Height/Width to match x-axis
   height: 30px;
-  width: calc(100% - 50px); // dot on the left takes up 50px
+  width: calc(
+    100% - 74px
+  ); // dot on the left takes up 50px, the edit button takes up 24
 }
 
 .prospective-area {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/public_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/public_types.ts
@@ -33,3 +33,10 @@ export enum InteractionState {
   SCROLL_ZOOMING = 'SCROLL_ZOOMING',
   PANNING = 'PANNING',
 }
+
+export const enum ChartSection {
+  NONE = 'NONE',
+  CHART = 'CHART',
+  XAXIS = 'XAXIS',
+  YAXIS = 'YAXIS',
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -19,6 +19,7 @@ limitations under the License.
   [ngClass]="{'container': true, 'dark-mode': useDarkMode, 'line-only-mode': lineOnly}"
   detectResize
   (onResize)="onViewResize()"
+  (mousemove)="onMouseMove($event)"
   [resizeEventDebouncePeriodInMs]="0"
   #overlayTarget="cdkOverlayOrigin"
   cdkOverlayOrigin
@@ -66,7 +67,10 @@ limitations under the License.
       ></ng-container>
     </div>
   </div>
-  <div class="y-axis" #yAxis>
+  <div
+    [ngClass]="{'y-axis': true, 'hovered': hoverSection.getValue() === 'YAXIS'}"
+    #yAxis
+  >
     <line-chart-axis
       *ngIf="!lineOnly"
       axis="y"
@@ -78,7 +82,10 @@ limitations under the License.
       (onViewExtentChange)="onViewBoxChangedFromAxis($event, 'y')"
     ></line-chart-axis>
   </div>
-  <div class="x-axis" #xAxis>
+  <div
+    [ngClass]="{'x-axis': true, 'hovered': hoverSection.getValue() === 'XAXIS'}"
+    #xAxis
+  >
     <line-chart-axis
       *ngIf="!lineOnly"
       axis="x"

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.scss
@@ -164,6 +164,8 @@ text {
 }
 
 .axis:hover .extent-edit-button,
+.x-axis.hover .extent-edit-button,
+.y-axis.hover .extent-edit-button,
 .axis:focus-within .extent-edit-button,
 .extent-edit-menu-opened {
   visibility: visible;


### PR DESCRIPTION
## Motivation for features / changes
Enabling the  prospective fob feature prevents the X Axis from being edited on the scalar card.

## Technical description of changes
The prospective fob area lies directly on top of the X Axis and thus prevents it from being hovered.
To resolve this I used TypeScript to compute the area of the chart the mouse is currently hovering and then conditionally added an additional class to the Axis components.

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/78179109/204612638-29cf9008-6409-41a3-96c6-94e88c4a179b.png)


## Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Navigate to http://localhost:6006/?enableLinkedTime=true&enableDataTable=true&allowRangeSelection=true&enableProspectiveFob=true#timeseries
3) Hover the X Axis of a scalar card
4) Assert the axis edit button appears

## Alternate designs / implementations considered
I considered reordering the DOM to place the fobs within the axis component but thought there would be issues with the lines. While this seems possible it doesn't seem worth the complexity.
I also considered either making hovering the entire chart cause the edit button to appear or making only hovering the corner cause the edit button to appear. Unfortunately I consider both of those to be a reduction of functionality.