### PR TITLE
Improve the feature flags modal

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -22,25 +22,29 @@ export type FeatureFlagType =
   | null
   | undefined;
 
+export type BasicFeatureFlagMetadata<T> = {
+  defaultValue: T;
+  // Some feature flags cannot be overridden by query params in the URL. They
+  // should specify null here.
+  queryParamOverride: null;
+};
+
+export type AdvancedFeatureFlagMetadata<T> = {
+  defaultValue: T;
+  // Some feature flags can be overridden by query params in the URL. They
+  // should specify the name of the query param here.
+  queryParamOverride: string;
+  // Additionally they should specify a way to parse the query param string
+  // values into the feature flag value.
+  parseValue: (str: string) => T;
+  // Indicates that the feature flag and value should be sent to the server
+  // if the user has specified an override value.
+  sendToServerWhenOverridden?: boolean;
+};
+
 export type FeatureFlagMetadata<T> =
-  | {
-      defaultValue: T;
-      // Some feature flags cannot be overridden by query params in the URL. They
-      // should specify null here.
-      queryParamOverride: null;
-    }
-  | {
-      defaultValue: T;
-      // Some feature flags can be overridden by query params in the URL. They
-      // should specify the name of the query param here.
-      queryParamOverride: string;
-      // Additionally they should specify a way to parse the query param string
-      // values into the feature flag value.
-      parseValue: (str: string) => T;
-      // Indicates that the feature flag and value should be sent to the server
-      // if the user has specified an override value.
-      sendToServerWhenOverridden?: boolean;
-    };
+  | BasicFeatureFlagMetadata<T>
+  | AdvancedFeatureFlagMetadata<T>;
 
 export type FeatureFlagMetadataMapType<T> = {
   [FlagName in keyof T]: FeatureFlagMetadata<T[FlagName]>;

--- a/tensorboard/webapp/feature_flag/views/feature_flag_page_component.ng.html
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_page_component.ng.html
@@ -21,11 +21,25 @@ limitations under the License.
     By enabling these features, you could put the application in an unusable
     state or expose yourself to untested features or potential bugs.
   </div>
+  <ng-container *ngIf="hasFlagsSentToServer">
+    <div class="message">
+      There is a difference between Default - (Enabled/Disabled) and
+      (Enabled/Disabled)
+    </div>
+    <div class="message">
+      Only flags with non default values are sent to the backend.
+    </div>
+  </ng-container>
   <table class="feature-flag-table">
     <ng-container *ngFor="let flagStatus of featureFlagStatuses;">
       <tr>
         <td>
-          <div>{{flagStatus.flag}}</div>
+          <div>
+            {{flagStatus.flag}}
+            <sup *ngIf="flagStatus.sendToServerWhenOverridden" class="note-1"
+              >1</sup
+            >
+          </div>
         </td>
         <ng-container
           *ngIf="isEditable(flagStatus); then selectBlock else unsupportedBlock"
@@ -47,6 +61,9 @@ limitations under the License.
         </ng-template>
       </tr>
     </ng-container>
-    <button mat-button (click)="allFlagsReset.emit()">Reset All</button>
   </table>
+  <button mat-button (click)="allFlagsReset.emit()">Reset All</button>
+  <div *ngIf="hasFlagsSentToServer" class="note-1">
+    1. Sent to server when overridden
+  </div>
 </div>

--- a/tensorboard/webapp/feature_flag/views/feature_flag_page_component.scss
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_page_component.scss
@@ -22,9 +22,12 @@ limitations under the License.
   margin-bottom: 16px;
 }
 
-.scolling-page {
-  height: 90vh;
-  overflow-y: scroll;
+.note-1 {
+  color: mat.get-color-from-palette($tb-accent);
+}
+
+.scrolling-page {
+  max-height: 90vh;
 }
 
 .feature-flag-table {

--- a/tensorboard/webapp/feature_flag/views/feature_flag_page_component.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_page_component.ts
@@ -25,6 +25,8 @@ import {FeatureFlagStatus, FeatureFlagStatusEvent} from './types';
 export class FeatureFlagPageComponent {
   @Input() featureFlagStatuses!: FeatureFlagStatus<keyof FeatureFlags>[];
 
+  @Input() hasFlagsSentToServer: boolean = false;
+
   @Output() flagChanged = new EventEmitter<FeatureFlagStatusEvent>();
 
   @Output() allFlagsReset = new EventEmitter();

--- a/tensorboard/webapp/feature_flag/views/feature_flag_page_container.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_page_container.ts
@@ -16,7 +16,6 @@ import {Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {map, withLatestFrom} from 'rxjs/operators';
-
 import {State} from '../../app_state';
 import {
   allFeatureFlagOverridesReset,

--- a/tensorboard/webapp/feature_flag/views/types.ts
+++ b/tensorboard/webapp/feature_flag/views/types.ts
@@ -24,6 +24,7 @@ export type FeatureFlagStatus<K extends keyof FeatureFlags> = {
   flag: K;
   status: FeatureFlagOverrideStatus;
   defaultValue: FeatureFlags[K];
+  sendToServerWhenOverridden?: boolean;
 };
 
 export type FeatureFlagStatusEvent = {


### PR DESCRIPTION
## Motivation for features / changes
The feature flag modal has a couple UX bugs
1) The modal does not scroll when there are too many flags.
2) The reset all button does not visually update the modal
3) There is a subtle difference between Default states and states overridden with the default value that is not stated.

## Technical description of changes
* There was a typo on one of the css class names.
* The modal was only being updated when the default flags changed while it should really have been when the overridden flags changed
* I added some text that only appears when relevant describing the distinction between default and overridden with default value.

## Screenshots of UI changes
OSS without needing to scroll
![image](https://user-images.githubusercontent.com/78179109/206795016-9549a8cc-00b8-4369-a462-ab49d3f04c1a.png)

OSS when the window is tiny
![image](https://user-images.githubusercontent.com/78179109/206795058-91676571-72c8-4fd4-adcc-47e83b1bb9c6.png)

Internal Screenshot for Googlers (contains messages about default flags)
https://screenshot.googleplex.com/LCiK2xtBVa2SpP4

## Detailed steps to verify changes work correctly (as executed by you)
1) Start TensorBoard
2) Navigate to http://localhost:6006?showFlags
3) Resize the window and assert it is able to scroll when needed
4) Change some flag values
5) Click reset button
6) Assert all the flags are visually reset in the modal

In internal tensorboard
Perform the same validation as OSS
Additionally verify appropriate flags contain the footnote

