### PR TITLE
Step Selection: Make card size more responsive to card content.

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
@@ -15,8 +15,9 @@ limitations under the License.
 import {
   ChangeDetectionStrategy,
   Component,
-  HostBinding,
+  EventEmitter,
   Input,
+  Output,
 } from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
@@ -64,8 +65,8 @@ export class CardViewContainer {
   @Input() groupName!: string | null;
   @Input() pluginType!: PluginType;
 
-  @HostBinding('class.full-width') showFullWidth: boolean = false;
-  @HostBinding('class.full-height') showFullHeight: boolean = false;
+  @Output() fullWidthChanged = new EventEmitter<boolean>();
+  @Output() fullHeightChanged = new EventEmitter<boolean>();
 
   onVisibilityChange({visible}: {visible: boolean}) {
     this.isEverVisible = this.isEverVisible || visible;
@@ -91,11 +92,11 @@ export class CardViewContainer {
     );
 
   onFullWidthChanged(showFullWidth: boolean) {
-    this.showFullWidth = showFullWidth;
+    this.fullWidthChanged.emit(showFullWidth);
   }
 
   onFullHeightChanged(showFullHeight: boolean) {
-    this.showFullHeight = showFullHeight;
+    this.fullHeightChanged.emit(showFullHeight);
   }
 
   onPinStateChanged() {

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -105,46 +105,52 @@ describe('card view test', () => {
     });
   });
 
-  it('updates full width upon card notification', () => {
+  it('emits fullWidthChanged after lower level fullWidthChanged', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';
     fixture.componentInstance.pluginType = PluginType.SCALARS;
     intersectionObserver.simulateVisibilityChange(fixture, true);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.classes['full-width']).not.toBeTruthy();
+    const onFullWidthChanged = jasmine.createSpy();
+    fixture.componentInstance.fullWidthChanged.subscribe(onFullWidthChanged);
+
+    expect(onFullWidthChanged.calls.allArgs()).toEqual([]);
 
     const scalarCard = fixture.debugElement.query(By.css('scalar-card'));
     scalarCard.componentInstance.fullWidthChanged.emit(true);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.classes['full-width']).toBe(true);
+    expect(onFullWidthChanged.calls.allArgs()).toEqual([[true]]);
 
     scalarCard.componentInstance.fullWidthChanged.emit(false);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.classes['full-width']).not.toBeTruthy();
+    expect(onFullWidthChanged.calls.allArgs()).toEqual([[true], [false]]);
   });
 
-  it('updates full height upon card notification', () => {
+  it('emits fullHeightChanged after lower level fullHeightChanged', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';
     fixture.componentInstance.pluginType = PluginType.SCALARS;
     intersectionObserver.simulateVisibilityChange(fixture, true);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.classes['full-height']).not.toBeTruthy();
+    const onFullHeightChanged = jasmine.createSpy();
+    fixture.componentInstance.fullHeightChanged.subscribe(onFullHeightChanged);
+
+    expect(onFullHeightChanged.calls.allArgs()).toEqual([]);
 
     const scalarCard = fixture.debugElement.query(By.css('scalar-card'));
     scalarCard.componentInstance.fullHeightChanged.emit(true);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.classes['full-height']).toBe(true);
+    expect(onFullHeightChanged.calls.allArgs()).toEqual([[true]]);
 
     scalarCard.componentInstance.fullHeightChanged.emit(false);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.classes['full-height']).not.toBeTruthy();
