### PR TITLE
Linked Time: Move time selection formatting to the selector layer

### DIFF
--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -23,6 +23,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
+        "//tensorboard/webapp/metrics/views/card_renderer:utils",
         "//tensorboard/webapp/persistent_settings",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/util:dom",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -69,8 +69,8 @@ import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {
   cardMinMaxChanged,
   dataTableColumnDrag,
-  metricsCardStateUpdated,
   metricsCardFullSizeToggled,
+  metricsCardStateUpdated,
   sortingDataTable,
   stepSelectorToggled,
   timeSelectionChanged,
@@ -82,7 +82,6 @@ import {
   getCardMetadata,
   getCardTimeSeries,
   getMetricsCardMinMax,
-  getMetricsCardRangeSelectionEnabled,
   getMetricsIgnoreOutliers,
   getMetricsScalarPartitionNonMonotonicX,
   getMetricsScalarSmoothing,
@@ -108,7 +107,6 @@ import {
   SortingInfo,
 } from './scalar_card_types';
 import {
-  formatTimeSelection,
   maybeClipTimeSelectionView,
   partitionSeries,
   TimeSelectionView,
@@ -450,22 +448,10 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
       })
     );
 
-    this.stepOrLinkedTimeSelection$ = this.store
-      .select(getMetricsCardTimeSelection, this.cardId)
-      .pipe(
-        combineLatestWith(
-          this.minMaxSteps$,
-          this.store.select(getMetricsCardRangeSelectionEnabled, this.cardId)
-        ),
-        map(([timeSelection, minMaxSteps, rangeSelection]) => {
-          if (!timeSelection || !minMaxSteps) return;
-          return formatTimeSelection(
-            timeSelection,
-            minMaxSteps,
-            rangeSelection
-          );
-        })
-      );
+    this.stepOrLinkedTimeSelection$ = this.store.select(
+      getMetricsCardTimeSelection,
+      this.cardId
+    );
 
     this.columnHeaders$ = combineLatest([
       this.stepOrLinkedTimeSelection$,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -76,8 +76,8 @@ import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_test
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
   cardMinMaxChanged,
-  metricsCardStateUpdated,
   metricsCardFullSizeToggled,
+  metricsCardStateUpdated,
   stepSelectorToggled,
   timeSelectionChanged,
 } from '../../actions';
@@ -2270,14 +2270,9 @@ describe('scalar card', () => {
           start: {step: 20},
           end: {step: 40},
         });
-        store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
-        store.overrideSelector(getCardStateMap, {
-          card1: {
-            dataMinMax: {
-              minStep: 0,
-              maxStep: 100,
-            },
-          },
+        store.overrideSelector(getMetricsCardTimeSelection, {
+          start: {step: 0},
+          end: {step: 100},
         });
       });
 
@@ -2645,7 +2640,7 @@ describe('scalar card', () => {
           },
         },
       });
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, false);
+      store.overrideSelector(getMetricsRangeSelectionEnabled, false);
     });
 
     it('builds single selected step data object', fakeAsync(() => {
@@ -2732,7 +2727,7 @@ describe('scalar card', () => {
         null /* metadataOverride */,
         runToSeries
       );
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(getMetricsRangeSelectionEnabled, true);
       store.overrideSelector(
         selectors.getCurrentRouteRunSelection,
         new Map([
@@ -2809,7 +2804,7 @@ describe('scalar card', () => {
         null /* metadataOverride */,
         runToSeries
       );
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(getMetricsRangeSelectionEnabled, true);
       store.overrideSelector(
         selectors.getCurrentRouteRunSelection,
         new Map([['run1', true]])
@@ -2870,7 +2865,7 @@ describe('scalar card', () => {
         null /* metadataOverride */,
         runToSeries
       );
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(getMetricsRangeSelectionEnabled, true);
       store.overrideSelector(
         selectors.getCurrentRouteRunSelection,
         new Map([['run1', true]])
@@ -2977,7 +2972,7 @@ describe('scalar card', () => {
         null /* metadataOverride */,
         runToSeries
       );
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(getMetricsRangeSelectionEnabled, true);
       store.overrideSelector(
         selectors.getCurrentRouteRunSelection,
         new Map([
@@ -3489,13 +3484,12 @@ describe('scalar card', () => {
         end: null,
       });
 
+      store.overrideSelector(getMetricsCardTimeSelection, {
+        start: {step: 2},
+        end: null,
+      });
       store.overrideSelector(getCardStateMap, {
         card1: {},
-      });
-      store.overrideSelector(getMetricsCardMinMax, {minStep: 0, maxStep: 100});
-      store.overrideSelector(getMetricsCardDataMinMax, {
-        minStep: 0,
-        maxStep: 100,
       });
     });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2266,18 +2266,23 @@ describe('scalar card', () => {
           runToSeries
         );
 
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
+        store.overrideSelector(getCardStateMap, {
+          card1: {
+            dataMinMax: {
+              minStep: 0,
+              maxStep: 100,
+            },
+          },
+        });
+
+        store.overrideSelector(getMetricsCardTimeSelection, {
           start: {step: 20},
           end: {step: 40},
-        });
-        store.overrideSelector(getMetricsCardTimeSelection, {
-          start: {step: 0},
-          end: {step: 100},
         });
       });
 
       it('renders fobs', fakeAsync(() => {
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
+        store.overrideSelector(getMetricsCardTimeSelection, {
           start: {step: 20},
           end: null,
         });
@@ -2331,7 +2336,7 @@ describe('scalar card', () => {
       }));
 
       it('dispatches timeSelectionChanged action when fob is dragged', fakeAsync(() => {
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
+        store.overrideSelector(getMetricsCardTimeSelection, {
           start: {step: 20},
           end: null,
         });
@@ -2356,7 +2361,7 @@ describe('scalar card', () => {
         testController.mouseMove(fakeEvent);
 
         // Simulate ngrx update from mouseMove;
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
+        store.overrideSelector(getMetricsCardTimeSelection, {
           start: {step: 25},
           end: null,
         });
@@ -2378,7 +2383,7 @@ describe('scalar card', () => {
         testController.mouseMove(fakeEvent);
 
         // Simulate ngrx update from mouseMove;
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
+        store.overrideSelector(getMetricsCardTimeSelection, {
           start: {step: 30},
           end: null,
         });
@@ -2427,7 +2432,7 @@ describe('scalar card', () => {
       }));
 
       it('toggles step selection when single fob is deselected even when linked time is enabled', fakeAsync(() => {
-        store.overrideSelector(getMetricsLinkedTimeSelection, {
+        store.overrideSelector(getMetricsCardTimeSelection, {
           start: {step: 20},
           end: null,
         });
@@ -2447,7 +2452,7 @@ describe('scalar card', () => {
       }));
 
       it('does not render fobs when no timeSelection is provided', fakeAsync(() => {
-        store.overrideSelector(getMetricsLinkedTimeSelection, null);
+        store.overrideSelector(getMetricsCardTimeSelection, undefined);
         const fixture = createComponent('card1');
         fixture.detectChanges();
         const fobController = fixture.debugElement.query(
@@ -3655,9 +3660,8 @@ describe('scalar card', () => {
         testController.prospectiveFobClicked(new MouseEvent('mouseclick'));
         store.overrideSelector(getMetricsCardTimeSelection, {
           start: {step: 10},
-          end: {step: 30},
+          end: null,
         });
-        store.overrideSelector(getMetricsCardRangeSelectionEnabled, false);
         store.refreshState();
         fixture.detectChanges();
 


### PR DESCRIPTION
## Motivation for features / changes
This is simply a change to our code organization. In #6229 we decided to handle formatting the time selection in container layer, but that has become a bit messy so I'm moving it back to the selector layer

## Technical description of changes
Rather than getting the cards time selection in the selector layer, then formatting it in the container layer, I'm opting to handle all the logic in the container layer.

## Screenshots of UI changes
None

## Detailed steps to verify changes work correctly (as executed by you)
I added lots of tests, all the tests should pass

For Googlers [internal tests passed](https://fusion2.corp.google.com/presubmit/tap/518714309/OCL:518714309:BASE:518717432:1679531577959:4d567b9a/targets)

## Alternate designs / implementations considered
