### PR TITLE
ci: Specify macOS-12 explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-22.04', 'macos-latest']
+        platform: ['ubuntu-22.04', 'macos-12']
         rust_version: ['1.65.0']
         include:
           - mode: 'universal'


### PR DESCRIPTION
Specifying `macOS-latest` results in a GH warning that "macOS-latest pipelines will use macOS-12 soon. For more details, see https://github.com/actions/runner-images/issues/6384".

To clean up the warnings, let's just pin to macOS-12 for now.