### PR TITLE
HParams: Add new experiments selector

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -264,6 +264,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/core/views:test_lib",
         "//tensorboard/webapp/customization:customization_test_lib",
         "//tensorboard/webapp/deeplink:deeplink_test_lib",
+        "//tensorboard/webapp/experiments/store:store_test_lib",
         "//tensorboard/webapp/header:test_lib",
         "//tensorboard/webapp/metrics:integration_test",
         "//tensorboard/webapp/metrics:test_lib",

--- a/tensorboard/webapp/experiments/store/BUILD
+++ b/tensorboard/webapp/experiments/store/BUILD
@@ -64,6 +64,7 @@ tf_ts_library(
     deps = [
         ":selectors",
         ":testing",
+        ":types",
         "//tensorboard/webapp/types",
         "@npm//@types/jasmine",
     ],

--- a/tensorboard/webapp/experiments/store/experiments_selectors.ts
+++ b/tensorboard/webapp/experiments/store/experiments_selectors.ts
@@ -44,3 +44,20 @@ export const getExperiment = createSelector(
     return state.experimentMap[experimentId] || null;
   }
 );
+
+/**
+ * Returns Observable that emits an object mapping the provided
+ * experiment ids to experiment names.
+ */
+export const getExperimentNames = (experimentIds: string[]) =>
+  createSelector(
+    getDataState,
+    (state: ExperimentsDataState): Record<string, string> =>
+      experimentIds
+        .map((experimentId) => state.experimentMap[experimentId])
+        .filter(Boolean)
+        .reduce((map, experiment) => {
+          map[experiment.id] = experiment.name;
+          return map;
+        }, {} as Record<string, string>)
+  );

--- a/tensorboard/webapp/experiments/store/experiments_selectors_test.ts
+++ b/tensorboard/webapp/experiments/store/experiments_selectors_test.ts
@@ -72,13 +72,9 @@ describe('experiments selectors', () => {
       });
     });
 
-    it('does not include experiments which are not found', () => {
-      expect(selectors.getExperimentNames(['foo', 'baz'])(state)).toEqual({
-        foo: 'foo name',
-      });
-    });
     it('returns an empty object when no experiments are provided', () => {
       expect(selectors.getExperimentNames([])(state)).toEqual({});
+      expect(selectors.getExperimentNames(['abc', '123'])(state)).toEqual({});
     });
   });
 });

--- a/tensorboard/webapp/experiments/store/experiments_selectors_test.ts
+++ b/tensorboard/webapp/experiments/store/experiments_selectors_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import * as selectors from './experiments_selectors';
+import {State} from './experiments_types';
 import {buildExperiment, buildStateFromExperimentsState} from './testing';
 
 describe('experiments selectors', () => {
@@ -45,6 +46,39 @@ describe('experiments selectors', () => {
       expect(selectors.getExperiment(state, {experimentId: 'tigger'})).toEqual(
         null
       );
+    });
+  });
+
+  describe('#getExperimentNames', () => {
+    let state: State;
+
+    beforeEach(() => {
+      const foo = buildExperiment({id: 'foo', name: 'foo name'});
+      const bar = buildExperiment({id: 'bar', name: 'bar name'});
+
+      state = buildStateFromExperimentsState({
+        data: {
+          experimentMap: {foo, bar},
+        },
+      });
+    });
+
+    it('translates experiment ids to experiment names', () => {
+      expect(
+        selectors.getExperimentNames(['foo', 'bar', 'baz'])(state)
+      ).toEqual({
+        foo: 'foo name',
+        bar: 'bar name',
+      });
+    });
+
+    it('does not include experiments which are not found', () => {
+      expect(selectors.getExperimentNames(['foo', 'baz'])(state)).toEqual({
+        foo: 'foo name',
+      });
+    });
+    it('returns an empty object when no experiments are provided', () => {
+      expect(selectors.getExperimentNames([])(state)).toEqual({});
     });
   });
 });


### PR DESCRIPTION
## Motivation for features / changes
As part of the effort to bring hparams to the time series dashboard a handful of new selectors need to be created. In particular I will be creating a new one to handle runs filtering by moving the logic out of the runs_table_container into the selector layer.
This will ensure filtered runs are consistent across the dashboard.

Getting a mapping of experiment id to name is a prerequisite for this.

Also the experiments tests weren't being run?

## Technical description of changes
I created a new selector factory which takes in a list of experiment ids and creates a `Record<ExperimentId, ExperimentName>`

## Screenshots of UI changes
None

## Detailed steps to verify changes work correctly (as executed by you)
The tests should pass (note that the webapp experiments tests should be run)
