### PR TITLE
Embedding Projector: fix t-SNE control when switching projections

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -402,9 +402,10 @@ class ProjectionsPanel extends LegacyElementMixin(PolymerElement) {
     this.customSelectedSearchByMetadataOption =
       this.searchByMetadataOptions[Math.max(0, searchByMetadataIndex)];
   }
-  public showTab(id: ProjectionType) {
-    this.currentProjection = id;
-    const tab = this.$$('.ink-tab[data-tab="' + id + '"]') as HTMLElement;
+  public showTab(projection: ProjectionType) {
+    const tab = this.$$(
+      '.ink-tab[data-tab="' + projection + '"]'
+    ) as HTMLElement;
     const allTabs = this.root?.querySelectorAll('.ink-tab');
     if (allTabs) {
       for (let i = 0; i < allTabs.length; i++) {
@@ -419,7 +420,9 @@ class ProjectionsPanel extends LegacyElementMixin(PolymerElement) {
       }
     }
     util.classed(
-      this.$$('.ink-panel-content[data-panel="' + id + '"]') as HTMLElement,
+      this.$$(
+        '.ink-panel-content[data-panel="' + projection + '"]'
+      ) as HTMLElement,
       'active',
       true
     );
@@ -432,25 +435,29 @@ class ProjectionsPanel extends LegacyElementMixin(PolymerElement) {
         this.style.height = main.clientHeight + 'px';
       });
     }
-    this.beginProjection(id);
+    this.beginProjection(projection);
   }
   private beginProjection(projection: ProjectionType) {
     if (this.polymerChangesTriggerReprojection === false) {
       return;
     }
-    if (projection === 'pca') {
+    if (this.currentProjection !== projection) {
+      this.currentProjection = projection;
       if (this.dataSet != null) {
-        this.dataSet.stopTSNE();
+        if (projection === 'tsne') {
+          this.dataSet.tSNEShouldPause = false;
+        } else {
+          this.dataSet.tSNEShouldPause = true;
+        }
       }
+    }
+    if (projection === 'pca') {
       this.showPCA();
     } else if (projection === 'tsne') {
       this.showTSNE();
     } else if (projection === 'umap') {
       this.showUmap();
     } else if (projection === 'custom') {
-      if (this.dataSet != null) {
-        this.dataSet.stopTSNE();
-      }
       this.computeAllCentroids();
       this.reprojectCustom();
     }
@@ -493,6 +500,7 @@ class ProjectionsPanel extends LegacyElementMixin(PolymerElement) {
       (iteration: number) => {
         if (iteration != null) {
           this.runTsneButton.disabled = false;
+          this.pauseTsneButton.innerText = 'Pause';
           this.pauseTsneButton.disabled = false;
           this.iterationLabelTsne.innerText = '' + iteration;
           this.projector.notifyProjectionPositionsUpdated();


### PR DESCRIPTION
## Motivation for features / changes
If projection is switched from t-SNE to UMAP, t-SNE doesn't pause and the framerate would crash (5fps on M1 pro)
If projection is switched from t-SNE to PCA/Custom, t-SNE is stopped, so user has to restart t-SNE when switching back.

## Technical description of changes
Pause t-SNE when switching away, resume t-SNE when 

## Screenshots of UI changes
N/A

## Detailed steps to verify changes work correctly (as executed by you)
toggle from t-SNE to any other panel and back to t-SNE will resume t-SNE immediately

## Alternate designs / implementations considered
