### PR TITLE
Column Customization: Add Scalar Column Editor Dragging

### DIFF
--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -45,6 +45,7 @@ tf_ts_library(
     ],
     visibility = ["//tensorboard/webapp/metrics:__subpackages__"],
     deps = [
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/widgets/card_fob:types",
         "//tensorboard/webapp/widgets/histogram:types",
     ],

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -25,6 +25,8 @@ import {
 } from '../data_source';
 import {
   CardId,
+  HeaderEditInfo,
+  HeaderToggleInfo,
   HistogramMode,
   PluginType,
   TooltipSort,
@@ -215,18 +217,12 @@ export const dataTableColumnDrag = createAction(
 
 export const dataTableColumnEdited = createAction(
   '[Metrics] Data table columns edited in edit menu',
-  props<{
-    dataTableMode: DataTableMode;
-    headers: ColumnHeader[];
-  }>()
+  props<HeaderEditInfo>()
 );
 
 export const dataTableColumnToggled = createAction(
   '[Metrics] Data table column toggled in edit menu',
-  props<{
-    dataTableMode: DataTableMode;
-    headerType: ColumnHeaderType;
-  }>()
+  props<HeaderToggleInfo>()
 );
 
 export const stepSelectorToggled = createAction(

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -14,6 +14,11 @@ limitations under the License.
 ==============================================================================*/
 import {TimeSelection} from '../widgets/card_fob/card_fob_types';
 import {HistogramMode} from '../widgets/histogram/histogram_types';
+import {
+  ColumnHeader,
+  ColumnHeaderType,
+  DataTableMode,
+} from './views/card_renderer/scalar_card_types';
 
 export {HistogramMode, TimeSelection};
 
@@ -87,6 +92,16 @@ export interface URLDeserializedState {
     smoothing: number | null;
     tagFilter: string | null;
   };
+}
+
+export interface HeaderEditInfo {
+  dataTableMode: DataTableMode;
+  headers: ColumnHeader[];
+}
+
+export interface HeaderToggleInfo {
+  dataTableMode: DataTableMode;
+  headerType: ColumnHeaderType;
 }
 
 export const SCALARS_SMOOTHING_MIN = 0;

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
@@ -24,6 +24,7 @@ tf_ng_module(
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_material_checkbox",
         "//tensorboard/webapp/angular:expect_angular_material_tabs",
+        "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/store",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -37,7 +37,15 @@ limitations under the License.
   let-dataTableMode="dataTableMode"
 >
   <div class="header-list">
-    <div class="header-list-item" *ngFor="let header of headers;">
+    <div
+      class="header-list-item"
+      *ngFor="let header of headers;"
+      draggable="true"
+      (dragstart)="dragStart(header)"
+      (dragend)="dragEnd(dataTableMode)"
+      (dragenter)="dragEnter(header, dataTableMode)"
+      [ngClass]="getHighlightClasses(header)"
+    >
       <mat-checkbox
         [checked]="header.enabled"
         (change)="toggleHeader(header, dataTableMode)"

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -34,3 +34,15 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 .header-list-item {
   padding: 3px;
 }
+
+.highlighted {
+  background-color: mat.get-color-from-palette(mat.$gray-palette, 200);
+}
+
+.highlight-bottom {
+  border-bottom: 2px solid mat.get-color-from-palette($_accent);
+}
+
+.highlight-top {
+  border-top: 2px solid mat.get-color-from-palette($_accent);
+}

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   EventEmitter,
   Input,
   OnDestroy,
@@ -79,13 +80,18 @@ export class ScalarColumnEditorComponent implements OnDestroy {
     headerType: ColumnHeaderType;
   }>();
 
+  constructor(private readonly hostElement: ElementRef) {}
+
   ngOnDestroy() {
-    document.removeEventListener('dragover', preventDefault);
+    this.hostElement.nativeElement.removeEventListener(
+      'dragover',
+      preventDefault
+    );
   }
 
   dragStart(header: ColumnHeader) {
     this.draggingHeaderType = header.type;
-    document.addEventListener('dragover', preventDefault);
+    this.hostElement.nativeElement.addEventListener('dragover', preventDefault);
   }
 
   dragEnd(dataTableMode: DataTableMode) {
@@ -103,7 +109,10 @@ export class ScalarColumnEditorComponent implements OnDestroy {
     });
     this.draggingHeaderType = undefined;
     this.highlightedHeaderType = undefined;
-    document.removeEventListener('dragover', preventDefault);
+    this.hostElement.nativeElement.removeEventListener(
+      'dragover',
+      preventDefault
+    );
   }
 
   dragEnter(header: ColumnHeader, dataTableMode: DataTableMode) {
@@ -111,6 +120,7 @@ export class ScalarColumnEditorComponent implements OnDestroy {
       return;
     }
 
+    // Highlight the position which the dragging header will go when dropped.
     const headers = this.getHeadersForMode(dataTableMode);
     if (
       getIndexOfType(header.type, headers) <
@@ -143,7 +153,7 @@ export class ScalarColumnEditorComponent implements OnDestroy {
     };
   }
 
-  getHeadersForMode(dataTableMode: DataTableMode) {
+  private getHeadersForMode(dataTableMode: DataTableMode) {
     return dataTableMode === DataTableMode.SINGLE
       ? this.singleHeaders
       : this.rangeHeaders;

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
@@ -17,6 +17,7 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnDestroy,
   Output,
 } from '@angular/core';
 import {
@@ -25,27 +26,126 @@ import {
   DataTableMode,
 } from '../../card_renderer/scalar_card_types';
 
+const preventDefault = (e: MouseEvent) => {
+  e.preventDefault();
+};
+
+// Move the item at sourceIndex to destinationIndex
+const moveHeader = (
+  sourceIndex: number,
+  destinationIndex: number,
+  headers: ColumnHeader[]
+) => {
+  const newHeaders = [...headers];
+  // Delete from original location
+  newHeaders.splice(sourceIndex, 1);
+  // Insert at destinationIndex.
+  newHeaders.splice(destinationIndex, 0, headers[sourceIndex]);
+  return newHeaders;
+};
+
+const getIndexOfType = (type: ColumnHeaderType, headers: ColumnHeader[]) => {
+  return headers.findIndex((header) => {
+    return header.type === type;
+  });
+};
+
+enum Edge {
+  TOP,
+  BOTTOM,
+}
+
 @Component({
   selector: 'metrics-scalar-column-editor-component',
   templateUrl: 'scalar_column_editor_component.ng.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: [`scalar_column_editor_component.css`],
 })
-export class ScalarColumnEditorComponent {
+export class ScalarColumnEditorComponent implements OnDestroy {
   DataTableMode = DataTableMode;
   selectedTab: DataTableMode = DataTableMode.SINGLE;
+  draggingHeaderType: ColumnHeaderType | undefined;
+  highlightedHeaderType: ColumnHeaderType | undefined;
+  highlightEdge: Edge = Edge.TOP;
   @Input() rangeHeaders!: ColumnHeader[];
   @Input() singleHeaders!: ColumnHeader[];
 
+  @Output() onScalarTableColumnEdit = new EventEmitter<{
+    dataTableMode: DataTableMode;
+    headers: ColumnHeader[];
+  }>();
   @Output() onScalarTableColumnToggled = new EventEmitter<{
     dataTableMode: DataTableMode;
     headerType: ColumnHeaderType;
   }>();
+
+  ngOnDestroy() {
+    document.removeEventListener('dragover', preventDefault);
+  }
+
+  dragStart(header: ColumnHeader) {
+    this.draggingHeaderType = header.type;
+    document.addEventListener('dragover', preventDefault);
+  }
+
+  dragEnd(dataTableMode: DataTableMode) {
+    if (!this.draggingHeaderType || !this.highlightedHeaderType) {
+      return;
+    }
+    const headers = this.getHeadersForMode(dataTableMode);
+    this.onScalarTableColumnEdit.emit({
+      dataTableMode: dataTableMode,
+      headers: moveHeader(
+        getIndexOfType(this.draggingHeaderType, headers),
+        getIndexOfType(this.highlightedHeaderType, headers),
+        headers
+      ),
+    });
+    this.draggingHeaderType = undefined;
+    this.highlightedHeaderType = undefined;
+    document.removeEventListener('dragover', preventDefault);
+  }
+
+  dragEnter(header: ColumnHeader, dataTableMode: DataTableMode) {
+    if (!this.draggingHeaderType) {
+      return;
+    }
+
+    const headers = this.getHeadersForMode(dataTableMode);
+    if (
+      getIndexOfType(header.type, headers) <
+      getIndexOfType(this.draggingHeaderType, headers)
+    ) {
+      this.highlightEdge = Edge.TOP;
+    } else {
+      this.highlightEdge = Edge.BOTTOM;
+    }
+
+    this.highlightedHeaderType = header.type;
+  }
 
   toggleHeader(header: ColumnHeader, dataTableMode: DataTableMode) {
     this.onScalarTableColumnToggled.emit({
       dataTableMode: dataTableMode,
       headerType: header.type,
     });
+  }
+
+  getHighlightClasses(header: ColumnHeader) {
+    if (header.type !== this.highlightedHeaderType) {
+      return {};
+    }
+
+    return {
+      highlighted: true,
+      'highlight-top': this.highlightEdge === Edge.TOP,
+      'highlight-bottom': this.highlightEdge === Edge.BOTTOM,
+    };
+  }
+
+  getHeadersForMode(dataTableMode: DataTableMode) {
+    return dataTableMode === DataTableMode.SINGLE
+      ? this.singleHeaders
+      : this.rangeHeaders;
   }
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -16,7 +16,7 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {State} from '../../../../app_state';
-import {dataTableColumnToggled} from '../../../actions';
+import {dataTableColumnEdited, dataTableColumnToggled} from '../../../actions';
 import {
   getRangeSelectionHeaders,
   getSingleSelectionHeaders,
@@ -34,6 +34,7 @@ import {
       [singleHeaders]="singleHeaders$ | async"
       [rangeHeaders]="rangeHeaders$ | async"
       (onScalarTableColumnToggled)="onScalarTableColumnToggled($event)"
+      (onScalarTableColumnEdit)="onScalarTableColumnEdit($event)"
     >
     </metrics-scalar-column-editor-component>
   `,
@@ -53,5 +54,15 @@ export class ScalarColumnEditorContainer {
     headerType: ColumnHeaderType;
   }) {
     this.store.dispatch(dataTableColumnToggled({dataTableMode, headerType}));
+  }
+
+  onScalarTableColumnEdit({
+    dataTableMode,
+    headers,
+  }: {
+    dataTableMode: DataTableMode;
+    headers: ColumnHeader[];
+  }) {
+    this.store.dispatch(dataTableColumnEdited({dataTableMode, headers}));
   }
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -21,6 +21,7 @@ import {
   getRangeSelectionHeaders,
   getSingleSelectionHeaders,
 } from '../../../store/metrics_selectors';
+import {HeaderEditInfo, HeaderToggleInfo} from '../../../types';
 import {
   ColumnHeader,
   ColumnHeaderType,
@@ -46,23 +47,11 @@ export class ScalarColumnEditorContainer {
   readonly singleHeaders$ = this.store.select(getSingleSelectionHeaders);
   readonly rangeHeaders$ = this.store.select(getRangeSelectionHeaders);
 
-  onScalarTableColumnToggled({
-    dataTableMode,
-    headerType,
-  }: {
-    dataTableMode: DataTableMode;
-    headerType: ColumnHeaderType;
-  }) {
-    this.store.dispatch(dataTableColumnToggled({dataTableMode, headerType}));
+  onScalarTableColumnToggled(toggleInfo: HeaderToggleInfo) {
+    this.store.dispatch(dataTableColumnToggled(toggleInfo));
   }
 
-  onScalarTableColumnEdit({
-    dataTableMode,
-    headers,
-  }: {
-    dataTableMode: DataTableMode;
-    headers: ColumnHeader[];
-  }) {
-    this.store.dispatch(dataTableColumnEdited({dataTableMode, headers}));
+  onScalarTableColumnEdit(editInfo: HeaderEditInfo) {
+    this.store.dispatch(dataTableColumnEdited(editInfo));
   }
 }


### PR DESCRIPTION
* Motivation for features / changes
This is part of the effort to allow users to customize their data table. This PR adds the ability to drag headers in the editor around to change the order in the tables. 

* Screenshots of UI changes
Here is a screenshot taken mid drag: 
<img width="358" alt="Screenshot 2023-02-06 at 3 33 26 PM" src="https://user-images.githubusercontent.com/8672809/217111019-5da042b1-ea6b-4ee0-96e7-7e432778aa90.png">
