### PR TITLE
Revert "fix: update debugger v2 test"

### DIFF
--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -812,11 +812,11 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         data = json.loads(response.get_data())
         self.assertEqual(data["begin"], 0)
         self.assertEqual(data["end"], 4)
-        self.assertEqual(data["num_digests"], 207)
+        self.assertEqual(data["num_digests"], 219)
         digests = data["graph_execution_digests"]
         self.assertLen(digests, 4)
         self.assertGreater(digests[0]["wall_time"], 0)
-        self.assertEqual(digests[0]["op_type"], "Const")
+        self.assertEqual(digests[0]["op_type"], "Placeholder")
         self.assertEqual(digests[0]["output_slot"], 0)
         self.assertTrue(digests[0]["op_name"])
         self.assertTrue(digests[0]["graph_id"])
@@ -824,7 +824,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertGreaterEqual(
             digests[1]["wall_time"], digests[0]["wall_time"]
         )
-        self.assertEqual(digests[1]["op_type"], "Unpack")
+        self.assertEqual(digests[1]["op_type"], "Const")
         self.assertEqual(digests[1]["output_slot"], 0)
         self.assertTrue(digests[1]["op_name"])
         self.assertNotEqual(digests[1]["op_name"], digests[0]["op_name"])
@@ -833,8 +833,8 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertGreaterEqual(
             digests[2]["wall_time"], digests[1]["wall_time"]
         )
-        self.assertEqual(digests[2]["op_type"], "Unpack")
-        self.assertEqual(digests[2]["output_slot"], 1)
+        self.assertEqual(digests[2]["op_type"], "Placeholder")
+        self.assertEqual(digests[2]["output_slot"], 0)
         self.assertTrue(digests[2]["op_name"])
         self.assertTrue(digests[2]["graph_id"])
 
@@ -843,7 +843,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
         # The unstack() function uses the Unpack op under the hood.
         self.assertEqual(digests[3]["op_type"], "Unpack")
-        self.assertEqual(digests[3]["output_slot"], 2)
+        self.assertEqual(digests[3]["output_slot"], 0)
         self.assertTrue(digests[3]["op_name"])
         self.assertTrue(digests[3]["graph_id"])
 
@@ -865,10 +865,10 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
         data = json.loads(response.get_data())
         self.assertEqual(data["begin"], 0)
-        self.assertEqual(data["end"], 207)
-        self.assertEqual(data["num_digests"], 207)
+        self.assertEqual(data["end"], 219)
+        self.assertEqual(data["num_digests"], 219)
         digests = data["graph_execution_digests"]
-        self.assertLen(digests, 207)
+        self.assertLen(digests, 219)
         self.assertGreater(digests[-1]["wall_time"], 0)
         # Due to the while loop in the tf.function, the last op executed
         # is a Less op.
@@ -898,7 +898,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
         self.assertEqual(
             json.loads(response.get_data()),
-            {"error": "Invalid argument: end index (300) out of bounds (207)"},
+            {"error": "Invalid argument: end index (300) out of bounds (219)"},
         )
 
         # begin = -1; end = 2
@@ -953,6 +953,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(data["end"], 1)
         self.assertLen(data["graph_executions"], 1)
         graph_exec = data["graph_executions"][0]
+        self.assertStartsWith(graph_exec["op_type"], "Placeholder")
         self.assertTrue(graph_exec["op_name"])
         self.assertEqual(graph_exec["output_slot"], 0)
         self.assertTrue(graph_exec["graph_id"])
@@ -960,7 +961,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(graph_exec["graph_ids"][-1], graph_exec["graph_id"])
         # [tensor_id, element_count, nan_count, neg_inf_count, pos_inf_count].
         self.assertEqual(
-            graph_exec["debug_tensor_value"], [4.0, 1.0, 0.0, 0.0, 0.0]
+            graph_exec["debug_tensor_value"], [1.0, 4.0, 0.0, 0.0, 0.0]
         )
         self.assertEndsWith(graph_exec["device_name"], _DEFAULT_DEVICE_SUFFIX)
 
@@ -986,6 +987,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertLen(data["graph_executions"], 3)
 
         graph_exec = data["graph_executions"][0]
+        self.assertStartsWith(graph_exec["op_type"], "Placeholder")
         self.assertTrue(graph_exec["op_name"])
         self.assertEqual(graph_exec["output_slot"], 0)
         self.assertTrue(graph_exec["graph_id"])
@@ -993,18 +995,19 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(graph_exec["graph_ids"][-1], graph_exec["graph_id"])
         # [tensor_id, element_count, nan_count, neg_inf_count, pos_inf_count].
         self.assertEqual(
-            graph_exec["debug_tensor_value"], [4.0, 1.0, 0.0, 0.0, 0.0]
+            graph_exec["debug_tensor_value"], [1.0, 4.0, 0.0, 0.0, 0.0]
         )
         self.assertEndsWith(graph_exec["device_name"], _DEFAULT_DEVICE_SUFFIX)
 
         graph_exec = data["graph_executions"][1]
