### PR TITLE
Update fsspec tests to account for change in root directory marker inclusion

### DIFF
--- a/tensorboard/compat/tensorflow_stub/io/gfile_fsspec_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_fsspec_test.py
@@ -531,10 +531,14 @@ class GFileFSSpecTest(tb_test.TestCase):
             ],
         )
 
-    def testGlobNonAbsolute(self):
+    def testGlobAbsolute(self):
         """
-        This tests glob with in memory file system which does not return
+        This tests glob with in memory file system which does return
         absolute paths from glob.
+
+        Note that this this changed in fsspec==2021.6.0. Prior to this version
+        absolute paths were not returned from glob.
+        (https://github.com/fsspec/filesystem_spec/pull/654),
         """
         fs = fsspec.filesystem("memory")
         fs.mkdir("dir")
@@ -547,8 +551,8 @@ class GFileFSSpecTest(tb_test.TestCase):
         self.assertCountEqual(
             files,
             [
-                posixpath.join(root, "foo.txt"),
-                posixpath.join(root, "bar.txt"),
+                "memory:///dir/bar.txt",
+                "memory:///dir/foo.txt",
             ],
         )
 

--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -22,7 +22,7 @@ pandas~=1.0
 boto3==1.9.86
 moto==1.3.7
 # For gfile fsspec test
-fsspec==0.7.4
+fsspec>=2021.06.0
 
 # For linting
 black==22.6.0


### PR DESCRIPTION
`fsspec` introduced a root directory marker in their [2021.06.0](https://filesystem-spec.readthedocs.io/en/latest/changelog.html#id21) release (see
[here](https://github.com/fsspec/filesystem_spec/pull/654/files#diff-e25f741c487482da9645eb7f7ec19d5e397f34825508311d7a4a442df6451b05)), which means absolute paths are returned for in-memory filesystems when globbing. One of our tests was specifically validating that non-absolute paths are returned in this case, so naturally it would break if you upgrade beyond `2021.6.0`.

Given that the most current version of fsspec is `2023.03.0`, we should update to match the later versions' implementation.

To fix this issue I've updated our development requirements to specify `fsspec>=2021.06.0` and updated the tests to specify that the absolute path should be expected.