### PR TITLE
Refactor: Handle Smoothed column logic in DataTable

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1100,24 +1100,9 @@ const reducer = createReducer(
       };
     }
 
-    // TODO(@jameshollyer): remove this logic with smoothing refactor *******
-    let orderAdjustedForSmoothed = newOrder;
-    const newSmoothedColumnIndex = newOrder.indexOf(ColumnHeaders.SMOOTHED);
-    const oldSmoothedColumnIndex = state.singleSelectionHeaders.indexOf(
-      ColumnHeaders.SMOOTHED
-    );
-
-    if (newSmoothedColumnIndex < 0 && oldSmoothedColumnIndex > 0) {
-      orderAdjustedForSmoothed = newOrder
-        .slice(0, oldSmoothedColumnIndex)
-        .concat([ColumnHeaders.SMOOTHED])
-        .concat(newOrder.slice(oldSmoothedColumnIndex, newOrder.length));
-    }
-    // *********************************************************************
-
     return {
       ...state,
-      singleSelectionHeaders: orderAdjustedForSmoothed,
+      singleSelectionHeaders: newOrder,
     };
   }),
   on(actions.metricsToggleVisiblePlugin, (state, {plugin}) => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -178,6 +178,7 @@ limitations under the License.
       [dataHeaders]="dataHeaders"
       [sortingInfo]="sortingInfo"
       [columnCustomizationEnabled]="columnCustomizationEnabled"
+      [smoothingEnabled]="smoothingEnabled"
       (sortDataBy)="sortDataBy($event)"
       (orderColumns)="reorderColumnHeaders.emit($event)"
     >

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -492,34 +492,17 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     );
 
     this.columnHeaders$ = combineLatest([
-      this.smoothingEnabled$,
       this.stepOrLinkedTimeSelection$,
       this.store.select(getSingleSelectionHeaders),
       this.store.select(getRangeSelectionHeaders),
     ]).pipe(
-      map(
-        ([
-          smoothingEnabled,
-          timeSelection,
-          singleSelectionHeaders,
-          rangeSelectionHeaders,
-        ]) => {
-          if (timeSelection === null || timeSelection.end === null) {
-            if (!smoothingEnabled) {
-              // Return single selection headers without smoothed header.
-              const indexOfSmoothed = singleSelectionHeaders.indexOf(
-                ColumnHeaders.SMOOTHED
-              );
-              return singleSelectionHeaders
-                .slice(0, indexOfSmoothed)
-                .concat(singleSelectionHeaders.slice(indexOfSmoothed + 1));
-            }
-            return singleSelectionHeaders;
-          } else {
-            return rangeSelectionHeaders;
-          }
+      map(([timeSelection, singleSelectionHeaders, rangeSelectionHeaders]) => {
+        if (timeSelection === null || timeSelection.end === null) {
+          return singleSelectionHeaders;
+        } else {
+          return rangeSelectionHeaders;
         }
-      )
+      })
     );
 
     this.chartMetadataMap$ = partitionedSeries$.pipe(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -39,6 +39,7 @@ import {
       [data]="getTimeSelectionTableData()"
       [sortingInfo]="sortingInfo"
       [columnCustomizationEnabled]="columnCustomizationEnabled"
+      [smoothingEnabled]="smoothingEnabled"
       (sortDataBy)="sortDataBy.emit($event)"
       (orderColumns)="orderColumns.emit($event)"
     ></tb-data-table>
@@ -52,6 +53,7 @@ export class ScalarCardDataTable {
   @Input() dataHeaders!: ColumnHeaders[];
   @Input() sortingInfo!: SortingInfo;
   @Input() columnCustomizationEnabled!: boolean;
+  @Input() smoothingEnabled!: boolean;
 
   @Output() sortDataBy = new EventEmitter<SortingInfo>();
   @Output() orderColumns = new EventEmitter<ColumnHeaders[]>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2628,6 +2628,7 @@ describe('scalar card', () => {
           RUN: 'run1',
           STEP: 2,
           VALUE: 10,
+          SMOOTHED: 10,
         },
         {
           id: 'run2',
@@ -2636,6 +2637,7 @@ describe('scalar card', () => {
           RUN: 'run2',
           STEP: 2,
           VALUE: 10,
+          SMOOTHED: 10,
         },
       ]);
     }));
@@ -3011,7 +3013,7 @@ describe('scalar card', () => {
       expect(data[1].RUN).toEqual('200 test alias 2/Run2 name');
     }));
 
-    it('adds smoothed column header when smoothed is enabled', fakeAsync(() => {
+    it('edits smoothed value when smoothed is enabled', fakeAsync(() => {
       store.overrideSelector(selectors.getMetricsScalarSmoothing, 0.8);
 
       const runToSeries = {
@@ -3051,39 +3053,6 @@ describe('scalar card', () => {
         scalarCardDataTable.componentInstance.getTimeSelectionTableData()[0]
           .SMOOTHED
       ).toBe(6.000000000000001);
-    }));
-
-    it('does not add smoothed column header when smoothed is disabled', fakeAsync(() => {
-      store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
-
-      const runToSeries = {
-        run1: [{wallTime: 1, value: 1, step: 10}],
-      };
-      provideMockCardRunToSeriesData(
-        selectSpy,
-        PluginType.SCALARS,
-        'card1',
-        null /* metadataOverride */,
-        runToSeries
-      );
-      store.overrideSelector(
-        selectors.getCurrentRouteRunSelection,
-        new Map([['run1', true]])
-      );
-      store.overrideSelector(getMetricsLinkedTimeSelection, {
-        start: {step: 20},
-        end: null,
-      });
-
-      const fixture = createComponent('card1');
-      fixture.detectChanges();
-      const scalarCardDataTable = fixture.debugElement.query(
-        By.directive(ScalarCardDataTable)
-      );
-
-      expect(scalarCardDataTable.componentInstance.dataHeaders).not.toContain(
-        ColumnHeaders.SMOOTHED
-      );
     }));
 
     it('orders data ascending', fakeAsync(() => {

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -20,7 +20,10 @@ limitations under the License.
           <!-- This header is intentionally left blank for the color column -->
         </th>
         <ng-container *ngFor="let header of headers;">
-          <th (click)="headerClicked(header)">
+          <th
+            *ngIf="smoothingEnabled || header !== ColumnHeaders.SMOOTHED"
+            (click)="headerClicked(header)"
+          >
             <div
               [draggable]="columnCustomizationEnabled"
               (dragstart)="dragStart(header)"
@@ -67,7 +70,10 @@ limitations under the License.
             <span [style.backgroundColor]="runData.COLOR"></span>
           </td>
           <ng-container *ngFor="let header of headers;">
-            <td [ngSwitch]="header">
+            <td
+              *ngIf="smoothingEnabled || header !== ColumnHeaders.SMOOTHED"
+              [ngSwitch]="header"
+            >
               <div *ngSwitchCase="ColumnHeaders.VALUE_CHANGE" class="cell">
                 <ng-container
                   *ngTemplateOutlet="arrow; context: {$implicit:runData.VALUE_CHANGE}"

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -55,6 +55,7 @@ export class DataTableComponent implements OnDestroy {
   @Input() data!: SelectedStepRunData[];
   @Input() sortingInfo!: SortingInfo;
   @Input() columnCustomizationEnabled!: boolean;
+  @Input() smoothingEnabled!: boolean;
 
   @Output() sortDataBy = new EventEmitter<SortingInfo>();
   @Output() orderColumns = new EventEmitter<ColumnHeaders[]>();


### PR DESCRIPTION
* Motivation for features / changes
The smoothed column in the scalar card data table does not render when smoothing is disabled. The logic for removing this column previously occurred in the ScalarCardContainer where it removed the column entirely from the list of headers. This causes some strange behavior which needs to be handled when dealing with changing the order of the columns. 

This change removes the special treatment of the Smoothed column everywhere except for when it is rendered.

* Screenshots of UI changes
No changes.