### PR TITLE
Column Customization: Add slideout affordance and toggle button

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -43,6 +43,10 @@ export const metricsSettingsPaneToggled = createAction(
   '[Metrics] Metrics Settings Pane Toggled'
 );
 
+export const metricsSlideoutMenuToggled = createAction(
+  '[Metrics] Slide out settings menu toggled'
+);
+
 export const metricsTagMetadataRequested = createAction(
   '[Metrics] Metrics Tag Metadata Requested'
 );

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -289,6 +289,7 @@ const {initialState, reducers: namespaceContextedReducer} =
     },
     {
       isSettingsPaneOpen: true,
+      isSlideoutMenuOpen: false,
       timeSeriesData: {
         scalars: {},
         histograms: {},
@@ -1118,6 +1119,9 @@ const reducer = createReducer(
   }),
   on(actions.metricsSettingsPaneClosed, (state) => {
     return {...state, isSettingsPaneOpen: false};
+  }),
+  on(actions.metricsSlideoutMenuToggled, (state) => {
+    return {...state, isSlideoutMenuOpen: !state.isSlideoutMenuOpen};
   })
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -462,3 +462,8 @@ export const isMetricsSettingsPaneOpen = createSelector(
   selectMetricsState,
   (state): boolean => state.isSettingsPaneOpen
 );
+
+export const isMetricsSlideoutMenuOpen = createSelector(
+  selectMetricsState,
+  (state): boolean => state.isSlideoutMenuOpen
+);

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -222,6 +222,7 @@ export interface MetricsSettings {
 export interface MetricsNonNamespacedState {
   timeSeriesData: TimeSeriesData;
   isSettingsPaneOpen: boolean;
+  isSlideoutMenuOpen: boolean;
   // Default settings. For the legacy reasons, we cannot change the name of the
   // prop. It either is set by application or a user via settings storage.
   settings: MetricsSettings;

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -107,6 +107,7 @@ function buildBlankState(): MetricsState {
     filteredPluginTypes: new Set(),
     stepMinMax: {min: Infinity, max: -Infinity},
     isSettingsPaneOpen: false,
+    isSlideoutMenuOpen: false,
   };
 }
 

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
@@ -97,6 +97,11 @@ limitations under the License.
       [cardObserver]="cardObserver"
     ></metrics-card-groups>
   </div>
+  <div
+    *ngIf="isSidepaneOpen"
+    class="slide-out-menu"
+    [ngClass]="{'slide-out-menu-expanded':slideOutMenuOpen}"
+  ></div>
   <div class="sidebar" *ngIf="isSidepaneOpen">
     <div class="header">
       <h2 class="title">Settings</h2>

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -77,10 +77,14 @@ limitations under the License.
 .main,
 .sidebar {
   contain: strict;
+  background-color: mat.get-color-from-palette($tb-background, background);
   overflow-x: hidden;
   overflow-y: auto;
   will-change: transform, scroll-position;
-  background-color: white;
+
+  @include tb-dark-theme {
+    background-color: map-get($tb-dark-background, background);
+  }
 }
 
 .main {
@@ -163,16 +167,23 @@ limitations under the License.
 }
 
 .slide-out-menu {
+  background-color: mat.get-color-from-palette($tb-background, background);
+  height: 100%;
   position: absolute;
-  height: calc(100% - 50px);
+  right: 50px;
   top: 50px;
-  left: calc(100vw - 250px);
-  width: 200px;
-  background-color: white;
-  border: 1px solid mat.get-color-from-palette(mat.$gray-palette, 300);
   transition: all 0.75s ease;
+  visibility: hidden;
+  width: 200px;
+
+  @include tb-theme-foreground-prop(border-left, border, 1px solid);
+
+  @include tb-dark-theme {
+    background-color: map-get($tb-dark-background, background);
+  }
 }
 
 .slide-out-menu-expanded {
-  left: calc(100vw - 450px);
+  right: 250px;
+  visibility: visible;
 }

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -171,7 +171,7 @@ limitations under the License.
   height: 100%;
   position: absolute;
   right: 50px;
-  top: 50px;
+  top: 49px;
   transition: all 0.75s ease;
   visibility: hidden;
   width: 200px;

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -80,6 +80,7 @@ limitations under the License.
   overflow-x: hidden;
   overflow-y: auto;
   will-change: transform, scroll-position;
+  background-color: white;
 }
 
 .main {
@@ -159,4 +160,19 @@ limitations under the License.
   mat-icon {
     margin-right: 4px;
   }
+}
+
+.slide-out-menu {
+  position: absolute;
+  height: calc(100% - 50px);
+  top: 50px;
+  left: calc(100vw - 250px);
+  width: 200px;
+  background-color: white;
+  border: 1px solid mat.get-color-from-palette(mat.$gray-palette, 300);
+  transition: all 0.75s ease;
+}
+
+.slide-out-menu-expanded {
+  left: calc(100vw - 450px);
 }

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ts
@@ -38,6 +38,8 @@ export class MainViewComponent {
 
   @Input() initialTagsLoading!: boolean;
 
+  @Input() slideOutMenuOpen!: boolean;
+
   @Output() onSettingsButtonClicked = new EventEmitter<void>();
 
   @Output() onCloseSidepaneButtonClicked = new EventEmitter<void>();

--- a/tensorboard/webapp/metrics/views/main_view/main_view_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_container.ts
@@ -29,6 +29,7 @@ import {
   getMetricsTagFilter,
   getMetricsTagMetadataLoadState,
   isMetricsSettingsPaneOpen,
+  isMetricsSlideoutMenuOpen,
 } from '../../store';
 import {PluginType} from '../../types';
 
@@ -40,6 +41,7 @@ import {PluginType} from '../../types';
       [isSidepaneOpen]="isSidepaneOpen$ | async"
       [initialTagsLoading]="initialTagsLoading$ | async"
       [filteredPluginTypes]="filteredPluginTypes$ | async"
+      [slideOutMenuOpen]="isSlideoutMenuOpen$ | async"
       (onSettingsButtonClicked)="onSettingsButtonClicked()"
       (onCloseSidepaneButtonClicked)="onCloseSidepaneButtonClicked()"
       (onPluginTypeToggled)="onPluginVisibilityToggled($event)"
@@ -80,6 +82,10 @@ export class MainViewContainer {
 
   readonly filteredPluginTypes$ = this.store.select(
     getMetricsFilteredPluginTypes
+  );
+
+  readonly isSlideoutMenuOpen$: Observable<boolean> = this.store.select(
+    isMetricsSlideoutMenuOpen
   );
 
   onSettingsButtonClicked() {

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -1735,7 +1735,7 @@ describe('metrics main view', () => {
       expect(slideoutMenu).toBeFalsy();
     });
 
-    it('renders slideout menu behind sidepanel when closed', () => {
+    it('renders non-expanded slideout menu when closed', () => {
       store.overrideSelector(selectors.isMetricsSettingsPaneOpen, true);
       store.overrideSelector(selectors.isMetricsSlideoutMenuOpen, false);
       const fixture = TestBed.createComponent(MainViewContainer);

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -203,6 +203,7 @@ describe('metrics main view', () => {
       lastLoadedTimeInMs: null,
     });
     store.overrideSelector(selectors.isMetricsSettingsPaneOpen, false);
+    store.overrideSelector(selectors.isMetricsSlideoutMenuOpen, false);
   });
 
   afterEach(() => {
@@ -1719,6 +1720,51 @@ describe('metrics main view', () => {
         const indicator = fixture.debugElement.query(byCss.INDICATOR);
         expect(indicator).toBeTruthy();
       });
+    });
+  });
+
+  describe('slideout menu', () => {
+    it('does not render slideout menu when sidepanel when closed', () => {
+      store.overrideSelector(selectors.isMetricsSettingsPaneOpen, false);
+      const fixture = TestBed.createComponent(MainViewContainer);
+      fixture.detectChanges();
+
+      const slideoutMenu = fixture.debugElement.query(
+        By.css('.slide-out-menu')
+      );
+      expect(slideoutMenu).toBeFalsy();
+    });
+
+    it('renders slideout menu behind sidepanel when closed', () => {
+      store.overrideSelector(selectors.isMetricsSettingsPaneOpen, true);
+      store.overrideSelector(selectors.isMetricsSlideoutMenuOpen, false);
+      const fixture = TestBed.createComponent(MainViewContainer);
+      fixture.detectChanges();
+
+      const slideoutMenu = fixture.debugElement.query(
+        By.css('.slide-out-menu')
+      );
+      expect(slideoutMenu).toBeTruthy();
+
+      expect(
+        slideoutMenu.nativeElement.classList.contains('slide-out-menu-expanded')
+      ).toBe(false);
+    });
+
+    it('renders expanded slideout menu when open', () => {
+      store.overrideSelector(selectors.isMetricsSettingsPaneOpen, true);
+      store.overrideSelector(selectors.isMetricsSlideoutMenuOpen, true);
+      const fixture = TestBed.createComponent(MainViewContainer);
+      fixture.detectChanges();
+
+      const slideoutMenu = fixture.debugElement.query(
+        By.css('.slide-out-menu')
+      );
+      expect(slideoutMenu).toBeTruthy();
+
+      expect(
+        slideoutMenu.nativeElement.classList.contains('slide-out-menu-expanded')
+      ).toBe(true);
     });
   });
 

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -94,10 +94,15 @@ describe('metrics right_pane', () => {
       store.overrideSelector(selectors.getIsMetricsImageSupportEnabled, true);
       store.overrideSelector(selectors.getIsLinkedTimeEnabled, false);
       store.overrideSelector(selectors.getIsDataTableEnabled, false);
+      store.overrideSelector(
+        selectors.getIsScalarColumnCustomizationEnabled,
+        false
+      );
       store.overrideSelector(selectors.getMetricsCardMinWidth, null);
       store.overrideSelector(selectors.getMetricsLinkedTimeEnabled, false);
       store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
       store.overrideSelector(selectors.getMetricsRangeSelectionEnabled, false);
+      store.overrideSelector(selectors.isMetricsSlideoutMenuOpen, false);
       store.overrideSelector(selectors.getAllowRangeSelection, false);
       store.overrideSelector(selectors.getMetricsLinkedTimeSelectionSetting, {
         start: {step: 0},
@@ -500,11 +505,7 @@ describe('metrics right_pane', () => {
           store.overrideSelector(selectors.getMetricsXAxisType, XAxisType.STEP);
           const fixture = TestBed.createComponent(SettingsViewContainer);
           fixture.detectChanges();
-          console.log(
-            'properties',
-            fixture.debugElement.query(By.css('.range-selection mat-checkbox'))
-              .properties
-          );
+
           const checkbox = fixture.debugElement.query(
             By.css('.range-selection mat-checkbox input')
           );
@@ -531,6 +532,54 @@ describe('metrics right_pane', () => {
               affordance: TimeSelectionToggleAffordance.CHECK_BOX,
             })
           );
+        });
+
+        describe('slide out menu', () => {
+          beforeEach(() => {
+            store.overrideSelector(
+              selectors.getIsScalarColumnCustomizationEnabled,
+              true
+            );
+          });
+
+          it('dispatches metricsSlideoutMenuToggled when Edit Menu Toggle is clicked', () => {
+            const fixture = TestBed.createComponent(SettingsViewContainer);
+            fixture.detectChanges();
+
+            fixture.debugElement
+              .query(By.css('.column-edit-menu-toggle'))
+              .nativeElement.click();
+
+            expect(dispatchSpy).toHaveBeenCalledWith(
+              actions.metricsSlideoutMenuToggled()
+            );
+          });
+
+          it('renders left cheron when slideout is closed', () => {
+            store.overrideSelector(selectors.isMetricsSlideoutMenuOpen, false);
+            const fixture = TestBed.createComponent(SettingsViewContainer);
+            fixture.detectChanges();
+
+            expect(
+              fixture.debugElement
+                .query(By.css('.column-edit-menu-toggle'))
+                .query(By.css('mat-icon'))
+                .nativeElement.getAttribute('svgIcon')
+            ).toBe('chevron_left_24px');
+          });
+
+          it('renders right cheron when slideout is open', () => {
+            store.overrideSelector(selectors.isMetricsSlideoutMenuOpen, true);
+            const fixture = TestBed.createComponent(SettingsViewContainer);
+            fixture.detectChanges();
+
+            expect(
+              fixture.debugElement
+                .query(By.css('.column-edit-menu-toggle'))
+                .query(By.css('mat-icon'))
+                .nativeElement.getAttribute('svgIcon')
+            ).toBe('chevron_right_24px');
+          });
         });
       });
     });

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -58,6 +58,21 @@ limitations under the License.
         >Link by step {{getLinkedTimeSelectionStartStep()}}
       </mat-checkbox>
     </div>
+    <div
+      *ngIf="isScalarColumnCustomizationEnabled"
+      class="column-edit-menu-toggle"
+      (click)="onSlideOutToggled.emit()"
+    >
+      <mat-icon
+        *ngIf="!isSlideOutMenuOpen"
+        svgIcon="chevron_left_24px"
+      ></mat-icon>
+      <mat-icon
+        *ngIf="isSlideOutMenuOpen"
+        svgIcon="chevron_right_24px"
+      ></mat-icon>
+      Open Column Edit Control
+    </div>
   </div>
 
   <div class="control-row card-width">

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -18,6 +18,8 @@ limitations under the License.
 :host {
   @include tb-theme-foreground-prop(color, secondary-text);
   font-size: 12px;
+  z-index: 1;
+  position: fixed;
 }
 
 section {
@@ -94,6 +96,16 @@ mat-slider {
   // https://github.com/angular/components/blob/master/src/material/slider/slider.scss#L10
   margin-left: -8px;
   margin-right: -8px;
+}
+
+.column-edit-menu-toggle {
+  align-items: center;
+  display: flex;
+  cursor: pointer;
+  mat-icon {
+    height: 15px;
+    width: 15px;
+  }
 }
 
 tb-dropdown {

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -70,8 +70,10 @@ export class SettingsViewComponent {
   @Input() isScalarStepSelectorFeatureEnabled!: boolean;
   @Input() isScalarStepSelectorEnabled!: boolean;
   @Input() isScalarStepSelectorRangeEnabled!: boolean;
+  @Input() isScalarColumnCustomizationEnabled!: boolean;
   @Input() linkedTimeSelection!: TimeSelection | null;
   @Input() stepMinMax!: {min: number; max: number};
+  @Input() isSlideOutMenuOpen!: boolean;
 
   @Output() linkedTimeToggled = new EventEmitter<void>();
   @Output()
@@ -79,6 +81,7 @@ export class SettingsViewComponent {
 
   @Output() stepSelectorToggled = new EventEmitter<void>();
   @Output() rangeSelectionToggled = new EventEmitter<void>();
+  @Output() onSlideOutToggled = new EventEmitter<void>();
 
   @Input() isImageSupportEnabled!: boolean;
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -36,6 +36,7 @@ import {
   metricsResetImageBrightness,
   metricsResetImageContrast,
   metricsScalarPartitionNonMonotonicXToggled,
+  metricsSlideoutMenuToggled,
   metricsToggleIgnoreOutliers,
   metricsToggleImageShowActualSize,
   rangeSelectionToggled,
@@ -92,12 +93,17 @@ const RANGE_INPUT_SOURCE_TO_AFFORDANCE: Record<
         isScalarStepSelectorRangeEnabled$ | async
       "
       [isLinkedTimeEnabled]="isLinkedTimeEnabled$ | async"
+      [isScalarColumnCustomizationEnabled]="
+        isScalarColumnCustomizationEnabled$ | async
+      "
       [linkedTimeSelection]="linkedTimeSelection$ | async"
       [stepMinMax]="stepMinMax$ | async"
+      [isSlideOutMenuOpen]="isSlideOutMenuOpen$ | async"
       (linkedTimeToggled)="onLinkedTimeToggled()"
       (linkedTimeSelectionChanged)="onLinkedTimeSelectionChanged($event)"
       (stepSelectorToggled)="onStepSelectorToggled()"
       (rangeSelectionToggled)="onRangeSelectionToggled()"
+      (onSlideOutToggled)="onSlideOutToggled()"
     >
     </metrics-dashboard-settings-component>
   `,
@@ -121,10 +127,16 @@ export class SettingsViewContainer {
   readonly isLinkedTimeEnabled$: Observable<boolean> = this.store.select(
     selectors.getMetricsLinkedTimeEnabled
   );
+  readonly isScalarColumnCustomizationEnabled$ = this.store.select(
+    selectors.getIsScalarColumnCustomizationEnabled
+  );
   readonly linkedTimeSelection$ = this.store.select(
     selectors.getMetricsLinkedTimeSelectionSetting
   );
   readonly stepMinMax$ = this.store.select(selectors.getMetricsStepMinMax);
+  readonly isSlideOutMenuOpen$ = this.store.select(
+    selectors.isMetricsSlideoutMenuOpen
+  );
 
   readonly isImageSupportEnabled$ = this.store
     .select(selectors.getIsFeatureFlagsLoaded)
@@ -246,5 +258,9 @@ export class SettingsViewContainer {
         affordance: RANGE_INPUT_SOURCE_TO_AFFORDANCE[source],
       })
     );
+  }
+
+  onSlideOutToggled() {
+    this.store.dispatch(metricsSlideoutMenuToggled());
   }
 }


### PR DESCRIPTION
* Motivation for features / changes
This affordance will be used to house the column customization menu. For reference to where we are heading please see this branch(https://github.com/tensorflow/tensorboard/compare/master...JamesHollyer:tensorboard:EditColumnMenu).

* Technical description of changes
The slideout affordance is added to the mainViewComponent as it must be able to move outside the settings menu. When it is toggled we add the .slide-out-menu-expanded class which moves it to be in view. This with the transition property make the slide out animation.

* Screenshots of UI changes
![2023-01-13_14-38-38 (1)](https://user-images.githubusercontent.com/8672809/212432515-a6be5dc5-594a-4a63-b17c-1787c7351ddb.gif)
