### PR TITLE
Embedding Projector: fix dark mode button contrast

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector.html.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.html.ts
@@ -219,6 +219,7 @@ export const template = html`
         position: absolute;
         top: 20px;
         left: 20px;
+        background: white;
       }
 
       #help3dDialog .main {


### PR DESCRIPTION
## Motivation for features / changes

Help button cannot be seen in dark mode

## Technical description of changes

force white background so the button is visible

## Screenshots of UI changes

Before:
![image](https://user-images.githubusercontent.com/31378877/232663149-f20a6ae5-da41-4ae7-bd57-f51aec914efc.png)

After:
<img width="208" alt="Screenshot 2023-04-17 at 8 29 01 PM" src="https://user-images.githubusercontent.com/31378877/232663682-c67c5326-5713-4e6e-9ae5-3ac03dfc80b6.png">


## Detailed steps to verify changes work correctly (as executed by you)
turn on dark mode and verify the dialog button is visible

## Alternate designs / implementations considered
