### PR TITLE
Shareability: convert CardFeatureOverride to enum string

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -127,9 +127,9 @@ export type CardMetadataMap = Record<
 >;
 
 export enum CardFeatureOverride {
-  NONE,
-  OVERRIDE_AS_ENABLED,
-  OVERRIDE_AS_DISABLED,
+  NONE = 'none',
+  OVERRIDE_AS_ENABLED = 'override_as_enabled',
+  OVERRIDE_AS_DISABLED = 'override_as_disabled',
 }
 
 export type CardState = {


### PR DESCRIPTION
For Google-internal project, to do proper conversation of stepSelectionOverride and rangeSelectionOverride we need enum `CardFeatureOverride` to be string type.

Googlers, please see cl/520263394

