### PR TITLE
build: fix version_test.py to work with setuptools >= 66

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -28,7 +28,7 @@ numpy >= 1.12.0
 # https://github.com/tensorflow/tensorflow/blob/9d22f4a0a9499c8e10a4312503e63e0da35ccd94/tensorflow/tools/pip_package/setup.py#L100-L107
 protobuf >= 3.19.6
 requests >= 2.21.0, < 3
-setuptools >= 41.0.0
+setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 tensorboard-data-server >= 0.7.0, < 0.8.0
 tensorboard-plugin-wit >= 1.6.0
 werkzeug >= 1.0.1

--- a/tensorboard/version_test.py
+++ b/tensorboard/version_test.py
@@ -22,10 +22,18 @@ from tensorboard import version
 class VersionTest(tb_test.TestCase):
     def test_valid_pep440_version(self):
         """Ensure that our version is PEP 440-compliant."""
-        # `Version` and `LegacyVersion` are vendored and not publicly
-        # exported; get handles to them.
+        # pkg_resources.parse_version() doesn't have a public return type,
+        # so we get a handle to it by parsing known good and bad versions.
+        #
+        # Note: depending on the version of the module (which is bundled
+        # with setuptools), when called with a non-compliant version, it
+        # either returns a `LegacyVersion` (setuptools < 66) or raises an
+        # `InvalidVersion` exception (setuptools >= 66). Handle both cases.
         compliant_version = pkg_resources.parse_version("1.0.0")
-        legacy_version = pkg_resources.parse_version("some arbitrary string")
+        try:
+            legacy_version = pkg_resources.parse_version("arbitrary string")
+        except Exception:
+            legacy_version = None
         self.assertNotEqual(type(compliant_version), type(legacy_version))
 
         tensorboard_version = pkg_resources.parse_version(version.VERSION)


### PR DESCRIPTION
Code in version_test.py relies on behavior of `pkg_resources.parse_version` in a way that was broken by changes in setuptools 66+ (see https://github.com/pypa/setuptools/issues/3772). The new logic throws an `InvalidVersion` exception when given a non-PEP440-compliant version, rather than returning `LegacyVersion`.  This PR updates our test to work with either behavior.

Test plan: ran test with both setuptools 65 and 66, and confirmed it now passes for both, rather than failing for 66.