### PR TITLE
Feature: Add a tooltip to the runs table experiment name column

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -244,6 +244,7 @@ limitations under the License.
         <tb-experiment-alias
           *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
           [alias]="item.experimentAlias"
+          [title]="item.experimentName"
         ></tb-experiment-alias>
 
         <span *ngSwitchCase="RunsTableColumn.RUN_NAME" class="name"

--- a/tensorboard/webapp/widgets/experiment_alias/experiment_alias_component.ts
+++ b/tensorboard/webapp/widgets/experiment_alias/experiment_alias_component.ts
@@ -31,7 +31,9 @@ import {ExperimentAlias} from '../../experiments/types';
       (onValueChange)="aliasChanged.emit($event)"
     ></content-wrapping-input>
     <ng-template #noEditAliasName>
-      <span [class.illegal]="!isAliasNameLegal">{{ alias.aliasText }}</span>
+      <span [class.illegal]="!isAliasNameLegal" [title]="title">{{
+        alias.aliasText
+      }}</span>
     </ng-template>
   `,
   styleUrls: [`experiment_alias_component.css`],
@@ -42,6 +44,9 @@ export class ExperimentAliasComponent {
 
   @Input()
   aliasEditable!: boolean;
+
+  @Input()
+  title?: string;
 
   @Input()
   isAliasNameLegal: boolean = true;


### PR DESCRIPTION
## Motivation for features / changes
For Googlers b/259431435
We abbreviate the name of the experiment which can lead to confusion. By showing the full name in a tooltip we provide users a way of accessing that information.

## Technical description of changes
Tooltips are generally created by setting the `title` attribute. However, this particular column is a custom element and thus required me to pass the attribute through.

## Screenshots of UI changes
IDK how to screenshot tooltips :shrug: 

## Detailed steps to verify changes work correctly (as executed by you)
I tested this on internal tensorboard where the experiment column gets used.
