### PR TITLE
Add HParam Plugin tab click telemetry

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
@@ -31,11 +31,9 @@ import '../tf_hparams_table_view/tf-hparams-table-view';
 class TfHparamsSessionsPane extends PolymerElement {
   constructor() {
     super();
-    // If window['ga'] is defined, use it, otherwise any logging calls will be
-    // no-ops.
-    // @ts-ignore
-    this.ga = window['ga'] || function () {};
+    this.logTabClick('Plugin Load');
   }
+
   static readonly template = html`
     <paper-header-panel>
       <paper-toolbar slot="header" class="tab-bar">
@@ -47,7 +45,7 @@ class TfHparamsSessionsPane extends PolymerElement {
             TABLE VIEW
           </paper-tab>
           <paper-tab
-            on-click="_parrellelCoordsTabClicked"
+            on-click="_parrallelCoordsTabClicked"
             view-id="parallel-coords-view"
           >
             PARALLEL COORDINATES VIEW
@@ -185,21 +183,28 @@ class TfHparamsSessionsPane extends PolymerElement {
   })
   _selectedTab: number = 0;
   _tableTabClicked: () => void = () => {
-    this.logTabClick('Table');
+    this.logTabClick('Tab Clicked', 'Table');
   };
-  _parrellelCoordsTabClicked: () => void = () => {
-    this.logTabClick('Parrellel Coords');
+  _parrallelCoordsTabClicked: () => void = () => {
+    this.logTabClick('Tab Clicked', 'Parrellel Coords');
   };
   _scatterPlotMatrixTabClicked: () => void = () => {
-    this.logTabClick('Scatter Plot Matrix');
+    this.logTabClick('Tab Clicked', 'Scatter Plot Matrix');
   };
 
-  logTabClick: (tabName: string) => void = (tabName: string) => {
+  logTabClick: (action: string, tabName?: string) => void = (
+    action: string,
+    tabName?: string
+  ) => {
+    // If window['ga'] is defined, use it, otherwise any logging calls will be
+    // no-ops. window['ga'] is only defined in the hosted TensorBoard.
+    // @ts-ignore
+    this.ga = window['ga'] || function () {};
     // @ts-ignore
     this.ga('send', {
       hitType: 'event',
-      eventCategory: 'HParam',
-      eventAction: 'Tab Clicked',
+      eventCategory: 'HParams',
+      eventAction: action,
       eventLabel: tabName,
     });
   };

--- a/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
@@ -186,7 +186,7 @@ class TfHparamsSessionsPane extends PolymerElement {
     this.logTabClick('Tab Clicked', 'Table');
   };
   _parrallelCoordsTabClicked: () => void = () => {
-    this.logTabClick('Tab Clicked', 'Parrellel Coords');
+    this.logTabClick('Tab Clicked', 'Parrallel Coords');
   };
   _scatterPlotMatrixTabClicked: () => void = () => {
     this.logTabClick('Tab Clicked', 'Scatter Plot Matrix');
@@ -199,9 +199,9 @@ class TfHparamsSessionsPane extends PolymerElement {
     // If window['ga'] is defined, use it, otherwise any logging calls will be
     // no-ops. window['ga'] is only defined in the hosted TensorBoard.
     // @ts-ignore
-    this.ga = window['ga'] || function () {};
+    const analytics = window['ga'] || function () {};
     // @ts-ignore
-    this.ga('send', {
+    analytics('send', {
       hitType: 'event',
       eventCategory: 'HParams',
       eventAction: action,

--- a/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
@@ -29,6 +29,13 @@ import '../tf_hparams_table_view/tf-hparams-table-view';
  */
 @customElement('tf-hparams-sessions-pane')
 class TfHparamsSessionsPane extends PolymerElement {
+  constructor() {
+    super();
+    // If window['ga'] is defined, use it, otherwise any logging calls will be
+    // no-ops.
+    // @ts-ignore
+    this.ga = window['ga'] || function () {};
+  }
   static readonly template = html`
     <paper-header-panel>
       <paper-toolbar slot="header" class="tab-bar">
@@ -36,11 +43,19 @@ class TfHparamsSessionsPane extends PolymerElement {
           <!-- view-id can be used by integration tests to locate a tab.
                It should be the name of the root element implementing the view
                without the 'tf-hparams-' prefix. -->
-          <paper-tab view-id="table-view"> TABLE VIEW </paper-tab>
-          <paper-tab view-id="parallel-coords-view">
+          <paper-tab on-click="_tableTabClicked" view-id="table-view">
+            TABLE VIEW
+          </paper-tab>
+          <paper-tab
+            on-click="_parrellelCoordsTabClicked"
+            view-id="parallel-coords-view"
+          >
             PARALLEL COORDINATES VIEW
           </paper-tab>
-          <paper-tab view-id="scatter-plot-matrix-view">
+          <paper-tab
+            on-click="_scatterPlotMatrixTabClicked"
+            view-id="scatter-plot-matrix-view"
+          >
             SCATTER PLOT MATRIX VIEW
           </paper-tab>
           <div class="help-and-feedback">
@@ -169,4 +184,23 @@ class TfHparamsSessionsPane extends PolymerElement {
     type: Number,
   })
   _selectedTab: number = 0;
+  _tableTabClicked: () => void = () => {
+    this.logTabClick('Table');
+  };
+  _parrellelCoordsTabClicked: () => void = () => {
+    this.logTabClick('Parrellel Coords');
+  };
+  _scatterPlotMatrixTabClicked: () => void = () => {
+    this.logTabClick('Scatter Plot Matrix');
+  };
+
+  logTabClick: (tabName: string) => void = (tabName: string) => {
+    // @ts-ignore
+    this.ga('send', {
+      hitType: 'event',
+      eventCategory: 'HParam',
+      eventAction: 'Tab Clicked',
+      eventLabel: tabName,
+    });
+  };
 }


### PR DESCRIPTION
* Motivation for features / changes
We are looking into building more hparam support in the timeseries dashboard. In order to make a more informed decision we want to log how often users are selecting other views from the plugin. Analytics are only available on our hosted services so there is some logic to do nothing when in OSS.