### PR TITLE
Remove python2-isms since we only support py3

### DIFF
--- a/tensorboard/auth.py
+++ b/tensorboard/auth.py
@@ -40,7 +40,7 @@ class AuthProvider(metaclass=abc.ABCMeta):
         pass
 
 
-class AuthContext(object):
+class AuthContext:
     """Authentication context within the scope of a single request.
 
     Auth providers are keyed within an `AuthContext` by arbitrary

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -171,7 +171,7 @@ def make_plugin_loader(plugin_spec):
     raise TypeError("Not a TBLoader or TBPlugin subclass: %r" % (plugin_spec,))
 
 
-class TensorBoardWSGI(object):
+class TensorBoardWSGI:
     """The TensorBoard WSGI app that delegates to a set of TBPlugin."""
 
     def __init__(

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -30,7 +30,7 @@ from tensorboard.data import provider
 from tensorboard.plugins import base_plugin
 
 
-class FakeFlags(object):
+class FakeFlags:
     def __init__(
         self,
         generic_data="auto",

--- a/tensorboard/backend/client_feature_flags.py
+++ b/tensorboard/backend/client_feature_flags.py
@@ -20,7 +20,7 @@ from tensorboard import context
 from tensorboard import errors
 
 
-class ClientFeatureFlagsMiddleware(object):
+class ClientFeatureFlagsMiddleware:
     """Middleware for injecting client-side feature flags into the Context.
 
     The client webapp is expected to include a json-serialized version of its

--- a/tensorboard/backend/empty_path_redirect.py
+++ b/tensorboard/backend/empty_path_redirect.py
@@ -26,7 +26,7 @@ the actual path "/foo", and so will be redirected to "/foo/".
 """
 
 
-class EmptyPathRedirectMiddleware(object):
+class EmptyPathRedirectMiddleware:
     """WSGI middleware to redirect from "" to "/"."""
 
     def __init__(self, application):

--- a/tensorboard/backend/empty_path_redirect_test.py
+++ b/tensorboard/backend/empty_path_redirect_test.py
@@ -26,7 +26,7 @@ class EmptyPathRedirectMiddlewareTest(tb_test.TestCase):
     """Tests for `EmptyPathRedirectMiddleware`."""
 
     def setUp(self):
-        super(EmptyPathRedirectMiddlewareTest, self).setUp()
+        super().setUp()
         app = werkzeug.Request.application(
             lambda req: werkzeug.Response(req.path)
         )

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -29,7 +29,7 @@ _ORIGINAL_IMPORT = __import__
 _TENSORFLOW_IO_MODULE = "tensorflow_io"
 
 
-class FakeFlags(object):
+class FakeFlags:
     def __init__(
         self,
         detect_file_replacement=None,

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -266,7 +266,7 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
 
 class FileSystemSupportTest(tb_test.TestCase):
     def setUp(self):
-        super(FileSystemSupportTest, self).setUp()
+        super().setUp()
         try:
             # Do a dummy call to triger lazy loading of `get_registered_schemes`
             # before mocking it in tests, otherwise it won't be able to unmock

--- a/tensorboard/backend/event_processing/data_provider_test.py
+++ b/tensorboard/backend/event_processing/data_provider_test.py
@@ -43,7 +43,7 @@ tf1.enable_eager_execution()
 
 class MultiplexerDataProviderTest(tf.test.TestCase):
     def setUp(self):
-        super(MultiplexerDataProviderTest, self).setUp()
+        super().setUp()
         self.logdir = self.get_temp_dir()
         self.ctx = context.RequestContext()
 

--- a/tensorboard/backend/event_processing/data_provider_test.py
+++ b/tensorboard/backend/event_processing/data_provider_test.py
@@ -173,7 +173,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             "second_1": 2.0,
         }
 
-        class FakeMultiplexer(object):
+        class FakeMultiplexer:
             def Runs(multiplexer):
                 result = ["second_2", "first", "no_time", "second_1"]
                 self.assertItemsEqual(result, start_times)

--- a/tensorboard/backend/event_processing/directory_loader.py
+++ b/tensorboard/backend/event_processing/directory_loader.py
@@ -29,7 +29,7 @@ logger = tb_logging.get_logger()
 _INACTIVE = object()
 
 
-class DirectoryLoader(object):
+class DirectoryLoader:
     """Loader for an entire directory, maintaining multiple active file
     loaders.
 

--- a/tensorboard/backend/event_processing/directory_loader_test.py
+++ b/tensorboard/backend/event_processing/directory_loader_test.py
@@ -31,7 +31,7 @@ from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.util import test_util
 
 
-class _TimestampedByteLoader(object):
+class _TimestampedByteLoader:
     """A loader that loads timestamped bytes from a file."""
 
     def __init__(self, path, registry=None):

--- a/tensorboard/backend/event_processing/directory_watcher.py
+++ b/tensorboard/backend/event_processing/directory_watcher.py
@@ -26,7 +26,7 @@ from tensorboard.util import tb_logging
 logger = tb_logging.get_logger()
 
 
-class DirectoryWatcher(object):
+class DirectoryWatcher:
     """A DirectoryWatcher wraps a loader to load from a sequence of paths.
 
     A loader reads a path and produces some kind of values as an iterator. A

--- a/tensorboard/backend/event_processing/directory_watcher_test.py
+++ b/tensorboard/backend/event_processing/directory_watcher_test.py
@@ -25,7 +25,7 @@ from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import io_wrapper
 
 
-class _ByteLoader(object):
+class _ByteLoader:
     """A loader that loads individual bytes from a file."""
 
     def __init__(self, path):

--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -116,7 +116,7 @@ STORE_EVERYTHING_SIZE_GUIDANCE = {
 }
 
 
-class EventAccumulator(object):
+class EventAccumulator:
     """An `EventAccumulator` takes an event generator, and accumulates the
     values.
 

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -34,7 +34,7 @@ tf.compat.v1.disable_v2_behavior()
 logger = tb_logging.get_logger()
 
 
-class _EventGenerator(object):
+class _EventGenerator:
     """Class that can add_events and then yield them back.
 
     Satisfies the EventGenerator API required for the EventAccumulator.

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -199,7 +199,7 @@ class EventAccumulatorTest(tf.test.TestCase):
 
 class MockingEventAccumulatorTest(EventAccumulatorTest):
     def setUp(self):
-        super(MockingEventAccumulatorTest, self).setUp()
+        super().setUp()
         self.stubs = tf.compat.v1.test.StubOutForTesting()
         self._real_constructor = ea.EventAccumulator
         self._real_generator = ea._GeneratorFromPath

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -82,7 +82,7 @@ def _make_tf_record_iterator(file_path):
             return tf.compat.v1.io.tf_record_iterator(file_path)
 
 
-class _PyRecordReaderIterator(object):
+class _PyRecordReaderIterator:
     """Python iterator for TF Records based on PyRecordReader."""
 
     def __init__(self, py_record_reader_new, file_path):
@@ -114,7 +114,7 @@ class _PyRecordReaderIterator(object):
     next = __next__  # for python2 compatibility
 
 
-class RawEventFileLoader(object):
+class RawEventFileLoader:
     """An iterator that yields Event protos as serialized bytestrings."""
 
     def __init__(self, file_path, detect_file_replacement=False):

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -241,7 +241,7 @@ class LegacyEventFileLoader(RawEventFileLoader):
         Yields:
           All events in the file that have not been yielded yet.
         """
-        for record in super(LegacyEventFileLoader, self).Load():
+        for record in super().Load():
             yield event_pb2.Event.FromString(record)
 
 
@@ -252,7 +252,7 @@ class EventFileLoader(LegacyEventFileLoader):
     """
 
     def __init__(self, *args, **kwargs):
-        super(EventFileLoader, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # Track initial metadata for each tag, for `dataclass_compat`.
         # This is meant to be tracked per run, not per event file, so
         # there is a potential failure case when the second event file
@@ -267,7 +267,7 @@ class EventFileLoader(LegacyEventFileLoader):
         self._initial_metadata = {}  # from tag name to `SummaryMetadata`
 
     def Load(self):
-        for event in super(EventFileLoader, self).Load():
+        for event in super().Load():
             event = data_compat.migrate_event(event)
             events = dataclass_compat.migrate_event(
                 event, self._initial_metadata
@@ -289,5 +289,5 @@ class TimestampedEventFileLoader(EventFileLoader):
           Pairs of (UNIX timestamp float, Event proto) for all events in the file
           that have not been yielded yet.
         """
