### PR TITLE
build: add missing protobuf deps as implied by imports

### DIFF
--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -23,6 +23,7 @@ py_test(
     ],
     deps = [
         ":protos_all_py_pb2",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
     ],
 )

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -15,6 +15,7 @@ py_library(
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/compat:tensorflow",
@@ -73,6 +74,7 @@ py_test(
         ":summary",
         "//tensorboard:context",
         "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:data_provider",
@@ -98,6 +100,7 @@ py_test(
         ":summary",
         "//tensorboard:context",
         "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:data_provider",

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -29,7 +29,10 @@ py_test(
     size = "small",
     srcs = ["graphs_plugin_test.py"],
     srcs_version = "PY3",
-    deps = [":graphs_plugin_test_lib"],
+    deps = [
+        ":graphs_plugin_test_lib",
+        "//tensorboard:expect_protobuf_installed",
+    ],
 )
 
 py_library(

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -76,6 +76,7 @@ py_test(
     deps = [
         ":hparams_plugin",
         "//tensorboard:context",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:data_provider",
         "//tensorboard/backend/event_processing:event_accumulator",
@@ -94,6 +95,7 @@ py_test(
     deps = [
         ":hparams_plugin",
         "//tensorboard:context",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
     ],
 )
@@ -107,6 +109,7 @@ py_test(
     deps = [
         ":hparams_plugin",
         "//tensorboard:context",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:data_provider",
         "//tensorboard/backend/event_processing:event_multiplexer",
@@ -140,6 +143,7 @@ py_binary(
         ":summary",
         "//tensorboard:expect_absl_app_installed",
         "//tensorboard:expect_absl_flags_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/scalar:summary",
     ],
@@ -296,6 +300,7 @@ py_test(
     deps = [
         ":protos_all_py_pb2",
         ":summary",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
     ],
 )

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -18,6 +18,7 @@ py_library(
         ":protos_all_py_pb2",
         "//tensorboard:context",
         "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:plugin_asset_util",
         "//tensorboard/compat:tensorflow",
@@ -35,6 +36,7 @@ py_library(
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard/compat:tensorflow",
     ],
 )
@@ -47,6 +49,7 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":projector",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/util:test_util",
     ],
@@ -61,6 +64,7 @@ py_test(
     deps = [
         ":projector_plugin",
         "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:data_provider",
@@ -82,6 +86,7 @@ py_test(
     deps = [
         ":projector_plugin",
         "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:data_provider",


### PR DESCRIPTION
While working on #6186, I noticed that we have many files that import `protobuf` but don't have an explicit dependency on it (easy to have happen without strict deps enforcement). This adds those missing dependencies.

I generated all the changes in this PR with the following command, which essentially 1) finds all files containing a `from google.protobuf` import line, 2) uses bazel query to go from the set of files to the set of python BUILD targets that depend on those files, and then 3) uses buildozer to add the `expect_protobuf_installed` dep to those targets.

`buildozer 'add deps //tensorboard:expect_protobuf_installed' $(bazel query 'let files = set('$(git grep -l -E '^from google.protobuf')') in kind("py", rdeps(//tensorboard/..., $files, 1))')`

This has no actual impact on the open source build since the `expect_protobuf_installed` target has no actual code associated with it, but it should make our build dependency graph more correct and make it easier for the google-internal build to express its dependencies strictly.