### PR TITLE
DEV: allow to set `rustboard` file read buffer size via ENV var

### DIFF
--- a/tensorboard/data/server/cli/dynamic_logdir.rs
+++ b/tensorboard/data/server/cli/dynamic_logdir.rs
@@ -17,6 +17,7 @@ limitations under the License.
 
 use log::error;
 use std::collections::HashMap;
+use std::env;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
@@ -93,6 +94,13 @@ impl DynLogdir {
     /// This constructor is heavyweight; it may construct an HTTP client and read a GCS credentials
     /// file from disk.
     ///
+    /// In the path represents a GCS logdir, the created `gcs::Logdir` will attempt to fetch the
+    /// `"TB_GCS_BUFFER_SIZE_KB"` environment variable that represent the read buffer size (in Kb)
+    /// for each TF events file.
+    /// Note: if reading a large number of TF events files, use the `"TB_GCS_BUFFER_SIZE_KB"`
+    /// environment variable to prevent running out of memory by controlling the total size of the
+    /// allocated memory.
+    ///
     /// # Panics
     ///
     /// May panic in debug mode if called from a thread with an active Tokio runtime; see
@@ -104,7 +112,13 @@ impl DynLogdir {
             ParsedLogdir::Disk(path) => Ok(DynLogdir::Disk(DiskLogdir::new(path))),
             ParsedLogdir::Gcs { bucket, prefix } => {
                 let client = gcs::Client::new()?;
-                let logdir = gcs::Logdir::new(client, bucket, prefix);
+                let buffer_capacity = env::var("TB_GCS_BUFFER_SIZE_KB")
+                    .ok()
+                    .map(|n| n.parse::<usize>().ok())
+                    .unwrap_or(None)
+                    .map(|n| n * 1024); // convert Kb to bytes
+
+                let logdir = gcs::Logdir::new(client, bucket, prefix, buffer_capacity);
                 Ok(DynLogdir::Gcs(logdir))
             }
         }

--- a/tensorboard/data/server/cli/dynamic_logdir.rs
+++ b/tensorboard/data/server/cli/dynamic_logdir.rs
@@ -116,7 +116,7 @@ impl DynLogdir {
                     .ok()
                     .map(|n| n.parse::<usize>().ok())
                     .unwrap_or(None)
-                    .map(|n| n * 1024); // convert Kb to bytes
+                    .map(|n| n * 1024); // convert the Kb buffer size to bytes
 
                 let logdir = gcs::Logdir::new(client, bucket, prefix, buffer_capacity);
                 Ok(DynLogdir::Gcs(logdir))

--- a/tensorboard/data/server/gcs/logdir.rs
+++ b/tensorboard/data/server/gcs/logdir.rs
@@ -86,7 +86,7 @@ pub struct Logdir {
     /// Note: if reading a large number of TF events files, set an appropriate value for
     /// `buffer_capacity` to prevent running out of memory. This determines the total size of the
     /// allocated memory.
-    /// The default value is defined by the `DEFAULT_BUFFER_CAPACITY` constant.
+    /// The default value is defined by the `DEFAULT_BUFFER_CAPACITY_KB` constant.
     buffer_capacity: usize,
 }
 

--- a/tensorboard/data/server/gcs/logdir.rs
+++ b/tensorboard/data/server/gcs/logdir.rs
@@ -84,8 +84,9 @@ pub struct Logdir {
     buffer_capacity: usize,
 }
 
+/// Default size of the GSC file read buffer.
 /// Read large chunks from GCS to reduce network roundtrips.
-const BUFFER_CAPACITY: usize = 1024 * 1024 * 16;
+const DEFAULT_BUFFER_CAPACITY: usize = 1024 * 1024 * 16;
 
 impl Logdir {
     pub fn new(
@@ -97,7 +98,7 @@ impl Logdir {
         if !prefix.is_empty() && !prefix.ends_with('/') {
             prefix.push('/');
         }
-        let buffer = buffer_capacity.unwrap_or(BUFFER_CAPACITY);
+        let buffer = buffer_capacity.unwrap_or(DEFAULT_BUFFER_CAPACITY);
         Self {
             gcs,
             bucket,

--- a/tensorboard/data/server/gcs/logdir.rs
+++ b/tensorboard/data/server/gcs/logdir.rs
@@ -18,6 +18,7 @@ limitations under the License.
 use log::warn;
 use reqwest::StatusCode;
 use std::collections::HashMap;
+use std::env;
 use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 
@@ -79,31 +80,41 @@ pub struct Logdir {
     /// Invariant: `prefix` either is empty or ends with `/`, and thus an event file name should be
     /// joined onto `prefix` to form its full object name.
     prefix: String,
-    /// Size of the opened file read buffer (in bytes) when reading from GCS.
-    /// The default value is defined by the `BUFFER_CAPACITY` constant.
+    /// Size of the opened file read buffer (in Kb) when reading from GCS.
+    /// The `gcs::Logdir::new` will attempt to fetch the `TB_GCS_BUFFER_SIZE_KB` environment
+    /// variable that represent the read buffer size (in Kb) for each TF events file.
+    /// Note: if reading a large number of TF events files, use the `TB_GCS_BUFFER_SIZE_KB`
+    /// environment variable to prevent running out of memory by controlling the total size of the
+    /// allocated memory.
+    /// The default value is defined by the `DEFAULT_BUFFER_CAPACITY` constant.
     buffer_capacity: usize,
 }
 
-/// Default size of the GSC file read buffer.
+/// Default size of the GCS file read buffer (in Kb).
 /// Read large chunks from GCS to reduce network roundtrips.
-const DEFAULT_BUFFER_CAPACITY: usize = 1024 * 1024 * 16;
+const DEFAULT_BUFFER_CAPACITY_KB: usize = 1024 * 16;
 
 impl Logdir {
-    pub fn new(
-        gcs: Client,
-        bucket: String,
-        mut prefix: String,
-        buffer_capacity: Option<usize>,
-    ) -> Self {
+    pub fn new(gcs: Client, bucket: String, mut prefix: String) -> Self {
         if !prefix.is_empty() && !prefix.ends_with('/') {
             prefix.push('/');
         }
-        let buffer = buffer_capacity.unwrap_or(DEFAULT_BUFFER_CAPACITY);
+        // convert the Kb buffer size to bytes
+        let buffer_capacity = match env::var("TB_GCS_BUFFER_SIZE_KB") {
+            Ok(val) => {
+                val.parse::<usize>()
+                    .ok()
+                    .unwrap_or(DEFAULT_BUFFER_CAPACITY_KB)
+                    * 1024
+            }
+            Err(_) => DEFAULT_BUFFER_CAPACITY_KB * 1024,
+        };
+
         Self {
             gcs,
             bucket,
             prefix,
-            buffer_capacity: buffer,
+            buffer_capacity,
         }
     }
 }

--- a/tensorboard/data/server/gcs/logdir.rs
+++ b/tensorboard/data/server/gcs/logdir.rs
@@ -83,8 +83,8 @@ pub struct Logdir {
     /// Size of the opened file read buffer (in Kb) when reading from GCS.
     /// The `gcs::Logdir::new` will attempt to fetch the `TB_GCS_BUFFER_SIZE_KB` environment
     /// variable that represent the read buffer size (in Kb) for each TF events file.
-    /// Note: if reading a large number of TF events files, use the `TB_GCS_BUFFER_SIZE_KB`
-    /// environment variable to prevent running out of memory by controlling the total size of the
+    /// Note: if reading a large number of TF events files, set an appropriate value for
+    /// `buffer_capacity` to prevent running out of memory. This determines the total size of the
     /// allocated memory.
     /// The default value is defined by the `DEFAULT_BUFFER_CAPACITY` constant.
     buffer_capacity: usize,


### PR DESCRIPTION
* Motivation for features / changes #6248 

* Technical description of changes

As discussed in the original issue, running `rustboard` on a large number of tf event files can result in a OOM because of a larged, fixed size read buffer for each file.

Allow to configure the buffer size via the `TB_GCS_BUFFER_SIZE_KB` environment variable (buffer size in Kb).

* Detailed steps to verify changes work correctly (as executed by you)

```sh
> cargo build
> RUST_LOG=debug TB_GCS_BUFFER_SIZE_KB=1024 cargo run -- --logdir=gs://PATH/TO/MANY/FILE --reload-once
```

* Alternate designs / implementations considered

Could have been a CLI flag, see https://github.com/tensorflow/tensorboard/issues/6248#issuecomment-1476593312
