### PR TITLE
Embedding Projector: fix regex suffix css

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-input.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-input.ts
@@ -47,12 +47,17 @@ class ProjectorInput extends LegacyElementMixin(PolymerElement) {
         background-color: #880e4f;
         color: white;
       }
+
+      .suffix {
+        display: flex;
+        flex-direction: row;
+      }
     </style>
 
     <paper-input label="[[label]]">
       <div class="slash" prefix slot="prefix">/</div>
-      <div class="slash" suffix slot="suffix">/</div>
-      <div suffix slot="suffix">
+      <div class="suffix" suffix slot="suffix">
+        <div class="slash">/</div>
         <paper-button id="regex" toggles class="toggle">.*</paper-button>
       </div>
     </paper-input>


### PR DESCRIPTION
## Motivation for features / changes

The regex end slash and the regex button did not fit in the same line.

## Technical description of changes

There should be a single suffix slot element that flex in the correct direction

## Screenshots of UI changes

### Before
<img width="141" alt="Screenshot 2023-04-17 at 8 18 31 PM" src="https://user-images.githubusercontent.com/31378877/232662251-e2b6dcf4-d6e4-4ea2-8334-cf79e7da26fe.png">

### After
![image](https://user-images.githubusercontent.com/31378877/232662384-e20d71d6-b152-4bcf-9f04-71bd5ee8b156.png)


## Detailed steps to verify changes work correctly (as executed by you)
Open the regex option in input

## Alternate designs / implementations considered
