### PR TITLE
refactor python files

### DIFF
--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -774,7 +774,7 @@ class TensorBoardPluginsTest(tb_test.TestCase):
     def testNameToPluginMapping(self):
         # The mapping from plugin name to instance should include all plugins.
         mapping = self.context.plugin_name_to_instance
-        self.assertItemsEqual(["foo", "bar", "whoami"], list(mapping.keys()))
+        self.assertCountEqual(["foo", "bar", "whoami"], list(mapping.keys()))
         self.assertEqual("foo", mapping["foo"].plugin_name)
         self.assertEqual("bar", mapping["bar"].plugin_name)
         self.assertEqual("whoami", mapping["whoami"].plugin_name)

--- a/tensorboard/backend/event_processing/data_provider_test.py
+++ b/tensorboard/backend/event_processing/data_provider_test.py
@@ -131,7 +131,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
     def test_list_plugins_with_no_graph(self):
         provider = self.create_provider()
         result = provider.list_plugins(self.ctx, experiment_id="unused")
-        self.assertItemsEqual(
+        self.assertCountEqual(
             result,
             [
                 "greetings",
@@ -150,7 +150,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
 
         provider = self.create_provider()
         result = provider.list_plugins(self.ctx, experiment_id="unused")
-        self.assertItemsEqual(
+        self.assertCountEqual(
             result,
             [
                 "greetings",
@@ -176,7 +176,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
         class FakeMultiplexer:
             def Runs(multiplexer):
                 result = ["second_2", "first", "no_time", "second_1"]
-                self.assertItemsEqual(result, start_times)
+                self.assertCountEqual(result, start_times)
                 return result
 
             def FirstEventTimestamp(multiplexer, run):
@@ -192,7 +192,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             multiplexer, "fake_logdir"
         )
         result = provider.list_runs(self.ctx, experiment_id="unused")
-        self.assertItemsEqual(
+        self.assertCountEqual(
             result,
             [
                 base_provider.Run(
@@ -210,9 +210,9 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             plugin_name=scalar_metadata.PLUGIN_NAME,
             run_tag_filter=None,
         )
-        self.assertItemsEqual(result.keys(), ["polynomials", "waves"])
-        self.assertItemsEqual(result["polynomials"].keys(), ["square", "cube"])
-        self.assertItemsEqual(result["waves"].keys(), ["square", "sine"])
+        self.assertCountEqual(result.keys(), ["polynomials", "waves"])
+        self.assertCountEqual(result["polynomials"].keys(), ["square", "cube"])
+        self.assertCountEqual(result["waves"].keys(), ["square", "sine"])
         sample = result["polynomials"]["square"]
         self.assertIsInstance(sample, base_provider.ScalarTimeSeries)
         self.assertEqual(sample.max_step, 18)
@@ -232,8 +232,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             plugin_name=scalar_metadata.PLUGIN_NAME,
             run_tag_filter=base_provider.RunTagFilter(["waves"], ["square"]),
         )
-        self.assertItemsEqual(result.keys(), ["waves"])
-        self.assertItemsEqual(result["waves"].keys(), ["square"])
+        self.assertCountEqual(result.keys(), ["waves"])
+        self.assertCountEqual(result["waves"].keys(), ["square"])
 
         result = provider.list_scalars(
             self.ctx,
@@ -243,9 +243,9 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
                 tags=["square", "quartic"]
             ),
         )
-        self.assertItemsEqual(result.keys(), ["polynomials", "waves"])
-        self.assertItemsEqual(result["polynomials"].keys(), ["square"])
-        self.assertItemsEqual(result["waves"].keys(), ["square"])
+        self.assertCountEqual(result.keys(), ["polynomials", "waves"])
+        self.assertCountEqual(result["polynomials"].keys(), ["square"])
+        self.assertCountEqual(result["waves"].keys(), ["square"])
 
         result = provider.list_scalars(
             self.ctx,
@@ -253,8 +253,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             plugin_name=scalar_metadata.PLUGIN_NAME,
             run_tag_filter=base_provider.RunTagFilter(runs=["waves", "hugs"]),
         )
-        self.assertItemsEqual(result.keys(), ["waves"])
-        self.assertItemsEqual(result["waves"].keys(), ["sine", "square"])
+        self.assertCountEqual(result.keys(), ["waves"])
+        self.assertCountEqual(result["waves"].keys(), ["sine", "square"])
 
         result = provider.list_scalars(
             self.ctx,
@@ -282,9 +282,9 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             downsample=100,
         )
 
-        self.assertItemsEqual(result.keys(), ["polynomials", "waves"])
-        self.assertItemsEqual(result["polynomials"].keys(), ["square", "cube"])
-        self.assertItemsEqual(result["waves"].keys(), ["square", "sine"])
+        self.assertCountEqual(result.keys(), ["polynomials", "waves"])
+        self.assertCountEqual(result["polynomials"].keys(), ["square", "cube"])
+        self.assertCountEqual(result["waves"].keys(), ["square", "sine"])
         for run in result:
             for tag in result[run]:
                 tensor_events = multiplexer.Tensors(run, tag)
@@ -336,8 +336,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             plugin_name=histogram_metadata.PLUGIN_NAME,
             run_tag_filter=None,
         )
-        self.assertItemsEqual(result.keys(), ["lebesgue"])
-        self.assertItemsEqual(result["lebesgue"].keys(), ["uniform", "bimodal"])
+        self.assertCountEqual(result.keys(), ["lebesgue"])
+        self.assertCountEqual(result["lebesgue"].keys(), ["uniform", "bimodal"])
         sample = result["lebesgue"]["uniform"]
         self.assertIsInstance(sample, base_provider.TensorTimeSeries)
         self.assertEqual(sample.max_step, 10)
@@ -361,8 +361,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
                 ["lebesgue"], ["uniform"]
             ),
         )
-        self.assertItemsEqual(result.keys(), ["lebesgue"])
-        self.assertItemsEqual(result["lebesgue"].keys(), ["uniform"])
+        self.assertCountEqual(result.keys(), ["lebesgue"])
+        self.assertCountEqual(result["lebesgue"].keys(), ["uniform"])
 
     def test_read_tensors(self):
         multiplexer = self.create_multiplexer()
@@ -382,8 +382,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             downsample=100,
         )
 
-        self.assertItemsEqual(result.keys(), ["lebesgue"])
-        self.assertItemsEqual(result["lebesgue"].keys(), ["uniform", "bimodal"])
+        self.assertCountEqual(result.keys(), ["lebesgue"])
+        self.assertCountEqual(result["lebesgue"].keys(), ["uniform", "bimodal"])
         for run in result:
             for tag in result[run]:
                 tensor_events = multiplexer.Tensors(run, tag)
@@ -418,8 +418,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
                 experiment_id="unused",
                 plugin_name=image_metadata.PLUGIN_NAME,
             )
-            self.assertItemsEqual(result.keys(), ["mondrian"])
-            self.assertItemsEqual(
+            self.assertCountEqual(result.keys(), ["mondrian"])
+            self.assertCountEqual(
                 result["mondrian"].keys(), ["red", "blue", "yellow"]
             )
             sample = result["mondrian"]["blue"]
@@ -440,8 +440,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
                     runs=["mondrian", "picasso"], tags=["yellow", "green't"]
                 ),
             )
