### PR TITLE
Linked time: Make card step selection slightly independent of global step selection state.

### DIFF
--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -101,6 +101,7 @@ tf_ts_library(
         "//tensorboard/webapp/routes:testing",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/util:dom",
+        "//tensorboard/webapp/widgets/card_fob:types",
         "@npm//@types/jasmine",
     ],
 )

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2911,7 +2911,7 @@ describe('metrics reducers', () => {
           actions.timeSelectionChanged({
             timeSelection: {
               start: {step: 2},
-              end: {step: 0},
+              end: {step: 10},
             },
           })
         );

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3334,45 +3334,17 @@ describe('metrics reducers', () => {
       expect(state3.stepSelectorEnabled).toBe(false);
     });
 
-    it('enables and disables stepSelection when linked time on', () => {
-      const state1 = buildMetricsState({
-        stepSelectorEnabled: false,
-        linkedTimeEnabled: true,
-      });
-
-      const state2 = reducers(
-        state1,
-        actions.stepSelectorToggled({
-          affordance: TimeSelectionToggleAffordance.FOB_DESELECT,
-        })
-      );
-      expect(state2.stepSelectorEnabled).toBe(true);
-
-      const state3 = reducers(
-        state2,
-        actions.stepSelectorToggled({
-          affordance: TimeSelectionToggleAffordance.FOB_DESELECT,
-        })
-      );
-      expect(state3.stepSelectorEnabled).toBe(false);
-    });
-
     it('disables linkedTime and rangeSelection when stepSelector is toggled off', () => {
       const state1 = buildMetricsState({
-        stepSelectorEnabled: false,
+        stepSelectorEnabled: true,
         linkedTimeEnabled: true,
         rangeSelectionEnabled: true,
       });
 
       const state2 = reducers(state1, actions.stepSelectorToggled({}));
-      expect(state2.stepSelectorEnabled).toBe(true);
-      expect(state2.linkedTimeEnabled).toBe(true);
-      expect(state2.rangeSelectionEnabled).toBe(true);
-
-      const state3 = reducers(state2, actions.stepSelectorToggled({}));
-      expect(state3.stepSelectorEnabled).toBe(false);
-      expect(state3.linkedTimeEnabled).toBe(false);
-      expect(state3.rangeSelectionEnabled).toBe(false);
+      expect(state2.stepSelectorEnabled).toBe(false);
+      expect(state2.linkedTimeEnabled).toBe(false);
+      expect(state2.rangeSelectionEnabled).toBe(false);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -20,6 +20,7 @@ import {globalSettingsLoaded} from '../../persistent_settings';
 import {buildDeserializedState} from '../../routes/testing';
 import {DataLoadState} from '../../types/data';
 import {nextElementId} from '../../util/dom';
+import {TimeSelectionToggleAffordance} from '../../widgets/card_fob/card_fob_types';
 import * as actions from '../actions';
 import {
   PluginType,
@@ -2820,21 +2821,6 @@ describe('metrics reducers', () => {
         });
       });
 
-      it('keeps linkedTimeEnabled disabled if previously disabled', () => {
-        const beforeState = buildMetricsState({
-          linkedTimeEnabled: false,
-        });
-
-        const nextState = reducers(
-          beforeState,
-          actions.timeSelectionChanged({
-            timeSelection: {start: {step: 2}, end: null},
-          })
-        );
-
-        expect(nextState.linkedTimeEnabled).toBe(false);
-      });
-
       it('flips `end` to `start` if new start is greater than new end', () => {
         const beforeState = buildMetricsState({
           linkedTimeSelection: null,
@@ -2857,35 +2843,10 @@ describe('metrics reducers', () => {
         });
       });
 
-      it('sets `rangeSelectionEnabled` to true when `endStep` is present and linked time selection is null', () => {
+      it('sets `rangeSelectionEnabled` to true when `endStep` is present', () => {
         const beforeState = buildMetricsState({
           rangeSelectionEnabled: false,
-          linkedTimeSelection: null,
-        });
-
-        const nextState = reducers(
-          beforeState,
-          actions.timeSelectionChanged({
-            timeSelection: {
-              start: {step: 2},
-              end: {step: 5},
-            },
-          })
-        );
-
-        expect(nextState.rangeSelectionEnabled).toEqual(true);
-      });
-
-      // This test case represents <tb-range-input> renders range slider from single slider.
-      it('sets `rangeSelectionEnabled` to true when `endStep` is present linked time selection is not null', () => {
-        const beforeState = buildMetricsState({
-          rangeSelectionEnabled: false,
-          linkedTimeSelection: {
-            start: {step: 0},
-            // When single slider is rendered, the end step is set to step max.
-            // Here set it as an arbitrary number.
-            end: {step: 100},
-          },
+          linkedTimeEnabled: true,
         });
 
         const nextState = reducers(
@@ -2904,10 +2865,7 @@ describe('metrics reducers', () => {
       it('sets `rangeSelectionEnabled` to true when `endStep` is 0', () => {
         const beforeState = buildMetricsState({
           rangeSelectionEnabled: false,
-          linkedTimeSelection: {
-            start: {step: 2},
-            end: {step: 100},
-          },
+          linkedTimeEnabled: true,
         });
 
         const nextState = reducers(
@@ -2923,10 +2881,10 @@ describe('metrics reducers', () => {
         expect(nextState.rangeSelectionEnabled).toEqual(true);
       });
 
-      it('keeps `rangeSelectionEnabled` to be false when only sets `startStep`', () => {
+      it('sets `rangeSelectionEnabled` to false when only sets `startStep`', () => {
         const beforeState1 = buildMetricsState({
-          rangeSelectionEnabled: false,
-          linkedTimeSelection: null,
+          rangeSelectionEnabled: true,
+          linkedTimeEnabled: true,
         });
 
         const nextState1 = reducers(
@@ -2940,6 +2898,25 @@ describe('metrics reducers', () => {
         );
 
         expect(nextState1.rangeSelectionEnabled).toEqual(false);
+      });
+
+      it('keeps `rangeSelectionEnabled` to false when linked time disabled', () => {
+        const beforeState = buildMetricsState({
+          rangeSelectionEnabled: false,
+          linkedTimeEnabled: false,
+        });
+
+        const nextState = reducers(
+          beforeState,
+          actions.timeSelectionChanged({
+            timeSelection: {
+              start: {step: 2},
+              end: {step: 0},
+            },
+          })
+        );
+
+        expect(nextState.rangeSelectionEnabled).toEqual(false);
       });
 
       it('sets `cardStepIndex` when step matches linked time selection', () => {
@@ -3022,28 +2999,6 @@ describe('metrics reducers', () => {
       });
     });
 
-    it('sets `rangeSelectionEnabled` to false when `endStep` is undefined', () => {
-      const beforeState = buildMetricsState({
-        rangeSelectionEnabled: true,
-        linkedTimeSelection: {
-          start: {step: 2},
-          end: {step: 100},
-        },
-      });
-
-      const nextState = reducers(
-        beforeState,
-        actions.timeSelectionChanged({
-          timeSelection: {
-            start: {step: 3},
-            end: null,
-          },
-        })
-      );
-
-      expect(nextState.rangeSelectionEnabled).toEqual(false);
-    });
-
     describe('#timeSelectionCleared', () => {
       it('clears linked time selection', () => {
         const beforeState = buildMetricsState({
@@ -3091,8 +3046,27 @@ describe('metrics reducers', () => {
         expect(state2.rangeSelectionEnabled).toBe(false);
       });
 
-      it('generates a value for linkedTimeSelection when needed', () => {
-        const state1 = buildMetricsState();
+      it('ignores linkedTimeSelection when toggled on, if not needed', () => {
+        const state1 = buildMetricsState({
+          linkedTimeSelection: {
+            start: {step: 100},
+            end: {step: 1000},
+          },
+          rangeSelectionEnabled: false,
+        });
+
+        const state2 = reducers(state1, actions.rangeSelectionToggled({}));
+        expect(state2.linkedTimeSelection).toEqual({
+          start: {step: 100},
+          end: {step: 1000},
+        });
+      });
+
+      it('generates linkedTimeSelection when toggled on, if needed', () => {
+        const state1 = buildMetricsState({
+          linkedTimeSelection: null,
+          rangeSelectionEnabled: false,
+        });
 
         const state2 = reducers(state1, actions.rangeSelectionToggled({}));
         expect(state2.linkedTimeSelection).toEqual({
@@ -3100,9 +3074,41 @@ describe('metrics reducers', () => {
           end: {step: -Infinity},
         });
       });
+
+      it('adds linkedTimeSelection.end when toggled on, if needed', () => {
+        const state1 = buildMetricsState({
+          linkedTimeSelection: {
+            start: {step: 100},
+            end: null,
+          },
+          rangeSelectionEnabled: false,
+        });
+
+        const state2 = reducers(state1, actions.rangeSelectionToggled({}));
+        expect(state2.linkedTimeSelection).toEqual({
+          start: {step: 100},
+          end: {step: -Infinity},
+        });
+      });
+
+      it('removes linkedTimeSelection.end when toggled off, if needed', () => {
+        const state1 = buildMetricsState({
+          linkedTimeSelection: {
+            start: {step: 100},
+            end: {step: 1000},
+          },
+          rangeSelectionEnabled: true,
+        });
+
+        const state2 = reducers(state1, actions.rangeSelectionToggled({}));
+        expect(state2.linkedTimeSelection).toEqual({
+          start: {step: 100},
+          end: null,
+        });
+      });
     });
 
-    describe('#linkedTimeEnabled', () => {
+    describe('#linkedTimeToggled', () => {
       const imageCardId = 'test image card id "plugin":"images"';
       const cardMetadataMap = {
         [imageCardId]: {
@@ -3290,53 +3296,83 @@ describe('metrics reducers', () => {
   });
 
   describe('step selector features', () => {
-    it('toggles whether stepSelector is enabled or not', () => {
-      const state1 = buildMetricsState({
-        stepSelectorEnabled: false,
-      });
-
-      const state2 = reducers(state1, actions.stepSelectorToggled({}));
-      expect(state2.stepSelectorEnabled).toBe(true);
-
-      const state3 = reducers(state2, actions.stepSelectorToggled({}));
-      expect(state3.stepSelectorEnabled).toBe(false);
-    });
-
-    it('disables linkedTime when stepSelector is disabled', () => {
+    it('does not enable and disable stepSelection when toggled by fobs', () => {
       const state1 = buildMetricsState({
         stepSelectorEnabled: false,
         linkedTimeEnabled: false,
       });
 
-      const state2 = reducers(state1, actions.stepSelectorToggled({}));
-      expect(state2.stepSelectorEnabled).toBe(true);
-      expect(state2.linkedTimeEnabled).toBe(false);
-
-      const state3 = buildMetricsState({
-        stepSelectorEnabled: true,
-        linkedTimeEnabled: true,
-      });
-      const state4 = reducers(state3, actions.stepSelectorToggled({}));
-      expect(state4.stepSelectorEnabled).toBe(false);
-      expect(state2.linkedTimeEnabled).toBe(false);
+      const state2 = reducers(
+        state1,
+        actions.stepSelectorToggled({
+          affordance: TimeSelectionToggleAffordance.FOB_DESELECT,
+        })
+      );
+      expect(state2.stepSelectorEnabled).toBe(false);
     });
 
-    it('disables rangeSelection when stepSelector is disabled', () => {
+    it('enables and disables stepSelection when toggled by check box', () => {
       const state1 = buildMetricsState({
         stepSelectorEnabled: false,
+        linkedTimeEnabled: false,
+      });
+
+      const state2 = reducers(
+        state1,
+        actions.stepSelectorToggled({
+          affordance: TimeSelectionToggleAffordance.CHECK_BOX,
+        })
+      );
+      expect(state2.stepSelectorEnabled).toBe(true);
+
+      const state3 = reducers(
+        state2,
+        actions.stepSelectorToggled({
+          affordance: TimeSelectionToggleAffordance.CHECK_BOX,
+        })
+      );
+      expect(state3.stepSelectorEnabled).toBe(false);
+    });
+
+    it('enables and disables stepSelection when linked time on', () => {
+      const state1 = buildMetricsState({
+        stepSelectorEnabled: false,
+        linkedTimeEnabled: true,
+      });
+
+      const state2 = reducers(
+        state1,
+        actions.stepSelectorToggled({
+          affordance: TimeSelectionToggleAffordance.FOB_DESELECT,
+        })
+      );
+      expect(state2.stepSelectorEnabled).toBe(true);
+
+      const state3 = reducers(
+        state2,
+        actions.stepSelectorToggled({
+          affordance: TimeSelectionToggleAffordance.FOB_DESELECT,
+        })
+      );
+      expect(state3.stepSelectorEnabled).toBe(false);
+    });
+
+    it('disables linkedTime and rangeSelection when stepSelector is toggled off', () => {
+      const state1 = buildMetricsState({
+        stepSelectorEnabled: false,
+        linkedTimeEnabled: true,
         rangeSelectionEnabled: true,
       });
+
       const state2 = reducers(state1, actions.stepSelectorToggled({}));
       expect(state2.stepSelectorEnabled).toBe(true);
+      expect(state2.linkedTimeEnabled).toBe(true);
       expect(state2.rangeSelectionEnabled).toBe(true);
 
-      const state3 = buildMetricsState({
-        stepSelectorEnabled: true,
-        rangeSelectionEnabled: true,
-      });
-      const state4 = reducers(state3, actions.stepSelectorToggled({}));
-      expect(state4.stepSelectorEnabled).toBe(false);
-      expect(state4.rangeSelectionEnabled).toBe(false);
+      const state3 = reducers(state2, actions.stepSelectorToggled({}));
+      expect(state3.stepSelectorEnabled).toBe(false);
+      expect(state3.linkedTimeEnabled).toBe(false);
+      expect(state3.rangeSelectionEnabled).toBe(false);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -444,10 +444,7 @@ export const getMetricsLinkedTimeSelection = createSelector(
     linkedTimeSelection: TimeSelection
   ): TimeSelection | null => {
     if (!state.linkedTimeEnabled) return null;
-    if (state.rangeSelectionEnabled) {
-      return linkedTimeSelection;
-    }
-    return {...linkedTimeSelection, end: null};
+    return linkedTimeSelection;
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -819,29 +819,11 @@ describe('metrics selectors', () => {
             end: {step: 100},
           },
           linkedTimeEnabled: true,
-          rangeSelectionEnabled: true,
         })
       );
       expect(selectors.getMetricsLinkedTimeSelection(state)).toEqual({
         start: {step: 0},
         end: {step: 100},
-      });
-    });
-
-    it('removes `end` when using single step mode', () => {
-      const state = appStateFromMetricsState(
-        buildMetricsState({
-          linkedTimeSelection: {
-            start: {step: 0},
-            end: {step: 100},
-          },
-          linkedTimeEnabled: true,
-          rangeSelectionEnabled: false,
-        })
-      );
-      expect(selectors.getMetricsLinkedTimeSelection(state)).toEqual({
-        start: {step: 0},
-        end: null,
       });
     });
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -65,7 +65,6 @@ limitations under the License.
   [timeProperty]="timeProperty(xAxisType)"
   [color]="runColorScale(runId)"
   [timeSelection]="convertToTimeSelection(linkedTimeSelection)"
-  [rangeSelectionEnabled]="rangeSelectionEnabled"
   (onLinkedTimeSelectionChanged)="onLinkedTimeSelectionChanged.emit($event)"
   (onLinkedTimeToggled)="onLinkedTimeToggled.emit()"
 ></tb-histogram>

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -50,7 +50,6 @@ export class HistogramCardComponent {
   @Input() showFullSize!: boolean;
   @Input() isPinned!: boolean;
   @Input() linkedTimeSelection!: TimeSelectionView | null;
-  @Input() rangeSelectionEnabled?: boolean;
   @Input() isClosestStepHighlighted!: boolean | null;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -41,7 +41,6 @@ import {
   getCardTimeSeries,
   getMetricsHistogramMode,
   getMetricsLinkedTimeSelection,
-  getMetricsRangeSelectionEnabled,
   getMetricsXAxisType,
 } from '../../store';
 import {CardId, CardMetadata} from '../../types';
@@ -74,7 +73,6 @@ type HistogramCardMetadata = CardMetadata & {
       [isPinned]="isPinned$ | async"
       [isClosestStepHighlighted]="isClosestStepHighlighted$ | async"
       [linkedTimeSelection]="linkedTimeSelection$ | async"
-      [rangeSelectionEnabled]="rangeSelectionEnabled$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       (onLinkedTimeSelectionChanged)="onLinkedTimeSelectionChanged($event)"
@@ -109,7 +107,6 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   data$?: Observable<HistogramDatum[]>;
   mode$ = this.store.select(getMetricsHistogramMode);
   xAxisType$ = this.store.select(getMetricsXAxisType);
-  rangeSelectionEnabled$ = this.store.select(getMetricsRangeSelectionEnabled);
   showFullSize = false;
   isPinned$?: Observable<boolean>;
   linkedTimeSelection$?: Observable<TimeSelectionView | null>;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -244,7 +244,6 @@ limitations under the License.
       [minMaxHorizontalViewExtend]="viewExtent.x"
       [minMaxStep]="minMaxStep"
       [axisSize]="domDim.width"
-      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [isProspectiveFobFeatureEnabled]="isProspectiveFobFeatureEnabled"
       (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
       (onTimeSelectionToggled)="onFobRemoved()"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -93,7 +93,6 @@ export class ScalarCardComponent<Downloader> {
   @Input() columnCustomizationEnabled!: boolean;
   @Input() linkedTimeSelection!: TimeSelectionView | null;
   @Input() stepOrLinkedTimeSelection!: TimeSelection | null;
-  @Input() rangeSelectionEnabled: boolean = false;
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
   @Input() minMaxStep!: MinMaxStep;
   @Input() columnHeaders!: ColumnHeader[];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -587,6 +587,28 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
     this.isPinned$ = this.store.select(getCardPinnedState, this.cardId);
 
+    // stepSelectorTimeSelection$ is partially independent of the global
+    // stepSelectorEnabled state. stepSelectorTimeSelection$ may change in
+    // response to changes to stepSelectorEnabled but may otherwise diverge
+    // while stepSelectorEnabled remains unchanged.
+    //
+    // For instance, as we see in the following code:
+    // * If stepSelectorTimeSelection$ is null when stepSelectorEnabled
+    //   is changed to true, then a default value is assigned to
+    //   stepSelectorTimeSelection$.
+    // * If stepSelectorTimeSelection$ has a value when stepSelectorEnabled
+    //   is changed to false, then null is assigned to
+    //   stepSelectorTimeSelection$.
+    //
+    // On the other hand, stepSelectorTimeSelection$ may later change
+    // independent of stepSelectorEnabled state:
+    // * It can be assigned a value while stepSelectorEnabled is still false (if
+    //   the user, for example, uses a fob to turn on step selection for this
+    //   particular chart).
+    // * It can be assigned to null when stepSelectorEnabled is still true (if
+    //   the user, for example, uses a fob to turn off step selection for this
+    //   particular chart).
+    // The link is lost until the next change to stepSelectorEnabled.
     this.store
       .select(getMetricsStepSelectorEnabled)
       .pipe(
@@ -612,6 +634,11 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         }
       });
 
+    // stepSelectorTimeSelection$ is also partially independent of the
+    // global rangeSelectionEnabled state, similar to its relationship with
+    // stepSelectorEnabled, described above. stepSelectorTimeSelection$ may
+    // change in response to changes to rangeSelectionEnabled but may otherwise
+    // diverge while rangeSelectionEnabled remains unchanged.
     this.store
       .select(getMetricsRangeSelectionEnabled)
       .pipe(withLatestFrom(this.minMaxSteps$), takeUntil(this.ngUnsubscribe))

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -41,6 +41,7 @@ import {
   startWith,
   switchMap,
   takeUntil,
+  withLatestFrom,
 } from 'rxjs/operators';
 import {State} from '../../../app_state';
 import {ExperimentAlias} from '../../../experiments/types';
@@ -97,7 +98,6 @@ import {getTagDisplayName} from '../utils';
 import {DataDownloadDialogContainer} from './data_download_dialog_container';
 import {
   ColumnHeader,
-  ColumnHeaderType,
   MinMaxStep,
   PartialSeries,
   PartitionedSeries,
@@ -164,7 +164,6 @@ function areSeriesEqual(
       [useDarkMode]="useDarkMode$ | async"
       [linkedTimeSelection]="linkedTimeSelection$ | async"
       [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection$ | async"
-      [rangeSelectionEnabled]="rangeSelectionEnabled$ | async"
       [isProspectiveFobFeatureEnabled]="isProspectiveFobFeatureEnabled$ | async"
       [forceSvg]="forceSvg$ | async"
       [columnCustomizationEnabled]="columnCustomizationEnabled$ | async"
@@ -233,9 +232,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   });
   readonly stepSelectorTimeSelection$ =
     new BehaviorSubject<TimeSelection | null>(null);
-  readonly rangeSelectionEnabled$ = this.store.select(
-    getMetricsRangeSelectionEnabled
-  );
   readonly useDarkMode$ = this.store.select(getDarkModeEnabled);
   readonly ignoreOutliers$ = this.store.select(getMetricsIgnoreOutliers);
   readonly tooltipSort$ = this.store.select(getMetricsTooltipSort);
@@ -437,16 +433,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
       this.store.select(getMetricsLinkedTimeEnabled),
       this.store.select(getMetricsLinkedTimeSelection),
       this.store.select(getMetricsXAxisType),
-      this.store.select(getMetricsRangeSelectionEnabled),
     ]).pipe(
       map(
-        ([
-          {minStep, maxStep},
-          linkedTimeEnabled,
-          timeSelection,
-          xAxisType,
-          rangeSelectionEnabled,
-        ]) => {
+        ([{minStep, maxStep}, linkedTimeEnabled, timeSelection, xAxisType]) => {
           if (
             !linkedTimeEnabled ||
             xAxisType !== XAxisType.STEP ||
@@ -454,16 +443,8 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
           ) {
             return null;
           }
-          const forkedTimeSelection = {...timeSelection};
-          if (!forkedTimeSelection.end && rangeSelectionEnabled) {
-            forkedTimeSelection.end = {step: maxStep};
-          }
 
-          return maybeClipTimeSelectionView(
-            forkedTimeSelection,
-            minStep,
-            maxStep
-          );
+          return maybeClipTimeSelectionView(timeSelection, minStep, maxStep);
         }
       )
     );
@@ -606,14 +587,61 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
     this.isPinned$ = this.store.select(getCardPinnedState, this.cardId);
 
-    combineLatest([
-      this.minMaxSteps$,
-      this.store.select(getMetricsStepSelectorEnabled),
-      this.store.select(getMetricsRangeSelectionEnabled),
-    ]).subscribe(
-      ([{minStep, maxStep}, enableStepSelector, rangeSelectionEnabled]) => {
-        if (!enableStepSelector) {
+    this.store
+      .select(getMetricsStepSelectorEnabled)
+      .pipe(
+        withLatestFrom(
+          this.store.select(getMetricsRangeSelectionEnabled),
+          this.minMaxSteps$
+        ),
+        takeUntil(this.ngUnsubscribe)
+      )
+      .subscribe(([stepSelectorEnabled, rangeSelectionEnabled, minMax]) => {
+        if (!stepSelectorEnabled) {
           this.stepSelectorTimeSelection$.next(null);
+          return;
+        }
+
+        const currentValue = this.stepSelectorTimeSelection$.getValue();
+        if (currentValue === null) {
+          this.stepSelectorTimeSelection$.next({
+            start: {step: minMax.minStep},
+            end: rangeSelectionEnabled ? {step: minMax.maxStep} : null,
+          });
+          return;
+        }
+      });
+
+    this.store
+      .select(getMetricsRangeSelectionEnabled)
+      .pipe(withLatestFrom(this.minMaxSteps$), takeUntil(this.ngUnsubscribe))
+      .subscribe(([rangeSelectionEnabled, minMax]) => {
+        const currentValue = this.stepSelectorTimeSelection$.getValue();
+        if (currentValue === null) {
+          return;
+        }
+
+        if (!rangeSelectionEnabled && currentValue.end !== null) {
+          this.stepSelectorTimeSelection$.next({
+            start: currentValue.start,
+            end: null,
+          });
+          return;
+        }
+
+        if (rangeSelectionEnabled && currentValue.end === null) {
+          this.stepSelectorTimeSelection$.next({
+            start: currentValue.start,
+            end: {step: minMax.maxStep},
+          });
+          return;
+        }
+      });
+
+    this.minMaxSteps$
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe(({minStep, maxStep}) => {
+        if (!this.stepSelectorTimeSelection$.getValue()) {
           return;
         }
         const currentStartStep =
@@ -626,7 +654,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
             start: {
               step: currentStartStep ?? minStep,
             },
-            end: rangeSelectionEnabled
+            end: this.stepSelectorTimeSelection$.getValue()?.end
               ? {step: currentEndStep ?? maxStep}
               : null,
           },
@@ -634,8 +662,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
           maxStep
         );
         this.stepSelectorTimeSelection$.next(potentiallyClippedTimeSelection);
-      }
-    );
+      });
   }
 
   ngOnDestroy() {
@@ -708,6 +735,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   }
 
   onStepSelectorToggled(affordance: TimeSelectionToggleAffordance) {
+    if (this.stepSelectorTimeSelection$.getValue()) {
+      this.stepSelectorTimeSelection$.next(null);
+    }
     this.store.dispatch(stepSelectorToggled({affordance}));
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -33,7 +33,6 @@ import {MinMaxStep} from './scalar_card_types';
       [style.pointerEvents]="disableInteraction ? 'none' : 'all'"
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [prospectiveStepAxisPosition]="getAxisPositionFromProspectiveStep()"
@@ -57,7 +56,6 @@ export class ScalarCardFobController {
   @Input() minMaxHorizontalViewExtend!: [number, number];
   @Input() minMaxStep!: MinMaxStep;
   @Input() axisSize!: number;
-  @Input() rangeSelectionEnabled: boolean = false;
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
   @Input() disableInteraction: boolean = false;
 

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -16,9 +16,7 @@ limitations under the License.
 -->
 
 <div>
-  <ng-container
-    *ngIf="isProspectiveFobFeatureEnabled && !rangeSelectionEnabled"
-  >
+  <ng-container *ngIf="isProspectiveFobFeatureEnabled">
     <div
       #prospectiveFobWrapper
       *ngIf="prospectiveStep !== null"
@@ -63,7 +61,7 @@ limitations under the License.
   </div>
   <div
     #endFobWrapper
-    *ngIf="timeSelection && timeSelection.end && rangeSelectionEnabled"
+    *ngIf="timeSelection && timeSelection.end"
     class="time-fob-wrapper"
     [style.transform]="getCssTranslatePxForEndFob()"
   >

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -55,7 +55,6 @@ export class CardFobControllerComponent {
   readonly prospectiveFobWrapper!: ElementRef;
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection?: TimeSelection;
-  @Input() rangeSelectionEnabled: boolean = false;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
   @Input() startStepAxisPosition!: number;
   @Input() endStepAxisPosition!: number | null;

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -33,7 +33,6 @@ import {
       #FobController
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [prospectiveStepAxisPosition]="getAxisPositionFromProspectiveStep()"
@@ -55,7 +54,6 @@ class TestableComponent {
 
   @Input() axisDirection!: AxisDirection;
   @Input() timeSelection!: TimeSelection;
-  @Input() rangeSelectionEnabled: boolean = false;
   @Input() cardFobHelper!: CardFobGetStepFromPositionHelper;
   @Input() showExtendedLine?: Boolean;
   @Input() highestStep!: number;
@@ -96,7 +94,6 @@ describe('card_fob_controller', () => {
   function createComponent(input: {
     axisDirection?: AxisDirection;
     timeSelection: TimeSelection;
-    enableRangeSelection?: boolean;
     showExtendedLine?: Boolean;
     steps?: number[];
     isProspectiveFobFeatureEnabled?: Boolean;
@@ -153,9 +150,6 @@ describe('card_fob_controller', () => {
       input.axisDirection ?? AxisDirection.VERTICAL;
 
     fixture.componentInstance.timeSelection = input.timeSelection;
-    fixture.componentInstance.rangeSelectionEnabled = Boolean(
-      input.enableRangeSelection
-    );
 
     fixture.componentInstance.showExtendedLine =
       input.showExtendedLine ?? false;
@@ -189,7 +183,6 @@ describe('card_fob_controller', () => {
   it('sets fob position based on time selection', () => {
     const fixture = createComponent({
       timeSelection: {start: {step: 2}, end: {step: 5}},
-      enableRangeSelection: true,
       axisDirection: AxisDirection.HORIZONTAL,
     });
     fixture.detectChanges();
@@ -260,7 +253,6 @@ describe('card_fob_controller', () => {
     it('swaps fobs being dragged when start > end', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -294,7 +286,6 @@ describe('card_fob_controller', () => {
     it('swaps fobs being dragged when end < start', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -328,7 +319,6 @@ describe('card_fob_controller', () => {
     it('does not swaps fobs when start === end', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -363,7 +353,6 @@ describe('card_fob_controller', () => {
     it('does not fire event when time selection does not change', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 2}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -555,7 +544,6 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging up and mouse is above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 1}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -594,7 +582,6 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging down and mouse is below the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -632,7 +619,6 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging down but, mouse is above the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -663,7 +649,6 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging up but, mouse is below the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -870,7 +855,6 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging left and mouse is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 1}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -910,7 +894,6 @@ describe('card_fob_controller', () => {
     it('end fob moves to the mouse when mouse is dragging right and mouse is right of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -949,7 +932,6 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging right but, mouse is left of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -981,7 +963,6 @@ describe('card_fob_controller', () => {
     it('end fob does not move when mouse is dragging left but, mouse is right of the fob', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
       });
       fixture.detectChanges();
@@ -1027,7 +1008,6 @@ describe('card_fob_controller', () => {
     it('renders two lines on range selection', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
         showExtendedLine: true,
       });
       fixture.detectChanges();
@@ -1041,7 +1021,6 @@ describe('card_fob_controller', () => {
     it('clicks and drags the line to change selected step in horizontal axis', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
         axisDirection: AxisDirection.HORIZONTAL,
         showExtendedLine: true,
       });
@@ -1132,7 +1111,6 @@ describe('card_fob_controller', () => {
     it('range selection start fob step typed which is less than end fob step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1150,7 +1128,6 @@ describe('card_fob_controller', () => {
     it('range selection end fob step typed which is greater than start fob step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1168,7 +1145,6 @@ describe('card_fob_controller', () => {
     it('range selection swaps when start step is typed in which is greater than end step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 2}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1186,7 +1162,6 @@ describe('card_fob_controller', () => {
     it('range selection swaps when end step is typed in which is less than start step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 3}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1204,7 +1179,6 @@ describe('card_fob_controller', () => {
     it('properly handles a 0 step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 3}, end: {step: 4}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
       const fobController = fixture.componentInstance.fobController;
@@ -1246,7 +1220,6 @@ describe('card_fob_controller', () => {
     it('changing end fob input modifies end step', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1290,7 +1263,6 @@ describe('card_fob_controller', () => {
     it('fires onTimeSelectionChanged to remove end fob when end fob is deselected', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
 
@@ -1312,7 +1284,6 @@ describe('card_fob_controller', () => {
     it('fires onTimeSelectionChanged to change the start fob step to the current end fob step and the end fob step to null when start fob is deselected in a range selection', () => {
       const fixture = createComponent({
         timeSelection: {start: {step: 1}, end: {step: 3}},
-        enableRangeSelection: true,
       });
       fixture.detectChanges();
 

--- a/tensorboard/webapp/widgets/histogram/histogram_card_fob_controller.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_card_fob_controller.ts
@@ -30,7 +30,6 @@ import {TemporalScale} from './histogram_component';
     <card-fob-controller
       [axisDirection]="axisDirection"
       [timeSelection]="timeSelection"
-      [rangeSelectionEnabled]="rangeSelectionEnabled"
       [startStepAxisPosition]="getAxisPositionFromStartStep()"
       [endStepAxisPosition]="getAxisPositionFromEndStep()"
       [highestStep]="getHighestStep()"
@@ -45,7 +44,6 @@ import {TemporalScale} from './histogram_component';
 export class HistogramCardFobController {
   @Input() steps!: number[];
   @Input() timeSelection!: TimeSelection;
-  @Input() rangeSelectionEnabled?: boolean;
   @Input() temporalScale!: TemporalScale;
   @Output() onTimeSelectionChanged = new EventEmitter<TimeSelection>();
   @Output() onTimeSelectionToggled = new EventEmitter();

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ng.html
@@ -54,7 +54,6 @@ limitations under the License.
       <histogram-card-fob-controller
         class="histogram-card-fob"
         [timeSelection]="timeSelection"
-        [rangeSelectionEnabled]="rangeSelectionEnabled"
         [steps]="getSteps()"
         [temporalScale]="scales.temporalScale"
         (onTimeSelectionChanged)="onLinkedTimeSelectionChanged.emit($event)"

--- a/tensorboard/webapp/widgets/histogram/histogram_component.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_component.ts
@@ -104,8 +104,6 @@ export class HistogramComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   @Input() timeSelection: TimeSelection | null = null;
 
-  @Input() rangeSelectionEnabled: boolean = false;
-
   @Output() onLinkedTimeSelectionChanged =
     new EventEmitter<TimeSelectionWithAffordance>();
   @Output() onLinkedTimeToggled = new EventEmitter();


### PR DESCRIPTION
This loosens the relationship between card-specific step selection and global step selection state. 

Before getting into technical details, here are some of the practial impacts:
* Linked time behavior remains unchanged. When linked time is enabled, changes in one card impact all other cards.
* When linked time is disabled:
  * Changes to step selection in one card do not impact step selection in other cards. Even if you turn on/off step selection or turn on/off range selection.
  * If you click the "Enable step selection" checkbox in settings to turn step selection on/off, step selection will turn on/off for all cards .
  * If you click the "Enable range selection" checkbox in settings to turn range selection on/off, range selection will turn on/off for all cards.

There are three main changes to get this to work:
* Per-card step selection state is slightly more independent of global stepSelectorEnabled and rangeSelectionEnabled state. Changes to stepSelectorEnabled and rangeSelectionEnabled continue to trigger changes to per-card selection state. However, per-card selection state can otherwise diverge while stepSelectorEnabled and rangeSelectionEnabled remain unchanged.
* Per-card toggling of selection state no longer impacts global stepSelectorEnabled or rangeSelectionEnabled state.
* Range selection rendering in any card no longer depends on rangeSelectionEnabled state. This is instead derived entirely from the `end` value in the step selection or linked time value.

Testing:
* A lot of manual testing of a local tensorboard.
* There is an internal CL with end-to-end tests that I will share independently that cover a lot of these cases.