### PR TITLE
What's New: Do not show notifications from the future.

### DIFF
--- a/tensorboard/webapp/notification_center/_data_source/backend_types.ts
+++ b/tensorboard/webapp/notification_center/_data_source/backend_types.ts
@@ -26,6 +26,7 @@ export abstract class NotificationCenterDataSource {
  * A notification from backend.
  */
 export declare interface BackendNotification {
+  // The date at which to begin showing the user the notification.
   dateInMs: number;
   title: string;
   content: string;

--- a/tensorboard/webapp/notification_center/_data_source/notification_center_data_source.ts
+++ b/tensorboard/webapp/notification_center/_data_source/notification_center_data_source.ts
@@ -35,18 +35,12 @@ export class TBNotificationCenterDataSource
       .get<NotificationCenterResponse>(`/data/notifications`)
       .pipe(
         map((response) => {
-          const todayInMs: number = new Date(
-            new Date().toDateString()
-          ).getTime();
           return {
             ...response,
-            notifications: response.notifications.map((notification) => {
-              if (!notification.hasOwnProperty('dateInMs')) return notification;
-              return {
-                ...notification,
-                // `dateInMs` can never exceed local machine's today at 12:00 AM.
-                dateInMs: Math.min(notification.dateInMs, todayInMs),
-              };
+            notifications: response.notifications.filter((notification) => {
+              // Do not return notifications that have been configured to
+              // start in the future.
+              return notification.dateInMs <= new Date().getTime();
             }),
           };
         })


### PR DESCRIPTION
The way we handle `Notification.dateInMs` continues to be confusing and error prone, despite attempts to address this in #5240.

The error case that hit us recently: If you set `dateInMs` to a day in the future, then the notication red dot will reappear every day until that day passes. (Note: #5240 only addressed problems when you set `dateInMs` to hours in the future, not days).

I propose we change the semantics of `dateInMs` to make it a little less error prone. It would now mean "do not show/notifiy this message until `dateInMs` or later".

The code filters out the notification at the TBNotificationCenterDataSource level.

To test, I imported the code into an internal repo and configured some notifications with `dateInMs` in the future. I verified that they do not appear until the time in `dateInMs` passes by and that they generate a red dot and that the red dot is dismissable.
