### PR TITLE
Eliminate flakiness of debugger_v2 karma tests.

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -386,6 +386,18 @@ describe('Debugger effects', () => {
         Tfdbg2HttpServerDataSource,
         provideMockStore({initialState}),
       ],
+      // The upgrade to Angular 13 caused this test file to fail flakily with
+      // errors like "Error: Injector has already been destroyed."
+      //
+      // Others have run into this problem:
+      // https://github.com/angular/angular/issues/44186
+      //
+      // The suggested workaround is to set `destroyAfterEach` to false. The
+      // default value for `destroyAfterEach` changed in Angular 13.
+      //
+      // The Angular team suggests this means we "have scope leakage in [our]
+      // tests" but we haven't been able to pinpoint the leakage.
+      teardown: { destroyAfterEach: false }
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -397,7 +397,7 @@ describe('Debugger effects', () => {
       //
       // The Angular team suggests this means we "have scope leakage in [our]
       // tests" but we haven't been able to pinpoint the leakage.
-      teardown: { destroyAfterEach: false }
+      teardown: {destroyAfterEach: false},
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;


### PR DESCRIPTION
The upgrade to Angular 13 caused debugger_v2 tests to fail flakily with errors like "Error: Injector has already been destroyed."

Others have run into this problem: https://github.com/angular/angular/issues/44186

The suggested workaround is to set `destroyAfterEach` to false. The default value for `destroyAfterEach` changed in Angular 13.

The Angular team suggests this means we "have scope leakage in [our]  tests" but we haven't been able to pinpoint the leakage.

Tested by running `bazel test //tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin:karma_test_chromium-local --nocache_test_results --runs_per_test=20`. Prior to the fix this would reliably fail for a good fraction of the test runs. After the fix all runs pass.