### PR TITLE
Linked Time: Use global range selection value when linked time is enabled

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -394,22 +394,6 @@ export const getMetricsRangeSelectionEnabled = createSelector(
   }
 );
 
-export const getMetricsCardRangeSelectionEnabled = createSelector(
-  getMetricsRangeSelectionEnabled,
-  getCardStateMap,
-  (
-    globalRangeSelectionEnabled: boolean,
-    cardStateMap: CardStateMap,
-    cardId: CardId
-  ) => {
-    const cardState = cardStateMap[cardId];
-    return getCardSelectionStateToBoolean(
-      cardState?.rangeSelectionOverride,
-      globalRangeSelectionEnabled
-    );
-  }
-);
-
 export const getMetricsStepMinMax = createSelector(
   selectMetricsState,
   (state: MetricsState): {min: number; max: number} => {
@@ -497,6 +481,28 @@ export const isMetricsSettingsPaneOpen = createSelector(
 export const isMetricsSlideoutMenuOpen = createSelector(
   selectMetricsState,
   (state): boolean => state.isSlideoutMenuOpen
+);
+
+export const getMetricsCardRangeSelectionEnabled = createSelector(
+  getMetricsRangeSelectionEnabled,
+  getMetricsLinkedTimeEnabled,
+  getCardStateMap,
+  (
+    globalRangeSelectionEnabled: boolean,
+    linkedTimeEnabled: boolean,
+    cardStateMap: CardStateMap,
+    cardId: CardId
+  ) => {
+    if (linkedTimeEnabled) {
+      return globalRangeSelectionEnabled;
+    }
+
+    const cardState = cardStateMap[cardId];
+    return getCardSelectionStateToBoolean(
+      cardState?.rangeSelectionOverride,
+      globalRangeSelectionEnabled
+    );
+  }
 );
 
 /**

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -1118,6 +1118,44 @@ describe('metrics selectors', () => {
         )
       ).toBeFalse();
     });
+
+    it('returns global value when linked time is enabled', () => {
+      expect(
+        selectors.getMetricsCardRangeSelectionEnabled(
+          appStateFromMetricsState(
+            buildMetricsState({
+              rangeSelectionEnabled: true,
+              linkedTimeEnabled: true,
+              cardStateMap: {
+                card1: {
+                  rangeSelectionOverride:
+                    CardFeatureOverride.OVERRIDE_AS_DISABLED,
+                },
+              },
+            })
+          ),
+          'card1'
+        )
+      ).toBeTrue();
+
+      expect(
+        selectors.getMetricsCardRangeSelectionEnabled(
+          appStateFromMetricsState(
+            buildMetricsState({
+              rangeSelectionEnabled: false,
+              linkedTimeEnabled: true,
+              cardStateMap: {
+                card1: {
+                  rangeSelectionOverride:
+                    CardFeatureOverride.OVERRIDE_AS_ENABLED,
+                },
+              },
+            })
+          ),
+          'card1'
+        )
+      ).toBeFalse();
+    });
   });
 
   describe('getMetricsStepMinMax', () => {


### PR DESCRIPTION
## Motivation for features / changes
See #6240 for why we are moving the step selector to redux.
When the linked time is enabled, card specific range selection overrides should be ignored.

## Screenshots of UI changes
None

## Detailed steps to verify changes work correctly (as executed by you)
1) Patch #6240
2) Start TensorBoard
3) Navigate to localhost:6006
4) Enable step selection on a scalar card
5) Enable step selection on a second card
6) Enable linked time
7) Add an end step to the second card
8) An end step should appear on the first card

* Alternate designs / implementations considered
