### PR TITLE
HParams: Add new hparams selector factories

### DIFF
--- a/tensorboard/webapp/hparams/_redux/BUILD
+++ b/tensorboard/webapp/hparams/_redux/BUILD
@@ -74,6 +74,7 @@ tf_ts_library(
         ":hparams_actions",
         ":types",
         ":utils",
+        "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/hparams:types",
         "//tensorboard/webapp/runs/actions",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
@@ -12,12 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {
-  createFeatureSelector,
-  createSelector,
-  MemoizedSelector,
-} from '@ngrx/store';
-import {State} from '../../app_state';
+import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {DiscreteFilter, HparamAndMetricSpec, IntervalFilter} from '../types';
 import {combineHparamAndMetricSpecs} from './hparams_selectors_utils';
 import {HparamsState, HPARAMS_FEATURE_KEY} from './types';
@@ -147,7 +142,7 @@ export function getMetricFilterMapFromExperimentIds(experimentIds: string[]) {
     getMetricsDefaultFiltersForExperimentsFromExperimentIds(experimentIds),
     (state, defaultFilterMap) =>
       getMetricFilterMapResultFunction(state, defaultFilterMap, experimentIds)
-  ) as MemoizedSelector<State, Map<string, IntervalFilter>>;
+  );
 }
 
 /**

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
@@ -12,7 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {createFeatureSelector, createSelector} from '@ngrx/store';
+import {
+  createFeatureSelector,
+  createSelector,
+  MemoizedSelector,
+} from '@ngrx/store';
+import {State} from '../../app_state';
 import {DiscreteFilter, HparamAndMetricSpec, IntervalFilter} from '../types';
 import {combineHparamAndMetricSpecs} from './hparams_selectors_utils';
 import {HparamsState, HPARAMS_FEATURE_KEY} from './types';
@@ -25,80 +30,125 @@ import {
 const getHparamsState =
   createFeatureSelector<HparamsState>(HPARAMS_FEATURE_KEY);
 
-const getHparamsDefaultFiltersForExperiments = createSelector(
-  getHparamsState,
-  (
-    state: HparamsState,
-    experimentIds: string[]
-  ): Map<string, DiscreteFilter | IntervalFilter> => {
-    const defaultFilterMaps: Array<
-      Map<string, DiscreteFilter | IntervalFilter>
-    > = [];
+function getHparamsDefaultFiltersForExperimentsResultFunction(
+  state: HparamsState,
+  experimentIds: string[]
+): Map<string, DiscreteFilter | IntervalFilter> {
+  const defaultFilterMaps: Array<Map<string, DiscreteFilter | IntervalFilter>> =
+    [];
 
-    for (const experimentId of experimentIds) {
-      if (!state.specs[experimentId]) {
-        continue;
-      }
-
-      defaultFilterMaps.push(state.specs[experimentId].hparam.defaultFilters);
+  for (const experimentId of experimentIds) {
+    if (!state.specs[experimentId]) {
+      continue;
     }
 
-    return combineDefaultHparamFilters(defaultFilterMaps);
+    defaultFilterMaps.push(state.specs[experimentId].hparam.defaultFilters);
   }
+
+  return combineDefaultHparamFilters(defaultFilterMaps);
+}
+
+const getHparamsDefaultFiltersForExperiments = createSelector(
+  getHparamsState,
+  getHparamsDefaultFiltersForExperimentsResultFunction
 );
+
+function getHparamsDefaultFiltersForExperimentsFromExperimentIds(
+  experimentIds: string[]
+) {
+  return createSelector(getHparamsState, (state) =>
+    getHparamsDefaultFiltersForExperimentsResultFunction(state, experimentIds)
+  );
+}
+
+function getHparamFilterMapResultFunction(
+  hparamState: HparamsState,
+  combinedDefaultfilterMap: Map<string, DiscreteFilter | IntervalFilter>,
+  experimentIds: string[]
+): Map<string, IntervalFilter | DiscreteFilter> {
+  const id = getIdFromExperimentIds(experimentIds);
+  const otherFilter = hparamState.filters[id];
+
+  return new Map([
+    ...combinedDefaultfilterMap,
+    ...(otherFilter?.hparams ?? []),
+  ]);
+}
 
 export const getHparamFilterMap = createSelector(
-  getHparamsDefaultFiltersForExperiments,
   getHparamsState,
-  (
-    combinedDefaultfilterMap,
-    hparamState,
-    experimentIds: string[]
-  ): Map<string, IntervalFilter | DiscreteFilter> => {
-    const id = getIdFromExperimentIds(experimentIds);
-    const otherFilter = hparamState.filters[id];
-
-    return new Map([
-      ...combinedDefaultfilterMap,
-      ...(otherFilter?.hparams ?? []),
-    ]);
-  }
+  getHparamsDefaultFiltersForExperiments,
+  getHparamFilterMapResultFunction
 );
+
+export function getHparamFilterMapFromExperimentIds(experimentIds: string[]) {
+  return createSelector(
+    getHparamsState,
+    getHparamsDefaultFiltersForExperimentsFromExperimentIds(experimentIds),
+    (hparamState, combinedDefaultFilterMap) =>
+      getHparamFilterMapResultFunction(
+        hparamState,
+        combinedDefaultFilterMap,
+        experimentIds
+      )
+  );
+}
+
+function getMetricsDefaultFiltersForExperimentsResultFunction(
+  state: HparamsState,
+  experimentIds: string[]
+): Map<string, IntervalFilter> {
+  const defaultFilterMaps: Array<Map<string, IntervalFilter>> = [];
+
+  for (const experimentId of experimentIds) {
+    if (!state.specs[experimentId]) {
+      continue;
+    }
+
+    defaultFilterMaps.push(state.specs[experimentId].metric.defaultFilters);
+  }
+
+  return combineDefaultMetricFilters(defaultFilterMaps);
+}
 
 const getMetricsDefaultFiltersForExperiments = createSelector(
   getHparamsState,
-  (
-    state: HparamsState,
-    experimentIds: string[]
-  ): Map<string, IntervalFilter> => {
-    const defaultFilterMaps: Array<Map<string, IntervalFilter>> = [];
-
-    for (const experimentId of experimentIds) {
-      if (!state.specs[experimentId]) {
-        continue;
-      }
-
-      defaultFilterMaps.push(state.specs[experimentId].metric.defaultFilters);
-    }
-
-    return combineDefaultMetricFilters(defaultFilterMaps);
-  }
+  getMetricsDefaultFiltersForExperimentsResultFunction
 );
+
+function getMetricsDefaultFiltersForExperimentsFromExperimentIds(
+  experimentIds: string[]
+) {
+  return createSelector(getHparamsState, (state) =>
+    getMetricsDefaultFiltersForExperimentsResultFunction(state, experimentIds)
+  );
+}
+
+function getMetricFilterMapResultFunction(
+  hparamState: HparamsState,
+  defaultFilterMap: Map<string, IntervalFilter>,
+  experimentIds: string[]
+): Map<string, IntervalFilter> {
+  const id = getIdFromExperimentIds(experimentIds);
+  const otherFilter = hparamState.filters[id];
+
+  return new Map([...defaultFilterMap, ...(otherFilter?.metrics ?? [])]);
+}
 
 export const getMetricFilterMap = createSelector(
-  getMetricsDefaultFiltersForExperiments,
   getHparamsState,
-  (
-    defaultfilterMap,
-    hparamState,
-    experimentIds: string[]
-  ): Map<string, IntervalFilter> => {
-    const id = getIdFromExperimentIds(experimentIds);
-    const otherFilter = hparamState.filters[id];
-
-    return new Map([...defaultfilterMap, ...(otherFilter?.metrics ?? [])]);
-  }
+  getMetricsDefaultFiltersForExperiments,
+  getMetricFilterMapResultFunction
 );
+
+export function getMetricFilterMapFromExperimentIds(experimentIds: string[]) {
+  return createSelector(
+    getHparamsState,
+    getMetricsDefaultFiltersForExperimentsFromExperimentIds(experimentIds),
+    (state, defaultFilterMap) =>
+      getMetricFilterMapResultFunction(state, defaultFilterMap, experimentIds)
+  ) as MemoizedSelector<State, Map<string, IntervalFilter>>;
+}
 
 /**
  * Returns Observable that emits hparams and metrics specs of experiments.

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
@@ -117,6 +117,98 @@ describe('hparams/_redux/hparams_selectors_test', () => {
     });
   });
 
+  describe('#getHparamFilterMapFromExperimentIds()', () => {
+    it('returns default hparam filter map', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState(
+          buildSpecs('foo', {
+            hparam: {
+              specs: [buildHparamSpec({name: 'optimizer'})],
+              defaultFilters: new Map([
+                [
+                  'optimizer',
+                  buildDiscreteFilter({
+                    filterValues: ['a', 'b', 'c'],
+                  }),
+                ],
+              ]),
+            },
+          })
+        )
+      );
+
+      expect(
+        selectors.getHparamFilterMapFromExperimentIds(['foo'])(state)
+      ).toEqual(
+        new Map([
+          ['optimizer', buildDiscreteFilter({filterValues: ['a', 'b', 'c']})],
+        ])
+      );
+    });
+
+    it('returns custom hparam filter map', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState(
+          buildSpecs('foo', {
+            hparam: {
+              specs: [buildHparamSpec({name: 'optimizer'})],
+              defaultFilters: new Map([
+                [
+                  'optimizer',
+                  buildDiscreteFilter({
+                    filterValues: ['a', 'b', 'c'],
+                  }),
+                ],
+              ]),
+            },
+          }),
+          buildFilterState(['foo'], {
+            hparams: new Map([
+              [
+                'optimizer',
+                buildDiscreteFilter({
+                  filterValues: ['d', 'e', 'f'],
+                }),
+              ],
+            ]),
+          })
+        )
+      );
+
+      expect(
+        selectors.getHparamFilterMapFromExperimentIds(['foo'])(state)
+      ).toEqual(
+        new Map([
+          [
+            'optimizer',
+            buildDiscreteFilter({
+              filterValues: ['d', 'e', 'f'],
+            }),
+          ],
+        ])
+      );
+    });
+
+    it('returns empty map for an unknown exp', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState(
+          buildSpecs('foo', {
+            hparam: {
+              specs: [buildHparamSpec({name: 'optimizer'})],
+              defaultFilters: new Map([
+                ['optimizer', buildDiscreteFilter({filterValues: ['a']})],
+              ]),
+            },
+          })
+        )
+      );
+
+      expect(
+        selectors.getHparamFilterMapFromExperimentIds(['bar'])(state)
+      ).toEqual(new Map());
+    });
+  });
+
   describe('#getMetricFilterMap', () => {
     beforeEach(() => {
       // Clear the memoization.
@@ -230,6 +322,123 @@ describe('hparams/_redux/hparams_selectors_test', () => {
         )
       );
       expect(selectors.getMetricFilterMap(state, ['bar'])).toEqual(new Map());
+    });
+  });
+
+  describe('#getMetricFilterMapFromExperimentIds', () => {
+    it('returns default metric filter map', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState(
+          buildSpecs('foo', {
+            metric: {
+              specs: [buildMetricSpec({tag: 'acc'})],
+              defaultFilters: new Map([
+                [
+                  'acc',
+                  buildIntervalFilter({
+                    filterLowerValue: 0,
+                    filterUpperValue: 1,
+                  }),
+                ],
+              ]),
+            },
+          })
+        )
+      );
+
+      expect(
+        selectors.getMetricFilterMapFromExperimentIds(['foo'])(state)
+      ).toEqual(
+        new Map([
+          [
+            'acc',
+            buildIntervalFilter({
+              filterLowerValue: 0,
+              filterUpperValue: 1,
+            }),
+          ],
+        ])
+      );
+    });
+
+    it('returns custom metric filter map', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState(
+          buildSpecs('foo', {
+            metric: {
+              specs: [buildMetricSpec({tag: 'acc'})],
+              defaultFilters: new Map([
+                [
+                  'acc',
+                  buildIntervalFilter({
+                    filterLowerValue: 0,
+                    filterUpperValue: 1,
+                  }),
+                ],
+              ]),
+            },
+          }),
+          buildFilterState(['foo'], {
+            metrics: new Map([
+              [
+                'acc',
+                buildIntervalFilter({
+                  filterLowerValue: 0,
+                  filterUpperValue: 0.1,
+                }),
+              ],
+            ]),
+          })
+        )
+      );
+      expect(
+        selectors.getMetricFilterMapFromExperimentIds(['foo'])(state)
+      ).toEqual(
+        new Map([
+          [
+            'acc',
+            buildIntervalFilter({
+              filterLowerValue: 0,
+              filterUpperValue: 0.1,
+            }),
+          ],
+        ])
+      );
+    });
+
+    it('returns empty map for an unknown exp', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState(
+          buildSpecs('foo', {
+            metric: {
+              specs: [buildMetricSpec({tag: 'acc'})],
+              defaultFilters: new Map([
+                [
+                  'acc',
+                  buildIntervalFilter({
+                    filterLowerValue: 0,
+                    filterUpperValue: 1,
+                  }),
+                ],
+              ]),
+            },
+          }),
+          buildFilterState(['foo'], {
+            metrics: new Map([
+              [
+                'acc',
+                buildIntervalFilter({
+                  filterLowerValue: 0,
+                  filterUpperValue: 0.1,
+                }),
+              ],
+            ]),
+          })
+        )
+      );
+      expect(
+        selectors.getMetricFilterMapFromExperimentIds(['bar'])(state)
+      ).toEqual(new Map());
     });
   });
 });


### PR DESCRIPTION
## Motivation for features / changes
As part of the effort to bring hparams to the time series dashboard a handful of new selectors need to be created. Rather than further the practice of creating selectors with props ([which is deprecated](https://ngrx.io/guide/migration/v12)) I am choosing to create them using the recommended solution of a selector factory. Unfortunately selector factories don't play nicely with selectors dependent selectors WITH props. There are a handful of hacky solutions to this problem but I am opting to create new dependent selectors using the factory pattern.

## Technical description of changes
I extracted the result functions from the existing selectors, then created new factories which call them with an additional closured parameter.

## Screenshots of UI changes
None

## Detailed steps to verify changes work correctly (as executed by you)
Tests should pass

## Alternate designs / implementations considered
I could have just wrapped the existing selectors and then called them passing in the global state instead. I chose this approach instead with the hope of removing the old selectors in a later pr.