-        for event in super(TimestampedEventFileLoader, self).Load():
+        for event in super().Load():
             yield (event.wall_time, event)

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -29,7 +29,7 @@ from tensorboard.util import tb_logging
 logger = tb_logging.get_logger()
 
 
-class EventMultiplexer(object):
+class EventMultiplexer:
     """An `EventMultiplexer` manages access to multiple `EventAccumulator`s.
 
     Each `EventAccumulator` is associated with a `run`, which is a self-contained

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -118,7 +118,7 @@ def _GetFakeAccumulator(
 
 class EventMultiplexerTest(tf.test.TestCase):
     def setUp(self):
-        super(EventMultiplexerTest, self).setUp()
+        super().setUp()
         self.stubs = tf.compat.v1.test.StubOutForTesting()
 
         self.stubs.Set(

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -39,7 +39,7 @@ def _CreateCleanDirectory(path):
     tf.io.gfile.mkdir(path)
 
 
-class _FakeAccumulator(object):
+class _FakeAccumulator:
     def __init__(self, path):
         """Constructs a fake accumulator with some fake events.
 

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -71,7 +71,7 @@ class TensorEvent:
     tensor_proto: tensor_pb2.TensorProto
 
 
-class EventAccumulator(object):
+class EventAccumulator:
     """An `EventAccumulator` takes an event generator, and accumulates the
     values.
 

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -42,7 +42,7 @@ from tensorboard.util import test_util
 logger = tb_logging.get_logger()
 
 
-class _EventGenerator(object):
+class _EventGenerator:
     """Class that can add_events and then yield them back.
 
     Satisfies the EventGenerator API required for the EventAccumulator.

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -134,11 +134,11 @@ class EventAccumulatorTest(tf.test.TestCase):
 
 class MockingEventAccumulatorTest(EventAccumulatorTest):
     def setUp(self):
-        super(MockingEventAccumulatorTest, self).setUp()
+        super().setUp()
         self.stubs = tf.compat.v1.test.StubOutForTesting()
 
     def tearDown(self):
-        super(MockingEventAccumulatorTest, self).tearDown()
+        super().tearDown()
         self.stubs.CleanUp()
 
     def _make_accumulator(self, generator, **kwargs):

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -32,7 +32,7 @@ from tensorboard.util import tb_logging
 logger = tb_logging.get_logger()
 
 
-class EventMultiplexer(object):
+class EventMultiplexer:
     """An `EventMultiplexer` manages access to multiple `EventAccumulator`s.
 
     Each `EventAccumulator` is associated with a `run`, which is a self-contained

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
@@ -105,7 +105,7 @@ def _GetFakeAccumulator(
 
 class EventMultiplexerTest(tf.test.TestCase):
     def setUp(self):
-        super(EventMultiplexerTest, self).setUp()
+        super().setUp()
         self.stubs = tf.compat.v1.test.StubOutForTesting()
 
         self.stubs.Set(

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
@@ -45,7 +45,7 @@ def _CreateCleanDirectory(path):
     tf.io.gfile.mkdir(path)
 
 
-class _FakeAccumulator(object):
+class _FakeAccumulator:
     def __init__(self, path):
         """Constructs a fake accumulator with some fake events.
 

--- a/tensorboard/backend/event_processing/reservoir.py
+++ b/tensorboard/backend/event_processing/reservoir.py
@@ -21,7 +21,7 @@ import random
 import threading
 
 
-class Reservoir(object):
+class Reservoir:
     """A map-to-arrays container, with deterministic Reservoir Sampling.
 
     Items are added with an associated key. Items may be retrieved by key, and
@@ -161,7 +161,7 @@ class Reservoir(object):
                 )
 
 
-class _ReservoirBucket(object):
+class _ReservoirBucket:
     """A container for items from a stream, that implements reservoir sampling.
 
     It always stores the most recent item as its final item.

--- a/tensorboard/backend/event_processing/reservoir_test.py
+++ b/tensorboard/backend/event_processing/reservoir_test.py
@@ -190,11 +190,11 @@ class ReservoirBucketTest(tf.test.TestCase):
         )
 
     def testLazyFunctionEvaluationAndAlwaysKeepLast(self):
-        class FakeRandom(object):
+        class FakeRandom:
             def randint(self, a, b):  # pylint:disable=unused-argument
                 return 999
 
-        class Incrementer(object):
+        class Incrementer:
             def __init__(self):
                 self.n = 0
 

--- a/tensorboard/backend/experiment_id.py
+++ b/tensorboard/backend/experiment_id.py
@@ -26,7 +26,7 @@ _EXPERIMENT_PATH_COMPONENT = "experiment"
 WSGI_ENVIRON_KEY = "HTTP_TENSORBOARD_EXPERIMENT_ID"
 
 
-class ExperimentIdMiddleware(object):
+class ExperimentIdMiddleware:
     """WSGI middleware extracting experiment IDs from URL to environment.
 
     Any request whose path matches `/experiment/SOME_EID[/...]` will have

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -42,7 +42,7 @@ class BaseTest:
         raise NotImplementedError()
 
     def setUp(self):
-        super(BaseTest, self).setUp()
+        super().setUp()
 
         self.app = self._create_app()
         self.server = werkzeug_test.Client(self.app, werkzeug.wrappers.Response)

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -24,7 +24,7 @@ from tensorboard import test as tb_test
 from tensorboard.backend import experiment_id
 
 
-class BaseTest(object):
+class BaseTest:
     """Base tests for `ExperimentIdMiddleware`."""
 
     def _echo_app(self, environ, start_response):

--- a/tensorboard/backend/experimental_plugin.py
+++ b/tensorboard/backend/experimental_plugin.py
@@ -18,7 +18,7 @@ Contains the mechanism for marking plugins as experimental.
 """
 
 
-class ExperimentalPlugin(object):
+class ExperimentalPlugin:
     """A marker class used to annotate a plugin as experimental.
 
     Experimental plugins are hidden from users by default. The plugin will only

--- a/tensorboard/backend/path_prefix.py
+++ b/tensorboard/backend/path_prefix.py
@@ -23,7 +23,7 @@ See the `--path_prefix` flag docs for more details.
 from tensorboard import errors
 
 
-class PathPrefixMiddleware(object):
+class PathPrefixMiddleware:
     """WSGI middleware for path prefixes.
 
     All requests to this middleware must begin with the specified path

--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -61,7 +61,7 @@ def _maybe_raise_value_error(error_msg):
     # TODO(3.x): raise a value error.
 
 
-class SecurityValidatorMiddleware(object):
+class SecurityValidatorMiddleware:
     """WSGI middleware validating security on response.
 
     It validates:

--- a/tensorboard/compat/tensorflow_stub/app.py
+++ b/tensorboard/compat/tensorflow_stub/app.py
@@ -64,7 +64,7 @@ class _HelpFlag(flags.BooleanFlag):
     SHORT_NAME = "h"
 
     def __init__(self):
-        super(_HelpFlag, self).__init__(
+        super().__init__(
             self.NAME, False, "show this help", short_name=self.SHORT_NAME
         )
 
@@ -87,7 +87,7 @@ class _HelpfullFlag(flags.BooleanFlag):
     """Display help for flags in main module and all dependent modules."""
 
     def __init__(self):
-        super(_HelpfullFlag, self).__init__("helpfull", False, "show full help")
+        super().__init__("helpfull", False, "show full help")
 
     def parse(self, arg):
         if arg:

--- a/tensorboard/compat/tensorflow_stub/dtypes.py
+++ b/tensorboard/compat/tensorflow_stub/dtypes.py
@@ -23,7 +23,7 @@ _np_bfloat16 = pywrap_tensorflow.TF_bfloat16_type()
 
 
 # @tf_export("DType")
-class DType(object):
+class DType:
     """Represents the type of the elements in a `Tensor`.
 
     The following `DType` objects are defined:

--- a/tensorboard/compat/tensorflow_stub/errors.py
+++ b/tensorboard/compat/tensorflow_stub/errors.py
@@ -518,7 +518,7 @@ def _make_specific_exception(node_def, op, message, error_code):
 # some object creation overhead.
 # TODO(b/77295559): expand use of TF_Status* SWIG typemap and deprecate this.
 # @tf_export("errors.raise_exception_on_not_ok_status")  # pylint: disable=invalid-name
-class raise_exception_on_not_ok_status(object):
+class raise_exception_on_not_ok_status:
     """Context manager to check for C API status."""
 
     def __enter__(self):

