### PR TITLE
Column Customization: Add Column Edit actions and reducers

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -33,7 +33,7 @@ import {
 import {
   ColumnHeader,
   ColumnHeaderType,
-  FobState,
+  DataTableMode,
   SortingInfo,
 } from '../views/card_renderer/scalar_card_types';
 
@@ -216,15 +216,15 @@ export const dataTableColumnDrag = createAction(
 export const dataTableColumnEdited = createAction(
   '[Metrics] Data table columns edited in edit menu',
   props<{
-    fobState: FobState;
-    newHeaders: ColumnHeader[];
+    fobState: DataTableMode;
+    headers: ColumnHeader[];
   }>()
 );
 
 export const dataTableColumnToggled = createAction(
-  '[Metrics] Data table columns toggled in edit menu',
+  '[Metrics] Data table column toggled in edit menu',
   props<{
-    fobState: FobState;
+    fobState: DataTableMode;
     headerType: ColumnHeaderType;
   }>()
 );

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -32,6 +32,8 @@ import {
 } from '../types';
 import {
   ColumnHeader,
+  ColumnHeaderType,
+  FobState,
   SortingInfo,
 } from '../views/card_renderer/scalar_card_types';
 
@@ -208,6 +210,22 @@ export const dataTableColumnDrag = createAction(
   '[Metrics] Data table column dragged',
   props<{
     newOrder: ColumnHeader[];
+  }>()
+);
+
+export const dataTableColumnEdited = createAction(
+  '[Metrics] Data table columns edited in edit menu',
+  props<{
+    fobState: FobState;
+    newHeaders: ColumnHeader[];
+  }>()
+);
+
+export const dataTableColumnToggled = createAction(
+  '[Metrics] Data table columns toggled in edit menu',
+  props<{
+    fobState: FobState;
+    headerType: ColumnHeaderType;
   }>()
 );
 

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -96,6 +96,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/data_source",
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/persistent_settings",
         "//tensorboard/webapp/routes:testing",
         "//tensorboard/webapp/types",

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -46,7 +46,11 @@ import {
   URLDeserializedState,
 } from '../types';
 import {groupCardIdWithMetdata} from '../utils';
-import {ColumnHeaderType} from '../views/card_renderer/scalar_card_types';
+import {
+  ColumnHeader,
+  ColumnHeaderType,
+  FobState,
+} from '../views/card_renderer/scalar_card_types';
 import {
   buildOrReturnStateWithPinnedCopy,
   buildOrReturnStateWithUnresolvedImportedPins,
@@ -1094,6 +1098,70 @@ const reducer = createReducer(
       singleSelectionHeaders: newOrder,
     };
   }),
+  on(actions.dataTableColumnEdited, (state, {fobState, newHeaders}) => {
+    const enabledNewHeaders: ColumnHeader[] = [];
+    const disabledNewHeaders: ColumnHeader[] = [];
+
+    newHeaders.forEach((header) => {
+      if (header.enabled) {
+        enabledNewHeaders.push(header);
+      } else {
+        disabledNewHeaders.push(header);
+      }
+    });
+
+    if (fobState === FobState.RANGE) {
+      return {
+        ...state,
+        rangeSelectionHeaders: enabledNewHeaders.concat(disabledNewHeaders),
+      };
+    }
+
+    return {
+      ...state,
+      singleSelectionHeaders: enabledNewHeaders.concat(disabledNewHeaders),
+    };
+  }),
+  on(actions.dataTableColumnToggled, (state, {fobState, headerType}) => {
+    const targetedHeaders =
+      fobState === FobState.RANGE
+        ? state.rangeSelectionHeaders
+        : state.singleSelectionHeaders;
+
+    const toggledHeaderCurrentIndex = targetedHeaders.findIndex(
+      (element) => element.type === headerType
+    );
+
+    // If the header is being enabled it goes at the bottom of the currently
+    // enabled headers. If it is being disabled it goes to the top of the
+    // currently disabled headers.
+    let newToggledHeaderIndex = getEnabledCount(targetedHeaders);
+    if (targetedHeaders[toggledHeaderCurrentIndex].enabled) {
+      newToggledHeaderIndex--;
+    }
+    const newHeaders = moveHeader(
+      toggledHeaderCurrentIndex,
+      newToggledHeaderIndex,
+      targetedHeaders
+    );
+
+    newHeaders[newToggledHeaderIndex] = {
+      type: newHeaders[newToggledHeaderIndex].type,
+      enabled: !newHeaders[newToggledHeaderIndex].enabled,
+    };
+
+    if (fobState === FobState.RANGE) {
+      return {
+        ...state,
+        rangeSelectionHeaders: newHeaders,
+      };
+    }
+
+    return {
+      ...state,
+      singleSelectionHeaders: newHeaders,
+    };
+  }),
   on(actions.metricsToggleVisiblePlugin, (state, {plugin}) => {
     let nextFilteredPluginTypes = new Set(state.filteredPluginTypes);
     if (nextFilteredPluginTypes.has(plugin)) {
@@ -1150,4 +1218,28 @@ function buildTagToRuns(runTagInfo: {[run: string]: string[]}) {
     }
   }
   return tagToRuns;
+}
+
+// Move the item at sourceIndex to destinationIndex
+function moveHeader(
+  sourceIndex: number,
+  destinationIndex: number,
+  headers: ColumnHeader[]
+) {
+  const newHeaders = [...headers];
+  // Delete from original location
+  newHeaders.splice(sourceIndex, 1);
+  // Insert at destinationIndex.
+  newHeaders.splice(destinationIndex, 0, headers[sourceIndex]);
+  return newHeaders;
+}
+
+function getEnabledCount(headers: ColumnHeader[]) {
+  let count = 0;
+  headers.forEach((header) => {
+    if (header.enabled) {
+      count++;
+    }
+  });
+  return count;
 }

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1616,7 +1616,7 @@ describe('metrics reducers', () => {
       });
     });
 