-            self.assertItemsEqual(result.keys(), ["mondrian"])
-            self.assertItemsEqual(result["mondrian"].keys(), ["yellow"])
+            self.assertCountEqual(result.keys(), ["mondrian"])
+            self.assertCountEqual(result["mondrian"].keys(), ["yellow"])
             self.assertIsInstance(
                 result["mondrian"]["yellow"],
                 base_provider.BlobSequenceTimeSeries,
@@ -457,8 +457,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
                 plugin_name=image_metadata.PLUGIN_NAME,
                 downsample=4,
             )
-            self.assertItemsEqual(result.keys(), ["mondrian"])
-            self.assertItemsEqual(
+            self.assertCountEqual(result.keys(), ["mondrian"])
+            self.assertCountEqual(
                 result["mondrian"].keys(), ["red", "blue", "yellow"]
             )
             sample = result["mondrian"]["blue"]
@@ -495,8 +495,8 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
                 ),
                 downsample=1,
             )
-            self.assertItemsEqual(result.keys(), ["mondrian"])
-            self.assertItemsEqual(result["mondrian"].keys(), ["yellow"])
+            self.assertCountEqual(result.keys(), ["mondrian"])
+            self.assertCountEqual(result["mondrian"].keys(), ["yellow"])
             self.assertIsInstance(
                 result["mondrian"]["yellow"][0],
                 base_provider.BlobSequenceDatum,

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -187,12 +187,12 @@ class EventAccumulatorTest(tf.test.TestCase):
         # Verifies that there are no unexpected keys in the actual response.
         # If this line fails, likely you added a new tag type, and need to update
         # the empty_tags dictionary above.
-        self.assertItemsEqual(actual.keys(), empty_tags.keys())
+        self.assertCountEqual(actual.keys(), empty_tags.keys())
 
         for key in actual:
             expected_value = expected.get(key, empty_tags[key])
             if isinstance(expected_value, list):
-                self.assertItemsEqual(actual[key], expected_value)
+                self.assertCountEqual(actual[key], expected_value)
             else:
                 self.assertEqual(actual[key], expected_value)
 

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -139,7 +139,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         x = event_multiplexer.EventMultiplexer(
             {"run1": "path1", "run2": "path2"}
         )
-        self.assertItemsEqual(sorted(x.Runs().keys()), ["run1", "run2"])
+        self.assertCountEqual(sorted(x.Runs().keys()), ["run1", "run2"])
         self.assertEqual(x.GetAccumulator("run1")._path, "path1")
         self.assertEqual(x.GetAccumulator("run2")._path, "path2")
 
@@ -206,7 +206,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         x = event_multiplexer.EventMultiplexer(
             {"run1": "path1", "run2": "path2"}
         )
-        self.assertItemsEqual(x.Runs(), ["run1", "run2"])
+        self.assertCountEqual(x.Runs(), ["run1", "run2"])
         self.assertEqual(x.GetAccumulator("run1")._path, "path1")
         self.assertEqual(x.GetAccumulator("run2")._path, "path2")
 
@@ -241,14 +241,14 @@ class EventMultiplexerTest(tf.test.TestCase):
 
         _AddEvents(path1)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), ["path1"], "loaded run: path1")
