### PR TITLE
Chore: use genrule.tools again instead of genrule.exec_tools

### DIFF
--- a/tensorboard/components/polymer/BUILD
+++ b/tensorboard/components/polymer/BUILD
@@ -68,7 +68,7 @@ genrule(
     ],
     outs = ["plottable-style.ts"],
     cmd = "$(execpath //tensorboard/tools:inline_file_content) $(SRCS) >'$@'",
-    exec_tools = ["//tensorboard/tools:inline_file_content"],
+    tools = ["//tensorboard/tools:inline_file_content"],
 )
 
 tf_ts_library(

--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -13,7 +13,7 @@ genrule(
     ],
     outs = ["tensor-widget-style.ts"],
     cmd = "$(execpath //tensorboard/tools:inline_file_content) $(SRCS) >'$@'",
-    exec_tools = ["//tensorboard/tools:inline_file_content"],
+    tools = ["//tensorboard/tools:inline_file_content"],
 )
 
 tf_web_library(

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -331,5 +331,5 @@ def tf_inline_pngs(name, html_template, images, out):
         srcs = [html_template] + images,
         outs = [out],
         cmd = "$(execpath //tensorboard/defs:inline_images) $(SRCS) >'$@'",
-        exec_tools = ["//tensorboard/defs:inline_images"],
+        tools = ["//tensorboard/defs:inline_images"],
     )

--- a/tensorboard/defs/internal/resource.bzl
+++ b/tensorboard/defs/internal/resource.bzl
@@ -51,7 +51,7 @@ def tf_resource_digest_suffixer(name, resources, template, out):
             $(execpath //tensorboard/defs/internal:resource_digest_suffixer) %s
           } > $@
         """ % " ".join(args),
-        exec_tools = [
+        tools = [
             "//tensorboard/defs/internal:resource_digest_suffixer",
         ],
     )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -117,7 +117,7 @@ genrule(
     name = "generate_dtypes",
     outs = ["tf_dtypes.ts"],
     cmd = "$(execpath :extract_dtypes_from_python) $@",
-    exec_tools = [
+    tools = [
         ":extract_dtypes_from_python",
     ],
 )


### PR DESCRIPTION
* Motivation for features / changes
This is part of an internal Large Scale Change(googlers see b/265933639).

In pr #4031 we switch from using the tools(host mode) to using exec_tools(exec mode). This was done as part of a Large Scale change(Googlers see b/163558320). This was always supposed to be a temporary measure until the host mode was switched to use python3 by default. That has now happened so we are switching back to using genrule.tools.

* Technical description of changes
For reference, the difference between host and exec mode:
genrule.tools uses host mode, which ignores the py_binary.python_version attribute and always use Python 3
genrule.exec_tools uses exec mode, which respects the py_binary.python_version attribute (unless an upstream host
dependency forces all downstream targets to stay in host)

* Detailed steps to verify changes work correctly (as executed by you)
bazel clean
bazel build tensorboard/components/tensor_widget:gen_tensor_widget_style  
bazel build tensorboard/components_polymer3/polymer:gen_plottable_style 
bazel build tensorboard/components/polymer:gen_plottable_style 