-    fdescribe('dataTableColumnToggled', () => {
+    describe('dataTableColumnToggled', () => {
       it('moves header down to the disabled headers when toggling to disabled', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -46,6 +46,10 @@ import {
   TooltipSort,
   XAxisType,
 } from '../types';
+import {
+  ColumnHeaderType,
+  FobState,
+} from '../views/card_renderer/scalar_card_types';
 import {reducers} from './metrics_reducers';
 import {getCardId, getPinnedCardId} from './metrics_store_internal_utils';
 import {
@@ -1483,6 +1487,271 @@ describe('metrics reducers', () => {
 
       expect(nextState.timeSeriesData).toBe(beforeState.timeSeriesData);
       expect(nextState.timeSeriesData).toEqual(createTimeSeriesData());
+    });
+
+    describe('dataTableColumnEdited', () => {
+      it('edits range selection when fobState is range', () => {
+        const beforeState = buildMetricsState({
+          rangeSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.START_VALUE, enabled: true},
+            {type: ColumnHeaderType.END_VALUE, enabled: true},
+            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          ],
+          singleSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.VALUE, enabled: true},
+            {type: ColumnHeaderType.STEP, enabled: true},
+            {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+          ],
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.dataTableColumnEdited({
+            fobState: FobState.RANGE,
+            newHeaders: [
+              {type: ColumnHeaderType.RUN, enabled: true},
+              {type: ColumnHeaderType.END_VALUE, enabled: true},
+              {type: ColumnHeaderType.START_VALUE, enabled: true},
+              {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+              {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+            ],
+          })
+        );
+
+        expect(nextState.rangeSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.END_VALUE, enabled: true},
+          {type: ColumnHeaderType.START_VALUE, enabled: true},
+          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+        ]);
+        expect(nextState.singleSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.VALUE, enabled: true},
+          {type: ColumnHeaderType.STEP, enabled: true},
+          {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+        ]);
+      });
+
+      it('edits single selection when fobState is single', () => {
+        const beforeState = buildMetricsState({
+          rangeSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.START_VALUE, enabled: true},
+            {type: ColumnHeaderType.END_VALUE, enabled: true},
+            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          ],
+          singleSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.VALUE, enabled: true},
+            {type: ColumnHeaderType.STEP, enabled: true},
+            {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+          ],
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.dataTableColumnEdited({
+            fobState: FobState.SINGLE,
+            newHeaders: [
+              {type: ColumnHeaderType.RUN, enabled: true},
+              {type: ColumnHeaderType.STEP, enabled: true},
+              {type: ColumnHeaderType.VALUE, enabled: true},
+              {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+            ],
+          })
+        );
+
+        expect(nextState.rangeSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.START_VALUE, enabled: true},
+          {type: ColumnHeaderType.END_VALUE, enabled: true},
+          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+        ]);
+        expect(nextState.singleSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.STEP, enabled: true},
+          {type: ColumnHeaderType.VALUE, enabled: true},
+          {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+        ]);
+      });
+
+      it('ensures ordering keeps enabled headers first', () => {
+        const beforeState = buildMetricsState({
+          rangeSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.START_VALUE, enabled: true},
+            {type: ColumnHeaderType.END_VALUE, enabled: true},
+            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          ],
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.dataTableColumnEdited({
+            fobState: FobState.RANGE,
+            newHeaders: [
+              {type: ColumnHeaderType.RUN, enabled: true},
+              {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+              {type: ColumnHeaderType.START_VALUE, enabled: true},
+              {type: ColumnHeaderType.END_VALUE, enabled: true},
+              {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+            ],
+          })
+        );
+
+        expect(nextState.rangeSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.START_VALUE, enabled: true},
+          {type: ColumnHeaderType.END_VALUE, enabled: true},
+          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+        ]);
+      });
+    });
+
+    describe('dataTableColumnToggled', () => {
+      it('moves header down to the disabled headers when toggling to disabled', () => {
+        const beforeState = buildMetricsState({
+          rangeSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.START_VALUE, enabled: true},
+            {type: ColumnHeaderType.END_VALUE, enabled: true},
+            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          ],
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.dataTableColumnToggled({
+            fobState: FobState.RANGE,
+            headerType: ColumnHeaderType.RUN,
+          })
+        );
+
+        expect(nextState.rangeSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.START_VALUE, enabled: true},
+          {type: ColumnHeaderType.END_VALUE, enabled: true},
+          {type: ColumnHeaderType.RUN, enabled: false},
+          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+        ]);
+      });
+
+      it('moves header up to the enabled headers when toggling to enabled', () => {
+        const beforeState = buildMetricsState({
+          rangeSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.START_VALUE, enabled: true},
+            {type: ColumnHeaderType.END_VALUE, enabled: true},
+            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          ],
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.dataTableColumnToggled({
+            fobState: FobState.RANGE,
+            headerType: ColumnHeaderType.MAX_VALUE,
+          })
+        );
+
+        expect(nextState.rangeSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.START_VALUE, enabled: true},
+          {type: ColumnHeaderType.END_VALUE, enabled: true},
+          {type: ColumnHeaderType.MAX_VALUE, enabled: true},
+          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+        ]);
+      });
+
+      it('only changes range selection headers when FobState is RANGE', () => {
+        const beforeState = buildMetricsState({
+          rangeSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.START_VALUE, enabled: true},
+            {type: ColumnHeaderType.END_VALUE, enabled: true},
+            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          ],
+          singleSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.STEP, enabled: true},
+            {type: ColumnHeaderType.VALUE, enabled: true},
+            {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+          ],
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.dataTableColumnToggled({
+            fobState: FobState.RANGE,
+            headerType: ColumnHeaderType.MAX_VALUE,
+          })
+        );
+
+        expect(nextState.rangeSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.START_VALUE, enabled: true},
+          {type: ColumnHeaderType.END_VALUE, enabled: true},
+          {type: ColumnHeaderType.MAX_VALUE, enabled: true},
+          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+        ]);
+        expect(nextState.singleSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.STEP, enabled: true},
+          {type: ColumnHeaderType.VALUE, enabled: true},
+          {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+        ]);
+      });
+
+      it('only changes single selection headers when FobState is SINGLE', () => {
+        const beforeState = buildMetricsState({
+          rangeSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.START_VALUE, enabled: true},
+            {type: ColumnHeaderType.END_VALUE, enabled: true},
+            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          ],
+          singleSelectionHeaders: [
+            {type: ColumnHeaderType.RUN, enabled: true},
+            {type: ColumnHeaderType.STEP, enabled: true},
+            {type: ColumnHeaderType.VALUE, enabled: true},
+            {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+          ],
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.dataTableColumnToggled({
+            fobState: FobState.SINGLE,
+            headerType: ColumnHeaderType.STEP,
+          })
+        );
+
+        expect(nextState.rangeSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.START_VALUE, enabled: true},
+          {type: ColumnHeaderType.END_VALUE, enabled: true},
+          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+        ]);
+        expect(nextState.singleSelectionHeaders).toEqual([
+          {type: ColumnHeaderType.RUN, enabled: true},
+          {type: ColumnHeaderType.VALUE, enabled: true},
+          {type: ColumnHeaderType.STEP, enabled: false},
+          {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+        ]);
+      });
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -48,7 +48,7 @@ import {
 } from '../types';
 import {
   ColumnHeaderType,
-  FobState,
+  DataTableMode,
 } from '../views/card_renderer/scalar_card_types';
 import {reducers} from './metrics_reducers';
 import {getCardId, getPinnedCardId} from './metrics_store_internal_utils';