+        self.assertCountEqual(x.Runs(), ["path1"], "loaded run: path1")
         loader1 = x.GetAccumulator("path1")
         self.assertEqual(loader1._path, path1, "has the correct path")
 
         path2 = join(realdir, "path2")
         _AddEvents(path2)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), ["path1", "path2"])
+        self.assertCountEqual(x.Runs(), ["path1", "path2"])
         self.assertEqual(
             x.GetAccumulator("path1"), loader1, "loader1 not regenerated"
         )
@@ -256,7 +256,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         path2_2 = join(path2, "path2")
         _AddEvents(path2_2)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), ["path1", "path2", "path2/path2"])
+        self.assertCountEqual(x.Runs(), ["path1", "path2", "path2/path2"])
         self.assertEqual(
             x.GetAccumulator("path2/path2")._path,
             path2_2,
@@ -275,12 +275,12 @@ class EventMultiplexerTest(tf.test.TestCase):
 
         _AddEvents(realdir)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), ["."])
+        self.assertCountEqual(x.Runs(), ["."])
 
         subdir = join(realdir, "subdir")
         _AddEvents(subdir)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), [".", "subdir"])
+        self.assertCountEqual(x.Runs(), [".", "subdir"])
 
     def testAddRunsFromDirectoryWithRunNames(self):
         x = event_multiplexer.EventMultiplexer()
@@ -294,12 +294,12 @@ class EventMultiplexerTest(tf.test.TestCase):
 
         _AddEvents(realdir)
         x.AddRunsFromDirectory(realdir, "foo")
-        self.assertItemsEqual(x.Runs(), ["foo/."])
+        self.assertCountEqual(x.Runs(), ["foo/."])
 
         subdir = join(realdir, "subdir")
         _AddEvents(subdir)
         x.AddRunsFromDirectory(realdir, "foo")
-        self.assertItemsEqual(x.Runs(), ["foo/.", "foo/subdir"])
+        self.assertCountEqual(x.Runs(), ["foo/.", "foo/subdir"])
 
     def testAddRunsFromDirectoryWalksTree(self):
         x = event_multiplexer.EventMultiplexer()
@@ -318,7 +318,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         _AddEvents(sub1_1)
         x.AddRunsFromDirectory(realdir)
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             x.Runs(),
             [".", "subdirectory/1", "subdirectory/2", "subdirectory/1/1"],
         )
@@ -347,7 +347,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         self.assertNotEqual(run1, new_run1)
 
         x.AddRun("runName3")
-        self.assertItemsEqual(sorted(x.Runs().keys()), ["run1", "runName3"])
+        self.assertCountEqual(sorted(x.Runs().keys()), ["run1", "runName3"])
         self.assertEqual(x.GetAccumulator("runName3")._path, "runName3")
 
     def testAddRunMaintainsLoading(self):

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -93,7 +93,7 @@ class IoWrapperTest(tf.test.TestCase):
             "model.ckpt",
             "waldo",
         )
-        self.assertItemsEqual(
+        self.assertCountEqual(
             (os.path.join(temp_dir, f) for f in expected_files),
             io_wrapper.ListDirectoryAbsolute(temp_dir),
         )
@@ -317,7 +317,7 @@ class IoWrapperTest(tf.test.TestCase):
             "quuz/garply/grault",
             "waldo/fred",
         ]
-        self.assertItemsEqual(
+        self.assertCountEqual(
             [
                 (os.path.join(temp_dir, subdir) if subdir else temp_dir)
                 for subdir in expected
@@ -389,7 +389,7 @@ class IoWrapperTest(tf.test.TestCase):
         gotten_directory_to_listing = {
             result[0]: list(result[1]) for result in gotten
         }
-        self.assertItemsEqual(
+        self.assertCountEqual(
             expected_directory_to_listing.keys(),
             gotten_directory_to_listing.keys(),
         )
@@ -399,7 +399,7 @@ class IoWrapperTest(tf.test.TestCase):
             expected_listing,
         ) in expected_directory_to_listing.items():
             gotten_listing = gotten_directory_to_listing[subdirectory]
-            self.assertItemsEqual(
+            self.assertCountEqual(
                 expected_listing,
                 gotten_listing,
                 "Files for subdirectory %r must match. Expected %r. Got %r."

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -122,12 +122,12 @@ class EventAccumulatorTest(tf.test.TestCase):
         # Verifies that there are no unexpected keys in the actual response.
         # If this line fails, likely you added a new tag type, and need to update
         # the empty_tags dictionary above.
-        self.assertItemsEqual(actual.keys(), empty_tags.keys())
+        self.assertCountEqual(actual.keys(), empty_tags.keys())
 
         for key in actual:
             expected_value = expected.get(key, empty_tags[key])
             if isinstance(expected_value, list):
-                self.assertItemsEqual(actual[key], expected_value)
+                self.assertCountEqual(actual[key], expected_value)
             else:
                 self.assertEqual(actual[key], expected_value)
 
@@ -470,7 +470,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
             },
         )
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             accumulator.ActivePlugins(),
             [scalar_metadata.PLUGIN_NAME, graph_metadata.PLUGIN_NAME],
         )
@@ -519,7 +519,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
             },
         )
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             accumulator.ActivePlugins(),
             [audio_metadata.PLUGIN_NAME, graph_metadata.PLUGIN_NAME],
         )