+        self.assertStartsWith(graph_exec["op_type"], "Placeholder")
         self.assertTrue(graph_exec["op_name"])
-        self.assertEqual(graph_exec["output_slot"], 1)
+        self.assertEqual(graph_exec["output_slot"], 0)
         self.assertTrue(graph_exec["graph_id"])
         self.assertGreaterEqual(len(graph_exec["graph_ids"]), 1)
         self.assertEqual(graph_exec["graph_ids"][-1], graph_exec["graph_id"])
         self.assertEqual(
-            graph_exec["debug_tensor_value"], [5.0, 1.0, 0.0, 0.0, 0.0]
+            graph_exec["debug_tensor_value"], [3.0, 4.0, 0.0, 0.0, 0.0]
         )
         self.assertEndsWith(graph_exec["device_name"], _DEFAULT_DEVICE_SUFFIX)
 
@@ -1012,12 +1015,12 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         # The unstack() function uses the Unpack op under the hood.
         self.assertStartsWith(graph_exec["op_type"], "Unpack")
         self.assertTrue(graph_exec["op_name"])
-        self.assertEqual(graph_exec["output_slot"], 2)
+        self.assertEqual(graph_exec["output_slot"], 0)
         self.assertTrue(graph_exec["graph_id"])
         self.assertGreaterEqual(len(graph_exec["graph_ids"]), 1)
         self.assertEqual(graph_exec["graph_ids"][-1], graph_exec["graph_id"])
         self.assertEqual(
-            graph_exec["debug_tensor_value"], [6.0, 1.0, 0.0, 0.0, 0.0]
+            graph_exec["debug_tensor_value"], [4.0, 1.0, 0.0, 0.0, 0.0]
         )
         self.assertEndsWith(graph_exec["device_name"], _DEFAULT_DEVICE_SUFFIX)
 
@@ -1043,7 +1046,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
         self.assertEqual(
             json.loads(response.get_data()),
-            {"error": "Invalid argument: end index (220) out of bounds (207)"},
+            {"error": "Invalid argument: end index (220) out of bounds (219)"},
         )
 
         # begin = -1; end = 2
@@ -1322,6 +1325,8 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
         _generate_tfdbg_v2_data(self.logdir)
         run = self._getExactlyOneRun()
+        # First, look up the graph_id and name of the Placeholder op in the
+        # same graph as the Unstack op. This Placeholder op has no inputs.
         response = self.server.get(
             _ROUTE_PREFIX + "/graph_execution/digests?run=%s" % run
         )
@@ -1329,9 +1334,13 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         digests = data["graph_execution_digests"]
         op_types = [digest["op_type"] for digest in digests]
         graph_ids = [digest["graph_id"] for digest in digests]
-        placeholder_op_index = op_types.index("Placeholder")
+        unpack_op_index = op_types.index("Unpack")
+        unpack_op_name = digests[unpack_op_index]["op_name"]
+        graph_id = digests[unpack_op_index]["graph_id"]
+        placeholder_op_index = list(zip(graph_ids, op_types)).index(
+            (graph_id, "Placeholder")
+        )
         op_name = digests[placeholder_op_index]["op_name"]
-        graph_id = digests[placeholder_op_index]["graph_id"]
         # Actually query the /graphs/op_info route.
         response = self.server.get(
             _ROUTE_PREFIX
@@ -1360,7 +1369,12 @@ class DebuggerV2PluginTest(tf.test.TestCase):
 
         # Check consumers.
         self.assertLen(data["consumers"], 1)
-        self.assertEmpty(data["consumers"][0])
+        self.assertLen(data["consumers"][0], 1)
+        self.assertEqual(data["consumers"][0][0]["op_name"], unpack_op_name)
+        self.assertEqual(data["consumers"][0][0]["input_slot"], 0)
+        consumer = data["consumers"][0][0]["data"]
+        self.assertEqual(consumer["op_type"], "Unpack")
+        self.assertEqual(consumer["op_name"], unpack_op_name)
 
     def testServeGraphOpInfoWithInputsAndConsumerLookupFailures(self):
         """Get the op info of an op with both inputs and consumers."""


### PR DESCRIPTION
Reverts tensorflow/tensorboard#6126. 

Confirmed with @u7javed that these changes are no longer needed and is blocking https://github.com/tensorflow/tensorboard/pull/6128 (https://github.com/tensorflow/tensorboard/actions/runs/3840743814/jobs/6554763016).

Googlers, see internal test at cl/500203241.

#oncall