### PR TITLE
Column Customization: New affordances

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -51,7 +51,7 @@ export const metricsSlideoutMenuToggled = createAction(
   '[Metrics] Slide out settings menu toggled'
 );
 
-export const metricsSlideoutMenuRequested = createAction(
+export const metricsSlideoutMenuOpened = createAction(
   '[Metrics] User requested to open the slide out menu'
 );
 

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -51,6 +51,14 @@ export const metricsSlideoutMenuToggled = createAction(
   '[Metrics] Slide out settings menu toggled'
 );
 
+export const metricsSlideoutMenuRequested = createAction(
+  '[Metrics] Slide out settings menu requested'
+);
+
+export const metricsSlideoutMenuClosed = createAction(
+  '[Metrics] Slide out settings menu closed'
+);
+
 export const metricsTagMetadataRequested = createAction(
   '[Metrics] Metrics Tag Metadata Requested'
 );

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -52,7 +52,7 @@ export const metricsSlideoutMenuToggled = createAction(
 );
 
 export const metricsSlideoutMenuRequested = createAction(
-  '[Metrics] Slide out settings menu requested'
+  '[Metrics] User requested to open the slide out menu'
 );
 
 export const metricsSlideoutMenuClosed = createAction(

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1348,7 +1348,11 @@ const reducer = createReducer(
   on(actions.metricsSlideoutMenuToggled, (state) => {
     return {...state, isSlideoutMenuOpen: !state.isSlideoutMenuOpen};
   }),
-  on(actions.metricsSlideoutMenuRequested, (state) => {
+  on(actions.metricsSlideoutMenuOpened, (state) => {
+    // The reason the toggle action does not open the settings pane is because
+    // the settings pane is the only place the menu can be toggled. The open
+    // request can be made from the card when the settings menu is closed,
+    // therefore we need to make sure the settings menu is opened, too.
     return {...state, isSlideoutMenuOpen: true, isSettingsPaneOpen: true};
   }),
   on(actions.metricsSlideoutMenuClosed, (state) => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1347,6 +1347,12 @@ const reducer = createReducer(
   }),
   on(actions.metricsSlideoutMenuToggled, (state) => {
     return {...state, isSlideoutMenuOpen: !state.isSlideoutMenuOpen};
+  }),
+  on(actions.metricsSlideoutMenuRequested, (state) => {
+    return {...state, isSlideoutMenuOpen: true, isSettingsPaneOpen: true};
+  }),
+  on(actions.metricsSlideoutMenuClosed, (state) => {
+    return {...state, isSlideoutMenuOpen: false};
   })
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3802,4 +3802,55 @@ describe('metrics reducers', () => {
       expect(state3.isSettingsPaneOpen).toBe(false);
     });
   });
+
+  describe('Metrics Slideout Menu', () => {
+    describe('#metricsSlideoutMenuToggled', () => {
+      it('toggles the isSlideoutMenuOpen state', () => {
+        const state1 = buildMetricsState({
+          isSlideoutMenuOpen: false,
+        });
+
+        const state2 = reducers(state1, actions.metricsSlideoutMenuToggled());
+        expect(state2.isSlideoutMenuOpen).toBe(true);
+
+        const state3 = reducers(state2, actions.metricsSlideoutMenuToggled());
+        expect(state3.isSlideoutMenuOpen).toBe(false);
+      });
+    });
+
+    describe('#metricsSlideoutMenuRequested', () => {
+      it('sets the isSlideoutMenuOpen and isSettingsPaneOpen to true', () => {
+        const state1 = buildMetricsState({
+          isSlideoutMenuOpen: false,
+          isSettingsPaneOpen: false,
+        });
+
+        const state2 = reducers(state1, actions.metricsSlideoutMenuRequested());
+        expect(state2.isSlideoutMenuOpen).toBe(true);
+        expect(state2.isSettingsPaneOpen).toBe(true);
+      });
+
+      it('leaves isSettingsPaneOpen as true when it is already set', () => {
+        const state1 = buildMetricsState({
+          isSlideoutMenuOpen: false,
+          isSettingsPaneOpen: true,
+        });
+
+        const state2 = reducers(state1, actions.metricsSlideoutMenuRequested());
+        expect(state2.isSlideoutMenuOpen).toBe(true);
+        expect(state2.isSettingsPaneOpen).toBe(true);
+      });
+    });
+
+    describe('#metricsSlideoutMenuClosed', () => {
+      it('sets the isSlideoutMenuOpen to false', () => {
+        const state1 = buildMetricsState({
+          isSlideoutMenuOpen: true,
+        });
+
+        const state2 = reducers(state1, actions.metricsSlideoutMenuClosed());
+        expect(state2.isSlideoutMenuOpen).toBe(false);
+      });
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3818,18 +3818,18 @@ describe('metrics reducers', () => {
       });
     });
 
-    describe('#metricsSlideoutMenuRequested', () => {
+    describe('#metricsSlideoutMenuOpened', () => {
       it('sets the isSlideoutMenuOpen and isSettingsPaneOpen to true', () => {
         const state1 = buildMetricsState({
           isSlideoutMenuOpen: false,
           isSettingsPaneOpen: false,
         });
 
-        const state2 = reducers(state1, actions.metricsSlideoutMenuRequested());
+        const state2 = reducers(state1, actions.metricsSlideoutMenuOpened());
         expect(state2.isSlideoutMenuOpen).toBe(true);
         expect(state2.isSettingsPaneOpen).toBe(true);
 
-        const state3 = reducers(state1, actions.metricsSlideoutMenuRequested());
+        const state3 = reducers(state1, actions.metricsSlideoutMenuOpened());
         expect(state3.isSlideoutMenuOpen).toBe(true);
         expect(state3.isSettingsPaneOpen).toBe(true);
       });
@@ -3840,7 +3840,7 @@ describe('metrics reducers', () => {
           isSettingsPaneOpen: true,
         });
 
-        const state2 = reducers(state1, actions.metricsSlideoutMenuRequested());
+        const state2 = reducers(state1, actions.metricsSlideoutMenuOpened());
         expect(state2.isSlideoutMenuOpen).toBe(true);
         expect(state2.isSettingsPaneOpen).toBe(true);
       });

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3828,6 +3828,10 @@ describe('metrics reducers', () => {
         const state2 = reducers(state1, actions.metricsSlideoutMenuRequested());
         expect(state2.isSlideoutMenuOpen).toBe(true);
         expect(state2.isSettingsPaneOpen).toBe(true);
+
+        const state3 = reducers(state1, actions.metricsSlideoutMenuRequested());
+        expect(state3.isSlideoutMenuOpen).toBe(true);
+        expect(state3.isSettingsPaneOpen).toBe(true);
       });
 
       it('leaves isSettingsPaneOpen as true when it is already set', () => {
@@ -3850,6 +3854,9 @@ describe('metrics reducers', () => {
 
         const state2 = reducers(state1, actions.metricsSlideoutMenuClosed());
         expect(state2.isSlideoutMenuOpen).toBe(false);
+
+        const state3 = reducers(state1, actions.metricsSlideoutMenuClosed());
+        expect(state3.isSlideoutMenuOpen).toBe(false);
       });
     });
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -93,6 +93,15 @@ limitations under the License.
           <mat-icon svgIcon="get_app_24px"></mat-icon>
           <span>Download data</span>
         </button>
+        <button
+          *ngIf="columnCustomizationEnabled"
+          mat-menu-item
+          (click)="openSlideoutColumnEditMenu.emit()"
+          aria-label="Open menu to edit data table columns"
+        >
+          <mat-icon svgIcon="edit_24px"></mat-icon>
+          <span>Edit Table Columns</span>
+        </button>
       </mat-menu>
     </span>
   </div>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -109,6 +109,7 @@ export class ScalarCardComponent<Downloader> {
     new EventEmitter<TimeSelectionToggleAffordance>();
   @Output() onDataTableSorting = new EventEmitter<SortingInfo>();
   @Output() reorderColumnHeaders = new EventEmitter<ColumnHeader[]>();
+  @Output() openSlideoutColumnEditMenu = new EventEmitter<void>();
 
   @Output() onLineChartZoom = new EventEmitter<Extent>();
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -80,7 +80,7 @@ import {
   sortingDataTable,
   stepSelectorToggled,
   timeSelectionChanged,
-  metricsSlideoutMenuRequested,
+  metricsSlideoutMenuOpened,
 } from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
@@ -836,6 +836,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   }
 
   openSlideoutColumnEditMenu() {
-    this.store.dispatch(metricsSlideoutMenuRequested());
+    this.store.dispatch(metricsSlideoutMenuOpened());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -80,6 +80,7 @@ import {
   sortingDataTable,
   stepSelectorToggled,
   timeSelectionChanged,
+  metricsSlideoutMenuRequested,
 } from '../../actions';
 import {PluginType, ScalarStepDatum} from '../../data_source';
 import {
@@ -191,6 +192,7 @@ function isMinMaxStepValid(minMax: MinMaxStep | undefined): boolean {
       (onLineChartZoom)="onLineChartZoom($event)"
       (reorderColumnHeaders)="reorderColumnHeaders($event)"
       (onCardStateChanged)="onCardStateChanged($event)"
+      (openSlideoutColumnEditMenu)="openSlideoutColumnEditMenu()"
     ></scalar-card-component>
   `,
   styles: [
@@ -831,5 +833,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   reorderColumnHeaders(headers: ColumnHeader[]) {
     this.store.dispatch(dataTableColumnDrag({newOrder: headers}));
+  }
+
+  openSlideoutColumnEditMenu() {
+    this.store.dispatch(metricsSlideoutMenuRequested());
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -80,7 +80,7 @@ import {
   metricsCardFullSizeToggled,
   stepSelectorToggled,
   timeSelectionChanged,
-  metricsSlideoutMenuRequested,
+  metricsSlideoutMenuOpened,
 } from '../../actions';
 import {PluginType} from '../../data_source';
 import {
@@ -841,7 +841,7 @@ describe('scalar card', () => {
       flush();
     }));
 
-    it('dispatches metricsSlideoutMenuRequested when edit columns button is clicked', fakeAsync(() => {
+    it('dispatches metricsSlideoutMenuOpened when edit columns button is clicked', fakeAsync(() => {
       store.overrideSelector(
         selectors.getIsScalarColumnCustomizationEnabled,
         true
@@ -852,7 +852,7 @@ describe('scalar card', () => {
       getMenuButton('Open menu to edit data table columns').click();
       fixture.detectChanges();
 
-      expect(dispatchedActions[0]).toEqual(metricsSlideoutMenuRequested());
+      expect(dispatchedActions[0]).toEqual(metricsSlideoutMenuOpened());
       flush();
     }));
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -80,6 +80,7 @@ import {
   metricsCardFullSizeToggled,
   stepSelectorToggled,
   timeSelectionChanged,
+  metricsSlideoutMenuRequested,
 } from '../../actions';
 import {PluginType} from '../../data_source';
 import {
@@ -837,6 +838,21 @@ describe('scalar card', () => {
       expect(lineChartEl.componentInstance.yScaleType).toBe(ScaleType.LINEAR);
 
       // Clicking on overflow menu and mat button enqueue asyncs. Flush them.
+      flush();
+    }));
+
+    it('dispatches metricsSlideoutMenuRequested when edit columns button is clicked', fakeAsync(() => {
+      store.overrideSelector(
+        selectors.getIsScalarColumnCustomizationEnabled,
+        true
+      );
+      const fixture = createComponent('card1');
+
+      openOverflowMenu(fixture);
+      getMenuButton('Open menu to edit data table columns').click();
+      fixture.detectChanges();
+
+      expect(dispatchedActions[0]).toEqual(metricsSlideoutMenuRequested());
       flush();
     }));
   });

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -168,7 +168,8 @@ limitations under the License.
 
 .slide-out-menu {
   background-color: mat.get-color-from-palette($tb-background, background);
-  height: 100%;
+  // Make the menu the full height minus the size of the toolbar.
+  height: calc(100% - 49px);
   position: absolute;
   right: 50px;
   top: 49px;

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -33,6 +33,7 @@ limitations under the License.
   </div>
   <div class="footer">
     <button
+      mat-button
       class="close-button"
       (click)="onScalarTableColumnEditorClosed.emit()"
       i18n-aria-label="Label on a button to close the column editor."

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -14,34 +14,32 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div>
-  <div class="editor-controls">
-    <mat-tab-group class="tab-group">
-      <mat-tab [label]="'Single'">
-        <ngContext
-          [ngTemplateOutlet]="headerList"
-          [ngTemplateOutletContext]="{headers: singleHeaders, dataTableMode:DataTableMode.SINGLE}"
-        ></ngContext>
-      </mat-tab>
-      <mat-tab [label]="'Range'">
-        <ngContext
-          [ngTemplateOutlet]="headerList"
-          [ngTemplateOutletContext]="{headers: rangeHeaders, dataTableMode:DataTableMode.RANGE}"
-        ></ngContext>
-      </mat-tab>
-    </mat-tab-group>
-  </div>
-  <div class="footer">
-    <button
-      mat-button
-      class="close-button"
-      (click)="onScalarTableColumnEditorClosed.emit()"
-      i18n-aria-label="Label on a button to close the column editor."
-      aria-label="Close column editor"
-    >
-      Close
-    </button>
-  </div>
+<div class="editor-controls">
+  <mat-tab-group class="tab-group">
+    <mat-tab [label]="'Single'">
+      <ngContext
+        [ngTemplateOutlet]="headerList"
+        [ngTemplateOutletContext]="{headers: singleHeaders, dataTableMode:DataTableMode.SINGLE}"
+      ></ngContext>
+    </mat-tab>
+    <mat-tab [label]="'Range'">
+      <ngContext
+        [ngTemplateOutlet]="headerList"
+        [ngTemplateOutletContext]="{headers: rangeHeaders, dataTableMode:DataTableMode.RANGE}"
+      ></ngContext>
+    </mat-tab>
+  </mat-tab-group>
+</div>
+<div class="footer">
+  <button
+    mat-button
+    class="close-button"
+    (click)="onScalarTableColumnEditorClosed.emit()"
+    i18n-aria-label="Label on a button to close the column editor."
+    aria-label="Close column editor"
+  >
+    Close
+  </button>
 </div>
 
 <ng-template

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -15,28 +15,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div>
-  <mat-tab-group class="tab-group">
-    <mat-tab [label]="'Single'">
-      <ngContext
-        [ngTemplateOutlet]="headerList"
-        [ngTemplateOutletContext]="{headers: singleHeaders, dataTableMode:DataTableMode.SINGLE}"
-      ></ngContext>
-    </mat-tab>
-    <mat-tab [label]="'Range'">
-      <ngContext
-        [ngTemplateOutlet]="headerList"
-        [ngTemplateOutletContext]="{headers: rangeHeaders, dataTableMode:DataTableMode.RANGE}"
-      ></ngContext>
-    </mat-tab>
-  </mat-tab-group>
-  <button
-    class="close-button"
-    (click)="onScalarTableColumnEditorClosed.emit()"
-    i18n-aria-label="Label on a button to close the column editor."
-    aria-label="Close column editor"
-  >
-    <mat-icon svgIcon="close_24px"></mat-icon>
-  </button>
+  <div class="editor-controls">
+    <mat-tab-group class="tab-group">
+      <mat-tab [label]="'Single'">
+        <ngContext
+          [ngTemplateOutlet]="headerList"
+          [ngTemplateOutletContext]="{headers: singleHeaders, dataTableMode:DataTableMode.SINGLE}"
+        ></ngContext>
+      </mat-tab>
+      <mat-tab [label]="'Range'">
+        <ngContext
+          [ngTemplateOutlet]="headerList"
+          [ngTemplateOutletContext]="{headers: rangeHeaders, dataTableMode:DataTableMode.RANGE}"
+        ></ngContext>
+      </mat-tab>
+    </mat-tab-group>
+  </div>
+  <div class="footer">
+    <button
+      class="close-button"
+      (click)="onScalarTableColumnEditorClosed.emit()"
+      i18n-aria-label="Label on a button to close the column editor."
+      aria-label="Close column editor"
+    >
+      Close
+    </button>
+  </div>
 </div>
 
 <ng-template

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -29,6 +29,14 @@ limitations under the License.
       ></ngContext>
     </mat-tab>
   </mat-tab-group>
+  <button
+    class="close-button"
+    (click)="onScalarTableColumnEditorClosed.emit()"
+    i18n-aria-label="Label on a button to close the column editor."
+    aria-label="Close column editor"
+  >
+    <mat-icon svgIcon="close_24px"></mat-icon>
+  </button>
 </div>
 
 <ng-template

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -23,15 +23,14 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 }
 .editor-controls {
   // controls should fill the full height except for the height of the footer.
-  height: calc(100% - 40px);
+  height: calc(100% - 45px);
 }
 .tab-group {
   // Override static position so this object is not seen in front of the
   // settings panel.
   position: relative;
   z-index: 0;
-  height: -webkit-fill-available;
-  height: -moz-available;
+  height: 100%;
 }
 .header-list {
   margin-top: 5%;
@@ -56,6 +55,11 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 
 .footer {
   display: flex;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  box-sizing: border-box;
+  width: 100%;
   align-items: center;
   justify-content: flex-end;
   padding: 4px;
@@ -69,9 +73,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 .close-button {
   color: mat.get-color-from-palette($tb-foreground, secondary-text);
   width: 84px;
-  & ::ng-deep .mat-button-focus-overlay {
-    display: none;
-  }
+
   @include tb-dark-theme {
     color: mat.get-color-from-palette($tb-dark-foreground, secondary-text);
   }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -22,9 +22,8 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   padding: 0 30px;
 }
 .editor-controls {
-  // 158px is the height of the Tensorboard header(64px), the tags filter
-  // box(49px), and the ScalarColumnEditor's footer(40px) combined.
-  height: calc(100vh - 153px);
+  // controls should fill the full height except for the height of the footer.
+  height: calc(100% - 40px);
 }
 .tab-group {
   // Override static position so this object is not seen in front of the
@@ -33,8 +32,6 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   z-index: 0;
   height: -webkit-fill-available;
   height: -moz-available;
-  height: fill-available;
-  min-width: none;
 }
 .header-list {
   margin-top: 5%;
@@ -61,8 +58,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  width: 100%;
-  height: 39px;
+  padding: 4px;
   border-top: 1px solid mat.get-color-from-palette($tb-foreground, border);
 
   @include tb-dark-theme {
@@ -72,7 +68,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 
 .close-button {
   color: mat.get-color-from-palette($tb-foreground, secondary-text);
-  width: calc(50% - 10px);
+  width: 84px;
   & ::ng-deep .mat-button-focus-overlay {
     display: none;
   }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -19,12 +19,22 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 
 :host ::ng-deep .mat-tab-label {
   min-width: 0;
+  padding: 0 30px;
+}
+.editor-controls {
+  // 148px is the height of the Tensorboard header(64px), the tags filter
+  // box(49px), and the ScalarColumnEditor's footer(35px) combined.
+  height: calc(100vh - 148px);
 }
 .tab-group {
   // Override static position so this object is not seen in front of the
   // settings panel.
   position: relative;
   z-index: 0;
+  height: -webkit-fill-available;
+  height: -moz-available;
+  height: fill-available;
+  min-width: none;
 }
 .header-list {
   margin-top: 5%;
@@ -47,15 +57,27 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   border-top: 2px solid mat.get-color-from-palette($_accent);
 }
 
-button {
-  display: grid;
-  cursor: pointer;
-  width: 25px;
-  justify-content: center;
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin: 8px;
-  background-color: inherit;
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  height: 34px;
+  border-top: 1px solid mat.get-color-from-palette(mat.$gray-palette, 300);
+}
+
+.close-button {
   border: unset;
+  border-radius: 4px;
+  color: mat.get-color-from-palette($tb-foreground, secondary-text);
+  font: inherit;
+  height: 20px;
+  margin-right: 5px;
+  text-align: center;
+  width: calc(50% - 10px);
+  @include tb-dark-theme {
+    color: mat.get-color-from-palette($tb-dark-foreground, secondary-text);
+  }
+
+  @include tb-theme-background-prop(background-color, selected-button);
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -22,9 +22,9 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   padding: 0 30px;
 }
 .editor-controls {
-  // 148px is the height of the Tensorboard header(64px), the tags filter
-  // box(49px), and the ScalarColumnEditor's footer(35px) combined.
-  height: calc(100vh - 148px);
+  // 158px is the height of the Tensorboard header(64px), the tags filter
+  // box(49px), and the ScalarColumnEditor's footer(40px) combined.
+  height: calc(100vh - 153px);
 }
 .tab-group {
   // Override static position so this object is not seen in front of the
@@ -62,22 +62,14 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   align-items: center;
   justify-content: flex-end;
   width: 100%;
-  height: 34px;
+  height: 39px;
   border-top: 1px solid mat.get-color-from-palette(mat.$gray-palette, 300);
 }
 
 .close-button {
-  border: unset;
-  border-radius: 4px;
   color: mat.get-color-from-palette($tb-foreground, secondary-text);
-  font: inherit;
-  height: 20px;
-  margin-right: 5px;
-  text-align: center;
   width: calc(50% - 10px);
-  @include tb-dark-theme {
-    color: mat.get-color-from-palette($tb-dark-foreground, secondary-text);
+  & ::ng-deep .mat-button-focus-overlay {
+    display: none;
   }
-
-  @include tb-theme-background-prop(background-color, selected-button);
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -46,3 +46,16 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 .highlight-top {
   border-top: 2px solid mat.get-color-from-palette($_accent);
 }
+
+button {
+  display: grid;
+  cursor: pointer;
+  width: 25px;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 8px;
+  background-color: inherit;
+  border: unset;
+}

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.scss
@@ -63,7 +63,11 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   justify-content: flex-end;
   width: 100%;
   height: 39px;
-  border-top: 1px solid mat.get-color-from-palette(mat.$gray-palette, 300);
+  border-top: 1px solid mat.get-color-from-palette($tb-foreground, border);
+
+  @include tb-dark-theme {
+    border-color: mat.get-color-from-palette($tb-dark-foreground, border);
+  }
 }
 
 .close-button {
@@ -71,5 +75,8 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   width: calc(50% - 10px);
   & ::ng-deep .mat-button-focus-overlay {
     display: none;
+  }
+  @include tb-dark-theme {
+    color: mat.get-color-from-palette($tb-dark-foreground, secondary-text);
   }
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
@@ -79,6 +79,7 @@ export class ScalarColumnEditorComponent implements OnDestroy {
     dataTableMode: DataTableMode;
     headerType: ColumnHeaderType;
   }>();
+  @Output() onScalarTableColumnEditorClosed = new EventEmitter<void>();
 
   constructor(private readonly hostElement: ElementRef) {}
 

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -55,7 +55,6 @@ export class ScalarColumnEditorContainer {
   }
 
   onScalarTableColumnEditorClosed() {
-    console.log('dispatching metricsSlideoutMenuClosed');
     this.store.dispatch(metricsSlideoutMenuClosed());
   }
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -14,19 +14,17 @@ limitations under the License.
 ==============================================================================*/
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
-import {Observable} from 'rxjs';
 import {State} from '../../../../app_state';
-import {dataTableColumnEdited, dataTableColumnToggled} from '../../../actions';
+import {
+  dataTableColumnEdited,
+  dataTableColumnToggled,
+  metricsSlideoutMenuClosed,
+} from '../../../actions';
 import {
   getRangeSelectionHeaders,
   getSingleSelectionHeaders,
 } from '../../../store/metrics_selectors';
 import {HeaderEditInfo, HeaderToggleInfo} from '../../../types';
-import {
-  ColumnHeader,
-  ColumnHeaderType,
-  DataTableMode,
-} from '../../card_renderer/scalar_card_types';
 
 @Component({
   selector: 'metrics-scalar-column-editor',
@@ -36,6 +34,7 @@ import {
       [rangeHeaders]="rangeHeaders$ | async"
       (onScalarTableColumnToggled)="onScalarTableColumnToggled($event)"
       (onScalarTableColumnEdit)="onScalarTableColumnEdit($event)"
+      (onScalarTableColumnEditorClosed)="onScalarTableColumnEditorClosed()"
     >
     </metrics-scalar-column-editor-component>
   `,
@@ -53,5 +52,10 @@ export class ScalarColumnEditorContainer {
 
   onScalarTableColumnEdit(editInfo: HeaderEditInfo) {
     this.store.dispatch(dataTableColumnEdited(editInfo));
+  }
+
+  onScalarTableColumnEditorClosed() {
+    console.log('dispatching metricsSlideoutMenuClosed');
+    this.store.dispatch(metricsSlideoutMenuClosed());
   }
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_module.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_module.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatIconModule} from '@angular/material/icon';
 import {MatTabsModule} from '@angular/material/tabs';
 import {ScalarColumnEditorComponent} from './scalar_column_editor_component';
 import {ScalarColumnEditorContainer} from './scalar_column_editor_container';
@@ -28,6 +29,7 @@ import {DataTableHeaderModule} from '../../../../widgets/data_table/data_table_h
     DataTableHeaderModule,
     MatCheckboxModule,
     MatTabsModule,
+    MatIconModule,
   ],
 })
 export class ScalarColumnEditorModule {}

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_module.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_module.ts
@@ -17,6 +17,7 @@ import {NgModule} from '@angular/core';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatIconModule} from '@angular/material/icon';
 import {MatTabsModule} from '@angular/material/tabs';
+import {MatButtonModule} from '@angular/material/button';
 import {ScalarColumnEditorComponent} from './scalar_column_editor_component';
 import {ScalarColumnEditorContainer} from './scalar_column_editor_container';
 import {DataTableHeaderModule} from '../../../../widgets/data_table/data_table_header_module';
@@ -30,6 +31,7 @@ import {DataTableHeaderModule} from '../../../../widgets/data_table/data_table_h
     MatCheckboxModule,
     MatTabsModule,
     MatIconModule,
+    MatButtonModule,
   ],
 })
 export class ScalarColumnEditorModule {}

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -302,12 +302,15 @@ describe('scalar column editor', () => {
   });
 
   describe('closing', () => {
-    it('dispatches metricsSlideoutMenuClosed', () => {
-      const fixture = createComponent();
-      const dispatchedActions: Action[] = [];
+    let dispatchedActions: Action[] = [];
+    beforeEach(() => {
+      dispatchedActions = [];
       spyOn(store, 'dispatch').and.callFake((action: Action) => {
         dispatchedActions.push(action);
       });
+    });
+    it('dispatches metricsSlideoutMenuClosed', () => {
+      const fixture = createComponent();
 
       fixture.debugElement
         .query(By.css('.close-button'))

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -24,7 +24,11 @@ import {By} from '@angular/platform-browser';
 import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {State} from '../../../../app_state';
-import {dataTableColumnEdited, dataTableColumnToggled} from '../../../actions';
+import {
+  dataTableColumnEdited,
+  dataTableColumnToggled,
+  metricsSlideoutMenuClosed,
+} from '../../../actions';
 import {
   getRangeSelectionHeaders,
   getSingleSelectionHeaders,
@@ -295,5 +299,21 @@ describe('scalar column editor', () => {
       expect(headerListItems[0].classes['highlighted']).toBeTrue();
       expect(headerListItems[0].classes['highlight-top']).toBeTrue();
     }));
+  });
+
+  describe('closing', () => {
+    it('dispatches metricsSlideoutMenuClosed', () => {
+      const fixture = createComponent();
+      const dispatchedActions: Action[] = [];
+      spyOn(store, 'dispatch').and.callFake((action: Action) => {
+        dispatchedActions.push(action);
+      });
+
+      fixture.debugElement
+        .query(By.css('.close-button'))
+        .triggerEventHandler('click', {});
+
+      expect(dispatchedActions[0]).toEqual(metricsSlideoutMenuClosed());
+    });
   });
 });


### PR DESCRIPTION
* Motivation for features / changes
This PR adds a new affordance for opening the column editor directly from the card menu. It also adds a close button inside the editor.

* Screenshots of UI
<img width="239" alt="Screenshot 2023-03-24 at 3 28 25 PM" src="https://user-images.githubusercontent.com/8672809/227654782-22bcbe4e-402d-4ed1-96a1-41ad105138ec.png">
<img width="259" alt="Screenshot 2023-03-24 at 3 28 18 PM" src="https://user-images.githubusercontent.com/8672809/227654785-d9b9be95-295f-44a7-b32f-744ad03282a6.png">



<img width="683" alt="Screenshot 2023-03-21 at 11 52 01 AM" src="https://user-images.githubusercontent.com/8672809/226712053-e0b78c56-0d57-4945-a17c-4bd7a6f8447b.png">
I changes