@@ -566,7 +566,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
             },
         )
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             accumulator.ActivePlugins(),
             [image_metadata.PLUGIN_NAME, graph_metadata.PLUGIN_NAME],
         )
@@ -607,7 +607,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         self.assertTrue(np.array_equal(vector, [1.0, 2.0, 3.0]))
         self.assertTrue(np.array_equal(string, b"foobar"))
 
-        self.assertItemsEqual(accumulator.ActivePlugins(), [])
+        self.assertCountEqual(accumulator.ActivePlugins(), [])
 
     def _testTFSummaryTensor_SizeGuidance(
         self, plugin_name, tensor_size_guidance, steps, expected_count
@@ -936,7 +936,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         )
         with self.assertRaisesRegex(KeyError, "plug"):
             acc.PluginTagToContent("plug")
-        self.assertItemsEqual(acc.ActivePlugins(), ["outlet"])
+        self.assertCountEqual(acc.ActivePlugins(), ["outlet"])
 
 
 if __name__ == "__main__":

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
@@ -126,7 +126,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         x = event_multiplexer.EventMultiplexer(
             {"run1": "path1", "run2": "path2"}
         )
-        self.assertItemsEqual(sorted(x.Runs().keys()), ["run1", "run2"])
+        self.assertCountEqual(sorted(x.Runs().keys()), ["run1", "run2"])
         self.assertEqual(x.GetAccumulator("run1")._path, "path1")
         self.assertEqual(x.GetAccumulator("run2")._path, "path2")
 
@@ -152,7 +152,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         x = event_multiplexer.EventMultiplexer(
             {"run1": "path1", "run2": "path2"}
         )
-        self.assertItemsEqual(
+        self.assertCountEqual(
             x.ActivePlugins(), ["path1_plugin", "path2_plugin"]
         )
 
@@ -190,7 +190,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         x = event_multiplexer.EventMultiplexer(
             {"run1": "path1", "run2": "path2"}
         )
-        self.assertItemsEqual(x.Runs(), ["run1", "run2"])
+        self.assertCountEqual(x.Runs(), ["run1", "run2"])
         self.assertEqual(x.GetAccumulator("run1")._path, "path1")
         self.assertEqual(x.GetAccumulator("run2")._path, "path2")
 
@@ -225,14 +225,14 @@ class EventMultiplexerTest(tf.test.TestCase):
 
         _AddEvents(path1)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), ["path1"], "loaded run: path1")
+        self.assertCountEqual(x.Runs(), ["path1"], "loaded run: path1")
         loader1 = x.GetAccumulator("path1")
         self.assertEqual(loader1._path, path1, "has the correct path")
 
         path2 = join(realdir, "path2")
         _AddEvents(path2)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), ["path1", "path2"])
+        self.assertCountEqual(x.Runs(), ["path1", "path2"])
         self.assertEqual(
             x.GetAccumulator("path1"), loader1, "loader1 not regenerated"
         )
@@ -240,7 +240,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         path2_2 = join(path2, "path2")
         _AddEvents(path2_2)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), ["path1", "path2", "path2/path2"])
+        self.assertCountEqual(x.Runs(), ["path1", "path2", "path2/path2"])
         self.assertEqual(
             x.GetAccumulator("path2/path2")._path,
             path2_2,
@@ -259,12 +259,12 @@ class EventMultiplexerTest(tf.test.TestCase):
 
         _AddEvents(realdir)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), ["."])
+        self.assertCountEqual(x.Runs(), ["."])
 
         subdir = join(realdir, "subdir")
         _AddEvents(subdir)
         x.AddRunsFromDirectory(realdir)
-        self.assertItemsEqual(x.Runs(), [".", "subdir"])
+        self.assertCountEqual(x.Runs(), [".", "subdir"])
 
     def testAddRunsFromDirectoryWithRunNames(self):
         x = event_multiplexer.EventMultiplexer()
@@ -278,12 +278,12 @@ class EventMultiplexerTest(tf.test.TestCase):
 
         _AddEvents(realdir)
         x.AddRunsFromDirectory(realdir, "foo")
-        self.assertItemsEqual(x.Runs(), ["foo/."])
+        self.assertCountEqual(x.Runs(), ["foo/."])
 
         subdir = join(realdir, "subdir")
         _AddEvents(subdir)
         x.AddRunsFromDirectory(realdir, "foo")
-        self.assertItemsEqual(x.Runs(), ["foo/.", "foo/subdir"])
+        self.assertCountEqual(x.Runs(), ["foo/.", "foo/subdir"])
 
     def testAddRunsFromDirectoryWalksTree(self):
         x = event_multiplexer.EventMultiplexer()
