### PR TITLE
Set mat-icon height in DataTableHeaderComponent

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_header_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_component.scss
@@ -24,5 +24,6 @@ limitations under the License.
 }
 
 mat-icon {
+  height: 12px;
   width: 12px;
 }


### PR DESCRIPTION
* Motivation for features / changes
In PR #6169 I introduced the DataTableHeaderComponent. This change was not supposed to have any affect on the UI. However, since the mat-icon was not set in that component it defaulted to a larger size than previously and that shifted some things around in an unwanted way. This remedies that.

* Screenshots of UI changes
Without the height set:
<img width="323" alt="Screenshot 2023-01-27 at 10 56 17 AM" src="https://user-images.githubusercontent.com/8672809/215172233-725e641f-2e4d-4728-9956-1752ccbe9843.png">

After this PR with the height set:
<img width="335" alt="Screenshot 2023-01-27 at 10 55 58 AM" src="https://user-images.githubusercontent.com/8672809/215172260-14e9fa93-d012-4d39-ba94-28d8d0bdea89.png">
