### PR TITLE
Rename Angular Material's legacy component TS symbols to match their cctual names

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_container.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
-import {MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {MAT_LEGACY_DIALOG_DATA} from '@angular/material/dialog';
 import {Store} from '@ngrx/store';
 import {BehaviorSubject, combineLatest, Observable} from 'rxjs';
 import {filter, map, startWith} from 'rxjs/operators';
@@ -54,7 +54,7 @@ export class DataDownloadDialogContainer {
   constructor(
     store: Store<State>,
     dataSource: MetricsDataSource,
-    @Inject(MAT_DIALOG_DATA) data: DataDownloadDialogData
+    @Inject(MAT_LEGACY_DIALOG_DATA) data: DataDownloadDialogData
   ) {
     this.cardMetadata$ = store
       .select(getCardMetadata, data.cardId)

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_dialog_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
-import {MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {MAT_LEGACY_DIALOG_DATA} from '@angular/material/dialog';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Store} from '@ngrx/store';
@@ -55,7 +55,7 @@ describe('metrics/views/data_download_dialog', () => {
       declarations: [DataDownloadDialogContainer, DataDownloadDialogComponent],
       providers: [
         provideMockStore({}),
-        {provide: MAT_DIALOG_DATA, useValue: dialogData},
+        {provide: MAT_LEGACY_DIALOG_DATA, useValue: dialogData},
         {provide: MetricsDataSource, useClass: TestingMetricsDataSource},
       ],
       schemas: [NO_ERRORS_SCHEMA],


### PR DESCRIPTION
`MAT_DIALOG_DATA` -> `MAT_LEGACY_DIALOG_DATA`
