### PR TITLE
Simplify Polymer Router implementation

### DIFF
--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 import {FEATURE_FLAGS_QUERY_STRING_NAME} from '../../webapp/feature_flag/http/const';
 import {getFeatureFlagsToSendToServer} from '../tf_feature_flags/feature-flags';
-import {ExperimentId} from './type';
 import {QueryParams} from './urlPathHelpers';
 
 const EXPERIMENTAL_PLUGINS_QUERY_PARAM = 'experimentalPlugin';
@@ -34,7 +33,6 @@ export interface Router {
   ) => string;
   pluginsListing: () => string;
   runs: () => string;
-  runsForExperiment: (id: ExperimentId) => string;
 }
 
 /**
@@ -47,29 +45,17 @@ let _router: Router = createRouter();
 /**
  * Create a router for communicating with the TensorBoard backend. You
  * can pass this to `setRouter` to make it the global router.
- *
- * @param dataDir {string=} The base prefix for data endpoints.
  */
-export function createRouter(
-  dataDir = 'data',
-  urlSearchParams = initialURLSearchParams
-): Router {
-  if (dataDir[dataDir.length - 1] === '/') {
-    dataDir = dataDir.slice(0, dataDir.length - 1);
-  }
+export function createRouter(): Router {
   return {
-    environment: () => createDataPath(dataDir, '/environment'),
-    experiments: () => createDataPath(dataDir, '/experiments'),
+    environment: () => createDataPath('/environment'),
+    experiments: () => createDataPath('/experiments'),
     pluginRoute: (
       pluginName: string,
       route: string,
       params?: URLSearchParams
     ): string => {
-      return createDataPath(
-        dataDir + '/plugin',
-        `/${pluginName}${route}`,
-        params
-      );
+      return createDataPath(`/plugin/${pluginName}${route}`, params);
     },
     pluginRouteForSrc: (
       pluginName: string,
@@ -83,30 +69,18 @@ export function createRouter(
           JSON.stringify(featureFlags)
         );
       }
-      return createDataPath(
-        dataDir + '/plugin',
-        `/${pluginName}${route}`,
-        params
-      );
+      return createDataPath(`/plugin/${pluginName}${route}`, params);
     },
     pluginsListing: () =>
       createDataPath(
-        dataDir,
         '/plugins_listing',
         createSearchParam({
-          [EXPERIMENTAL_PLUGINS_QUERY_PARAM]: urlSearchParams.getAll(
+          [EXPERIMENTAL_PLUGINS_QUERY_PARAM]: initialURLSearchParams.getAll(
             EXPERIMENTAL_PLUGINS_QUERY_PARAM
           ),
         })
       ),
-    runs: () => createDataPath(dataDir, '/runs'),
-    runsForExperiment: (id) => {
-      return createDataPath(
-        dataDir,
-        '/experiment_runs',
-        createSearchParam({experiment: String(id)})
-      );
-    },
+    runs: () => createDataPath('/runs'),
   };
 }
 
@@ -117,27 +91,11 @@ export function getRouter(): Router {
   return _router;
 }
 
-/**
- * Set the global router, to be returned by future calls to `getRouter`.
- * You may wish to invoke this if you are running a demo server with a
- * custom path prefix, or if you have customized the TensorBoard backend
- * to use a different path.
- *
- * @param {Router} router the new global router
- */
-export function setRouter(router: Router): void {
-  if (router == null) {
-    throw new Error('Router required, but got: ' + router);
-  }
-  _router = router;
-}
-
 function createDataPath(
-  dataDir: string,
   route: string,
   params: URLSearchParams = new URLSearchParams()
 ): string {
-  let relativePath = dataDir + route;
+  let relativePath = 'data' + route;
   if (String(params)) {
     const delimiter = route.includes('?') ? '&' : '?';
     relativePath += delimiter + String(params);


### PR DESCRIPTION
Remove the ability to create and inject Polymer Router instances with customizations.

The customizations are no longer necessary.
* The`dataDir` argument may be a remnant of internal extensions of the Router that no longer exist.
* The `urlSearchParams` argument may be a remnant from when the polymer code had tests.

Additionally, the setRouter() function is no longer necessary as its Google-internal usage was recently removed.

Tested:
* There are no tests for the polymer code so this was tested by hand. I ensured the Scalars, Images, and Hparams dashboards all continued to work with these changes.
* Additionally I imported the changes internally and ran presubmit tests.