### PR TITLE
Feature: Allow timeSeries tags metadata to be filtered to only include some runs

### DIFF
--- a/tensorboard/plugins/metrics/metrics_plugin.py
+++ b/tensorboard/plugins/metrics/metrics_plugin.py
@@ -307,27 +307,28 @@ class MetricsPlugin(base_plugin.TBPlugin):
         ctx = plugin_util.context(request.environ)
         experiment = plugin_util.experiment_id(request.environ)
 
-        run_ids = None
+        runs = None
         query_params = urllib.parse.parse_qs(request.environ["QUERY_STRING"])
-        if query_params.get("runIds"):
-            run_ids = query_params.get("runIds")
+        if query_params.get("runs"):
+            runs = query_params.get("runs")
 
-        index = self._tags_impl(ctx, experiment=experiment, run_ids=run_ids)
+        index = self._tags_impl(ctx, experiment=experiment, runs=runs)
         return http_util.Respond(request, index, "application/json")
 
-    def _tags_impl(self, ctx, experiment=None, run_ids=None):
+    def _tags_impl(self, ctx, experiment=None, runs=None):
         """Returns tag metadata for a given experiment's logged metrics.
 
         Args:
             ctx: A `tensorboard.context.RequestContext` value.
             experiment: optional string ID of the request's experiment.
+            runs: A list of Run names used to filter the tags returned.
 
         Returns:
             A nested dict 'd' with keys in ("scalars", "histograms", "images")
                 and values being the return type of _format_*mapping.
         """
 
-        run_tag_filter = provider.RunTagFilter(runs=run_ids)
+        run_tag_filter = provider.RunTagFilter(runs=runs)
         scalar_mapping = self._data_provider.list_scalars(
             ctx,
             experiment_id=experiment,

--- a/tensorboard/plugins/metrics/metrics_plugin_test.py
+++ b/tensorboard/plugins/metrics/metrics_plugin_test.py
@@ -385,7 +385,7 @@ class MetricsPluginTest(tf.test.TestCase):
 
         self._multiplexer.Reload()
         response = self._plugin._tags_impl(
-            context.RequestContext(), "eid", run_ids=["run1"]
+            context.RequestContext(), "eid", runs=["run1"]
         )
 
         self.assertEqual(


### PR DESCRIPTION
## Motivation for features / changes
When the runs are filtered in the timeseries dashboard there are often many empty scalar cards. Unfortunately this cannot be handled purely on the frontend because timeseries data is paginated.

By allowing allowing the tags metadata endpoint to return only the tags which contain a given set of runs this feature should be easy to implement correctly while still working well with pagination.

For Googlers [b/241511328](b/241511328)

## Technical description of changes
I modified the timeseries/tags endpoint to parse the query params and look for a param `runIds`. If found this is then passed to the implementation and transformed into the existing `RunTagFilter` type and used as a filter when generating the tags metadata.

## Screenshots of UI changes
None

## Detailed steps to verify changes work correctly (as executed by you)
I added a new test which should pass
