### PR TITLE
Add support for client feature flags to be passed as query parameters

### DIFF
--- a/tensorboard/backend/client_feature_flags.py
+++ b/tensorboard/backend/client_feature_flags.py
@@ -101,9 +101,13 @@ class ClientFeatureFlagsMiddleware:
         try:
             client_feature_flags = json.loads(potential_feature_flags[0])
         except json.JSONDecodeError:
-            return {}
+            raise errors.InvalidArgumentError(
+                "tensorBoardFeatureFlags cannot be JSON decoded."
+            )
 
         if not isinstance(client_feature_flags, dict):
-            return {}
+            raise errors.InvalidArgumentError(
+                "tensorBoardFeatureFlags cannot be decoded to a dict."
+            )
 
         return client_feature_flags

--- a/tensorboard/backend/client_feature_flags_test.py
+++ b/tensorboard/backend/client_feature_flags_test.py
@@ -153,14 +153,15 @@ class ClientFeatureFlagsMiddlewareTest(tb_test.TestCase):
         app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
         server = werkzeug_test.Client(app, wrappers.Response)
 
-        response = server.get(
-            "",
-            query_string={
-                "tensorBoardFeatureFlags": "some_invalid_json {} {}",
-            },
-        )
-
-        self._assert_ok(response, {})
+        with self.assertRaisesRegex(
+            errors.InvalidArgumentError, "cannot be JSON decoded."
+        ):
+            response = server.get(
+                "",
+                query_string={
+                    "tensorBoardFeatureFlags": "some_invalid_json {} {}",
+                },
+            )
 
     def test_header_with_json_not_dict(self):
         app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
@@ -183,14 +184,15 @@ class ClientFeatureFlagsMiddlewareTest(tb_test.TestCase):
         app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)
         server = werkzeug_test.Client(app, wrappers.Response)
 
-        response = server.get(
-            "",
-            query_string={
-                "tensorBoardFeatureFlags": '["not", "a", "dict"]',
-            },
-        )
-
-        self._assert_ok(response, {})
+        with self.assertRaisesRegex(
+            errors.InvalidArgumentError, "cannot be decoded to a dict"
+        ):
+            response = server.get(
+                "",
+                query_string={
+                    "tensorBoardFeatureFlags": '["not", "a", "dict"]',
+                },
+            )
 
     def test_header_feature_flags_take_precedence(self):
         app = client_feature_flags.ClientFeatureFlagsMiddleware(self._echo_app)

--- a/tensorboard/webapp/feature_flag/http/const.ts
+++ b/tensorboard/webapp/feature_flag/http/const.ts
@@ -14,3 +14,4 @@ limitations under the License.
 ==============================================================================*/
 
 export const FEATURE_FLAGS_HEADER_NAME = 'X-TensorBoard-Feature-Flags';
+export const FEATURE_FLAGS_QUERY_STRING_NAME = 'tensorBoardFeatureFlags';


### PR DESCRIPTION
Some plugins (e.g. [image](https://github.com/tensorflow/tensorboard/blob/963afb7be883c15373c121c96c9039828e3fb728/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.ts#L356) and [audio](https://github.com/tensorflow/tensorboard/blob/963afb7be883c15373c121c96c9039828e3fb728/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.ts#L111)) specify URLs as src attributes on some HTML elements, which precludes them from attaching the necessary client feature flags via the `requestManager`. This PR adds support to the client feature flags middleware to also accept feature flags via query parameters, so that we can support this use case.