### PR TITLE
Column Customization: Encapsulate data table header into separate component

### DIFF
--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -8,6 +8,12 @@ tf_sass_binary(
     deps = ["//tensorboard/webapp:angular_material_sass_deps"],
 )
 
+tf_sass_binary(
+    name = "data_table_header_styles",
+    src = "data_table_header_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_sass_deps"],
+)
+
 tf_ng_module(
     name = "data_table",
     srcs = [
@@ -19,9 +25,28 @@ tf_ng_module(
         ":data_table_styles",
     ],
     deps = [
+        ":data_table_header",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ng_module(
+    name = "data_table_header",
+    srcs = [
+        "data_table_header_component.ts",
+        "data_table_header_module.ts",
+    ],
+    assets = [
+        "data_table_header_component.ng.html",
+        ":data_table_header_styles",
+    ],
+    deps = [
+        "//tensorboard/webapp/angular:expect_angular_material_icon",
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -26,22 +26,10 @@ limitations under the License.
               (dragstart)="dragStart(header)"
               (dragend)="dragEnd()"
               (dragenter)="dragEnter(header)"
-              [ngSwitch]="header.type"
               class="cell"
               [ngClass]="getHeaderHighlightStyle(header.type)"
             >
-              <!-- order icon -->
-              <mat-icon
-                *ngSwitchCase="ColumnHeaders.VALUE_CHANGE"
-                svgIcon="change_history_24px"
-              ></mat-icon>
-              <mat-icon
-                *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE"
-                svgIcon="change_history_24px"
-              ></mat-icon>
-              <div *ngSwitchDefault class="extra-right-padding"></div>
-
-              <span>{{ getHeaderTextColumn(header.type) }}</span>
+              <tb-data-table-header [header]="header"></tb-data-table-header>
 
               <div class="sorting-icon-container">
                 <mat-icon

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -73,41 +73,6 @@ export class DataTableComponent implements OnDestroy {
     document.removeEventListener('dragover', preventDefault);
   }
 
-  getHeaderTextColumn(columnHeader: ColumnHeaderType): string {
-    switch (columnHeader) {
-      case ColumnHeaderType.RUN:
-        return 'Run';
-      case ColumnHeaderType.VALUE:
-        return 'Value';
-      case ColumnHeaderType.STEP:
-        return 'Step';
-      case ColumnHeaderType.TIME:
-        return 'Time';
-      case ColumnHeaderType.RELATIVE_TIME:
-        return 'Relative';
-      case ColumnHeaderType.SMOOTHED:
-        return 'Smoothed';
-      case ColumnHeaderType.VALUE_CHANGE:
-        return 'Value';
-      case ColumnHeaderType.START_STEP:
-        return 'Start Step';
-      case ColumnHeaderType.END_STEP:
-        return 'End Step';
-      case ColumnHeaderType.START_VALUE:
-        return 'Start Value';
-      case ColumnHeaderType.END_VALUE:
-        return 'End Value';
-      case ColumnHeaderType.MIN_VALUE:
-        return 'Min';
-      case ColumnHeaderType.MAX_VALUE:
-        return 'Max';
-      case ColumnHeaderType.PERCENTAGE_CHANGE:
-        return '%';
-      default:
-        return '';
-    }
-  }
-
   getFormattedDataForColumn(
     columnHeader: ColumnHeaderType,
     selectedStepRunData: SelectedStepRunData

--- a/tensorboard/webapp/widgets/data_table/data_table_header_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_component.ng.html
@@ -1,0 +1,27 @@
+<!--
+@license
+Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div class="header-container" [ngSwitch]="header.type">
+  <mat-icon
+    *ngSwitchCase="ColumnHeaderType.VALUE_CHANGE"
+    svgIcon="change_history_24px"
+  ></mat-icon>
+  <mat-icon
+    *ngSwitchCase="ColumnHeaderType.PERCENTAGE_CHANGE"
+    svgIcon="change_history_24px"
+  ></mat-icon>
+  <div *ngSwitchDefault class="extra-right-padding"></div>
+
+  <span>{{ getHeaderTextColumn(header.type) }}</span>
+</div>

--- a/tensorboard/webapp/widgets/data_table/data_table_header_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_component.scss
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,15 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {CommonModule} from '@angular/common';
-import {NgModule} from '@angular/core';
-import {MatIconModule} from '@angular/material/icon';
-import {DataTableComponent} from './data_table_component';
-import {DataTableHeaderModule} from './data_table_header_module';
+.header-container {
+  align-items: center;
+  display: flex;
+}
 
-@NgModule({
-  declarations: [DataTableComponent],
-  exports: [DataTableComponent],
-  imports: [CommonModule, MatIconModule, DataTableHeaderModule],
-})
-export class DataTableModule {}
+.extra-right-padding {
+  // Add artificial padding to keep consistent with icons which have whitespace
+  padding-right: 1px;
+}
+
+mat-icon {
+  width: 12px;
+}

--- a/tensorboard/webapp/widgets/data_table/data_table_header_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_component.ts
@@ -1,0 +1,71 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnDestroy,
+} from '@angular/core';
+import {
+  ColumnHeaderType,
+  ColumnHeader,
+} from '../../metrics/views/card_renderer/scalar_card_types';
+
+@Component({
+  selector: 'tb-data-table-header',
+  templateUrl: 'data_table_header_component.ng.html',
+  styleUrls: ['data_table_header_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DataTableHeaderComponent {
+  @Input() header!: ColumnHeader;
+  ColumnHeaderType = ColumnHeaderType;
+
+  getHeaderTextColumn(columnHeader: ColumnHeaderType): string {
+    switch (columnHeader) {
+      case ColumnHeaderType.RUN:
+        return 'Run';
+      case ColumnHeaderType.VALUE:
+        return 'Value';
+      case ColumnHeaderType.STEP:
+        return 'Step';
+      case ColumnHeaderType.TIME:
+        return 'Time';
+      case ColumnHeaderType.RELATIVE_TIME:
+        return 'Relative';
+      case ColumnHeaderType.SMOOTHED:
+        return 'Smoothed';
+      case ColumnHeaderType.VALUE_CHANGE:
+        return 'Value';
+      case ColumnHeaderType.START_STEP:
+        return 'Start Step';
+      case ColumnHeaderType.END_STEP:
+        return 'End Step';
+      case ColumnHeaderType.START_VALUE:
+        return 'Start Value';
+      case ColumnHeaderType.END_VALUE:
+        return 'End Value';
+      case ColumnHeaderType.MIN_VALUE:
+        return 'Min';
+      case ColumnHeaderType.MAX_VALUE:
+        return 'Max';
+      case ColumnHeaderType.PERCENTAGE_CHANGE:
+        return '%';
+      default:
+        return '';
+    }
+  }
+}

--- a/tensorboard/webapp/widgets/data_table/data_table_header_module.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_module.ts
@@ -16,12 +16,11 @@ limitations under the License.
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatIconModule} from '@angular/material/icon';
-import {DataTableComponent} from './data_table_component';
-import {DataTableHeaderModule} from './data_table_header_module';
+import {DataTableHeaderComponent} from './data_table_header_component';
 
 @NgModule({
-  declarations: [DataTableComponent],
-  exports: [DataTableComponent],
-  imports: [CommonModule, MatIconModule, DataTableHeaderModule],
+  declarations: [DataTableHeaderComponent],
+  exports: [DataTableHeaderComponent],
+  imports: [CommonModule, MatIconModule],
 })
-export class DataTableModule {}
+export class DataTableHeaderModule {}

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -25,6 +25,7 @@ import {
   SortingOrder,
 } from '../../metrics/views/card_renderer/scalar_card_types';
 import {DataTableComponent} from './data_table_component';
+import {DataTableModule} from './data_table_module';
 
 @Component({
   selector: 'testable-comp',
@@ -59,7 +60,7 @@ describe('data table', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [TestableComponent, DataTableComponent],
-      imports: [MatIconModule],
+      imports: [MatIconModule, DataTableModule],
     }).compileComponents();
   });
 


### PR DESCRIPTION
* Motivation for features / changes
The goal here is to enable reusability for the data table headers. We want the column editor menu to display the headers in the exact same way as the headers themselves. This new component will be imported into that menu.

* Technical description of changes
This simply creates a new component for the header and moves the logic from the data_table_component to the data_table_header_component.

* Screenshots of UI changes
There are not functional changes from this PR.