### PR TITLE
Linked Time: Start writing scalar card min max changes to redux

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -73,6 +73,7 @@ import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer'
 import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {
+  cardMinMaxChanged,
   dataTableColumnDrag,
   metricsCardStateUpdated,
   sortingDataTable,
@@ -405,6 +406,12 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
         const maxStep = Math.min(max, viewPort.maxStep);
 
         this.minMaxSteps$.next({minStep, maxStep});
+        this.store.dispatch(
+          cardMinMaxChanged({
+            minMax: {minStep, maxStep},
+            cardId: this.cardId,
+          })
+        );
       }
     );
 


### PR DESCRIPTION
## Motivation for features / changes
There are a variety of issues caused by cards storing their step selection state without passing it to redux.
1) Pinned versions of cards lose their step selection
2) Adding another card using the comparison view resets all step selections
3) Shareable links cannot contain step selection information

The time selection is actually derived from a handful of other settings
 * Linked Time Enabled + Linked Time Selection
 * Step Selection Enabled
 * Range Selection
 * Min/Max step contained within a card
 * Min/Max step that a user has set (by zooming, modifying the axis, etc)
 * The actual step selection value stored in the card

Previously in #6172 I modified the redux state to ensure all these values can be stored in redux
In #6234 I started storing the step selection in redux

Now I am adding the user defined min/max step to redux. This is the last piece of data that needs to be written to redux before we can start reading it back out.

## Technical description of changes
At the moment a card's min max is actually a `BehaviorSubject` with a naive default value which gets updated when the min/max changes.

I am not changing that, yet, instead I am just dispatching new values to redux.

## Screenshots of UI changes
None

## Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Navigate to localhost:6006
3) Add a fob to a card
4) View the console and find the most recent time selection changed event
5) Assert the action contains a cardId
6) Assert the state a timeSelection value exists in the states metrics.cardStateMap[cardId] bucket

