### PR TITLE
Embedding Projector: exit select mode onMouseUp

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/scatterPlot.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlot.ts
@@ -334,16 +334,12 @@ export class ScatterPlot {
   }
   /** When we stop dragging/zooming, return to normal behavior. */
   private onMouseUp(e: any) {
-    if (this.selecting) {
+    if (this.selecting || !this.orbitCameraControls.enabled) {
       this.orbitCameraControls.enabled = true;
       this.rectangleSelector.onMouseUp();
       this.render();
     }
     this.mouseIsDown = false;
-    this.selecting = this.getMouseMode() === MouseMode.AREA_SELECT;
-    if (!this.selecting) {
-      this.container.style.cursor = 'default';
-    }
   }
   /**
    * When the mouse moves, find the nearest point (if any) and send it to the

--- a/tensorboard/plugins/projector/vz_projector/scatterPlot.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlot.ts
@@ -340,6 +340,10 @@ export class ScatterPlot {
       this.render();
     }
     this.mouseIsDown = false;
+    this.selecting = this.getMouseMode() === MouseMode.AREA_SELECT;
+    if (!this.selecting) {
+      this.container.style.cursor = 'default';
+    }
   }
   /**
    * When the mouse moves, find the nearest point (if any) and send it to the


### PR DESCRIPTION
* Motivation for features / changes
When Shift key is used to select points and is released before mouseUp, UI does not exist selection mode after mouse is released, leaving a permanent rectangular selection box with no way of panning.

* Technical description of changes
Reset orbit mode properly after mouse is released

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
