### PR TITLE
Chore: Prefer window.localStorage over localStorage

### DIFF
--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -245,7 +245,7 @@ export class PersistentSettingsDataSourceImpl<UiSettings, StorageSettings>
 
     return this.getSettings().pipe(
       tap((currentPartialSettings) => {
-        localStorage.setItem(
+        window.localStorage.setItem(
           GLOBAL_LOCAL_STORAGE_KEY,
           JSON.stringify(
             this.converter.uiToBackend({
@@ -254,8 +254,8 @@ export class PersistentSettingsDataSourceImpl<UiSettings, StorageSettings>
             })
           )
         );
-        localStorage.removeItem(LEGACY_METRICS_LOCAL_STORAGE_KEY);
-        localStorage.removeItem(NOTIFICATION_LAST_READ_TIME_KEY);
+        window.localStorage.removeItem(LEGACY_METRICS_LOCAL_STORAGE_KEY);
+        window.localStorage.removeItem(NOTIFICATION_LAST_READ_TIME_KEY);
       }),
       map(() => void null)
     );
@@ -270,7 +270,9 @@ export class PersistentSettingsDataSourceImpl<UiSettings, StorageSettings>
   }
 
   getSettings(): Observable<Partial<UiSettings>> {
-    const lastReadTime = localStorage.getItem(NOTIFICATION_LAST_READ_TIME_KEY);
+    const lastReadTime = window.localStorage.getItem(
+      NOTIFICATION_LAST_READ_TIME_KEY
+    );
     const notificationSettings = this.converter.backendToUi(
       this.deserialize(
         lastReadTime
@@ -282,12 +284,14 @@ export class PersistentSettingsDataSourceImpl<UiSettings, StorageSettings>
     );
     const legacySettings = this.converter.backendToUi(
       this.deserialize(
-        localStorage.getItem(LEGACY_METRICS_LOCAL_STORAGE_KEY) ?? '{}'
+        window.localStorage.getItem(LEGACY_METRICS_LOCAL_STORAGE_KEY) ?? '{}'
       )
     );
 
     const settings = this.converter.backendToUi(
-      this.deserialize(localStorage.getItem(GLOBAL_LOCAL_STORAGE_KEY) ?? '{}')
+      this.deserialize(
+        window.localStorage.getItem(GLOBAL_LOCAL_STORAGE_KEY) ?? '{}'
+      )
     );
     return of({
       ...notificationSettings,

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -61,7 +61,10 @@ export class FeatureFlagOverrideDataSource implements TBFeatureFlagDataSource {
       ...currentState,
       ...flags,
     };
-    localStorage.setItem(FEATURE_FLAG_STORAGE_KEY, JSON.stringify(newState));
+    window.localStorage.setItem(
+      FEATURE_FLAG_STORAGE_KEY,
+      JSON.stringify(newState)
+    );
   }
 
   resetPersistedFeatureFlag<K extends keyof FeatureFlags>(featureFlag: K) {
@@ -74,21 +77,21 @@ export class FeatureFlagOverrideDataSource implements TBFeatureFlagDataSource {
     // Remove the entire key-value from localStorage when there are no more
     // overrides.
     if (Object.keys(currentState).length === 0) {
-      localStorage.removeItem(FEATURE_FLAG_STORAGE_KEY);
+      window.localStorage.removeItem(FEATURE_FLAG_STORAGE_KEY);
       return;
     }
-    localStorage.setItem(
+    window.localStorage.setItem(
       FEATURE_FLAG_STORAGE_KEY,
       JSON.stringify(currentState)
     );
   }
 
   resetAllPersistedFeatureFlags() {
-    localStorage.removeItem(FEATURE_FLAG_STORAGE_KEY);
+    window.localStorage.removeItem(FEATURE_FLAG_STORAGE_KEY);
   }
 
   getPersistentFeatureFlags(): Partial<FeatureFlags> {
-    const currentState = localStorage.getItem(FEATURE_FLAG_STORAGE_KEY);
+    const currentState = window.localStorage.getItem(FEATURE_FLAG_STORAGE_KEY);
     if (currentState == null) {
       return {};
     }


### PR DESCRIPTION
* Motivation for features / changes
Internal checks throw JSC_UNDEFINED_VARIABLE errors when using localStorage directly. However, window is defined so window.localStorage does not throw an error. This change helps us pass those checks internally.