### PR TITLE
ci: Update macOS platform to `macOS-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-22.04', 'macos-11']
+        platform: ['ubuntu-22.04', 'macos-latest']
         rust_version: ['1.65.0']
         include:
           - mode: 'universal'


### PR DESCRIPTION
The macOS `latest` runner image has been updated to point to `macOS-12` (Monterey) as of last week (actions/runner-images#6901), while we still specify `macOS-11` (Big Sur). Given that macOS 13 (Ventura) is already available, we should at least update to `macOS-12`. There is currently no EOL specified for `macOS-11` (Big Sur), but changing to `macOS-latest` should help us ensure we're always validating with a relatively recent version of macOS and avoid missing any future deprecation windows.