### PR TITLE
Column Customization: Refactor Column Headers to include enabled

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -31,7 +31,7 @@ import {
   XAxisType,
 } from '../internal_types';
 import {
-  ColumnHeaders,
+  ColumnHeader,
   SortingInfo,
 } from '../views/card_renderer/scalar_card_types';
 
@@ -203,7 +203,7 @@ export const sortingDataTable = createAction(
 export const dataTableColumnDrag = createAction(
   '[Metrics] Data table column dragged',
   props<{
-    newOrder: ColumnHeaders[];
+    newOrder: ColumnHeader[];
   }>()
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -46,7 +46,7 @@ import {
   URLDeserializedState,
 } from '../internal_types';
 import {groupCardIdWithMetdata} from '../utils';
-import {ColumnHeaders} from '../views/card_renderer/scalar_card_types';
+import {ColumnHeaderType} from '../views/card_renderer/scalar_card_types';
 import {
   buildOrReturnStateWithPinnedCopy,
   buildOrReturnStateWithUnresolvedImportedPins,
@@ -264,22 +264,22 @@ const {initialState, reducers: namespaceContextedReducer} =
       stepSelectorEnabled: false,
       rangeSelectionEnabled: false,
       singleSelectionHeaders: [
-        ColumnHeaders.RUN,
-        ColumnHeaders.SMOOTHED,
-        ColumnHeaders.VALUE,
-        ColumnHeaders.STEP,
-        ColumnHeaders.RELATIVE_TIME,
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.SMOOTHED, enabled: true},
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
       ],
       rangeSelectionHeaders: [
-        ColumnHeaders.RUN,
-        ColumnHeaders.MIN_VALUE,
-        ColumnHeaders.MAX_VALUE,
-        ColumnHeaders.START_VALUE,
-        ColumnHeaders.END_VALUE,
-        ColumnHeaders.VALUE_CHANGE,
-        ColumnHeaders.PERCENTAGE_CHANGE,
-        ColumnHeaders.START_STEP,
-        ColumnHeaders.END_STEP,
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
+        {type: ColumnHeaderType.START_VALUE, enabled: true},
+        {type: ColumnHeaderType.END_VALUE, enabled: true},
+        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.START_STEP, enabled: true},
+        {type: ColumnHeaderType.END_STEP, enabled: true},
       ],
       filteredPluginTypes: new Set(),
       stepMinMax: {

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -30,7 +30,7 @@ import {
   TooltipSort,
   XAxisType,
 } from '../internal_types';
-import {ColumnHeaders} from '../views/card_renderer/scalar_card_types';
+import {ColumnHeader} from '../views/card_renderer/scalar_card_types';
 import * as storeUtils from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
@@ -389,14 +389,14 @@ export const getMetricsStepMinMax = createSelector(
 
 export const getSingleSelectionHeaders = createSelector(
   selectMetricsState,
-  (state: MetricsState): ColumnHeaders[] => {
+  (state: MetricsState): ColumnHeader[] => {
     return state.singleSelectionHeaders;
   }
 );
 
 export const getRangeSelectionHeaders = createSelector(
   selectMetricsState,
-  (state: MetricsState): ColumnHeaders[] => {
+  (state: MetricsState): ColumnHeader[] => {
     return state.rangeSelectionHeaders;
   }
 );

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -36,7 +36,7 @@ import {
   TooltipSort,
   XAxisType,
 } from '../internal_types';
-import {ColumnHeaders} from '../views/card_renderer/scalar_card_types';
+import {ColumnHeader} from '../views/card_renderer/scalar_card_types';
 
 export const METRICS_FEATURE_KEY = 'metrics';
 
@@ -177,8 +177,8 @@ export interface MetricsNamespacedState {
   linkedTimeEnabled: boolean;
   stepSelectorEnabled: boolean;
   rangeSelectionEnabled: boolean;
-  singleSelectionHeaders: ColumnHeaders[];
-  rangeSelectionHeaders: ColumnHeaders[];
+  singleSelectionHeaders: ColumnHeader[];
+  rangeSelectionHeaders: ColumnHeader[];
   // Empty Set would signify "show all". `filteredPluginTypes` will never have
   // all pluginTypes in the Set.
   filteredPluginTypes: Set<PluginType>;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -175,7 +175,7 @@ limitations under the License.
       [chartMetadataMap]="chartMetadataMap"
       [dataSeries]="dataSeries"
       [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection"
-      [dataHeaders]="dataHeaders"
+      [columnHeaders]="columnHeaders"
       [sortingInfo]="sortingInfo"
       [columnCustomizationEnabled]="columnCustomizationEnabled"
       [smoothingEnabled]="smoothingEnabled"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -45,7 +45,8 @@ import {
 } from '../../../widgets/line_chart_v2/types';
 import {TooltipSort, XAxisType} from '../../types';
 import {
-  ColumnHeaders,
+  ColumnHeader,
+  ColumnHeaderType,
   MinMaxStep,
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
@@ -96,7 +97,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() rangeSelectionEnabled: boolean = false;
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
   @Input() minMaxStep!: MinMaxStep;
-  @Input() dataHeaders!: ColumnHeaders[];
+  @Input() columnHeaders!: ColumnHeader[];
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
@@ -107,7 +108,7 @@ export class ScalarCardComponent<Downloader> {
   @Output() onStepSelectorToggled =
     new EventEmitter<TimeSelectionToggleAffordance>();
   @Output() onDataTableSorting = new EventEmitter<SortingInfo>();
-  @Output() reorderColumnHeaders = new EventEmitter<ColumnHeaders[]>();
+  @Output() reorderColumnHeaders = new EventEmitter<ColumnHeader[]>();
 
   @Output() onLineChartZoom = new EventEmitter<Extent>();
 
@@ -115,7 +116,7 @@ export class ScalarCardComponent<Downloader> {
   @ViewChild(LineChartComponent)
   lineChart?: LineChartComponent;
   sortingInfo: SortingInfo = {
-    header: ColumnHeaders.RUN,
+    header: ColumnHeaderType.RUN,
     order: SortingOrder.ASCENDING,
   };
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -96,7 +96,8 @@ import {CardRenderer} from '../metrics_view_types';
 import {getTagDisplayName} from '../utils';
 import {DataDownloadDialogContainer} from './data_download_dialog_container';
 import {
-  ColumnHeaders,
+  ColumnHeader,
+  ColumnHeaderType,
   MinMaxStep,
   PartialSeries,
   PartitionedSeries,
@@ -168,7 +169,7 @@ function areSeriesEqual(
       [forceSvg]="forceSvg$ | async"
       [columnCustomizationEnabled]="columnCustomizationEnabled$ | async"
       [minMaxStep]="minMaxSteps$ | async"
-      [dataHeaders]="columnHeaders$ | async"
+      [columnHeaders]="columnHeaders$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       observeIntersection
@@ -212,7 +213,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   dataSeries$?: Observable<ScalarCardDataSeries[]>;
   chartMetadataMap$?: Observable<ScalarCardSeriesMetadataMap>;
   linkedTimeSelection$?: Observable<TimeSelectionView | null>;
-  columnHeaders$?: Observable<ColumnHeaders[]>;
+  columnHeaders$?: Observable<ColumnHeader[]>;
   stepOrLinkedTimeSelection$?: Observable<TimeSelection | null>;
 
   readonly isProspectiveFobFeatureEnabled$: Observable<boolean> =
@@ -719,7 +720,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.lineChartZoom$.next(minMaxStepInViewPort);
   }
 
-  reorderColumnHeaders(headers: ColumnHeaders[]) {
+  reorderColumnHeaders(headers: ColumnHeader[]) {
     this.store.dispatch(dataTableColumnDrag({newOrder: headers}));
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -22,7 +22,8 @@ import {
 import {TimeSelection} from '../../../widgets/card_fob/card_fob_types';
 import {findClosestIndex} from '../../../widgets/line_chart_v2/sub_view/line_chart_interactive_utils';
 import {
-  ColumnHeaders,
+  ColumnHeader,
+  ColumnHeaderType,
   ScalarCardDataSeries,
   ScalarCardPoint,
   ScalarCardSeriesMetadataMap,
@@ -35,7 +36,7 @@ import {
   selector: 'scalar-card-data-table',
   template: `
     <tb-data-table
-      [headers]="dataHeaders"
+      [headers]="columnHeaders"
       [data]="getTimeSelectionTableData()"
       [sortingInfo]="sortingInfo"
       [columnCustomizationEnabled]="columnCustomizationEnabled"
@@ -50,13 +51,13 @@ export class ScalarCardDataTable {
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() stepOrLinkedTimeSelection!: TimeSelection;
-  @Input() dataHeaders!: ColumnHeaders[];
+  @Input() columnHeaders!: ColumnHeader[];
   @Input() sortingInfo!: SortingInfo;
   @Input() columnCustomizationEnabled!: boolean;
   @Input() smoothingEnabled!: boolean;
 
   @Output() sortDataBy = new EventEmitter<SortingInfo>();
-  @Output() orderColumns = new EventEmitter<ColumnHeaders[]>();
+  @Output() orderColumns = new EventEmitter<ColumnHeader[]>();
 
   getMinValueInRange(
     points: ScalarCardPoint[],
@@ -120,54 +121,54 @@ export class ScalarCardDataTable {
           id: datum.id,
         };
         selectedStepData.COLOR = metadata.color;
-        for (const header of this.dataHeaders) {
-          switch (header) {
-            case ColumnHeaders.RUN:
+        for (const header of this.columnHeaders) {
+          switch (header.type) {
+            case ColumnHeaderType.RUN:
               let alias = '';
               if (metadata.alias) {
                 alias = `${metadata.alias.aliasNumber} ${metadata.alias.aliasText}/`;
               }
               selectedStepData.RUN = `${alias}${metadata.displayName}`;
               continue;
-            case ColumnHeaders.STEP:
+            case ColumnHeaderType.STEP:
               selectedStepData.STEP = closestStartPoint.step;
               continue;
-            case ColumnHeaders.VALUE:
+            case ColumnHeaderType.VALUE:
               selectedStepData.VALUE = closestStartPoint.value;
               continue;
-            case ColumnHeaders.RELATIVE_TIME:
+            case ColumnHeaderType.RELATIVE_TIME:
               selectedStepData.RELATIVE_TIME =
                 closestStartPoint.relativeTimeInMs;
               continue;
-            case ColumnHeaders.SMOOTHED:
+            case ColumnHeaderType.SMOOTHED:
               selectedStepData.SMOOTHED = closestStartPoint.y;
               continue;
-            case ColumnHeaders.VALUE_CHANGE:
+            case ColumnHeaderType.VALUE_CHANGE:
               if (!closestEndPoint) {
                 continue;
               }
               selectedStepData.VALUE_CHANGE =
                 closestEndPoint.y - closestStartPoint.y;
               continue;
-            case ColumnHeaders.START_STEP:
+            case ColumnHeaderType.START_STEP:
               selectedStepData.START_STEP = closestStartPoint.step;
               continue;
-            case ColumnHeaders.END_STEP:
+            case ColumnHeaderType.END_STEP:
               if (!closestEndPoint) {
                 continue;
               }
               selectedStepData.END_STEP = closestEndPoint.step;
               continue;
-            case ColumnHeaders.START_VALUE:
+            case ColumnHeaderType.START_VALUE:
               selectedStepData.START_VALUE = closestStartPoint.y;
               continue;
-            case ColumnHeaders.END_VALUE:
+            case ColumnHeaderType.END_VALUE:
               if (!closestEndPoint) {
                 continue;
               }
               selectedStepData.END_VALUE = closestEndPoint.y;
               continue;
-            case ColumnHeaders.MIN_VALUE:
+            case ColumnHeaderType.MIN_VALUE:
               if (!closestEndPointIndex) {
                 continue;
               }
@@ -178,7 +179,7 @@ export class ScalarCardDataTable {
                 true
               );
               continue;
-            case ColumnHeaders.MAX_VALUE:
+            case ColumnHeaderType.MAX_VALUE:
               if (!closestEndPointIndex) {
                 continue;
               }
@@ -189,7 +190,7 @@ export class ScalarCardDataTable {
                 true
               );
               continue;
-            case ColumnHeaders.PERCENTAGE_CHANGE:
+            case ColumnHeaderType.PERCENTAGE_CHANGE:
               if (!closestEndPoint) {
                 continue;
               }
@@ -219,11 +220,14 @@ export class ScalarCardDataTable {
     return dataTableData;
   }
 
-  private getSortableValue(point: SelectedStepRunData, header: ColumnHeaders) {
+  private getSortableValue(
+    point: SelectedStepRunData,
+    header: ColumnHeaderType
+  ) {
     switch (header) {
       // The value shown in the "RUN" column is a string concatenation of Alias Id + Alias + Run Name
       // but we would actually prefer to sort by just the run name.
-      case ColumnHeaders.RUN:
+      case ColumnHeaderType.RUN:
         return makeValueSortable(this.chartMetadataMap[point.id].displayName);
       default:
         return makeValueSortable(point[header]);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -96,7 +96,8 @@ import {ScalarCardContainer} from './scalar_card_container';
 import {ScalarCardDataTable} from './scalar_card_data_table';
 import {ScalarCardFobController} from './scalar_card_fob_controller';
 import {
-  ColumnHeaders,
+  ColumnHeader,
+  ColumnHeaderType,
   MinMaxStep,
   ScalarCardPoint,
   ScalarCardSeriesMetadata,
@@ -2559,22 +2560,22 @@ describe('scalar card', () => {
     beforeEach(() => {
       store.overrideSelector(getMetricsLinkedTimeEnabled, true);
       store.overrideSelector(getSingleSelectionHeaders, [
-        ColumnHeaders.RUN,
-        ColumnHeaders.SMOOTHED,
-        ColumnHeaders.VALUE,
-        ColumnHeaders.STEP,
-        ColumnHeaders.RELATIVE_TIME,
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.SMOOTHED, enabled: true},
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
       ]);
       store.overrideSelector(getRangeSelectionHeaders, [
-        ColumnHeaders.RUN,
-        ColumnHeaders.MIN_VALUE,
-        ColumnHeaders.MAX_VALUE,
-        ColumnHeaders.START_VALUE,
-        ColumnHeaders.END_VALUE,
-        ColumnHeaders.VALUE_CHANGE,
-        ColumnHeaders.PERCENTAGE_CHANGE,
-        ColumnHeaders.START_STEP,
-        ColumnHeaders.END_STEP,
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
+        {type: ColumnHeaderType.START_VALUE, enabled: true},
+        {type: ColumnHeaderType.END_VALUE, enabled: true},
+        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.START_STEP, enabled: true},
+        {type: ColumnHeaderType.END_STEP, enabled: true},
       ]);
     });
 
@@ -3045,10 +3046,11 @@ describe('scalar card', () => {
         By.directive(ScalarCardDataTable)
       );
 
-      expect(scalarCardDataTable.componentInstance.dataHeaders).toContain(
-        ColumnHeaders.SMOOTHED
-      );
-
+      expect(
+        scalarCardDataTable.componentInstance.columnHeaders.findIndex(
+          (element: ColumnHeader) => element.type === ColumnHeaderType.SMOOTHED
+        )
+      ).toBeGreaterThanOrEqual(0);
       expect(
         scalarCardDataTable.componentInstance.getTimeSelectionTableData()[0]
           .SMOOTHED
@@ -3087,7 +3089,7 @@ describe('scalar card', () => {
         By.directive(ScalarCardDataTable)
       );
       scalarCardDataTable.componentInstance.sortingInfo = {
-        header: ColumnHeaders.VALUE,
+        header: ColumnHeaderType.VALUE,
         order: SortingOrder.ASCENDING,
       };
       fixture.detectChanges();
@@ -3132,7 +3134,7 @@ describe('scalar card', () => {
         By.directive(ScalarCardDataTable)
       );
       scalarCardDataTable.componentInstance.sortingInfo = {
-        header: ColumnHeaders.VALUE,
+        header: ColumnHeaderType.VALUE,
         order: SortingOrder.DESCENDING,
       };
       fixture.detectChanges();
@@ -3185,7 +3187,7 @@ describe('scalar card', () => {
         By.directive(ScalarCardDataTable)
       );
       scalarCardDataTable.componentInstance.sortingInfo = {
-        header: ColumnHeaders.VALUE,
+        header: ColumnHeaderType.VALUE,
         order: SortingOrder.DESCENDING,
       };
       fixture.detectChanges();
@@ -3242,7 +3244,7 @@ describe('scalar card', () => {
         By.directive(ScalarCardDataTable)
       );
       scalarCardDataTable.componentInstance.sortingInfo = {
-        header: ColumnHeaders.RUN,
+        header: ColumnHeaderType.RUN,
         order: SortingOrder.ASCENDING,
       };
       scalarCardDataTable.componentInstance.chartMetadataMap.run1.alias = {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -76,7 +76,7 @@ export interface PartitionedSeries {
  * ScalarCardComponent must know which piece of data is associated with each
  * value and the DataTable widget must know how to display each value.
  */
-export enum ColumnHeaders {
+export enum ColumnHeaderType {
   COLOR = 'COLOR',
   RELATIVE_TIME = 'RELATIVE_TIME',
   RUN = 'RUN',
@@ -94,13 +94,18 @@ export enum ColumnHeaders {
   PERCENTAGE_CHANGE = 'PERCENTAGE_CHANGE',
 }
 
+export interface ColumnHeader {
+  type: ColumnHeaderType;
+  enabled: boolean;
+}
+
 export enum SortingOrder {
   ASCENDING,
   DESCENDING,
 }
 
 export interface SortingInfo {
-  header: ColumnHeaders;
+  header: ColumnHeaderType;
   order: SortingOrder;
 }
 
@@ -110,7 +115,7 @@ export interface SortingInfo {
  * run.
  */
 export type SelectedStepRunData = {
-  [key in ColumnHeaders]?: string | number;
+  [key in ColumnHeaderType]?: string | number;
 } & {id: string};
 
 /**

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -20,18 +20,15 @@ limitations under the License.
           <!-- This header is intentionally left blank for the color column -->
         </th>
         <ng-container *ngFor="let header of headers;">
-          <th
-            *ngIf="smoothingEnabled || header !== ColumnHeaders.SMOOTHED"
-            (click)="headerClicked(header)"
-          >
+          <th *ngIf="showColumn(header)" (click)="headerClicked(header.type)">
             <div
               [draggable]="columnCustomizationEnabled"
               (dragstart)="dragStart(header)"
               (dragend)="dragEnd()"
               (dragenter)="dragEnter(header)"
-              [ngSwitch]="header"
+              [ngSwitch]="header.type"
               class="cell"
-              [ngClass]="getHeaderHighlightStyle(header)"
+              [ngClass]="getHeaderHighlightStyle(header.type)"
             >
               <!-- order icon -->
               <mat-icon
@@ -44,17 +41,17 @@ limitations under the License.
               ></mat-icon>
               <div *ngSwitchDefault class="extra-right-padding"></div>
 
-              <span>{{ getHeaderTextColumn(header) }}</span>
+              <span>{{ getHeaderTextColumn(header.type) }}</span>
 
               <div class="sorting-icon-container">
                 <mat-icon
-                  *ngIf="sortingInfo.order === SortingOrder.ASCENDING || header !== sortingInfo.header"
-                  [ngClass]="header === sortingInfo.header ? 'show' : 'show-on-hover'"
+                  *ngIf="sortingInfo.order === SortingOrder.ASCENDING || header.type !== sortingInfo.header"
+                  [ngClass]="header.type === sortingInfo.header ? 'show' : 'show-on-hover'"
                   svgIcon="arrow_upward_24px"
                 ></mat-icon>
                 <mat-icon
-                  *ngIf="sortingInfo.order === SortingOrder.DESCENDING && header === sortingInfo.header"
-                  [ngClass]="header === sortingInfo.header ? 'show' : 'show-on-hover'"
+                  *ngIf="sortingInfo.order === SortingOrder.DESCENDING && header.type === sortingInfo.header"
+                  [ngClass]="header.type === sortingInfo.header ? 'show' : 'show-on-hover'"
                   svgIcon="arrow_downward_24px"
                 ></mat-icon>
               </div>
@@ -70,24 +67,21 @@ limitations under the License.
             <span [style.backgroundColor]="runData.COLOR"></span>
           </td>
           <ng-container *ngFor="let header of headers;">
-            <td
-              *ngIf="smoothingEnabled || header !== ColumnHeaders.SMOOTHED"
-              [ngSwitch]="header"
-            >
+            <td *ngIf="showColumn(header)" [ngSwitch]="header.type">
               <div *ngSwitchCase="ColumnHeaders.VALUE_CHANGE" class="cell">
                 <ng-container
                   *ngTemplateOutlet="arrow; context: {$implicit:runData.VALUE_CHANGE}"
                 ></ng-container>
-                {{ getFormattedDataForColumn(header, runData) }}
+                {{ getFormattedDataForColumn(header.type, runData) }}
               </div>
               <div *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE" class="cell">
                 <ng-container
                   *ngTemplateOutlet="arrow; context: {$implicit:runData.PERCENTAGE_CHANGE}"
                 ></ng-container>
-                {{ getFormattedDataForColumn(header, runData) }}
+                {{ getFormattedDataForColumn(header.type, runData) }}
               </div>
               <div *ngSwitchDefault class="cell extra-right-padding">
-                {{ getFormattedDataForColumn(header, runData) }}
+                {{ getFormattedDataForColumn(header.type, runData) }}
               </div>
             </td>
           </ng-container>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -22,7 +22,8 @@ import {
   Output,
 } from '@angular/core';
 import {
-  ColumnHeaders,
+  ColumnHeader,
+  ColumnHeaderType,
   SelectedStepRunData,
   SortingInfo,
   SortingOrder,
@@ -42,6 +43,10 @@ const preventDefault = function (e: MouseEvent) {
   e.preventDefault();
 };
 
+const isHeaderOfType = function (type: ColumnHeaderType, header: ColumnHeader) {
+  return header.type === type;
+};
+
 @Component({
   selector: 'tb-data-table',
   templateUrl: 'data_table_component.ng.html',
@@ -51,56 +56,56 @@ const preventDefault = function (e: MouseEvent) {
 export class DataTableComponent implements OnDestroy {
   // The order of this array of headers determines the order which they are
   // displayed in the table.
-  @Input() headers!: ColumnHeaders[];
+  @Input() headers!: ColumnHeader[];
   @Input() data!: SelectedStepRunData[];
   @Input() sortingInfo!: SortingInfo;
   @Input() columnCustomizationEnabled!: boolean;
   @Input() smoothingEnabled!: boolean;
 
   @Output() sortDataBy = new EventEmitter<SortingInfo>();
-  @Output() orderColumns = new EventEmitter<ColumnHeaders[]>();
+  @Output() orderColumns = new EventEmitter<ColumnHeader[]>();
 
-  readonly ColumnHeaders = ColumnHeaders;
+  readonly ColumnHeaders = ColumnHeaderType;
   readonly SortingOrder = SortingOrder;
   readonly Side = Side;
 
-  draggingHeader: ColumnHeaders | undefined;
-  highlightedColumn: ColumnHeaders | undefined;
+  draggingHeaderType: ColumnHeaderType | undefined;
+  highlightedColumnType: ColumnHeaderType | undefined;
   highlightSide: Side = Side.RIGHT;
 
   ngOnDestroy() {
     document.removeEventListener('dragover', preventDefault);
   }
 
-  getHeaderTextColumn(columnHeader: ColumnHeaders): string {
+  getHeaderTextColumn(columnHeader: ColumnHeaderType): string {
     switch (columnHeader) {
-      case ColumnHeaders.RUN:
+      case ColumnHeaderType.RUN:
         return 'Run';
-      case ColumnHeaders.VALUE:
+      case ColumnHeaderType.VALUE:
         return 'Value';
-      case ColumnHeaders.STEP:
+      case ColumnHeaderType.STEP:
         return 'Step';
-      case ColumnHeaders.TIME:
+      case ColumnHeaderType.TIME:
         return 'Time';
-      case ColumnHeaders.RELATIVE_TIME:
+      case ColumnHeaderType.RELATIVE_TIME:
         return 'Relative';
-      case ColumnHeaders.SMOOTHED:
+      case ColumnHeaderType.SMOOTHED:
         return 'Smoothed';
-      case ColumnHeaders.VALUE_CHANGE:
+      case ColumnHeaderType.VALUE_CHANGE:
         return 'Value';
-      case ColumnHeaders.START_STEP:
+      case ColumnHeaderType.START_STEP:
         return 'Start Step';
-      case ColumnHeaders.END_STEP:
+      case ColumnHeaderType.END_STEP:
         return 'End Step';
-      case ColumnHeaders.START_VALUE:
+      case ColumnHeaderType.START_VALUE:
         return 'Start Value';
-      case ColumnHeaders.END_VALUE:
+      case ColumnHeaderType.END_VALUE:
         return 'End Value';
-      case ColumnHeaders.MIN_VALUE:
+      case ColumnHeaderType.MIN_VALUE:
         return 'Min';
-      case ColumnHeaders.MAX_VALUE:
+      case ColumnHeaderType.MAX_VALUE:
         return 'Max';
-      case ColumnHeaders.PERCENTAGE_CHANGE:
+      case ColumnHeaderType.PERCENTAGE_CHANGE:
         return '%';
       default:
         return '';
@@ -108,97 +113,97 @@ export class DataTableComponent implements OnDestroy {
   }
 
   getFormattedDataForColumn(
-    columnHeader: ColumnHeaders,
+    columnHeader: ColumnHeaderType,
     selectedStepRunData: SelectedStepRunData
   ): string {
     switch (columnHeader) {
-      case ColumnHeaders.RUN:
+      case ColumnHeaderType.RUN:
         if (selectedStepRunData.RUN === undefined) {
           return '';
         }
         return selectedStepRunData.RUN as string;
-      case ColumnHeaders.VALUE:
+      case ColumnHeaderType.VALUE:
         if (selectedStepRunData.VALUE === undefined) {
           return '';
         }
         return numberFormatter.formatShort(selectedStepRunData.VALUE as number);
-      case ColumnHeaders.STEP:
+      case ColumnHeaderType.STEP:
         if (selectedStepRunData.STEP === undefined) {
           return '';
         }
         return intlNumberFormatter.formatShort(
           selectedStepRunData.STEP as number
         );
-      case ColumnHeaders.TIME:
+      case ColumnHeaderType.TIME:
         if (selectedStepRunData.TIME === undefined) {
           return '';
         }
         const time = new Date(selectedStepRunData.TIME!);
         return time.toISOString();
-      case ColumnHeaders.RELATIVE_TIME:
+      case ColumnHeaderType.RELATIVE_TIME:
         if (selectedStepRunData.RELATIVE_TIME === undefined) {
           return '';
         }
         return relativeTimeFormatter.formatReadable(
           selectedStepRunData.RELATIVE_TIME as number
         );
-      case ColumnHeaders.SMOOTHED:
+      case ColumnHeaderType.SMOOTHED:
         if (selectedStepRunData.SMOOTHED === undefined) {
           return '';
         }
         return numberFormatter.formatShort(
           selectedStepRunData.SMOOTHED as number
         );
-      case ColumnHeaders.VALUE_CHANGE:
+      case ColumnHeaderType.VALUE_CHANGE:
         if (selectedStepRunData.VALUE_CHANGE === undefined) {
           return '';
         }
         return numberFormatter.formatShort(
           Math.abs(selectedStepRunData.VALUE_CHANGE as number)
         );
-      case ColumnHeaders.START_STEP:
+      case ColumnHeaderType.START_STEP:
         if (selectedStepRunData.START_STEP === undefined) {
           return '';
         }
         return intlNumberFormatter.formatShort(
           selectedStepRunData.START_STEP as number
         );
-      case ColumnHeaders.END_STEP:
+      case ColumnHeaderType.END_STEP:
         if (selectedStepRunData.END_STEP === undefined) {
           return '';
         }
         return intlNumberFormatter.formatShort(
           selectedStepRunData.END_STEP as number
         );
-      case ColumnHeaders.START_VALUE:
+      case ColumnHeaderType.START_VALUE:
         if (selectedStepRunData.START_VALUE === undefined) {
           return '';
         }
         return intlNumberFormatter.formatShort(
           selectedStepRunData.START_VALUE as number
         );
-      case ColumnHeaders.END_VALUE:
+      case ColumnHeaderType.END_VALUE:
         if (selectedStepRunData.END_VALUE === undefined) {
           return '';
         }
         return intlNumberFormatter.formatShort(
           selectedStepRunData.END_VALUE as number
         );
-      case ColumnHeaders.MIN_VALUE:
+      case ColumnHeaderType.MIN_VALUE:
         if (selectedStepRunData.MIN_VALUE === undefined) {
           return '';
         }
         return intlNumberFormatter.formatShort(
           selectedStepRunData.MIN_VALUE as number
         );
-      case ColumnHeaders.MAX_VALUE:
+      case ColumnHeaderType.MAX_VALUE:
         if (selectedStepRunData.MAX_VALUE === undefined) {
           return '';
         }
         return intlNumberFormatter.formatShort(
           selectedStepRunData.MAX_VALUE as number
         );
-      case ColumnHeaders.PERCENTAGE_CHANGE:
+      case ColumnHeaderType.PERCENTAGE_CHANGE:
         if (selectedStepRunData.PERCENTAGE_CHANGE === undefined) {
           return '';
         }
@@ -212,7 +217,7 @@ export class DataTableComponent implements OnDestroy {
     }
   }
 
-  headerClicked(header: ColumnHeaders) {
+  headerClicked(header: ColumnHeaderType) {
     if (
       this.sortingInfo.header === header &&
       this.sortingInfo.order === SortingOrder.ASCENDING
@@ -223,41 +228,50 @@ export class DataTableComponent implements OnDestroy {
     this.sortDataBy.emit({header, order: SortingOrder.ASCENDING});
   }
 
-  dragStart(header: ColumnHeaders) {
-    this.draggingHeader = header;
+  dragStart(header: ColumnHeader) {
+    this.draggingHeaderType = header.type;
 
     // This stop the end drag animation
     document.addEventListener('dragover', preventDefault);
   }
 
   dragEnd() {
-    if (!this.draggingHeader || !this.highlightedColumn) {
+    if (!this.draggingHeaderType || !this.highlightedColumnType) {
       return;
     }
 
     this.orderColumns.emit(
       this.moveHeader(
-        this.headers.indexOf(this.draggingHeader),
-        this.headers.indexOf(this.highlightedColumn)
+        this.headers.findIndex((element) =>
+          isHeaderOfType(this.draggingHeaderType!, element)
+        ),
+        this.headers.findIndex((element) =>
+          isHeaderOfType(this.highlightedColumnType!, element)
+        )
       )
     );
-    this.draggingHeader = undefined;
-    this.highlightedColumn = undefined;
+    this.draggingHeaderType = undefined;
+    this.highlightedColumnType = undefined;
     document.removeEventListener('dragover', preventDefault);
   }
 
-  dragEnter(header: ColumnHeaders) {
-    if (!this.draggingHeader) {
+  dragEnter(header: ColumnHeader) {
+    if (!this.draggingHeaderType) {
       return;
     }
     if (
-      this.headers.indexOf(header) < this.headers.indexOf(this.draggingHeader)
+      this.headers.findIndex((element) =>
+        isHeaderOfType(header.type, element)
+      ) <
+      this.headers.findIndex((element) =>
+        isHeaderOfType(this.draggingHeaderType!, element)
+      )
     ) {
       this.highlightSide = Side.LEFT;
     } else {
       this.highlightSide = Side.RIGHT;
     }
-    this.highlightedColumn = header;
+    this.highlightedColumnType = header.type;
   }
 
   // Move the item at sourceIndex to destinationIndex
@@ -270,8 +284,8 @@ export class DataTableComponent implements OnDestroy {
     return newHeaders;
   }
 
-  getHeaderHighlightStyle(header: ColumnHeaders) {
-    if (header !== this.highlightedColumn) {
+  getHeaderHighlightStyle(header: ColumnHeaderType) {
+    if (header !== this.highlightedColumnType) {
       return {};
     }
 
@@ -280,5 +294,12 @@ export class DataTableComponent implements OnDestroy {
       'highlight-border-right': this.highlightSide === Side.RIGHT,
       'highlight-border-left': this.highlightSide === Side.LEFT,
     };
+  }
+
+  showColumn(header: ColumnHeader) {
+    return (
+      header.enabled &&
+      (this.smoothingEnabled || header.type !== ColumnHeaderType.SMOOTHED)
+    );
   }
 }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -43,10 +43,6 @@ const preventDefault = function (e: MouseEvent) {
   e.preventDefault();
 };
 
-const isHeaderOfType = function (type: ColumnHeaderType, header: ColumnHeader) {
-  return header.type === type;
-};
-
 @Component({
   selector: 'tb-data-table',
   templateUrl: 'data_table_component.ng.html',
@@ -242,12 +238,8 @@ export class DataTableComponent implements OnDestroy {
 
     this.orderColumns.emit(
       this.moveHeader(
-        this.headers.findIndex((element) =>
-          isHeaderOfType(this.draggingHeaderType!, element)
-        ),
-        this.headers.findIndex((element) =>
-          isHeaderOfType(this.highlightedColumnType!, element)
-        )
+        this.getIndexOfHeaderWithType(this.draggingHeaderType!),
+        this.getIndexOfHeaderWithType(this.highlightedColumnType!)
       )
     );
     this.draggingHeaderType = undefined;
@@ -260,12 +252,8 @@ export class DataTableComponent implements OnDestroy {
       return;
     }
     if (
-      this.headers.findIndex((element) =>
-        isHeaderOfType(header.type, element)
-      ) <
-      this.headers.findIndex((element) =>
-        isHeaderOfType(this.draggingHeaderType!, element)
-      )
+      this.getIndexOfHeaderWithType(header.type) <
+      this.getIndexOfHeaderWithType(this.draggingHeaderType!)
     ) {
       this.highlightSide = Side.LEFT;
     } else {
@@ -301,5 +289,11 @@ export class DataTableComponent implements OnDestroy {
       header.enabled &&
       (this.smoothingEnabled || header.type !== ColumnHeaderType.SMOOTHED)
     );
+  }
+
+  getIndexOfHeaderWithType(type: ColumnHeaderType) {
+    return this.headers.findIndex((element) => {
+      return type === element.type;
+    });
   }
 }

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -18,7 +18,8 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatIconModule} from '@angular/material/icon';
 import {By} from '@angular/platform-browser';
 import {
-  ColumnHeaders,
+  ColumnHeader,
+  ColumnHeaderType,
   SelectedStepRunData,
   SortingInfo,
   SortingOrder,
@@ -43,13 +44,13 @@ class TestableComponent {
   @ViewChild('DataTable')
   dataTable!: DataTableComponent;
 
-  @Input() headers!: ColumnHeaders[];
+  @Input() headers!: ColumnHeader[];
   @Input() data!: SelectedStepRunData[];
   @Input() sortingInfo!: SortingInfo;
   @Input() smoothingEnabled!: boolean;
 
   @Input() sortDataBy!: (sortingInfo: SortingInfo) => void;
-  @Input() orderColumns!: (newOrder: ColumnHeaders[]) => void;
+  @Input() orderColumns!: (newOrder: ColumnHeaderType[]) => void;
 }
 
 describe('data table', () => {
@@ -63,7 +64,7 @@ describe('data table', () => {
   });
 
   function createComponent(input: {
-    headers?: ColumnHeaders[];
+    headers?: ColumnHeader[];
     data?: SelectedStepRunData[];
     sortingInfo?: SortingInfo;
     smoothingEnabled?: boolean;
@@ -73,7 +74,7 @@ describe('data table', () => {
     fixture.componentInstance.headers = input.headers || [];
     fixture.componentInstance.data = input.data || [];
     fixture.componentInstance.sortingInfo = input.sortingInfo || {
-      header: ColumnHeaders.RUN,
+      header: ColumnHeaderType.RUN,
       order: SortingOrder.ASCENDING,
     };
 
@@ -99,19 +100,19 @@ describe('data table', () => {
   it('displays given headers in order', () => {
     const fixture = createComponent({
       headers: [
-        ColumnHeaders.VALUE,
-        ColumnHeaders.RUN,
-        ColumnHeaders.STEP,
-        ColumnHeaders.RELATIVE_TIME,
-        ColumnHeaders.VALUE_CHANGE,
-        ColumnHeaders.START_STEP,
-        ColumnHeaders.END_STEP,
-        ColumnHeaders.START_VALUE,
-        ColumnHeaders.END_VALUE,
-        ColumnHeaders.MIN_VALUE,
-        ColumnHeaders.MAX_VALUE,
-        ColumnHeaders.PERCENTAGE_CHANGE,
-        ColumnHeaders.SMOOTHED,
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
+        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.START_STEP, enabled: true},
+        {type: ColumnHeaderType.END_STEP, enabled: true},
+        {type: ColumnHeaderType.START_VALUE, enabled: true},
+        {type: ColumnHeaderType.END_VALUE, enabled: true},
+        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
+        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.SMOOTHED, enabled: true},
       ],
     });
     fixture.detectChanges();
@@ -147,19 +148,19 @@ describe('data table', () => {
   it('displays data in order', () => {
     const fixture = createComponent({
       headers: [
-        ColumnHeaders.VALUE,
-        ColumnHeaders.RUN,
-        ColumnHeaders.STEP,
-        ColumnHeaders.RELATIVE_TIME,
-        ColumnHeaders.VALUE_CHANGE,
-        ColumnHeaders.START_STEP,
-        ColumnHeaders.END_STEP,
-        ColumnHeaders.START_VALUE,
-        ColumnHeaders.END_VALUE,
-        ColumnHeaders.MIN_VALUE,
-        ColumnHeaders.MAX_VALUE,
-        ColumnHeaders.PERCENTAGE_CHANGE,
-        ColumnHeaders.SMOOTHED,
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
+        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.START_STEP, enabled: true},
+        {type: ColumnHeaderType.END_STEP, enabled: true},
+        {type: ColumnHeaderType.START_VALUE, enabled: true},
+        {type: ColumnHeaderType.END_VALUE, enabled: true},
+        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
+        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.SMOOTHED, enabled: true},
       ],
       data: [
         {
@@ -212,13 +213,44 @@ describe('data table', () => {
     expect(dataElements[13].nativeElement.innerText).toBe('2');
   });
 
+  it('does not displays headers or data when header is disabled', () => {
+    const fixture = createComponent({
+      headers: [
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: false},
+        {type: ColumnHeaderType.STEP, enabled: true},
+      ],
+      data: [
+        {
+          id: 'someid',
+          RUN: 'run name',
+          VALUE: 3,
+          STEP: 1,
+        },
+      ],
+    });
+    fixture.detectChanges();
+    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+    const dataElements = fixture.debugElement.queryAll(By.css('td'));
+
+    // The first header should always be blank as it is the run color column.
+    expect(headerElements[0].nativeElement.innerText).toBe('');
+    expect(headerElements[1].nativeElement.innerText).toBe('Value');
+    expect(headerElements[2].nativeElement.innerText).toBe('Step');
+
+    // The first column should always be blank as it is the run color column.
+    expect(dataElements[0].nativeElement.innerText).toBe('');
+    expect(dataElements[1].nativeElement.innerText).toBe('3');
+    expect(dataElements[2].nativeElement.innerText).toBe('1');
+  });
+
   it('displays nothing when no data is available', () => {
     const fixture = createComponent({
       headers: [
-        ColumnHeaders.VALUE,
-        ColumnHeaders.RUN,
-        ColumnHeaders.STEP,
-        ColumnHeaders.RELATIVE_TIME,
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
       ],
       data: [{id: 'someid'}],
     });
@@ -236,10 +268,10 @@ describe('data table', () => {
   it('emits sortDataBy event when header clicked', () => {
     const fixture = createComponent({
       headers: [
-        ColumnHeaders.VALUE,
-        ColumnHeaders.RUN,
-        ColumnHeaders.STEP,
-        ColumnHeaders.RELATIVE_TIME,
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
       ],
     });
     fixture.detectChanges();
@@ -247,7 +279,7 @@ describe('data table', () => {
 
     headerElements[3].triggerEventHandler('click', {});
     expect(sortDataBySpy).toHaveBeenCalledOnceWith({
-      header: ColumnHeaders.STEP,
+      header: ColumnHeaderType.STEP,
       order: SortingOrder.ASCENDING,
     });
   });
@@ -255,27 +287,37 @@ describe('data table', () => {
   it('emits sortDataBy event with DESCENDING when header that is currently sorted is clicked', () => {
     const fixture = createComponent({
       headers: [
-        ColumnHeaders.VALUE,
-        ColumnHeaders.RUN,
-        ColumnHeaders.STEP,
-        ColumnHeaders.RELATIVE_TIME,
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
       ],
-      sortingInfo: {header: ColumnHeaders.STEP, order: SortingOrder.ASCENDING},
+      sortingInfo: {
+        header: ColumnHeaderType.STEP,
+        order: SortingOrder.ASCENDING,
+      },
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(By.css('th'));
 
     headerElements[3].triggerEventHandler('click', {});
     expect(sortDataBySpy).toHaveBeenCalledOnceWith({
-      header: ColumnHeaders.STEP,
+      header: ColumnHeaderType.STEP,
       order: SortingOrder.DESCENDING,
     });
   });
 
   it('keeps sorting arrow invisible unless sorting on that header', () => {
     const fixture = createComponent({
-      headers: [ColumnHeaders.VALUE, ColumnHeaders.RUN, ColumnHeaders.STEP],
-      sortingInfo: {header: ColumnHeaders.VALUE, order: SortingOrder.ASCENDING},
+      headers: [
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+      ],
+      sortingInfo: {
+        header: ColumnHeaderType.VALUE,
+        order: SortingOrder.ASCENDING,
+      },
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(By.css('th'));
@@ -314,8 +356,15 @@ describe('data table', () => {
 
   it('shows downward arrow when order is DESCENDING', () => {
     const fixture = createComponent({
-      headers: [ColumnHeaders.VALUE, ColumnHeaders.RUN, ColumnHeaders.STEP],
-      sortingInfo: {header: ColumnHeaders.STEP, order: SortingOrder.DESCENDING},
+      headers: [
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+      ],
+      sortingInfo: {
+        header: ColumnHeaderType.STEP,
+        order: SortingOrder.DESCENDING,
+      },
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(By.css('th'));
@@ -354,8 +403,15 @@ describe('data table', () => {
 
   it('emits orderColumns with new order when dragged left', () => {
     const fixture = createComponent({
-      headers: [ColumnHeaders.VALUE, ColumnHeaders.RUN, ColumnHeaders.STEP],
-      sortingInfo: {header: ColumnHeaders.STEP, order: SortingOrder.DESCENDING},
+      headers: [
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+      ],
+      sortingInfo: {
+        header: ColumnHeaderType.STEP,
+        order: SortingOrder.DESCENDING,
+      },
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(By.css('th'));
@@ -376,16 +432,23 @@ describe('data table', () => {
     headerElements[2].query(By.css('.cell')).triggerEventHandler('dragend');
 
     expect(orderColumnsSpy).toHaveBeenCalledOnceWith([
-      ColumnHeaders.RUN,
-      ColumnHeaders.VALUE,
-      ColumnHeaders.STEP,
+      {type: ColumnHeaderType.RUN, enabled: true},
+      {type: ColumnHeaderType.VALUE, enabled: true},
+      {type: ColumnHeaderType.STEP, enabled: true},
     ]);
   });
 
   it('emits orderColumns with new order when dragged right', () => {
     const fixture = createComponent({
-      headers: [ColumnHeaders.VALUE, ColumnHeaders.RUN, ColumnHeaders.STEP],
-      sortingInfo: {header: ColumnHeaders.STEP, order: SortingOrder.DESCENDING},
+      headers: [
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+      ],
+      sortingInfo: {
+        header: ColumnHeaderType.STEP,
+        order: SortingOrder.DESCENDING,
+      },
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(By.css('th'));
@@ -406,19 +469,19 @@ describe('data table', () => {
     headerElements[2].query(By.css('.cell')).triggerEventHandler('dragend');
 
     expect(orderColumnsSpy).toHaveBeenCalledOnceWith([
-      ColumnHeaders.VALUE,
-      ColumnHeaders.STEP,
-      ColumnHeaders.RUN,
+      {type: ColumnHeaderType.VALUE, enabled: true},
+      {type: ColumnHeaderType.STEP, enabled: true},
+      {type: ColumnHeaderType.RUN, enabled: true},
     ]);
   });
 
   it('does not display Smoothed column when smoothingEnabled is false', () => {
     const fixture = createComponent({
       headers: [
-        ColumnHeaders.VALUE,
-        ColumnHeaders.RUN,
-        ColumnHeaders.SMOOTHED,
-        ColumnHeaders.STEP,
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.SMOOTHED, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
       ],
       data: [
         {


### PR DESCRIPTION
* Motivation for features / changes
Our goal is to allow users to select which columns they what displayed in the data table and in which order. To do this we have to have a notion of which columns are enabled and which are disabled. This change makes the column headers in the ngrx state objects with have a type and an enabled boolean so that this info can be stored and utilized.