### PR TITLE
Fixes bug with the config passed to the "limited-input device" auth flow

### DIFF
--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -251,7 +251,9 @@ class _LimitedInputDeviceAuthFlow:
     """
 
     def __init__(self, client_config, scopes):
-        self._client_config = client_config
+        # The config is loaded from a json string from the GCP project, which
+        # comes with an "installed" wrapper layer on the values we need.
+        self._client_config = client_config["installed"]
         self._scopes = scopes
 
     def run(self) -> google.oauth2.credentials.Credentials:

--- a/tensorboard/uploader/auth_test.py
+++ b/tensorboard/uploader/auth_test.py
@@ -252,11 +252,20 @@ class FakeHttpResponse:
 
 
 class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
-    _OAUTH_CONFIG = {
-        "client_id": "console_client_id",
-        "token_uri": "https://google.com/token",
-        "client_secret": "console_client_secret",
-    }
+    # A "realistic" JSON client config string, like the ones we download from
+    # our GCP project.
+    _OAUTH_CONFIG_JSON = """
+        {
+            "installed":{
+                "client_id":"console_client_id",
+                "project_id":"some GCP cloud project id",
+                "auth_uri":"https://accounts.google.com/o/oauth2/auth",
+                "token_uri":"https://google.com/token",
+                "auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs",
+                "client_secret":"console_client_secret"
+            }
+        }
+    """
 
     _SCOPES = ["email", "openid"]
 
@@ -300,8 +309,9 @@ class LimitedInputDeviceAuthFlowTest(tb_test.TestCase):
             mock.patch.object(requests, "post", autospec=True)
         )
 
+        client_config = json.loads(self._OAUTH_CONFIG_JSON)
         self.flow = auth._LimitedInputDeviceAuthFlow(
-            self._OAUTH_CONFIG,
+            client_config,
             self._SCOPES,
         )
 


### PR DESCRIPTION
* Motivation for features / changes
  There's a bug in the limited-input device auth flow.

  The tests did not catch this issue because the config is read from a JSON string, and the test was using an "already parsed" config (dictionary), with a different structure from the json downloaded from our GCP project.

* Technical description of changes
Unwraps the parsed client_config from the "installed" layer, and updates test with a "realistic" configuration (which uses this structure).

* Screenshots of UI changes
N/A

* Detailed steps to verify changes work correctly (as executed by you)
Ran both auth flows manually (with and without browser), and updated tests.

* Alternate designs / implementations considered
N/A