### PR TITLE
Cleanup: Allow undefined State in runs reducers definition.

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -415,7 +415,7 @@ const uiReducers = composeReducers(uiReducer, uiNamespaceContextedReducers);
 /**
  * Reducers for the experiments.
  */
-export function reducers(state: RunsState, action: Action) {
+export function reducers(state: RunsState | undefined, action: Action) {
   return combineReducers({
     data: dataReducers,
     ui: uiReducers,


### PR DESCRIPTION
This is a small modification to the runs feature's `reducers()` function to make it more extensible.

This changes the reducers' `state` argument to allow for an `undefined` value in addition to `RunsState`. 

This will allow me to use `reducers` as an argument to [composeReducers](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/webapp/util/ngrx.ts) for some extensions I am adding to the internal code base.

The ngrx documentation (https://v8.ngrx.io/guide/store/reducers) seems to suggest this is how we should be typing our reducers functions anyhow. 