### PR TITLE
Shareability: update xAxisType enum to string enum

### DIFF
--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -29,9 +29,9 @@ export enum PluginType {
 }
 
 export enum XAxisType {
-  STEP,
-  RELATIVE,
-  WALL_TIME,
+  STEP = 'step',
+  RELATIVE = 'relative',
+  WALL_TIME = 'walltime',
 }
 
 export interface CardMetadata {


### PR DESCRIPTION
* Motivation for features / changes
Adjust xAxisType to string enum as it will be utilized for internal link sharing.
Number enum will cause mismatch on proto conversion.

Googlers, please see cl/515062969.
