### PR TITLE
Linked Time: Add lots of different ways to resize the data table

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -82,6 +82,7 @@ tf_sass_binary(
     src = "histogram_card_component.scss",
     strict_deps = False,
     deps = [
+        "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
     ],

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -179,7 +179,7 @@ limitations under the License.
     #dataTableContainer
     [ngClass]="{
       'data-table-container': true,
-      'expanded': cardState!.tableExpanded || showFullSize
+      'expanded': cardState!.tableExpanded
     }"
   >
     <scalar-card-data-table

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -201,11 +201,11 @@ limitations under the License.
       i18n-aria-label="Expand Table"
       class="expand-button"
       aria-label="Expand Table"
-      [title]="cardState!.tableExpanded ? 'Collapse Table' : 'Expand Table'"
+      [title]="shouldExpandTable() ? 'Expand Table' : 'Collapse Table'"
       (click)="toggleTableExpanded()"
     >
       <mat-icon
-        [svgIcon]="cardState!.tableExpanded ? 'expand_less_24px' : 'expand_more_24px'"
+        [svgIcon]="shouldExpandTable() ? 'expand_more_24px' : 'expand_less_24px'"
       ></mat-icon>
     </button>
   </div>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -96,7 +96,7 @@ limitations under the License.
       </mat-menu>
     </span>
   </div>
-  <div class="chart-container">
+  <div #chartContainer class="chart-container">
     <mat-spinner
       diameter="18"
       *ngIf="loadState === DataLoadState.LOADING"
@@ -175,7 +175,13 @@ limitations under the License.
   </div>
 </div>
 <ng-container *ngIf="showDataTable()">
-  <div class="data-table-container">
+  <div
+    #dataTableContainer
+    [ngClass]="{
+      'data-table-container': true,
+      'expanded': cardState!.tableExpanded || showFullSize
+    }"
+  >
     <scalar-card-data-table
       [chartMetadataMap]="chartMetadataMap"
       [dataSeries]="dataSeries"
@@ -188,6 +194,20 @@ limitations under the License.
       (orderColumns)="reorderColumnHeaders.emit($event)"
     >
     </scalar-card-data-table>
+  </div>
+  <div class="bottom-area">
+    <button
+      mat-icon-button
+      i18n-aria-label="Expand Table"
+      class="expand-button"
+      aria-label="Expand Table"
+      [title]="cardState!.tableExpanded ? 'Collapse Table' : 'Expand Table'"
+      (click)="toggleTableExpanded()"
+    >
+      <mat-icon
+        [svgIcon]="cardState!.tableExpanded ? 'expand_less_24px' : 'expand_more_24px'"
+      ></mat-icon>
+    </button>
   </div>
 </ng-container>
 <ng-template

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -12,31 +12,47 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 @import '../common';
 
 $_title-to-heading-gap: 12px;
