### PR TITLE
hparams: fix type check bug

### DIFF
--- a/tensorboard/plugins/hparams/summary.py
+++ b/tensorboard/plugins/hparams/summary.py
@@ -126,12 +126,14 @@ def session_start_pb(
         start_time_secs=start_time_secs,
     )
     for (hp_name, hp_val) in hparams.items():
-        if isinstance(hp_val, (float, int)):
+        # Boolean typed values need to be checked before integers since in Python
+        # isinstance(True/False, int) returns True.
+        if isinstance(hp_val, bool):
+            session_start_info.hparams[hp_name].bool_value = hp_val
+        elif isinstance(hp_val, (float, int)):
             session_start_info.hparams[hp_name].number_value = hp_val
         elif isinstance(hp_val, str):
             session_start_info.hparams[hp_name].string_value = hp_val
-        elif isinstance(hp_val, bool):
-            session_start_info.hparams[hp_name].bool_value = hp_val
         elif isinstance(hp_val, (list, tuple)):
             session_start_info.hparams[hp_name].string_value = str(hp_val)
         else:


### PR DESCRIPTION
Boolean typed values should be checked before integers:
```shell
>>> isinstance(True, int)
True
>>> isinstance(True, bool)
True
>>> isinstance(False, (float, int))
True
>>> isinstance(1, bool)
False
```

See https://stackoverflow.com/questions/8169001/why-is-bool-a-subclass-of-int for context.

For Googlers - this came up in cl/492278796.
