### PR TITLE
Revert "Temporarily disable fsspec glob test for sync"

### DIFF
--- a/tensorboard/compat/tensorflow_stub/io/gfile_fsspec_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_fsspec_test.py
@@ -15,7 +15,6 @@
 
 
 import posixpath
-import unittest
 
 from tensorboard import test as tb_test
 from tensorboard.compat.tensorflow_stub import errors
@@ -532,9 +531,6 @@ class GFileFSSpecTest(tb_test.TestCase):
             ],
         )
 
-    @unittest.skip(
-        "Temporarily disabling to avoid internal sync breakage across fsspec versions"
-    )
     def testGlobAbsolute(self):
         """
         This tests glob with in memory file system which does return


### PR DESCRIPTION
Reverts tensorflow/tensorboard#6231

The upstream update to fsspec has been submitted, so we can re-enable this test.