### PR TITLE
Shareability: updates minMaxStep on data loaded 

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -373,22 +373,20 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
       shareReplay(1)
     );
 
-    this.minMaxSteps$ = this.store
-      .select(getMetricsCardMinMax, this.cardId)
-      .pipe(
-        withLatestFrom(
-          this.store.select(getMetricsCardDataMinMax, this.cardId)
-        ),
-        map(([minMax, dataMinMax]) => {
-          if (!minMax || !dataMinMax) {
-            return;
-          }
-          return {
-            minStep: Math.max(minMax?.minStep!, dataMinMax?.minStep!),
-            maxStep: Math.min(minMax?.maxStep!, dataMinMax?.maxStep!),
-          };
-        })
-      );
+    this.minMaxSteps$ = combineLatest([
+      this.store.select(getMetricsCardMinMax, this.cardId),
+      this.store.select(getMetricsCardDataMinMax, this.cardId),
+    ]).pipe(
+      map(([minMax, dataMinMax]) => {
+        if (!minMax || !dataMinMax) {
+          return;
+        }
+        return {
+          minStep: Math.max(minMax?.minStep!, dataMinMax?.minStep!),
+          maxStep: Math.min(minMax?.maxStep!, dataMinMax?.maxStep!),
+        };
+      })
+    );
 
     this.dataSeries$ = partitionedSeries$.pipe(
       // Smooth


### PR DESCRIPTION
* Motivation for features / changes
The current logic of calculating minMaxStep$ assumes data has existed. However, for Google-internal project, we might have other card state (userMinMax, timeSelection..) first then fetch time series data later. Then minMaxStep$ will not emit new values with "withLatestFrom". Therefore, this PR simply move that part above to assume we update minMaxStep$ on data loaded.

Googlers, please see cl/520194063 for demo.

* Screenshots of UI changes
Manually examine zoom and step selection, no serious issue found, it should not affect anything.