--- a/tensorboard/compat/tensorflow_stub/errors.py
+++ b/tensorboard/compat/tensorflow_stub/errors.py
@@ -39,7 +39,7 @@ class OpError(Exception):
           message: The message string describing the failure.
           error_code: The `error_codes.Code` describing the error.
         """
-        super(OpError, self).__init__()
+        super().__init__()
         self._message = message
         self._node_def = node_def
         self._op = op
@@ -198,7 +198,7 @@ class CancelledError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates a `CancelledError`."""
-        super(CancelledError, self).__init__(node_def, op, message, CANCELLED)
+        super().__init__(node_def, op, message, CANCELLED)
 
 
 # @tf_export("errors.UnknownError")
@@ -216,7 +216,7 @@ class UnknownError(OpError):
 
     def __init__(self, node_def, op, message, error_code=UNKNOWN):
         """Creates an `UnknownError`."""
-        super(UnknownError, self).__init__(node_def, op, message, error_code)
+        super().__init__(node_def, op, message, error_code)
 
 
 # @tf_export("errors.InvalidArgumentError")
@@ -236,9 +236,7 @@ class InvalidArgumentError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates an `InvalidArgumentError`."""
-        super(InvalidArgumentError, self).__init__(
-            node_def, op, message, INVALID_ARGUMENT
-        )
+        super().__init__(node_def, op, message, INVALID_ARGUMENT)
 
 
 # @tf_export("errors.DeadlineExceededError")
@@ -252,9 +250,7 @@ class DeadlineExceededError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates a `DeadlineExceededError`."""
-        super(DeadlineExceededError, self).__init__(
-            node_def, op, message, DEADLINE_EXCEEDED
-        )
+        super().__init__(node_def, op, message, DEADLINE_EXCEEDED)
 
 
 # @tf_export("errors.NotFoundError")
@@ -272,7 +268,7 @@ class NotFoundError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates a `NotFoundError`."""
-        super(NotFoundError, self).__init__(node_def, op, message, NOT_FOUND)
+        super().__init__(node_def, op, message, NOT_FOUND)
 
 
 # @tf_export("errors.AlreadyExistsError")
@@ -289,9 +285,7 @@ class AlreadyExistsError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates an `AlreadyExistsError`."""
-        super(AlreadyExistsError, self).__init__(
-            node_def, op, message, ALREADY_EXISTS
-        )
+        super().__init__(node_def, op, message, ALREADY_EXISTS)
 
 
 # @tf_export("errors.PermissionDeniedError")
@@ -308,9 +302,7 @@ class PermissionDeniedError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates a `PermissionDeniedError`."""
-        super(PermissionDeniedError, self).__init__(
-            node_def, op, message, PERMISSION_DENIED
-        )
+        super().__init__(node_def, op, message, PERMISSION_DENIED)
 
 
 # @tf_export("errors.UnauthenticatedError")
@@ -324,9 +316,7 @@ class UnauthenticatedError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates an `UnauthenticatedError`."""
-        super(UnauthenticatedError, self).__init__(
-            node_def, op, message, UNAUTHENTICATED
-        )
+        super().__init__(node_def, op, message, UNAUTHENTICATED)
 
 
 # @tf_export("errors.ResourceExhaustedError")
@@ -341,9 +331,7 @@ class ResourceExhaustedError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates a `ResourceExhaustedError`."""
-        super(ResourceExhaustedError, self).__init__(
-            node_def, op, message, RESOURCE_EXHAUSTED
-        )
+        super().__init__(node_def, op, message, RESOURCE_EXHAUSTED)
 
 
 # @tf_export("errors.FailedPreconditionError")
@@ -360,9 +348,7 @@ class FailedPreconditionError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates a `FailedPreconditionError`."""
-        super(FailedPreconditionError, self).__init__(
-            node_def, op, message, FAILED_PRECONDITION
-        )
+        super().__init__(node_def, op, message, FAILED_PRECONDITION)
 
 
 # @tf_export("errors.AbortedError")
@@ -380,7 +366,7 @@ class AbortedError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates an `AbortedError`."""
-        super(AbortedError, self).__init__(node_def, op, message, ABORTED)
+        super().__init__(node_def, op, message, ABORTED)
 
 
 # @tf_export("errors.OutOfRangeError")
@@ -398,9 +384,7 @@ class OutOfRangeError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates an `OutOfRangeError`."""
-        super(OutOfRangeError, self).__init__(
-            node_def, op, message, OUT_OF_RANGE
-        )
+        super().__init__(node_def, op, message, OUT_OF_RANGE)
 
 
 # @tf_export("errors.UnimplementedError")
@@ -418,9 +402,7 @@ class UnimplementedError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates an `UnimplementedError`."""
-        super(UnimplementedError, self).__init__(
-            node_def, op, message, UNIMPLEMENTED
-        )
+        super().__init__(node_def, op, message, UNIMPLEMENTED)
 
 
 # @tf_export("errors.InternalError")
@@ -435,7 +417,7 @@ class InternalError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates an `InternalError`."""
-        super(InternalError, self).__init__(node_def, op, message, INTERNAL)
+        super().__init__(node_def, op, message, INTERNAL)
 
 
 # @tf_export("errors.UnavailableError")
@@ -449,9 +431,7 @@ class UnavailableError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates an `UnavailableError`."""
-        super(UnavailableError, self).__init__(
-            node_def, op, message, UNAVAILABLE
-        )
+        super().__init__(node_def, op, message, UNAVAILABLE)
 
 
 # @tf_export("errors.DataLossError")
@@ -467,7 +447,7 @@ class DataLossError(OpError):
 
     def __init__(self, node_def, op, message):
         """Creates a `DataLossError`."""
-        super(DataLossError, self).__init__(node_def, op, message, DATA_LOSS)
+        super().__init__(node_def, op, message, DATA_LOSS)
 
 
 _CODE_TO_EXCEPTION_CLASS = {

--- a/tensorboard/compat/tensorflow_stub/flags.py
+++ b/tensorboard/compat/tensorflow_stub/flags.py
@@ -58,7 +58,7 @@ def _wrap_define_function(original_function):
     return wrapper
 
 
-class _FlagValuesWrapper(object):
+class _FlagValuesWrapper:
     """Wrapper class for absl.flags.FLAGS.
 
     The difference is that tf.compat.v1.flags.FLAGS implicitly parses

--- a/tensorboard/compat/tensorflow_stub/flags.py
+++ b/tensorboard/compat/tensorflow_stub/flags.py
@@ -71,7 +71,7 @@ class _FlagValuesWrapper:
 
     def __getattribute__(self, name):
         if name == "__dict__":
-            return super(_FlagValuesWrapper, self).__getattribute__(name)
+            return super().__getattribute__(name)
         return self.__dict__["__wrapped"].__getattribute__(name)
 
     def __getattr__(self, name):

--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -95,7 +95,7 @@ class StatData:
     length: int
 
 
-class LocalFileSystem(object):
+class LocalFileSystem:
     """Provides local fileystem access."""
 
     def exists(self, filename):
@@ -218,7 +218,7 @@ class LocalFileSystem(object):
         return StatData(file_length)
 
 
-class S3FileSystem(object):
+class S3FileSystem:
     """Provides filesystem access to S3."""
 
     def __init__(self):
@@ -418,7 +418,7 @@ class S3FileSystem(object):
                 raise
 
 
-class FSSpecFileSystem(object):
+class FSSpecFileSystem:
     """Provides filesystem access via fsspec.
 
     The current gfile interface doesn't map perfectly to the fsspec interface
@@ -659,7 +659,7 @@ if S3_ENABLED:
     register_filesystem("s3", S3FileSystem())
 
 
-class GFile(object):
+class GFile:
     # Only methods needed for TensorBoard are implemented.
 
     def __init__(self, filename, mode):

--- a/tensorboard/compat/tensorflow_stub/tensor_shape.py
+++ b/tensorboard/compat/tensorflow_stub/tensor_shape.py
@@ -19,7 +19,7 @@ from tensorboard.compat.proto import tensor_shape_pb2
 
 
 # @tf_export("Dimension")
-class Dimension(object):
+class Dimension:
     """Represents the value of one dimension in a TensorShape."""
 
     def __init__(self, value):
@@ -488,7 +488,7 @@ def as_dimension(value):
 
 
 # @tf_export("TensorShape")
-class TensorShape(object):
+class TensorShape:
     """Represents the shape of a `Tensor`.
 
     A `TensorShape` represents a possibly-partial shape specification for a

