### PR TITLE
tensorboard-data-server 0.7.0

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "rustboard"
-version = "0.7.0"
+version = "0.8.0-alpha.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "rustboard"
-version = "0.7.0-alpha.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "rustboard"
-version = "0.7.0-alpha.0"
+version = "0.7.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 # Keep in sync with `edition` in rustfmt.toml.
 edition = "2018"

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "rustboard"
-version = "0.7.0"
+version = "0.8.0-alpha.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 # Keep in sync with `edition` in rustfmt.toml.
 edition = "2018"

--- a/tensorboard/data/server/lib.rs
+++ b/tensorboard/data/server/lib.rs
@@ -19,7 +19,7 @@ limitations under the License.
 
 /// Package version. Keep in sync with `Cargo.toml`. We don't use `env!("CARGO_PKG_VERSION")`
 /// because of <https://github.com/bazelbuild/rules_rust/issues/573>.
-pub(crate) const VERSION: &str = "0.7.0";
+pub(crate) const VERSION: &str = "0.8.0-alpha.0";
 
 pub mod blob_key;
 pub mod cli;

--- a/tensorboard/data/server/lib.rs
+++ b/tensorboard/data/server/lib.rs
@@ -19,7 +19,7 @@ limitations under the License.
 
 /// Package version. Keep in sync with `Cargo.toml`. We don't use `env!("CARGO_PKG_VERSION")`
 /// because of <https://github.com/bazelbuild/rules_rust/issues/573>.
-pub(crate) const VERSION: &str = "0.7.0-alpha.0";
+pub(crate) const VERSION: &str = "0.7.0";
 
 pub mod blob_key;
 pub mod cli;

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.7.0"
+__version__ = "0.8.0a0"
 
 
 def server_binary():

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.7.0a0"
+__version__ = "0.7.0"
 
 
 def server_binary():


### PR DESCRIPTION
Changes since 0.6.1:
* [Add Apple M1 Support](https://github.com/tensorflow/tensorboard/pull/5715)
* [Add Linux aarch64 support](https://github.com/tensorflow/tensorboard/pull/6101)
* [Use gcp_auth for GCP authentication](https://github.com/tensorflow/tensorboard/pull/5939)

Merge plan: rebase and merge, then release from the unique commit where
the version numbers are 0.7.0.