### PR TITLE
Shareability: preserve two-dimensional zoom range in state

### DIFF
--- a/tensorboard/webapp/metrics/actions/BUILD
+++ b/tensorboard/webapp/metrics/actions/BUILD
@@ -16,6 +16,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/util:dom",
         "//tensorboard/webapp/widgets/card_fob:types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
         "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -39,6 +39,7 @@ import {
   DataTableMode,
   SortingInfo,
 } from '../views/card_renderer/scalar_card_types';
+import {Extent} from '../../widgets/line_chart_v2/lib/public_types';
 
 export const metricsSettingsPaneClosed = createAction(
   '[Metrics] Metrics Settings Pane Closed'
@@ -218,9 +219,9 @@ export const timeSelectionChanged = createAction(
   props<{cardId?: CardId} & TimeSelectionWithAffordance>()
 );
 
-export const cardMinMaxChanged = createAction(
-  '[Metrics] Card Min Max Changed',
-  props<{cardId: CardId; minMax: MinMaxStep}>()
+export const cardViewPortChanged = createAction(
+  '[Metrics] Card View Port Changed',
+  props<{cardId: CardId; viewPort: Extent}>()
 );
 
 export const timeSelectionCleared = createAction(

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -219,9 +219,9 @@ export const timeSelectionChanged = createAction(
   props<{cardId?: CardId} & TimeSelectionWithAffordance>()
 );
 
-export const cardViewPortChanged = createAction(
-  '[Metrics] Card View Port Changed',
-  props<{cardId: CardId; viewPort: Extent}>()
+export const cardViewBoxChanged = createAction(
+  '[Metrics] Card View Box Changed',
+  props<{cardId: CardId; viewBox: Extent}>()
 );
 
 export const timeSelectionCleared = createAction(

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -74,6 +74,7 @@ tf_ts_library(
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/types",
         "//tensorboard/webapp/util:dom",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
     ],
 )
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1183,11 +1183,11 @@ const reducer = createReducer(
       rangeSelectionEnabled: nextRangeSelectionEnabled,
     };
   }),
-  on(actions.cardMinMaxChanged, (state, {cardId, minMax}) => {
+  on(actions.cardViewPortChanged, (state, {cardId, viewPort}) => {
     const nextCardStateMap = {...state.cardStateMap};
     nextCardStateMap[cardId] = {
       ...nextCardStateMap[cardId],
-      userMinMax: minMax,
+      userViewBox: viewPort,
     };
 
     return {

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1183,11 +1183,11 @@ const reducer = createReducer(
       rangeSelectionEnabled: nextRangeSelectionEnabled,
     };
   }),
-  on(actions.cardViewPortChanged, (state, {cardId, viewPort}) => {
+  on(actions.cardViewBoxChanged, (state, {cardId, viewBox}) => {
     const nextCardStateMap = {...state.cardStateMap};
     nextCardStateMap[cardId] = {
       ...nextCardStateMap[cardId],
-      userViewBox: viewPort,
+      userViewBox: viewBox,
     };
 
     return {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3430,13 +3430,8 @@ describe('metrics reducers', () => {
       });
     });
 
-    describe('#cardMinMaxChanged', () => {
-      it('adds a new value to an existing cardToMinMax map', () => {
-        const initialCardToMinMax = new Map<NonPinnedCardId, MinMaxStep>();
-        initialCardToMinMax.set('card1', {
-          minStep: 0,
-          maxStep: 100,
-        });
+    describe('#cardViewPortChanged', () => {
+      it('adds a new value to an existing cardState map', () => {
         const state1 = buildMetricsState({
           cardStateMap: {
             card1: {},
@@ -3444,11 +3439,11 @@ describe('metrics reducers', () => {
         });
         const state2 = reducers(
           state1,
-          actions.cardMinMaxChanged({
+          actions.cardViewPortChanged({
             cardId: 'card2',
-            minMax: {
-              minStep: 1,
-              maxStep: 5,
+            viewPort: {
+              x: [0, 1],
+              y: [2, 5],
             },
           })
         );
@@ -3456,21 +3451,21 @@ describe('metrics reducers', () => {
         expect(state2.cardStateMap).toEqual({
           card1: {},
           card2: {
-            userMinMax: {
-              minStep: 1,
-              maxStep: 5,
+            userViewBox: {
+              x: [0, 1],
+              y: [2, 5],
             },
           },
         });
       });
 
-      it('overrides an existing cards min max', () => {
+      it('overrides an existing card viewport', () => {
         const state1 = buildMetricsState({
           cardStateMap: {
             card1: {
-              userMinMax: {
-                minStep: 0,
-                maxStep: 100,
+              userViewBox: {
+                x: [0, 100],
+                y: [2, 5],
               },
               timeSelection: {
                 start: {step: 0},
@@ -3482,20 +3477,20 @@ describe('metrics reducers', () => {
 
         const state2 = reducers(
           state1,
-          actions.cardMinMaxChanged({
+          actions.cardViewPortChanged({
             cardId: 'card1',
-            minMax: {
-              minStep: 1,
-              maxStep: 5,
+            viewPort: {
+              x: [1, 5],
+              y: [2, 5],
             },
           })
         );
 
         expect(state2.cardStateMap).toEqual({
           card1: {
-            userMinMax: {
-              minStep: 1,
-              maxStep: 5,
+            userViewBox: {
+              x: [1, 5],
+              y: [2, 5],
             },
             timeSelection: {
               start: {step: 0},

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3430,7 +3430,7 @@ describe('metrics reducers', () => {
       });
     });
 
-    describe('#cardViewPortChanged', () => {
+    describe('#cardViewBoxChanged', () => {
       it('adds a new value to an existing cardState map', () => {
         const state1 = buildMetricsState({
           cardStateMap: {
@@ -3439,9 +3439,9 @@ describe('metrics reducers', () => {
         });
         const state2 = reducers(
           state1,
-          actions.cardViewPortChanged({
+          actions.cardViewBoxChanged({
             cardId: 'card2',
-            viewPort: {
+            viewBox: {
               x: [0, 1],
               y: [2, 5],
             },
@@ -3459,7 +3459,7 @@ describe('metrics reducers', () => {
         });
       });
 
-      it('overrides an existing card viewport', () => {
+      it('overrides an existing card viewBox', () => {
         const state1 = buildMetricsState({
           cardStateMap: {
             card1: {
@@ -3477,9 +3477,9 @@ describe('metrics reducers', () => {
 
         const state2 = reducers(
           state1,
-          actions.cardViewPortChanged({
+          actions.cardViewBoxChanged({
             cardId: 'card1',
-            viewPort: {
+            viewBox: {
               x: [1, 5],
               y: [2, 5],
             },

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -515,9 +515,9 @@ export const getMetricsCardRangeSelectionEnabled = createSelector(
 /**
  * Gets the min and max step visible in a metrics card.
  * This value can either be the data min max or be overridden
- * by a user min max.
+ * by min max within userViewBox.
  *
- * Note: userMinMax is not necessarily a subset of dataMinMax.
+ * Note: min max within userViewBox is not necessarily a subset of dataMinMax.
  */
 export const getMetricsCardMinMax = createSelector(
   getCardStateMap,

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -802,15 +802,15 @@ describe('metrics selectors', () => {
     });
   });
 
-  describe('getMetricsCardMinMax', () => {
+  fdescribe('getMetricsCardMinMax', () => {
     it('returns userMinMax when defined', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({
           cardStateMap: {
             card1: {
-              userMinMax: {
-                minStep: 10,
-                maxStep: 20,
+              userViewBox: {
+                x: [10, 20],
+                y: [11, 22],
               },
               dataMinMax: {
                 minStep: 0,

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -802,7 +802,7 @@ describe('metrics selectors', () => {
     });
   });
 
-  fdescribe('getMetricsCardMinMax', () => {
+  describe('getMetricsCardMinMax', () => {
     it('returns userMinMax when defined', () => {
       const state = appStateFromMetricsState(
         buildMetricsState({

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -578,8 +578,15 @@ function getNextImageCardStepIndexFromRangeSelection(
  * @param cardState
  */
 export function getMinMaxStepFromCardState(cardState: Partial<CardState>) {
-  const {dataMinMax, userMinMax} = cardState;
-  return userMinMax || dataMinMax;
+  const {dataMinMax, userViewBox} = cardState;
+  const x = userViewBox?.x;
+  if (!x) return dataMinMax;
+
+  const minStep = x[0] < x[1] ? x[0] : x[1];
+  const maxStep = minStep === x[0] ? x[1] : x[0];
+  return (
+    {minStep: Math.ceil(minStep), maxStep: Math.floor(maxStep)} || dataMinMax
+  );
 }
 
 export function getCardSelectionStateToBoolean(

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -1163,13 +1163,13 @@ describe('metrics store utils', () => {
     });
   });
 
-  describe('getMinMaxStepFromCardState', () => {
-    it('returns userMinMax when defined', () => {
+  fdescribe('getMinMaxStepFromCardState', () => {
+    it('returns userViewBox when defined', () => {
       expect(
         getMinMaxStepFromCardState({
-          userMinMax: {
-            minStep: 10,
-            maxStep: 20,
+          userViewBox: {
+            x: [10, 20],
+            y: [11, 22],
           },
           dataMinMax: {
             minStep: 0,
@@ -1182,7 +1182,25 @@ describe('metrics store utils', () => {
       });
     });
 
-    it('returns dataMinMax when userMinMax is not defined', () => {
+    it('returns min max within userViewBox range', () => {
+      expect(
+        getMinMaxStepFromCardState({
+          userViewBox: {
+            x: [11.2, 20.3],
+            y: [11, 22],
+          },
+          dataMinMax: {
+            minStep: 0,
+            maxStep: 100,
+          },
+        })
+      ).toEqual({
+        minStep: 12,
+        maxStep: 20,
+      });
+    });
+
+    it('returns dataMinMax when userViewBox is not defined', () => {
       expect(
         getMinMaxStepFromCardState({
           dataMinMax: {

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -1182,6 +1182,24 @@ describe('metrics store utils', () => {
       });
     });
 
+    it('minStep is lower than maxStep', () => {
+      expect(
+        getMinMaxStepFromCardState({
+          userViewBox: {
+            x: [20, 10],
+            y: [22, 11],
+          },
+          dataMinMax: {
+            minStep: 0,
+            maxStep: 100,
+          },
+        })
+      ).toEqual({
+        minStep: 10,
+        maxStep: 20,
+      });
+    });
+
     it('returns min max within userViewBox range', () => {
       expect(
         getMinMaxStepFromCardState({

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -1182,7 +1182,7 @@ describe('metrics store utils', () => {
       });
     });
 
-    it('minStep is lower than maxStep', () => {
+    it('returns minStep lower than maxStep on descending x extent', () => {
       expect(
         getMinMaxStepFromCardState({
           userViewBox: {

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -1163,7 +1163,7 @@ describe('metrics store utils', () => {
     });
   });
 
-  fdescribe('getMinMaxStepFromCardState', () => {
+  describe('getMinMaxStepFromCardState', () => {
     it('returns userViewBox when defined', () => {
       expect(
         getMinMaxStepFromCardState({

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -41,6 +41,7 @@ import {
   ColumnHeader,
   DataTableMode,
 } from '../views/card_renderer/scalar_card_types';
+import {Extent} from '../../widgets/line_chart_v2/lib/public_types';
 
 export const METRICS_FEATURE_KEY = 'metrics';
 
@@ -137,7 +138,7 @@ export enum CardFeatureOverride {
 
 export type CardState = {
   dataMinMax: MinMaxStep;
-  userMinMax: MinMaxStep;
+  userViewBox: Extent;
   timeSelection: TimeSelection;
   stepSelectionOverride: CardFeatureOverride;
   rangeSelectionOverride: CardFeatureOverride;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -67,7 +67,7 @@ import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer'
 import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {
-  cardViewPortChanged,
+  cardViewBoxChanged,
   dataTableColumnEdited,
   metricsCardFullSizeToggled,
   metricsCardStateUpdated,
@@ -659,8 +659,8 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   onLineChartZoom(lineChartViewBox: Extent) {
     this.store.dispatch(
-      cardViewPortChanged({
-        viewPort: lineChartViewBox,
+      cardViewBoxChanged({
+        viewBox: lineChartViewBox,
         cardId: this.cardId,
       })
     );

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -67,7 +67,7 @@ import {classicSmoothing} from '../../../widgets/line_chart_v2/data_transformer'
 import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {ScaleType} from '../../../widgets/line_chart_v2/types';
 import {
-  cardMinMaxChanged,
+  cardViewPortChanged,
   dataTableColumnEdited,
   metricsCardFullSizeToggled,
   metricsCardStateUpdated,
@@ -658,14 +658,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   }
 
   onLineChartZoom(lineChartViewBox: Extent) {
-    const minMax = lineChartViewBox.x;
-    const minMaxStepInViewPort: MinMaxStep = {
-      minStep: Math.ceil(Math.min(...minMax)),
-      maxStep: Math.floor(Math.max(...minMax)),
-    };
     this.store.dispatch(
-      cardMinMaxChanged({
-        minMax: minMaxStepInViewPort,
+      cardViewPortChanged({
+        viewPort: lineChartViewBox,
         cardId: this.cardId,
       })
     );

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -75,7 +75,7 @@ import {
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
-  cardViewPortChanged,
+  cardViewBoxChanged,
   metricsCardFullSizeToggled,
   metricsCardStateUpdated,
   stepSelectorToggled,
@@ -2599,7 +2599,7 @@ describe('scalar card', () => {
     });
 
     describe('line chart integration', () => {
-      it('updates viewPort value when line chart is zoomed', fakeAsync(async () => {
+      it('updates viewBox value when line chart is zoomed', fakeAsync(async () => {
         const runToSeries = {
           run1: [buildScalarStepData({step: 10})],
           run2: [buildScalarStepData({step: 20})],
@@ -2636,15 +2636,15 @@ describe('scalar card', () => {
           y: [0, 100],
         });
         expect(dispatchedActions).toEqual([
-          cardViewPortChanged({
-            viewPort: {
+          cardViewBoxChanged({
+            viewBox: {
               x: [9.235, 30.4],
               y: [0, 100],
             },
             cardId: 'card1',
           }),
-          cardViewPortChanged({
-            viewPort: {
+          cardViewBoxChanged({
+            viewBox: {
               x: [8, 31],
               y: [0, 100],
             },

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -75,7 +75,7 @@ import {
 import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_testing_module';
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
-  cardMinMaxChanged,
+  cardViewPortChanged,
   metricsCardFullSizeToggled,
   metricsCardStateUpdated,
   stepSelectorToggled,
@@ -2599,7 +2599,7 @@ describe('scalar card', () => {
     });
 
     describe('line chart integration', () => {
-      it('updates minMax value when line chart is zoomed', fakeAsync(async () => {
+      it('updates viewPort value when line chart is zoomed', fakeAsync(async () => {
         const runToSeries = {
           run1: [buildScalarStepData({step: 10})],
           run2: [buildScalarStepData({step: 20})],
@@ -2636,17 +2636,17 @@ describe('scalar card', () => {
           y: [0, 100],
         });
         expect(dispatchedActions).toEqual([
-          cardMinMaxChanged({
-            minMax: {
-              minStep: 10,
-              maxStep: 30,
+          cardViewPortChanged({
+            viewPort: {
+              x: [9.235, 30.4],
+              y: [0, 100],
             },
             cardId: 'card1',
           }),
-          cardMinMaxChanged({
-            minMax: {
-              minStep: 8,
-              maxStep: 31,
+          cardViewPortChanged({
+            viewPort: {
+              x: [8, 31],
+              y: [0, 100],
             },
             cardId: 'card1',
           }),


### PR DESCRIPTION
* Motivation for features / changes
For internal project, we want to preserve zoom, which is a two-dimension range. However, in current card state we only have x direction. This PR prepares the preservation by replacing "userMinMax"(type MinMaxStep) with "userViewBox"(type: Extent)
Googlers, please see cl/526116905 for full PoC and demo.

* Technical description of changes
  - update CardState type
  - rename action `cardMinMaxChanged` to `cardViewPortChanged`
  - additional handling on `getMinMaxStepFromCardState` selector

following pr: https://github.com/japie1235813/tensorboard/pull/30

* Screenshots of UI changes
Manually checked step selection on zoom interactions, they behave the same as expected. 