### PR TITLE
ci: `setup-python` - check latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
           architecture: 'x64'
+          check-latest: true
       - name: 'Set up Bazel'
         run: |
           ci/download_bazel.sh "${BAZEL_VERSION}" "${BAZEL_SHA256SUM}" ~/bazel
@@ -72,9 +73,7 @@ jobs:
             ;
       - name: 'Install TensorFlow'
         run: pip install "${TENSORFLOW_VERSION}"
-        if: matrix.tf_version_id != 'notf'
-        with:
-          check-latest: true
+        if: matrix.tf_version_id != 'notf'          
       - name: 'Install Python dependencies'
         run: |
           python -m pip install -U pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
             ;
       - name: 'Install TensorFlow'
         run: pip install "${TENSORFLOW_VERSION}"
-        if: matrix.tf_version_id != 'notf'          
+        if: matrix.tf_version_id != 'notf'
       - name: 'Install Python dependencies'
         run: |
           python -m pip install -U pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
       - name: 'Install TensorFlow'
         run: pip install "${TENSORFLOW_VERSION}"
         if: matrix.tf_version_id != 'notf'
+        with:
+          check-latest: true
       - name: 'Install Python dependencies'
         run: |
           python -m pip install -U pip


### PR DESCRIPTION
`actions/setup-python` (upgraded in https://github.com/tensorflow/tensorboard/pull/6122) now has built-in functionality for caching and restoring dependencies: https://github.com/actions/setup-python#caching-packages-dependencies

This is causing problems when run CI on a cached older version of `tf-nightly`: https://github.com/tensorflow/tensorboard/pull/6128#issuecomment-1374002257

#oncall
