### PR TITLE
Column Customization: Add Scalar Column Editor

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -277,6 +277,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/metrics/views/card_renderer:card_renderer_tests",
         "//tensorboard/webapp/metrics/views/main_view:main_view_tests",
         "//tensorboard/webapp/metrics/views/right_pane:right_pane_test",
+        "//tensorboard/webapp/metrics/views/right_pane/scalar_column_editor:scalar_column_editor_test",
         "//tensorboard/webapp/plugins:plugins_container_test_lib",
         "//tensorboard/webapp/plugins/npmi:npmi_test_lib",
         "//tensorboard/webapp/plugins/npmi/data_source:data_source_test_lib",

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -216,7 +216,7 @@ export const dataTableColumnDrag = createAction(
 export const dataTableColumnEdited = createAction(
   '[Metrics] Data table columns edited in edit menu',
   props<{
-    fobState: DataTableMode;
+    dataTableMode: DataTableMode;
     headers: ColumnHeader[];
   }>()
 );
@@ -224,7 +224,7 @@ export const dataTableColumnEdited = createAction(
 export const dataTableColumnToggled = createAction(
   '[Metrics] Data table column toggled in edit menu',
   props<{
-    fobState: DataTableMode;
+    dataTableMode: DataTableMode;
     headerType: ColumnHeaderType;
   }>()
 );

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1098,7 +1098,7 @@ const reducer = createReducer(
       singleSelectionHeaders: newOrder,
     };
   }),
