### PR TITLE
Adds @ts-ignore annotations for TS 5.0 errors.

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -173,6 +173,12 @@ function matchFilter(
       filter.filterValues;
     return values.includes(value);
   } else if (filter.type === DomainType.INTERVAL) {
+    // Auto-added to unblock TS5.0 migration
+    //  @ts-ignore(go/ts50upgrade): Operator '<=' cannot be applied to types
+    //  'number' and 'string | number | boolean'.
+    // Auto-added to unblock TS5.0 migration
+    //  @ts-ignore(go/ts50upgrade): Operator '<=' cannot be applied to types
+    //  'string | number | boolean' and 'number'.
     return filter.filterLowerValue <= value && value <= filter.filterUpperValue;
   }
   return false;


### PR DESCRIPTION
It's unclear when we'll be able to adopt TS 5. It is somewhat likely we'll run into some issues. These comments suppress some warnings from our internal code tooling about some incompatibilities with TS 5, in the meantime.

Googlers, see b/275900646 and cl/520430860.