### PR TITLE
Start using the vectorized EncodePng Op

### DIFF
--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -244,13 +244,15 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
         pb = self.image("mona_lisa", data)
 
         self.assertLen(pb.value, 2)
+
         encoded0 = pb.value[0].tensor.string_val[2]  # skip width, height
-        decoded0 = tf.image.decode_png(encoded).numpy()
-        encoded1 = pb.value[1].tensor.string_val[2]  # skip width, height
-        decoded1 = tf.image.decode_png(encoded).numpy()
+        decoded0 = tf.image.decode_png(encoded0).numpy()
         # Float values outside [0, 1) are truncated, and everything is scaled to the
         # range [0, 255] with 229 = 0.9 * 255, truncated.
         self.assertAllEqual([0, 0, 229, 255, 255], list(decoded0.flat))
+
+        encoded1 = pb.value[1].tensor.string_val[2]  # skip width, height
+        decoded1 = tf.image.decode_png(encoded1).numpy()
         self.assertAllEqual([0, 0, 255, 229, 255], list(decoded1.flat))
 
 

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -239,8 +239,10 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
 
     def test_vector_data(self):
         data = np.array(
-            [-0.01, 0.0, 0.9, 1.0, 1.1],
-            [-0.01, 0.0, 1.0, 0.9, 1.1],
+            [
+                [-0.01, 0.0, 0.9, 1.0, 1.1],
+                [-0.01, 0.0, 1.0, 0.9, 1.1],
+            ]
         ).reshape((2, -1, 1, 1))
         pb = self.image("mona_lisa", data)
 

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -246,15 +246,13 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
         ).reshape((2, -1, 1, 1))
         pb = self.image("mona_lisa", data)
 
-        self.assertLen(pb.value, 2)
-
         encoded0 = pb.value[0].tensor.string_val[2]  # skip width, height
         decoded0 = tf.image.decode_png(encoded0).numpy()
         # Float values outside [0, 1) are truncated, and everything is scaled to the
         # range [0, 255] with 229 = 0.9 * 255, truncated.
         self.assertAllEqual([0, 0, 229, 255, 255], list(decoded0.flat))
 
-        encoded1 = pb.value[1].tensor.string_val[2]  # skip width, height
+        encoded1 = pb.value[0].tensor.string_val[3]  # skip width, height
         decoded1 = tf.image.decode_png(encoded1).numpy()
         self.assertAllEqual([0, 0, 255, 229, 255], list(decoded1.flat))
 

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -238,9 +238,10 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
         self.assertAllEqual([0, 0, 229, 255, 255], list(decoded.flat))
 
     def test_vector_data(self):
-        data = np.array([-0.01, 0.0, 0.9, 1.0, 1.1],
-                        [-0.01, 0.0, 1.0, 0.9, 1.1],
-               ).reshape((2, -1, 1, 1))
+        data = np.array(
+            [-0.01, 0.0, 0.9, 1.0, 1.1],
+            [-0.01, 0.0, 1.0, 0.9, 1.1],
+        ).reshape((2, -1, 1, 1))
         pb = self.image("mona_lisa", data)
 
         self.assertLen(pb.value, 2)

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -237,6 +237,22 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
         # range [0, 255] with 229 = 0.9 * 255, truncated.
         self.assertAllEqual([0, 0, 229, 255, 255], list(decoded.flat))
 
+    def test_vector_data(self):
+        data = np.array([-0.01, 0.0, 0.9, 1.0, 1.1],
+                        [-0.01, 0.0, 1.0, 0.9, 1.1],
+               ).reshape((2, -1, 1, 1))
+        pb = self.image("mona_lisa", data)
+
+        self.assertLen(pb.value, 2)
+        encoded0 = pb.value[0].tensor.string_val[2]  # skip width, height
+        decoded0 = tf.image.decode_png(encoded).numpy()
+        encoded1 = pb.value[1].tensor.string_val[2]  # skip width, height
+        decoded1 = tf.image.decode_png(encoded).numpy()
+        # Float values outside [0, 1) are truncated, and everything is scaled to the
+        # range [0, 255] with 229 = 0.9 * 255, truncated.
+        self.assertAllEqual([0, 0, 229, 255, 255], list(decoded0.flat))
+        self.assertAllEqual([0, 0, 255, 229, 255], list(decoded1.flat))
+
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -113,18 +113,21 @@ def image(name, data, step=None, max_outputs=3, description=None):
             tf.debugging.assert_non_negative(max_outputs)
             images = tf.image.convert_image_dtype(data, tf.uint8, saturate=True)
             limited_images = images[:max_outputs]
