### PR TITLE
Update `rules_rust` to point to the latest rule version and update deprecated API call

### DIFF
--- a/third_party/rust.bzl
+++ b/third_party/rust.bzl
@@ -16,10 +16,11 @@
 TensorBoard external Rust dependencies (both infrastructure and frontend libs)
 """
 
-load("@rules_rust//rust:repositories.bzl", "rust_repositories")
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
 load("//third_party/rust:crates.bzl", "raze_fetch_remote_crates")
 
 def tensorboard_rust_workspace():
     """TensorBoard Rust dependencies."""
-    rust_repositories(version = "1.58.1")
+    rules_rust_dependencies()
+    rust_register_toolchains(version = "1.65.0")
     raze_fetch_remote_crates()


### PR DESCRIPTION
The latest rust version is `1.65.0`, which is now being used in CI. Additionally, `rust_repositories` is [deprecated](https://github.com/bazelbuild/rules_rust/blob/main/rust/repositories.bzl#L214) in favor of [rules_rust_dependencies](https://github.com/bazelbuild/rules_rust/blob/main/rust/repositories.bzl#L47) and [rust_register_toolchains](https://github.com/bazelbuild/rules_rust/blob/main/rust/repositories.bzl#L102).