### PR TITLE
Bug Fix: Fix regressions created by #6200

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -607,7 +607,10 @@ const reducer = createReducer(
   ),
   on(actions.metricsCardStateUpdated, (state, {cardId, settings}) => {
     const nextcardStateMap = {...state.cardStateMap};
-    nextcardStateMap[cardId] = {...settings};
+    nextcardStateMap[cardId] = {
+      ...nextcardStateMap[cardId],
+      ...settings,
+    };
 
     return {
       ...state,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2301,6 +2301,10 @@ describe('metrics reducers', () => {
       const state = buildMetricsState({
         cardStateMap: {
           card1: {
+            timeSelection: {
+              start: {step: 5},
+              end: null,
+            },
             tableExpanded: true,
           },
         },
@@ -2314,6 +2318,10 @@ describe('metrics reducers', () => {
       const nextState = reducers(state, action);
       expect(nextState.cardStateMap).toEqual({
         card1: {
+          timeSelection: {
+            start: {step: 5},
+            end: null,
+          },
           tableExpanded: false,
         },
       });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -197,7 +197,7 @@ limitations under the License.
   </div>
   <div class="bottom-area">
     <button
-      *ngIf="dataSeries.length > 3"
+      *ngIf="canExpandTable()"
       mat-icon-button
       i18n-aria-label="Expand Table"
       class="expand-button"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -197,6 +197,7 @@ limitations under the License.
   </div>
   <div class="bottom-area">
     <button
+      *ngIf="dataSeries.length > 3"
       mat-icon-button
       i18n-aria-label="Expand Table"
       class="expand-button"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -18,6 +18,8 @@ limitations under the License.
 
 $_title-to-heading-gap: 12px;
 
+$_card_padding_top: $metrics-preferred-gap - $_title-to-heading-gap;
+
 :host {
   display: flex;
   flex-direction: column;
@@ -26,17 +28,20 @@ $_title-to-heading-gap: 12px;
   padding: $metrics-preferred-gap;
   // When vertically centered, the title's text-top contains extra space above
   // the text, which counts towards the visually perceived white space.
-  padding-top: $metrics-preferred-gap - $_title-to-heading-gap;
+  padding-top: $_card_padding_top;
 
   &:has(.expand-button) {
     // Remove the bottom padding when the expand button appears
-    padding: $metrics-preferred-gap $metrics-preferred-gap 0;
+    padding: $_card_padding_top $metrics-preferred-gap 0;
   }
 }
 
 .always-visible {
   display: flex;
   flex-direction: column;
+  &:not(:has(.expand-button)) {
+    flex-grow: 1;
+  }
 
   // The content that is always visible should match the min height of a card,
   // taking into account padding and 2px for the card border.
@@ -174,7 +179,7 @@ $_title-to-heading-gap: 12px;
 }
 
 .data-table-container {
-  height: 100px;
+  height: 100px; // If this is changed, please also update the ngIf on the expand button
   max-height: 50em;
   overflow: auto;
   resize: vertical;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -20,6 +20,9 @@ $_title-to-heading-gap: 12px;
 
 $_card_padding_top: $metrics-preferred-gap - $_title-to-heading-gap;
 
+// If this is changed, please also update canExpandTable
+$_data_table_initial_height: 100px;
+
 :host {
   display: flex;
   flex-direction: column;
@@ -179,7 +182,8 @@ $_card_padding_top: $metrics-preferred-gap - $_title-to-heading-gap;
 }
 
 .data-table-container {
-  height: 100px; // If this is changed, please also update the ngIf on the expand button
+  height: $_data_table_initial_height;
+  min-height: $_data_table_initial_height;
   max-height: 50em;
   overflow: auto;
   resize: vertical;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -55,7 +55,7 @@ import {
   SortingInfo,
   SortingOrder,
 } from './scalar_card_types';
-import {TimeSelectionView} from './utils';
+import {isDatumVisible, TimeSelectionView} from './utils';
 
 type ScalarTooltipDatum = TooltipDatum<
   ScalarCardSeriesMetadata & {
@@ -250,6 +250,14 @@ export class ScalarCardComponent<Downloader> {
       (this.stepOrLinkedTimeSelection !== null ||
         this.isProspectiveFobFeatureEnabled)
     );
+  }
+
+  canExpandTable() {
+    const visbleRuns = this.dataSeries.filter((datum) => {
+      return isDatumVisible(datum, this.chartMetadataMap);
+    });
+
+    return visbleRuns.length > 3;
   }
 
   shouldExpandTable() {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -257,6 +257,8 @@ export class ScalarCardComponent<Downloader> {
       return isDatumVisible(datum, this.chartMetadataMap);
     });
 
+    // 3 is the maximum number of runs that can be shown before
+    // the height of the table exceeds $_data_table_initial_height.
     return visbleRuns.length > 3;
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -31,6 +31,7 @@ import {
   SortingInfo,
   SortingOrder,
 } from './scalar_card_types';
+import {isDatumVisible} from './utils';
 
 @Component({
   selector: 'scalar-card-data-table',
@@ -101,8 +102,7 @@ export class ScalarCardDataTable {
     const endStep = this.stepOrLinkedTimeSelection.end?.step;
     const dataTableData: SelectedStepRunData[] = this.dataSeries
       .filter((datum) => {
-        const metadata = this.chartMetadataMap[datum.id];
-        return metadata && metadata.visible && !Boolean(metadata.aux);
+        return isDatumVisible(datum, this.chartMetadataMap);
       })
       .map((datum) => {
         const metadata = this.chartMetadataMap[datum.id];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -3432,6 +3432,16 @@ describe('scalar card', () => {
           {wallTime: 2, value: 10, step: 2},
           {wallTime: 3, value: 20, step: 3},
         ],
+        run3: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 2},
+          {wallTime: 3, value: 20, step: 3},
+        ],
+        run4: [
+          {wallTime: 1, value: 1, step: 1},
+          {wallTime: 2, value: 10, step: 2},
+          {wallTime: 3, value: 20, step: 3},
+        ],
       };
       provideMockCardRunToSeriesData(
         selectSpy,
@@ -3455,6 +3465,23 @@ describe('scalar card', () => {
 
       store.overrideSelector(getCardStateMap, {});
     });
+
+    it('does not render expand button when the datatable does not overflow', fakeAsync(() => {
+      provideMockCardRunToSeriesData(
+        selectSpy,
+        PluginType.SCALARS,
+        'card1',
+        null /* metadataOverride */,
+        {}
+      );
+      const fixture = createComponent('card1');
+      fixture.detectChanges();
+      const component = fixture.debugElement.query(
+        By.directive(ScalarCardComponent)
+      );
+      expect(component.componentInstance.dataTableContainer).toBeDefined();
+      expect(fixture.debugElement.query(By.css('.expand-button'))).toBeNull();
+    }));
 
     it('clears inline styles', fakeAsync(() => {
       let dispatchedActions: Action[] = [];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -3455,6 +3455,8 @@ describe('scalar card', () => {
         new Map([
           ['run1', true],
           ['run2', true],
+          ['run3', true],
+          ['run4', true],
         ])
       );
 
@@ -3467,12 +3469,14 @@ describe('scalar card', () => {
     });
 
     it('does not render expand button when the datatable does not overflow', fakeAsync(() => {
-      provideMockCardRunToSeriesData(
-        selectSpy,
-        PluginType.SCALARS,
-        'card1',
-        null /* metadataOverride */,
-        {}
+      store.overrideSelector(
+        selectors.getCurrentRouteRunSelection,
+        new Map([
+          ['run1', true],
+          ['run2', true],
+          ['run3', false],
+          ['run4', false],
+        ])
       );
       const fixture = createComponent('card1');
       fixture.detectChanges();

--- a/tensorboard/webapp/metrics/views/card_renderer/utils.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/utils.ts
@@ -15,7 +15,12 @@ limitations under the License.
 import {ExperimentAlias} from '../../../experiments/types';
 import {Run} from '../../../runs/store/runs_types';
 import {TimeSelection} from '../../types';
-import {PartialSeries, PartitionedSeries} from './scalar_card_types';
+import {
+  PartialSeries,
+  PartitionedSeries,
+  ScalarCardDataSeries,
+  ScalarCardSeriesMetadataMap,
+} from './scalar_card_types';
 
 export function getDisplayNameForRun(
   runId: string,
@@ -187,4 +192,15 @@ export function getClosestStep(
     }
   }
   return closestStep;
+}
+
+/**
+ * Used to determine if a data point should be rendered given the metadata.
+ */
+export function isDatumVisible(
+  datum: ScalarCardDataSeries,
+  metadataMap: ScalarCardSeriesMetadataMap
+) {
+  const metadata = metadataMap[datum.id];
+  return metadata && metadata.visible && !Boolean(metadata.aux);
 }


### PR DESCRIPTION
## Motivation for features / changes
After #6200 merged, we noticed a handful of issues. Rather than revert, we've opted to patch forward. This is the patch.

### For Googlers
[Scuba Before](https://scuba.corp.google.com/#/report/5aac4b0b-c8c3-4751-8aca-c1c0ab57891e?groupBy=Golden+Location&pageSize=25&pageIndex=0&selected_node=5aac4b0b-c8c3-4751-8aca-c1c0ab57891e&status=2
)

[Scuba After](https://scuba.corp.google.com/#/report/11258c25-5a3e-47fb-939b-979fceded566?groupBy=Golden+Location&pageSize=25&pageIndex=0&selected_node=11258c25-5a3e-47fb-939b-979fceded566&status=2)

Here are the issues we noticed:
1) The scalar card top padding was wrong.
2) Tables without many runs shrank when expanded.
3) Charts on full size cards did not expand if step selection was disabled.
4) Toggling a card to full size persisted settings incorrectly.

## Technical description of changes
### The scalar card top padding was wrong
The top padding was simply wrong, it is now fixed.

### Tables without many runs shrank when expanded.
Tables with 3 or fewer runs can no longer be expanded. 4 runs is the minimum amount to trigger an overflow.

### Charts on full size cards did not expand if step selection was disabled.
Now full size charts will only only reserve the lower space for expansion if the expand button exists.
I've also added a min height so that cards cannot be collapsed below their starting height.

### Toggling a card to full size persisted settings incorrectly.
I updated the reducer to only override settings that have been changed.

## Screenshots of UI changes
### The number of runs effects the appearance of the expand button
![image](https://user-images.githubusercontent.com/78179109/222792970-4b4eb023-64e6-4356-bfa8-cb966276afbf.png)

### The selected state of the runs matters
![image](https://user-images.githubusercontent.com/78179109/222800974-e68d970c-0359-458f-9fe0-3388643be871.png)

### Expanding a card with only a single run
![image](https://user-images.githubusercontent.com/78179109/222793158-caa83d1e-ca9e-4567-8abc-6de600913d24.png)

### Expanding a card with many runs
![image](https://user-images.githubusercontent.com/78179109/222793207-0d5f48ed-4bf6-4de9-b776-8ab8be6e1d9f.png)

### Expanding a card without step selection enabled
![image](https://user-images.githubusercontent.com/78179109/222793291-5d51812c-0eb6-4b8a-ac59-46d33f0bb380.png)

## Detailed steps to verify changes work correctly (as executed by you)
See screenshots. I also added unit tests for the new logic

## Alternate designs / implementations considered
The logic for showing the expand button could also have been tied to the size of the data table component. I tried both approaches and liked approach for its simplicity.
