### PR TITLE
Bug Fix: Stop `tb_feature_flag_data_source` from loading unsupported feature flags

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -77,6 +77,7 @@ export const getFeatureFlagsToSendToServer = createSelector(
     for (const entry in state.flagOverrides) {
       const entryMetadata = state.metadata[entry as keyof FeatureFlags];
       if (
+        entryMetadata &&
         entryMetadata.queryParamOverride &&
         entryMetadata.sendToServerWhenOverridden
       ) {

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -43,9 +43,14 @@ export class FeatureFlagOverrideDataSource implements TBFeatureFlagDataSource {
       featureFlagsMetadata,
       this.queryParams.getParams()
     );
+    const persistedFlags = Object.fromEntries(
+      Object.entries(this.getPersistentFeatureFlags()).filter(
+        ([key]) => featureFlagsMetadata[key as keyof FeatureFlags]
+      )
+    );
     return {
       ...featuresFromMediaQuery,
-      ...this.getPersistentFeatureFlags(),
+      ...persistedFlags,
       ...overriddenFeatures,
     } as Partial<FeatureFlags>;
   }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -141,6 +141,12 @@ describe('tb_feature_flag_data_source', () => {
             inColab: true,
           });
         });
+
+        it('ignores features not contained within the provided FeatureFlagMetadataMap', () => {
+          expect(
+            getFeatures({localStorageOverrides: '{"abc123": true}'})
+          ).toEqual({});
+        });
       });
     });
 


### PR DESCRIPTION
## Motivation for features / changes
Different flavors of TensorBoard have different feature flags. If you have saved a feature flag to `localStorage` then switch to running a different version a null pointer exception will occur until you clear the key from `localStorage`.

This could also happen if a feature flag is removed but still stored in some clients `localStorage`.

## Technical description of changes
* The null pointer exception was occurring in the `getFeatureFlagsToSendToServer` function thus I added a null check. This is not a strictly necessary change.
* I then filtered the feature flags being loaded to ensure unsupported feature flags are not loaded.

* Screenshots of UI changes
N/A

* Detailed steps to verify changes work correctly (as executed by you)
1) Start TensorBoard
2) Navigate to http://localhost:6006?showFlags
3) Store some flags to `localStorage`
4) Clear out the query params and refresh the page.
5) Assert the feature flags are still in effect.
6) Open the dev console and modify the value of the `tb_feature_flag_storage_key` key in `localStorage` to include an arbitrary key value pair
7) Refresh the page and assert everything loads correctly.

* Alternate designs / implementations considered
The change to the selector is optional but seemed like a safe thing to include
I considered changing `getPersistentFeatureFlags` instead of `getFeatures` but didn't because a) it doesn't have access to the `FeatureFlagMetadata` and b) because the unsupported features DO technically exist.