-  on(actions.dataTableColumnEdited, (state, {fobState, headers}) => {
+  on(actions.dataTableColumnEdited, (state, {dataTableMode, headers}) => {
     const enabledNewHeaders: ColumnHeader[] = [];
     const disabledNewHeaders: ColumnHeader[] = [];
 
@@ -1111,7 +1111,7 @@ const reducer = createReducer(
       }
     });
 
-    if (fobState === DataTableMode.RANGE) {
+    if (dataTableMode === DataTableMode.RANGE) {
       return {
         ...state,
         rangeSelectionHeaders: enabledNewHeaders.concat(disabledNewHeaders),
@@ -1123,9 +1123,9 @@ const reducer = createReducer(
       singleSelectionHeaders: enabledNewHeaders.concat(disabledNewHeaders),
     };
   }),
-  on(actions.dataTableColumnToggled, (state, {fobState, headerType}) => {
+  on(actions.dataTableColumnToggled, (state, {dataTableMode, headerType}) => {
     const targetedHeaders =
-      fobState === DataTableMode.RANGE
+      dataTableMode === DataTableMode.RANGE
         ? state.rangeSelectionHeaders
         : state.singleSelectionHeaders;
 
@@ -1151,7 +1151,7 @@ const reducer = createReducer(
       enabled: !newHeaders[newToggledHeaderIndex].enabled,
     };
 
-    if (fobState === DataTableMode.RANGE) {
+    if (dataTableMode === DataTableMode.RANGE) {
       return {
         ...state,
         rangeSelectionHeaders: newHeaders,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1490,7 +1490,7 @@ describe('metrics reducers', () => {
     });
 
     describe('dataTableColumnEdited', () => {
-      it('edits range selection when fobState is range', () => {
+      it('edits range selection when dataTableMode is range', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
             {type: ColumnHeaderType.RUN, enabled: true},
@@ -1510,7 +1510,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnEdited({
-            fobState: DataTableMode.RANGE,
+            dataTableMode: DataTableMode.RANGE,
             headers: [
               {type: ColumnHeaderType.RUN, enabled: true},
               {type: ColumnHeaderType.END_VALUE, enabled: true},
@@ -1536,7 +1536,7 @@ describe('metrics reducers', () => {
         ]);
       });
 
-      it('edits single selection when fobState is single', () => {
+      it('edits single selection when dataTableMode is single', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
             {type: ColumnHeaderType.RUN, enabled: true},
@@ -1556,7 +1556,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnEdited({
-            fobState: DataTableMode.SINGLE,
+            dataTableMode: DataTableMode.SINGLE,
             headers: [
               {type: ColumnHeaderType.RUN, enabled: true},
               {type: ColumnHeaderType.STEP, enabled: true},
@@ -1595,7 +1595,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnEdited({
-            fobState: DataTableMode.RANGE,
+            dataTableMode: DataTableMode.RANGE,
             headers: [
               {type: ColumnHeaderType.RUN, enabled: true},
               {type: ColumnHeaderType.MAX_VALUE, enabled: false},
@@ -1631,7 +1631,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnToggled({
-            fobState: DataTableMode.RANGE,
+            dataTableMode: DataTableMode.RANGE,
             headerType: ColumnHeaderType.RUN,
           })
         );
@@ -1659,7 +1659,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnToggled({
-            fobState: DataTableMode.RANGE,
+            dataTableMode: DataTableMode.RANGE,
             headerType: ColumnHeaderType.MAX_VALUE,
           })
         );
@@ -1673,7 +1673,7 @@ describe('metrics reducers', () => {
         ]);
       });
 
-      it('only changes range selection headers when FobState is RANGE', () => {
+      it('only changes range selection headers when dataTableMode is RANGE', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
             {type: ColumnHeaderType.RUN, enabled: true},
@@ -1693,7 +1693,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnToggled({
-            fobState: DataTableMode.RANGE,
+            dataTableMode: DataTableMode.RANGE,
             headerType: ColumnHeaderType.MAX_VALUE,
           })
         );
@@ -1713,7 +1713,7 @@ describe('metrics reducers', () => {
         ]);
       });
 
-      it('only changes single selection headers when FobState is SINGLE', () => {
+      it('only changes single selection headers when dataTableMode is SINGLE', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
             {type: ColumnHeaderType.RUN, enabled: true},
@@ -1733,7 +1733,7 @@ describe('metrics reducers', () => {
         const nextState = reducers(
           beforeState,
           actions.dataTableColumnToggled({
-            fobState: DataTableMode.SINGLE,
+            dataTableMode: DataTableMode.SINGLE,
             headerType: ColumnHeaderType.STEP,
           })
         );

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -129,6 +129,7 @@ tf_ng_module(
         "//tensorboard/webapp/metrics/views:utils",
         "//tensorboard/webapp/metrics/views/card_renderer",
         "//tensorboard/webapp/metrics/views/right_pane",
+        "//tensorboard/webapp/metrics/views/right_pane/scalar_column_editor",
         "//tensorboard/webapp/settings",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/types:ui",

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ng.html
@@ -101,7 +101,9 @@ limitations under the License.
     *ngIf="isSidepaneOpen"
     class="slide-out-menu"
     [ngClass]="{'slide-out-menu-expanded':slideOutMenuOpen}"
-  ></div>
+  >
+    <metrics-scalar-column-editor></metrics-scalar-column-editor>
+  </div>
   <div class="sidebar" *ngIf="isSidepaneOpen">
     <div class="header">
       <h2 class="title">Settings</h2>

--- a/tensorboard/webapp/metrics/views/main_view/main_view_module.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_module.ts
@@ -24,6 +24,7 @@ import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {FilterInputModule} from '../../../widgets/filter_input/filter_input_module';
 import {CardRendererModule} from '../card_renderer/card_renderer_module';
 import {RightPaneModule} from '../right_pane/right_pane_module';
+import {ScalarColumnEditorModule} from '../right_pane/scalar_column_editor/scalar_column_editor_module';
 import {CardGridComponent} from './card_grid_component';
 import {CardGridContainer} from './card_grid_container';
 import {CardGroupsComponent} from './card_groups_component';
@@ -72,6 +73,7 @@ import {PinnedViewContainer} from './pinned_view_container';
     MatInputModule,
     MatProgressSpinnerModule,
     RightPaneModule,
+    ScalarColumnEditorModule,
     ScrollingModule,
   ],
 })

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
@@ -1,0 +1,59 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_sass_binary(
+    name = "scalar_column_editor_styles",
+    src = "scalar_column_editor_component.scss",
+    deps = ["//tensorboard/webapp:angular_material_sass_deps"],
+)
+
+tf_ng_module(
+    name = "scalar_column_editor",
+    srcs = [
+        "scalar_column_editor_component.ts",
+        "scalar_column_editor_container.ts",
+        "scalar_column_editor_module.ts",
+    ],
+    assets = [
+        ":scalar_column_editor_styles",
+        "scalar_column_editor_component.ng.html",
+    ],
+    deps = [
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/angular:expect_angular_material_checkbox",
+        "//tensorboard/webapp/angular:expect_angular_material_tabs",
+        "//tensorboard/webapp/metrics/actions",
+        "//tensorboard/webapp/metrics/store",
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
+        "//tensorboard/webapp/widgets/data_table:data_table_header",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "scalar_column_editor_test",
+    testonly = True,
+    srcs = [
+        "scalar_column_editor_test.ts",
+    ],
+    deps = [
+        ":scalar_column_editor",
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_material_tabs",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/metrics/actions",
+        "//tensorboard/webapp/metrics/store",
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
+        "//tensorboard/webapp/widgets/data_table:data_table_header",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -1,0 +1,42 @@
+<!--
+@license
+Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div>
+  <mat-tab-group (selectedIndexChange)="onTabChange($event)" class="tab-group">
+    <mat-tab [label]="'Single'">
+      <ngContext
+        [ngTemplateOutlet]="headerList"
+        [ngTemplateOutletContext]="{headers: singleHeaders}"
+      ></ngContext>
+    </mat-tab>
+    <mat-tab [label]="'Range'">
+      <ngContext
+        [ngTemplateOutlet]="headerList"
+        [ngTemplateOutletContext]="{headers: rangeHeaders}"
+      ></ngContext>
+    </mat-tab>
+  </mat-tab-group>
+</div>
+
+<ng-template #headerList let-headers="headers">
+  <div class="header-list">
+    <div class="header-list-item" *ngFor="let header of headers;">
+      <mat-checkbox [checked]="header.enabled" (change)="toggleHeader(header)"
+        ><tb-data-table-header [header]="header"></tb-data-table-header
+      ></mat-checkbox>
+    </div>
+  </div>
+</ng-template>

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,26 +15,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div>
-  <mat-tab-group (selectedIndexChange)="onTabChange($event)" class="tab-group">
+  <mat-tab-group class="tab-group">
     <mat-tab [label]="'Single'">
       <ngContext
         [ngTemplateOutlet]="headerList"
-        [ngTemplateOutletContext]="{headers: singleHeaders}"
+        [ngTemplateOutletContext]="{headers: singleHeaders, dataTableMode:DataTableMode.SINGLE}"
       ></ngContext>
     </mat-tab>
     <mat-tab [label]="'Range'">
       <ngContext
         [ngTemplateOutlet]="headerList"
-        [ngTemplateOutletContext]="{headers: rangeHeaders}"
+        [ngTemplateOutletContext]="{headers: rangeHeaders, dataTableMode:DataTableMode.RANGE}"
       ></ngContext>
     </mat-tab>
   </mat-tab-group>
 </div>
 
-<ng-template #headerList let-headers="headers">
+<ng-template
+  #headerList
+  let-headers="headers"
+  let-dataTableMode="dataTableMode"
+>
   <div class="header-list">
     <div class="header-list-item" *ngFor="let header of headers;">
-      <mat-checkbox [checked]="header.enabled" (change)="toggleHeader(header)"
+      <mat-checkbox
+        [checked]="header.enabled"
+        (change)="toggleHeader(header, dataTableMode)"
         ><tb-data-table-header [header]="header"></tb-data-table-header
       ></mat-checkbox>
     </div>

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -1,0 +1,53 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+@use '@angular/material' as mat;
+@import 'tensorboard/webapp/theme/tb_theme';
+
+$_accent: map-get(mat.get-color-config($tb-theme), accent);
+
+:host ::ng-deep .mat-tab-label {
+  min-width: 0;
+}
+.tab-group {
+  // Override static position so this object is not seen in front of the
+  // settings panel.
+  position: fixed;
+}
+.header-list {
+  display: block;
+  border-bottom: 0px;
+  height: 90%;
+  margin-top: 5%;
+  width: 90%;
+  margin-left: 5%;
+}
+
+.header-list-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 3px;
+}
+
+.highlighted {
+  background-color: mat.get-color-from-palette(mat.$gray-palette, 200);
+}
+
+.highlight-bottom {
+  border-bottom: 2px solid mat.get-color-from-palette($_accent);
+}
+
+.highlight-top {
+  border-top: 2px solid mat.get-color-from-palette($_accent);
+}

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,31 +23,14 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 .tab-group {
   // Override static position so this object is not seen in front of the
   // settings panel.
-  position: fixed;
+  position: relative;
+  z-index: 0;
 }
 .header-list {
-  display: block;
-  border-bottom: 0px;
-  height: 90%;
   margin-top: 5%;
-  width: 90%;
   margin-left: 5%;
 }
 
 .header-list-item {
-  display: flex;
-  justify-content: space-between;
   padding: 3px;
-}
-
-.highlighted {
-  background-color: mat.get-color-from-palette(mat.$gray-palette, 200);
-}
-
-.highlight-bottom {
-  border-bottom: 2px solid mat.get-color-from-palette($_accent);
-}
-
-.highlight-top {
-  border-top: 2px solid mat.get-color-from-palette($_accent);
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
@@ -1,0 +1,80 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  Output,
+} from '@angular/core';
+import {
+  ColumnHeader,
+  ColumnHeaderType,
+  DataTableMode,
+} from '../../card_renderer/scalar_card_types';
+
+const preventDefault = function (e: MouseEvent) {
+  e.preventDefault();
+};
+
+enum Edge {
+  TOP,
+  BOTTOM,
+}
+
+const isHeaderOfType = function (type: ColumnHeaderType, header: ColumnHeader) {
+  return header.type === type;
+};
+
+@Component({
+  selector: 'metrics-scalar-column-editor-component',
+  templateUrl: 'scalar_column_editor_component.ng.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styleUrls: [`scalar_column_editor_component.css`],
+})
+export class ScalarColumnEditorComponent implements OnDestroy {
+  dataTableMode = DataTableMode;
+  selectedTab: DataTableMode = DataTableMode.SINGLE;
+  @Input() rangeHeaders!: ColumnHeader[];
+  @Input() singleHeaders!: ColumnHeader[];
+
+  @Output() onScalarTableColumnToggled = new EventEmitter<{
+    dataTableMode: DataTableMode;
+    headerType: ColumnHeaderType;
+  }>();
+
+  ngOnDestroy() {
+    document.removeEventListener('dragover', preventDefault);
+  }
+
+  onTabChange(tabIndex: number) {
+    switch (tabIndex) {
+      case 0:
+        this.selectedTab = DataTableMode.SINGLE;
+        break;
+      case 1:
+        this.selectedTab = DataTableMode.RANGE;
+        break;
+    }
+  }
+
+  toggleHeader(header: ColumnHeader) {
+    this.onScalarTableColumnToggled.emit({
+      dataTableMode: this.selectedTab,
+      headerType: header.type,
+    });
+  }
+}

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  OnDestroy,
   Output,
 } from '@angular/core';
 import {
@@ -26,27 +25,14 @@ import {
   DataTableMode,
 } from '../../card_renderer/scalar_card_types';
 
-const preventDefault = function (e: MouseEvent) {
-  e.preventDefault();
-};
-
-enum Edge {
-  TOP,
-  BOTTOM,
-}
-
-const isHeaderOfType = function (type: ColumnHeaderType, header: ColumnHeader) {
-  return header.type === type;
-};
-
 @Component({
   selector: 'metrics-scalar-column-editor-component',
   templateUrl: 'scalar_column_editor_component.ng.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: [`scalar_column_editor_component.css`],
 })
-export class ScalarColumnEditorComponent implements OnDestroy {
-  dataTableMode = DataTableMode;
+export class ScalarColumnEditorComponent {
+  DataTableMode = DataTableMode;
   selectedTab: DataTableMode = DataTableMode.SINGLE;
   @Input() rangeHeaders!: ColumnHeader[];
   @Input() singleHeaders!: ColumnHeader[];
@@ -56,24 +42,9 @@ export class ScalarColumnEditorComponent implements OnDestroy {
     headerType: ColumnHeaderType;
   }>();
 
-  ngOnDestroy() {
-    document.removeEventListener('dragover', preventDefault);
-  }
-
-  onTabChange(tabIndex: number) {
-    switch (tabIndex) {
-      case 0:
-        this.selectedTab = DataTableMode.SINGLE;
-        break;
-      case 1:
-        this.selectedTab = DataTableMode.RANGE;
-        break;
-    }
-  }
-
-  toggleHeader(header: ColumnHeader) {
+  toggleHeader(header: ColumnHeader, dataTableMode: DataTableMode) {
     this.onScalarTableColumnToggled.emit({
-      dataTableMode: this.selectedTab,
+      dataTableMode: dataTableMode,
       headerType: header.type,
     });
   }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,12 +42,8 @@ import {
 export class ScalarColumnEditorContainer {
   constructor(private readonly store: Store<State>) {}
 
-  readonly singleHeaders$: Observable<ColumnHeader[]> = this.store.select(
-    getSingleSelectionHeaders
-  );
-  readonly rangeHeaders$: Observable<ColumnHeader[]> = this.store.select(
-    getRangeSelectionHeaders
-  );
+  readonly singleHeaders$ = this.store.select(getSingleSelectionHeaders);
+  readonly rangeHeaders$ = this.store.select(getRangeSelectionHeaders);
 
   onScalarTableColumnToggled({
     dataTableMode,

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -1,0 +1,61 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {Observable} from 'rxjs';
+import {State} from '../../../../app_state';
+import {dataTableColumnToggled} from '../../../actions';
+import {
+  getRangeSelectionHeaders,
+  getSingleSelectionHeaders,
+} from '../../../store/metrics_selectors';
+import {
+  ColumnHeader,
+  ColumnHeaderType,
+  DataTableMode,
+} from '../../card_renderer/scalar_card_types';
+
+@Component({
+  selector: 'metrics-scalar-column-editor',
+  template: `
+    <metrics-scalar-column-editor-component
+      [singleHeaders]="singleHeaders$ | async"
+      [rangeHeaders]="rangeHeaders$ | async"
+      (onScalarTableColumnToggled)="onScalarTableColumnToggled($event)"
+    >
+    </metrics-scalar-column-editor-component>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ScalarColumnEditorContainer {
+  constructor(private readonly store: Store<State>) {}
+
+  readonly singleHeaders$: Observable<ColumnHeader[]> = this.store.select(
+    getSingleSelectionHeaders
+  );
+  readonly rangeHeaders$: Observable<ColumnHeader[]> = this.store.select(
+    getRangeSelectionHeaders
+  );
+
+  onScalarTableColumnToggled({
+    dataTableMode,
+    headerType,
+  }: {
+    dataTableMode: DataTableMode;
+    headerType: ColumnHeaderType;
+  }) {
+    this.store.dispatch(dataTableColumnToggled({dataTableMode, headerType}));
+  }
+}

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_module.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_module.ts
@@ -1,0 +1,37 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatIconModule} from '@angular/material/icon';
+import {MatTabsModule} from '@angular/material/tabs';
+import {ScalarColumnEditorComponent} from './scalar_column_editor_component';
+import {ScalarColumnEditorContainer} from './scalar_column_editor_container';
+import {DataTableHeaderModule} from '../../../../widgets/data_table/data_table_header_module';
+
+@NgModule({
+  declarations: [ScalarColumnEditorComponent, ScalarColumnEditorContainer],
+  exports: [ScalarColumnEditorContainer],
+  imports: [
+    CommonModule,
+    DataTableHeaderModule,
+    MatButtonToggleModule,
+    MatCheckboxModule,
+    MatIconModule,
+    MatTabsModule,
+  ],
+})
+export class ScalarColumnEditorModule {}

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_module.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_module.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,9 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
-import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {MatCheckboxModule} from '@angular/material/checkbox';
-import {MatIconModule} from '@angular/material/icon';
 import {MatTabsModule} from '@angular/material/tabs';
 import {ScalarColumnEditorComponent} from './scalar_column_editor_component';
 import {ScalarColumnEditorContainer} from './scalar_column_editor_container';
@@ -28,9 +26,7 @@ import {DataTableHeaderModule} from '../../../../widgets/data_table/data_table_h
   imports: [
     CommonModule,
     DataTableHeaderModule,
-    MatButtonToggleModule,
     MatCheckboxModule,
-    MatIconModule,
     MatTabsModule,
   ],
 })

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -1,0 +1,189 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {
+  ComponentFixture,
+  fakeAsync,
+  flush,
+  TestBed,
+} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {Action, Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {State} from '../../../../app_state';
+import {dataTableColumnToggled} from '../../../actions';
+import {
+  getRangeSelectionHeaders,
+  getSingleSelectionHeaders,
+} from '../../../store/metrics_selectors';
+import {
+  ColumnHeaderType,
+  DataTableMode,
+} from '../../card_renderer/scalar_card_types';
+import {DataTableHeaderModule} from '../../../../widgets/data_table/data_table_header_module';
+import {ScalarColumnEditorComponent} from './scalar_column_editor_component';
+import {ScalarColumnEditorContainer} from './scalar_column_editor_container';
+import {MatTabsModule} from '@angular/material/tabs';
+
+describe('scalar column editor', () => {
+  let store: MockStore<State>;
+
+  function createComponent(): ComponentFixture<ScalarColumnEditorContainer> {
+    const fixture = TestBed.createComponent(ScalarColumnEditorContainer);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function switchTabs(
+    fixture: ComponentFixture<ScalarColumnEditorContainer>,
+    mode: DataTableMode
+  ) {
+    let index = mode === DataTableMode.SINGLE ? 0 : 1;
+    // Get mat-tab to queue the task of switching tabs
+    fixture.debugElement
+      .queryAll(By.css('.mat-tab-label'))
+      [index].nativeElement.click();
+    fixture.detectChanges();
+
+    // flush the task to fire the selectedIndexChange event.
+    flush();
+    // Detect the changes after that event was fired.
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DataTableHeaderModule, MatTabsModule, NoopAnimationsModule],
+      declarations: [ScalarColumnEditorContainer, ScalarColumnEditorComponent],
+      providers: [provideMockStore()],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    store.overrideSelector(getRangeSelectionHeaders, []);
+    store.overrideSelector(getSingleSelectionHeaders, []);
+  });
+
+  afterEach(() => {
+    store?.resetSelectors();
+  });
+
+  it('renders', () => {
+    const fixture = createComponent();
+    expect(fixture.debugElement.query(By.css('mat-tab-group'))).toBeTruthy();
+  });
+
+  it('renders single selection headers when selectedTab is set to SINGLE', fakeAsync(() => {
+    store.overrideSelector(getSingleSelectionHeaders, [
+      {type: ColumnHeaderType.RUN, enabled: true},
+      {type: ColumnHeaderType.VALUE, enabled: true},
+    ]);
+    const fixture = createComponent();
+
+    switchTabs(fixture, DataTableMode.SINGLE);
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('.header-list-item')
+    );
+
+    expect(headerElements.length).toEqual(2);
+    expect(headerElements[0].nativeElement.innerText).toEqual('Run');
+    expect(headerElements[1].nativeElement.innerText).toEqual('Value');
+  }));
+
+  it('renders range selection headers when selectedTab is set to RANGE', fakeAsync(() => {
+    store.overrideSelector(getRangeSelectionHeaders, [
+      {type: ColumnHeaderType.RUN, enabled: true},
+      {type: ColumnHeaderType.VALUE, enabled: true},
+    ]);
+    const fixture = createComponent();
+    switchTabs(fixture, DataTableMode.RANGE);
+
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('.header-list-item')
+    );
+
+    expect(headerElements.length).toEqual(2);
+    expect(headerElements[0].nativeElement.innerText).toEqual('Run');
+    expect(headerElements[1].nativeElement.innerText).toEqual('Value');
+  }));
+
+  it('checkboxes reflect enabled state', fakeAsync(() => {
+    store.overrideSelector(getSingleSelectionHeaders, [
+      {type: ColumnHeaderType.RUN, enabled: true},
+      {type: ColumnHeaderType.VALUE, enabled: false},
+    ]);
+    const fixture = createComponent();
+
+    switchTabs(fixture, DataTableMode.SINGLE);
+    const checkboxes = fixture.debugElement.queryAll(By.css('mat-checkbox'));
+
+    expect(checkboxes.length).toEqual(2);
+    expect(checkboxes[0].nativeElement.innerText).toEqual('Run');
+    expect(checkboxes[0].nativeElement.checked).toBeTrue();
+    expect(checkboxes[1].nativeElement.innerText).toEqual('Value');
+    expect(checkboxes[1].nativeElement.checked).toBeFalse();
+  }));
+
+  describe('toggling', () => {
+    let dispatchedActions: Action[] = [];
+    beforeEach(() => {
+      dispatchedActions = [];
+      spyOn(store, 'dispatch').and.callFake((action: Action) => {
+        dispatchedActions.push(action);
+      });
+    });
+
+    it('dispatches dataTableColumnToggled action with singe selection when checkbox is clicked', fakeAsync(() => {
+      store.overrideSelector(getSingleSelectionHeaders, [
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.VALUE, enabled: false},
+      ]);
+      const fixture = createComponent();
+      switchTabs(fixture, DataTableMode.SINGLE);
+
+      const checkboxes = fixture.debugElement.queryAll(By.css('mat-checkbox'));
+
+      checkboxes[0].triggerEventHandler('change');
+      fixture.detectChanges();
+
+      expect(dispatchedActions[0]).toEqual(
+        dataTableColumnToggled({
+          dataTableMode: DataTableMode.SINGLE,
+          headerType: ColumnHeaderType.RUN,
+        })
+      );
+    }));
+
+    it('dispatches dataTableColumnToggled action with range selection when checkbox is clicked', fakeAsync(() => {
+      store.overrideSelector(getRangeSelectionHeaders, [
+        {type: ColumnHeaderType.SMOOTHED, enabled: true},
+        {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+      ]);
+      const fixture = createComponent();
+
+      switchTabs(fixture, DataTableMode.RANGE);
+      const checkboxes = fixture.debugElement.queryAll(By.css('mat-checkbox'));
+      checkboxes[1].triggerEventHandler('change', {});
+      fixture.detectChanges();
+
+      expect(dispatchedActions[0]).toEqual(
+        dataTableColumnToggled({
+          dataTableMode: DataTableMode.RANGE,
+          headerType: ColumnHeaderType.MAX_VALUE,
+        })
+      );
+    }));
+  });
+});

--- a/tensorboard/webapp/widgets/data_table/data_table_header_module.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_module.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Motivation for features / changes
This is part of the larger column customization effort. This PR adds the actual menu which will be used to edit the columns.  This menu's current functionality includes displaying the columns for both range and single selection as well as checkboxes which allow the enabling and disabling of those columns. The dragging to reorder functionality will come in a later PR.

Side note: I renamed the fobState attribute in the dataTableColmnEdited action. This was supposed to happen in a previous PR but was overlooked.

* Technical description of changes
The editor menu is added as its own component with it's own container. This follows the precedence set by the other components included directly into the MainViewComponent.

* Screenshots of UI changes
<img width="394" alt="Screenshot 2023-01-27 at 11 25 18 AM" src="https://user-images.githubusercontent.com/8672809/215179519-1bce5d0b-91d9-44bb-8a69-c2b337dcd034.png">
<img width="391" alt="Screenshot 2023-01-27 at 11 25 25 AM" src="https://user-images.githubusercontent.com/8672809/215179509-35dbfc5d-3609-40af-9b8a-2d49de852a86.png">