@@ -302,7 +302,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         _AddEvents(sub1_1)
         x.AddRunsFromDirectory(realdir)
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             x.Runs(),
             [".", "subdirectory/1", "subdirectory/2", "subdirectory/1/1"],
         )
@@ -331,7 +331,7 @@ class EventMultiplexerTest(tf.test.TestCase):
         self.assertNotEqual(run1, new_run1)
 
         x.AddRun("runName3")
-        self.assertItemsEqual(sorted(x.Runs().keys()), ["run1", "runName3"])
+        self.assertCountEqual(sorted(x.Runs().keys()), ["run1", "runName3"])
         self.assertEqual(x.GetAccumulator("runName3")._path, "runName3")
 
     def testAddRunMaintainsLoading(self):

--- a/tensorboard/backend/event_processing/reservoir_test.py
+++ b/tensorboard/backend/event_processing/reservoir_test.py
@@ -33,7 +33,7 @@ class ReservoirTest(tf.test.TestCase):
         r.AddItem("foo", 4)
         r.AddItem("bar", 9)
         r.AddItem("foo", 19)
-        self.assertItemsEqual(r.Keys(), ["foo", "bar"])
+        self.assertCountEqual(r.Keys(), ["foo", "bar"])
         self.assertEqual(r.Items("foo"), [4, 19])
         self.assertEqual(r.Items("bar"), [9])
 

--- a/tensorboard/compat/tensorflow_stub/io/gfile_tf_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_tf_test.py
@@ -127,7 +127,7 @@ class FileIoTest(tb_test.TestCase):
         subdir_file_path = os.path.join(subdir_path, "file4.txt")
         gfile.GFile(subdir_file_path, mode="w").write("testing")
         dir_list = gfile.listdir(dir_path)
-        self.assertItemsEqual(files + ["sub_dir"], dir_list)
+        self.assertCountEqual(files + ["sub_dir"], dir_list)
 
     def testListDirectoryFailure(self):
         dir_path = os.path.join(self._base_dir, "test_dir")
@@ -162,7 +162,7 @@ class FileIoTest(tb_test.TestCase):
             all_dirs.append(w_dir)
             all_subdirs.append(w_subdirs)
             all_files.append(w_files)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             all_dirs,
             [dir_path]
             + [
@@ -180,11 +180,11 @@ class FileIoTest(tb_test.TestCase):
             all_dirs.index(os.path.join(dir_path, "subdir1_2")),
             all_dirs.index(os.path.join(dir_path, "subdir1_2/subdir2")),
         )
