### PR TITLE
Shareability: do not overwrite card state userMinMax if it exists

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -486,6 +486,8 @@ export const isMetricsSlideoutMenuOpen = createSelector(
 export const getMetricsCardMinMax = createSelector(
   getCardStateMap,
   (cardStateMap: CardStateMap, cardId: CardId): MinMaxStep | undefined => {
+    if (!Object.keys(cardStateMap).includes(cardId)) return undefined;
+
     return getMinMaxStepFromCardState(cardStateMap[cardId]);
   }
 );

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -486,7 +486,7 @@ export const isMetricsSlideoutMenuOpen = createSelector(
 export const getMetricsCardMinMax = createSelector(
   getCardStateMap,
   (cardStateMap: CardStateMap, cardId: CardId): MinMaxStep | undefined => {
-    if (!Object.keys(cardStateMap).includes(cardId)) return undefined;
+    if (!cardStateMap[cardId]) return;
 
     return getMinMaxStepFromCardState(cardStateMap[cardId]);
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -83,6 +83,7 @@ import {
 import {PluginType} from '../../data_source';
 import {
   getCardStateMap,
+  getMetricsCardMinMax,
   getMetricsLinkedTimeEnabled,
   getMetricsLinkedTimeSelection,
   getMetricsRangeSelectionEnabled,
@@ -2163,6 +2164,11 @@ describe('scalar card', () => {
           start: {step: 0},
           end: {step: 5},
         });
+        // Workaround to align minMax state with minMaxSteps$
+        store.overrideSelector(getMetricsCardMinMax, {
+          minStep: 10,
+          maxStep: 30,
+        });
         const fixture = createComponent('card1');
         fixture.detectChanges();
 
@@ -2187,6 +2193,11 @@ describe('scalar card', () => {
         store.overrideSelector(getMetricsLinkedTimeSelection, {
           start: {step: -100},
           end: {step: 0},
+        });
+        // Workaround to align minMax state with minMaxSteps$
+        store.overrideSelector(getMetricsCardMinMax, {
+          minStep: 10,
+          maxStep: 30,
         });
         const fixture = createComponent('card1');
         fixture.detectChanges();
@@ -2215,6 +2226,11 @@ describe('scalar card', () => {
         store.overrideSelector(getMetricsLinkedTimeSelection, {
           start: {step: 50},
           end: {step: 100},
+        });
+        // Workaround to align minMax state with minMaxSteps$
+        store.overrideSelector(getMetricsCardMinMax, {
+          minStep: 10,
+          maxStep: 30,
         });
         const fixture = createComponent('card1');
         fixture.detectChanges();
@@ -2657,6 +2673,11 @@ describe('scalar card', () => {
         store.overrideSelector(getMetricsLinkedTimeSelection, {
           start: {step: 0},
           end: {step: 50},
+        });
+        // Workaround to align minMax state with minMaxSteps$
+        store.overrideSelector(getMetricsCardMinMax, {
+          minStep: 10,
+          maxStep: 30,
         });
         const fixture = createComponent('card1');
 
@@ -3658,6 +3679,11 @@ describe('scalar card', () => {
         );
         store.overrideSelector(getMetricsStepSelectorEnabled, false);
         store.overrideSelector(getMetricsRangeSelectionEnabled, false);
+        // Workaround to align minMax state with minMaxSteps$
+        store.overrideSelector(getMetricsCardMinMax, {
+          minStep: 10,
+          maxStep: 30,
+        });
       });
 
       it('does not render fobs by default', fakeAsync(() => {


### PR DESCRIPTION
* Motivation for features / changes
On developing internal project (settings preservation), the series data loaded after we rehydrate preserved settings and that overwrites the state minMax. Therefore, we want to take the card state userMinMax into consideration. If it exists, we don't dispatch cardMinMax change.

Googlers please see cl/515750547.

* Technical description of changes
Need to clean up tests once we remove minMaxStep$ from scalar card container.

* Screenshots of UI changes
Manually test and no significant errors found.