### PR TITLE
Feature: Add redux setting to control the visibility of empty scalar cards

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -248,5 +248,10 @@ export const rangeSelectionToggled = createAction(
     affordance?: TimeSelectionToggleAffordance;
   }>()
 );
+
+export const metricsHideEmptyCardsChanged = createAction(
+  '[Metrics] Hide Empty Cards Changed'
+);
+
 // TODO(jieweiwu): Delete after internal code is updated.
 export const stepSelectorTimeSelectionChanged = timeSelectionChanged;

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -249,7 +249,7 @@ export const rangeSelectionToggled = createAction(
   }>()
 );
 
-export const metricsHideEmptyCardsChanged = createAction(
+export const metricsHideEmptyCardsToggled = createAction(
   '[Metrics] Hide Empty Cards Changed'
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -742,6 +742,15 @@ const reducer = createReducer(
       },
     };
   }),
+  on(actions.metricsHideEmptyCardsChanged, (state) => {
+    return {
+      ...state,
+      settingOverrides: {
+        ...state.settingOverrides,
+        hideEmptyCards: !state.settingOverrides.hideEmptyCards,
+      },
+    };
+  }),
   on(
     actions.multipleTimeSeriesRequested,
     (

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -742,7 +742,7 @@ const reducer = createReducer(
       },
     };
   }),
-  on(actions.metricsHideEmptyCardsChanged, (state) => {
+  on(actions.metricsHideEmptyCardsToggled, (state) => {
     return {
       ...state,
       settingOverrides: {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1217,13 +1217,20 @@ describe('metrics reducers', () => {
         settingOverrides: {},
       });
 
-      const nextState = reducers(
+      const secondState = reducers(
         prevState,
-        actions.metricsHideEmptyCardsChanged()
+        actions.metricsHideEmptyCardsToggled()
       );
 
-      expect(nextState.settings.hideEmptyCards).toBe(false);
-      expect(nextState.settingOverrides.hideEmptyCards).toBe(true);
+      expect(secondState.settings.hideEmptyCards).toBe(false);
+      expect(secondState.settingOverrides.hideEmptyCards).toBe(true);
+
+      const thirdState = reducers(
+        secondState,
+        actions.metricsHideEmptyCardsToggled()
+      );
+      expect(thirdState.settings.hideEmptyCards).toBe(false);
+      expect(thirdState.settingOverrides.hideEmptyCards).toBe(false);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1208,6 +1208,23 @@ describe('metrics reducers', () => {
       expect(nextState.settings.cardMinWidth).toBe(400);
       expect(nextState.settingOverrides.cardMinWidth).toBeNull();
     });
+
+    it('updates hideEmptyCards', () => {
+      const prevState = buildMetricsState({
+        settings: buildMetricsSettingsState({
+          hideEmptyCards: false,
+        }),
+        settingOverrides: {},
+      });
+
+      const nextState = reducers(
+        prevState,
+        actions.metricsHideEmptyCardsChanged()
+      );
+
+      expect(nextState.settings.hideEmptyCards).toBe(false);
+      expect(nextState.settingOverrides.hideEmptyCards).toBe(true);
+    });
   });
 
   describe('loading time series data', () => {

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -326,6 +326,11 @@ export const getMetricsHistogramMode = createSelector(
   (settings): HistogramMode => settings.histogramMode
 );
 
+export const getMetricsHideEmptyCards = createSelector(
+  selectSettings,
+  (settings): boolean => settings.hideEmptyCards
+);
+
 export const getMetricsScalarSmoothing = createSelector(
   selectSettings,
   (settings): number => settings.scalarSmoothing

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -612,7 +612,7 @@ describe('metrics selectors', () => {
 
     it('returns hideEmptyCards when getMetricsHideEmptyCards is called', () => {
       selectors.getMetricsHideEmptyCards.release();
-      const state = appStateFromMetricsState(
+      let state = appStateFromMetricsState(
         buildMetricsState({
           settings: buildMetricsSettingsState({
             hideEmptyCards: false,
@@ -620,6 +620,16 @@ describe('metrics selectors', () => {
         })
       );
       expect(selectors.getMetricsHideEmptyCards(state)).toBe(false);
+
+      state = appStateFromMetricsState(
+        buildMetricsState({
+          settings: buildMetricsSettingsState({
+            hideEmptyCards: true,
+          }),
+        })
+      );
+
+      expect(selectors.getMetricsHideEmptyCards(state)).toBe(true);
     });
 
     it('returns scalarSmoothing when called getMetricsScalarSmoothing', () => {

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -610,6 +610,18 @@ describe('metrics selectors', () => {
       expect(selectors.getMetricsXAxisType(state)).toBe(XAxisType.WALL_TIME);
     });
 
+    it('returns hideEmptyCards when getMetricsHideEmptyCards is called', () => {
+      selectors.getMetricsHideEmptyCards.release();
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          settings: buildMetricsSettingsState({
+            hideEmptyCards: false,
+          }),
+        })
+      );
+      expect(selectors.getMetricsHideEmptyCards(state)).toBe(false);
+    });
+
     it('returns scalarSmoothing when called getMetricsScalarSmoothing', () => {
       selectors.getMetricsScalarSmoothing.release();
       const state = appStateFromMetricsState(

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -202,6 +202,7 @@ export interface MetricsSettings {
   ignoreOutliers: boolean;
   xAxisType: XAxisType;
   scalarSmoothing: number;
+  hideEmptyCards: boolean;
   /**
    * https://github.com/tensorflow/tensorboard/issues/3732
    *
@@ -254,6 +255,7 @@ export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
   tooltipSort: TooltipSort.ALPHABETICAL,
   ignoreOutliers: true,
   xAxisType: XAxisType.STEP,
+  hideEmptyCards: false,
   scalarSmoothing: 0.6,
   scalarPartitionNonMonotonicX: false,
   imageBrightnessInMilli: 1000,

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -255,7 +255,7 @@ export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
   tooltipSort: TooltipSort.ALPHABETICAL,
   ignoreOutliers: true,
   xAxisType: XAxisType.STEP,
-  hideEmptyCards: false,
+  hideEmptyCards: true,
   scalarSmoothing: 0.6,
   scalarPartitionNonMonotonicX: false,
   imageBrightnessInMilli: 1000,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -52,7 +52,7 @@ export function buildMetricsSettingsState(
     ignoreOutliers: false,
     xAxisType: XAxisType.WALL_TIME,
     scalarSmoothing: 0.3,
-    hideEmptyCards: false,
+    hideEmptyCards: true,
     scalarPartitionNonMonotonicX: false,
     imageBrightnessInMilli: 123,
     imageContrastInMilli: 123,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -52,6 +52,7 @@ export function buildMetricsSettingsState(
     ignoreOutliers: false,
     xAxisType: XAxisType.WALL_TIME,
     scalarSmoothing: 0.3,
+    hideEmptyCards: false,
     scalarPartitionNonMonotonicX: false,
     imageBrightnessInMilli: 123,
     imageContrastInMilli: 123,


### PR DESCRIPTION
## Motivation for features / changes
When none of the runs shown in a scalar card are selected, the scalar card is still shown. This is inconsistent with the image and histogram cards and is a generally poor experience.

For Googlers [b/241511328](https://github.com/tensorflow/tensorboard/pull/b/241511328)

## Technical description of changes
This first PR just adds the action, reducer, and selector for the new setting. The setting will default to true.

See #6218 for usage

## Screenshots of UI changes
No changes

## Detailed steps to verify changes work correctly (as executed by you)
The tests should pass
