### PR TITLE
infra: drop support for Python 3.7 and mark 3.11 as supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         tf_version_id: ['tf', 'notf']
-        python_version: ['3.7']
+        python_version: ['3.8']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
@@ -214,7 +214,7 @@ jobs:
         # flake8 should run on each Python version that we target,
         # because the errors and warnings can differ due to language
         # changes, and we want to catch them all.
-        python_version: ['3.7', '3.8', '3.9', '3.10']
+        python_version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
@@ -237,7 +237,7 @@ jobs:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           architecture: 'x64'
       - name: 'Install black, yamllint, and the TensorFlow docs notebook tools'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
         # flake8 should run on each Python version that we target,
         # because the errors and warnings can differ due to language
         # changes, and we want to catch them all.
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -76,6 +76,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -64,7 +64,7 @@ setup(
     },
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     # PyPI package information.
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -73,7 +73,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Fixes #6138.

Python 3.7 is almost at EOL (coming up in [a few months](https://devguide.python.org/versions/#supported-versions)), and has already been [dropped by TensorFlow](https://github.com/tensorflow/tensorflow/commit/53ffdf135db0cc35ed8fc601d10fdfcd27df2295).

This updates our CI to use Python 3.8. It also marks Python 3.11 as supported (it was released to stable last fall).

Tested: confirmed that TensorBoard works as expected with Python 3.11, as follows:

```
$ docker run -it -p 6006:6006 --mount source=$HOME/scratch/demodir,destination=/logs,readonly python:3.11 bash
root@dac67b60b6af:/# python --version
Python 3.11.1
root@dac67b60b6af:/# pip install tensorboard
...
root@dac67b60b6af:/# tensorboard --logdir /logs --bind_all
...
```
