### PR TITLE
Add state attribute to Experiment interface

### DIFF
--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -24,6 +24,9 @@ export declare interface Experiment {
   related_links?: Array<{name: string; url: string}>;
   // These state values were chosen to follow these AIPs
   // https://google.aip.dev/164 and https://google.aip.dev/216.
+  // However, we replaced 'delete' with 'hidden' as this feature is different
+  // from the soft delete described in the AIP. In this case 'hidden' simply
+  // means that the experiment is not shown in the experiment list.
   state?: 'active' | 'hidden' | 'unspecified';
 }
 

--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -22,6 +22,9 @@ export declare interface Experiment {
   hparams?: string;
   tags?: string[];
   related_links?: Array<{name: string; url: string}>;
+  // These state values were chosen to follow these AIPs
+  // https://google.aip.dev/164 and https://google.aip.dev/216.
+  state?: 'active' | 'hidden' | 'unspecified';
 }
 
 export interface ExperimentAlias {


### PR DESCRIPTION
* Motivation for features / changes
This attribute is used internally to determine if the experiment is active or hidden.