### PR TITLE
Updates references to numpy deprecated type aliases.

### DIFF
--- a/tensorboard/plugins/npmi/csv_to_plugin_data_demo.py
+++ b/tensorboard/plugins/npmi/csv_to_plugin_data_demo.py
@@ -70,7 +70,7 @@ def convert_file(file_path):
         for row in csv_reader:
             annotations.append(row[0])
             values.append(row[1:])
-        values = np.array(values).astype(np.float)
+        values = np.array(values).astype(float)
 
     writer = tf.summary.create_file_writer(os.path.dirname(file_path))
     with writer.as_default():

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -215,7 +215,7 @@ def pb(
 
     # Compute bins of true positives and false positives.
     bucket_indices = np.int32(np.floor(predictions * (num_thresholds - 1)))
-    float_labels = labels.astype(np.float)
+    float_labels = labels.astype(float)
     histogram_range = (0, num_thresholds - 1)
     tp_buckets, _ = np.histogram(
         bucket_indices,


### PR DESCRIPTION
Numpy library deprecated some type aliases in version 1.20.0 [1], and then removed them in version 1.24.0 [2], which was released on Dec 18, 2022.

Without this change, our build would be broken when using numpy version >= 1.24.0,
with error `AttributeError: module 'numpy' has no attribute 'float'`.

The fix suggested in release notes from numpy version 1.20.0 is to replace these types with the equivalent primitive python types. (In this case, simply `float`.)

[1] http://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated  
[2] http://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations

* Motivation for features / changes
Newer numpy versions break our build. This code is exactly equivalent, as the identifiers used previously were aliases for the same type.

* Technical description of changes
Replace occurrences of `np.float` for the primitive type `float`.

* Screenshots of UI changes
N/A

* Detailed steps to verify changes work correctly (as executed by you)
Ran tests.

* Alternate designs / implementations considered
N/A.