### PR TITLE
Implements limited-input device auth flow, to replace deprecated OOB auth flow.

### DIFF
--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -251,7 +251,7 @@ class _LimitedInputDeviceAuthFlow:
     """
 
     def __init__(self, client_config, scopes):
-        self._client_config = client_config["limited-input device"]
+        self._client_config = client_config
         self._scopes = scopes
 
     def run(self) -> google.oauth2.credentials.Credentials:

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -214,8 +214,9 @@ class _LimitedInputDeviceAuthFlow(auth_flows.Flow):
     def run(self) -> google.oauth2.credentials.Credentials:
         device_response = self._send_device_auth_request()
         prompt_message = (
-            "Please visit this URL in another device, and enter the provided "
-            "code to authenticate with the TensorBoard Uploader:\n"
+            "Please visit this URL in a browser window (can be on a different "
+            "device), and enter the provided code to authenticate with the "
+            "TensorBoard Uploader:\n"
             "\n"
             "url: {url}\n"
             "code: {code}\n".format(

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -50,8 +50,7 @@ OPENID_CONNECT_SCOPES = (
 # where this runs. See:
 # https://developers.google.com/identity/protocols/OAuth2?csw=1#installed and
 # https://developers.google.com/identity/protocols/oauth2/limited-input-device
-_OAUTH_CLIENT_CONFIG = """
-{
+_OAUTH_CLIENT_CONFIG = {
   "installed": {
     "client_id": "373649185512-8v619h5kft38l4456nm2dj4ubeqsrvh6.apps.googleusercontent.com",
     "project_id": "hosted-tensorboard-prod",
@@ -69,7 +68,6 @@ _OAUTH_CLIENT_CONFIG = """
     "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
   }
 }
-"""
 
 
 # Components of the relative path (within the user settings directory) at which
@@ -210,7 +208,7 @@ class _LimitedInputDeviceAuthFlow(auth_flows.Flow):
     """
 
     def __init__(self, client_config, scopes):
-        self._client_config = json.loads(client_config)["limited-input device"]
+        self._client_config = client_config["limited-input device"]
         self._scopes = scopes
 
     def run(self) -> google.oauth2.credentials.Credentials:

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -15,8 +15,6 @@
 # Lint as: python3
 """Provides authentication support for TensorBoardUploader."""
 
-from typing import Iterable
-
 import datetime
 import errno
 import json

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -159,7 +159,8 @@ class CredentialsStore:
 
 
 def authenticate_user(
-    force_console=False) -> google.oauth2.credentials.Credentials:
+    force_console=False,
+) -> google.oauth2.credentials.Credentials:
     """Makes the user authenticate to retrieve auth credentials.
 
     The default behavior is to use the [installed app flow](
@@ -190,14 +191,14 @@ def authenticate_user(
     if not force_console and os.getenv("DISPLAY"):
         try:
             flow = auth_flows.InstalledAppFlow.from_client_config(
-                    _OAUTH_CLIENT_CONFIG, scopes=OPENID_CONNECT_SCOPES)
+                _OAUTH_CLIENT_CONFIG, scopes=OPENID_CONNECT_SCOPES
+            )
             return flow.run_local_server(port=0)
         except webbrowser.Error:
-            sys.stderr.write(
-                "Falling back to remote authentication flow...\n"
-            )
+            sys.stderr.write("Falling back to remote authentication flow...\n")
     flow = _LimitedInputDeviceAuthFlow(
-        _OAUTH_CLIENT_CONFIG, scopes=OPENID_CONNECT_SCOPES)
+        _OAUTH_CLIENT_CONFIG, scopes=OPENID_CONNECT_SCOPES
+    )
     return flow.run()
 
 
@@ -238,7 +239,7 @@ class _LimitedInputDeviceAuthFlow(auth_flows.Flow):
         device_uri = self._client_config["device_uri"]
         params = {
             "client_id": self._client_config["client_id"],
-            "scope": " ".join(self._scopes)
+            "scope": " ".join(self._scopes),
         }
         r = requests.post(device_uri, data=params).json()
         if "device_code" not in r:
@@ -248,7 +249,8 @@ class _LimitedInputDeviceAuthFlow(auth_flows.Flow):
         return r
 
     def _poll_for_auth_token(
-        self, device_code: str, polling_interval: int, expiration_seconds: int):
+        self, device_code: str, polling_interval: int, expiration_seconds: int
+    ):
         token_uri = self._client_config["token_uri"]
         params = {
             "client_id": self._client_config["client_id"],

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -15,14 +15,18 @@
 # Lint as: python3
 """Provides authentication support for TensorBoardUploader."""
 
+from typing import Iterable
 
+import datetime
 import errno
 import json
 import os
+import requests
 import sys
+import time
 import webbrowser
 
-import google_auth_oauthlib.flow
+import google_auth_oauthlib.flow as auth_flows
 import grpc
 import google.auth
 import google.auth.transport.requests
@@ -34,7 +38,6 @@ from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
 
-
 # OAuth2 scopes used for OpenID Connect:
 # https://developers.google.com/identity/protocols/OpenIDConnect#scope-param
 OPENID_CONNECT_SCOPES = (
@@ -42,10 +45,18 @@ OPENID_CONNECT_SCOPES = (
     "https://www.googleapis.com/auth/userinfo.email",
 )
 
-
+# A config used to authenticate using a browser in the same machine or
+# environment where the uploader is running.
+#
 # The client "secret" is public by design for installed apps. See
 # https://developers.google.com/identity/protocols/OAuth2?csw=1#installed
-OAUTH_CLIENT_CONFIG = """
+#
+# The implementation of the auth flow that uses this config currently accepts
+# only configs for "installed" or "web" apps, so there's a separate config below
+# for the "limited-input device" flow, which is used to authenticate from a
+# separate device when the uploader is running in an environment without a
+# browser.
+_BROWSER_OAUTH_CLIENT_CONFIG = """
 {
   "installed": {
     "client_id": "373649185512-8v619h5kft38l4456nm2dj4ubeqsrvh6.apps.googleusercontent.com",
@@ -54,11 +65,27 @@ OAUTH_CLIENT_CONFIG = """
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "client_secret": "pOyAuU2yq2arsM98Bw5hwYtr",
-    "redirect_uris": [
-      "urn:ietf:wg:oauth:2.0:oob",
-      "http://localhost"
-    ]
+    "redirect_uris": ["http://localhost"]
   }
+}
+"""
+
+# The config for authenticating using a separate device with a browser, to be
+# used when the environment where this uploader is running does not have a
+# browser available.
+#
+# The client "secret" is considered public, as it's distributed to the client
+# devices where this runs. See:
+# https://developers.google.com/identity/protocols/oauth2/limited-input-device
+#
+# Also see comment in previous constant.
+_CONSOLE_OAUTH_CLIENT_CONFIG = """
+{
+    "client_id": "373649185512-26ojik4u7dt0rdtfdmfnhpajqqh579qd.apps.googleusercontent.com",
+    "device_uri": "https://oauth2.googleapis.com/device/code",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "client_secret": "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",
+    "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
 }
 """
 
@@ -149,36 +176,173 @@ class CredentialsStore:
                 raise
 
 
-def build_installed_app_flow(client_config):
-    """Returns a `CustomInstalledAppFlow` for the given config.
+def authenticate_user(
+    force_console=False) -> google.oauth2.credentials.Credentials:
+    """Makes the user authenticate to retrieve auth credentials."""
+    flow = _TbUploaderAuthFlow(
+        _BROWSER_OAUTH_CLIENT_CONFIG,
+        _CONSOLE_OAUTH_CLIENT_CONFIG,
+        OPENID_CONNECT_SCOPES)
+    return flow.run(force_console)
 
-    Args:
-      client_config (Mapping[str, Any]): The client configuration in the Google
-          client secrets format.
 
-    Returns:
-      CustomInstalledAppFlow: the constructed flow.
+class _TbUploaderAuthFlow(auth_flows.Flow):
+    """Customized version of an OAuth2 flow for the TB.dev uploader.
+
+    When a browser is not available or the `--auth_force_console` flag is
+    specified, it will use the [limited-input device flow]
+    (http://developers.google.com/identity/protocols/oauth2/limited-input-device#allowedscopes)
+    to authenticate the user.
+
+    Otherwise, it will use [a flow similar to the one used for installed apps]
+    (http://developers.google.com/identity/protocols/oauth2/native-app), in
+    which the response will include a redirect to localhost and a local web
+    server will handle the request after the redirect, with the appropriate
+    information.
     """
-    return CustomInstalledAppFlow.from_client_config(
-        client_config, scopes=OPENID_CONNECT_SCOPES
-    )
 
+    def __init__(
+        self,
+        installed_app_client_config,
+        limited_input_device_client_config,
+        scopes):
+        self._installed_app_client_config = (
+            json.loads(installed_app_client_config))
+        self._limited_input_device_client_config = (
+            json.loads(limited_input_device_client_config))
+        self.scopes = scopes
 
-class CustomInstalledAppFlow(google_auth_oauthlib.flow.InstalledAppFlow):
-    """Customized version of the Installed App OAuth2 flow."""
+    def run(self, force_console=False) -> google.oauth2.credentials.Credentials:
+        """Runs an auth flow to authenticate the user.
 
-    def run(self, force_console=False):
-        """Run the flow using a local server if possible, otherwise the
-        console."""
+        The default behavior is to have the user authenticate on the browser in
+        the same machine where this is running, which would produce a redirect
+        response with an authorization code as a parameter in the http request,
+        which would be received by a webserver started here locally.
+
+        If any of the following is true, a different auth flow will be used:
+        - the flag `--auth_force_console` is set to true, or
+        - a browser is not available, or
+        - a local web server cannot be started
+
+        In this case, a "limited-input device" flow will be used, in which the
+        user is presented with a URL and a short code that they'd need to use to
+        authenticate and authorize access in a separate device, after which the
+        uploader will poll for access until the access is granted or rejected,
+        or the initiated auth request expires.
+        """
         # TODO(b/141721828): make auto-detection smarter, especially for macOS.
         if not force_console and os.getenv("DISPLAY"):
             try:
-                return self.run_local_server(port=0)
+                return self.run_installed_app_flow()
             except webbrowser.Error:
                 sys.stderr.write(
-                    "Falling back to console authentication flow...\n"
-                )
-        return self.run_console()
+                    "Falling back to remote authentication flow...\n")
+        return self.run_limited_input_device_flow()
+
+    def run_installed_app_flow(self) -> google.oauth2.credentials.Credentials:
+        flow = auth_flows.InstalledAppFlow.from_client_config(
+            self._installed_app_client_config, scopes=self.scopes)
+        return flow.run_local_server(port=0)
+
+    def run_limited_input_device_flow(
+        self, **kwargs) -> google.oauth2.credentials.Credentials:
+        print("Using authentication without a browser.\n")
+        device_response = self._send_device_auth_request()
+        prompt_message = (
+            "Please visit this URL in another device, and enter the provided "
+                "code to authenticate with the TensorBoard Uploader:\n"
+                "\n"
+                "url: {url}\n"
+                "code: {code}\n"
+            .format(
+                url=device_response["verification_url"],
+                code=device_response["user_code"]))
+        print(prompt_message)
+
+        auth_response = self._poll_for_auth_token(
+            device_code=device_response["device_code"],
+            grant_type=self._limited_input_device_client_config["grant_type"],
+            polling_interval=device_response["interval"],
+            expiration_seconds=device_response["expires_in"])
+
+        if not auth_response:
+            # Should not happen, as any failed authentication should have raised
+            # a different error when polling for access.
+            raise RuntimeError(
+                "An unexpected error occurred while authenticating, "
+                "please try again.")
+
+        return self._build_credentials(auth_response)
+
+    def _send_device_auth_request(self):
+        device_uri = self._limited_input_device_client_config["device_uri"]
+        client_id = self._limited_input_device_client_config["client_id"]
+        params = {
+            "client_id": client_id,
+            "scope": " ".join(self.scopes)
+        }
+        r = requests.post(device_uri, data=params).json()
+        if "device_code" not in r:
+            raise RuntimeError(
+                "Auth service temporarily unavailable, try again later.")
+        return r
+
+    def _poll_for_auth_token(
+        self,
+        device_code: str,
+        grant_type: str,
+        polling_interval: int,
+        expiration_seconds: int):
+
+        token_uri = self._limited_input_device_client_config["token_uri"]
+        client_id = self._limited_input_device_client_config["client_id"]
+        client_secret = (
+            self._limited_input_device_client_config["client_secret"])
+        params = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "device_code": device_code,
+            "grant_type": grant_type
+            }
+        expiration_time = time.time() + expiration_seconds
+        # Error cases documented in
+        # https://developers.google.com/identity/protocols/oauth2/limited-input-device#step-2:-handle-the-authorization-server-response
+        while time.time() < expiration_time:
+            resp = requests.post(token_uri, data=params)
+            r = resp.json()
+            if "access_token" in r:
+                return r
+            if "error" in r and r["error"] == "access_denied":
+                raise PermissionError("Auth was denied.")
+            if resp.status_code in {400, 401}:
+                raise ValueError("There must be an error in the request.")
+
+            if "error" in r and r["error"] == "authorization_pending":
+                time.sleep(polling_interval)
+            elif "error" in r and r["error"] == "slow_down":
+                time.sleep(int(polling_interval * 1.5))
+            else:
+                raise RuntimeError(
+                    "An unexpected error occurred while authenticating.")
+        raise TimeoutError("Timed out waiting for authorization.")
+
+    def _build_credentials(
+        self, auth_response) -> google.oauth2.credentials.Credentials:
+        expiration_timestamp = datetime.datetime.utcfromtimestamp(
+            int(time.time()) + auth_response["expires_in"])
+
+        return google.oauth2.credentials.Credentials(
+            auth_response["access_token"],
+            refresh_token=auth_response["refresh_token"],
+            id_token=auth_response["id_token"],
+            token_uri=self._limited_input_device_client_config["token_uri"],
+            client_id=self._limited_input_device_client_config["client_id"],
+            client_secret= (
+                self._limited_input_device_client_config["client_secret"]),
+            scopes=self.scopes,
+            expiry=expiration_timestamp
+        )
 
 
 class IdTokenAuthMetadataPlugin(grpc.AuthMetadataPlugin):

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -51,22 +51,22 @@ OPENID_CONNECT_SCOPES = (
 # https://developers.google.com/identity/protocols/OAuth2?csw=1#installed and
 # https://developers.google.com/identity/protocols/oauth2/limited-input-device
 _OAUTH_CLIENT_CONFIG = {
-  "installed": {
-    "client_id": "373649185512-8v619h5kft38l4456nm2dj4ubeqsrvh6.apps.googleusercontent.com",
-    "project_id": "hosted-tensorboard-prod",
-    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "token_uri": "https://oauth2.googleapis.com/token",
-    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_secret": "pOyAuU2yq2arsM98Bw5hwYtr",
-    "redirect_uris": ["http://localhost"]
-  },
-  "limited-input device": {
-    "client_id": "373649185512-26ojik4u7dt0rdtfdmfnhpajqqh579qd.apps.googleusercontent.com",
-    "device_uri": "https://oauth2.googleapis.com/device/code",
-    "token_uri": "https://oauth2.googleapis.com/token",
-    "client_secret": "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",
-    "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
-  }
+    "installed": {
+        "client_id": "373649185512-8v619h5kft38l4456nm2dj4ubeqsrvh6.apps.googleusercontent.com",
+        "project_id": "hosted-tensorboard-prod",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_secret": "pOyAuU2yq2arsM98Bw5hwYtr",
+        "redirect_uris": ["http://localhost"],
+    },
+    "limited-input device": {
+        "client_id": "373649185512-26ojik4u7dt0rdtfdmfnhpajqqh579qd.apps.googleusercontent.com",
+        "device_uri": "https://oauth2.googleapis.com/device/code",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "client_secret": "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",
+        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+    },
 }
 
 

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -15,6 +15,7 @@
 # Lint as: python3
 """Provides authentication support for TensorBoardUploader."""
 
+
 import datetime
 import errno
 import json
@@ -36,6 +37,7 @@ from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
 
+
 # OAuth2 scopes used for OpenID Connect:
 # https://developers.google.com/identity/protocols/OpenIDConnect#scope-param
 OPENID_CONNECT_SCOPES = (
@@ -43,18 +45,12 @@ OPENID_CONNECT_SCOPES = (
     "https://www.googleapis.com/auth/userinfo.email",
 )
 
-# A config used to authenticate using a browser in the same machine or
-# environment where the uploader is running.
-#
-# The client "secret" is public by design for installed apps. See
-# https://developers.google.com/identity/protocols/OAuth2?csw=1#installed
-#
-# The implementation of the auth flow that uses this config currently accepts
-# only configs for "installed" or "web" apps, so there's a separate config below
-# for the "limited-input device" flow, which is used to authenticate from a
-# separate device when the uploader is running in an environment without a
-# browser.
-_BROWSER_OAUTH_CLIENT_CONFIG = """
+
+# The client "secret" is considered public, as it's distributed to the devices
+# where this runs. See:
+# https://developers.google.com/identity/protocols/OAuth2?csw=1#installed and
+# https://developers.google.com/identity/protocols/oauth2/limited-input-device
+_OAUTH_CLIENT_CONFIG = """
 {
   "installed": {
     "client_id": "373649185512-8v619h5kft38l4456nm2dj4ubeqsrvh6.apps.googleusercontent.com",
@@ -64,26 +60,14 @@ _BROWSER_OAUTH_CLIENT_CONFIG = """
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "client_secret": "pOyAuU2yq2arsM98Bw5hwYtr",
     "redirect_uris": ["http://localhost"]
-  }
-}
-"""
-
-# The config for authenticating using a separate device with a browser, to be
-# used when the environment where this uploader is running does not have a
-# browser available.
-#
-# The client "secret" is considered public, as it's distributed to the client
-# devices where this runs. See:
-# https://developers.google.com/identity/protocols/oauth2/limited-input-device
-#
-# Also see comment in previous constant.
-_CONSOLE_OAUTH_CLIENT_CONFIG = """
-{
+  },
+  "limited-input device": {
     "client_id": "373649185512-26ojik4u7dt0rdtfdmfnhpajqqh579qd.apps.googleusercontent.com",
     "device_uri": "https://oauth2.googleapis.com/device/code",
     "token_uri": "https://oauth2.googleapis.com/token",
     "client_secret": "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",
     "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
+  }
 }
 """
 
@@ -175,85 +159,60 @@ class CredentialsStore:
 
 
 def authenticate_user(
-    force_console=False,
-) -> google.oauth2.credentials.Credentials:
-    """Makes the user authenticate to retrieve auth credentials."""
-    flow = _TbUploaderAuthFlow(
-        _BROWSER_OAUTH_CLIENT_CONFIG,
-        _CONSOLE_OAUTH_CLIENT_CONFIG,
-        OPENID_CONNECT_SCOPES,
-    )
-    return flow.run(force_console)
+    force_console=False) -> google.oauth2.credentials.Credentials:
+    """Makes the user authenticate to retrieve auth credentials.
+
+    The default behavior is to use the [installed app flow](
+    http://developers.google.com/identity/protocols/oauth2/native-app), in which
+    a browser is started for the user to authenticate, along with a local web
+    server. The authentication in the browser would produce a redirect response
+    to `localhost` with an authorization code that would then be received by the
+    local web server started here.
+
+    Notably, when the uploaoder is run from a colab notebook, this flow cannot
+    be used, as colab notebooks are run in an environment where a browser is not
+    available, even tho the machine where user is interacting with such notebook
+    might have a browser available.
+
+    If any of the following is true, a different auth flow will be used:
+    - the flag `--auth_force_console` is set to true, or
+    - a browser is not available (e.g. when running in a colab notebook), or
+    - a local web server cannot be started
+
+    In this case, a [limited-input device flow](
+    http://developers.google.com/identity/protocols/oauth2/limited-input-device)
+    will be used, in which the user is presented with a URL and a short code
+    that they'd need to use to authenticate and authorize access in a separate
+    browser or device, after which the uploader will poll for access until the
+    access is granted or rejected, or the initiated auth request expires.
+    """
+    # TODO(b/141721828): make auto-detection smarter, especially for macOS.
+    if not force_console and os.getenv("DISPLAY"):
+        try:
+            flow = auth_flows.InstalledAppFlow.from_client_config(
+                    _OAUTH_CLIENT_CONFIG, scopes=OPENID_CONNECT_SCOPES)
+            return flow.run_local_server(port=0)
+        except webbrowser.Error:
+            sys.stderr.write(
+                "Falling back to remote authentication flow...\n"
+            )
+    flow = _LimitedInputDeviceAuthFlow(
+        _OAUTH_CLIENT_CONFIG, scopes=OPENID_CONNECT_SCOPES)
+    return flow.run()
 
 
-class _TbUploaderAuthFlow(auth_flows.Flow):
-    """Customized version of an OAuth2 flow for the TB.dev uploader.
+class _LimitedInputDeviceAuthFlow(auth_flows.Flow):
+    """OAuth flow to authenticate using the limited-input device flow.
 
-    When a browser is not available or the `--auth_force_console` flag is
-    specified, it will use the [limited-input device flow]
-    (http://developers.google.com/identity/protocols/oauth2/limited-input-device#allowedscopes)
-    to authenticate the user.
-
-    Otherwise, it will use [a flow similar to the one used for installed apps]
-    (http://developers.google.com/identity/protocols/oauth2/native-app), in
-    which the response will include a redirect to localhost and a local web
-    server will handle the request after the redirect, with the appropriate
-    information.
+    See:
+    http://developers.google.com/identity/protocols/oauth2/limited-input-device
     """
 
-    def __init__(
-        self,
-        installed_app_client_config,
-        limited_input_device_client_config,
-        scopes,
-    ):
-        self._installed_app_client_config = json.loads(
-            installed_app_client_config
-        )
-        self._limited_input_device_client_config = json.loads(
-            limited_input_device_client_config
-        )
-        self.scopes = scopes
+    def __init__(self, client_config, scopes):
+        self._client_config = json.loads(client_config)["limited-input device"]
+        self._scopes = scopes
 
-    def run(self, force_console=False) -> google.oauth2.credentials.Credentials:
-        """Runs an auth flow to authenticate the user.
-
-        The default behavior is to have the user authenticate on the browser in
-        the same machine where this is running, which would produce a redirect
-        response with an authorization code as a parameter in the http request,
-        which would be received by a webserver started here locally.
-
-        If any of the following is true, a different auth flow will be used:
-        - the flag `--auth_force_console` is set to true, or
-        - a browser is not available, or
-        - a local web server cannot be started
-
-        In this case, a "limited-input device" flow will be used, in which the
-        user is presented with a URL and a short code that they'd need to use to
-        authenticate and authorize access in a separate device, after which the
-        uploader will poll for access until the access is granted or rejected,
-        or the initiated auth request expires.
-        """
-        # TODO(b/141721828): make auto-detection smarter, especially for macOS.
-        if not force_console and os.getenv("DISPLAY"):
-            try:
-                return self.run_installed_app_flow()
-            except webbrowser.Error:
-                sys.stderr.write(
-                    "Falling back to remote authentication flow...\n"
-                )
-        return self.run_limited_input_device_flow()
-
-    def run_installed_app_flow(self) -> google.oauth2.credentials.Credentials:
-        flow = auth_flows.InstalledAppFlow.from_client_config(
-            self._installed_app_client_config, scopes=self.scopes
-        )
-        return flow.run_local_server(port=0)
-
-    def run_limited_input_device_flow(
-        self, **kwargs
-    ) -> google.oauth2.credentials.Credentials:
-        print("Using authentication without a browser.\n")
+    def run(self) -> google.oauth2.credentials.Credentials:
         device_response = self._send_device_auth_request()
         prompt_message = (
             "Please visit this URL in another device, and enter the provided "
@@ -269,25 +228,18 @@ class _TbUploaderAuthFlow(auth_flows.Flow):
 
         auth_response = self._poll_for_auth_token(
             device_code=device_response["device_code"],
-            grant_type=self._limited_input_device_client_config["grant_type"],
             polling_interval=device_response["interval"],
             expiration_seconds=device_response["expires_in"],
         )
 
-        if not auth_response:
-            # Should not happen, as any failed authentication should have raised
-            # a different error when polling for access.
-            raise RuntimeError(
-                "An unexpected error occurred while authenticating, "
-                "please try again."
-            )
-
         return self._build_credentials(auth_response)
 
     def _send_device_auth_request(self):
-        device_uri = self._limited_input_device_client_config["device_uri"]
-        client_id = self._limited_input_device_client_config["client_id"]
-        params = {"client_id": client_id, "scope": " ".join(self.scopes)}
+        device_uri = self._client_config["device_uri"]
+        params = {
+            "client_id": self._client_config["client_id"],
+            "scope": " ".join(self._scopes)
+        }
         r = requests.post(device_uri, data=params).json()
         if "device_code" not in r:
             raise RuntimeError(
@@ -296,23 +248,13 @@ class _TbUploaderAuthFlow(auth_flows.Flow):
         return r
 
     def _poll_for_auth_token(
-        self,
-        device_code: str,
-        grant_type: str,
-        polling_interval: int,
-        expiration_seconds: int,
-    ):
-
-        token_uri = self._limited_input_device_client_config["token_uri"]
-        client_id = self._limited_input_device_client_config["client_id"]
-        client_secret = self._limited_input_device_client_config[
-            "client_secret"
-        ]
+        self, device_code: str, polling_interval: int, expiration_seconds: int):
+        token_uri = self._client_config["token_uri"]
         params = {
-            "client_id": client_id,
-            "client_secret": client_secret,
+            "client_id": self._client_config["client_id"],
+            "client_secret": self._client_config["client_secret"],
             "device_code": device_code,
-            "grant_type": grant_type,
+            "grant_type": self._client_config["grant_type"],
         }
         expiration_time = time.time() + expiration_seconds
         # Error cases documented in
@@ -340,20 +282,18 @@ class _TbUploaderAuthFlow(auth_flows.Flow):
     def _build_credentials(
         self, auth_response
     ) -> google.oauth2.credentials.Credentials:
+
         expiration_timestamp = datetime.datetime.utcfromtimestamp(
             int(time.time()) + auth_response["expires_in"]
         )
-
         return google.oauth2.credentials.Credentials(
             auth_response["access_token"],
             refresh_token=auth_response["refresh_token"],
             id_token=auth_response["id_token"],
-            token_uri=self._limited_input_device_client_config["token_uri"],
-            client_id=self._limited_input_device_client_config["client_id"],
-            client_secret=(
-                self._limited_input_device_client_config["client_secret"]
-            ),
-            scopes=self.scopes,
+            token_uri=self._client_config["token_uri"],
+            client_id=self._client_config["client_id"],
+            client_secret=self._client_config["client_secret"],
+            scopes=self._scopes,
             expiry=expiration_timestamp,
         )
 

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -226,8 +226,8 @@ def authenticate_user(
     browser or device. The uploader will poll for access until the access is
     granted or rejected, or the initiated authorization request expires.
     """
-    # TODO(b/141721828): make auto-detection smarter, especially for macOS.
     scopes = OPENID_CONNECT_SCOPES
+    # TODO(b/141721828): make auto-detection smarter, especially for macOS.
     if not force_console and os.getenv("DISPLAY"):
         try:
             client_config = json.loads(_INSTALLED_APP_OAUTH_CLIENT_CONFIG)

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -15,12 +15,17 @@
 # Lint as: python3
 """Tests for tensorboard.uploader.auth."""
 
-
+from datetime import datetime
 import json
 import os
+import requests
+import time
+from typing import Dict
+from unittest import mock
 
+import google_auth_oauthlib.flow as auth_flows
 import google.auth.credentials
-import google.oauth2.credentials
+from google.oauth2.credentials import Credentials
 
 from tensorboard.uploader import auth
 from tensorboard import test as tb_test
@@ -147,6 +152,260 @@ class CredentialsStoreTest(tb_test.TestCase):
             f.write("{}")
         with self.assertRaises(ValueError):
             store.read_credentials()
+
+
+class FakeHttpResponse():
+    """A fake implementation of the response from the requests library."""
+
+    def __init__(self, data: Dict, status:int = 200):
+        self.status_code = status
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+class AuthFlowTest(tb_test.TestCase):
+
+    # Original config passed to the auth flow for the "browser" auth flow (aka
+    # installed app flow).
+    _INSTALLED_APP_AUTH_CONFIG_JSON = """
+        {
+            "installed": {
+                "client_id": "installed_client_id",
+                "auth_uri": "https://google.com/auth",
+                "token_uri": "https://google.com/token",
+                "client_secret": "installed_client_secret",
+                "redirect_uris": ["http://localhost"]
+            }
+        }
+        """
+
+    # Original config passed to the auth flow for the "no browser" auth flow
+    # (aka "console" or "limited-input device" flow).
+    _CONSOLE_AUTH_CONFIG_JSON = """
+        {
+            "client_id": "console_client_id",
+            "device_uri": "https://google.com/device",
+            "token_uri": "https://google.com/token",
+            "client_secret": "console_client_secret",
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
+        }
+        """
+
+    _SCOPES = ["email", "openid"]
+
+    _DEVICE_RESPONSE = FakeHttpResponse({
+            "device_code": "resp_device_code",
+            "verification_url": "auth.google.com/device",
+            "user_code": "resp_user_code",
+            "interval": 5,
+            "expires_in": 300
+        })
+
+    _AUTH_PENDING_RESPONSE = FakeHttpResponse({
+            "error": "authorization_pending"
+        }, status=428)
+
+    _AUTH_GRANTED_RESPONSE = FakeHttpResponse({
+        "access_token": "some_access_token",
+        "refresh_token": "some_refresh_token",
+        "id_token": "some_id_token",
+        "expires_in": 3600,
+    })
+
+    def setUp(self):
+        super().setUp()
+
+        # The faked installed app flow that we use from the common library.
+        # That class should already be tested, so we mostly want to test
+        # high-level interactions with it.
+        self.fake_auth_flow = FakeInstalledAppFlow(Credentials("access_token"))
+
+        self.mocked_time = self.enter_context(
+            mock.patch.object(time, 'time', autospec=True))
+        # Timestamps from a fake clock. The values don't matter in most tests.
+        self.mocked_time.side_effect = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        self.mocked_sleep = self.enter_context(
+            mock.patch.object(time, 'sleep', autospec=True))
+
+        self.mocked_post = self.enter_context(
+            mock.patch.object(requests, 'post', autospec=True))
+
+        self.mocked_auth_flow_creator_fn = self.enter_context(
+            mock.patch.object(
+                auth_flows.InstalledAppFlow,
+                'from_client_config',
+                return_value=self.fake_auth_flow))
+
+        # Used to estimate if a browser is available in this env.
+        self.mocked_getenv = self.enter_context(
+            mock.patch.object(os, 'getenv', return_value="some_display"))
+
+        self.flow = auth._TbUploaderAuthFlow(
+            self._INSTALLED_APP_AUTH_CONFIG_JSON,
+            self._CONSOLE_AUTH_CONFIG_JSON,
+            self._SCOPES)
+
+    def test_auth_flow__browser__uses_intalled_app_flow(self):
+        self.flow.run()
+        self.mocked_auth_flow_creator_fn.assert_called_once()
+        self.assertTrue(self.fake_auth_flow.run_local_server_was_called)
+
+    def test_auth_flow__console__device_request_fails__raises(self):
+        mocked_post = self.enter_context(
+            mock.patch.object(requests, 'post', autospec=True))
+        mocked_post.return_value = (
+            FakeHttpResponse({"error": "quota exceeded"}, status=403))
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Auth service temporarily unavailable"):
+            self.flow.run(force_console=True)
+
+    def test_auth_flow__console__polling__auth_pending_response__keeps_polling(
+        self):
+        self.mocked_post.side_effect = [
+            self._DEVICE_RESPONSE,
+            self._AUTH_PENDING_RESPONSE,
+            self._AUTH_GRANTED_RESPONSE,
+        ]
+
+        self.flow.run(force_console=True)
+
+        device_params = {
+            "client_id": "console_client_id",
+            "scope": "email openid"
+        }
+        polling_params = {
+            "client_id": "console_client_id",
+            "client_secret": "console_client_secret",
+            "device_code": "resp_device_code",
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
+        }
+        device_uri = "https://google.com/device"
+        token_uri = "https://google.com/token"
+        # One device code request, then two polling calls:
+        # the first poll returned auth_pending, the second one returned success.
+        expected_post_requests = [
+            mock.call(device_uri, data=device_params),
+            mock.call(token_uri, data=polling_params),
+            mock.call(token_uri, data=polling_params),
+        ]
+        self.assertSequenceEqual(
+            expected_post_requests,
+            self.mocked_post.call_args_list)
+        sleep_time = self._DEVICE_RESPONSE.json()["interval"]
+        self.mocked_sleep.assert_called_once_with(sleep_time)
+
+    def test_auth_flow__console__polling__access_granted__returns_credentials(
+        self):
+        self.mocked_post.side_effect = [
+            self._DEVICE_RESPONSE,
+            self._AUTH_GRANTED_RESPONSE,
+        ]
+        # Based on these mocked responses, time.time() is called 3 times:
+        # 1. To generate an expiration time for polling
+        # 2. While polling to check if we reached the expiration time
+        # 3. To calculate an expiration time for the credentials (useful below)
+        #
+        # The third timestamp corresponds to: 2022/12/13 16:00:00Z
+        #
+        # Note that I could have simply used 3, it doesn't really matter if this
+        # is a realistic timestamp, but for the sake of clarity and having a
+        # realistic setup, I decided to use this.
+        now_timestamp = 1670947200
+        self.mocked_time.side_effect = [1, 2, now_timestamp]
+
+        creds = self.flow.run(force_console=True)
+
+        auth_response = self._AUTH_GRANTED_RESPONSE.json()
+        console_config = json.loads(self._CONSOLE_AUTH_CONFIG_JSON)
+
+        expected_expiration_timestamp = datetime.utcfromtimestamp(
+            now_timestamp + auth_response["expires_in"])
+
+        expected_credentials = Credentials(
+            auth_response["access_token"],
+            refresh_token=auth_response["refresh_token"],
+            id_token=auth_response["id_token"],
+            token_uri=console_config["token_uri"],
+            client_id=console_config["client_id"],
+            client_secret= console_config["client_secret"],
+            scopes=self._SCOPES,
+            expiry=expected_expiration_timestamp
+        )
+        self.assertEqual(creds.to_json(), expected_credentials.to_json())
+
+    def test_auth_flow__console__polling__access_denied__raises(self):
+        access_denied_response = FakeHttpResponse(
+            {"error": "access_denied"}, 403)
+        self.mocked_post.side_effect = [
+            self._DEVICE_RESPONSE,
+            access_denied_response,
+        ]
+
+        with self.assertRaisesRegex(PermissionError, "Auth was denied."):
+            self.flow.run(force_console=True)
+
+    def test_auth_flow__console__polling__slow_down_response__waits_longer(
+        self):
+        slow_down_response = FakeHttpResponse({"error": "slow_down"})
+        self.mocked_post.side_effect = [
+            self._DEVICE_RESPONSE,
+            slow_down_response,
+            self._AUTH_GRANTED_RESPONSE
+        ]
+
+        self.flow.run(force_console=True)
+
+        interval = self._DEVICE_RESPONSE.json()["interval"]
+        sleep_time = int(interval * 1.5)
+        self.mocked_sleep.assert_called_once_with(sleep_time)
+
+    def test_auth_flow__console__polling__bad_request_response__raises(self):
+        bad_request_response = FakeHttpResponse(
+            {"error": "bad_request"}, 401)
+        self.mocked_post.side_effect = [
+            self._DEVICE_RESPONSE,
+            bad_request_response,
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError, "There must be an error in the request."):
+            self.flow.run(force_console=True)
+
+    def test_auth_flow__console__polling__timed_out__raises(self):
+        self.mocked_post.return_value = self._DEVICE_RESPONSE
+        # Before polling, the time increased more than the expiration time from
+        # the device response.
+        self.mocked_time.side_effect = [1, 5000]
+
+        with self.assertRaisesRegex(
+            TimeoutError, "Timed out waiting for authorization."):
+            self.flow.run(force_console=True)
+
+    def test_auth_flow__console__polling__unexpected_error__raises(self):
+        unexpected_response = FakeHttpResponse({"error": "unexpected 500"}, 500)
+        self.mocked_post.side_effect = [
+            self._DEVICE_RESPONSE,
+            unexpected_response,
+        ]
+
+        with self.assertRaisesRegex(
+            RuntimeError, "An unexpected error occurred while authenticating."):
+            self.flow.run(force_console=True)
+
+
+class FakeInstalledAppFlow():
+    """A minimal fake for the InstalledApp flow with the function we call."""
+    def __init__(self, credentials):
+        self.run_local_server_was_called = False
+        self._creds = credentials
+
+    def run_local_server(self, port=8080):
+        self.run_local_server_was_called = True
+        return self._creds
 
 
 if __name__ == "__main__":

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -180,29 +180,31 @@ class FakeInstalledAppFlow:
 
 
 class AuthenticateUserTest(tb_test.TestCase):
-
     def setUp(self):
         super().setUp()
         # Used to estimate if a browser is available in this env.
         self.os_env_display_fn = self.enter_context(
-            mock.patch.object(os, "getenv"))
+            mock.patch.object(os, "getenv")
+        )
 
         self.mocked_installed_auth_flow_creator_fn = self.enter_context(
             mock.patch.object(auth_flows.InstalledAppFlow, "from_client_config")
         )
 
         self.mocked_device_auth_flow = self.enter_context(
-            mock.patch.object(auth,
-            "_LimitedInputDeviceAuthFlow",
-            autospec=True)
+            mock.patch.object(
+                auth, "_LimitedInputDeviceAuthFlow", autospec=True
+            )
         )
 
     def test_authenticate_user__no_force_console_override__has_display__uses_installed_app_flow(
-        self):
+        self,
+    ):
         self.os_env_display_fn.return_value = "some_display"
 
         fake_auth_flow = FakeInstalledAppFlow(
-            credentials=Credentials("fake_access_token"))
+            credentials=Credentials("fake_access_token")
+        )
         self.mocked_installed_auth_flow_creator_fn.return_value = fake_auth_flow
 
         auth.authenticate_user()
@@ -212,7 +214,8 @@ class AuthenticateUserTest(tb_test.TestCase):
         self.mocked_device_auth_flow.assert_not_called()
 
     def test_authenticate_user__no_force_console_override__no_display__uses_device_flow(
-        self):
+        self,
+    ):
         self.os_env_display_fn.return_value = None
 
         auth.authenticate_user()
@@ -222,7 +225,8 @@ class AuthenticateUserTest(tb_test.TestCase):
         self.mocked_device_auth_flow.return_value.run.assert_called_once()
 
     def test_authenticate_user__no_force_console_override__has_display__webbrowser_error__uses_device_flow(
-        self):
+        self,
+    ):
         fake_auth_flow = FakeInstalledAppFlow(raiseError=True)
         self.mocked_installed_auth_flow_creator_fn.return_value = fake_auth_flow
         self.os_env_display_fn.return_value = "some_display"
@@ -242,6 +246,7 @@ class AuthenticateUserTest(tb_test.TestCase):
         self.mocked_device_auth_flow.assert_called_once()
         self.mocked_device_auth_flow.return_value.run.assert_called_once()
 
+
 class FakeHttpResponse:
     """A fake implementation of the response from the requests library."""
 
@@ -251,6 +256,7 @@ class FakeHttpResponse:
 
     def json(self):
         return self._data
+
 
 class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
     _OAUTH_CONFIG_JSON = """
@@ -300,7 +306,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
                 "time",
                 # Timestamps from a fake clock.
                 # The values don't matter in most tests.
-                side_effect=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                side_effect=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             )
         )
 
@@ -381,7 +387,8 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
 
         credentials_ttl = self._AUTH_GRANTED_RESPONSE.json()["expires_in"]
         expected_expiration_timestamp = datetime.utcfromtimestamp(
-            now_timestamp + credentials_ttl)
+            now_timestamp + credentials_ttl
+        )
 
         expected_credentials = Credentials(
             "some_access_token",

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -315,7 +315,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
             self._SCOPES,
         )
 
-    def test_auth_flow__console__device_request_fails__raises(self):
+    def test_run__device_request_fails__raises(self):
         self.mocked_post.return_value = FakeHttpResponse(
             {"error": "quota exceeded"}, status=403
         )
@@ -325,9 +325,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
         ):
             self.flow.run()
 
-    def test_auth_flow__console__polling__auth_pending_response__keeps_polling(
-        self,
-    ):
+    def test_run__polling__auth_pending_response__keeps_polling(self):
         auth_pending_response = FakeHttpResponse(
             {"error": "authorization_pending"}, status=428
         )
@@ -364,9 +362,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
         # `interval` in _DEVICE_RESPONSE is 5
         self.mocked_sleep.assert_called_once_with(5)
 
-    def test_auth_flow__console__polling__access_granted__returns_credentials(
-        self,
-    ):
+    def test_run__polling__access_granted__returns_credentials(self):
         self.mocked_post.side_effect = [
             self._DEVICE_RESPONSE,
             self._AUTH_GRANTED_RESPONSE,
@@ -397,7 +393,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
         )
         self.assertEqual(creds.to_json(), expected_credentials.to_json())
 
-    def test_auth_flow__console__polling__access_denied__raises(self):
+    def test_run__polling__access_denied__raises(self):
         access_denied_response = FakeHttpResponse(
             {"error": "access_denied"}, 403
         )
@@ -409,9 +405,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
         with self.assertRaisesRegex(PermissionError, "Auth was denied."):
             self.flow.run()
 
-    def test_auth_flow__console__polling__slow_down_response__waits_longer(
-        self,
-    ):
+    def test_run__polling__slow_down_response__waits_longer(self):
         slow_down_response = FakeHttpResponse({"error": "slow_down"})
         self.mocked_post.side_effect = [
             self._DEVICE_RESPONSE,
@@ -426,7 +420,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
         sleep_time = 7
         self.mocked_sleep.assert_called_once_with(sleep_time)
 
-    def test_auth_flow__console__polling__bad_request_response__raises(self):
+    def test_run__polling__bad_request_response__raises(self):
         bad_request_response = FakeHttpResponse({"error": "bad_request"}, 401)
         self.mocked_post.side_effect = [
             self._DEVICE_RESPONSE,
@@ -438,7 +432,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
         ):
             self.flow.run()
 
-    def test_auth_flow__console__polling__timed_out__raises(self):
+    def test_run__polling__timed_out__raises(self):
         self.mocked_post.return_value = self._DEVICE_RESPONSE
         # Not very realistic, but before starting to poll, the time increased
         # more than the expiration time from the _DEVICE_RESPONSE.
@@ -449,7 +443,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
         ):
             self.flow.run()
 
-    def test_auth_flow__console__polling__unexpected_error__raises(self):
+    def test_run__polling__unexpected_error__raises(self):
         unexpected_response = FakeHttpResponse({"error": "unexpected 500"}, 500)
         self.mocked_post.side_effect = [
             self._DEVICE_RESPONSE,

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -167,8 +167,8 @@ class FakeHttpResponse():
 
 class AuthFlowTest(tb_test.TestCase):
 
-    # Original config passed to the auth flow for the "browser" auth flow (aka
-    # installed app flow).
+    # Config passed to the auth flow for the "browser" auth flow (aka installed
+    # app flow).
     _INSTALLED_APP_AUTH_CONFIG_JSON = """
         {
             "installed": {
@@ -181,8 +181,8 @@ class AuthFlowTest(tb_test.TestCase):
         }
         """
 
-    # Original config passed to the auth flow for the "no browser" auth flow
-    # (aka "console" or "limited-input device" flow).
+    # Config passed to the auth flow for the "no browser" auth flow (aka
+    # "console" or "limited-input device" flow).
     _CONSOLE_AUTH_CONFIG_JSON = """
         {
             "client_id": "console_client_id",
@@ -254,9 +254,7 @@ class AuthFlowTest(tb_test.TestCase):
         self.assertTrue(self.fake_auth_flow.run_local_server_was_called)
 
     def test_auth_flow__console__device_request_fails__raises(self):
-        mocked_post = self.enter_context(
-            mock.patch.object(requests, 'post', autospec=True))
-        mocked_post.return_value = (
+        self.mocked_post.return_value = (
             FakeHttpResponse({"error": "quota exceeded"}, status=403))
 
         with self.assertRaisesRegex(

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -16,7 +16,6 @@
 """Tests for tensorboard.uploader.auth."""
 
 from datetime import datetime
-from distutils.log import error
 import json
 import os
 import webbrowser
@@ -233,8 +232,8 @@ class AuthenticateUserTest(tb_test.TestCase):
 
         auth.authenticate_user()
 
-        # "installed app" flow was instantiated and ran, which raied an exception,
-        # so the other flow also ran.
+        # "installed app" flow was instantiated and ran, which raised an
+        # exception, so the other flow also ran.
         self.mocked_installed_auth_flow_creator_fn.assert_called_once()
         self.assertTrue(fake_auth_flow.run_local_server_was_called)
         self.mocked_device_auth_flow.assert_called_once()
@@ -279,10 +278,6 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
             "interval": 5,
             "expires_in": 300,
         }
-    )
-
-    _AUTH_PENDING_RESPONSE = FakeHttpResponse(
-        {"error": "authorization_pending"}, status=428
     )
 
     _AUTH_GRANTED_RESPONSE = FakeHttpResponse(
@@ -333,9 +328,12 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
     def test_auth_flow__console__polling__auth_pending_response__keeps_polling(
         self,
     ):
+        auth_pending_response = FakeHttpResponse(
+            {"error": "authorization_pending"}, status=428
+        )
         self.mocked_post.side_effect = [
             self._DEVICE_RESPONSE,
-            self._AUTH_PENDING_RESPONSE,
+            auth_pending_response,
             self._AUTH_GRANTED_RESPONSE,
         ]
 

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -260,13 +260,12 @@ class FakeHttpResponse:
 
 class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
     _OAUTH_CONFIG = {
-        "limited-input device":
-        {
+        "limited-input device": {
             "client_id": "console_client_id",
             "device_uri": "https://google.com/device",
             "token_uri": "https://google.com/token",
             "client_secret": "console_client_secret",
-            "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
         }
     }
 

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -259,8 +259,7 @@ class FakeHttpResponse:
 
 
 class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
-    _OAUTH_CONFIG_JSON = """
-    {
+    _OAUTH_CONFIG = {
         "limited-input device":
         {
             "client_id": "console_client_id",
@@ -270,7 +269,6 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
         }
     }
-    """
 
     _SCOPES = ["email", "openid"]
 
@@ -319,7 +317,7 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
         )
 
         self.flow = auth._LimitedInputDeviceAuthFlow(
-            self._OAUTH_CONFIG_JSON,
+            self._OAUTH_CONFIG,
             self._SCOPES,
         )
 

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -16,7 +16,6 @@
 
 
 import abc
-import json
 import os
 import sys
 import textwrap

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -92,7 +92,8 @@ def _run(flags, experiment_url_callback=None):
     if not credentials:
         _prompt_for_user_ack(intent)
         credentials = auth.authenticate_user(
-            force_console=flags.auth_force_console)
+            force_console=flags.auth_force_console
+        )
         sys.stderr.write("\n")  # Extra newline after auth flow messages.
         store.write_credentials(credentials)
 

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -92,9 +92,8 @@ def _run(flags, experiment_url_callback=None):
     credentials = store.read_credentials()
     if not credentials:
         _prompt_for_user_ack(intent)
-        client_config = json.loads(auth.OAUTH_CLIENT_CONFIG)
-        flow = auth.build_installed_app_flow(client_config)
-        credentials = flow.run(force_console=flags.auth_force_console)
+        credentials = auth.authenticate_user(
+            force_console=flags.auth_force_console)
         sys.stderr.write("\n")  # Extra newline after auth flow messages.
         store.write_credentials(credentials)
 


### PR DESCRIPTION
* Motivation for features / changes
The OOB auth flow has been deprecated. We concluded that the limited-input device flow is appropriate for our use case where the uploader runs in an environment where a browser is not available.

* Technical description of changes
Implements a new auth flow which calls an RPC to fetch a device_code, verification_url and user_code, and asks user to visit the verification_url in another device and enter the user_code; then starts polling for the access token after the user authorizes the access from another device.

* Screenshots of UI changes
N/A

* Detailed steps to verify changes work correctly (as executed by you)
- Wrote test script that uses this class, and tested the auth flow and was able to print the credentials.
- Wrote tests.

* Alternate designs / implementations considered
Basically, implementing something similar to this flow or the OOB flow ourselves.