### PR TITLE
Expand tilde at the beginning of paths

### DIFF
--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -201,6 +201,7 @@ class EventMultiplexer:
         Returns:
           The `EventMultiplexer`.
         """
+        path = os.path.expanduser(path)
         logger.info("Starting AddRunsFromDirectory: %s", path)
         for subdir in io_wrapper.GetLogdirSubdirectories(path):
             logger.info("Adding run from directory %s", subdir)


### PR DESCRIPTION
* Motivation for features / changes
Executing event_exporter with `--root_dir=~/tensorboard-logdirs/my_test_dir` fails because gfile does not automatically expand the homedir tilde.

* Technical description of changes
Explicitly expands the user directory before scanning subdirs.

* Detailed steps to verify changes work correctly (as executed by you)
Ran tests and attempted uploads using both alias and unaliased dir.
Played around with unit tests and gave up.  All our other tests put files in a tempdir, which is different from the homedir by definition.  Decided it wasn't worth playing with the tester's homedir or mocking it out.
