### PR TITLE
Chore: Upgrade protobuf dependency to unblock TF upgrade

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -28,7 +28,7 @@ numpy >= 1.12.0
 # See: http://b/182876485
 # See: https://github.com/protocolbuffers/protobuf/issues/9954#issuecomment-1128283911
 # See: https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/tools/pip_package/setup.py?q=protobuf
-protobuf >= 4
+protobuf >= 3.9.2
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
 tensorboard-data-server >= 0.6.0, < 0.7.0

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -28,7 +28,7 @@ numpy >= 1.12.0
 # See: http://b/182876485
 # See: https://github.com/protocolbuffers/protobuf/issues/9954#issuecomment-1128283911
 # See: https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/tools/pip_package/setup.py?q=protobuf
-protobuf >= 3.9.2, < 4
+protobuf >= 4
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0
 tensorboard-data-server >= 0.6.0, < 0.7.0


### PR DESCRIPTION
## Motivation for features / changes
For googlers b/182876485

TensorFlow is trying to upgrade their protobuf dependency to 4.21 but is blocked by our dependency.
Our dependency on TensorFlow leads to an awkward cycle where one of us has to upgrade first.
