### PR TITLE
build: bump max bazel version from 5.4.0 to end of 6.x series

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,8 +18,10 @@ versions.check(
     # Keep this version in sync with:
     #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
     minimum_bazel_version = "4.2.2",
-    # TODO(https://github.com/tensorflow/tensorboard/issues/6115): Support building TensorBoard with Bazel version >= 6.0.0
-    maximum_bazel_version = "5.4.0",
+    # Preemptively assume the next Bazel major version will break us, since historically they do,
+    # and provide a clean error message in that case. Since the maximum version is inclusive rather
+    # than exclusive, we set it to the 999th patch release of the current major version.
+    maximum_bazel_version = "6.999.0",
 )
 
 http_archive(


### PR DESCRIPTION
We inadvertently resolved #6115 via #6147, so we no longer need to pin to a maximum Bazel version of 5.4.0.

That said, I think it's still a good idea to retain a maximum compatible version, since Bazel major version upgrades have reliably resulted in our build breaking in the past. That way, when Bazel 7.0.0 arrives, we'll get a clean error message, and if we then try to remove the pin, we'll either be pleasantly surprised that it's fine, or we'll be expecting a build failure and know the cause (rather than encountering a build failure during a routine build, and then wasting time debugging before realizing Bazel was silently upgraded).

Putting this in place now also ensures this protection extends to older commits, rather than doing it reactively, which then relies on people syncing past that commit before trying to build.

Tested via `USE_BAZEL_VERSION=6.0.0 bazel run tensorboard` (w/ bazel set to bazelisk) and confirmed it builds successfully and runs apparently normally.
