### PR TITLE
Bug Fix: Update runs_data_source to request hparams data using FormData

### DIFF
--- a/tensorboard/webapp/runs/data_source/runs_data_source.ts
+++ b/tensorboard/webapp/runs/data_source/runs_data_source.ts
@@ -74,10 +74,6 @@ function transformBackendMetricSpec(
   };
 }
 
-declare interface GetExperimentHparamRequestPayload {
-  experimentName: string;
-}
-
 @Injectable()
 export class TBRunsDataSource implements RunsDataSource {
   constructor(private readonly http: TBHttpClient) {}
@@ -98,13 +94,12 @@ export class TBRunsDataSource implements RunsDataSource {
   }
 
   fetchHparamsMetadata(experimentId: string): Observable<HparamsAndMetadata> {
-    const requestPayload: GetExperimentHparamRequestPayload = {
-      experimentName: experimentId,
-    };
+    const formData = new FormData();
+    formData.append('experimentName', experimentId);
     return this.http
       .post<backendTypes.BackendHparamsExperimentResponse>(
         `/experiment/${experimentId}/${HPARAMS_HTTP_PATH_PREFIX}/experiment`,
-        requestPayload
+        formData
       )
       .pipe(
         map((response) => {


### PR DESCRIPTION
## Motivation for features / changes
The dashboard will not load when `inColab` is true because the runs data cannot be fetched.

Googlers see b/278706604 for why this is important

## Technical description of changes
When `inColab` is true `POST` requests are automatically converted to `GET` requests see [tensorboard/webapp/webapp_data_source/tb_http_client.ts](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/webapp/webapp_data_source/tb_http_client.ts). This conversion assumes the provided body is of type `FormData`, however, when I open sourced `runs_data_source` in #6318 I was unaware of this conversion taking place and didn't modify the format of the post request body.

## Screenshots of UI changes
Before:
![image](https://user-images.githubusercontent.com/78179109/232854635-c95e2047-0203-4677-ac1f-98962f034faf.png)

After:
![image](https://user-images.githubusercontent.com/78179109/232854359-57c0b7e2-a1da-45c0-b948-a9139271b380.png)


## Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Navigate to http://localhost:6006?tensorboardColab#timeseries
3) Assert that the dashboard loads

## Alternate designs / implementations considered
I could have updated the conversion happening in [tensorboard/webapp/webapp_data_source/tb_http_client.ts](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/webapp/webapp_data_source/tb_http_client.ts) to accept JSON bodies