### PR TITLE
Fixed AttributeError to get io from tf

### DIFF
--- a/tensorboard/summary/writer/event_file_writer.py
+++ b/tensorboard/summary/writer/event_file_writer.py
@@ -21,7 +21,7 @@ import socket
 import threading
 import time
 
-from tensorboard.compat import tf
+from tensorboard.compat import tensorflow_stub as tf
 from tensorboard.compat.proto import event_pb2
 from tensorboard.summary.writer.record_writer import RecordWriter
 


### PR DESCRIPTION
Fixed Error:
Line 72 and 86: AttributeError: module 'tensorflow' has no attribute 'io' 

since: 
    from tensorboard.compat import tf == tensorflow
    which gives AttributeError: module 'tensorflow' has no attribute 'io'
but we need: 
    from tensorboard.compat import tensorflow_stub as tf

now 'io' can be imported from tensorflow_stub