### PR TITLE
ci: upgrade `setup-python` and `upload-artifact` actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         python_version: ['3.7']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
           python-version: ${{ matrix.python_version }}
           architecture: 'x64'
@@ -124,7 +124,7 @@ jobs:
       - name: 'Upload Pip package as an artifact (with TensorFlow only)'
         # Prevent uploads when running on forks or non-master branch.
         if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ 83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: tb-nightly
           path: /tmp/tb_nightly_pip_package/*
@@ -143,7 +143,7 @@ jobs:
             rust_version: '1.65.0'
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
           python-version: '3.8'
           architecture: 'x64'
@@ -201,7 +201,7 @@ jobs:
             --out-dir /tmp/pip_package \
             ;
       - name: 'Upload'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ 83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: tensorboard-data-server
           path: /tmp/pip_package/*
@@ -217,7 +217,7 @@ jobs:
         python_version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
           python-version: ${{ matrix.python_version }}
           architecture: 'x64'
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
           python-version: '3.7'
           architecture: 'x64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         tf_version_id: ['tf', 'notf']
         python_version: ['3.7']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
@@ -142,7 +142,7 @@ jobs:
             platform: 'ubuntu-22.04'
             rust_version: '1.65.0'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
@@ -216,7 +216,7 @@ jobs:
         # changes, and we want to catch them all.
         python_version: ['3.7', '3.8', '3.9', '3.10']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
@@ -234,7 +234,7 @@ jobs:
   lint-python-yaml-docs:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
@@ -267,7 +267,7 @@ jobs:
         rust_version: ['1.65.0']
         cargo_raze_version: ['0.16.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - name: 'Cache Cargo artifacts'
         uses: actions/cache@1a9e2138d905efd099035b49d8b7a3888c653ca8
         with:
@@ -307,7 +307,7 @@ jobs:
   lint-frontend:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
         with:
           # default on setup-node@1 is v10.24.1.
@@ -338,7 +338,7 @@ jobs:
   lint-misc: # build, protos, etc.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - name: 'Set up Buildifier'
         run: |
           ci/download_buildifier.sh "${BUILDTOOLS_VERSION}" "${BUILDIFIER_SHA256SUM}" ~/buildifier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         tf_version_id: ['tf', 'notf']
         python_version: ['3.7']
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
@@ -142,7 +142,7 @@ jobs:
             platform: 'ubuntu-22.04'
             rust_version: '1.65.0'
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
@@ -216,7 +216,7 @@ jobs:
         # changes, and we want to catch them all.
         python_version: ['3.7', '3.8', '3.9', '3.10']
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
@@ -234,7 +234,7 @@ jobs:
   lint-python-yaml-docs:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
@@ -267,7 +267,7 @@ jobs:
         rust_version: ['1.65.0']
         cargo_raze_version: ['0.16.1']
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - uses: actions/checkout@v3
       - name: 'Cache Cargo artifacts'
         uses: actions/cache@1a9e2138d905efd099035b49d8b7a3888c653ca8
         with:
@@ -307,7 +307,7 @@ jobs:
   lint-frontend:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
         with:
           # default on setup-node@1 is v10.24.1.
@@ -338,7 +338,7 @@ jobs:
   lint-misc: # build, protos, etc.
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - uses: actions/checkout@v3
       - name: 'Set up Buildifier'
         run: |
           ci/download_buildifier.sh "${BUILDTOOLS_VERSION}" "${BUILDIFIER_SHA256SUM}" ~/buildifier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         python_version: ['3.7']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
           architecture: 'x64'
@@ -143,7 +143,7 @@ jobs:
             rust_version: '1.65.0'
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
           architecture: 'x64'
@@ -217,7 +217,7 @@ jobs:
         python_version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
           architecture: 'x64'
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-      - uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
           architecture: 'x64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: 'Upload Pip package as an artifact (with TensorFlow only)'
         # Prevent uploads when running on forks or non-master branch.
         if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@ 83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: tb-nightly
           path: /tmp/tb_nightly_pip_package/*
@@ -201,7 +201,7 @@ jobs:
             --out-dir /tmp/pip_package \
             ;
       - name: 'Upload'
-        uses: actions/upload-artifact@ 83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: tensorboard-data-server
           path: /tmp/pip_package/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
             --out-dir /tmp/pip_package \
             ;
       - name: 'Upload'
-        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
+        uses: actions/upload-artifact@v3
         with:
           name: tensorboard-data-server
           path: /tmp/pip_package/*


### PR DESCRIPTION
This PR upgrades the following Github actions to reduce the deprecation warnings for commands `save-state` and `set-output`:
- `actions/setup-python` to `v4.3.0` 
  - https://github.com/actions/setup-python/issues/524
- `actions/upload-artifact` to `v3.1.1`

Note that `cache` action isn't upgraded here since `actions/cache@v3` still returns deprecation warnings: https://github.com/actions/cache/issues/1045.
 
Googlers, see b/257310824.

#oncall
