### PR TITLE
Remove unnecessary style properties

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -18,8 +18,6 @@ limitations under the License.
 :host {
   @include tb-theme-foreground-prop(color, secondary-text);
   font-size: 12px;
-  z-index: 1;
-  position: fixed;
 }
 
 section {


### PR DESCRIPTION
* Motivation for features / changes
These properties(which were introduced in #6146) were leftover from testing the slide out feature and are not needed. Moreover, it causes sizing problems with certain scrollbars.