### PR TITLE
HParams: Add feature flag to control the rollout of the hparams in time series

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -130,6 +130,11 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       queryParamOverride: 'enableScalarColumnCustomization',
       parseValue: parseBoolean,
     },
+    enableHparmasInTimeSeries: {
+      defaultValue: false,
+      queryParamOverride: 'enableHparmasInTimeSeries',
+      parseValue: parseBoolean,
+    },
   };
 
 /**

--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -130,9 +130,9 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       queryParamOverride: 'enableScalarColumnCustomization',
       parseValue: parseBoolean,
     },
-    enableHparmasInTimeSeries: {
+    enableHparamsInTimeSeries: {
       defaultValue: false,
-      queryParamOverride: 'enableHparmasInTimeSeries',
+      queryParamOverride: 'enableHparamsInTimeSeries',
       parseValue: parseBoolean,
     },
   };

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -55,5 +55,5 @@ export interface FeatureFlags {
   // Card Data Table
   enableScalarColumnCustomization: boolean;
   // Adds hparam columns to the runs table and the scalar card data table.
-  enableHparmasInTimeSeries: boolean;
+  enableHparamsInTimeSeries: boolean;
 }

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -54,4 +54,6 @@ export interface FeatureFlags {
   // Adds affordance for users to select and reorder the columns in the Scalar
   // Card Data Table
   enableScalarColumnCustomization: boolean;
+  // Adds hparam columns to the runs table and the scalar card data table.
+  enableHparmasInTimeSeries: boolean;
 }


### PR DESCRIPTION
## Motivation for features / changes
We are about to start working on a new feature to show hparams in the runs table and the scalar card data table and would like to control its roll out.

## Technical description of changes
I added a new feature flag.

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/78179109/231518750-a20110aa-3efa-4b2c-897c-ce09f9d71a71.png)

## Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Navigate to localhost:6006?showFlags=hparams
3) Ensure the new feature flag is shown in the modal
![image](https://user-images.githubusercontent.com/78179109/231519055-cddbeb62-fc5c-4e59-8dd6-d112cfa6ec18.png)

