### PR TITLE
Shareability: Do not set cardStepIndex to null on no series data

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -157,7 +157,6 @@ function getMaxStepIndex(
  * - assign a default step
  * - reselect the max step, if the previous series' max was selected
  * - clamp to the new series' max
- * - set to `null` if the series contains no step data
  */
 function buildNormalizedCardStepIndexMap(
   cardMetadataMap: CardMetadataMap,
@@ -176,9 +175,6 @@ function buildNormalizedCardStepIndexMap(
       timeSeriesData
     );
     if (maxStepIndex === null) {
-      if (cardStepIndex.hasOwnProperty(cardId)) {
-        result[cardId] = null;
-      }
       continue;
     }
     const stepIndex = cardStepIndex.hasOwnProperty(cardId)

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2007,7 +2007,7 @@ describe('metrics reducers', () => {
         });
       });
 
-      it('sets step index to null if time series is empty', () => {
+      it('does not reset step index to null when time series is empty', () => {
         const runToSeries = {};
         let beforeState = createScalarCardLoadedState(
           'card1',
@@ -2031,8 +2031,8 @@ describe('metrics reducers', () => {
         });
         const nextState = reducers(beforeState, action);
         expect(nextState.cardStepIndex).toEqual({
-          card1: null,
-          pinnedCopy1: null,
+          card1: buildStepIndexMetadata({index: 5}),
+          pinnedCopy1: buildStepIndexMetadata({index: 5}),
         });
       });
     });

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2006,35 +2006,6 @@ describe('metrics reducers', () => {
           pinnedCopy1: buildStepIndexMetadata({index: 2}),
         });
       });
-
-      it('does not reset step index to null when time series is empty', () => {
-        const runToSeries = {};
-        let beforeState = createScalarCardLoadedState(
-          'card1',
-          runToSeries,
-          'tagA'
-        );
-        beforeState = {
-          ...stateWithPinnedCopy(beforeState, 'card1', 'pinnedCopy1'),
-          cardStepIndex: {
-            card1: buildStepIndexMetadata({index: 5}),
-            pinnedCopy1: buildStepIndexMetadata({index: 5}),
-          },
-        };
-
-        const action = actions.fetchTimeSeriesLoaded({
-          response: {
-            plugin: PluginType.SCALARS,
-            tag: 'tagA',
-            runToSeries: {},
-          },
-        });
-        const nextState = reducers(beforeState, action);
-        expect(nextState.cardStepIndex).toEqual({
-          card1: buildStepIndexMetadata({index: 5}),
-          pinnedCopy1: buildStepIndexMetadata({index: 5}),
-        });
-      });
     });
   });
 


### PR DESCRIPTION
* Motivation for features / changes
On internal project of preserving settings, we rehydrate step index data from shareable link, however, the step index contains unloaded cards too. That is to say, that setting will be set to null here. This PR is to remove that condition.
Also manually inspect cardStepIndex state, the map slightly increase on card visibility change (increase on viewing more cards). This makes sense to me. No obvious issues noticed.

The downside is, we might store some unnecessary data in cardStepIndex, but now we don't have a way to tell whether that is necessary (in sharing) or not
