### PR TITLE
Add repository to persistable settings

### DIFF
--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -94,6 +94,9 @@ export class OSSSettingsConverter extends SettingsConverter<
     if (settings.linkedTimeEnabled !== undefined) {
       serializableSettings.linkedTimeEnabled = settings.linkedTimeEnabled;
     }
+    if (settings.repository !== undefined) {
+      serializableSettings.repository = settings.repository;
+    }
     return serializableSettings;
   }
 
@@ -198,6 +201,13 @@ export class OSSSettingsConverter extends SettingsConverter<
       typeof backendSettings.linkedTimeEnabled === 'boolean'
     ) {
       settings.linkedTimeEnabled = backendSettings.linkedTimeEnabled;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('repository') &&
+      typeof backendSettings.repository === 'string'
+    ) {
+      settings.repository = backendSettings.repository;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -182,6 +182,19 @@ describe('persistent_settings data_source test', () => {
           linkedTimeEnabled: true,
         });
       });
+      it('properly converts repository', async () => {
+        getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
+          JSON.stringify({
+            repository: 'xid',
+          })
+        );
+
+        const actual = await firstValueFrom(dataSource.getSettings());
+
+        expect(actual).toEqual({
+          repository: 'xid',
+        });
+      });
     });
 
     describe('#setSettings', () => {
@@ -262,6 +275,25 @@ describe('persistent_settings data_source test', () => {
           TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
           JSON.stringify({
             linkedTimeEnabled: true,
+          })
+        );
+      });
+
+      it('properly converts repository', async () => {
+        getItemSpy
+          .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
+          .and.returnValue(null);
+
+        await firstValueFrom(
+          dataSource.setSettings({
+            repository: 'xid',
+          })
+        );
+
+        expect(setItemSpy).toHaveBeenCalledOnceWith(
+          TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
+          JSON.stringify({
+            repository: 'xid',
           })
         );
       });

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -43,6 +43,7 @@ export declare interface BackendSettings {
   stepSelectorEnabled?: boolean;
   rangeSelectionEnabled?: boolean;
   linkedTimeEnabled?: boolean;
+  repository?: string;
 }
 
 /**
@@ -65,4 +66,5 @@ export interface PersistableSettings {
   stepSelectorEnabled?: boolean;
   rangeSelectionEnabled?: boolean;
   linkedTimeEnabled?: boolean;
+  repository?: string;
 }


### PR DESCRIPTION
* Motivation for features / changes
Our internal service can now access information from multiple repositories. When a users chooses to pull from a repository we want to persist that choice. This is part of that effort. More internal updates will follow this to make it functional. For full feature googlers see cl/515373215.