### PR TITLE
re enable tests which were temporarily disabled

### DIFF
--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -793,12 +793,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
 
     def testServeGraphExecutionDigestsPartialRange(self):
-        self.skipTest(
-            "Temporarily disabled while internal Tensorflow "
-            "changes are made. Googlers see b/264288347. This "
-            "should be reenabled after the changes make it into "
-            "tf-nightly"
-        )
         _generate_tfdbg_v2_data(self.logdir)
         run = self._getExactlyOneRun()
         response = self.server.get(
@@ -848,12 +842,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertTrue(digests[3]["graph_id"])
 
     def testServeGraphExecutionDigestsImplicitFullRange(self):
-        self.skipTest(
-            "Temporarily disabled while internal Tensorflow "
-            "changes are made. Googlers see b/264288347. This "
-            "should be reenabled after the changes make it into "
-            "tf-nightly"
-        )
         _generate_tfdbg_v2_data(self.logdir)
         run = self._getExactlyOneRun()
         response = self.server.get(
@@ -878,12 +866,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertTrue(digests[-1]["graph_id"])
 
     def testServeGraphExecutionDigestOutOfBoundsError(self):
-        self.skipTest(
-            "Temporarily disabled while internal Tensorflow "
-            "changes are made. Googlers see b/264288347. This "
-            "should be reenabled after the changes make it into "
-            "tf-nightly"
-        )
         _generate_tfdbg_v2_data(self.logdir)
         run = self._getExactlyOneRun()
 
@@ -933,12 +915,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
 
     def testServeASingleGraphExecutionDataObject(self):
-        self.skipTest(
-            "Temporarily disabled while internal Tensorflow "
-            "changes are made. Googlers see b/264288347. This "
-            "should be reenabled after the changes make it into "
-            "tf-nightly"
-        )
         _generate_tfdbg_v2_data(self.logdir, tensor_debug_mode="CONCISE_HEALTH")
         run = self._getExactlyOneRun()
         response = self.server.get(
@@ -965,12 +941,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEndsWith(graph_exec["device_name"], _DEFAULT_DEVICE_SUFFIX)
 
     def testServeMultipleGraphExecutionDataObjects(self):
-        self.skipTest(
-            "Temporarily disabled while internal Tensorflow "
-            "changes are made. Googlers see b/264288347. This "
-            "should be reenabled after the changes make it into "
-            "tf-nightly"
-        )
         _generate_tfdbg_v2_data(self.logdir, tensor_debug_mode="CONCISE_HEALTH")
         run = self._getExactlyOneRun()
         response = self.server.get(
@@ -1022,12 +992,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEndsWith(graph_exec["device_name"], _DEFAULT_DEVICE_SUFFIX)
 
     def testServeGraphExecutionDataObjectsOutOfBoundsError(self):
-        self.skipTest(
-            "Temporarily disabled while internal Tensorflow "
-            "changes are made. Googlers see b/264288347. This "
-            "should be reenabled after the changes make it into "
-            "tf-nightly"
-        )
         _generate_tfdbg_v2_data(self.logdir)
         run = self._getExactlyOneRun()
 
@@ -1314,12 +1278,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
 
     def testServeGraphOpInfoForOpWithNoInputs(self):
         """Get the op info of an op with no inputs."""
-        self.skipTest(
-            "Temporarily disabled while internal Tensorflow "
-            "changes are made. Googlers see b/264288347. This "
-            "should be reenabled after the changes make it into "
-            "tf-nightly"
-        )
         _generate_tfdbg_v2_data(self.logdir)
         run = self._getExactlyOneRun()
         response = self.server.get(


### PR DESCRIPTION
* Motivation for features / changes
These tests were disable to allow for a change in the tensorflow code this relies on. We are now re-enabling them.

Googlers, see b/264288347.