### PR TITLE
build: depend on protobuf runtime from pip rather than Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,8 +117,14 @@ sass_repositories()
 # This dependency specifies the version of protobuf that will be used to compile
 # protos as part of TensorBoard's build (i.e., the protoc version).
 #
-# This version must always be <= the protobuf runtime version, which is the version of
-# the "protobuf" pip package as specified in our requirements.txt file.
+# The generated Python code for those protos relies on a Python runtime library,
+# which is provided by the `protobuf` pip package. To ensure compatibility, the
+# protoc version must be <= the runtime version. In our case, that means we must
+# set the minimum `protobuf` version in our requirements.txt to be at least as
+# high as the version of protobuf we depend on below, and we cannot increase the
+# version below without bumping the requirements.txt version.
+#
+# TODO(#6185): Remove the TODO below once the TF constraint no longer applies.
 #
 # NOTE: This dependency currently cannot be advanced past 3.19.x. This is because
 # TF is currently unable to use a runtime any greater than 3.19.x, see details here:

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -506,13 +506,13 @@ py_library(
     srcs = ["data_compat.py"],
     srcs_version = "PY3",
     deps = [
+        ":expect_protobuf_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/audio:metadata",
         "//tensorboard/plugins/histogram:metadata",
         "//tensorboard/plugins/image:metadata",
         "//tensorboard/plugins/scalar:metadata",
         "//tensorboard/util:tensor_util",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -490,6 +490,17 @@ py_library(name = "expect_pandas_installed")
 # optional dependency.
 py_library(name = "expect_fsspec_installed")
 
+# This is a dummy rule used as a protobuf dependency in open-source.
+# We expect protobuf to already be installed on the system, e.g. via
+# `pip install protobuf`.
+#
+# Note that this dependency only represents the protobuf runtime library,
+# it is not used for compiling .proto files to generated code, which is
+# done by protoc as part of the build process. The protoc version may
+# differ from the runtime version, but to be compatible, the runtime
+# version should always be >= the protoc version.
+py_library(name = "expect_protobuf_installed")
+
 py_library(
     name = "data_compat",
     srcs = ["data_compat.py"],

--- a/tensorboard/defs/protos.bzl
+++ b/tensorboard/defs/protos.bzl
@@ -14,6 +14,7 @@
 
 load("@com_google_protobuf//:protobuf.bzl", "proto_gen")
 
+# TODO(#6185): try to reduce the complexity in this rule.
 def tb_proto_library(
         name,
         srcs = None,
@@ -27,18 +28,37 @@ def tb_proto_library(
     outs_grpc = _PyOuts(srcs, grpc = True) if has_services else []
     outs_all = outs_proto + outs_grpc
 
-    runtime = "@com_google_protobuf//:protobuf_python"
+    # Dependencies we need to operate protoc (the protobuf compiler), including
+    # protoc itself, the intermediate generated proto output from the runtime
+    # bundled with protoc (to provide proto types used during the protoc code
+    # generation process itself), and the grpc plugin to protoc used for gRPC
+    # service generation.
+    protoc = "@com_google_protobuf//:protoc"
+    protoc_runtime_genproto = "@com_google_protobuf//:protobuf_python_genproto"
+    grpc_python_plugin = "//external:grpc_python_plugin"
+
+    # Python generated code relies on a Python protobuf runtime to be present.
+    # The runtime version must be compatible (typically, >=) with the protoc
+    # that was used to generate the code. There is a runtime provided along
+    # with protoc as part of our build-time dependency on protobuf (the target
+    # is "@com_google_protobuf//:protobuf_python"), but we deliberately don't
+    # use it, because our tests may need to use a protobuf runtime that is
+    # higher than our protoc version in order to be compatible with generated
+    # protobuf code used by our dependencies (namely, TensorFlow). Instead, we
+    # rely on picking up protobuf ambiently from the virtual environment, the
+    # same way that it will behave when released in our pip package.
+    runtime = "//tensorboard:expect_protobuf_installed"
 
     proto_gen(
         name = name + "_genproto",
         srcs = srcs,
-        deps = [s + "_genproto" for s in deps] + [runtime + "_genproto"],
+        deps = [s + "_genproto" for s in deps] + [protoc_runtime_genproto],
         includes = [],
-        protoc = "@com_google_protobuf//:protoc",
+        protoc = protoc,
         gen_py = True,
         outs = outs_all,
         visibility = ["//visibility:public"],
-        plugin = "//external:grpc_python_plugin" if has_services else None,
+        plugin = grpc_python_plugin if has_services else None,
         plugin_language = "grpc",
     )
 

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -14,12 +14,12 @@ py_library(
         ":keras_util",
         ":metadata",
         "//tensorboard:errors",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend:process_graph",
         "//tensorboard/data:provider",
         "//tensorboard/plugins:base_plugin",
-        "@com_google_protobuf//:protobuf_python",
         "@org_pocoo_werkzeug",
     ],
 )
@@ -40,13 +40,13 @@ py_library(
     deps = [
         ":graphs_plugin",
         "//tensorboard:context",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:data_provider",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/util:test_util",
-        "@com_google_protobuf//:protobuf_python",
         "@org_pocoo_werkzeug",
     ],
 )
@@ -62,9 +62,9 @@ py_test(
         ":graphs_plugin_test_lib",
         "//tensorboard:errors",
         "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -77,6 +77,7 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":graphs_plugin",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:data_provider",
         "//tensorboard/backend/event_processing:event_multiplexer",
@@ -84,7 +85,6 @@ py_test(
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/util:test_util",
-        "@com_google_protobuf//:protobuf_python",
         "@org_pocoo_werkzeug",
     ],
 )
@@ -118,9 +118,9 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":keras_util",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -142,9 +142,9 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":graph_util",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -38,6 +38,7 @@ py_library(
         ":error",
         ":metadata",
         ":protos_all_py_pb2",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/data:provider",
@@ -46,7 +47,6 @@ py_library(
         "//tensorboard/plugins/scalar:scalars_plugin",
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:tensor_util",
-        "@com_google_protobuf//:protobuf_python",
         "@org_pocoo_werkzeug",
     ],
 )
@@ -59,10 +59,10 @@ py_test(
     ],
     deps = [
         ":hparams_plugin",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -157,8 +157,8 @@ py_binary(
         ":summary",
         "//tensorboard:expect_absl_app_installed",
         "//tensorboard:expect_absl_flags_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -220,8 +220,8 @@ py_test(
         ":metadata",
         ":protos_all_py_pb2",
         ":summary_v2",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -248,10 +248,10 @@ py_test(
         ":protos_all_py_pb2",
         ":summary_v2",
         "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -267,10 +267,10 @@ py_test(
         ":protos_all_py_pb2",
         ":summary_v2",
         "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:test",
         "//tensorboard/compat:no_tensorflow",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -105,6 +105,7 @@ py_library(
         ":upload_tracker",
         ":util",
         "//tensorboard:expect_grpc_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard/backend:process_graph",
         "//tensorboard/backend/event_processing:directory_loader",
         "//tensorboard/backend/event_processing:event_file_loader",
@@ -115,7 +116,6 @@ py_library(
         "//tensorboard/util:grpc_util",
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:tensor_util",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -140,6 +140,7 @@ py_test(
         "//tensorboard:dataclass_compat",
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_grpc_testing_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat:no_tensorflow",
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -151,7 +152,6 @@ py_test(
         "//tensorboard/uploader/proto:protos_all_py_pb2",
         "//tensorboard/uploader/proto:protos_all_py_pb2_grpc",
         "//tensorboard/util:test_util",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -239,8 +239,8 @@ py_library(
     srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_grpc_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -256,8 +256,8 @@ py_test(
     deps = [
         ":test_util",
         ":util",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:test",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -266,11 +266,11 @@ py_library(
     srcs = ["server_info.py"],
     srcs_version = "PY3",
     deps = [
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_requests_installed",
         "//tensorboard:version",
         "//tensorboard/plugins/scalar:metadata",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
-        "@com_google_protobuf//:protobuf_python",
     ],
 )
 


### PR DESCRIPTION
This PR changes how we depend on the Python protobuf runtime library when running under Bazel. Now, we follow the same approach we use for depending on TensorFlow, numpy, etc and expect the package to be importable from the environment, non-hermetically. We introduce an `:expect_protobuf_installed` dummy target to facilitate syncing to our internal repository. (Note: this PR has no effect on the actual generated pip package, which has always imported `protobuf` from the environment in this way.)

Previously, when running under Bazel (e.g. `bazel test` or `bazel run`), the Python protobuf runtime was provided hermetically as part of the build via the target `@com_google_protobuf//:protobuf_python`. This target was used in two different ways:

- Our generated Python protobuf code (produced by `protoc` via compilation of the .proto files) automatically includes this target in the `deps` attribute of the resulting `py_library()`, because it uses our `tb_proto_library()` Starlark macro which encapsulated this behavior
- A smaller number of normal Python targets explicitly depend on this target, because they [`import google.protobuf` directly](https://cs.opensource.google/search?ss=tensorflow%2Ftensorboard&q=import.*protobuf%7Cprotobuf.*import%20lang:py) (typical use cases would be to use a well-known common proto like `timestamp` or a utility like `text_format`)

The problem with the hermetic approach is that it forces our Python protobuf runtime to match our `protoc` version, since they come from the same `@com_google_protobuf` repository. That poses an issue because we don't want to advance our `protoc` version past 3.19.6 for the reasons described in [this comment](https://github.com/tensorflow/tensorboard/blob/22becc02379375785c1ad3b61f712050843aea5c/WORKSPACE#L117-L131), but we depend on TensorFlow which has [recently increased its minimum protobuf runtime to 3.20.3](https://github.com/tensorflow/tensorflow/commit/84f40925e929d05e72ab9234e53c729224e3af38#diff-f526feeafa1000c4773410bdc5417c4022cb2c7b686ae658b629beb541ae9112). As a result, trying to run our Bazel tests against TF at HEAD causes protobuf compatibility failures for the TF generated protos due to an insufficient runtime version.

This PR resolves this skew by allowing the protobuf runtime to "float" to whatever version the pip requirements dictate, at the cost of increased non-hermeticity. We might ultimately be able to resolve this hermetically - for all our `expect_<name>_installed` deps - by depending on newer versions of protobuf Starlark rules and/or migrating our pip-specified dependencies to use rules_python. I've filed #6185 as a tracking issue for trying to improve this situation longer-term.