### PR TITLE
Embedding Projector: fix UMAP sampling message

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -363,6 +363,8 @@ class ProjectionsPanel extends LegacyElementMixin(PolymerElement) {
     this.clearCentroids();
     (this.$$('#tsne-sampling') as HTMLElement).style.display =
       pointCount > TSNE_SAMPLE_SIZE ? null! : 'none';
+    (this.$$('#umap-sampling') as HTMLElement).style.display =
+      pointCount > UMAP_SAMPLE_SIZE ? null! : 'none';
     const wasSampled =
       dataSet == null
         ? false


### PR DESCRIPTION
## Motivation for features / changes
unlike t-SNE sampling message, the UMAP sampling message isn't hidden properly

## Technical description of changes
Show UMAP sampling message only when number of points exceeds 5000

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/31378877/232667480-e3a253f8-186d-4d68-a7f1-f6ce622e8bb6.png)

## Detailed steps to verify changes work correctly (as executed by you)
1. Change to Iris data set
1. Navigate to UMAP
1. verify the 5000 sampling mage doesn't show

## Alternate designs / implementations considered