+    expect(onFullHeightChanged.calls.allArgs()).toEqual([[true], [false]]);
   });
 
   it('dispatches action when pin state changes', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.scss
@@ -18,9 +18,12 @@ limitations under the License.
 $_title-to-heading-gap: 12px;
 
 :host {
-  display: flex;
-  flex-direction: column;
   box-sizing: border-box;
+  display: flex;
+  // Remove 2px from height to account for the card border.
+  flex-basis: $metrics-min-card-height - 2px;
+  flex-direction: column;
+  flex-grow: 1;
   height: 100%;
   overflow: auto;
   padding: $metrics-preferred-gap;

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -84,7 +84,8 @@ type HistogramCardMetadata = CardMetadata & {
   styles: [
     `
       :host {
-        display: block;
+        display: flex;
+        flex-direction: column;
         height: 100%;
       }
     `,

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -20,9 +20,12 @@ $_title-to-heading-gap: 12px;
 $_tick_width: 14px;
 
 :host {
-  display: flex;
-  flex-direction: column;
   box-sizing: border-box;
+  display: flex;
+  // Remove 2px from height to account for the card border.
+  flex-basis: $metrics-min-card-height - 2px;
+  flex-direction: column;
+  flex-grow: 1;
   height: 100%;
   overflow: auto;
   padding: $metrics-preferred-gap;
@@ -110,7 +113,7 @@ $_tick_width: 14px;
 }
 
 .img-container {
-  flex: 1 1 0;
+  flex-grow: 1;
   overflow-y: auto;
   position: relative;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_container.ts
@@ -94,6 +94,15 @@ type ImageCardMetadata = CardMetadata & {
       (onPinClicked)="pinStateChanged.emit($event)"
     ></image-card-component>
   `,
+  styles: [
+    `
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+    `,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ImageCardContainer implements CardRenderer, OnInit, OnDestroy {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -14,163 +14,165 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div class="heading">
-  <span class="name">
-    <tb-truncated-path
-      class="tag"
-      title="{{ tag }}"
-      value="{{ title }}"
-    ></tb-truncated-path>
-    <vis-linked-time-selection-warning
-      [isClipped]="linkedTimeSelection && linkedTimeSelection.clipped"
-    ></vis-linked-time-selection-warning>
-  </span>
-  <span class="controls">
-    <button
-      mat-icon-button
-      [disabled]="!lineChart || !(lineChart.getIsViewBoxOverridden() | async)"
-      (click)="resetDomain()"
-      [title]="
-          !lineChart || !(lineChart.getIsViewBoxOverridden() | async) ?
-              'Fit line chart domains to data' :
-              'Line chart is already fitted to data. When data updates, the line chart '
-                + 'will auto fit to its domain.'
-      "
-      i18n-aria-label="A button that resets line chart domain to the data"
-      aria-label="Fit line chart domains to data"
-    >
-      <mat-icon svgIcon="settings_overscan_24px"></mat-icon>
-    </button>
-    <button
-      mat-icon-button
-      class="pin-button"
-      i18n-aria-label="A button to pin a card."
-      aria-label="Pin card"
-      [attr.title]="isPinned ? 'Unpin card' : 'Pin card'"
-      (click)="onPinClicked.emit(!isPinned)"
-    >
-      <mat-icon
-        [svgIcon]="isPinned ? 'keep_24px' : 'keep_outline_24px'"
-      ></mat-icon>
-    </button>
-    <button
-      mat-icon-button
-      i18n-aria-label="A button on line chart that toggles full size mode."
-      aria-label="Toggle full size mode"
-      title="Toggle full size mode"
-      (click)="onFullSizeToggle.emit()"
-    >
-      <mat-icon
-        [svgIcon]="showFullSize ? 'fullscreen_exit_24px' : 'fullscreen_24px'"
-      ></mat-icon>
-    </button>
-    <!-- overflow menu cannot use mat-tooltip since it interferes with the mat-menu. -->
-    <button
-      mat-icon-button
-      [matMenuTriggerFor]="menu"
-      i18n-aria-label="An overflow menu button that opens more line chart options"
-      aria-label="More line chart options"
-      title="More line chart options"
-    >
-      <mat-icon svgIcon="more_vert_24px"></mat-icon>
-    </button>
-    <mat-menu #menu="matMenu">
+<div class="always-visible">
+  <div class="heading">
+    <span class="name">
+      <tb-truncated-path
+        class="tag"
+        title="{{ tag }}"
+        value="{{ title }}"
+      ></tb-truncated-path>
+      <vis-linked-time-selection-warning
+        [isClipped]="linkedTimeSelection && linkedTimeSelection.clipped"
+      ></vis-linked-time-selection-warning>
+    </span>
+    <span class="controls">
       <button
-        mat-menu-item
-        (click)="toggleYScaleType()"
-        i18n-aria-label="A button that toggles log scale on y-axis on a line chart"
-        aria-label="Toggle Y-axis log scale on line chart"
+        mat-icon-button
+        [disabled]="!lineChart || !(lineChart.getIsViewBoxOverridden() | async)"
+        (click)="resetDomain()"
+        [title]="
+            !lineChart || !(lineChart.getIsViewBoxOverridden() | async) ?
+                'Fit line chart domains to data' :
+                'Line chart is already fitted to data. When data updates, the line chart '
+                  + 'will auto fit to its domain.'
+        "
+        i18n-aria-label="A button that resets line chart domain to the data"
+        aria-label="Fit line chart domains to data"
       >
-        <mat-icon svgIcon="line_weight_24px"></mat-icon>
-        <span>Toggle Y-axis log scale</span>
+        <mat-icon svgIcon="settings_overscan_24px"></mat-icon>
       </button>
       <button
-        mat-menu-item
-        (click)="openDataDownloadDialog()"
-        aria-label="Open dialog to download data"
+        mat-icon-button
+        class="pin-button"
+        i18n-aria-label="A button to pin a card."
+        aria-label="Pin card"
+        [attr.title]="isPinned ? 'Unpin card' : 'Pin card'"
+        (click)="onPinClicked.emit(!isPinned)"
       >
-        <mat-icon svgIcon="get_app_24px"></mat-icon>
-        <span>Download data</span>
+        <mat-icon
+          [svgIcon]="isPinned ? 'keep_24px' : 'keep_outline_24px'"
+        ></mat-icon>
       </button>
-    </mat-menu>
-  </span>
-</div>
-<div class="chart-container">
-  <mat-spinner
-    diameter="18"
-    *ngIf="loadState === DataLoadState.LOADING"
-  ></mat-spinner>
-  <line-chart
-    [disableUpdate]="!isCardVisible"
-    [preferredRendererType]="forceSvg ? RendererType.SVG : RendererType.WEBGL"
-    [seriesData]="dataSeries"
-    [seriesMetadataMap]="chartMetadataMap"
-    [xScaleType]="xScaleType"
-    [yScaleType]="yScaleType"
-    [customXFormatter]="getCustomXFormatter()"
-    [ignoreYOutliers]="ignoreOutliers"
-    [tooltipTemplate]="tooltip"
-    [useDarkMode]="useDarkMode"
-    (onViewBoxOverridden)="isViewBoxOverridden = $event"
-    (viewBoxChanged)="onLineChartZoom.emit($event)"
-    [customVisTemplate]="lineChartCustomVis"
-    [customChartOverlayTemplate]="lineChartCustomXAxisVis"
-  ></line-chart>
-  <ng-template
-    #tooltip
-    let-tooltipData="data"
-    let-cursorLocationInDataCoord="cursorLocationInDataCoord"
-    let-cursorLocation="cursorLocation"
-  >
-    <table class="tooltip">
-      <thead>
-        <tr>
-          <th class="circle-header"></th>
-          <th>Run</th>
-          <th *ngIf="smoothingEnabled">Smoothed</th>
-          <th>Value</th>
-          <th>Step</th>
-          <th>Time</th>
-          <th>Relative</th>
-        </tr>
-      </thead>
-      <tbody>
-        <ng-container
-          *ngFor="
-            let datum of getCursorAwareTooltipData(tooltipData,
-              cursorLocationInDataCoord, cursorLocation);
-            trackBy: trackByTooltipDatum
-          "
+      <button
+        mat-icon-button
+        i18n-aria-label="A button on line chart that toggles full size mode."
+        aria-label="Toggle full size mode"
+        title="Toggle full size mode"
+        (click)="onFullSizeToggle.emit()"
+      >
+        <mat-icon
+          [svgIcon]="showFullSize ? 'fullscreen_exit_24px' : 'fullscreen_24px'"
+        ></mat-icon>
+      </button>
+      <!-- overflow menu cannot use mat-tooltip since it interferes with the mat-menu. -->
+      <button
+        mat-icon-button
+        [matMenuTriggerFor]="menu"
+        i18n-aria-label="An overflow menu button that opens more line chart options"
+        aria-label="More line chart options"
+        title="More line chart options"
+      >
+        <mat-icon svgIcon="more_vert_24px"></mat-icon>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button
+          mat-menu-item
+          (click)="toggleYScaleType()"
+          i18n-aria-label="A button that toggles log scale on y-axis on a line chart"
+          aria-label="Toggle Y-axis log scale on line chart"
         >
-          <tr class="tooltip-row" [class.closest]="datum.metadata.closest">
-            <td class="tooltip-row-circle">
-              <span [style.backgroundColor]="datum.metadata.color"></span>
-            </td>
-            <td class="name">
-              <ng-container *ngIf="datum.metadata.alias"
-                ><tb-experiment-alias
-                  [alias]="datum.metadata.alias"
-                ></tb-experiment-alias
-                >/</ng-container
-              >{{ datum.metadata.displayName }}
-            </td>
-            <td *ngIf="smoothingEnabled">
-              {{ valueFormatter.formatShort(datum.dataPoint.y) }}
-            </td>
-            <td>{{ valueFormatter.formatShort(datum.dataPoint.value) }}</td>
-            <!-- Print the step with comma for readability. -->
-            <td>{{ stepFormatter.formatShort(datum.dataPoint.step) }}</td>
-            <td>{{ datum.dataPoint.wallTime | date: 'short' }}</td>
-            <td>
-              {{
-              relativeXFormatter.formatReadable(datum.dataPoint.relativeTimeInMs)
-              }}
-            </td>
+          <mat-icon svgIcon="line_weight_24px"></mat-icon>
+          <span>Toggle Y-axis log scale</span>
+        </button>
+        <button
+          mat-menu-item
+          (click)="openDataDownloadDialog()"
+          aria-label="Open dialog to download data"
+        >
+          <mat-icon svgIcon="get_app_24px"></mat-icon>
+          <span>Download data</span>
+        </button>
+      </mat-menu>
+    </span>
+  </div>
+  <div class="chart-container">
+    <mat-spinner
+      diameter="18"
+      *ngIf="loadState === DataLoadState.LOADING"
+    ></mat-spinner>
+    <line-chart
+      [disableUpdate]="!isCardVisible"
+      [preferredRendererType]="forceSvg ? RendererType.SVG : RendererType.WEBGL"
+      [seriesData]="dataSeries"
+      [seriesMetadataMap]="chartMetadataMap"
+      [xScaleType]="xScaleType"
+      [yScaleType]="yScaleType"
+      [customXFormatter]="getCustomXFormatter()"
+      [ignoreYOutliers]="ignoreOutliers"
+      [tooltipTemplate]="tooltip"
+      [useDarkMode]="useDarkMode"
+      (onViewBoxOverridden)="isViewBoxOverridden = $event"
+      (viewBoxChanged)="onLineChartZoom.emit($event)"
+      [customVisTemplate]="lineChartCustomVis"
+      [customChartOverlayTemplate]="lineChartCustomXAxisVis"
+    ></line-chart>
+    <ng-template
+      #tooltip
+      let-tooltipData="data"
+      let-cursorLocationInDataCoord="cursorLocationInDataCoord"
+      let-cursorLocation="cursorLocation"
+    >
+      <table class="tooltip">
+        <thead>
+          <tr>
+            <th class="circle-header"></th>
+            <th>Run</th>
+            <th *ngIf="smoothingEnabled">Smoothed</th>
+            <th>Value</th>
+            <th>Step</th>
+            <th>Time</th>
+            <th>Relative</th>
           </tr>
-        </ng-container>
-      </tbody>
-    </table>
-  </ng-template>
+        </thead>
+        <tbody>
+          <ng-container
+            *ngFor="
+              let datum of getCursorAwareTooltipData(tooltipData,
+                cursorLocationInDataCoord, cursorLocation);
+              trackBy: trackByTooltipDatum
+            "
+          >
+            <tr class="tooltip-row" [class.closest]="datum.metadata.closest">
+              <td class="tooltip-row-circle">
+                <span [style.backgroundColor]="datum.metadata.color"></span>
+              </td>
+              <td class="name">
+                <ng-container *ngIf="datum.metadata.alias"
+                  ><tb-experiment-alias
+                    [alias]="datum.metadata.alias"
+                  ></tb-experiment-alias
+                  >/</ng-container
+                >{{ datum.metadata.displayName }}
+              </td>
+              <td *ngIf="smoothingEnabled">
+                {{ valueFormatter.formatShort(datum.dataPoint.y) }}
+              </td>
+              <td>{{ valueFormatter.formatShort(datum.dataPoint.value) }}</td>
+              <!-- Print the step with comma for readability. -->
+              <td>{{ stepFormatter.formatShort(datum.dataPoint.step) }}</td>
+              <td>{{ datum.dataPoint.wallTime | date: 'short' }}</td>
+              <td>
+                {{
+                relativeXFormatter.formatReadable(datum.dataPoint.relativeTimeInMs)
+                }}
+              </td>
+            </tr>
+          </ng-container>
+        </tbody>
+      </table>
+    </ng-template>
+  </div>
 </div>
 <ng-container *ngIf="showDataTable()">
   <div class="data-table-container">

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -29,6 +29,15 @@ $_title-to-heading-gap: 12px;
   padding-top: $metrics-preferred-gap - $_title-to-heading-gap;
 }
 
+.always-visible {
+  display: flex;
+  // The content that is always visible should match the min height of a card,
+  // taking into account padding and 2px for the card border.
+  flex-basis: $metrics-min-card-height - 2px - ($metrics-preferred-gap * 2) + $_title-to-heading-gap;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
 .heading {
   $heading-content-gap: 4px;
 
@@ -68,8 +77,7 @@ $_title-to-heading-gap: 12px;
 }
 
 .chart-container {
-  position: relative;
-  flex: 1;
+  flex-grow: 1;
 
   mat-spinner {
     $mat-icon-button-diameter: 40px;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -33,7 +33,8 @@ $_title-to-heading-gap: 12px;
   display: flex;
   // The content that is always visible should match the min height of a card,
   // taking into account padding and 2px for the card border.
-  flex-basis: $metrics-min-card-height - 2px - ($metrics-preferred-gap * 2) + $_title-to-heading-gap;
+  flex-basis: $metrics-min-card-height - 2px - ($metrics-preferred-gap * 2) +
+    $_title-to-heading-gap;
   flex-direction: column;
   flex-grow: 1;
 }

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -21,24 +21,25 @@ limitations under the License.
   ></ng-container>
 
   <div class="card-grid" [style.grid-template-columns]="gridTemplateColumn">
-      <div
-        *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
-        class="card-space"
-        [ngClass]="{
+    <div
+      *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
+      class="card-space"
+      [ngClass]="{
           'full-width': cardsAtFullWidth.has(item.cardId),
           'full-height': cardsAtFullHeight.has(item.cardId)
-        }">
-        <card-view
-          [cardId]="item.cardId"
-          [groupName]="groupName"
-          [pluginType]="item.plugin"
-          [cardObserver]="cardObserver"
-          [cardLazyLoader]="item.cardId"
-          (fullWidthChanged)="onFullWidthChanged(item.cardId, $event)"
-          (fullHeightChanged)="onFullHeightChanged(item.cardId, $event)"
-        >
-        </card-view>
-     </div>
+        }"
+    >
+      <card-view
+        [cardId]="item.cardId"
+        [groupName]="groupName"
+        [pluginType]="item.plugin"
+        [cardObserver]="cardObserver"
+        [cardLazyLoader]="item.cardId"
+        (fullWidthChanged)="onFullWidthChanged(item.cardId, $event)"
+        (fullHeightChanged)="onFullHeightChanged(item.cardId, $event)"
+      >
+      </card-view>
+    </div>
   </div>
 
   <ng-container

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -21,16 +21,24 @@ limitations under the License.
   ></ng-container>
 
   <div class="card-grid" [style.grid-template-columns]="gridTemplateColumn">
-    <card-view
-      *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
-      [ngClass]="isShowingDataTable(item) ? 'height-with-table' : ''"
-      [cardId]="item.cardId"
-      [groupName]="groupName"
-      [pluginType]="item.plugin"
-      [cardObserver]="cardObserver"
-      [cardLazyLoader]="item.cardId"
-    >
-    </card-view>
+      <div
+        *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
+        class="card-space"
+        [ngClass]="{
+          'full-width': cardsAtFullWidth.has(item.cardId),
+          'full-height': cardsAtFullHeight.has(item.cardId)
+        }">
+        <card-view
+          [cardId]="item.cardId"
+          [groupName]="groupName"
+          [pluginType]="item.plugin"
+          [cardObserver]="cardObserver"
+          [cardLazyLoader]="item.cardId"
+          (fullWidthChanged)="onFullWidthChanged(item.cardId, $event)"
+          (fullHeightChanged)="onFullHeightChanged(item.cardId, $event)"
+        >
+        </card-view>
+     </div>
   </div>
 
   <ng-container

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
@@ -25,33 +25,34 @@ $_background: map-get($tb-theme, background);
   display: grid;
   grid-template-columns: repeat(
     auto-fill,
-    minmax($metrics-min-card-width, auto)
+    minmax($metrics-min-card-width, 1fr)
   );
   gap: $metrics-preferred-gap;
   padding: $metrics-preferred-gap;
+}
+
+.card-space.full-width {
+  grid-column-start: 1;
+  grid-column-end: -1;
+}
+
+.card-space.full-height {
+  min-height: $metrics-min-card-height * 1.5;
+
+  card-view {
+    height: 100%;
+  }
 }
 
 card-view {
   @include tb-theme-foreground-prop(border, border, 1px solid);
   border-radius: 4px;
   box-sizing: border-box;
-  contain: strict;
-  height: 100%;
+  contain: layout paint;
+  display: block;
+  // Make sure the cards generally have some guaranteed minimum height to avoid
+  // jank as cards load.
   min-height: $metrics-min-card-height;
-
-  &.full-width {
-    // Remove `contain: size` to let the content's intrinsic size define height.
-    contain: layout paint;
-    grid-column-start: 1;
-    grid-column-end: -1;
-  }
-
-  &.full-height {
-    min-height: $metrics-min-card-height * 1.5;
-  }
-  &.height-with-table {
-    min-height: $metrics-min-card-height + 100px;
-  }
 }
 
 .group-controls {

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -23,7 +23,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import {PluginType} from '../../data_source';
-import {XAxisType} from '../../types';
+import {CardId} from '../../types';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 
@@ -40,6 +40,9 @@ export class CardGridComponent {
   readonly PluginType = PluginType;
   gridTemplateColumn = '';
 
+  cardsAtFullWidth = new Set<CardId>();
+  cardsAtFullHeight = new Set<CardId>();
+
   @Input() isGroupExpanded!: boolean;
   @Input() pageIndex!: number;
   @Input() numPages!: number;
@@ -47,8 +50,6 @@ export class CardGridComponent {
   @Input() cardMinWidth!: number | null;
   @Input() cardObserver!: CardObserver;
   @Input() showPaginationControls!: boolean;
-  @Input() isStepSelectorEnabled!: boolean;
-  @Input() xAxisType!: XAxisType;
 
   @Output() pageIndexChanged = new EventEmitter<number>();
 
@@ -58,7 +59,7 @@ export class CardGridComponent {
 
   ngOnInit() {
     if (this.isCardWidthValid(this.cardMinWidth)) {
-      this.gridTemplateColumn = `repeat(auto-fill, minmax(${this.cardMinWidth}px, auto))`;
+      this.gridTemplateColumn = `repeat(auto-fill, minmax(${this.cardMinWidth}px, 1fr))`;
     }
   }
 
@@ -67,7 +68,7 @@ export class CardGridComponent {
       const newCardWidth = changes['cardMinWidth'].currentValue;
       if (this.isCardWidthValid(newCardWidth)) {
         this.cardMinWidth = newCardWidth;
-        this.gridTemplateColumn = `repeat(auto-fill, minmax(${this.cardMinWidth}px, auto))`;
+        this.gridTemplateColumn = `repeat(auto-fill, minmax(${this.cardMinWidth}px, 1fr))`;
       } else {
         this.gridTemplateColumn = '';
       }
@@ -136,11 +137,19 @@ export class CardGridComponent {
     this.handlePageChange(nextValue, input);
   }
 
-  isShowingDataTable(item: CardIdWithMetadata) {
-    return (
-      this.isStepSelectorEnabled &&
-      item.plugin === PluginType.SCALARS &&
-      this.xAxisType === XAxisType.STEP
-    );
+  onFullWidthChanged(cardId: CardId, showFullWidth: boolean) {
+    if (showFullWidth) {
+      this.cardsAtFullWidth.add(cardId);
+    } else {
+      this.cardsAtFullWidth.delete(cardId);
+    }
+  }
+
+  onFullHeightChanged(cardId: CardId, showFullHeight: boolean) {
+    if (showFullHeight) {
+      this.cardsAtFullHeight.add(cardId);
+    } else {
+      this.cardsAtFullHeight.delete(cardId);
+    }
   }
 }

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -26,9 +26,7 @@ import {map, shareReplay, switchMap, takeUntil, tap} from 'rxjs/operators';
 import {State} from '../../../app_state';
 import {
   getMetricsCardMinWidth,
-  getMetricsStepSelectorEnabled,
   getMetricsTagGroupExpansionState,
-  getMetricsXAxisType,
 } from '../../../selectors';
 import {selectors as settingsSelectors} from '../../../settings';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
@@ -45,8 +43,6 @@ import {CardIdWithMetadata} from '../metrics_view_types';
       [cardIdsWithMetadata]="pagedItems$ | async"
       [cardMinWidth]="cardMinWidth$ | async"
       [cardObserver]="cardObserver"
-      [isStepSelectorEnabled]="isStepSelectorEnabled$ | async"
-      [xAxisType]="getMetricsXAxisType$ | async"
       (pageIndexChanged)="onPageIndexChanged($event)"
     >
     </metrics-card-grid-component>
@@ -63,11 +59,6 @@ export class CardGridContainer implements OnChanges, OnDestroy {
   readonly pageIndex$ = new BehaviorSubject<number>(0);
   private readonly items$ = new BehaviorSubject<CardIdWithMetadata[]>([]);
   private readonly ngUnsubscribe = new Subject<void>();
-
-  readonly isStepSelectorEnabled$ = this.store.select(
-    getMetricsStepSelectorEnabled
-  );
-  readonly getMetricsXAxisType$ = this.store.select(getMetricsXAxisType);
 
   readonly numPages$ = combineLatest([
     this.items$,

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -13,7 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {ScrollingModule} from '@angular/cdk/scrolling';
-import {Component, EventEmitter, Input, NO_ERRORS_SCHEMA, Output} from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  NO_ERRORS_SCHEMA,
+  Output,
+} from '@angular/core';
 import {
   ComponentFixture,
   discardPeriodicTasks,
@@ -250,11 +256,17 @@ describe('card grid', () => {
 
     it('shows cards at min dimensions by default', () => {
       const cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
-      expect(cardSpaces[0].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
       expect(cardSpaces[0].nativeElement.classList).not.toContain('full-width');
-      expect(cardSpaces[1].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[1].nativeElement.classList).not.toContain(
+        'full-height'
+      );
       expect(cardSpaces[1].nativeElement.classList).not.toContain('full-width');
-      expect(cardSpaces[2].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
       expect(cardSpaces[2].nativeElement.classList).not.toContain('full-width');
     });
 
@@ -264,27 +276,43 @@ describe('card grid', () => {
 
       cardViews[1].componentInstance.fullHeightChanged.emit(true);
       fixture.detectChanges();
-      expect(cardSpaces[0].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
       expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
-      expect(cardSpaces[2].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
 
       cardViews[0].componentInstance.fullHeightChanged.emit(true);
       fixture.detectChanges();
       expect(cardSpaces[0].nativeElement.classList).toContain('full-height');
       expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
-      expect(cardSpaces[2].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
 
       cardViews[1].componentInstance.fullHeightChanged.emit(false);
       fixture.detectChanges();
       expect(cardSpaces[0].nativeElement.classList).toContain('full-height');
-      expect(cardSpaces[1].nativeElement.classList).not.toContain('full-height');
-      expect(cardSpaces[2].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[1].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
 
       cardViews[0].componentInstance.fullHeightChanged.emit(false);
       fixture.detectChanges();
-      expect(cardSpaces[0].nativeElement.classList).not.toContain('full-height');
-      expect(cardSpaces[1].nativeElement.classList).not.toContain('full-height');
-      expect(cardSpaces[2].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[1].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
     });
 
     it('does not change height if emitted value is same', () => {
@@ -293,21 +321,33 @@ describe('card grid', () => {
 
       cardViews[1].componentInstance.fullHeightChanged.emit(true);
       fixture.detectChanges();
-      expect(cardSpaces[0].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
       expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
-      expect(cardSpaces[2].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
 
       cardViews[0].componentInstance.fullHeightChanged.emit(false);
       fixture.detectChanges();
-      expect(cardSpaces[0].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
       expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
-      expect(cardSpaces[2].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
 
       cardViews[1].componentInstance.fullHeightChanged.emit(true);
       fixture.detectChanges();
-      expect(cardSpaces[0].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
       expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
-      expect(cardSpaces[2].nativeElement.classList).not.toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
     });
 
     it('changes width after card event', () => {
@@ -361,6 +401,5 @@ describe('card grid', () => {
       expect(cardSpaces[1].nativeElement.classList).toContain('full-width');
       expect(cardSpaces[2].nativeElement.classList).not.toContain('full-width');
     });
-
   });
 });

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -922,7 +922,7 @@ describe('metrics main view', () => {
           fixture.debugElement.query(By.css('.card-grid')).styles[
             'grid-template-columns'
           ]
-        ).toBe('repeat(auto-fill, minmax(500px, auto))');
+        ).toBe('repeat(auto-fill, minmax(500px, 1fr))');
       });
 
       it('does not set the max width with invalid width value', () => {
@@ -981,7 +981,7 @@ describe('metrics main view', () => {
           fixture.debugElement.query(By.css('.card-grid')).styles[
             'grid-template-columns'
           ]
-        ).toBe('repeat(auto-fill, minmax(500px, auto))');
+        ).toBe('repeat(auto-fill, minmax(500px, 1fr))');
 
         getMetricsCardMinWidthSubject.next(null);
         fixture.detectChanges();

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -32,12 +32,12 @@ limitations under the License.
     *ngIf="isScalarStepSelectorFeatureEnabled"
     [title]="!isAxisTypeStep()? 'Only available when Horizontal Axis is set to step': ''"
   >
-    <mat-checkbox
+      <mat-checkbox
       [checked]="isScalarStepSelectorEnabled"
       (change)="stepSelectorToggled.emit()"
-      [disabled]="!isAxisTypeStep()"
+        [disabled]="!isAxisTypeStep()"
       >Enable step selection and data table
-    </mat-checkbox>
+      </mat-checkbox>
     <span class="indent">(Scalars only)</span>
     <div class="indent range-selection" *ngIf="isRangeSelectionAllowed">
       <mat-checkbox

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -32,12 +32,12 @@ limitations under the License.
     *ngIf="isScalarStepSelectorFeatureEnabled"
     [title]="!isAxisTypeStep()? 'Only available when Horizontal Axis is set to step': ''"
   >
-      <mat-checkbox
+    <mat-checkbox
       [checked]="isScalarStepSelectorEnabled"
       (change)="stepSelectorToggled.emit()"
-        [disabled]="!isAxisTypeStep()"
+      [disabled]="!isAxisTypeStep()"
       >Enable step selection and data table
-      </mat-checkbox>
+    </mat-checkbox>
     <span class="indent">(Scalars only)</span>
     <div class="indent range-selection" *ngIf="isRangeSelectionAllowed">
       <mat-checkbox


### PR DESCRIPTION
These are some adjustments to how time series cards change size as their content changes.

The fundamental change is for the card-view to have a minimum height ('320px' in practice) but to otherwise allow the height of the card to be determined by the content of the card. Each card-view is enclosed in a card-space. The card-space grows in height with other card-spaces in the same row of cards. But the card-view is protected from this and continues to just maintain the height of its content.

We can think of each type of card to have an "always visible" portion of content. The "always visible" portion of each card also has a minimum height of '320px' but can grow if its card-parent's height grows, too.
  * In the case of scalar cards, the "always visible" content is all content except the data table and is explicitly marked as so in the DOM. 
  * In the case of histogram and image cards, the "always visible" content is actually all the content and remains implicit (ie no DOM changes).

We treat "full size" mode for scalars and histograms a little differently. In that case the card-view is given a rigid '480px' height and the content must adapt to that.

The practical implications are:
* In normal mode, scalars cards will continue to grow from 320px to 420px when the data table is turned on but instead of this height change being defined at the card-view level, it happens naturally due to the change in content of the card.
* In normal mode, histograms and image cards are always 320px.
  * So you will have rows of cards that could look like this: 
  * ![image](https://user-images.githubusercontent.com/17152369/214349883-b8dba98d-d295-4362-abb0-c920a6ed72d3.png)
* In "full size" mode, we fix a bug where scalar cards with data tables will actually also be 480px rather than being 400px.
  * 
![image](https://user-images.githubusercontent.com/17152369/214350091-7ff9c9f9-0bfb-4b11-bf6a-c44a7be10ae8.png)

