### PR TITLE
Linked Time: Remove step selection overrides when global range selection is toggled

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1084,6 +1084,7 @@ const reducer = createReducer(
         // again have the "global" state.
         cardStateMap[cardId] = {
           ...cardState,
+          stepSelectionOverride: CardFeatureOverride.NONE,
           rangeSelectionOverride: CardFeatureOverride.NONE,
         };
         return cardStateMap;

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3342,9 +3342,11 @@ describe('metrics reducers', () => {
           cardStateMap: {
             card1: {
               rangeSelectionOverride: CardFeatureOverride.OVERRIDE_AS_ENABLED,
+              stepSelectionOverride: CardFeatureOverride.OVERRIDE_AS_ENABLED,
             },
             card2: {
               rangeSelectionOverride: CardFeatureOverride.OVERRIDE_AS_DISABLED,
+              stepSelectionOverride: CardFeatureOverride.OVERRIDE_AS_DISABLED,
             },
             card3: {},
           },
@@ -3353,12 +3355,15 @@ describe('metrics reducers', () => {
         expect(state2.cardStateMap).toEqual({
           card1: {
             rangeSelectionOverride: CardFeatureOverride.NONE,
+            stepSelectionOverride: CardFeatureOverride.NONE,
           },
           card2: {
             rangeSelectionOverride: CardFeatureOverride.NONE,
+            stepSelectionOverride: CardFeatureOverride.NONE,
           },
           card3: {
             rangeSelectionOverride: CardFeatureOverride.NONE,
+            stepSelectionOverride: CardFeatureOverride.NONE,
           },
         });
       });


### PR DESCRIPTION
## Motivation for features / changes
See #6240 for context around why the step selector is being moved to redux.
Part of this has involved decoupling card specific step and range selection from the global values.

For Googlers see [internal test failures]( https://fusion2.corp.google.com/invocations/88e32921-2cbc-4924-9dcc-986ffaa5f6a2/targets/%2F%2Flearning%2Fbrain%2Ftensorboard%2Fservice%2Ftbcorp%2Fwebtests:linked_time_complex_test_chrome-linux/tests)

## Technical Description of Changes
Whenever the global range selection value is changed, I remove all step selection overrides at the reducer level.

## Screenshots of UI changes
![7574630a-d08f-45da-a499-d686cf12fa8c](https://user-images.githubusercontent.com/78179109/226986094-115e1a6e-6598-4b54-8443-3d33c022dad8.gif)

## Detailed steps to verify changes work correctly (as executed by you)
1) Patch #6240 
2) Start tensorboard
3) Navigate to localhost:6006
4) Enable global step selection
5) Remove the start fob from a scalar card
6) Enable global range selection
7) Ensure start and end fobs appear on all cards
