### PR TITLE
Shareability: use table expansion from state for fullsize mode

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -72,6 +72,11 @@ export const metricsCardStateUpdated = createAction(
   }>()
 );
 
+export const metricsCardTableExpansionToggled = createAction(
+  '[Metrics] Metrics Card Table Expansion Toiggled',
+  props<{cardId: CardId}>()
+);
+
 export const metricsChangeTooltipSort = createAction(
   '[Metrics] Metrics Settings Change Tooltip',
   props<{sort: TooltipSort}>()

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -72,8 +72,8 @@ export const metricsCardStateUpdated = createAction(
   }>()
 );
 
-export const metricsCardTableExpansionToggled = createAction(
-  '[Metrics] Metrics Card Table Expansion Toiggled',
+export const metricsCardFullSizeToggled = createAction(
+  '[Metrics] Metrics Card Full Size Toggled',
   props<{cardId: CardId}>()
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -625,7 +625,7 @@ const reducer = createReducer(
       ...nextcardStateMap[cardId],
       // When the action is fired and card id does not exist on cardStateMap,
       // this means the full size icon is clicked.
-      fullSize: !nextcardStateMap[cardId]?.fullSize ?? true,
+      fullSize: !nextcardStateMap[cardId]?.fullSize,
     };
 
     return {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -619,6 +619,20 @@ const reducer = createReducer(
       cardStateMap: nextcardStateMap,
     };
   }),
+  on(actions.metricsCardTableExpansionToggled, (state, {cardId}) => {
+    const nextcardStateMap = {...state.cardStateMap};
+    console.log('nextcardStateMap:', nextcardStateMap);
+    nextcardStateMap[cardId] = {
+      ...nextcardStateMap[cardId],
+      // When card id does not exist on cardStateMap, this means expanding the table.
+      tableExpanded: !nextcardStateMap[cardId]?.tableExpanded ?? true,
+    };
+
+    return {
+      ...state,
+      cardStateMap: nextcardStateMap,
+    };
+  }),
   on(actions.metricsTagFilterChanged, (state, {tagFilter}) => {
     return {
       ...state,

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -623,9 +623,8 @@ const reducer = createReducer(
     const nextcardStateMap = {...state.cardStateMap};
     nextcardStateMap[cardId] = {
       ...nextcardStateMap[cardId],
-      // When the action is fired and card id does not exist on cardStateMap,
-      // this means the full size icon is clicked.
-      fullSize: !nextcardStateMap[cardId]?.fullSize,
+      fullWidth: !nextcardStateMap[cardId]?.fullWidth,
+      tableExpanded: !nextcardStateMap[cardId]?.fullWidth,
     };
 
     return {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -621,7 +621,6 @@ const reducer = createReducer(
   }),
   on(actions.metricsCardTableExpansionToggled, (state, {cardId}) => {
     const nextcardStateMap = {...state.cardStateMap};
-    console.log('nextcardStateMap:', nextcardStateMap);
     nextcardStateMap[cardId] = {
       ...nextcardStateMap[cardId],
       // When card id does not exist on cardStateMap, this means expanding the table.

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -619,12 +619,13 @@ const reducer = createReducer(
       cardStateMap: nextcardStateMap,
     };
   }),
-  on(actions.metricsCardTableExpansionToggled, (state, {cardId}) => {
+  on(actions.metricsCardFullSizeToggled, (state, {cardId}) => {
     const nextcardStateMap = {...state.cardStateMap};
     nextcardStateMap[cardId] = {
       ...nextcardStateMap[cardId],
-      // When card id does not exist on cardStateMap, this means expanding the table.
-      tableExpanded: !nextcardStateMap[cardId]?.tableExpanded ?? true,
+      // When the action is fired and card id does not exist on cardStateMap,
+      // this means the full size icon is clicked.
+      fullSize: !nextcardStateMap[cardId]?.fullSize ?? true,
     };
 
     return {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2336,7 +2336,7 @@ describe('metrics reducers', () => {
       });
     });
 
-    it('expands card when table has expanded', () => {
+    it('expands card when table is already expanded', () => {
       const state = buildMetricsState({
         cardStateMap: {card1: {tableExpanded: true}},
       });
@@ -2362,7 +2362,7 @@ describe('metrics reducers', () => {
       });
     });
 
-    it('collapse card on table is expanded', () => {
+    it('collapses card when table is already expanded', () => {
       const state = buildMetricsState({
         cardStateMap: {card1: {fullWidth: true, tableExpanded: true}},
       });

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2324,6 +2324,57 @@ describe('metrics reducers', () => {
     });
   });
 
+  describe('metricsCardFullSizeToggled', () => {
+    it('expands card', () => {
+      const state = buildMetricsState();
+      const action = actions.metricsCardFullSizeToggled({
+        cardId: 'card1',
+      });
+      const nextState = reducers(state, action);
+      expect(nextState.cardStateMap).toEqual({
+        card1: {fullWidth: true, tableExpanded: true},
+      });
+    });
+
+    it('expands card when table has expanded', () => {
+      const state = buildMetricsState({
+        cardStateMap: {card1: {tableExpanded: true}},
+      });
+      const action = actions.metricsCardFullSizeToggled({
+        cardId: 'card1',
+      });
+      const nextState = reducers(state, action);
+      expect(nextState.cardStateMap).toEqual({
+        card1: {fullWidth: true, tableExpanded: true},
+      });
+    });
+
+    it('collapse card', () => {
+      const state = buildMetricsState({
+        cardStateMap: {card1: {fullWidth: true}},
+      });
+      const action = actions.metricsCardFullSizeToggled({
+        cardId: 'card1',
+      });
+      const nextState = reducers(state, action);
+      expect(nextState.cardStateMap).toEqual({
+        card1: {fullWidth: false, tableExpanded: false},
+      });
+    });
+
+    it('collapse card on table is expanded', () => {
+      const state = buildMetricsState({
+        cardStateMap: {card1: {fullWidth: true, tableExpanded: true}},
+      });
+      const action = actions.metricsCardFullSizeToggled({
+        cardId: 'card1',
+      });
+      const nextState = reducers(state, action);
+      expect(nextState.cardStateMap).toEqual({
+        card1: {fullWidth: false, tableExpanded: false},
+      });
+    });
+  });
   describe('metricsTagFilterChanged', () => {
     it('sets the tagFilter state', () => {
       const state = buildMetricsState({tagFilter: 'foo'});

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -139,6 +139,7 @@ export type CardState = {
   stepSelectionOverride: CardFeatureOverride;
   rangeSelectionOverride: CardFeatureOverride;
   tableExpanded: boolean;
+  fullSize: boolean;
 };
 
 export type CardStateMap = Record<CardId, Partial<CardState>>;

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -139,7 +139,7 @@ export type CardState = {
   stepSelectionOverride: CardFeatureOverride;
   rangeSelectionOverride: CardFeatureOverride;
   tableExpanded: boolean;
-  fullSize: boolean;
+  fullWidth: boolean;
 };
 
 export type CardStateMap = Record<CardId, Partial<CardState>>;

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -104,6 +104,7 @@ tf_ng_module(
         ":utils",
         ":vis_linked_time_selection_warning",
         "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_material_progress_spinner",

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
@@ -29,6 +29,7 @@ limitations under the License.
     *ngSwitchCase="PluginType.SCALARS"
     [cardId]="cardId"
     [groupName]="groupName"
+    (fullHeightChanged)="onFullHeightChanged($event)"
     (pinStateChanged)="onPinStateChanged()"
   ></scalar-card>
 

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
@@ -29,7 +29,6 @@ limitations under the License.
     *ngSwitchCase="PluginType.SCALARS"
     [cardId]="cardId"
     [groupName]="groupName"
-    (fullHeightChanged)="onFullHeightChanged($event)"
     (pinStateChanged)="onPinStateChanged()"
   ></scalar-card>
 

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_component.ng.html
@@ -29,8 +29,6 @@ limitations under the License.
     *ngSwitchCase="PluginType.SCALARS"
     [cardId]="cardId"
     [groupName]="groupName"
-    (fullWidthChanged)="onFullWidthChanged($event)"
-    (fullHeightChanged)="onFullHeightChanged($event)"
     (pinStateChanged)="onPinStateChanged()"
   ></scalar-card>
 
@@ -39,8 +37,6 @@ limitations under the License.
     [cardId]="cardId"
     [groupName]="groupName"
     [runColorScale]="runColorScale"
-    (fullWidthChanged)="onFullWidthChanged($event)"
-    (fullHeightChanged)="onFullHeightChanged($event)"
     (pinStateChanged)="onPinStateChanged()"
   ></histogram-card>
 

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -105,6 +105,30 @@ describe('card view test', () => {
     });
   });
 
+  it('emits fullHeightChanged after lower level fullHeightChanged', () => {
+    const fixture = TestBed.createComponent(CardViewContainer);
+    fixture.componentInstance.cardId = 'cardId';
+    fixture.componentInstance.pluginType = PluginType.SCALARS;
+    intersectionObserver.simulateVisibilityChange(fixture, true);
+    fixture.detectChanges();
+
+    const onFullHeightChanged = jasmine.createSpy();
+    fixture.componentInstance.fullHeightChanged.subscribe(onFullHeightChanged);
+
+    expect(onFullHeightChanged.calls.allArgs()).toEqual([]);
+
+    const scalarCard = fixture.debugElement.query(By.css('scalar-card'));
+    scalarCard.componentInstance.fullHeightChanged.emit(true);
+    fixture.detectChanges();
+
+    expect(onFullHeightChanged.calls.allArgs()).toEqual([[true]]);
+
+    scalarCard.componentInstance.fullHeightChanged.emit(false);
+    fixture.detectChanges();
+
+    expect(onFullHeightChanged.calls.allArgs()).toEqual([[true], [false]]);
+  });
+
   it('dispatches action when pin state changes', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -105,28 +105,28 @@ describe('card view test', () => {
     });
   });
 
-  it('emits fullHeightChanged after lower level fullHeightChanged', () => {
+  fit('emits fullWidthChanged after lower level fullWidthChanged', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';
-    fixture.componentInstance.pluginType = PluginType.SCALARS;
+    fixture.componentInstance.pluginType = PluginType.IMAGES;
     intersectionObserver.simulateVisibilityChange(fixture, true);
     fixture.detectChanges();
 
-    const onFullHeightChanged = jasmine.createSpy();
-    fixture.componentInstance.fullHeightChanged.subscribe(onFullHeightChanged);
+    const onFullWidthChanged = jasmine.createSpy();
+    fixture.componentInstance.fullWidthChanged.subscribe(onFullWidthChanged);
 
-    expect(onFullHeightChanged.calls.allArgs()).toEqual([]);
+    expect(onFullWidthChanged.calls.allArgs()).toEqual([]);
 
-    const scalarCard = fixture.debugElement.query(By.css('scalar-card'));
-    scalarCard.componentInstance.fullHeightChanged.emit(true);
+    const imageCard = fixture.debugElement.query(By.css('image-card'));
+    imageCard.componentInstance.fullWidthChanged.emit(true);
     fixture.detectChanges();
 
-    expect(onFullHeightChanged.calls.allArgs()).toEqual([[true]]);
+    expect(onFullWidthChanged.calls.allArgs()).toEqual([[true]]);
 
-    scalarCard.componentInstance.fullHeightChanged.emit(false);
+    imageCard.componentInstance.fullWidthChanged.emit(false);
     fixture.detectChanges();
 
-    expect(onFullHeightChanged.calls.allArgs()).toEqual([[true], [false]]);
+    expect(onFullWidthChanged.calls.allArgs()).toEqual([[true], [false]]);
   });
 
   it('dispatches action when pin state changes', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -105,7 +105,7 @@ describe('card view test', () => {
     });
   });
 
-  fit('emits fullWidthChanged after lower level fullWidthChanged', () => {
+  it('emits fullWidthChanged after lower level fullWidthChanged', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';
     fixture.componentInstance.pluginType = PluginType.IMAGES;

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -105,54 +105,6 @@ describe('card view test', () => {
     });
   });
 
-  it('emits fullWidthChanged after lower level fullWidthChanged', () => {
-    const fixture = TestBed.createComponent(CardViewContainer);
-    fixture.componentInstance.cardId = 'cardId';
-    fixture.componentInstance.pluginType = PluginType.SCALARS;
-    intersectionObserver.simulateVisibilityChange(fixture, true);
-    fixture.detectChanges();
-
-    const onFullWidthChanged = jasmine.createSpy();
-    fixture.componentInstance.fullWidthChanged.subscribe(onFullWidthChanged);
-
-    expect(onFullWidthChanged.calls.allArgs()).toEqual([]);
-
-    const scalarCard = fixture.debugElement.query(By.css('scalar-card'));
-    scalarCard.componentInstance.fullWidthChanged.emit(true);
-    fixture.detectChanges();
-
-    expect(onFullWidthChanged.calls.allArgs()).toEqual([[true]]);
-
-    scalarCard.componentInstance.fullWidthChanged.emit(false);
-    fixture.detectChanges();
-
-    expect(onFullWidthChanged.calls.allArgs()).toEqual([[true], [false]]);
-  });
-
-  it('emits fullHeightChanged after lower level fullHeightChanged', () => {
-    const fixture = TestBed.createComponent(CardViewContainer);
-    fixture.componentInstance.cardId = 'cardId';
-    fixture.componentInstance.pluginType = PluginType.SCALARS;
-    intersectionObserver.simulateVisibilityChange(fixture, true);
-    fixture.detectChanges();
-
-    const onFullHeightChanged = jasmine.createSpy();
-    fixture.componentInstance.fullHeightChanged.subscribe(onFullHeightChanged);
-
-    expect(onFullHeightChanged.calls.allArgs()).toEqual([]);
-
-    const scalarCard = fixture.debugElement.query(By.css('scalar-card'));
-    scalarCard.componentInstance.fullHeightChanged.emit(true);
-    fixture.detectChanges();
-
-    expect(onFullHeightChanged.calls.allArgs()).toEqual([[true]]);
-
-    scalarCard.componentInstance.fullHeightChanged.emit(false);
-    fixture.detectChanges();
-
-    expect(onFullHeightChanged.calls.allArgs()).toEqual([[true], [false]]);
-  });
-
   it('dispatches action when pin state changes', () => {
     const fixture = TestBed.createComponent(CardViewContainer);
     fixture.componentInstance.cardId = 'cardId';

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ng.html
@@ -50,7 +50,7 @@ limitations under the License.
       (click)="onFullSizeToggle.emit()"
     >
       <mat-icon
-        [svgIcon]="showFullSize ? 'fullscreen_exit_24px' : 'fullscreen_24px'"
+        [svgIcon]="showFullWidth ? 'fullscreen_exit_24px' : 'fullscreen_24px'"
       ></mat-icon>
     </button>
   </span>

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_component.ts
@@ -47,7 +47,7 @@ export class HistogramCardComponent {
   @Input() mode!: HistogramMode;
   @Input() xAxisType!: XAxisType;
   @Input() runColorScale!: RunColorScale;
-  @Input() showFullSize!: boolean;
+  @Input() showFullWidth!: boolean;
   @Input() isPinned!: boolean;
   @Input() linkedTimeSelection!: TimeSelectionView | null;
   @Input() isClosestStepHighlighted!: boolean | null;

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -127,9 +127,7 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   }
 
   onFullSizeToggle() {
-    this.store.dispatch(
-      metricsCardFullSizeToggled({cardId: this.cardId})
-    );
+    this.store.dispatch(metricsCardFullSizeToggled({cardId: this.cardId}));
   }
 
   /**

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -74,7 +74,7 @@ type HistogramCardMetadata = CardMetadata & {
       [mode]="mode$ | async"
       [xAxisType]="xAxisType$ | async"
       [runColorScale]="runColorScale"
-      [showFullSize]="showFullSize$ | async"
+      [showFullWidth]="showFullWidth$ | async"
       [isPinned]="isPinned$ | async"
       [isClosestStepHighlighted]="isClosestStepHighlighted$ | async"
       [linkedTimeSelection]="linkedTimeSelection$ | async"
@@ -110,9 +110,9 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   data$?: Observable<HistogramDatum[]>;
   mode$ = this.store.select(getMetricsHistogramMode);
   xAxisType$ = this.store.select(getMetricsXAxisType);
-  readonly showFullSize$ = this.store
+  readonly showFullWidth$ = this.store
     .select(getCardStateMap)
-    .pipe(map((map) => map[this.cardId]?.fullSize));
+    .pipe(map((map) => map[this.cardId]?.fullWidth));
   isPinned$?: Observable<boolean>;
   linkedTimeSelection$?: Observable<TimeSelectionView | null>;
   isClosestStepHighlighted$?: Observable<boolean | null>;

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -33,7 +33,7 @@ import {
 import {HistogramDatum} from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
 import {
-  metricsCardTableExpansionToggled,
+  metricsCardFullSizeToggled,
   stepSelectorToggled,
   timeSelectionChanged,
 } from '../../actions';
@@ -112,7 +112,7 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   xAxisType$ = this.store.select(getMetricsXAxisType);
   readonly showFullSize$ = this.store
     .select(getCardStateMap)
-    .pipe(map((map) => map[this.cardId]?.tableExpanded));
+    .pipe(map((map) => map[this.cardId]?.fullSize));
   isPinned$?: Observable<boolean>;
   linkedTimeSelection$?: Observable<TimeSelectionView | null>;
   isClosestStepHighlighted$?: Observable<boolean | null>;
@@ -128,7 +128,7 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
 
   onFullSizeToggle() {
     this.store.dispatch(
-      metricsCardTableExpansionToggled({cardId: this.cardId})
+      metricsCardFullSizeToggled({cardId: this.cardId})
     );
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_container.ts
@@ -127,7 +127,6 @@ export class HistogramCardContainer implements CardRenderer, OnInit {
   }
 
   onFullSizeToggle() {
-    console.log('onFullSizeToggle:', this.cardId);
     this.store.dispatch(
       metricsCardTableExpansionToggled({cardId: this.cardId})
     );

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -38,7 +38,11 @@ import {
 } from '../../../widgets/histogram/histogram_types';
 import {buildNormalizedHistograms} from '../../../widgets/histogram/histogram_util';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
-import {stepSelectorToggled, timeSelectionChanged} from '../../actions';
+import {
+  stepSelectorToggled,
+  timeSelectionChanged,
+  metricsCardTableExpansionToggled,
+} from '../../actions';
 import {PluginType} from '../../data_source';
 import * as selectors from '../../store/metrics_selectors';
 import {
@@ -256,31 +260,29 @@ describe('histogram card', () => {
   });
 
   describe('full size', () => {
+    let dispatchedActions: Action[];
+
     beforeEach(() => {
       provideMockCardSeriesData(selectSpy, PluginType.HISTOGRAMS, 'card1');
+
+      dispatchedActions = [];
+      spyOn(store, 'dispatch').and.callFake((action: Action) => {
+        dispatchedActions.push(action);
+      });
     });
 
-    it('requests full size on toggle', () => {
-      const onFullWidthChanged = jasmine.createSpy();
-      const onFullHeightChanged = jasmine.createSpy();
+    it('dispatches metricsCardTableExpansionToggled on full size toggle', () => {
       const fixture = createHistogramCardContainer();
       fixture.detectChanges();
 
-      fixture.componentInstance.fullWidthChanged.subscribe(onFullWidthChanged);
-      fixture.componentInstance.fullHeightChanged.subscribe(
-        onFullHeightChanged
-      );
       const button = fixture.debugElement.query(
         By.css('[aria-label="Toggle full size mode"]')
       );
 
       button.nativeElement.click();
-      expect(onFullWidthChanged.calls.allArgs()).toEqual([[true]]);
-      expect(onFullHeightChanged.calls.allArgs()).toEqual([[true]]);
-
-      button.nativeElement.click();
-      expect(onFullWidthChanged.calls.allArgs()).toEqual([[true], [false]]);
-      expect(onFullHeightChanged.calls.allArgs()).toEqual([[true], [false]]);
+      expect(dispatchedActions).toEqual([
+        metricsCardTableExpansionToggled({cardId: 'card1'}),
+      ]);
     });
   });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -41,7 +41,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
   stepSelectorToggled,
   timeSelectionChanged,
-  metricsCardTableExpansionToggled,
+  metricsCardFullSizeToggled,
 } from '../../actions';
 import {PluginType} from '../../data_source';
 import * as selectors from '../../store/metrics_selectors';
@@ -271,7 +271,7 @@ describe('histogram card', () => {
       });
     });
 
-    it('dispatches metricsCardTableExpansionToggled on full size toggle', () => {
+    it('dispatches metricsCardFullSizeToggled on full size toggle', () => {
       const fixture = createHistogramCardContainer();
       fixture.detectChanges();
 
@@ -281,7 +281,7 @@ describe('histogram card', () => {
 
       button.nativeElement.click();
       expect(dispatchedActions).toEqual([
-        metricsCardTableExpansionToggled({cardId: 'card1'}),
+        metricsCardFullSizeToggled({cardId: 'card1'}),
       ]);
     });
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -179,7 +179,7 @@ limitations under the License.
     #dataTableContainer
     [ngClass]="{
       'data-table-container': true,
-      'expanded': cardState!.tableExpanded
+      'expanded': cardState!.tableExpanded || cardState!.fullSize
     }"
   >
     <scalar-card-data-table

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -62,7 +62,7 @@ limitations under the License.
         (click)="onFullSizeToggle.emit()"
       >
         <mat-icon
-          [svgIcon]="showFullSize ? 'fullscreen_exit_24px' : 'fullscreen_24px'"
+          [svgIcon]="showFullWidth ? 'fullscreen_exit_24px' : 'fullscreen_24px'"
         ></mat-icon>
       </button>
       <!-- overflow menu cannot use mat-tooltip since it interferes with the mat-menu. -->
@@ -179,7 +179,7 @@ limitations under the License.
     #dataTableContainer
     [ngClass]="{
       'data-table-container': true,
-      'expanded': cardState!.tableExpanded || cardState!.fullSize
+      'expanded': cardState!.tableExpanded
     }"
   >
     <scalar-card-data-table

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -83,7 +83,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() isCardVisible!: boolean;
   @Input() isPinned!: boolean;
   @Input() loadState!: DataLoadState;
-  @Input() showFullSize!: boolean;
+  @Input() showFullWidth!: boolean;
   @Input() smoothingEnabled!: boolean;
   @Input() tag!: string;
   @Input() title!: string;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -78,7 +78,7 @@ import {
   cardMinMaxChanged,
   dataTableColumnDrag,
   metricsCardStateUpdated,
-  metricsCardTableExpansionToggled,
+  metricsCardFullSizeToggled,
   sortingDataTable,
   stepSelectorToggled,
   timeSelectionChanged,
@@ -276,7 +276,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   readonly showFullSize$ = this.store
     .select(getCardStateMap)
-    .pipe(map((map) => map[this.cardId]?.tableExpanded));
+    .pipe(map((map) => map[this.cardId]?.fullSize));
 
   private readonly ngUnsubscribe = new Subject<void>();
 
@@ -289,7 +289,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   onFullSizeToggle() {
     this.store.dispatch(
-      metricsCardTableExpansionToggled({cardId: this.cardId})
+      metricsCardFullSizeToggled({cardId: this.cardId})
     );
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -29,7 +29,6 @@ import {
   from,
   Observable,
   of,
-  ReplaySubject,
   Subject,
 } from 'rxjs';
 import {
@@ -41,7 +40,6 @@ import {
   shareReplay,
   startWith,
   switchMap,
-  take,
   takeUntil,
   withLatestFrom,
 } from 'rxjs/operators';
@@ -215,6 +213,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     DataDownloadDialogContainer;
   @Input() cardId!: CardId;
   @Input() groupName!: string | null;
+  @Output() fullHeightChanged = new EventEmitter<boolean>();
   @Output() pinStateChanged = new EventEmitter<boolean>();
 
   isVisible: boolean = false;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -213,7 +213,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     DataDownloadDialogContainer;
   @Input() cardId!: CardId;
   @Input() groupName!: string | null;
-  @Output() fullHeightChanged = new EventEmitter<boolean>();
   @Output() pinStateChanged = new EventEmitter<boolean>();
 
   isVisible: boolean = false;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -165,7 +165,7 @@ function isMinMaxStepValid(minMax: MinMaxStep | undefined): boolean {
       [isCardVisible]="isVisible"
       [isPinned]="isPinned$ | async"
       [loadState]="loadState$ | async"
-      [showFullSize]="showFullSize$ | async"
+      [showFullWidth]="showFullWidth$ | async"
       [smoothingEnabled]="smoothingEnabled$ | async"
       [tag]="tag$ | async"
       [title]="title$ | async"
@@ -273,9 +273,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     .select(getMetricsScalarSmoothing)
     .pipe(map((smoothing) => smoothing > 0));
 
-  readonly showFullSize$ = this.store
+  readonly showFullWidth$ = this.store
     .select(getCardStateMap)
-    .pipe(map((map) => map[this.cardId]?.fullSize));
+    .pipe(map((map) => map[this.cardId]?.fullWidth));
 
   private readonly ngUnsubscribe = new Subject<void>();
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -288,9 +288,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   }
 
   onFullSizeToggle() {
-    this.store.dispatch(
-      metricsCardFullSizeToggled({cardId: this.cardId})
-    );
+    this.store.dispatch(metricsCardFullSizeToggled({cardId: this.cardId}));
   }
 
   /**

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -77,7 +77,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
   cardMinMaxChanged,
   metricsCardStateUpdated,
-  metricsCardTableExpansionToggled,
+  metricsCardFullSizeToggled,
   stepSelectorToggled,
   timeSelectionChanged,
 } from '../../actions';
@@ -851,7 +851,7 @@ describe('scalar card', () => {
       );
     });
 
-    it('dispatches metricsCardTableExpansionToggled on full size toggle', fakeAsync(() => {
+    it('dispatches metricsCardFullSizeToggled on full size toggle', fakeAsync(() => {
       const fixture = createComponent('card1');
       fixture.detectChanges();
 
@@ -861,7 +861,7 @@ describe('scalar card', () => {
 
       button.nativeElement.click();
       expect(dispatchedActions).toEqual([
-        metricsCardTableExpansionToggled({cardId: 'card1'}),
+        metricsCardFullSizeToggled({cardId: 'card1'}),
       ]);
     }));
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -77,6 +77,7 @@ import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
   cardMinMaxChanged,
   metricsCardStateUpdated,
+  metricsCardTableExpansionToggled,
   stepSelectorToggled,
   timeSelectionChanged,
 } from '../../actions';
@@ -850,27 +851,18 @@ describe('scalar card', () => {
       );
     });
 
-    it('requests full size on toggle', fakeAsync(() => {
-      const onFullWidthChanged = jasmine.createSpy();
-      const onFullHeightChanged = jasmine.createSpy();
+    it('dispatches metricsCardTableExpansionToggled on full size toggle', fakeAsync(() => {
       const fixture = createComponent('card1');
       fixture.detectChanges();
 
-      fixture.componentInstance.fullWidthChanged.subscribe(onFullWidthChanged);
-      fixture.componentInstance.fullHeightChanged.subscribe(
-        onFullHeightChanged
-      );
       const button = fixture.debugElement.query(
         By.css('[aria-label="Toggle full size mode"]')
       );
 
       button.nativeElement.click();
-      expect(onFullWidthChanged.calls.allArgs()).toEqual([[true]]);
-      expect(onFullHeightChanged.calls.allArgs()).toEqual([[true]]);
-
-      button.nativeElement.click();
-      expect(onFullWidthChanged.calls.allArgs()).toEqual([[true], [false]]);
-      expect(onFullHeightChanged.calls.allArgs()).toEqual([[true], [false]]);
+      expect(dispatchedActions).toEqual([
+        metricsCardTableExpansionToggled({cardId: 'card1'}),
+      ]);
     }));
   });
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -25,8 +25,8 @@ limitations under the License.
       *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
       class="card-space"
       [ngClass]="{
-          'full-width': cardsAtFullWidth.has(item.cardId),
-          'full-height': cardsAtFullHeight.has(item.cardId)
+          'full-width': cardStateMap[item.cardId]?.tableExpanded,
+          'full-height': cardStateMap[item.cardId]?.tableExpanded
         }"
     >
       <card-view

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -25,8 +25,8 @@ limitations under the License.
       *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
       class="card-space"
       [ngClass]="{
-          'full-width': cardStateMap[item.cardId]?.tableExpanded,
-          'full-height': cardStateMap[item.cardId]?.tableExpanded
+          'full-width': cardStateMap[item.cardId]?.fullSize,
+          'full-height': cardStateMap[item.cardId]?.fullSize || cardsAtFullHeight.has(item.cardId)
         }"
     >
       <card-view

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -25,8 +25,8 @@ limitations under the License.
       *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
       class="card-space"
       [ngClass]="{
-          'full-width': cardStateMap[item.cardId]?.fullSize,
-          'full-height': cardStateMap[item.cardId]?.fullSize || cardsAtFullHeight.has(item.cardId)
+          'full-width': cardStateMap[item.cardId]?.fullWidth,
+          'full-height': cardStateMap[item.cardId]?.tableExpanded
         }"
     >
       <card-view

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -25,8 +25,8 @@ limitations under the License.
       *ngFor="let item of cardIdsWithMetadata; trackBy: trackByCards"
       class="card-space"
       [ngClass]="{
-          'full-width': cardStateMap[item.cardId]?.fullWidth,
-          'full-height': cardStateMap[item.cardId]?.tableExpanded
+          'full-width': cardsAtFullWidth.has(item.cardId) || cardStateMap[item.cardId]?.fullWidth,
+          'full-height': cardsAtFullHeight.has(item.cardId) || cardStateMap[item.cardId]?.tableExpanded
         }"
     >
       <card-view

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.ts
@@ -26,6 +26,7 @@ import {PluginType} from '../../data_source';
 import {CardId} from '../../types';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
+import {CardStateMap} from '../../store/metrics_types';
 
 const MIN_CARD_MIN_WIDTH_IN_PX = 335;
 const MAX_CARD_MIN_WIDTH_IN_PX = 735;
@@ -50,6 +51,7 @@ export class CardGridComponent {
   @Input() cardMinWidth!: number | null;
   @Input() cardObserver!: CardObserver;
   @Input() showPaginationControls!: boolean;
+  @Input() cardStateMap!: CardStateMap;
 
   @Output() pageIndexChanged = new EventEmitter<number>();
 

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_container.ts
@@ -31,6 +31,7 @@ import {
 import {selectors as settingsSelectors} from '../../../settings';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
+import * as selectors from '../../../selectors';
 
 @Component({
   selector: 'metrics-card-grid',
@@ -43,6 +44,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
       [cardIdsWithMetadata]="pagedItems$ | async"
       [cardMinWidth]="cardMinWidth$ | async"
       [cardObserver]="cardObserver"
+      [cardStateMap]="cardStateMap$ | async"
       (pageIndexChanged)="onPageIndexChanged($event)"
     >
     </metrics-card-grid-component>
@@ -59,6 +61,7 @@ export class CardGridContainer implements OnChanges, OnDestroy {
   readonly pageIndex$ = new BehaviorSubject<number>(0);
   private readonly items$ = new BehaviorSubject<CardIdWithMetadata[]>([]);
   private readonly ngUnsubscribe = new Subject<void>();
+  readonly cardStateMap$ = this.store.select(selectors.getCardStateMap);
 
   readonly numPages$ = combineLatest([
     this.items$,

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -300,7 +300,7 @@ describe('card grid', () => {
       expect(cardSpaces[2].nativeElement.classList).not.toContain('full-width');
     });
 
-    fit('renders card height based on getCardStateMap', () => {
+    it('renders card height based on getCardStateMap', () => {
       store.overrideSelector(getCardStateMap, {card2: {tableExpanded: true}});
       let fixture = createComponent();
       let cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -352,7 +352,7 @@ describe('card grid', () => {
       );
     });
 
-    fit('renders card width based on getCardStateMap', () => {
+    it('renders card width based on getCardStateMap', () => {
       store.overrideSelector(getCardStateMap, {card3: {tableExpanded: true}});
       let fixture = createComponent();
       let cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -12,38 +12,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ScrollingModule} from '@angular/cdk/scrolling';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 import {
   Component,
   EventEmitter,
   Input,
   NO_ERRORS_SCHEMA,
-  Output,
+  Output
 } from '@angular/core';
 import {
   ComponentFixture,
   discardPeriodicTasks,
   fakeAsync,
   TestBed,
-  tick,
+  tick
 } from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {Store} from '@ngrx/store';
-import {MockStore} from '@ngrx/store/testing';
-import {State} from '../../../app_state';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Store } from '@ngrx/store';
+import { MockStore } from '@ngrx/store/testing';
+import { State } from '../../../app_state';
 import * as selectors from '../../../selectors';
 import {
   getCardStateMap,
   getMetricsCardMinWidth,
-  getMetricsTagGroupExpansionState,
+  getMetricsTagGroupExpansionState
 } from '../../../selectors';
-import {selectors as settingsSelectors} from '../../../settings';
-import {provideMockTbStore} from '../../../testing/utils';
-import {PluginType} from '../../data_source';
-import {CardIdWithMetadata} from '../metrics_view_types';
-import {CardGridComponent} from './card_grid_component';
-import {CardGridContainer} from './card_grid_container';
+import { selectors as settingsSelectors } from '../../../settings';
+import { provideMockTbStore } from '../../../testing/utils';
+import { PluginType } from '../../data_source';
+import { CardIdWithMetadata } from '../metrics_view_types';
+import { CardGridComponent } from './card_grid_component';
+import { CardGridContainer } from './card_grid_container';
 
 const scrollElementHeight = 100;
 
@@ -277,8 +277,90 @@ describe('card grid', () => {
       expect(cardSpaces[2].nativeElement.classList).not.toContain('full-width');
     });
 
-    it('renders card height based on getCardStateMap', () => {
-      store.overrideSelector(getCardStateMap, {card2: {tableExpanded: true}});
+    it('changes height after card event', () => {
+      const fixture = createComponent();
+      const cardViews = fixture.debugElement.queryAll(By.css('card-view'));
+      const cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
+
+      cardViews[1].componentInstance.fullHeightChanged.emit(true);
+      fixture.detectChanges();
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+
+      cardViews[0].componentInstance.fullHeightChanged.emit(true);
+      fixture.detectChanges();
+      expect(cardSpaces[0].nativeElement.classList).toContain('full-height');
+      expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+
+      cardViews[1].componentInstance.fullHeightChanged.emit(false);
+      fixture.detectChanges();
+      expect(cardSpaces[0].nativeElement.classList).toContain('full-height');
+      expect(cardSpaces[1].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+
+      cardViews[0].componentInstance.fullHeightChanged.emit(false);
+      fixture.detectChanges();
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[1].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+    });
+
+    it('does not change height if emitted value is same', () => {
+      const fixture = createComponent();
+      const cardViews = fixture.debugElement.queryAll(By.css('card-view'));
+      const cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
+
+      cardViews[1].componentInstance.fullHeightChanged.emit(true);
+      fixture.detectChanges();
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+
+      cardViews[0].componentInstance.fullHeightChanged.emit(false);
+      fixture.detectChanges();
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+
+      cardViews[1].componentInstance.fullHeightChanged.emit(true);
+      fixture.detectChanges();
+      expect(cardSpaces[0].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+      expect(cardSpaces[1].nativeElement.classList).toContain('full-height');
+      expect(cardSpaces[2].nativeElement.classList).not.toContain(
+        'full-height'
+      );
+    });
+
+    it('renders card width based on card state full size', () => {
+      store.overrideSelector(getCardStateMap, {card2: {fullSize: true}});
       let fixture = createComponent();
       let cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
       expect(cardSpaces[0].nativeElement.classList).not.toContain(
@@ -290,8 +372,8 @@ describe('card grid', () => {
       );
 
       store.overrideSelector(getCardStateMap, {
-        card1: {tableExpanded: true},
-        card2: {tableExpanded: true},
+        card1: {fullSize: true},
+        card2: {fullSize: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -302,8 +384,8 @@ describe('card grid', () => {
       );
 
       store.overrideSelector(getCardStateMap, {
-        card1: {tableExpanded: false},
-        card2: {tableExpanded: true},
+        card1: {fullSize: false},
+        card2: {fullSize: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -329,8 +411,8 @@ describe('card grid', () => {
       );
     });
 
-    it('renders card width based on getCardStateMap', () => {
-      store.overrideSelector(getCardStateMap, {card3: {tableExpanded: true}});
+    it('renders card width based on card state full size', () => {
+      store.overrideSelector(getCardStateMap, {card3: {fullSize: true}});
       let fixture = createComponent();
       let cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
       expect(cardSpaces[0].nativeElement.classList).not.toContain('full-width');
@@ -338,8 +420,8 @@ describe('card grid', () => {
       expect(cardSpaces[2].nativeElement.classList).toContain('full-width');
 
       store.overrideSelector(getCardStateMap, {
-        card2: {tableExpanded: true},
-        card3: {tableExpanded: true},
+        card2: {fullSize: true},
+        card3: {fullSize: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -348,8 +430,8 @@ describe('card grid', () => {
       expect(cardSpaces[2].nativeElement.classList).toContain('full-width');
 
       store.overrideSelector(getCardStateMap, {
-        card2: {tableExpanded: false},
-        card3: {tableExpanded: true},
+        card2: {fullSize: false},
+        card3: {fullSize: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -359,8 +359,8 @@ describe('card grid', () => {
       );
     });
 
-    it('renders card width based on card state full size', () => {
-      store.overrideSelector(getCardStateMap, {card2: {fullWidth: true}});
+    it('renders card width based on card state table expanded', () => {
+      store.overrideSelector(getCardStateMap, {card2: {tableExpanded: true}});
       let fixture = createComponent();
       let cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
       expect(cardSpaces[0].nativeElement.classList).not.toContain(
@@ -372,8 +372,8 @@ describe('card grid', () => {
       );
 
       store.overrideSelector(getCardStateMap, {
-        card1: {fullWidth: true},
-        card2: {fullWidth: true},
+        card1: {tableExpanded: true},
+        card2: {tableExpanded: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -384,8 +384,8 @@ describe('card grid', () => {
       );
 
       store.overrideSelector(getCardStateMap, {
-        card1: {fullWidth: false},
-        card2: {fullWidth: true},
+        card1: {tableExpanded: false},
+        card2: {tableExpanded: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -411,7 +411,7 @@ describe('card grid', () => {
       );
     });
 
-    it('renders card width based on card state full size', () => {
+    it('renders card width based on card state full width', () => {
       store.overrideSelector(getCardStateMap, {card3: {fullWidth: true}});
       let fixture = createComponent();
       let cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -360,7 +360,7 @@ describe('card grid', () => {
     });
 
     it('renders card width based on card state full size', () => {
-      store.overrideSelector(getCardStateMap, {card2: {fullSize: true}});
+      store.overrideSelector(getCardStateMap, {card2: {fullWidth: true}});
       let fixture = createComponent();
       let cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
       expect(cardSpaces[0].nativeElement.classList).not.toContain(
@@ -372,8 +372,8 @@ describe('card grid', () => {
       );
 
       store.overrideSelector(getCardStateMap, {
-        card1: {fullSize: true},
-        card2: {fullSize: true},
+        card1: {fullWidth: true},
+        card2: {fullWidth: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -384,8 +384,8 @@ describe('card grid', () => {
       );
 
       store.overrideSelector(getCardStateMap, {
-        card1: {fullSize: false},
-        card2: {fullSize: true},
+        card1: {fullWidth: false},
+        card2: {fullWidth: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -412,7 +412,7 @@ describe('card grid', () => {
     });
 
     it('renders card width based on card state full size', () => {
-      store.overrideSelector(getCardStateMap, {card3: {fullSize: true}});
+      store.overrideSelector(getCardStateMap, {card3: {fullWidth: true}});
       let fixture = createComponent();
       let cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
       expect(cardSpaces[0].nativeElement.classList).not.toContain('full-width');
@@ -420,8 +420,8 @@ describe('card grid', () => {
       expect(cardSpaces[2].nativeElement.classList).toContain('full-width');
 
       store.overrideSelector(getCardStateMap, {
-        card2: {fullSize: true},
-        card3: {fullSize: true},
+        card2: {fullWidth: true},
+        card3: {fullWidth: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
@@ -430,8 +430,8 @@ describe('card grid', () => {
       expect(cardSpaces[2].nativeElement.classList).toContain('full-width');
 
       store.overrideSelector(getCardStateMap, {
-        card2: {fullSize: false},
-        card3: {fullSize: true},
+        card2: {fullWidth: false},
+        card3: {fullWidth: true},
       });
       fixture = createComponent();
       cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -232,30 +232,6 @@ describe('card grid', () => {
 
   describe('card dimensions', () => {
     let fixture: ComponentFixture<TestableScrollingContainer>;
-    beforeEach(() => {
-      // fixture = TestBed.createComponent(TestableScrollingContainer);
-      // fixture.componentInstance.cardIdsWithMetadata = [
-      //   {
-      //     cardId: 'card1',
-      //     plugin: PluginType.SCALARS,
-      //     tag: 'tagA',
-      //     runId: null,
-      //   },
-      //   {
-      //     cardId: 'card2',
-      //     plugin: PluginType.SCALARS,
-      //     tag: 'tagA',
-      //     runId: null,
-      //   },
-      //   {
-      //     cardId: 'card3',
-      //     plugin: PluginType.SCALARS,
-      //     tag: 'tagA',
-      //     runId: null,
-      //   },
-      // ];
-      // fixture.detectChanges();
-    });
 
     function createComponent() {
       fixture = TestBed.createComponent(TestableScrollingContainer);
@@ -285,6 +261,7 @@ describe('card grid', () => {
     }
 
     it('shows cards at min dimensions by default', () => {
+      const fixture = createComponent();
       const cardSpaces = fixture.debugElement.queryAll(By.css('.card-space'));
       expect(cardSpaces[0].nativeElement.classList).not.toContain(
         'full-height'

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -12,38 +12,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import { ScrollingModule } from '@angular/cdk/scrolling';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 import {
   Component,
   EventEmitter,
   Input,
   NO_ERRORS_SCHEMA,
-  Output
+  Output,
 } from '@angular/core';
 import {
   ComponentFixture,
   discardPeriodicTasks,
   fakeAsync,
   TestBed,
-  tick
+  tick,
 } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Store } from '@ngrx/store';
-import { MockStore } from '@ngrx/store/testing';
-import { State } from '../../../app_state';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Store} from '@ngrx/store';
+import {MockStore} from '@ngrx/store/testing';
+import {State} from '../../../app_state';
 import * as selectors from '../../../selectors';
 import {
   getCardStateMap,
   getMetricsCardMinWidth,
-  getMetricsTagGroupExpansionState
+  getMetricsTagGroupExpansionState,
 } from '../../../selectors';
-import { selectors as settingsSelectors } from '../../../settings';
-import { provideMockTbStore } from '../../../testing/utils';
-import { PluginType } from '../../data_source';
-import { CardIdWithMetadata } from '../metrics_view_types';
-import { CardGridComponent } from './card_grid_component';
-import { CardGridContainer } from './card_grid_container';
+import {selectors as settingsSelectors} from '../../../settings';
+import {provideMockTbStore} from '../../../testing/utils';
+import {PluginType} from '../../data_source';
+import {CardIdWithMetadata} from '../metrics_view_types';
+import {CardGridComponent} from './card_grid_component';
+import {CardGridContainer} from './card_grid_container';
 
 const scrollElementHeight = 100;
 


### PR DESCRIPTION
* Motivation for features / changes
To be able to remember the fullsize mode settings, we need to have it in state and also take the value from
state as the source of truth for fullsize mode.

