### PR TITLE
Remove deprecated alias `numpy.bool8`

### DIFF
--- a/tensorboard/compat/tensorflow_stub/dtypes.py
+++ b/tensorboard/compat/tensorflow_stub/dtypes.py
@@ -323,7 +323,6 @@ class DType(object):
 # Define data type range of numpy dtype
 dtype_range = {
     np.bool_: (False, True),
-    np.bool8: (False, True),
     np.uint8: (0, 255),
     np.uint16: (0, 65535),
     np.int8: (-128, 127),


### PR DESCRIPTION
`numpy.bool8` is just a deprecated alias of [`numpy.bool_`](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool_). Removed here to get rid of the deprecation warnings (https://github.com/tensorflow/tensorboard/issues/6110).

Googlers, see cl/498031924 for internal tests.

#oncall