### PR TITLE
Column Customization: Open Editor to the expected tab

### DIFF
--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -88,6 +88,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/store",
         "//tensorboard/webapp/metrics/store:types",
+        "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/widgets/histogram:types",
         "@npm//@angular/core",

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -36,6 +36,7 @@ import {
 } from '../types';
 import {
   ColumnHeader,
+  DataTableMode,
   SortingInfo,
 } from '../views/card_renderer/scalar_card_types';
 
@@ -52,7 +53,13 @@ export const metricsSlideoutMenuToggled = createAction(
 );
 
 export const metricsSlideoutMenuOpened = createAction(
-  '[Metrics] User requested to open the slide out menu'
+  '[Metrics] User requested to open the slide out menu',
+  props<{mode: DataTableMode}>()
+);
+
+export const tableEditorTabChanged = createAction(
+  '[Metrics] User changed the tab in the table editor',
+  props<{tab: DataTableMode}>()
 );
 
 export const metricsSlideoutMenuClosed = createAction(

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -299,6 +299,7 @@ const {initialState, reducers: namespaceContextedReducer} =
     {
       isSettingsPaneOpen: true,
       isSlideoutMenuOpen: false,
+      tableEditorSelectedTab: DataTableMode.SINGLE,
       timeSeriesData: {
         scalars: {},
         histograms: {},
@@ -1252,6 +1253,12 @@ const reducer = createReducer(
       linkedTimeSelection: null,
     };
   }),
+  on(actions.tableEditorTabChanged, (state, {tab}) => {
+    return {
+      ...state,
+      tableEditorSelectedTab: tab,
+    };
+  }),
   on(actions.dataTableColumnEdited, (state, {dataTableMode, headers}) => {
     const enabledNewHeaders: ColumnHeader[] = [];
     const disabledNewHeaders: ColumnHeader[] = [];
@@ -1346,12 +1353,17 @@ const reducer = createReducer(
   on(actions.metricsSlideoutMenuToggled, (state) => {
     return {...state, isSlideoutMenuOpen: !state.isSlideoutMenuOpen};
   }),
-  on(actions.metricsSlideoutMenuOpened, (state) => {
+  on(actions.metricsSlideoutMenuOpened, (state, {mode}) => {
     // The reason the toggle action does not open the settings pane is because
     // the settings pane is the only place the menu can be toggled. The open
     // request can be made from the card when the settings menu is closed,
     // therefore we need to make sure the settings menu is opened, too.
-    return {...state, isSlideoutMenuOpen: true, isSettingsPaneOpen: true};
+    return {
+      ...state,
+      isSlideoutMenuOpen: true,
+      isSettingsPaneOpen: true,
+      tableEditorSelectedTab: mode,
+    };
   }),
   on(actions.metricsSlideoutMenuClosed, (state) => {
     return {...state, isSlideoutMenuOpen: false};

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3964,7 +3964,6 @@ describe('metrics reducers', () => {
         );
         expect(state2.isSlideoutMenuOpen).toBe(true);
         expect(state2.isSettingsPaneOpen).toBe(true);
-        expect(state2.tableEditorSelectedTab).toBe(DataTableMode.SINGLE);
       });
     });
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3929,19 +3929,27 @@ describe('metrics reducers', () => {
     });
 
     describe('#metricsSlideoutMenuOpened', () => {
-      it('sets the isSlideoutMenuOpen and isSettingsPaneOpen to true', () => {
+      it('sets the isSlideoutMenuOpen and isSettingsPaneOpen to true and always updates tableEditorSelectedTab', () => {
         const state1 = buildMetricsState({
           isSlideoutMenuOpen: false,
           isSettingsPaneOpen: false,
         });
 
-        const state2 = reducers(state1, actions.metricsSlideoutMenuOpened());
+        const state2 = reducers(
+          state1,
+          actions.metricsSlideoutMenuOpened({mode: DataTableMode.RANGE})
+        );
         expect(state2.isSlideoutMenuOpen).toBe(true);
         expect(state2.isSettingsPaneOpen).toBe(true);
+        expect(state2.tableEditorSelectedTab).toBe(DataTableMode.RANGE);
 
-        const state3 = reducers(state1, actions.metricsSlideoutMenuOpened());
+        const state3 = reducers(
+          state2,
+          actions.metricsSlideoutMenuOpened({mode: DataTableMode.SINGLE})
+        );
         expect(state3.isSlideoutMenuOpen).toBe(true);
         expect(state3.isSettingsPaneOpen).toBe(true);
+        expect(state3.tableEditorSelectedTab).toBe(DataTableMode.SINGLE);
       });
 
       it('leaves isSettingsPaneOpen as true when it is already set', () => {
@@ -3950,9 +3958,13 @@ describe('metrics reducers', () => {
           isSettingsPaneOpen: true,
         });
 
-        const state2 = reducers(state1, actions.metricsSlideoutMenuOpened());
+        const state2 = reducers(
+          state1,
+          actions.metricsSlideoutMenuOpened({mode: DataTableMode.SINGLE})
+        );
         expect(state2.isSlideoutMenuOpen).toBe(true);
         expect(state2.isSettingsPaneOpen).toBe(true);
+        expect(state2.tableEditorSelectedTab).toBe(DataTableMode.SINGLE);
       });
     });
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -31,6 +31,7 @@ import {
 } from '../types';
 import {
   ColumnHeader,
+  DataTableMode,
   MinMaxStep,
 } from '../views/card_renderer/scalar_card_types';
 import {formatTimeSelection} from '../views/card_renderer/utils';
@@ -482,6 +483,11 @@ export const isMetricsSettingsPaneOpen = createSelector(
 export const isMetricsSlideoutMenuOpen = createSelector(
   selectMetricsState,
   (state): boolean => state.isSlideoutMenuOpen
+);
+
+export const getTableEditorSelectedTab = createSelector(
+  selectMetricsState,
+  (state): DataTableMode => state.tableEditorSelectedTab
 );
 
 export const getMetricsCardRangeSelectionEnabled = createSelector(

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -26,6 +26,7 @@ import {
   createTimeSeriesData,
 } from '../testing';
 import {HistogramMode, TooltipSort, XAxisType} from '../types';
+import {DataTableMode} from '../views/card_renderer/scalar_card_types';
 import * as selectors from './metrics_selectors';
 import {CardFeatureOverride, MetricsState} from './metrics_types';
 
@@ -1471,6 +1472,21 @@ describe('metrics selectors', () => {
         buildMetricsState({isSettingsPaneOpen: false})
       );
       expect(selectors.isMetricsSettingsPaneOpen(state)).toEqual(false);
+    });
+  });
+
+  describe('#getTableEditorSelectedTab', () => {
+    beforeEach(() => {
+      selectors.getTableEditorSelectedTab.release();
+    });
+
+    it('returns current settings pane open state', () => {
+      const state = appStateFromMetricsState(
+        buildMetricsState({tableEditorSelectedTab: DataTableMode.RANGE})
+      );
+      expect(selectors.getTableEditorSelectedTab(state)).toEqual(
+        DataTableMode.RANGE
+      );
     });
   });
 });

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -37,7 +37,10 @@ import {
   TooltipSort,
   XAxisType,
 } from '../types';
-import {ColumnHeader} from '../views/card_renderer/scalar_card_types';
+import {
+  ColumnHeader,
+  DataTableMode,
+} from '../views/card_renderer/scalar_card_types';
 
 export const METRICS_FEATURE_KEY = 'metrics';
 
@@ -244,6 +247,7 @@ export interface MetricsNonNamespacedState {
   timeSeriesData: TimeSeriesData;
   isSettingsPaneOpen: boolean;
   isSlideoutMenuOpen: boolean;
+  tableEditorSelectedTab: DataTableMode;
   // Default settings. For the legacy reasons, we cannot change the name of the
   // prop. It either is set by application or a user via settings storage.
   settings: MetricsSettings;

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -42,6 +42,7 @@ import {
   StepDatum,
 } from './store/metrics_types';
 import {CardId, CardMetadata, TooltipSort, XAxisType} from './types';
+import {DataTableMode} from './views/card_renderer/scalar_card_types';
 
 export function buildMetricsSettingsState(
   overrides?: Partial<MetricsSettings>
@@ -110,6 +111,7 @@ function buildBlankState(): MetricsState {
     stepMinMax: {min: Infinity, max: -Infinity},
     isSettingsPaneOpen: false,
     isSlideoutMenuOpen: false,
+    tableEditorSelectedTab: DataTableMode.SINGLE,
   };
 }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -96,7 +96,7 @@ limitations under the License.
         <button
           *ngIf="columnCustomizationEnabled"
           mat-menu-item
-          (click)="openSlideoutColumnEditMenu.emit()"
+          (click)="openTableEditMenu()"
           aria-label="Open menu to edit data table columns"
         >
           <mat-icon svgIcon="edit_24px"></mat-icon>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -48,6 +48,7 @@ import {HeaderEditInfo, TooltipSort, XAxisType} from '../../types';
 import {
   ColumnHeader,
   ColumnHeaderType,
+  DataTableMode,
   MinMaxStep,
   ScalarCardDataSeries,
   ScalarCardSeriesMetadata,
@@ -98,6 +99,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() isProspectiveFobFeatureEnabled: Boolean = false;
   @Input() minMaxStep!: MinMaxStep;
   @Input() columnHeaders!: ColumnHeader[];
+  @Input() rangeEnabled!: boolean;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();
   @Output() onPinClicked = new EventEmitter<boolean>();
@@ -109,7 +111,7 @@ export class ScalarCardComponent<Downloader> {
     new EventEmitter<TimeSelectionToggleAffordance>();
   @Output() onDataTableSorting = new EventEmitter<SortingInfo>();
   @Output() editColumnHeaders = new EventEmitter<HeaderEditInfo>();
-  @Output() openSlideoutColumnEditMenu = new EventEmitter<void>();
+  @Output() openTableEditMenuToMode = new EventEmitter<DataTableMode>();
 
   @Output() onLineChartZoom = new EventEmitter<Extent>();
 
@@ -281,5 +283,12 @@ export class ScalarCardComponent<Downloader> {
     if (this.dataTableContainer) {
       this.dataTableContainer.nativeElement.style.height = '';
     }
+  }
+
+  openTableEditMenu() {
+    const currentTableMode = this.rangeEnabled
+      ? DataTableMode.RANGE
+      : DataTableMode.SINGLE;
+    this.openTableEditMenuToMode.emit(currentTableMode);
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -34,7 +34,6 @@ import {
   startWith,
   switchMap,
   takeUntil,
-  withLatestFrom,
 } from 'rxjs/operators';
 import {State} from '../../../app_state';
 import {ExperimentAlias} from '../../../experiments/types';
@@ -54,6 +53,7 @@ import {
   getMetricsCardTimeSelection,
   getMetricsLinkedTimeEnabled,
   getMetricsLinkedTimeSelection,
+  getMetricsCardRangeSelectionEnabled,
   getRun,
   getRunColorMap,
 } from '../../../selectors';
@@ -175,6 +175,7 @@ function isMinMaxStepValid(minMax: MinMaxStep | undefined): boolean {
       [columnCustomizationEnabled]="columnCustomizationEnabled$ | async"
       [minMaxStep]="minMaxSteps$ | async"
       [columnHeaders]="columnHeaders$ | async"
+      [rangeEnabled]="rangeEnabled$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       observeIntersection
@@ -185,7 +186,7 @@ function isMinMaxStepValid(minMax: MinMaxStep | undefined): boolean {
       (onLineChartZoom)="onLineChartZoom($event)"
       (editColumnHeaders)="editColumnHeaders($event)"
       (onCardStateChanged)="onCardStateChanged($event)"
-      (openSlideoutColumnEditMenu)="openSlideoutColumnEditMenu()"
+      (openTableEditMenuToMode)="openTableEditMenuToMode($event)"
     ></scalar-card-component>
   `,
   styles: [
@@ -222,6 +223,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   minMaxSteps$?: Observable<MinMaxStep | undefined>;
   stepOrLinkedTimeSelection$?: Observable<TimeSelection | undefined>;
   cardState$?: Observable<Partial<CardState>>;
+  rangeEnabled$?: Observable<boolean>;
 
   readonly isProspectiveFobFeatureEnabled$: Observable<boolean> =
     this.store.select(getIsLinkedTimeProspectiveFobEnabled);
@@ -573,6 +575,11 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     );
 
     this.isPinned$ = this.store.select(getCardPinnedState, this.cardId);
+
+    this.rangeEnabled$ = this.store.select(
+      getMetricsCardRangeSelectionEnabled,
+      this.cardId
+    );
   }
 
   ngOnDestroy() {
@@ -668,7 +675,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.store.dispatch(dataTableColumnEdited(headerEditInfo));
   }
 
-  openSlideoutColumnEditMenu() {
-    this.store.dispatch(metricsSlideoutMenuOpened());
+  openTableEditMenuToMode(tableMode: DataTableMode) {
+    this.store.dispatch(metricsSlideoutMenuOpened({mode: tableMode}));
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -849,24 +849,7 @@ describe('scalar card', () => {
       flush();
     }));
 
-    it('dispatches metricsSlideoutMenuOpened with mode SINGLE when there are no fobs when edit columns button is clicked', fakeAsync(() => {
-      store.overrideSelector(
-        selectors.getIsScalarColumnCustomizationEnabled,
-        true
-      );
-      const fixture = createComponent('card1');
-
-      openOverflowMenu(fixture);
-      getMenuButton('Open menu to edit data table columns').click();
-      fixture.detectChanges();
-
-      expect(dispatchedActions[0]).toEqual(
-        metricsSlideoutMenuOpened({mode: DataTableMode.SINGLE})
-      );
-      flush();
-    }));
-
-    it('dispatches metricsSlideoutMenuOpened with mode SINGLE when there is a single fob when edit columns button is clicked', fakeAsync(() => {
+    it('dispatches metricsSlideoutMenuOpened with mode SINGLE when range disabled for card', fakeAsync(() => {
       store.overrideSelector(
         selectors.getIsScalarColumnCustomizationEnabled,
         true
@@ -884,7 +867,7 @@ describe('scalar card', () => {
       flush();
     }));
 
-    it('dispatches metricsSlideoutMenuOpened with mode set to RANGE when edit columns button is clicked and there are 2 fobs', fakeAsync(() => {
+    it('dispatches metricsSlideoutMenuOpened with mode RANGE when range enabled for card', fakeAsync(() => {
       store.overrideSelector(
         selectors.getIsScalarColumnCustomizationEnabled,
         true

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -384,6 +384,10 @@ describe('scalar card', () => {
       selectors.getIsLinkedTimeProspectiveFobEnabled,
       true
     );
+    store.overrideSelector(
+      selectors.getMetricsCardRangeSelectionEnabled,
+      false
+    );
 
     dispatchedActions = [];
     spyOn(store, 'dispatch').and.callFake((action: Action) => {
@@ -845,7 +849,7 @@ describe('scalar card', () => {
       flush();
     }));
 
-    it('dispatches metricsSlideoutMenuOpened when edit columns button is clicked', fakeAsync(() => {
+    it('dispatches metricsSlideoutMenuOpened with mode SINGLE when there are no fobs when edit columns button is clicked', fakeAsync(() => {
       store.overrideSelector(
         selectors.getIsScalarColumnCustomizationEnabled,
         true
@@ -856,7 +860,45 @@ describe('scalar card', () => {
       getMenuButton('Open menu to edit data table columns').click();
       fixture.detectChanges();
 
-      expect(dispatchedActions[0]).toEqual(metricsSlideoutMenuOpened());
+      expect(dispatchedActions[0]).toEqual(
+        metricsSlideoutMenuOpened({mode: DataTableMode.SINGLE})
+      );
+      flush();
+    }));
+
+    it('dispatches metricsSlideoutMenuOpened with mode SINGLE when there is a single fob when edit columns button is clicked', fakeAsync(() => {
+      store.overrideSelector(
+        selectors.getIsScalarColumnCustomizationEnabled,
+        true
+      );
+      store.overrideSelector(getMetricsCardRangeSelectionEnabled, false);
+      const fixture = createComponent('card1');
+
+      openOverflowMenu(fixture);
+      getMenuButton('Open menu to edit data table columns').click();
+      fixture.detectChanges();
+
+      expect(dispatchedActions[0]).toEqual(
+        metricsSlideoutMenuOpened({mode: DataTableMode.SINGLE})
+      );
+      flush();
+    }));
+
+    it('dispatches metricsSlideoutMenuOpened with mode set to RANGE when edit columns button is clicked and there are 2 fobs', fakeAsync(() => {
+      store.overrideSelector(
+        selectors.getIsScalarColumnCustomizationEnabled,
+        true
+      );
+      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      const fixture = createComponent('card1');
+
+      openOverflowMenu(fixture);
+      getMenuButton('Open menu to edit data table columns').click();
+      fixture.detectChanges();
+
+      expect(dispatchedActions[0]).toEqual(
+        metricsSlideoutMenuOpened({mode: DataTableMode.RANGE})
+      );
       flush();
     }));
   });

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -17,7 +17,7 @@ limitations under the License.
 <div class="editor-controls">
   <mat-tab-group
     class="tab-group"
-    [selectedIndex]="selectedTab"
+    [selectedIndex]="getSelectedTabIndex()"
     (selectedTabChange)="tabChange($event)"
   >
     <mat-tab [label]="'Single'">

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ng.html
@@ -15,7 +15,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="editor-controls">
-  <mat-tab-group class="tab-group">
+  <mat-tab-group
+    class="tab-group"
+    [selectedIndex]="selectedTab"
+    (selectedTabChange)="tabChange($event)"
+  >
     <mat-tab [label]="'Single'">
       <ngContext
         [ngTemplateOutlet]="headerList"

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
@@ -20,7 +20,9 @@ import {
   Input,
   OnDestroy,
   Output,
+  ViewChild,
 } from '@angular/core';
+import {MatTabChangeEvent, MatTabGroup} from '@angular/material/tabs';
 import {
   ColumnHeader,
   ColumnHeaderType,
@@ -64,12 +66,12 @@ enum Edge {
 })
 export class ScalarColumnEditorComponent implements OnDestroy {
   DataTableMode = DataTableMode;
-  selectedTab: DataTableMode = DataTableMode.SINGLE;
   draggingHeaderType: ColumnHeaderType | undefined;
   highlightedHeaderType: ColumnHeaderType | undefined;
   highlightEdge: Edge = Edge.TOP;
   @Input() rangeHeaders!: ColumnHeader[];
   @Input() singleHeaders!: ColumnHeader[];
+  @Input() selectedTab!: DataTableMode;
 
   @Output() onScalarTableColumnEdit = new EventEmitter<{
     dataTableMode: DataTableMode;
@@ -80,6 +82,7 @@ export class ScalarColumnEditorComponent implements OnDestroy {
     headerType: ColumnHeaderType;
   }>();
   @Output() onScalarTableColumnEditorClosed = new EventEmitter<void>();
+  @Output() onTabChange = new EventEmitter<DataTableMode>();
 
   constructor(private readonly hostElement: ElementRef) {}
 
@@ -88,6 +91,12 @@ export class ScalarColumnEditorComponent implements OnDestroy {
       'dragover',
       preventDefault
     );
+  }
+
+  tabChange(event: MatTabChangeEvent) {
+    const newMode =
+      event.index === 0 ? DataTableMode.SINGLE : DataTableMode.RANGE;
+    this.onTabChange.emit(newMode);
   }
 
   dragStart(header: ColumnHeader) {

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
@@ -163,6 +163,10 @@ export class ScalarColumnEditorComponent implements OnDestroy {
     };
   }
 
+  getSelectedTabIndex() {
+    return this.selectedTab === DataTableMode.SINGLE ? 0 : 1;
+  }
+
   private getHeadersForMode(dataTableMode: DataTableMode) {
     return dataTableMode === DataTableMode.SINGLE
       ? this.singleHeaders

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -19,12 +19,15 @@ import {
   dataTableColumnEdited,
   dataTableColumnToggled,
   metricsSlideoutMenuClosed,
+  tableEditorTabChanged,
 } from '../../../actions';
 import {
   getRangeSelectionHeaders,
   getSingleSelectionHeaders,
+  getTableEditorSelectedTab,
 } from '../../../store/metrics_selectors';
 import {HeaderEditInfo, HeaderToggleInfo} from '../../../types';
+import {DataTableMode} from '../../card_renderer/scalar_card_types';
 
 @Component({
   selector: 'metrics-scalar-column-editor',
@@ -32,9 +35,11 @@ import {HeaderEditInfo, HeaderToggleInfo} from '../../../types';
     <metrics-scalar-column-editor-component
       [singleHeaders]="singleHeaders$ | async"
       [rangeHeaders]="rangeHeaders$ | async"
+      [selectedTab]="selectedTab$ | async"
       (onScalarTableColumnToggled)="onScalarTableColumnToggled($event)"
       (onScalarTableColumnEdit)="onScalarTableColumnEdit($event)"
       (onScalarTableColumnEditorClosed)="onScalarTableColumnEditorClosed()"
+      (onTabChange)="onTabChange($event)"
     >
     </metrics-scalar-column-editor-component>
   `,
@@ -45,6 +50,7 @@ export class ScalarColumnEditorContainer {
 
   readonly singleHeaders$ = this.store.select(getSingleSelectionHeaders);
   readonly rangeHeaders$ = this.store.select(getRangeSelectionHeaders);
+  readonly selectedTab$ = this.store.select(getTableEditorSelectedTab);
 
   onScalarTableColumnToggled(toggleInfo: HeaderToggleInfo) {
     this.store.dispatch(dataTableColumnToggled(toggleInfo));
@@ -56,5 +62,9 @@ export class ScalarColumnEditorContainer {
 
   onScalarTableColumnEditorClosed() {
     this.store.dispatch(metricsSlideoutMenuClosed());
+  }
+
+  onTabChange(tab: DataTableMode) {
+    this.store.dispatch(tableEditorTabChanged({tab}));
   }
 }

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -358,7 +358,6 @@ describe('scalar column editor', () => {
       const fixture = createComponent();
       fixture.detectChanges();
       const tabs = fixture.debugElement.queryAll(By.css('.mat-tab-label'));
-      console.log('tabs', tabs[0].attributes.class);
 
       expect(
         tabs[0].attributes.class?.includes('mat-tab-label-active')

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -28,10 +28,12 @@ import {
   dataTableColumnEdited,
   dataTableColumnToggled,
   metricsSlideoutMenuClosed,
+  tableEditorTabChanged,
 } from '../../../actions';
 import {
   getRangeSelectionHeaders,
   getSingleSelectionHeaders,
+  getTableEditorSelectedTab,
 } from '../../../store/metrics_selectors';
 import {
   ColumnHeaderType,
@@ -78,6 +80,7 @@ describe('scalar column editor', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getRangeSelectionHeaders, []);
     store.overrideSelector(getSingleSelectionHeaders, []);
+    store.overrideSelector(getTableEditorSelectedTab, DataTableMode.SINGLE);
   });
 
   afterEach(() => {
@@ -156,7 +159,8 @@ describe('scalar column editor', () => {
       ]);
       const fixture = createComponent();
       switchTabs(fixture, DataTableMode.SINGLE);
-
+      // Clear action fired on tab change.
+      dispatchedActions = [];
       const checkboxes = fixture.debugElement.queryAll(By.css('mat-checkbox'));
 
       checkboxes[0].triggerEventHandler('change');
@@ -178,6 +182,8 @@ describe('scalar column editor', () => {
       const fixture = createComponent();
 
       switchTabs(fixture, DataTableMode.RANGE);
+      // Clear action fired on tab change.
+      dispatchedActions = [];
       const checkboxes = fixture.debugElement.queryAll(By.css('mat-checkbox'));
       checkboxes[1].triggerEventHandler('change', {});
       fixture.detectChanges();
@@ -208,7 +214,8 @@ describe('scalar column editor', () => {
       ]);
       const fixture = createComponent();
       switchTabs(fixture, DataTableMode.SINGLE);
-
+      // Clear action fired on tab change.
+      dispatchedActions = [];
       const headerListItems = fixture.debugElement.queryAll(
         By.css('.header-list-item')
       );
@@ -237,7 +244,8 @@ describe('scalar column editor', () => {
       ]);
       const fixture = createComponent();
       switchTabs(fixture, DataTableMode.RANGE);
-
+      // Clear action fired on tab change.
+      dispatchedActions = [];
       const headerListItems = fixture.debugElement.queryAll(
         By.css('.header-list-item')
       );
@@ -317,6 +325,58 @@ describe('scalar column editor', () => {
         .triggerEventHandler('click', {});
 
       expect(dispatchedActions[0]).toEqual(metricsSlideoutMenuClosed());
+    });
+  });
+
+  describe('tabs', () => {
+    let dispatchedActions: Action[] = [];
+    beforeEach(() => {
+      dispatchedActions = [];
+      spyOn(store, 'dispatch').and.callFake((action: Action) => {
+        dispatchedActions.push(action);
+      });
+    });
+    it('dispatches tableEditorTabChanged action when tab is clicked', fakeAsync(() => {
+      const fixture = createComponent();
+      switchTabs(fixture, DataTableMode.RANGE);
+      fixture.detectChanges();
+
+      expect(dispatchedActions[0]).toEqual(
+        tableEditorTabChanged({tab: DataTableMode.RANGE})
+      );
+
+      dispatchedActions = [];
+      switchTabs(fixture, DataTableMode.SINGLE);
+      fixture.detectChanges();
+
+      expect(dispatchedActions[0]).toEqual(
+        tableEditorTabChanged({tab: DataTableMode.SINGLE})
+      );
+    }));
+
+    it('update when global tableEditorSelectedTab changes', () => {
+      const fixture = createComponent();
+      fixture.detectChanges();
+      const tabs = fixture.debugElement.queryAll(By.css('.mat-tab-label'));
+      console.log('tabs', tabs[0].attributes.class);
+
+      expect(
+        tabs[0].attributes.class?.includes('mat-tab-label-active')
+      ).toBeTrue();
+      expect(
+        tabs[1].attributes.class?.includes('mat-tab-label-active')
+      ).toBeFalse();
+
+      store.overrideSelector(getTableEditorSelectedTab, DataTableMode.RANGE);
+      store.refreshState();
+      fixture.detectChanges();
+
+      expect(
+        tabs[0].attributes.class?.includes('mat-tab-label-active')
+      ).toBeFalse();
+      expect(
+        tabs[1].attributes.class?.includes('mat-tab-label-active')
+      ).toBeTrue();
     });
   });
 });


### PR DESCRIPTION
## Motivation for features / changes
When the Column Editor is opened from the scalar card it opens to whatever the default or last selected tab is. However, it would be expected to open to the mode that the card used to open it is in(Single vs Range). This makes that happen

## Technical description of changes
This PR creates a new value in the metricsState(tableEditorSelectedTab) which reflects the selected tab in the table editor. It then pulls that value into the editor and uses it to select the tab. It is kept up to date with calls to tableEditorTabChanged (a new action created for this purpose) when the tab is changed inside the controller. 

Lastly it adds a new prop to the metricsSlideoutMenuOpened action which contains the current mode of the chart which dispatched the action. This mode is used to update the new tableEditorSelectedTab value.

## Screenshots of UI changes
![2023-04-13_23-47-03 (1)](https://user-images.githubusercontent.com/8672809/231965710-9b124054-cf47-4394-9789-18894e06574c.gif)
