### PR TITLE
Update rust lint version for CI to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        rust_version: ['1.58.1']
+        rust_version: ['1.65.0']
         cargo_raze_version: ['0.13.0']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e


### PR DESCRIPTION
Moving to the latest Rust release version, [1.65.0](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html) for CI lint.