### PR TITLE
Linked Time: Add card specific settings to redux

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,13 +15,13 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check(
-    # Keep this version in sync with:
-    #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
-    minimum_bazel_version = "4.2.2",
     # Preemptively assume the next Bazel major version will break us, since historically they do,
     # and provide a clean error message in that case. Since the maximum version is inclusive rather
     # than exclusive, we set it to the 999th patch release of the current major version.
     maximum_bazel_version = "6.999.0",
+    # Keep this version in sync with:
+    #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
+    minimum_bazel_version = "4.2.2",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,13 +15,13 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check(
+    # Keep this version in sync with:
+    #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
+    minimum_bazel_version = "4.2.2",
     # Preemptively assume the next Bazel major version will break us, since historically they do,
     # and provide a clean error message in that case. Since the maximum version is inclusive rather
     # than exclusive, we set it to the 999th patch release of the current major version.
     maximum_bazel_version = "6.999.0",
-    # Keep this version in sync with:
-    #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
-    minimum_bazel_version = "4.2.2",
 )
 
 http_archive(

--- a/tensorboard/webapp/metrics/actions/BUILD
+++ b/tensorboard/webapp/metrics/actions/BUILD
@@ -12,6 +12,7 @@ tf_ts_library(
     deps = [
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/metrics/data_source",
+        "//tensorboard/webapp/metrics/store:types",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/util:dom",
         "//tensorboard/webapp/widgets/card_fob:types",

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -23,7 +23,7 @@ import {
   TimeSeriesRequest,
   TimeSeriesResponse,
 } from '../data_source';
-import {CardSettings} from '../store/metrics_types';
+import {CardState} from '../store/metrics_types';
 import {
   CardId,
   HeaderEditInfo,
@@ -63,11 +63,11 @@ export const metricsTagMetadataFailed = createAction(
   '[Metrics] Metrics Tag Metadata Failed'
 );
 
-export const metricsCardSettingsUpdated = createAction(
-  '[Metrics] Metrics Card Settings Updated',
+export const metricsCardStateUpdated = createAction(
+  '[Metrics] Metrics Card State Updated',
   props<{
     cardId: CardId;
-    settings: Partial<CardSettings>;
+    settings: Partial<CardState>;
   }>()
 );
 

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -23,6 +23,7 @@ import {
   TimeSeriesRequest,
   TimeSeriesResponse,
 } from '../data_source';
+import {CardSettings} from '../store/metrics_types';
 import {
   CardId,
   HeaderEditInfo,
@@ -62,6 +63,14 @@ export const metricsTagMetadataLoaded = createAction(
 
 export const metricsTagMetadataFailed = createAction(
   '[Metrics] Metrics Tag Metadata Failed'
+);
+
+export const metricsCardSettingsUpdated = createAction(
+  '[Metrics] Metrics Card Settings Updated',
+  props<{
+    cardId: CardId;
+    settings: CardSettings;
+  }>()
 );
 
 export const metricsChangeTooltipSort = createAction(

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -35,8 +35,6 @@ import {
 } from '../types';
 import {
   ColumnHeader,
-  ColumnHeaderType,
-  DataTableMode,
   SortingInfo,
 } from '../views/card_renderer/scalar_card_types';
 
@@ -69,7 +67,7 @@ export const metricsCardSettingsUpdated = createAction(
   '[Metrics] Metrics Card Settings Updated',
   props<{
     cardId: CardId;
-    settings: CardSettings;
+    settings: Partial<CardSettings>;
   }>()
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -260,7 +260,7 @@ const {initialState, reducers: namespaceContextedReducer} =
       pinnedCardToOriginal: new Map(),
       unresolvedImportedPinnedCards: [],
       cardMetadataMap: {},
-      cardSettingsMap: {},
+      cardStateMap: {},
       cardStepIndex: {},
       tagFilter: '',
       tagGroupExpanded: new Map<string, boolean>(),
@@ -400,7 +400,7 @@ const reducer = createReducer(
       state.cardToPinnedCopyCache,
       state.pinnedCardToOriginal,
       state.cardStepIndex,
-      state.cardSettingsMap
+      state.cardStateMap
     );
 
     const hydratedSmoothing = hydratedState.metrics.smoothing;
@@ -587,7 +587,7 @@ const reducer = createReducer(
         state.cardToPinnedCopyCache,
         nextPinnedCardToOriginal,
         nextCardStepIndex,
-        state.cardSettingsMap
+        state.cardStateMap
       );
 
       return {
@@ -603,13 +603,13 @@ const reducer = createReducer(
       };
     }
   ),
-  on(actions.metricsCardSettingsUpdated, (state, {cardId, settings}) => {
-    const nextCardSettingsMap = {...state.cardSettingsMap};
-    nextCardSettingsMap[cardId] = {...settings};
+  on(actions.metricsCardStateUpdated, (state, {cardId, settings}) => {
+    const nextcardStateMap = {...state.cardStateMap};
+    nextcardStateMap[cardId] = {...settings};
 
     return {
       ...state,
-      cardSettingsMap: nextCardSettingsMap,
+      cardStateMap: nextcardStateMap,
     };
   }),
   on(actions.metricsTagFilterChanged, (state, {tagFilter}) => {
@@ -939,7 +939,7 @@ const reducer = createReducer(
     let nextPinnedCardToOriginal = new Map(state.pinnedCardToOriginal);
     let nextCardMetadataMap = {...state.cardMetadataMap};
     let nextCardStepIndexMap = {...state.cardStepIndex};
-    let nextCardSettingsMap = {...state.cardSettingsMap};
+    let nextCardStateMap = {...state.cardStateMap};
 
     if (isPinnedCopy) {
       const originalCardId = state.pinnedCardToOriginal.get(cardId);
@@ -948,7 +948,7 @@ const reducer = createReducer(
       nextPinnedCardToOriginal.delete(cardId);
       delete nextCardMetadataMap[cardId];
       delete nextCardStepIndexMap[cardId];
-      delete nextCardSettingsMap[cardId];
+      delete nextCardStateMap[cardId];
     } else {
       if (shouldPin) {
         const resolvedResult = buildOrReturnStateWithPinnedCopy(
@@ -958,14 +958,14 @@ const reducer = createReducer(
           nextPinnedCardToOriginal,
           nextCardStepIndexMap,
           nextCardMetadataMap,
-          nextCardSettingsMap
+          nextCardStateMap
         );
         nextCardToPinnedCopy = resolvedResult.cardToPinnedCopy;
         nextCardToPinnedCopyCache = resolvedResult.cardToPinnedCopyCache;
         nextPinnedCardToOriginal = resolvedResult.pinnedCardToOriginal;
         nextCardMetadataMap = resolvedResult.cardMetadataMap;
         nextCardStepIndexMap = resolvedResult.cardStepIndex;
-        nextCardSettingsMap = resolvedResult.cardSettingsMap;
+        nextCardStateMap = resolvedResult.cardStateMap;
       } else {
         const pinnedCardId = state.cardToPinnedCopy.get(cardId)!;
         nextCardToPinnedCopy.delete(cardId);
@@ -973,13 +973,13 @@ const reducer = createReducer(
         nextPinnedCardToOriginal.delete(pinnedCardId);
         delete nextCardMetadataMap[pinnedCardId];
         delete nextCardStepIndexMap[pinnedCardId];
-        delete nextCardSettingsMap[cardId];
+        delete nextCardStateMap[cardId];
       }
     }
     return {
       ...state,
       cardMetadataMap: nextCardMetadataMap,
-      cardSettingsMap: nextCardSettingsMap,
+      cardStateMap: nextCardStateMap,
       cardStepIndex: nextCardStepIndexMap,
       cardToPinnedCopy: nextCardToPinnedCopy,
       cardToPinnedCopyCache: nextCardToPinnedCopyCache,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2186,7 +2186,7 @@ describe('metrics reducers', () => {
         },
       };
       const beforeState = buildMetricsState({
-        cardSettingsMap: {
+        cardStateMap: {
           card1: {},
         },
         cardMetadataMap: {
@@ -2212,7 +2212,7 @@ describe('metrics reducers', () => {
 
       const expectedPinnedCopyId = getPinnedCardId('card1');
       const expectedState = buildMetricsState({
-        cardSettingsMap: {
+        cardStateMap: {
           card1: {},
           [expectedPinnedCopyId]: {},
         },
@@ -2272,35 +2272,35 @@ describe('metrics reducers', () => {
     });
   });
 
-  describe('metricsCardSettingsUpdated', () => {
+  describe('metricsCardStateUpdated', () => {
     it('adds new cardId', () => {
       const state = buildMetricsState();
-      const action = actions.metricsCardSettingsUpdated({
+      const action = actions.metricsCardStateUpdated({
         cardId: 'card1',
         settings: {},
       });
       const nextState = reducers(state, action);
-      expect(nextState.cardSettingsMap).toEqual({
+      expect(nextState.cardStateMap).toEqual({
         card1: {},
       });
     });
 
     it('updates existing card settings', () => {
       const state = buildMetricsState({
-        cardSettingsMap: {
+        cardStateMap: {
           card1: {
             tableExpanded: true,
           },
         },
       });
-      const action = actions.metricsCardSettingsUpdated({
+      const action = actions.metricsCardStateUpdated({
         cardId: 'card1',
         settings: {
           tableExpanded: false,
         },
       });
       const nextState = reducers(state, action);
-      expect(nextState.cardSettingsMap).toEqual({
+      expect(nextState.cardStateMap).toEqual({
         card1: {
           tableExpanded: false,
         },

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2186,6 +2186,9 @@ describe('metrics reducers', () => {
         },
       };
       const beforeState = buildMetricsState({
+        cardSettingsMap: {
+          card1: {},
+        },
         cardMetadataMap: {
           card1: cardMetadata,
         },
@@ -2209,6 +2212,10 @@ describe('metrics reducers', () => {
 
       const expectedPinnedCopyId = getPinnedCardId('card1');
       const expectedState = buildMetricsState({
+        cardSettingsMap: {
+          card1: {},
+          [expectedPinnedCopyId]: {},
+        },
         cardMetadataMap: {
           card1: cardMetadata,
           [expectedPinnedCopyId]: cardMetadata,
@@ -2262,6 +2269,42 @@ describe('metrics reducers', () => {
       expect(() => {
         return reducers(beforeState, action);
       }).toThrow();
+    });
+  });
+
+  describe('metricsCardSettingsUpdated', () => {
+    it('adds new cardId', () => {
+      const state = buildMetricsState();
+      const action = actions.metricsCardSettingsUpdated({
+        cardId: 'card1',
+        settings: {},
+      });
+      const nextState = reducers(state, action);
+      expect(nextState.cardSettingsMap).toEqual({
+        card1: {},
+      });
+    });
+
+    it('updates existing card settings', () => {
+      const state = buildMetricsState({
+        cardSettingsMap: {
+          card1: {
+            tableExpanded: true,
+          },
+        },
+      });
+      const action = actions.metricsCardSettingsUpdated({
+        cardId: 'card1',
+        settings: {
+          tableExpanded: false,
+        },
+      });
+      const nextState = reducers(state, action);
+      expect(nextState.cardSettingsMap).toEqual({
+        card1: {
+          tableExpanded: false,
+        },
+      });
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -34,7 +34,7 @@ import {ColumnHeader} from '../views/card_renderer/scalar_card_types';
 import * as storeUtils from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
-  CardSettingsMap,
+  CardStateMap,
   CardStepIndexMetaData,
   MetricsSettings,
   MetricsState,
@@ -143,10 +143,10 @@ export const getCardMetadata = createSelector(
   }
 );
 
-export const getCardSettingsMap = createSelector(
+export const getCardStateMap = createSelector(
   selectMetricsState,
-  (state: MetricsState): CardSettingsMap => {
-    return state.cardSettingsMap;
+  (state: MetricsState): CardStateMap => {
+    return state.cardStateMap;
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -34,6 +34,7 @@ import {ColumnHeader} from '../views/card_renderer/scalar_card_types';
 import * as storeUtils from './metrics_store_internal_utils';
 import {
   CardMetadataMap,
+  CardSettingsMap,
   CardStepIndexMetaData,
   MetricsSettings,
   MetricsState,
@@ -139,6 +140,13 @@ export const getCardMetadata = createSelector(
       return null;
     }
     return metadataMap[cardId];
+  }
+);
+
+export const getCardSettingsMap = createSelector(
+  selectMetricsState,
+  (state: MetricsState): CardSettingsMap => {
+    return state.cardSettingsMap;
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -238,6 +238,25 @@ describe('metrics selectors', () => {
     });
   });
 
+  describe('getCardSettingsMap', () => {
+    it('returns cardSettings', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          cardSettingsMap: {
+            card1: {
+              tableExpanded: true,
+            },
+          },
+        })
+      );
+      expect(selectors.getCardSettingsMap(state)).toEqual({
+        card1: {
+          tableExpanded: true,
+        },
+      });
+    });
+  });
+
   describe('getNonEmptyCardIdsWithMetadata', () => {
     beforeEach(() => {
       selectors.getNonEmptyCardIdsWithMetadata.release();

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -242,14 +242,14 @@ describe('metrics selectors', () => {
     it('returns cardSettings', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
-          cardSettingsMap: {
+          cardStateMap: {
             card1: {
               tableExpanded: true,
             },
           },
         })
       );
-      expect(selectors.getCardSettingsMap(state)).toEqual({
+      expect(selectors.getCardStateMap(state)).toEqual({
         card1: {
           tableExpanded: true,
         },

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -27,6 +27,7 @@ import {
 } from '../internal_types';
 import {
   CardMetadataMap,
+  CardSettingsMap,
   CardStepIndexMap,
   CardStepIndexMetaData,
   CardToPinnedCard,
@@ -45,6 +46,7 @@ type ResolvedPinPartialState = Pick<
   | 'cardToPinnedCopyCache'
   | 'pinnedCardToOriginal'
   | 'cardStepIndex'
+  | 'cardSettingsMap'
 >;
 
 const DISTANCE_RATIO = 0.1;
@@ -206,7 +208,8 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
   cardToPinnedCopy: CardToPinnedCard,
   cardToPinnedCopyCache: CardToPinnedCard,
   pinnedCardToOriginal: PinnedCardToCard,
-  cardStepIndexMap: CardStepIndexMap
+  cardStepIndexMap: CardStepIndexMap,
+  cardSettingsMap: CardSettingsMap
 ): ResolvedPinPartialState & {unresolvedImportedPinnedCards: CardUniqueInfo[]} {
   const unresolvedPinSet = new Set(unresolvedImportedPinnedCards);
   const nonPinnedCardsWithMatch = [];
@@ -229,6 +232,7 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
       cardToPinnedCopyCache,
       pinnedCardToOriginal,
       cardStepIndex: cardStepIndexMap,
+      cardSettingsMap,
     };
   }
 
@@ -238,6 +242,7 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
     pinnedCardToOriginal,
     cardStepIndex: cardStepIndexMap,
     cardMetadataMap,
+    cardSettingsMap,
   };
   for (const cardToPin of nonPinnedCardsWithMatch) {
     stateWithResolvedPins = buildOrReturnStateWithPinnedCopy(
@@ -246,7 +251,8 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
       stateWithResolvedPins.cardToPinnedCopyCache,
       stateWithResolvedPins.pinnedCardToOriginal,
       stateWithResolvedPins.cardStepIndex,
-      stateWithResolvedPins.cardMetadataMap
+      stateWithResolvedPins.cardMetadataMap,
+      cardSettingsMap
     );
   }
 
@@ -266,7 +272,8 @@ export function buildOrReturnStateWithPinnedCopy(
   cardToPinnedCopyCache: CardToPinnedCard,
   pinnedCardToOriginal: PinnedCardToCard,
   cardStepIndexMap: CardStepIndexMap,
-  cardMetadataMap: CardMetadataMap
+  cardMetadataMap: CardMetadataMap,
+  cardSettingsMap: CardSettingsMap
 ): ResolvedPinPartialState {
   // No-op if the card already has a pinned copy.
   if (cardToPinnedCopy.has(cardId)) {
@@ -276,6 +283,7 @@ export function buildOrReturnStateWithPinnedCopy(
       pinnedCardToOriginal,
       cardStepIndex: cardStepIndexMap,
       cardMetadataMap,
+      cardSettingsMap,
     };
   }
 
@@ -284,6 +292,7 @@ export function buildOrReturnStateWithPinnedCopy(
   const nextPinnedCardToOriginal = new Map(pinnedCardToOriginal);
   const nextCardStepIndexMap = {...cardStepIndexMap};
   const nextCardMetadataMap = {...cardMetadataMap};
+  const nextCardSettingsMap = {...cardSettingsMap};
 
   // Create a pinned copy. Copies step index from the original card.
   const pinnedCardId = getPinnedCardId(cardId);
@@ -299,6 +308,9 @@ export function buildOrReturnStateWithPinnedCopy(
     throw new Error('Cannot pin a card without metadata');
   }
   nextCardMetadataMap[pinnedCardId] = metadata;
+  if (nextCardSettingsMap[cardId]) {
+    nextCardSettingsMap[pinnedCardId] = {...cardSettingsMap[cardId]};
+  }
 
   return {
     cardToPinnedCopy: nextCardToPinnedCopy,
@@ -306,6 +318,7 @@ export function buildOrReturnStateWithPinnedCopy(
     pinnedCardToOriginal: nextPinnedCardToOriginal,
     cardStepIndex: nextCardStepIndexMap,
     cardMetadataMap: nextCardMetadataMap,
+    cardSettingsMap: nextCardSettingsMap,
   };
 }
 

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -27,7 +27,7 @@ import {
 } from '../internal_types';
 import {
   CardMetadataMap,
-  CardSettingsMap,
+  CardStateMap,
   CardStepIndexMap,
   CardStepIndexMetaData,
   CardToPinnedCard,
@@ -46,7 +46,7 @@ type ResolvedPinPartialState = Pick<
   | 'cardToPinnedCopyCache'
   | 'pinnedCardToOriginal'
   | 'cardStepIndex'
-  | 'cardSettingsMap'
+  | 'cardStateMap'
 >;
 
 const DISTANCE_RATIO = 0.1;
@@ -209,10 +209,10 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
   cardToPinnedCopyCache: CardToPinnedCard,
   pinnedCardToOriginal: PinnedCardToCard,
   cardStepIndexMap: CardStepIndexMap,
-  cardSettingsMap: CardSettingsMap
+  cardStateMap: CardStateMap
 ): ResolvedPinPartialState & {unresolvedImportedPinnedCards: CardUniqueInfo[]} {
   const unresolvedPinSet = new Set(unresolvedImportedPinnedCards);
-  const nonPinnedCardsWithMatch = [];
+  const nonPinnedCardsWithMatch: string[] = [];
   for (const unresolvedPin of unresolvedImportedPinnedCards) {
     for (const nonPinnedCardId of nonPinnedCards) {
       const cardMetadata = cardMetadataMap[nonPinnedCardId];
@@ -232,7 +232,7 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
       cardToPinnedCopyCache,
       pinnedCardToOriginal,
       cardStepIndex: cardStepIndexMap,
-      cardSettingsMap,
+      cardStateMap,
     };
   }
 
@@ -242,7 +242,7 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
     pinnedCardToOriginal,
     cardStepIndex: cardStepIndexMap,
     cardMetadataMap,
-    cardSettingsMap,
+    cardStateMap,
   };
   for (const cardToPin of nonPinnedCardsWithMatch) {
     stateWithResolvedPins = buildOrReturnStateWithPinnedCopy(
@@ -252,7 +252,7 @@ export function buildOrReturnStateWithUnresolvedImportedPins(
       stateWithResolvedPins.pinnedCardToOriginal,
       stateWithResolvedPins.cardStepIndex,
       stateWithResolvedPins.cardMetadataMap,
-      cardSettingsMap
+      cardStateMap
     );
   }
 
@@ -273,7 +273,7 @@ export function buildOrReturnStateWithPinnedCopy(
   pinnedCardToOriginal: PinnedCardToCard,
   cardStepIndexMap: CardStepIndexMap,
   cardMetadataMap: CardMetadataMap,
-  cardSettingsMap: CardSettingsMap
+  cardStateMap: CardStateMap
 ): ResolvedPinPartialState {
   // No-op if the card already has a pinned copy.
   if (cardToPinnedCopy.has(cardId)) {
@@ -283,7 +283,7 @@ export function buildOrReturnStateWithPinnedCopy(
       pinnedCardToOriginal,
       cardStepIndex: cardStepIndexMap,
       cardMetadataMap,
-      cardSettingsMap,
+      cardStateMap,
     };
   }
 
@@ -292,7 +292,7 @@ export function buildOrReturnStateWithPinnedCopy(
   const nextPinnedCardToOriginal = new Map(pinnedCardToOriginal);
   const nextCardStepIndexMap = {...cardStepIndexMap};
   const nextCardMetadataMap = {...cardMetadataMap};
-  const nextCardSettingsMap = {...cardSettingsMap};
+  const nextCardStateMap = {...cardStateMap};
 
   // Create a pinned copy. Copies step index from the original card.
   const pinnedCardId = getPinnedCardId(cardId);
@@ -308,8 +308,8 @@ export function buildOrReturnStateWithPinnedCopy(
     throw new Error('Cannot pin a card without metadata');
   }
   nextCardMetadataMap[pinnedCardId] = metadata;
-  if (nextCardSettingsMap[cardId]) {
-    nextCardSettingsMap[pinnedCardId] = {...cardSettingsMap[cardId]};
+  if (nextCardStateMap[cardId]) {
+    nextCardStateMap[pinnedCardId] = {...cardStateMap[cardId]};
   }
 
   return {
@@ -318,7 +318,7 @@ export function buildOrReturnStateWithPinnedCopy(
     pinnedCardToOriginal: nextPinnedCardToOriginal,
     cardStepIndex: nextCardStepIndexMap,
     cardMetadataMap: nextCardMetadataMap,
-    cardSettingsMap: nextCardSettingsMap,
+    cardStateMap: nextCardStateMap,
   };
 }
 
@@ -410,7 +410,7 @@ export function generateNextCardStepIndexFromLinkedTimeSelection(
 
     const steps = getImageCardSteps(cardId, cardMetadataMap, timeSeriesData);
 
-    let nextStepIndexMetaData = null;
+    let nextStepIndexMetaData: CardStepIndexMetaData | null = null;
     if (timeSelection.end === null) {
       // Single Selection
       nextStepIndexMetaData = getNextImageCardStepIndexFromSingleSelection(
@@ -480,7 +480,7 @@ function getSelectedSteps(
   }
 
   // Range selection.
-  const selectedStepsInRange = [];
+  const selectedStepsInRange: number[] = [];
   for (const step of steps) {
     if (step >= timeSelection.start.step && step <= timeSelection.end.step) {
       selectedStepsInRange.push(step);

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -374,7 +374,8 @@ describe('metrics store utils', () => {
         new Map(),
         new Map(),
         new Map(),
-        {card1: buildStepIndexMetadata({index: 2})}
+        {card1: buildStepIndexMetadata({index: 2})},
+        {}
       );
 
       const pinnedCardId = getPinnedCardId('card1');
@@ -405,7 +406,8 @@ describe('metrics store utils', () => {
         new Map(),
         new Map(),
         {card1: buildStepIndexMetadata({index: 2})},
-        {card1: createCardMetadata()}
+        {card1: createCardMetadata()},
+        {}
       );
       const pinnedCardId = getPinnedCardId('card1');
 
@@ -429,6 +431,7 @@ describe('metrics store utils', () => {
           new Map(),
           new Map(),
           new Map(),
+          {},
           {},
           {}
         );
@@ -455,7 +458,8 @@ describe('metrics store utils', () => {
         cardToPinnedCopyCache,
         pinnedCardToOriginal,
         cardStepIndexMap,
-        cardMetadataMap
+        cardMetadataMap,
+        {}
       );
 
       expect(result.cardToPinnedCopy).toEqual(originals.cardToPinnedCopy);

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -125,6 +125,12 @@ export type CardMetadataMap = Record<
   CardMetadata
 >;
 
+export type CardSettings = {
+  tableExpanded?: boolean;
+};
+
+export type CardSettingsMap = Record<CardId, CardSettings>;
+
 /**
  * A step index in a card could be set from actions or "modified" from the closest step index
  * set when linked time selection changed. When it is set from linked time selection, closest is true.
@@ -170,6 +176,7 @@ export interface MetricsNamespacedState {
    */
   unresolvedImportedPinnedCards: CardUniqueInfo[];
   cardMetadataMap: CardMetadataMap;
+  cardSettingsMap: CardSettingsMap;
   cardStepIndex: CardStepIndexMap;
   tagFilter: string;
   tagGroupExpanded: Map<string, boolean>;

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -125,11 +125,11 @@ export type CardMetadataMap = Record<
   CardMetadata
 >;
 
-export type CardSettings = {
+export type CardState = {
   tableExpanded: boolean;
 };
 
-export type CardSettingsMap = Record<CardId, Partial<CardSettings>>;
+export type CardStateMap = Record<CardId, Partial<CardState>>;
 
 /**
  * A step index in a card could be set from actions or "modified" from the closest step index
@@ -176,7 +176,7 @@ export interface MetricsNamespacedState {
    */
   unresolvedImportedPinnedCards: CardUniqueInfo[];
   cardMetadataMap: CardMetadataMap;
-  cardSettingsMap: CardSettingsMap;
+  cardStateMap: CardStateMap;
   cardStepIndex: CardStepIndexMap;
   tagFilter: string;
   tagGroupExpanded: Map<string, boolean>;

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -126,10 +126,10 @@ export type CardMetadataMap = Record<
 >;
 
 export type CardSettings = {
-  tableExpanded?: boolean;
+  tableExpanded: boolean;
 };
 
-export type CardSettingsMap = Record<CardId, CardSettings>;
+export type CardSettingsMap = Record<CardId, Partial<CardSettings>>;
 
 /**
  * A step index in a card could be set from actions or "modified" from the closest step index

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -94,7 +94,7 @@ function buildBlankState(): MetricsState {
     pinnedCardToOriginal: new Map(),
     unresolvedImportedPinnedCards: [],
     cardMetadataMap: {},
-    cardSettingsMap: {},
+    cardStateMap: {},
     cardStepIndex: {},
     visibleCardMap: new Map(),
     tagFilter: '',

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -94,6 +94,7 @@ function buildBlankState(): MetricsState {
     pinnedCardToOriginal: new Map(),
     unresolvedImportedPinnedCards: [],
     cardMetadataMap: {},
+    cardSettingsMap: {},
     cardStepIndex: {},
     visibleCardMap: new Map(),
     tagFilter: '',
@@ -286,7 +287,7 @@ export function provideMockCardSeriesData(
 ) {
   const cardMetadata = {...createCardMetadata(plugin), ...metadataOverride};
   const runId = cardMetadata.runId;
-  let runToSeries = null;
+  let runToSeries: RunToSeries | null = null;
   let steps: number[] = [];
 
   if (timeSeries !== null) {


### PR DESCRIPTION
## Motivation for features / changes
With the upcoming plans to make tensorboard links shareable we need to ensure the entire state is persisted to redux. In preparation for that I am adding card specific settings to redux which will help with rehydrating cards.
I'm adding the `tableExpanded` in preparation for #6200.

## Technical description of changes
The current redux state contains a number of card specific mappings `Map<CardId, SomeDataType>`. This is starting to get clutterie and doesn't scale very well. To get around that I am adding new type `CardSettings` and a `Map<CardId, CardSettings>` to redux. Whenever a new card specific setting is added, this will be an easy place to add it.

## Screenshots of UI changes
None

## Detailed steps to verify changes work correctly (as executed by you)
Tests should pass, see #6200 for UI testing

* Alternate designs / implementations considered