--- a/tensorboard/context.py
+++ b/tensorboard/context.py
@@ -21,7 +21,7 @@ from tensorboard import auth as auth_lib
 _WSGI_KEY = "tensorboard.request_context"
 
 
-class RequestContext(object):
+class RequestContext:
     """Container of request-scoped values.
 
     This context is for cross-cutting concerns: authentication,

--- a/tensorboard/data/experimental/experiment_from_dev.py
+++ b/tensorboard/data/experimental/experiment_from_dev.py
@@ -60,7 +60,7 @@ class ExperimentFromDev(base_experiment.BaseExperiment):
           api_endpoint: Optional override value for API endpoint. Used for
             development only.
         """
-        super(ExperimentFromDev, self).__init__()
+        super().__init__()
         self._experiment_id = experiment_id
         self._api_client = get_api_client(api_endpoint=api_endpoint)
 

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -359,7 +359,7 @@ class DataProvider(metaclass=abc.ABCMeta):
         pass
 
 
-class ExperimentMetadata(object):
+class ExperimentMetadata:
     """Metadata about an experiment.
 
     All fields have default values: i.e., they will always be present on
@@ -432,7 +432,7 @@ class ExperimentMetadata(object):
         )
 
 
-class Run(object):
+class Run:
     """Metadata about a run.
 
     Attributes:
@@ -486,7 +486,7 @@ class Run(object):
         )
 
 
-class _TimeSeries(object):
+class _TimeSeries:
     """Metadata about time series data for a particular run and tag.
 
     Superclass of `ScalarTimeSeries`, `TensorTimeSeries`, and
@@ -592,7 +592,7 @@ class ScalarTimeSeries(_TimeSeries):
         )
 
 
-class ScalarDatum(object):
+class ScalarDatum:
     """A single datum in a scalar time series for a run and tag.
 
     Attributes:
@@ -701,7 +701,7 @@ class TensorTimeSeries(_TimeSeries):
         )
 
 
-class TensorDatum(object):
+class TensorDatum:
     """A single datum in a tensor time series for a run and tag.
 
     Attributes:
@@ -842,7 +842,7 @@ class BlobSequenceTimeSeries(_TimeSeries):
         )
 
 
-class BlobReference(object):
+class BlobReference:
     """A reference to a blob.
 
     Attributes:
@@ -911,7 +911,7 @@ class BlobReference(object):
         )
 
 
-class BlobSequenceDatum(object):
+class BlobSequenceDatum:
     """A single datum in a blob sequence time series for a run and tag.
 
     Attributes:
@@ -966,7 +966,7 @@ class BlobSequenceDatum(object):
         )
 
 
-class RunTagFilter(object):
+class RunTagFilter:
     """Filters data by run and tag names."""
 
     def __init__(self, runs=None, tags=None):

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -787,7 +787,7 @@ class BlobSequenceTimeSeries(_TimeSeries):
         description,
         display_name,
     ):
-        super(BlobSequenceTimeSeries, self).__init__(
+        super().__init__(
             max_step=max_step,
             max_wall_time=max_wall_time,
             plugin_content=plugin_content,

--- a/tensorboard/errors.py
+++ b/tensorboard/errors.py
@@ -38,7 +38,7 @@ class PublicError(RuntimeError):
     http_code = 500  # default; subclasses should override
 
     def __init__(self, details):
-        super(PublicError, self).__init__(details)
+        super().__init__(details)
         self.headers = []
 
 
@@ -56,7 +56,7 @@ class InvalidArgumentError(PublicError):
 
     def __init__(self, details=None):
         msg = _format_message("Invalid argument", details)
-        super(InvalidArgumentError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class NotFoundError(PublicError):
@@ -73,7 +73,7 @@ class NotFoundError(PublicError):
 
     def __init__(self, details=None):
         msg = _format_message("Not found", details)
-        super(NotFoundError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class UnauthenticatedError(PublicError):
@@ -102,7 +102,7 @@ class UnauthenticatedError(PublicError):
             as described in RFC 7235.
         """
         msg = _format_message("Unauthenticated", details)
-        super(UnauthenticatedError, self).__init__(msg)
+        super().__init__(msg)
         self.headers.append(("WWW-Authenticate", challenge))
 
 
@@ -120,7 +120,7 @@ class PermissionDeniedError(PublicError):
 
     def __init__(self, details=None):
         msg = _format_message("Permission denied", details)
-        super(PermissionDeniedError, self).__init__(msg)
+        super().__init__(msg)
 
 
 def _format_message(code_name, details):

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -95,7 +95,7 @@ class LazyTest(unittest.TestCase):
     def test_loads_only_once_even_when_result_equal_to_everything(self):
         # This would fail if the implementation of `_memoize` used `==`
         # rather than `is` to check for the sentinel value.
-        class EqualToEverything(object):
+        class EqualToEverything:
             def __eq__(self, other):
                 return True
 

--- a/tensorboard/manager_e2e_test.py
+++ b/tensorboard/manager_e2e_test.py
@@ -36,7 +36,7 @@ from tensorboard import manager
 
 class ManagerEndToEndTest(tf.test.TestCase):
     def setUp(self):
-        super(ManagerEndToEndTest, self).setUp()
+        super().setUp()
 
         # Spy on subprocesses spawned so that we can kill them.
         self.popens = []

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -237,7 +237,7 @@ class TensorBoardInfoIoTest(tb_test.TestCase):
     """Tests for `write_info_file`, `remove_info_file`, and `get_all`."""
 
     def setUp(self):
-        super(TensorBoardInfoIoTest, self).setUp()
+        super().setUp()
         patcher = mock.patch.dict(os.environ, {"TMPDIR": self.get_temp_dir()})
         patcher.start()
         self.addCleanup(patcher.stop)

--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -47,7 +47,7 @@ if audio_ops is None:
 
 class SummaryBaseTest:
     def setUp(self):
-        super(SummaryBaseTest, self).setUp()
+        super().setUp()
         self.samples_rate = 44100
         self.audio_count = 1
         self.num_samples = 20
@@ -147,7 +147,7 @@ class SummaryBaseTest:
 
 class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
     def setUp(self):
-        super(SummaryV1PbTest, self).setUp()
+        super().setUp()
 
     def audio(self, *args, **kwargs):
         return summary.pb(*args, **kwargs)
@@ -167,7 +167,7 @@ class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
 
 class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
     def setUp(self):
