### PR TITLE
tensorboard-data-server: add Linux aarch64 support

### DIFF
--- a/tensorboard/data/server/pip_package/build.py
+++ b/tensorboard/data/server/pip_package/build.py
@@ -38,7 +38,7 @@ def main():
         mac_platform = "macosx_11_0"
     platform_name = {
         # using platform tag values from TensorFlow releases
-        "Linux": "manylinux2010",
+        "Linux": "manylinux2014",
         "Darwin": mac_platform,
     }.get(platform.system())
 


### PR DESCRIPTION
* Motivation for features / changes

When building tensorboard-data-server from source on Linux aarch64, pip install raises the following error:
```
pip._internal.exceptions.UnsupportedWheel: tensorboard_data_server-0.6.1-py3-none-manylinux2010_aarch64.whl is not a supported wheel on this platform.
```

* Technical description of changes

From what I can tell, manylinux2014 is the first version that supports aarch64. TensorFlow also moved to manylinux2014, so there should be no issues with us updating as well: https://pypi.org/project/tensorflow/#files

* Screenshots of UI changes

N/A

* Detailed steps to verify changes work correctly (as executed by you)

I don't have access to Linux aarch64 myself (this was discovered in our CI) but anyone who does should be able to confirm that this works using:
```console
$ cd tensorboard/data/server
$ cargo build --release
$ cd pip_package
$ python3 build.py
$ pip install *.whl
```
* Alternate designs / implementations considered

Alternatively, we could use manylinux2010 on x86_64 and manylinux2014 on all other architectures, but I see no reason to avoid manylinux2014.

This is sort of a follow-up to #5715, @japie1235813 may be willing to review this