+
+$_min_content_height: $metrics-min-card-height - 2px -
+  ($metrics-preferred-gap * 2) + $_title-to-heading-gap;
 
 :host {
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
   height: 100%;
-  overflow: auto;
   padding: $metrics-preferred-gap;
   // When vertically centered, the title's text-top contains extra space above
   // the text, which counts towards the visually perceived white space.
   padding-top: $metrics-preferred-gap - $_title-to-heading-gap;
+
+  &:has(.data-table-container) {
+    padding: $metrics-preferred-gap $metrics-preferred-gap 0;
+  }
+
+  &:hover {
+    .bottom-area {
+      .expand-button {
+        visibility: visible;
+      }
+    }
+  }
 }
 
 .always-visible {
   display: flex;
-  // The content that is always visible should match the min height of a card,
-  // taking into account padding and 2px for the card border.
-  flex-basis: $metrics-min-card-height - 2px - ($metrics-preferred-gap * 2) +
-    $_title-to-heading-gap;
   flex-direction: column;
   flex-grow: 1;
+  transition: flex-basis 300ms ease-in-out;
+
+  // The content that is always visible should match the min height of a card,
+  // taking into account padding and 2px for the card border.
+  flex-basis: $_min_content_height;
 }
 
 .heading {
@@ -78,7 +94,9 @@ $_title-to-heading-gap: 12px;
 }
 
 .chart-container {
+  overflow: hidden;
   flex-grow: 1;
+  resize: vertical;
 
   mat-spinner {
     $mat-icon-button-diameter: 40px;
@@ -167,7 +185,47 @@ $_title-to-heading-gap: 12px;
 }
 
 .data-table-container {
-  width: 100%;
+  flex-grow: 1;
   height: 100px;
+  width: 100%;
+  min-height: 0;
+
   overflow: auto;
+  resize: vertical;
+
+  max-height: 50em;
+
+  &:hover {
+    overflow-x: auto;
+  }
+
+  &.expanded {
+    height: auto;
+  }
+}
+
+$expand-button-height: 40px;
+
+.bottom-area {
+  // position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  bottom: 0;
+
+  .expand-button {
+    color: mat.get-color-from-palette($tb-foreground, secondary-text);
+
+    @include tb-dark-theme {
+      color: mat.get-color-from-palette($tb-dark-foreground, secondary-text);
+      background-color: map-get($tb-dark-background, background);
+    }
+  }
+
+  &:hover {
+    .expand-button {
+      visibility: visible;
+    }
+  }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -18,9 +18,6 @@ limitations under the License.
 
 $_title-to-heading-gap: 12px;
 
-$_min_content_height: $metrics-min-card-height - 2px -
-  ($metrics-preferred-gap * 2) + $_title-to-heading-gap;
-
 :host {
   display: flex;
   flex-direction: column;
@@ -34,14 +31,6 @@ $_min_content_height: $metrics-min-card-height - 2px -
   &:has(.data-table-container) {
     padding: $metrics-preferred-gap $metrics-preferred-gap 0;
   }
-
-  &:hover {
-    .bottom-area {
-      .expand-button {
-        visibility: visible;
-      }
-    }
-  }
 }
 
 .always-visible {
@@ -52,7 +41,8 @@ $_min_content_height: $metrics-min-card-height - 2px -
 
   // The content that is always visible should match the min height of a card,
   // taking into account padding and 2px for the card border.
-  flex-basis: $_min_content_height;
+  flex-basis: $metrics-min-card-height - 2px - ($metrics-preferred-gap * 2) +
+    $_title-to-heading-gap;
 }
 
 .heading {
@@ -195,10 +185,6 @@ $_min_content_height: $metrics-min-card-height - 2px -
 
   max-height: 50em;
 
-  &:hover {
-    overflow-x: auto;
-  }
-
   &.expanded {
     height: auto;
   }
@@ -207,7 +193,6 @@ $_min_content_height: $metrics-min-card-height - 2px -
 $expand-button-height: 40px;
 
 .bottom-area {
-  // position: absolute;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -220,12 +205,6 @@ $expand-button-height: 40px;
     @include tb-dark-theme {
       color: mat.get-color-from-palette($tb-dark-foreground, secondary-text);
       background-color: map-get($tb-dark-background, background);
-    }
-  }
-
-  &:hover {
-    .expand-button {
-      visibility: visible;
     }
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -28,7 +28,8 @@ $_title-to-heading-gap: 12px;
   // the text, which counts towards the visually perceived white space.
   padding-top: $metrics-preferred-gap - $_title-to-heading-gap;
 
-  &:has(.data-table-container) {
+  &:has(.expand-button) {
+    // Remove the bottom padding when the expand button appears
     padding: $metrics-preferred-gap $metrics-preferred-gap 0;
   }
 }
@@ -36,8 +37,6 @@ $_title-to-heading-gap: 12px;
 .always-visible {
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
-  transition: flex-basis 300ms ease-in-out;
 
   // The content that is always visible should match the min height of a card,
   // taking into account padding and 2px for the card border.
@@ -85,7 +84,6 @@ $_title-to-heading-gap: 12px;
 
 .chart-container {
   overflow: hidden;
-  flex-grow: 1;
   resize: vertical;
 
   mat-spinner {
@@ -175,29 +173,20 @@ $_title-to-heading-gap: 12px;
 }
 
 .data-table-container {
-  flex-grow: 1;
   height: 100px;
-  width: 100%;
-  min-height: 0;
-
+  max-height: 50em;
   overflow: auto;
   resize: vertical;
-
-  max-height: 50em;
 
   &.expanded {
     height: auto;
   }
 }
 
-$expand-button-height: 40px;
-
 .bottom-area {
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
-  bottom: 0;
 
   .expand-button {
     color: mat.get-color-from-palette($tb-foreground, secondary-text);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -83,6 +83,7 @@ $_title-to-heading-gap: 12px;
 }
 
 .chart-container {
+  flex-grow: 1;
   overflow: hidden;
   resize: vertical;
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -252,16 +252,26 @@ export class ScalarCardComponent<Downloader> {
     );
   }
 
+  shouldExpandTable() {
+    // If the user has resized the data table a height style will be set.
+    // If the data table has been resized we always want to expand the table.
+    // Otherwise the table should be toggled.
+    return Boolean(
+      this.dataTableContainer?.nativeElement.style.height ||
+        !this.cardState?.tableExpanded
+    );
+  }
+
   toggleTableExpanded() {
+    this.onCardStateChanged.emit({
+      ...this.cardState,
+      tableExpanded: this.shouldExpandTable(),
+    });
     // Manually resizing an element sets a style value on the element which takes
     // precedence over any classes the element may have. This value must be removed
     // for the table to expand or collapse correctly.
     if (this.dataTableContainer) {
       this.dataTableContainer.nativeElement.style.height = '';
     }
-    this.onCardStateChanged.emit({
-      ...this.cardState,
-      tableExpanded: !this.cardState?.tableExpanded,
-    });
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -43,6 +43,7 @@ import {
   ScaleType,
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
+import {CardState} from '../../store';
 import {TooltipSort, XAxisType} from '../../types';
 import {
   ColumnHeader,
@@ -75,6 +76,7 @@ export class ScalarCardComponent<Downloader> {
 
   @Input() cardId!: string;
   @Input() chartMetadataMap!: ScalarCardSeriesMetadataMap;
+  @Input() cardState?: CardState;
   @Input() DataDownloadComponent!: ComponentType<Downloader>;
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() ignoreOutliers!: boolean;
@@ -110,6 +112,8 @@ export class ScalarCardComponent<Downloader> {
 
   @Output() onLineChartZoom = new EventEmitter<Extent>();
 
+  @Output() onCardStateChanged = new EventEmitter<Partial<CardState>>();
+
   // Line chart may not exist when was never visible (*ngIf).
   @ViewChild(LineChartComponent)
   lineChart?: LineChartComponent;
@@ -117,6 +121,9 @@ export class ScalarCardComponent<Downloader> {
     header: ColumnHeaderType.RUN,
     order: SortingOrder.ASCENDING,
   };
+
+  @ViewChild('dataTableContainer')
+  dataTableContainer?: ElementRef;
 
   constructor(private readonly ref: ElementRef, private dialog: MatDialog) {}
 
@@ -243,5 +250,18 @@ export class ScalarCardComponent<Downloader> {
       (this.stepOrLinkedTimeSelection !== null ||
         this.isProspectiveFobFeatureEnabled)
     );
+  }
+
+  toggleTableExpanded() {
+    // Manually resizing an element sets a style value on the element which takes
+    // precedence over any classes the element may have. This value must be removed
+    // for the table to expand or collapse correctly.
+    if (this.dataTableContainer) {
+      this.dataTableContainer.nativeElement.style.height = '';
+    }
+    this.onCardStateChanged.emit({
+      ...this.cardState,
+      tableExpanded: !this.cardState?.tableExpanded,
+    });
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -281,6 +281,14 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.showFullSize = !this.showFullSize;
     this.fullWidthChanged.emit(this.showFullSize);
     this.fullHeightChanged.emit(this.showFullSize);
+    this.store.dispatch(
+      metricsCardStateUpdated({
+        cardId: this.cardId,
+        settings: {
+          tableExpanded: this.showFullSize,
+        },
+      })
+    );
   }
 
   /**

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -51,6 +51,7 @@ import {
 } from '../../../feature_flag/store/feature_flag_selectors';
 import {
   getCardPinnedState,
+  getCardStateMap,
   getCurrentRouteRunSelection,
   getDarkModeEnabled,
   getExperimentIdForRunId,
@@ -73,12 +74,14 @@ import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {
   dataTableColumnDrag,
+  metricsCardStateUpdated,
   sortingDataTable,
   stepSelectorToggled,
   timeSelectionChanged,
 } from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
+  CardState,
   getCardLoadState,
   getCardMetadata,
   getCardTimeSeries,
@@ -158,6 +161,7 @@ function areSeriesEqual(
       [smoothingEnabled]="smoothingEnabled$ | async"
       [tag]="tag$ | async"
       [title]="title$ | async"
+      [cardState]="cardState$ | async"
       [tooltipSort]="tooltipSort$ | async"
       [xAxisType]="xAxisType$ | async"
       [xScaleType]="xScaleType$ | async"
@@ -178,6 +182,7 @@ function areSeriesEqual(
       (onDataTableSorting)="onDataTableSorting($event)"
       (onLineChartZoom)="onLineChartZoom($event)"
       (reorderColumnHeaders)="reorderColumnHeaders($event)"
+      (onCardStateChanged)="onCardStateChanged($event)"
     ></scalar-card-component>
   `,
   styles: [
@@ -214,6 +219,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   linkedTimeSelection$?: Observable<TimeSelectionView | null>;
   columnHeaders$?: Observable<ColumnHeader[]>;
   stepOrLinkedTimeSelection$?: Observable<TimeSelection | null>;
+  cardState$?: Observable<Partial<CardState>>;
 
   readonly isProspectiveFobFeatureEnabled$: Observable<boolean> =
     this.store.select(getIsLinkedTimeProspectiveFobEnabled);
@@ -579,6 +585,12 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
       })
     );
 
+    this.cardState$ = this.store.select(getCardStateMap).pipe(
+      map((cardStateMap) => {
+        return cardStateMap[this.cardId] || {};
+      })
+    );
+
     this.title$ = this.tag$.pipe(
       map((tag) => {
         return getTagDisplayName(tag, this.groupName);
@@ -741,6 +753,15 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   onDataTableSorting(sortingInfo: SortingInfo) {
     this.store.dispatch(sortingDataTable(sortingInfo));
+  }
+
+  onCardStateChanged(newSettings: Partial<CardState>) {
+    this.store.dispatch(
+      metricsCardStateUpdated({
+        cardId: this.cardId,
+        settings: newSettings,
+      })
+    );
   }
 
   onTimeSelectionChanged(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -77,7 +77,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {stepSelectorToggled, timeSelectionChanged} from '../../actions';
 import {PluginType} from '../../data_source';
 import {
-  getCardSettingsMap,
+  getCardStateMap,
   getMetricsLinkedTimeEnabled,
   getMetricsLinkedTimeSelection,
   getMetricsRangeSelectionEnabled,
@@ -3459,7 +3459,7 @@ describe('scalar card', () => {
         end: null,
       });
 
-      store.overrideSelector(getCardSettingsMap, {});
+      store.overrideSelector(getCardStateMap, {});
     });
 
     it('clears inline styles', fakeAsync(() => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -77,6 +77,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {stepSelectorToggled, timeSelectionChanged} from '../../actions';
 import {PluginType} from '../../data_source';
 import {
+  getCardSettingsMap,
   getMetricsLinkedTimeEnabled,
   getMetricsLinkedTimeSelection,
   getMetricsRangeSelectionEnabled,
@@ -3401,6 +3402,80 @@ describe('scalar card', () => {
       expect(data[4].RUN).toEqual('2 b/run5');
       expect(data[5].RUN).toEqual('3 c/run6');
       expect(data[6].RUN).toEqual('1 a/run7');
+    }));
+  });
+
+  describe('toggleTableExpanded', () => {
+    beforeEach(() => {
+      store.overrideSelector(getMetricsLinkedTimeEnabled, true);
+      store.overrideSelector(getSingleSelectionHeaders, [
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.SMOOTHED, enabled: true},
+        {type: ColumnHeaderType.VALUE, enabled: true},
+        {type: ColumnHeaderType.STEP, enabled: true},
+        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
+      ]);
+      store.overrideSelector(getRangeSelectionHeaders, [
+        {type: ColumnHeaderType.RUN, enabled: true},
+        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
+        {type: ColumnHeaderType.START_VALUE, enabled: true},
+        {type: ColumnHeaderType.END_VALUE, enabled: true},
+        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
+        {type: ColumnHeaderType.START_STEP, enabled: true},
+        {type: ColumnHeaderType.END_STEP, enabled: true},
+      ]);
+
+      const runToSeries = {
+        run1: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 2},
+          {wallTime: 3, value: 20, step: 3},
+        ],
+        run2: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 2},
+          {wallTime: 3, value: 20, step: 3},
+        ],
+      };
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        runToSeries
+      );
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+        ])
+      );
+
+      store.overrideSelector(getMetricsLinkedTimeSelection, {
+        start: {step: 2},
+        end: null,
+      });
+
+      store.overrideSelector(getCardSettingsMap, {});
+    });
+
+    it('clears inline styles', fakeAsync(() => {
+      const fixture = createComponent('card1');
+      fixture.detectChanges();
+      const component = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      expect(component.componentInstance.dataTableContainer).toBeDefined();
+      component.componentInstance.dataTableContainer.nativeElement.style =
+        'height: 123px;';
+      component.componentInstance.toggleTableExpanded();
+      expect(
+        component.componentInstance.dataTableContainer.nativeElement.style
+          .cssText
+      ).toEqual('');
     }));
   });
 

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -20,6 +20,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 .data-table {
   border-spacing: 4px;
   font-size: 13px;
+  width: 100%;
 
   th {
     background-color: mat.get-color-from-palette($tb-background, background);


### PR DESCRIPTION
~Blocked by #6202~

## Motivation for features / changes
The data table seems to be a popular feature but its limited size makes it hard to use. Given the current size is arbitrary I would like to add the ability to resize it dynamically.

## Technical description of changes
Most of the changes in this PR are CSS updates. The exception is the expand / collapse feature which stores its state in redux.

 * I updated the redux state to store more information about the state of each card (is it expanded) to ensure this feature is forwards compatible with the upcoming share feature.

## Screenshots of UI changes
New Drag Handles and a resize button
![image](https://user-images.githubusercontent.com/78179109/218554807-e77d2bc8-edb0-445b-8be5-e78438ae18e3.png)

Resize button in action
![b3734ccc-ceec-4276-a389-6fb13dbe7fff](https://user-images.githubusercontent.com/78179109/218554956-2f414ee2-5b1d-4782-ba31-73cc0598abb6.gif)

Manual Resize + using the resize button
![25ce402d-0be9-4a7e-ab59-041d85291ffc](https://user-images.githubusercontent.com/78179109/218555078-dbb0f7a1-0999-4bf5-9856-5a438a35f377.gif)

Big Card Mode
![b1d84ced-5330-4c2c-b9c4-aa0ef9f0be25](https://user-images.githubusercontent.com/78179109/218555220-9be93a59-d671-413a-8518-672e1d1354e5.gif)

Resizing the chart
![05ecf6c5-df80-489b-a7f0-ac1ac91f1363](https://user-images.githubusercontent.com/78179109/218555336-03587cf1-259a-470e-9abb-a97693a4bd5a.gif)


## Detailed steps to verify changes work correctly (as executed by you)
I did all the things in the gifs above

## Alternate designs / implementations considered
I explored lots of different placements for the expand/collapse button
I also explored adding the ability to hide the chart entirely