-        super(SummaryV1OpTest, self).setUp()
+        super().setUp()
 
     def audio(self, *args, **kwargs):
         return tf.compat.v1.Summary.FromString(
@@ -200,7 +200,7 @@ class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
 
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     def setUp(self):
-        super(SummaryV2OpTest, self).setUp()
+        super().setUp()
         if tf2 is None:
             self.skipTest("TF v2 summary API not available")
 

--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -45,7 +45,7 @@ if audio_ops is None:
     from tensorflow.python.ops import gen_audio_ops as audio_ops
 
 
-class SummaryBaseTest(object):
+class SummaryBaseTest:
     def setUp(self):
         super(SummaryBaseTest, self).setUp()
         self.samples_rate = 44100

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -101,7 +101,7 @@ class TBPlugin(metaclass=ABCMeta):
         return (self.plugin_name,)
 
 
-class FrontendMetadata(object):
+class FrontendMetadata:
     """Metadata required to render a plugin on the frontend.
 
     Each argument to the constructor is publicly accessible under a
@@ -226,7 +226,7 @@ class FrontendMetadata(object):
         )
 
 
-class TBContext(object):
+class TBContext:
     """Magic container of information passed from TensorBoard core to plugins.
 
     A TBContext instance is passed to the constructor of a TBPlugin class. Plugins
@@ -291,7 +291,7 @@ class TBContext(object):
         self.window_title = window_title
 
 
-class TBLoader(object):
+class TBLoader:
     """TBPlugin factory base class.
 
     Plugins can override this class to customize how a plugin is loaded at

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -44,7 +44,7 @@ NO_CACHE_CONTROL_VALUE = "no-cache, must-revalidate"
 ONE_DAY_CACHE_CONTROL_VALUE = "private, max-age=86400"
 
 
-class FakeFlags(object):
+class FakeFlags:
     def __init__(
         self,
         bind_all=False,
@@ -255,7 +255,7 @@ class CorePluginTest(tf.test.TestCase):
         self.assertEqual(parsed_object["data_location"], self.get_temp_dir())
 
     def testEnvironmentWithExperimentMetadata(self):
-        class FakeDataProvider(object):
+        class FakeDataProvider:
             def experiment_metadata(self, ctx, *, experiment_id):
                 del experiment_id  # Unused.
                 return provider.ExperimentMetadata(

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -46,7 +46,7 @@ tf.compat.v1.disable_v2_behavior()
 
 class CustomScalarsPluginTest(tf.test.TestCase):
     def __init__(self, *args, **kwargs):
-        super(CustomScalarsPluginTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.logdir = os.path.join(self.get_temp_dir(), "logdir")
         os.makedirs(self.logdir)
 

--- a/tensorboard/plugins/custom_scalar/summary_test.py
+++ b/tensorboard/plugins/custom_scalar/summary_test.py
@@ -29,7 +29,7 @@ from tensorboard.util import test_util
 
 class LayoutTest(tf.test.TestCase):
     def setUp(self):
-        super(LayoutTest, self).setUp()
+        super().setUp()
         self.logdir = self.get_temp_dir()
 
     def testSetLayout(self):

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -103,7 +103,7 @@ def parse_tensor_name(tensor_name):
     return op_name, output_slot
 
 
-class DebuggerV2EventMultiplexer(object):
+class DebuggerV2EventMultiplexer:
     """A class used for accessing tfdbg v2 DebugEvent data on local filesystem.
 
     This class is a short-term hack, mirroring the EventMultiplexer for the main

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -474,7 +474,7 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
           logdir: Path to the directory from which the tfdbg v2 data will be
             loaded.
         """
-        super(LocalDebuggerV2DataProvider, self).__init__()
+        super().__init__()
         self._multiplexer = debug_data_multiplexer.DebuggerV2EventMultiplexer(
             logdir
         )

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -50,7 +50,7 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         Args:
           context: A base_plugin.TBContext instance.
         """
-        super(DebuggerV2Plugin, self).__init__(context)
+        super().__init__(context)
         self._logdir = context.logdir
         self._underlying_data_provider = None
         # Held while initializing `_underlying_data_provider` for the first

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -110,7 +110,7 @@ _DEFAULT_DEVICE_SUFFIX = "GPU:0" if tf.test.is_gpu_available() else "CPU:0"
 
 class DebuggerV2PluginTest(tf.test.TestCase):
     def setUp(self):
-        super(DebuggerV2PluginTest, self).setUp()
+        super().setUp()
         self.logdir = self.get_temp_dir()
         context = base_plugin.TBContext(logdir=self.logdir)
         self.plugin = debugger_v2_plugin.DebuggerV2Plugin(context)
@@ -135,7 +135,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
 
     def tearDown(self):
         self.run_in_background_patch.stop()
-        super(DebuggerV2PluginTest, self).tearDown()
+        super().tearDown()
 
     def _getExactlyOneRun(self):
         """Assert there is exactly one DebuggerV2 run and get its ID."""

--- a/tensorboard/plugins/distribution/distributions_plugin_test.py
+++ b/tensorboard/plugins/distribution/distributions_plugin_test.py
@@ -54,7 +54,7 @@ class DistributionsPluginTest(tf.test.TestCase):
     _RUN_WITH_SCALARS = "_RUN_WITH_SCALARS"
 
     def __init__(self, *args, **kwargs):
-        super(DistributionsPluginTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.logdir = None
         self.plugin = None
 

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -59,7 +59,7 @@ _RUN_WITHOUT_GRAPH_WITHOUT_METADATA = (
 )
 
 
-class GraphsPluginBaseTest(object):
+class GraphsPluginBaseTest:
 
     _METADATA_TAG = "secret-stats"
     _MESSAGE_PREFIX_LENGTH_LOWER_BOUND = 1024

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -65,11 +65,11 @@ class GraphsPluginBaseTest:
     _MESSAGE_PREFIX_LENGTH_LOWER_BOUND = 1024
 
     def __init__(self, *args, **kwargs):
-        super(GraphsPluginBaseTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.plugin = None
 
     def setUp(self):
-        super(GraphsPluginBaseTest, self).setUp()
+        super().setUp()
 
     def generate_run(
         self, logdir, run_name, include_graph, include_run_metadata

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -53,7 +53,7 @@ class HistogramsPluginTest(tf.test.TestCase):
     _RUN_WITH_SCALARS = "_RUN_WITH_SCALARS"
 
     def __init__(self, *args, **kwargs):
-        super(HistogramsPluginTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.logdir = None
 
     def load_runs(self, run_names):

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -41,7 +41,7 @@ except AttributeError:
     pass
 
 
-class SummaryBaseTest(object):
+class SummaryBaseTest:
     def setUp(self):
         super(SummaryBaseTest, self).setUp()
         np.random.seed(0)

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -43,7 +43,7 @@ except AttributeError:
 
 class SummaryBaseTest:
     def setUp(self):
-        super(SummaryBaseTest, self).setUp()
+        super().setUp()
         np.random.seed(0)
         self.gaussian = np.random.normal(size=[100])
 
@@ -215,7 +215,7 @@ class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
 
 class SummaryV3OpTest(SummaryBaseTest, tf.test.TestCase):
     def setUp(self):
-        super(SummaryV3OpTest, self).setUp()
+        super().setUp()
         if tf2 is None:
             self.skipTest("v3 histogram summary API not available")
 

--- a/tensorboard/plugins/hparams/_keras_test.py
+++ b/tensorboard/plugins/hparams/_keras_test.py
@@ -31,7 +31,7 @@ tf.compat.v1.enable_eager_execution()
 
 class CallbackTest(tf.test.TestCase):
     def setUp(self):
-        super(CallbackTest, self).setUp()
+        super().setUp()
         self.logdir = os.path.join(self.get_temp_dir(), "logs")
 
     def _initialize_model(self, writer):

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -26,7 +26,7 @@ from google.protobuf import json_format
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 
 
-class Context(object):
+class Context:
     """Wraps the base_plugin.TBContext to stores additional data shared across
     API handlers for the HParams plugin backend.
 

--- a/tensorboard/plugins/hparams/download_data.py
+++ b/tensorboard/plugins/hparams/download_data.py
@@ -22,7 +22,7 @@ import math
 from tensorboard.plugins.hparams import error
 
 
-class OutputFormat(object):
+class OutputFormat:
     """An enum used to list the valid output formats for API calls."""
 
     JSON = "json"
@@ -30,7 +30,7 @@ class OutputFormat(object):
     LATEX = "latex"
 
 
-class Handler(object):
+class Handler:
     """Handles a DownloadData request."""
 
     def __init__(

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -15,7 +15,7 @@
 """Classes and functions for handling the GetExperiment API call."""
 
 
-class Handler(object):
+class Handler:
     """Handles a GetExperiment request."""
 
     def __init__(self, request_context, backend_context, experiment_id):

--- a/tensorboard/plugins/hparams/list_metric_evals.py
+++ b/tensorboard/plugins/hparams/list_metric_evals.py
@@ -19,7 +19,7 @@ from tensorboard.plugins.hparams import metrics
 from tensorboard.plugins.scalar import scalars_plugin
 
 
-class Handler(object):
+class Handler:
     """Handles a ListMetricEvals request."""
 
     def __init__(

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -30,7 +30,7 @@ from tensorboard.plugins.hparams import metadata
 from tensorboard.plugins.hparams import metrics
 
 
-class Handler(object):
+class Handler:
     """Handles a ListSessionGroups request."""
 
     def __init__(
@@ -572,7 +572,7 @@ class _MetricIdentifier:
     tag: str
 
 
-class _MetricStats(object):
+class _MetricStats:
     """A simple class to hold metric stats used in calculating metric averages.
 
     Used in _set_avg_session_metrics(). See the comments in that function

--- a/tensorboard/plugins/hparams/summary_v2.py
+++ b/tensorboard/plugins/hparams/summary_v2.py
@@ -275,7 +275,7 @@ def _summary_pb(tag, hparams_plugin_data):
     return summary
 
 
-class HParam(object):
+class HParam:
     """A hyperparameter in an experiment.
 
     This class describes a hyperparameter in the abstract. It ranges
@@ -542,7 +542,7 @@ class Discrete(Domain):
         hparam_info.domain_discrete.extend(self._values)
 
 
-class Metric(object):
+class Metric:
     """A metric in an experiment.
 
     A metric is a real-valued function of a model. Each metric is

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -39,7 +39,7 @@ except AttributeError:
     pass
 
 
-class SummaryBaseTest(object):
+class SummaryBaseTest:
     def setUp(self):
         super(SummaryBaseTest, self).setUp()
         np.random.seed(0)

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -41,7 +41,7 @@ except AttributeError:
 
 class SummaryBaseTest:
     def setUp(self):
-        super(SummaryBaseTest, self).setUp()
+        super().setUp()
         np.random.seed(0)
         self.image_width = 20
         self.image_height = 15
@@ -184,7 +184,7 @@ class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
 
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     def setUp(self):
-        super(SummaryV2OpTest, self).setUp()
+        super().setUp()
         if tf2 is None:
             self.skipTest("TF v2 summary API not available")
 

--- a/tensorboard/plugins/mesh/summary_v2_test.py
+++ b/tensorboard/plugins/mesh/summary_v2_test.py
@@ -41,7 +41,7 @@ except AttributeError:
 
 class MeshSummaryV2Test(tf.test.TestCase):
     def setUp(self):
-        super(MeshSummaryV2Test, self).setUp()
+        super().setUp()
         if tf2 is None:
             self.skipTest("v2 summary API not available")
 

--- a/tensorboard/plugins/metrics/metrics_plugin_test.py
+++ b/tensorboard/plugins/metrics/metrics_plugin_test.py
@@ -37,7 +37,7 @@ tf1.enable_eager_execution()
 
 class MetricsPluginTest(tf.test.TestCase):
     def setUp(self):
-        super(MetricsPluginTest, self).setUp()
+        super().setUp()
         self._logdir = self.get_temp_dir()
         self._multiplexer = event_multiplexer.EventMultiplexer()
 

--- a/tensorboard/plugins/npmi/npmi_plugin.py
+++ b/tensorboard/plugins/npmi/npmi_plugin.py
@@ -64,7 +64,7 @@ class NpmiPlugin(base_plugin.TBPlugin):
         Args:
             context: A base_plugin.TBContext instance.
         """
-        super(NpmiPlugin, self).__init__(context)
+        super().__init__(context)
         self._logdir = context.logdir
         self._downsample_to = (context.sampling_hints or {}).get(
             self.plugin_name, _DEFAULT_DOWNSAMPLING

--- a/tensorboard/plugins/npmi/summary_test.py
+++ b/tensorboard/plugins/npmi/summary_test.py
@@ -38,7 +38,7 @@ except AttributeError:
 
 class SummaryTest(tf.test.TestCase):
     def setUp(self):
-        super(SummaryTest, self).setUp()
+        super().setUp()
         if tf2 is None:
             self.skipTest("v2 summary API not available")
 

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -41,7 +41,7 @@ assert_allclose = functools.partial(
 
 class PrCurvesPluginTest(tf.test.TestCase):
     def setUp(self):
-        super(PrCurvesPluginTest, self).setUp()
+        super().setUp()
         logdir = os.path.join(self.get_temp_dir(), "logdir")
 
         # Generate data.

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -30,7 +30,7 @@ tf.compat.v1.disable_v2_behavior()
 
 class PrCurveTest(tf.test.TestCase):
     def setUp(self):
-        super(PrCurveTest, self).setUp()
+        super().setUp()
         tf.compat.v1.reset_default_graph()
         np.random.seed(42)
 
@@ -427,7 +427,7 @@ class PrCurveTest(tf.test.TestCase):
 
 class StreamingOpTest(tf.test.TestCase):
     def setUp(self):
-        super(StreamingOpTest, self).setUp()
+        super().setUp()
         tf.compat.v1.reset_default_graph()
         np.random.seed(1)
 

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -59,7 +59,7 @@ _IMGHDR_TO_MIMETYPE = {
 _DEFAULT_IMAGE_MIMETYPE = "application/octet-stream"
 
 
-class LRUCache(object):
+class LRUCache:
     """LRU cache.
 
     Used for storing the last used tensor.
@@ -90,7 +90,7 @@ class LRUCache(object):
         self._dict[key] = value
 
 
-class EmbeddingMetadata(object):
+class EmbeddingMetadata:
     """Metadata container for an embedding.
 
     The metadata holds different columns with values used for

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -49,7 +49,7 @@ USING_REAL_TF = tf_compat.__version__ != "stub"
 
 class ProjectorAppTest(tf.test.TestCase):
     def __init__(self, *args, **kwargs):
-        super(ProjectorAppTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.logdir = None
         self.plugin = None
         self.server = None

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -35,7 +35,7 @@ from tensorboard.plugins.scalar import metadata
 _DEFAULT_DOWNSAMPLING = 1000  # scalars per time series
 
 
-class OutputFormat(object):
+class OutputFormat:
     """An enum used to list the valid output formats for API calls."""
 
     JSON = "json"

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -140,7 +140,7 @@ class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
 
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     def setUp(self):
-        super(SummaryV2OpTest, self).setUp()
+        super().setUp()
         if tf2 is None:
             self.skipTest("v2 summary API not available")
 

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -41,7 +41,7 @@ except AttributeError:
     pass
 
 
-class SummaryBaseTest(object):
+class SummaryBaseTest:
     def scalar(self, *args, **kwargs):
         raise NotImplementedError()
 

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -162,7 +162,7 @@ class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
 
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     def setUp(self):
-        super(SummaryV2OpTest, self).setUp()
+        super().setUp()
         if tf2 is None:
             self.skipTest("TF v2 summary API not available")
 

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -41,7 +41,7 @@ except AttributeError:
     pass
 
 
-class SummaryBaseTest(object):
+class SummaryBaseTest:
     def text(self, *args, **kwargs):
         raise NotImplementedError()
 

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -699,9 +699,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
 
         self._fix_werkzeug_logging()
         try:
-            super(WerkzeugServer, self).__init__(
-                host, port, wsgi_app, _WSGIRequestHandler
-            )
+            super().__init__(host, port, wsgi_app, _WSGIRequestHandler)
         except socket.error as e:
             if hasattr(errno, "EACCES") and e.errno == errno.EACCES:
                 raise TensorBoardServerException(
@@ -818,7 +816,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
                     logger.warning(
                         "Failed to dual-bind to IPv4 wildcard: %s", str(e)
                     )
-        super(WerkzeugServer, self).server_bind()
+        super().server_bind()
 
     def handle_error(self, request, client_address):
         """Override to get rid of noisy EPIPE errors."""
@@ -868,7 +866,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
                 "use a proxy or pass --bind_all\n"
             )
             sys.stderr.flush()
-        super(WerkzeugServer, self).print_serving_message()
+        super().print_serving_message()
 
     def _fix_werkzeug_logging(self):
         """Fix werkzeug logging setup so it inherits TensorBoard's log level.

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -82,7 +82,7 @@ Could not start data server: %s.
 """
 
 
-class TensorBoard(object):
+class TensorBoard:
     """Class for running TensorBoard.
 
     Fields:

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -107,7 +107,7 @@ class WerkzeugServerTest(tb_test.TestCase):
     IPv4, only IPv6, and both IPv4 and IPv6 enabled.
     """
 
-    class _StubApplication(object):
+    class _StubApplication:
         pass
 
     def make_flags(self, **kwargs):

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -169,7 +169,7 @@ class WerkzeugServerTest(tb_test.TestCase):
 
 class SubcommandTest(tb_test.TestCase):
     def setUp(self):
-        super(SubcommandTest, self).setUp()
+        super().setUp()
         self.stderr = io.StringIO()
         patchers = [
             mock.patch.object(program.TensorBoard, "_install_signal_handler"),

--- a/tensorboard/summary/summary_test.py
+++ b/tensorboard/summary/summary_test.py
@@ -29,7 +29,7 @@ import tensorboard.summary.v1 as tb_summary_v1
 import tensorboard.summary.v2 as tb_summary_v2
 
 
-class SummaryExportsBaseTest(object):
+class SummaryExportsBaseTest:
     module = None
     plugins = None
     allowed = frozenset()

--- a/tensorboard/summary/writer/event_file_writer.py
+++ b/tensorboard/summary/writer/event_file_writer.py
@@ -26,7 +26,7 @@ from tensorboard.compat.proto import event_pb2
 from tensorboard.summary.writer.record_writer import RecordWriter
 
 
-class AtomicCounter(object):
+class AtomicCounter:
     def __init__(self, initial_value):
         self._value = initial_value
         self._lock = threading.Lock()
@@ -42,7 +42,7 @@ class AtomicCounter(object):
 _global_uid = AtomicCounter(0)
 
 
-class EventFileWriter(object):
+class EventFileWriter:
     """Writes `Event` protocol buffers to an event file.
 
     The `EventFileWriter` class creates an event file in the specified
@@ -134,7 +134,7 @@ class EventFileWriter(object):
         self._async_writer.close()
 
 
-class _AsyncWriter(object):
+class _AsyncWriter:
     """Writes bytes to a file."""
 
     def __init__(self, record_writer, max_queue_size=20, flush_secs=120):

--- a/tensorboard/summary/writer/record_writer.py
+++ b/tensorboard/summary/writer/record_writer.py
@@ -17,7 +17,7 @@ import struct
 from tensorboard.compat.tensorflow_stub.pywrap_tensorflow import masked_crc32c
 
 
-class RecordWriter(object):
+class RecordWriter:
     """Write encoded protobuf to a file with packing defined in tensorflow."""
 
     def __init__(self, writer):

--- a/tensorboard/test.py
+++ b/tensorboard/test.py
@@ -30,7 +30,7 @@ class TestCase(absltest.TestCase):
     """
 
     def __init__(self, *args, **kwargs):
-        super(TestCase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._tempdir = None
 
     def get_temp_dir(self):

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -72,7 +72,7 @@ TENSORBOARD_CREDENTIALS_FILEPATH_PARTS = [
 ]
 
 
-class CredentialsStore(object):
+class CredentialsStore:
     """Private file store for a `google.oauth2.credentials.Credentials`."""
 
     _DEFAULT_CONFIG_DIRECTORY = object()  # Sentinel value.

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -200,7 +200,7 @@ class IdTokenAuthMetadataPlugin(grpc.AuthMetadataPlugin):
           request (google.auth.transport.Request): A HTTP transport request object
             used to refresh credentials as needed.
         """
-        super(IdTokenAuthMetadataPlugin, self).__init__()
+        super().__init__()
         if not isinstance(credentials, google.oauth2.credentials.Credentials):
             raise TypeError(
                 "Cannot get ID tokens from credentials type %s"

--- a/tensorboard/uploader/dry_run_stubs.py
+++ b/tensorboard/uploader/dry_run_stubs.py
@@ -18,7 +18,7 @@
 from tensorboard.uploader.proto import write_service_pb2
 
 
-class DryRunTensorBoardWriterStub(object):
+class DryRunTensorBoardWriterStub:
     """A dry-run TensorBoardWriter gRPC Server.
 
     Only the methods used by the `tensorboard dev upload` are

--- a/tensorboard/uploader/dry_run_stubs_test.py
+++ b/tensorboard/uploader/dry_run_stubs_test.py
@@ -22,7 +22,7 @@ from tensorboard.uploader.proto import write_service_pb2
 
 class DryRunTensorBoardWriterServicerTest(tb_test.TestCase):
     def setUp(self):
-        super(DryRunTensorBoardWriterServicerTest, self).setUp()
+        super().setUp()
         self._stub = dry_run_stubs.DryRunTensorBoardWriterStub()
 
     def testCreateExperiment(self):

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -474,7 +474,7 @@ class OutputDirectoryExistsError(ValueError):
 
 class GrpcTimeoutException(Exception):
     def __init__(self, experiment_id):
-        super(GrpcTimeoutException, self).__init__(experiment_id)
+        super().__init__(experiment_id)
         self.experiment_id = experiment_id
 
 

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -70,7 +70,7 @@ _FILENAME_BLOBS_SUFFIX = ".bin"
 logger = tb_logging.get_logger()
 
 
-class TensorBoardExporter(object):
+class TensorBoardExporter:
     """Exports all of the user's experiment data from TensorBoard.dev.
 
     Data is exported into a directory, with one file per experiment. Each

--- a/tensorboard/uploader/formatters.py
+++ b/tensorboard/uploader/formatters.py
@@ -49,7 +49,7 @@ class ReadableFormatter(BaseExperimentFormatter):
     _NAME_COLUMN_WIDTH = 20
 
     def __init__(self):
-        super(ReadableFormatter, self).__init__()
+        super().__init__()
 
     def format_experiment(self, experiment, experiment_url):
         output = []
@@ -83,7 +83,7 @@ class JsonFormatter:
     _JSON_INDENT = 2
 
     def __init__(self):
-        super(JsonFormatter, self).__init__()
+        super().__init__()
 
     def format_experiment(self, experiment, experiment_url):
         data = [

--- a/tensorboard/uploader/formatters.py
+++ b/tensorboard/uploader/formatters.py
@@ -22,7 +22,7 @@ import json
 from tensorboard.uploader import util
 
 
-class BaseExperimentFormatter(object):
+class BaseExperimentFormatter:
     """Abstract base class for formatting experiment information as a string."""
 
     __metaclass__ = abc.ABCMeta
@@ -77,7 +77,7 @@ class ReadableFormatter(BaseExperimentFormatter):
         return "\n".join(output)
 
 
-class JsonFormatter(object):
+class JsonFormatter:
     """A formatter implementation: outputs experiment as JSON."""
 
     _JSON_INDENT = 2

--- a/tensorboard/uploader/logdir_loader.py
+++ b/tensorboard/uploader/logdir_loader.py
@@ -26,7 +26,7 @@ from tensorboard.util import tb_logging
 logger = tb_logging.get_logger()
 
 
-class LogdirLoader(object):
+class LogdirLoader:
     """Loader for a root log directory, maintaining multiple DirectoryLoaders.
 
     This class takes a root log directory and a factory for DirectoryLoaders, and

--- a/tensorboard/uploader/test_util.py
+++ b/tensorboard/uploader/test_util.py
@@ -23,7 +23,7 @@ from google.protobuf import timestamp_pb2
 from tensorboard.compat.proto import summary_pb2
 
 
-class FakeTime(object):
+class FakeTime:
     """Thread-safe fake replacement for the `time` module."""
 
     def __init__(self, current=0.0):

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -36,7 +36,7 @@ def readable_bytes_string(bytes):
         return "%d B" % bytes
 
 
-class UploadStats(object):
+class UploadStats:
     """Statistics of uploading."""
 
     def __init__(self):
@@ -254,7 +254,7 @@ _STYLE_DARKGRAY = "\033[90m"
 _STYLE_ERASE_LINE = "\033[2K"
 
 
-class UploadTracker(object):
+class UploadTracker:
     """Tracker for uploader progress and status."""
 
     _SUPPORTED_VERBISITY_VALUES = (0, 1)
@@ -418,7 +418,7 @@ class UploadTracker(object):
             pass
 
 
-class _BlobTracker(object):
+class _BlobTracker:
     def __init__(self, upload_stats, blob_bytes):
         self._upload_stats = upload_stats
         self._blob_bytes = blob_bytes

--- a/tensorboard/uploader/upload_tracker_test.py
+++ b/tensorboard/uploader/upload_tracker_test.py
@@ -218,7 +218,7 @@ class UploadTrackerTest(tb_test.TestCase):
     """Test for the UploadTracker class."""
 
     def setUp(self):
-        super(UploadTrackerTest, self).setUp()
+        super().setUp()
         self.cumulative_bar = mock.MagicMock()
         self.skipped_bar = mock.MagicMock()
         self.uploading_bar = mock.MagicMock()
@@ -236,7 +236,7 @@ class UploadTrackerTest(tb_test.TestCase):
     def tearDown(self):
         self.mock_stdout_write.stop()
         self.mock_stdout_flush.stop()
-        super(UploadTrackerTest, self).tearDown()
+        super().tearDown()
 
     def testSendTracker(self):
         tracker = upload_tracker.UploadTracker(verbosity=1)

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -55,7 +55,7 @@ _MAX_VARINT64_LENGTH_BYTES = 10
 logger = tb_logging.get_logger()
 
 
-class TensorBoardUploader(object):
+class TensorBoardUploader:
     """Uploads a TensorBoard logdir to TensorBoard.dev."""
 
     def __init__(
@@ -320,7 +320,7 @@ class _OutOfSpaceError(Exception):
     pass
 
 
-class _BatchedRequestSender(object):
+class _BatchedRequestSender:
     """Helper class for building requests that fit under a size limit.
 
     This class maintains stateful request builders for each of the possible
@@ -468,7 +468,7 @@ class _BatchedRequestSender(object):
                     yield (run_name, event, value)
 
 
-class _ScalarBatchedRequestSender(object):
+class _ScalarBatchedRequestSender:
     """Helper class for building requests that fit under a size limit.
 
     This class accumulates a current request.  `add_event(...)` may or may not
@@ -627,7 +627,7 @@ class _ScalarBatchedRequestSender(object):
             raise
 
 
-class _TensorBatchedRequestSender(object):
+class _TensorBatchedRequestSender:
     """Helper class for building WriteTensor() requests that fit under a size limit.
 
     This class accumulates a current request.  `add_event(...)` may or may not
@@ -829,7 +829,7 @@ class _TensorBatchedRequestSender(object):
             )
 
 
-class _ByteBudgetManager(object):
+class _ByteBudgetManager:
     """Helper class for managing the request byte budget for certain RPCs.
 
     This should be used for RPCs that organize data by Runs, Tags, and Points,
@@ -942,7 +942,7 @@ class _ByteBudgetManager(object):
         self._byte_budget -= cost
 
 
-class _BlobRequestSender(object):
+class _BlobRequestSender:
     """Uploader for blob-type event data.
 
     Unlike the other types, this class does not accumulate events in batches;

--- a/tensorboard/uploader/util.py
+++ b/tensorboard/uploader/util.py
@@ -22,7 +22,7 @@ import os.path
 import time
 
 
-class RateLimiter(object):
+class RateLimiter:
     """Helper class for rate-limiting using a fixed minimum interval."""
 
     def __init__(self, interval_secs):

--- a/tensorboard/util/encoder.py
+++ b/tensorboard/util/encoder.py
@@ -38,7 +38,7 @@ class _TensorFlowPngEncoder(op_evaluator.PersistentOpEvaluator):
     """
 
     def __init__(self):
-        super(_TensorFlowPngEncoder, self).__init__()
+        super().__init__()
         self._image_placeholder = None
         self._encode_op = None
 
@@ -78,7 +78,7 @@ class _TensorFlowWavEncoder(op_evaluator.PersistentOpEvaluator):
     """
 
     def __init__(self):
-        super(_TensorFlowWavEncoder, self).__init__()
+        super().__init__()
         self._audio_placeholder = None
         self._samples_per_second_placeholder = None
         self._encode_op = None

--- a/tensorboard/util/encoder_test.py
+++ b/tensorboard/util/encoder_test.py
@@ -21,7 +21,7 @@ from tensorboard.util import encoder
 
 class TensorFlowPngEncoderTest(tf.test.TestCase):
     def setUp(self):
-        super(TensorFlowPngEncoderTest, self).setUp()
+        super().setUp()
         self._encode = encoder._TensorFlowPngEncoder()
         self._rgb = np.arange(12 * 34 * 3).reshape((12, 34, 3)).astype(np.uint8)
         self._rgba = (
@@ -52,7 +52,7 @@ class TensorFlowPngEncoderTest(tf.test.TestCase):
 
 class TensorFlowWavEncoderTest(tf.test.TestCase):
     def setUp(self):
-        super(TensorFlowWavEncoderTest, self).setUp()
+        super().setUp()
         self._encode = encoder._TensorFlowWavEncoder()
         space = np.linspace(0.0, 100.0, 44100)
         self._stereo = np.array([np.sin(space), np.cos(space)]).transpose()

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -43,7 +43,7 @@ class TestGrpcServer(grpc_util_test_pb2_grpc.TestServiceServicer):
     """Helper for testing gRPC client logic with a dummy gRPC server."""
 
     def __init__(self, handler):
-        super(TestGrpcServer, self).__init__()
+        super().__init__()
         self._handler = handler
 
     def TestRpc(self, request, context):

--- a/tensorboard/util/lazy_tensor_creator.py
+++ b/tensorboard/util/lazy_tensor_creator.py
@@ -24,7 +24,7 @@ from tensorboard.compat import tf2 as tf
 _CALL_IN_PROGRESS_SENTINEL = object()
 
 
-class LazyTensorCreator(object):
+class LazyTensorCreator:
     """Lazy auto-converting wrapper for a callable that returns a `tf.Tensor`.
 
     This class wraps an arbitrary callable that returns a `Tensor` so that it

--- a/tensorboard/util/op_evaluator.py
+++ b/tensorboard/util/op_evaluator.py
@@ -21,7 +21,7 @@ Requires TensorFlow.
 import threading
 
 
-class PersistentOpEvaluator(object):
+class PersistentOpEvaluator:
     """Evaluate a fixed TensorFlow graph repeatedly, safely, efficiently.
 
     Extend this class to create a particular kind of op evaluator, like an

--- a/tensorboard/util/op_evaluator.py
+++ b/tensorboard/util/op_evaluator.py
@@ -60,7 +60,7 @@ class PersistentOpEvaluator:
     """
 
     def __init__(self):
-        super(PersistentOpEvaluator, self).__init__()
+        super().__init__()
         self._session = None
         self._initialization_lock = threading.Lock()
 

--- a/tensorboard/util/op_evaluator_test.py
+++ b/tensorboard/util/op_evaluator_test.py
@@ -20,7 +20,7 @@ from tensorboard.util import op_evaluator
 
 class PersistentOpEvaluatorTest(tf.test.TestCase):
     def setUp(self):
-        super(PersistentOpEvaluatorTest, self).setUp()
+        super().setUp()
 
         patch = tf.test.mock.patch(
             "tensorflow.compat.v1.Session", wraps=tf.Session
@@ -30,7 +30,7 @@ class PersistentOpEvaluatorTest(tf.test.TestCase):
 
         class Squarer(op_evaluator.PersistentOpEvaluator):
             def __init__(self):
-                super(Squarer, self).__init__()
+                super().__init__()
                 self._input = None
                 self._squarer = None
 

--- a/tensorboard/util/tensor_util.py
+++ b/tensorboard/util/tensor_util.py
@@ -181,7 +181,7 @@ _TENSOR_CONTENT_TYPES = frozenset(
 )
 
 
-class _Message(object):
+class _Message:
     def __init__(self, message):
         self._message = message
 

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -45,7 +45,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
         # Briefly enter graph mode context so this testing FileWriter can be
         # created from an eager mode context without triggering a usage error.
         with tf.compat.v1.Graph().as_default():
-            super(FileWriter, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
     def add_test_summary(self, tag, simple_value=1.0, step=None):
         """Convenience for writing a simple summary for a given tag."""
@@ -63,7 +63,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
                     "Added TensorFlow event proto. "
                     "Please prefer TensorBoard copy of the proto"
                 )
-        super(FileWriter, self).add_event(tf_event)
+        super().add_event(tf_event)
 
     def add_summary(self, summary, global_step=None):
         if isinstance(summary, summary_pb2.Summary):
@@ -77,7 +77,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
                     "Added TensorFlow summary proto. "
                     "Please prefer TensorBoard copy of the proto"
                 )
-        super(FileWriter, self).add_summary(tf_summary, global_step)
+        super().add_summary(tf_summary, global_step)
 
     def add_session_log(self, session_log, global_step=None):
         if isinstance(session_log, event_pb2.SessionLog):
@@ -91,7 +91,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
                     "Added TensorFlow session_log proto. "
                     "Please prefer TensorBoard copy of the proto"
                 )
-        super(FileWriter, self).add_session_log(tf_session_log, global_step)
+        super().add_session_log(tf_session_log, global_step)
 
     def add_graph(self, graph, global_step=None, graph_def=None):
         if isinstance(graph_def, graph_pb2.GraphDef):
@@ -101,7 +101,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
         else:
             tf_graph_def = graph_def
 
-        super(FileWriter, self).add_graph(
+        super().add_graph(
             graph, global_step=global_step, graph_def=tf_graph_def
         )
 
@@ -113,7 +113,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
         else:
             tf_meta_graph_def = meta_graph_def
 
-        super(FileWriter, self).add_meta_graph(
+        super().add_meta_graph(
             meta_graph_def=tf_meta_graph_def, global_step=global_step
         )
 

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -118,7 +118,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
         )
 
 
-class FileWriterCache(object):
+class FileWriterCache:
     """Cache for TensorBoard test file writers."""
 
     # Cache, keyed by directory.
@@ -145,7 +145,7 @@ class FileWriterCache(object):
             return FileWriterCache._cache[logdir]
 
 
-class FakeTime(object):
+class FakeTime:
     """Thread-safe fake replacement for the `time` module."""
 
     def __init__(self, current=0.0):


### PR DESCRIPTION
Cleans up unnecessary inheritance from object and unnecessary arguments to super calls, which aren't necessary in py3.
