### PR TITLE
fix github ci pip version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
         if: matrix.tf_version_id != 'notf'
       - name: 'Install Python dependencies'
         run: |
-          python -m pip install -U pip
           pip install \
             -r ./tensorboard/pip_package/requirements.txt \
             -r ./tensorboard/pip_package/requirements_dev.txt \
@@ -174,7 +173,6 @@ jobs:
           components: rustfmt
       - name: 'Install Python packaging deps'
         run: |
-          python -m pip install -U pip
           pip install \
             -c ./tensorboard/pip_package/requirements.txt \
             -c ./tensorboard/pip_package/requirements_dev.txt \
@@ -224,7 +222,6 @@ jobs:
           architecture: 'x64'
       - name: 'Install flake8'
         run: |
-          python -m pip install -U pip
           pip install flake8 -c ./tensorboard/pip_package/requirements_dev.txt
       - run: pip freeze --all
       - name: 'Lint Python code for errors with flake8'
@@ -242,7 +239,6 @@ jobs:
           architecture: 'x64'
       - name: 'Install black, yamllint, and the TensorFlow docs notebook tools'
         run: |
-          python -m pip install -U pip
           nbfmt_version="174c9a5c1cc51a3af1de98d84824c811ecd49029"
           pip install black yamllint -c ./tensorboard/pip_package/requirements_dev.txt
           pip install -U git+https://github.com/tensorflow/docs@${nbfmt_version}


### PR DESCRIPTION
* Motivation for features / changes

pip released 23.1 and ci workflow pulled it in.
It seems to be incompatible with tensorflow/docs

* Technical description of changes
Use the default pip version in the github ci python image (23.0.1)

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