@@ -1510,8 +1510,8 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnEdited({
-            fobState: FobState.RANGE,
-            newHeaders: [
+            fobState: DataTableMode.RANGE,
+            headers: [
               {type: ColumnHeaderType.RUN, enabled: true},
               {type: ColumnHeaderType.END_VALUE, enabled: true},
               {type: ColumnHeaderType.START_VALUE, enabled: true},
@@ -1556,8 +1556,8 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnEdited({
-            fobState: FobState.SINGLE,
-            newHeaders: [
+            fobState: DataTableMode.SINGLE,
+            headers: [
               {type: ColumnHeaderType.RUN, enabled: true},
               {type: ColumnHeaderType.STEP, enabled: true},
               {type: ColumnHeaderType.VALUE, enabled: true},
@@ -1595,8 +1595,8 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnEdited({
-            fobState: FobState.RANGE,
-            newHeaders: [
+            fobState: DataTableMode.RANGE,
+            headers: [
               {type: ColumnHeaderType.RUN, enabled: true},
               {type: ColumnHeaderType.MAX_VALUE, enabled: false},
               {type: ColumnHeaderType.START_VALUE, enabled: true},
@@ -1616,7 +1616,7 @@ describe('metrics reducers', () => {
       });
     });
 
-    describe('dataTableColumnToggled', () => {
+    fdescribe('dataTableColumnToggled', () => {
       it('moves header down to the disabled headers when toggling to disabled', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
@@ -1631,7 +1631,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnToggled({
-            fobState: FobState.RANGE,
+            fobState: DataTableMode.RANGE,
             headerType: ColumnHeaderType.RUN,
           })
         );
@@ -1659,7 +1659,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnToggled({
-            fobState: FobState.RANGE,
+            fobState: DataTableMode.RANGE,
             headerType: ColumnHeaderType.MAX_VALUE,
           })
         );
@@ -1693,7 +1693,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnToggled({
-            fobState: FobState.RANGE,
+            fobState: DataTableMode.RANGE,
             headerType: ColumnHeaderType.MAX_VALUE,
           })
         );
@@ -1733,7 +1733,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnToggled({
-            fobState: FobState.SINGLE,
+            fobState: DataTableMode.SINGLE,
             headerType: ColumnHeaderType.STEP,
           })
         );

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -99,7 +99,7 @@ export interface ColumnHeader {
   enabled: boolean;
 }
 
-export enum FobState {
+export enum DataTableMode {
   SINGLE,
   RANGE,
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -99,6 +99,11 @@ export interface ColumnHeader {
   enabled: boolean;
 }
 
+export enum FobState {
+  SINGLE,
+  RANGE,
+}
+
 export enum SortingOrder {
   ASCENDING,
   DESCENDING,


### PR DESCRIPTION
* Motivation for features / changes
This is part of the Column Customization effort to allow for more columns in the scalar data table. This PR adds the actions which the Column Edit Menu will need when making changes.

* Detailed steps to verify changes work correctly (as executed by you)
These were tested in this [POC branch](https://github.com/tensorflow/tensorboard/compare/master...JamesHollyer:tensorboard:EditColumnMenu)
