### PR TITLE
Bug Fix: add a null check to selectors reading from the feature flag state

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -57,32 +57,36 @@ export const getOverriddenFeatureFlags = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): Partial<FeatureFlags> => {
     // Temporarily assume state.flagOverrides can be undefined for sync purposes.
-    return state.flagOverrides || {};
+    return state?.flagOverrides || {};
   }
 );
 
 export const getFeatureFlagsMetadata = createSelector(
   selectFeatureFlagState,
   (state: FeatureFlagState): FeatureFlagMetadataMapType<FeatureFlags> => {
-    return state.metadata;
+    return state?.metadata;
   }
 );
 
 export const getFeatureFlagsToSendToServer = createSelector(
-  selectFeatureFlagState,
-  (state: FeatureFlagState): Partial<FeatureFlags> => {
+  getOverriddenFeatureFlags,
+  getFeatureFlagsMetadata,
+  (
+    flagOverrides: Partial<FeatureFlags>,
+    metadata: FeatureFlagMetadataMapType<FeatureFlags>
+  ): Partial<FeatureFlags> => {
     const featureFlagsToSendToServer: Partial<
       Record<keyof FeatureFlags, FeatureFlagType>
     > = {};
-    for (const entry in state.flagOverrides) {
-      const entryMetadata = state.metadata[entry as keyof FeatureFlags];
+    for (const entry in flagOverrides) {
+      const entryMetadata = metadata[entry as keyof FeatureFlags];
       if (
         entryMetadata &&
         entryMetadata.queryParamOverride &&
         entryMetadata.sendToServerWhenOverridden
       ) {
         featureFlagsToSendToServer[entry as keyof FeatureFlags] =
-          state.flagOverrides[entry as keyof FeatureFlags];
+          flagOverrides[entry as keyof FeatureFlags];
       }
     }
     return featureFlagsToSendToServer as Partial<FeatureFlags>;


### PR DESCRIPTION
## Motivation for features / changes
It seems like there are still test flakes after #6180. Rather than trying to patch the issue systemically, this time I'm just going directly after the displayed error.
https://github.com/tensorflow/tensorboard/actions/runs/4170050224/jobs/7218643282
For Googlers [b/264529288](b/264529288)

FWIW this only seems to happen in CI and thus is likely due to a package version difference with CI.

## Technical description of changes
Adding a null check but retaining the existing typing **should** stop this particular error from popping up. Hopefully the issue goes away entirely, but if it does not, it will ideally give us a better error message.

## Screenshots of UI changes
None

## Detailed steps to verify changes work correctly (as executed by you)
Tests should pass