-        self.assertItemsEqual(all_subdirs[1:5], [[], ["subdir2"], [], []])
-        self.assertItemsEqual(
+        self.assertCountEqual(all_subdirs[1:5], [[], ["subdir2"], [], []])
+        self.assertCountEqual(
             all_subdirs[0], ["subdir1_1", "subdir1_2", "subdir1_3"]
         )
-        self.assertItemsEqual(
+        self.assertCountEqual(
             all_files, [["file1.txt"], ["file2.txt"], [], [], []]
         )
         self.assertLess(
@@ -202,7 +202,7 @@ class FileIoTest(tb_test.TestCase):
             all_dirs.append(w_dir)
             all_subdirs.append(w_subdirs)
             all_files.append(w_files)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             all_dirs,
             [
                 os.path.join(dir_path, item)
@@ -220,11 +220,11 @@ class FileIoTest(tb_test.TestCase):
             all_dirs.index(os.path.join(dir_path, "subdir1_2/subdir2")),
             all_dirs.index(os.path.join(dir_path, "subdir1_2")),
         )
-        self.assertItemsEqual(all_subdirs[0:4], [[], [], ["subdir2"], []])
-        self.assertItemsEqual(
+        self.assertCountEqual(all_subdirs[0:4], [[], [], ["subdir2"], []])
+        self.assertCountEqual(
             all_subdirs[4], ["subdir1_1", "subdir1_2", "subdir1_3"]
         )
-        self.assertItemsEqual(
+        self.assertCountEqual(
             all_files, [["file2.txt"], [], [], [], ["file1.txt"]]
         )
         self.assertLess(
@@ -241,9 +241,9 @@ class FileIoTest(tb_test.TestCase):
             all_dirs.append(w_dir)
             all_subdirs.append(w_subdirs)
             all_files.append(w_files)
-        self.assertItemsEqual(all_dirs, [])
-        self.assertItemsEqual(all_subdirs, [])
-        self.assertItemsEqual(all_files, [])
+        self.assertCountEqual(all_dirs, [])
+        self.assertCountEqual(all_subdirs, [])
+        self.assertCountEqual(all_files, [])
 
     def testStat(self):
         file_path = os.path.join(self._base_dir, "temp_file")

--- a/tensorboard/manager_e2e_test.py
+++ b/tensorboard/manager_e2e_test.py
@@ -167,7 +167,7 @@ class ManagerEndToEndTest(tf.test.TestCase):
         self.assertNotEqual(r1.info.port, r2.info.port)
         self.assertNotEqual(r1.info.pid, r2.info.pid)
         infos = manager.get_all()
-        self.assertItemsEqual(infos, [r1.info, r2.info])
+        self.assertCountEqual(infos, [r1.info, r2.info])
         self._assert_live(r1.info, expected_logdir="./logs")
         self._assert_live(r2.info, expected_logdir="./adders")
 
@@ -186,7 +186,7 @@ class ManagerEndToEndTest(tf.test.TestCase):
         self.assertIsInstance(r2, manager.StartLaunched)  # (picked a new port)
         self.assertEqual(r1.info.cache_key, r2.info.cache_key)
         infos = manager.get_all()
-        self.assertItemsEqual(infos, [r2.info])
+        self.assertCountEqual(infos, [r2.info])
         self._assert_live(r1.info, expected_logdir="./logs")
         self._assert_live(r2.info, expected_logdir="./logs")
 

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -360,19 +360,19 @@ class TensorBoardInfoIoTest(tb_test.TestCase):
             with mock.patch("os.getpid", lambda: 76540 + i):
                 manager.remove_info_file()
 
-        self.assertItemsEqual(manager.get_all(), [])
+        self.assertCountEqual(manager.get_all(), [])
         add_info(1)
-        self.assertItemsEqual(manager.get_all(), [_make_info(1)])
+        self.assertCountEqual(manager.get_all(), [_make_info(1)])
         add_info(2)
-        self.assertItemsEqual(manager.get_all(), [_make_info(1), _make_info(2)])
+        self.assertCountEqual(manager.get_all(), [_make_info(1), _make_info(2)])
         remove_info(1)
-        self.assertItemsEqual(manager.get_all(), [_make_info(2)])
+        self.assertCountEqual(manager.get_all(), [_make_info(2)])
         add_info(3)
-        self.assertItemsEqual(manager.get_all(), [_make_info(2), _make_info(3)])
+        self.assertCountEqual(manager.get_all(), [_make_info(2), _make_info(3)])
         remove_info(3)
-        self.assertItemsEqual(manager.get_all(), [_make_info(2)])
+        self.assertCountEqual(manager.get_all(), [_make_info(2)])
         remove_info(2)
-        self.assertItemsEqual(manager.get_all(), [])
+        self.assertCountEqual(manager.get_all(), [])
 
     def test_get_all_ignores_bad_files(self):
         with open(os.path.join(self.info_dir, "pid-1234.info"), "w") as outfile:

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -220,7 +220,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
         ctx = context.RequestContext()
         body = self.plugin.scalars_impl(ctx, "bar", "increments", "exp_id")
         self.assertTrue(body["regex_valid"])
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ["increments/scalar_summary"], list(body["tag_to_events"].keys())
         )
         data = body["tag_to_events"]["increments/scalar_summary"]

--- a/tensorboard/plugins/hparams/_keras_test.py
+++ b/tensorboard/plugins/hparams/_keras_test.py
@@ -99,7 +99,7 @@ class CallbackTest(tf.test.TestCase):
         end_pb.end_time_secs = 6789.0
 
         expected_start_pb = plugin_data_pb2.SessionStartInfo()
-        text_format.Merge(
+        text_format.Parse(
             """
             start_time_secs: 1234.5
             group_name: "my_trial"
@@ -121,7 +121,7 @@ class CallbackTest(tf.test.TestCase):
         self.assertEqual(start_pb, expected_start_pb)
 
         expected_end_pb = plugin_data_pb2.SessionEndInfo()
-        text_format.Merge(
+        text_format.Parse(
             """
             end_time_secs: 6789.0
             status: STATUS_SUCCESS

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -154,14 +154,14 @@ class ImagesPluginTest(tf.test.TestCase):
         entry = entries[0]
         self.assertEqual(0, entry["step"])
         parsed_query_1 = urllib.parse.parse_qs(entry["query"])
-        self.assertItemsEqual(["blob_key"], parsed_query_1)
+        self.assertCountEqual(["blob_key"], parsed_query_1)
         self.assertTrue(parsed_query_1["blob_key"])
 
         # Verify that the 2nd entry is correct.
         entry = entries[1]
         self.assertEqual(1, entry["step"])
         parsed_query_2 = urllib.parse.parse_qs(entry["query"])
-        self.assertItemsEqual(["blob_key"], parsed_query_2)
+        self.assertCountEqual(["blob_key"], parsed_query_2)
         self.assertTrue(parsed_query_2["blob_key"])
 
         self.assertNotEqual(parsed_query_1, parsed_query_2)
@@ -181,14 +181,14 @@ class ImagesPluginTest(tf.test.TestCase):
         entry = entries[0]
         self.assertEqual(0, entry["step"])
         parsed_query_1 = urllib.parse.parse_qs(entry["query"])
-        self.assertItemsEqual(["blob_key"], parsed_query_1)
+        self.assertCountEqual(["blob_key"], parsed_query_1)
         self.assertTrue(parsed_query_1["blob_key"])
 
         # Verify that the 2nd entry is correct.
         entry = entries[1]
         self.assertEqual(1, entry["step"])
         parsed_query_2 = urllib.parse.parse_qs(entry["query"])
-        self.assertItemsEqual(["blob_key"], parsed_query_2)
+        self.assertCountEqual(["blob_key"], parsed_query_2)
         self.assertTrue(parsed_query_2["blob_key"])
 
         self.assertNotEqual(parsed_query_1, parsed_query_2)

--- a/tensorboard/plugins/npmi/npmi_plugin_test.py
+++ b/tensorboard/plugins/npmi/npmi_plugin_test.py
@@ -127,9 +127,9 @@ class NpmiPluginTest(tf.test.TestCase):
             "_npmi_/values",
             "_npmi_/embeddings",
         ]
-        self.assertItemsEqual(gt_runs, tags.keys())
-        self.assertItemsEqual(gt_tags, tags["run_1"])
-        self.assertItemsEqual(gt_tags, tags["run_2"])
+        self.assertCountEqual(gt_runs, tags.keys())
+        self.assertCountEqual(gt_tags, tags["run_1"])
+        self.assertCountEqual(gt_tags, tags["run_2"])
 
     def testAnnotations(self):
         plugin = self.create_plugin()
@@ -137,8 +137,8 @@ class NpmiPluginTest(tf.test.TestCase):
             context.RequestContext(),
             experiment="exp",
         )
-        self.assertItemsEqual(["name_1", "name_2"], annotations["run_1"])
-        self.assertItemsEqual(["name_1", "name_2"], annotations["run_2"])
+        self.assertCountEqual(["name_1", "name_2"], annotations["run_1"])
+        self.assertCountEqual(["name_1", "name_2"], annotations["run_2"])
 
     def testMetrics(self):
         plugin = self.create_plugin()
@@ -146,26 +146,26 @@ class NpmiPluginTest(tf.test.TestCase):
             context.RequestContext(),
             experiment="exp",
         )
-        self.assertItemsEqual(["A", "B"], metrics["run_1"])
-        self.assertItemsEqual(["A", "B"], metrics["run_2"])
+        self.assertCountEqual(["A", "B"], metrics["run_1"])
+        self.assertCountEqual(["A", "B"], metrics["run_2"])
 
     def testValues(self):
         plugin = self.create_plugin()
         values = plugin.values_impl(context.RequestContext(), experiment="exp")
-        self.assertItemsEqual([1.0, -1.0], values["run_1"][0])
-        self.assertItemsEqual([0.5, -0.5], values["run_1"][1])
-        self.assertItemsEqual([1.0, -1.0], values["run_2"][0])
-        self.assertItemsEqual([-0.5, None], values["run_2"][1])
+        self.assertCountEqual([1.0, -1.0], values["run_1"][0])
+        self.assertCountEqual([0.5, -0.5], values["run_1"][1])
+        self.assertCountEqual([1.0, -1.0], values["run_2"][0])
+        self.assertCountEqual([-0.5, None], values["run_2"][1])
 
     def testEmbeddings(self):
         plugin = self.create_plugin()
         embeddings = plugin.embeddings_impl(
             context.RequestContext(), experiment="exp"
         )
-        self.assertItemsEqual([1.0, 0.5], embeddings["run_1"][0])
-        self.assertItemsEqual([-0.5, 0.5], embeddings["run_1"][1])
-        self.assertItemsEqual([1.0, 0.5], embeddings["run_2"][0])
-        self.assertItemsEqual([-0.5, 0.5], embeddings["run_2"][1])
+        self.assertCountEqual([1.0, 0.5], embeddings["run_1"][0])
+        self.assertCountEqual([-0.5, 0.5], embeddings["run_1"][1])
+        self.assertCountEqual([1.0, 0.5], embeddings["run_2"][0])
+        self.assertCountEqual([-0.5, 0.5], embeddings["run_2"][1])
 
     def testIsActiveReturnsFalse(self):
         """The plugin should always return false because this is now handled

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -128,17 +128,17 @@ class PrCurvesPluginTest(tf.test.TestCase):
         tags_response = self.plugin.tags_impl(context.RequestContext(), "123")
 
         # Assert that the runs are right.
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ["colors", "mask_every_other_prediction"],
             list(tags_response.keys()),
         )
 
         # Assert that the tags for each run are correct.
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ["red/pr_curves", "green/pr_curves", "blue/pr_curves"],
             list(tags_response["colors"].keys()),
         )
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ["red/pr_curves", "green/pr_curves", "blue/pr_curves"],
             list(tags_response["mask_every_other_prediction"].keys()),
         )
@@ -198,7 +198,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
         )
 
         # Assert that the runs are correct.
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ["colors", "mask_every_other_prediction"],
             list(pr_curves_response.keys()),
         )

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -182,7 +182,7 @@ def _latest_checkpoints_changed(configs, run_path_pairs):
             if tf.io.gfile.exists(config_fpath):
                 with tf.io.gfile.GFile(config_fpath, "r") as f:
                     file_content = f.read()
-                text_format.Merge(file_content, config)
+                text_format.Parse(file_content, config)
         else:
             config = configs[run_name]
 
@@ -441,7 +441,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
             if tf.io.gfile.exists(config_fpath):
                 with tf.io.gfile.GFile(config_fpath, "r") as f:
                     file_content = f.read()
-                text_format.Merge(file_content, config)
+                text_format.Parse(file_content, config)
             has_tensor_files = False
             for embedding in config.embeddings:
                 if embedding.tensor_path:

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -104,7 +104,7 @@ class ProjectorAppTest(tf.test.TestCase):
         self._SetupWSGIApp()
 
         info_json = self._GetJson("/data/plugin/projector/info?run=.")
-        self.assertItemsEqual(
+        self.assertCountEqual(
             info_json["embeddings"],
             [
                 {
@@ -128,7 +128,7 @@ class ProjectorAppTest(tf.test.TestCase):
         self.assertTrue(run_json)
         run = run_json[0]
         info_json = self._GetJson("/data/plugin/projector/info?run=%s" % run)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             info_json["embeddings"],
             [
                 {

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -95,9 +95,9 @@ class TextPluginTest(tf.test.TestCase):
     def testIndex(self):
         plugin = self.load_plugin()
         index = plugin.index_impl(context.RequestContext(), experiment="123")
-        self.assertItemsEqual(["fry", "leela"], index.keys())
-        self.assertItemsEqual(["message", "vector"], index["fry"])
-        self.assertItemsEqual(["message", "vector"], index["leela"])
+        self.assertCountEqual(["fry", "leela"], index.keys())
+        self.assertCountEqual(["message", "vector"], index["fry"])
+        self.assertCountEqual(["message", "vector"], index["leela"])
 
     def testText(self):
         plugin = self.load_plugin()
@@ -430,9 +430,9 @@ class TextPluginTest(tf.test.TestCase):
         run_to_tags = plugin.index_impl(
             context.RequestContext(), experiment="123"
         )
-        self.assertItemsEqual(["fry", "leela"], run_to_tags.keys())
-        self.assertItemsEqual(["message", "vector"], run_to_tags["fry"])
-        self.assertItemsEqual(["message", "vector"], run_to_tags["leela"])
+        self.assertCountEqual(["fry", "leela"], run_to_tags.keys())
+        self.assertCountEqual(["message", "vector"], run_to_tags["fry"])
+        self.assertCountEqual(["message", "vector"], run_to_tags["leela"])
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/text_v2/text_v2_plugin_test.py
+++ b/tensorboard/plugins/text_v2/text_v2_plugin_test.py
@@ -94,9 +94,9 @@ class TextPluginTest(tf.test.TestCase):
     def testIndex(self):
         plugin = self.create_plugin()
         index = plugin.index_impl(context.RequestContext(), experiment="123")
-        self.assertItemsEqual(["fry", "leela"], index.keys())
-        self.assertItemsEqual(["message", "vector"], index["fry"])
-        self.assertItemsEqual(["message", "vector"], index["leela"])
+        self.assertCountEqual(["fry", "leela"], index.keys())
+        self.assertCountEqual(["message", "vector"], index["fry"])
+        self.assertCountEqual(["message", "vector"], index["leela"])
 
     def testText(self):
         plugin = self.create_plugin()

--- a/tensorboard/uploader/util.py
+++ b/tensorboard/uploader/util.py
@@ -174,7 +174,7 @@ def format_time_absolute(timestamp_pb):
     Returns:
       An RFC 3339 date-time string.
     """
-    dt = datetime.datetime.utcfromtimestamp(
+    dt = datetime.datetime.fromtimestamp(
         timestamp_pb.seconds, tz=datetime.timezone.utc
     )
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tensorboard/uploader/util.py
+++ b/tensorboard/uploader/util.py
@@ -174,7 +174,9 @@ def format_time_absolute(timestamp_pb):
     Returns:
       An RFC 3339 date-time string.
     """
-    dt = datetime.datetime.utcfromtimestamp(timestamp_pb.seconds)
+    dt = datetime.datetime.utcfromtimestamp(
+        timestamp_pb.seconds, tz=datetime.timezone.utc
+    )
     return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 

--- a/tensorboard/util/tensor_util.py
+++ b/tensorboard/util/tensor_util.py
@@ -577,9 +577,7 @@ def make_ndarray(tensor):
                 np.array(tensor.string_val[0], dtype=dtype), num_elements
             ).reshape(shape)
         else:
-            return np.array(
-                [x for x in tensor.string_val], dtype=dtype
-            ).reshape(shape)
+            return np.array(list(tensor.string_val), dtype=dtype).reshape(shape)
     elif tensor_dtype == dtypes.complex64:
         it = iter(tensor.scomplex_val)
         if len(tensor.scomplex_val) == 2:


### PR DESCRIPTION
This PR
  - replaces deprecated alias `assertItemsEqual` with `assertCountEqual`: 
    - `sed -i 's/assertItemsEqual/assertCountEqual/g' tensorboard/**/*.py`
  - replaces `text_format.Merge` with its non-lossy version `text_format.Parse`
  - uses `fromtimestamp` with UTC timezone
    - `utcfromtimestamp()` returns a timezone-naive UTC datetime, which is bug-prone: [https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp](https://www.google.com/url?sa=D&q=https%3A%2F%2Fdocs.python.org%2F3%2Flibrary%2Fdatetime.html%23datetime.datetime.utcfromtimestamp)
  - uses list comprehension

Googlers, see the linting suggestions in cl/499227915.

#oncall
