### PR TITLE
Pin to a more recent docs repo to stop the pip 23.1 error message as part of the nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         tf_version_id: ['tf', 'notf']
-        python_version: ['3.8']
+        python_version: ['3.10']
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         tf_version_id: ['tf', 'notf']
-        python_version: ['3.10']
+        python_version: ['3.8']
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
@@ -238,7 +238,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           architecture: 'x64'
       - name: 'Install black, yamllint, and the TensorFlow docs notebook tools'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       - name: 'Install black, yamllint, and the TensorFlow docs notebook tools'
         run: |
           python -m pip install -U pip
-          nbfmt_version="174c9a5c1cc51a3af1de98d84824c811ecd49029"
+          nbfmt_version="84bd7bea0c468667dd0ec273d426ed50f23e1a15"
           pip install black yamllint -c ./tensorboard/pip_package/requirements_dev.txt
           pip install -U git+https://github.com/tensorflow/docs@${nbfmt_version}
         # Workaround tensorflow incompatibility with protobuf>4.


### PR DESCRIPTION
* Motivation for features / changes
 Nightly Build broken after the pip 23.0->23.1 release

* Technical description of changes
Found a newer version of the docs repo that doesn't exhibit the error and pinned to that version of the repo.

* Screenshots of UI changes
none
* Detailed steps to verify changes work correctly (as executed by you)
Creating the PR and seeing if it triggers the new workflow, in flight.

* Alternate designs / implementations considered
none