### PR TITLE
build: make nightly version update script more robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,13 +115,14 @@ jobs:
           bazel test //tensorboard/summary/writer:event_file_writer_s3_test &&
           bazel test //tensorboard/compat/tensorflow_stub:gfile_fsspec_test &&
           bazel test //tensorboard/summary/writer:event_file_writer_fsspec_test
-      - name: 'Bazel: build Pip package (with TensorFlow only)'
-        if: matrix.tf_version_id == 'tf'
+      - name: 'Bazel: build Pip package (master branch TF build only)'
+        # Only bother creating the pip package if it will be updated in the next step.
+        if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
         run: |
           ./tensorboard/tools/update_version.sh
           rm -rf /tmp/tb_nightly_pip_package && mkdir /tmp/tb_nightly_pip_package
           bazel run //tensorboard/pip_package:build_pip_package -- /tmp/tb_nightly_pip_package
-      - name: 'Upload Pip package as an artifact (with TensorFlow only)'
+      - name: 'Upload Pip package as an artifact (master branch TF build only)
         # Prevent uploads when running on forks or non-master branch.
         if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,8 @@ jobs:
           bazel test //tensorboard/compat/tensorflow_stub:gfile_fsspec_test &&
           bazel test //tensorboard/summary/writer:event_file_writer_fsspec_test
       - name: 'Bazel: build Pip package (master branch TF build only)'
-        # Only bother creating the pip package if it will be updated in the next step.
+        # This pip package is only needed if we will upload it, so run this step
+        # only under the same conditions as the next step (see comment below).
         if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
         run: |
           ./tensorboard/tools/set_nightly_version.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           ./tensorboard/tools/set_nightly_version.sh
           rm -rf /tmp/tb_nightly_pip_package && mkdir /tmp/tb_nightly_pip_package
           bazel run //tensorboard/pip_package:build_pip_package -- /tmp/tb_nightly_pip_package
-      - name: 'Upload Pip package as an artifact (master branch TF build only)
+      - name: 'Upload Pip package as an artifact (master branch TF build only)'
         # Prevent uploads when running on forks or non-master branch.
         if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         # Only bother creating the pip package if it will be updated in the next step.
         if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
         run: |
-          ./tensorboard/tools/update_version.sh
+          ./tensorboard/tools/set_nightly_version.sh
           rm -rf /tmp/tb_nightly_pip_package && mkdir /tmp/tb_nightly_pip_package
           bazel run //tensorboard/pip_package:build_pip_package -- /tmp/tb_nightly_pip_package
       - name: 'Upload Pip package as an artifact (master branch TF build only)

--- a/tensorboard/tools/set_nightly_version.sh
+++ b/tensorboard/tools/set_nightly_version.sh
@@ -15,8 +15,15 @@
 # ==============================================================================
 
 # Updates package version and renames the package to `tb-nightly`.
-version="$(grep -Po "(?<=VERSION = ['\"]).*?(?=['\"])" tensorboard/version.py)"
-series="$(grep -Po "(?<=VERSION = ['\"]).*?(?=a0['\"])" tensorboard/version.py)"
-release="${series}a$(date +%Y%m%d)"
-sed -i -e "s/${version}/${release}/" tensorboard/version.py
-sed -i -e "s/name *= *['\"][^'\"]*['\"]/name=\"tb-nightly\"/" tensorboard/pip_package/setup.py
+version="$(python tensorboard/version.py)"
+case "${version}" in
+  *a0)
+    # Strip a0 as the suffix and add "a" plus today's date.
+    release="${version%a0}a$(date +%Y%m%d)"
+    sed -i -e "s/${version}/${release}/" tensorboard/version.py
+    sed -i -e "s/name *= *['\"][^'\"]*['\"]/name=\"tb-nightly\"/" tensorboard/pip_package/setup.py
+    ;;
+  *)
+    printf "error: found non-placeholder version %s\n" "${version}"
+    exit 1
+esac

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -16,3 +16,6 @@
 """Contains the version string."""
 
 VERSION = "2.13.0a0"
+
+if __name__ == "__main__":
+    print(VERSION)


### PR DESCRIPTION
This addresses an issue we had with the `update_version.sh` script in the most recent release, where running it on a branch where the version number did not end in the placeholder `a0` produced an invalid version and caused CI to fail. We make two changes:

- Stop running that script (and building the pip package) if we aren't going to use the resulting pip package. Doing so just adds extra latency to the build, and we already do build and test the pip package as part of the CI earlier, so I don't think it adds meaningful coverage except for the version update script itself
- Make the version update script itself more robust by avoiding reliance on hard-to-read `grep` regexes with multiple non-capturing groups, and favoring just using Python and bash primitives. I made it fail with an error if the placeholder `a0` is not present, rather than generating an invalid output. Lastly, I've also renamed it to `set_nightly_version.sh` to make it clearer that its only purpose is in preparing the tb-nightly pip package and should not be part of a normal non-nightly release. 

Tested by running the script locally and confirming it makes the expected changes, and confirming that it fails if the version doesn't have the `a0` placeholder suffix.