### PR TITLE
Pass tensors instead of python literals for graphs demo

### DIFF
--- a/tensorboard/plugins/graph/graphs_demo.py
+++ b/tensorboard/plugins/graph/graphs_demo.py
@@ -115,24 +115,24 @@ def profile():
 
     @tf.function
     def f(i):
-        return tf.constant(i) + tf.constant(i)
+        return i + i
 
     @tf.function
     def g(i):
-        return tf.constant(i) * tf.constant(i)
+        return i * i
 
     with tf.summary.create_file_writer(logdir).as_default():
         for step in range(3):
             # Suppress the profiler deprecation warnings from tf.summary.trace_*.
             with _silence_deprecation_warnings():
                 tf.summary.trace_on(profiler=True)
-                print(f(step).numpy())
+                print(f(tf.constant(step)).numpy())
                 tf.summary.trace_export(
                     "prof_f", step=step, profiler_outdir=logdir
                 )
 
                 tf.summary.trace_on(profiler=False)
-                print(g(step).numpy())
+                print(g(tf.constant(step)).numpy())
                 tf.summary.trace_export("prof_g", step=step)
 
 


### PR DESCRIPTION
To avoid retracing every time one of the `tf.function`s are called, we should pass tensors instead of python literals as described [here](https://tensorflow.google.cn/guide/function#pass_tensors_instead_of_python_literals)

Fixes #6219