### PR TITLE
Add min-width to  info mat-icon

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -85,6 +85,7 @@ section .control-row:not(:last-child) {
     height: $_dim;
     margin-left: 5px;
     width: $_dim;
+    min-width: $_dim;
   }
 }
 


### PR DESCRIPTION
* Motivation for features / changes
When scroll bars are fixed(which is optional on mac and default on linux) the "?" info icon shrinks. This fixes that icon to the correct size.

googlers see b/266229349

* Screenshots of UI changes

With fixed scroll bar
Before this change:
<img width="243" alt="Screenshot 2023-03-14 at 3 32 35 PM" src="https://user-images.githubusercontent.com/8672809/225157140-7c23eb88-55e2-46d2-8679-e8839ff39698.png">

After this change:
<img width="242" alt="Screenshot 2023-03-14 at 3 32 47 PM" src="https://user-images.githubusercontent.com/8672809/225157138-27c4ceec-22a6-49bc-b6a1-5b489f165c0e.png">

Without scrollbar before and after:
<img width="242" alt="Screenshot 2023-03-14 at 3 33 24 PM" src="https://user-images.githubusercontent.com/8672809/225157136-e0ab1ef0-ee5f-4da0-a656-676747fd1d87.png">