### PR TITLE
Embedding Projector: show error on task failure

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data-provider-demo.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider-demo.ts
@@ -134,7 +134,7 @@ export class DemoDataProvider implements DataProvider {
     const xhr = new XMLHttpRequest();
     xhr.open('GET', embedding.bookmarksPath!);
     xhr.onerror = (err) => {
-      logging.setErrorMessage(xhr.responseText);
+      logging.setErrorMessage(xhr.responseText, 'fetching bookmarks');
     };
     xhr.onload = () => {
       const bookmarks = JSON.parse(xhr.responseText) as State[];

--- a/tensorboard/plugins/projector/vz_projector/data-provider.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider.ts
@@ -123,8 +123,8 @@ export function retrieveTensorAsBytes(
     let data: Float32Array;
     try {
       data = new Float32Array(xhr.response);
-    } catch (e: any) {
-      logging.setErrorMessage(e, 'parsing tensor bytes');
+    } catch (ex: any) {
+      logging.setErrorMessage((ex as Error).message, 'parsing tensor bytes');
       return;
     }
     let dim = embedding.tensorShape[1];
@@ -241,14 +241,16 @@ export function parseTensors(
         numDim = dataPoint.vector.length;
       }
       if (numDim !== dataPoint.vector.length) {
-        logging.setModalMessage(
-          'Parsing failed. Vector dimensions do not match'
+        logging.setErrorMessage(
+          'Vector dimensions do not match',
+          'parsing tensors'
         );
         throw Error('Parsing failed');
       }
       if (numDim <= 1) {
-        logging.setModalMessage(
-          'Parsing failed. Found a vector with only one dimension?'
+        logging.setErrorMessage(
+          'Found a vector with only one dimension?',
+          'parsing tensors'
         );
         throw Error('Parsing failed');
       }
@@ -445,18 +447,22 @@ export function retrieveSpriteAndMetadataInfo(
       (spriteImage.height > MAX_SPRITE_IMAGE_SIZE_PX ||
         spriteImage.width > MAX_SPRITE_IMAGE_SIZE_PX)
     ) {
-      logging.setModalMessage(
+      logging.setErrorMessage(
         `Error: Sprite image of dimensions ${spriteImage.width}px x ` +
           `${spriteImage.height}px exceeds maximum dimensions ` +
-          `${MAX_SPRITE_IMAGE_SIZE_PX}px x ${MAX_SPRITE_IMAGE_SIZE_PX}px`
+          `${MAX_SPRITE_IMAGE_SIZE_PX}px x ${MAX_SPRITE_IMAGE_SIZE_PX}px`,
+        'parsing sprite images'
       );
     } else {
       metadata.spriteImage = spriteImage!;
       metadata.spriteMetadata = spriteMetadata;
       try {
         callback(metadata);
-      } catch (e) {
-        logging.setModalMessage(String(e));
+      } catch (ex) {
+        logging.setErrorMessage(
+          (ex as Error).message,
+          'parsing sprite metadata'
+        );
       }
     }
   });

--- a/tensorboard/plugins/projector/vz_projector/util.ts
+++ b/tensorboard/plugins/projector/vz_projector/util.ts
@@ -192,6 +192,7 @@ export function runAsyncTask<T>(
         }
         resolve(result);
       } catch (ex) {
+        logging.setErrorMessage((ex as Error).message);
         reject(ex);
       }
       return true;


### PR DESCRIPTION
## Motivation for features / changes

When an error occurs user gets stuck with a modal that can't be dismissed.

## Technical description of changes

show a proper error modal that can be dismissed.

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/31378877/232664638-8023c5a5-0ac5-48f2-bc6d-32b8b599c18f.png)

## Detailed steps to verify changes work correctly (as executed by you)

1. Open Word2Vec 10K
2. open t-SNE
3. open UMAP
4. see this error

## Alternate designs / implementations considered
