### PR TITLE
Hparams: Add better support for session groups with NaN values.

### DIFF
--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -168,11 +168,9 @@ class HParamsPlugin(base_plugin.TBPlugin):
                 raise werkzeug.exceptions.NotFound("Scalars plugin not loaded")
             return http_util.Respond(
                 request,
-                json.dumps(
-                    list_metric_evals.Handler(
-                        ctx, request_proto, scalars_plugin, experiment_id
-                    ).run()
-                ),
+                list_metric_evals.Handler(
+                    ctx, request_proto, scalars_plugin, experiment_id
+                ).run(),
                 "application/json",
             )
         except error.HParamsError as e:

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
@@ -269,7 +269,8 @@ class TfHparamsParallelCoordsPlot extends LegacyElementMixin(
         if (!this.options.configuration.columnsVisibility[colIndex]) {
           continue;
         }
-        if (utils.columnValueByIndex(schema, sg, colIndex) === undefined) {
+        const columnValue = utils.columnValueByIndex(schema, sg, colIndex);
+        if (columnValue === undefined || columnValue === 'NaN') {
           return false;
         }
       }

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
@@ -808,7 +808,8 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
       let colParam = {hparam: hparam.info.name} as any;
       if (hparam.filter.domainDiscrete) {
         const allChecked = hparam.filter.domainDiscrete.every(
-            (filterVal) => filterVal.checked);
+          (filterVal) => filterVal.checked
+        );
         if (!allChecked) {
           colParam.filterDiscrete = [];
           hparam.filter.domainDiscrete.forEach((filterVal) => {
@@ -818,10 +819,13 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
           });
         }
       } else if (hparam.filter.interval) {
-        if (hparam.filter.interval.min.value !== '' ||
-            hparam.filter.interval.max.value !== '') {
-          colParam.filterInterval =
-              parseInputInterval('_hparams.' + index + '.filter.interval');
+        if (
+          hparam.filter.interval.min.value !== '' ||
+          hparam.filter.interval.max.value !== ''
+        ) {
+          colParam.filterInterval = parseInputInterval(
+            '_hparams.' + index + '.filter.interval'
+          );
         }
       } else if (hparam.filter.regexp) {
         colParam.filterRegexp = hparam.filter.regexp;
@@ -831,12 +835,15 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
     // Build the metric filters in the request.
     this._metrics.forEach((metric, index) => {
       let colParam = {
-        metric: metric.info.name
+        metric: metric.info.name,
       } as any;
-      if (metric.filter.interval.min.value !== '' ||
-          metric.filter.interval.max.value !== '') {
-        colParam.filterInterval =
-              parseInputInterval('_metrics.' + index + '.filter.interval');
+      if (
+        metric.filter.interval.min.value !== '' ||
+        metric.filter.interval.max.value !== ''
+      ) {
+        colParam.filterInterval = parseInputInterval(
+          '_metrics.' + index + '.filter.interval'
+        );
       }
       colParams.push(colParam);
     });

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
@@ -807,16 +807,22 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
     this._hparams.forEach((hparam, index) => {
       let colParam = {hparam: hparam.info.name} as any;
       if (hparam.filter.domainDiscrete) {
-        colParam.filterDiscrete = [];
-        hparam.filter.domainDiscrete.forEach((filterVal) => {
-          if (filterVal.checked) {
-            colParam.filterDiscrete.push(filterVal.value);
-          }
-        });
+        const allChecked = hparam.filter.domainDiscrete.every(
+            (filterVal) => filterVal.checked);
+        if (!allChecked) {
+          colParam.filterDiscrete = [];
+          hparam.filter.domainDiscrete.forEach((filterVal) => {
+            if (filterVal.checked) {
+              colParam.filterDiscrete.push(filterVal.value);
+            }
+          });
+        }
       } else if (hparam.filter.interval) {
-        colParam.filterInterval = parseInputInterval(
-          '_hparams.' + index + '.filter.interval'
-        );
+        if (hparam.filter.interval.min.value !== '' ||
+            hparam.filter.interval.max.value !== '') {
+          colParam.filterInterval =
+              parseInputInterval('_hparams.' + index + '.filter.interval');
+        }
       } else if (hparam.filter.regexp) {
         colParam.filterRegexp = hparam.filter.regexp;
       }
@@ -825,11 +831,13 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
     // Build the metric filters in the request.
     this._metrics.forEach((metric, index) => {
       let colParam = {
-        metric: metric.info.name,
-        filterInterval: parseInputInterval(
-          '_metrics.' + index + '.filter.interval'
-        ),
-      };
+        metric: metric.info.name
+      } as any;
+      if (metric.filter.interval.min.value !== '' ||
+          metric.filter.interval.max.value !== '') {
+        colParam.filterInterval =
+              parseInputInterval('_metrics.' + index + '.filter.interval');
+      }
       colParams.push(colParam);
     });
     // Sorting.

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
@@ -22,6 +22,25 @@ import {Canceller} from '../../../components/tf_backend/canceller';
 import '../tf_hparams_utils/hparams-split-layout';
 import * as tf_hparams_utils from '../tf_hparams_utils/tf-hparams-utils';
 
+interface MinMax {
+  minValue: number | 'Infinity' | '-Infinity';
+  maxValue: number | 'Infinity' | '-Infinity';
+}
+
+interface ColumnHparam {
+  hparam: string;
+  filterDiscrete?: any[];
+  filterInterval?: MinMax | null;
+  filterRegexp?: string;
+  order?: string;
+}
+
+interface ColumnMetric {
+  metric: string;
+  filterInterval?: MinMax | null;
+  order?: string;
+}
+
 /**
  * The tf-hparams-query-pane element implements controls for querying the
  * server for a list of session groups. It provides filtering, and
@@ -748,6 +767,11 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
     const _this = this;
     // Will be set to false if we encounter any invalid inputs.
     let queryValid = true;
+    // Determines if an interval has been set to any range of values other than
+    // the default.
+    function isIntervalSet(interval) {
+      return interval.min.value !== '' || interval.max.value !== '';
+    }
     // Parses an inputInterval object of the form:
     // {min: {value: string, invalid: boolean},
     //  max: {value: string  invalid: boolean}}. Returns an object
@@ -759,20 +783,22 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
     // The inputIntervalPath should be a Polymer path for the inputInterval
     // object. We work with paths, rather than the object, so that we
     // can make observable changes.
-    function parseInputInterval(inputIntervalPath) {
+    function parseInputInterval(inputIntervalPath): MinMax | null {
       const minValueStr = _this.get(inputIntervalPath + '.min.value');
       console.assert(minValueStr !== undefined);
       // The protobuffer JSON mapping maps the strings "-Infinity" and
       // "Infinity" to the floating-point infinity and -infinity values.
-      const minValue: any = minValueStr === '' ? '-Infinity' : +minValueStr;
-      _this.set(inputIntervalPath + '.min.invalid', isNaN(minValue));
-      queryValid = queryValid && !isNaN(minValue);
+      const minValue = minValueStr === '' ? '-Infinity' : +minValueStr;
+      const minValueIsNan = isNaN(minValue as number);
+      _this.set(inputIntervalPath + '.min.invalid', minValueIsNan);
+      queryValid = queryValid && !minValueIsNan;
       const maxValueStr = _this.get(inputIntervalPath + '.max.value');
       console.assert(maxValueStr !== undefined);
-      const maxValue: any = maxValueStr === '' ? 'Infinity' : +maxValueStr;
-      _this.set(inputIntervalPath + '.max.invalid', isNaN(maxValue));
-      queryValid = queryValid && !isNaN(maxValue);
-      if (isNaN(minValue) || isNaN(maxValue)) {
+      const maxValue = maxValueStr === '' ? 'Infinity' : +maxValueStr;
+      const maxValueIsNan = isNaN(maxValue as number);
+      _this.set(inputIntervalPath + '.max.invalid', maxValueIsNan);
+      queryValid = queryValid && !maxValueIsNan;
+      if (minValueIsNan || maxValueIsNan) {
         return null;
       }
       return {minValue: minValue, maxValue: maxValue};
@@ -802,10 +828,10 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
     const allowedStatuses = this._statuses
       .filter((s) => s.allowed)
       .map((s) => s.value);
-    let colParams: any[] = [];
+    let colParams: (ColumnHparam | ColumnMetric)[] = [];
     // Build the hparams filters in the request.
     this._hparams.forEach((hparam, index) => {
-      let colParam = {hparam: hparam.info.name} as any;
+      let colParam: ColumnHparam = {hparam: hparam.info.name};
       if (hparam.filter.domainDiscrete) {
         const allChecked = hparam.filter.domainDiscrete.every(
           (filterVal) => filterVal.checked
@@ -814,15 +840,12 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
           colParam.filterDiscrete = [];
           hparam.filter.domainDiscrete.forEach((filterVal) => {
             if (filterVal.checked) {
-              colParam.filterDiscrete.push(filterVal.value);
+              colParam.filterDiscrete!.push(filterVal.value);
             }
           });
         }
       } else if (hparam.filter.interval) {
-        if (
-          hparam.filter.interval.min.value !== '' ||
-          hparam.filter.interval.max.value !== ''
-        ) {
+        if (isIntervalSet(hparam.filter.interval)) {
           colParam.filterInterval = parseInputInterval(
             '_hparams.' + index + '.filter.interval'
           );
@@ -830,17 +853,15 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
       } else if (hparam.filter.regexp) {
         colParam.filterRegexp = hparam.filter.regexp;
       }
+
       colParams.push(colParam);
     });
     // Build the metric filters in the request.
     this._metrics.forEach((metric, index) => {
-      let colParam = {
+      let colParam: ColumnMetric = {
         metric: metric.info.name,
-      } as any;
-      if (
-        metric.filter.interval.min.value !== '' ||
-        metric.filter.interval.max.value !== ''
-      ) {
+      };
+      if (isIntervalSet(metric.filter.interval)) {
         colParam.filterInterval = parseInputInterval(
           '_metrics.' + index + '.filter.interval'
         );

--- a/tensorboard/plugins/hparams/tf_hparams_utils/tf-hparams-utils.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_utils/tf-hparams-utils.ts
@@ -132,7 +132,7 @@ export function hparamValueByIndex(schema, sessionGroup, hparamIndex) {
 export function metricValueByIndex(schema, sessionGroup, metricIndex) {
   const metricName = schema.metricColumns[metricIndex].metricInfo.name;
   const metricValue = metricValueByName(sessionGroup.metricValues, metricName);
-  return metricValue === undefined ? undefined : metricValue.value;
+  return metricValue === undefined || metricValue.value === 'NaN' ? undefined : metricValue.value;
 }
 
 // Returns sessionGroup's column value of the column with index
@@ -270,7 +270,7 @@ export function metricValueByVisibleIndex(
 ) {
   const metricName = visibleSchema.metricInfos[visibleMetricIndex].name;
   const metricValue = metricValueByName(sessionGroup.metricValues, metricName);
-  return metricValue === undefined ? undefined : metricValue.value;
+  return metricValue === undefined || metricValue.value === 'NaN' ? undefined : metricValue.value;
 }
 
 // DEPRECATED. Use columnValueByIndex with a schema columnIndex instead.

--- a/tensorboard/plugins/hparams/tf_hparams_utils/tf-hparams-utils.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_utils/tf-hparams-utils.ts
@@ -132,7 +132,9 @@ export function hparamValueByIndex(schema, sessionGroup, hparamIndex) {
 export function metricValueByIndex(schema, sessionGroup, metricIndex) {
   const metricName = schema.metricColumns[metricIndex].metricInfo.name;
   const metricValue = metricValueByName(sessionGroup.metricValues, metricName);
-  return metricValue === undefined || metricValue.value === 'NaN' ? undefined : metricValue.value;
+  return metricValue === undefined || metricValue.value === 'NaN'
+    ? undefined
+    : metricValue.value;
 }
 
 // Returns sessionGroup's column value of the column with index
@@ -270,7 +272,9 @@ export function metricValueByVisibleIndex(
 ) {
   const metricName = visibleSchema.metricInfos[visibleMetricIndex].name;
   const metricValue = metricValueByName(sessionGroup.metricValues, metricName);
-  return metricValue === undefined || metricValue.value === 'NaN' ? undefined : metricValue.value;
+  return metricValue === undefined || metricValue.value === 'NaN'
+    ? undefined
+    : metricValue.value;
 }
 
 // DEPRECATED. Use columnValueByIndex with a schema columnIndex instead.


### PR DESCRIPTION
Googlers, see b/268530875.

An internal hparams user recently discovered that session groups with NaN values are not returned to the plugin in the results. (Note on terminology: A "session group" is effectively a row in the table of results). Therefore some rows were surprisingly missing from the hparams table results.

The root cause: The request from the client to the server was aggressively adding filters even for fields that were not being set. The server, as a side-effect, was filtering out NaN values for these fields.

This change modifies the request from the client to the server so that we only add a filter for fields that actually specify some sort of constraint in the left-hand panel. For example, we only send a filter for a discrete field if at least one of the discrete values is unchecked. Also, we only send a filter for an interval field if either min or max are specified. This means the server no longer performs the filtering and won't aggressively filter out NaN values.

Other adjustments must be made to handle the NaN values in the rest of the UI:
* For the metric plots in the hparams table view we must fix the server response to properly return NaN values in a way that the client recognizes.
* For the parallel coordinates view we treat session groups with NaNs similar to session groups with empty values: We just don't render them at all in the parallel coordinates visualization.
* For the scalar plot matrix, we also treat session groups with NaNs similar to session groups with empty values: We don't plot NaN points.

There are no tests that accompany this PR because, unfortunately, there just doesn't exist tests for the hparams code in this repo. I instead built a set of regression tests internally which you can reference in cl/513617093 and cl/513788288. You can see the impact of this PR on these tests in cl/513824569.