-            encoded_images = tf.map_fn(
-                tf.image.encode_png,
-                limited_images,
-                dtype=tf.string,
-                name="encode_each_image",
-            )
-            # Workaround for map_fn returning float dtype for an empty elems input.
-            encoded_images = tf.cond(
-                tf.shape(input=encoded_images)[0] > 0,
-                lambda: encoded_images,
-                lambda: tf.constant([], tf.string),
-            )
+            if tf.compat.forward_compatible(2023, 5, 1):
+              encoded_images = tf.image.encode_png(limited_images)
+            else:
+              encoded_images = tf.map_fn(
+                  tf.image.encode_png,
+                  limited_images,
+                  dtype=tf.string,
+                  name="encode_each_image",
+              )
+              # Workaround for map_fn returning float dtype for an empty elems input.
+              encoded_images = tf.cond(
+                  tf.shape(input=encoded_images)[0] > 0,
+                  lambda: encoded_images,
+                  lambda: tf.constant([], tf.string),
+              )
             image_shape = tf.shape(input=images)
             dimensions = tf.stack(
                 [

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -114,20 +114,21 @@ def image(name, data, step=None, max_outputs=3, description=None):
             images = tf.image.convert_image_dtype(data, tf.uint8, saturate=True)
             limited_images = images[:max_outputs]
             if tf.compat.forward_compatible(2023, 5, 1):
-              encoded_images = tf.image.encode_png(limited_images)
+                encoded_images = tf.image.encode_png(limited_images)
             else:
-              encoded_images = tf.map_fn(
-                  tf.image.encode_png,
-                  limited_images,
-                  dtype=tf.string,
-                  name="encode_each_image",
-              )
-              # Workaround for map_fn returning float dtype for an empty elems input.
-              encoded_images = tf.cond(
-                  tf.shape(input=encoded_images)[0] > 0,
-                  lambda: encoded_images,
-                  lambda: tf.constant([], tf.string),
-              )
+                encoded_images = tf.map_fn(
+                    tf.image.encode_png,
+                    limited_images,
+                    dtype=tf.string,
+                    name="encode_each_image",
+                )
+                # Workaround for map_fn returning float dtype for an empty
+                # elems input.
+                encoded_images = tf.cond(
+                    tf.shape(input=encoded_images)[0] > 0,
+                    lambda: encoded_images,
+                    lambda: tf.constant([], tf.string),
+                )
             image_shape = tf.shape(input=images)
             dimensions = tf.stack(
                 [

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -116,7 +116,7 @@ def image(name, data, step=None, max_outputs=3, description=None):
             if tf.compat.forward_compatible(2023, 5, 1):
                 encoded_images = tf.image.encode_png(limited_images)
             else:
-                # TODO(b/276803093): The kernel was updated around 2023/04/15. 
+                # TODO(b/276803093): The kernel was updated around 2023/04/15.
                 # After 90 days (2023/07/15), please remove the False branch.
                 encoded_images = tf.map_fn(
                     tf.image.encode_png,

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -116,6 +116,8 @@ def image(name, data, step=None, max_outputs=3, description=None):
             if tf.compat.forward_compatible(2023, 5, 1):
                 encoded_images = tf.image.encode_png(limited_images)
             else:
+                # TODO(b/276803093): The kernel was updated around 2023/04/15. 
+                # After 90 days (2023/07/15), please remove the False branch.
                 encoded_images = tf.map_fn(
                     tf.image.encode_png,
                     limited_images,


### PR DESCRIPTION
## Motivation for features / changes
The vectorization unblocks running tf.summary.image under DTensor.

Vectorization of EncodePNG is added in https://github.com/tensorflow/tensorflow/commit/7c422273dc560005c82cd0a91875ddfbb41b9791

## Technical description of changes
Applied a forward compatibility wrapper for 14 days since the EncodePNG change landed.

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)
Verified by both branches work without DTensor, and the new (vectorized) branch works under DTensor.
Note that I manually applied the internal patch to the OSS format. 

## Alternate designs / implementations considered (or N/A)
N/A

## Verification: 
cl/488391097