### PR TITLE
HParam UI: update ColumnHeader type

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -269,26 +269,116 @@ const {initialState, reducers: namespaceContextedReducer} =
       stepSelectorEnabled: false,
       rangeSelectionEnabled: false,
       singleSelectionHeaders: [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.SMOOTHED, enabled: true},
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
-        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.SMOOTHED,
+          name: 'smoothed',
+          displayName: 'Smoothed',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RELATIVE_TIME,
+          name: 'relative',
+          displayName: 'Relative',
+          enabled: true,
+        },
       ],
       rangeSelectionHeaders: [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-        {type: ColumnHeaderType.START_VALUE, enabled: true},
-        {type: ColumnHeaderType.END_VALUE, enabled: true},
-        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
-        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
-        {type: ColumnHeaderType.START_STEP, enabled: true},
-        {type: ColumnHeaderType.END_STEP, enabled: true},
-        {type: ColumnHeaderType.STEP_AT_MAX, enabled: false},
-        {type: ColumnHeaderType.STEP_AT_MIN, enabled: false},
-        {type: ColumnHeaderType.MEAN, enabled: false},
-        {type: ColumnHeaderType.RAW_CHANGE, enabled: false},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'min',
+          displayName: 'Min',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'max',
+          displayName: 'Max',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.START_VALUE,
+          name: 'start',
+          displayName: 'Start Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.END_VALUE,
+          name: 'end',
+          displayName: 'End Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE_CHANGE,
+          name: 'valueChange',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.PERCENTAGE_CHANGE,
+          name: 'percentageChange',
+          displayName: '%',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.START_STEP,
+          name: 'startStep',
+          displayName: 'Start Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.END_STEP,
+          name: 'endStep',
+          displayName: 'End Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP_AT_MAX,
+          name: 'stepAtMax',
+          displayName: 'Step At Max',
+          enabled: false,
+        },
+        {
+          type: ColumnHeaderType.STEP_AT_MIN,
+          name: 'stepAtMin',
+          displayName: 'Step At Min',
+          enabled: false,
+        },
+        {
+          type: ColumnHeaderType.MEAN,
+          name: 'mean',
+          displayName: 'Mean',
+          enabled: false,
+        },
+        {
+          type: ColumnHeaderType.RAW_CHANGE,
+          name: 'rawChange',
+          displayName: 'Raw',
+          enabled: false,
+        },
       ],
       filteredPluginTypes: new Set(),
       stepMinMax: {
@@ -1308,7 +1398,7 @@ const reducer = createReducer(
     );
 
     newHeaders[newToggledHeaderIndex] = {
-      type: newHeaders[newToggledHeaderIndex].type,
+      ...newHeaders[newToggledHeaderIndex],
       enabled: !newHeaders[newToggledHeaderIndex].enabled,
     };
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1543,17 +1543,62 @@ describe('metrics reducers', () => {
       it('edits range selection when dataTableMode is range', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.START_VALUE, enabled: true},
-            {type: ColumnHeaderType.END_VALUE, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.START_VALUE,
+              name: 'startValue',
+              displayName: 'Start Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.END_VALUE,
+              name: 'endValue',
+              displayName: 'End Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: false,
+            },
+            {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: false,
+            },
           ],
           singleSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.VALUE, enabled: true},
-            {type: ColumnHeaderType.STEP, enabled: true},
-            {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.VALUE,
+              name: 'value',
+              displayName: 'Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.STEP,
+              name: 'step',
+              displayName: 'Step',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RELATIVE_TIME,
+              name: 'relativeTime',
+              displayName: 'Relative',
+              enabled: false,
+            },
           ],
         });
 
@@ -1562,44 +1607,159 @@ describe('metrics reducers', () => {
           actions.dataTableColumnEdited({
             dataTableMode: DataTableMode.RANGE,
             headers: [
-              {type: ColumnHeaderType.RUN, enabled: true},
-              {type: ColumnHeaderType.END_VALUE, enabled: true},
-              {type: ColumnHeaderType.START_VALUE, enabled: true},
-              {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-              {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+              {
+                type: ColumnHeaderType.RUN,
+                name: 'run',
+                displayName: 'Run',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.END_VALUE,
+                name: 'endValue',
+                displayName: 'End Value',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.START_VALUE,
+                name: 'startValue',
+                displayName: 'Start Value',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.MIN_VALUE,
+                name: 'minValue',
+                displayName: 'Min',
+                enabled: false,
+              },
+              {
+                type: ColumnHeaderType.MAX_VALUE,
+                name: 'maxValue',
+                displayName: 'Max',
+                enabled: false,
+              },
             ],
           })
         );
 
         expect(nextState.rangeSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.END_VALUE, enabled: true},
-          {type: ColumnHeaderType.START_VALUE, enabled: true},
-          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.END_VALUE,
+            name: 'endValue',
+            displayName: 'End Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.START_VALUE,
+            name: 'startValue',
+            displayName: 'Start Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MIN_VALUE,
+            name: 'minValue',
+            displayName: 'Min',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: false,
+          },
         ]);
         expect(nextState.singleSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.VALUE, enabled: true},
-          {type: ColumnHeaderType.STEP, enabled: true},
-          {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.STEP,
+            name: 'step',
+            displayName: 'Step',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.RELATIVE_TIME,
+            name: 'relativeTime',
+            displayName: 'Relative',
+            enabled: false,
+          },
         ]);
       });
 
       it('edits single selection when dataTableMode is single', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.START_VALUE, enabled: true},
-            {type: ColumnHeaderType.END_VALUE, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.START_VALUE,
+              name: 'startValue',
+              displayName: 'Start Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.END_VALUE,
+              name: 'endValue',
+              displayName: 'End Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: false,
+            },
+            {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: false,
+            },
           ],
           singleSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.VALUE, enabled: true},
-            {type: ColumnHeaderType.STEP, enabled: true},
-            {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.VALUE,
+              name: 'value',
+              displayName: 'Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.STEP,
+              name: 'step',
+              displayName: 'Step',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RELATIVE_TIME,
+              name: 'relativeTime',
+              displayName: 'Relative',
+              enabled: false,
+            },
           ],
         });
 
@@ -1608,37 +1768,127 @@ describe('metrics reducers', () => {
           actions.dataTableColumnEdited({
             dataTableMode: DataTableMode.SINGLE,
             headers: [
-              {type: ColumnHeaderType.RUN, enabled: true},
-              {type: ColumnHeaderType.STEP, enabled: true},
-              {type: ColumnHeaderType.VALUE, enabled: true},
-              {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+              {
+                type: ColumnHeaderType.RUN,
+                name: 'run',
+                displayName: 'Run',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.STEP,
+                name: 'step',
+                displayName: 'Step',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.VALUE,
+                name: 'value',
+                displayName: 'Value',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.RELATIVE_TIME,
+                name: 'relativeTime',
+                displayName: 'Relative',
+                enabled: false,
+              },
             ],
           })
         );
 
         expect(nextState.rangeSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.START_VALUE, enabled: true},
-          {type: ColumnHeaderType.END_VALUE, enabled: true},
-          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.START_VALUE,
+            name: 'startValue',
+            displayName: 'Start Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.END_VALUE,
+            name: 'endValue',
+            displayName: 'End Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MIN_VALUE,
+            name: 'minValue',
+            displayName: 'Min',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: false,
+          },
         ]);
         expect(nextState.singleSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.STEP, enabled: true},
-          {type: ColumnHeaderType.VALUE, enabled: true},
-          {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.STEP,
+            name: 'step',
+            displayName: 'Step',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.RELATIVE_TIME,
+            name: 'relativeTime',
+            displayName: 'Relative',
+            enabled: false,
+          },
         ]);
       });
 
       it('ensures ordering keeps enabled headers first', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.START_VALUE, enabled: true},
-            {type: ColumnHeaderType.END_VALUE, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.START_VALUE,
+              name: 'startValue',
+              displayName: 'Start Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.END_VALUE,
+              name: 'endValue',
+              displayName: 'End Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: false,
+            },
+            {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: false,
+            },
           ],
         });
 
@@ -1647,21 +1897,71 @@ describe('metrics reducers', () => {
           actions.dataTableColumnEdited({
             dataTableMode: DataTableMode.RANGE,
             headers: [
-              {type: ColumnHeaderType.RUN, enabled: true},
-              {type: ColumnHeaderType.MAX_VALUE, enabled: false},
-              {type: ColumnHeaderType.START_VALUE, enabled: true},
-              {type: ColumnHeaderType.END_VALUE, enabled: true},
-              {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+              {
+                type: ColumnHeaderType.RUN,
+                name: 'run',
+                displayName: 'Run',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.MAX_VALUE,
+                name: 'maxValue',
+                displayName: 'Max',
+                enabled: false,
+              },
+              {
+                type: ColumnHeaderType.START_VALUE,
+                name: 'startValue',
+                displayName: 'Start Value',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.END_VALUE,
+                name: 'endValue',
+                displayName: 'End Value',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.MIN_VALUE,
+                name: 'minValue',
+                displayName: 'Min',
+                enabled: false,
+              },
             ],
           })
         );
 
         expect(nextState.rangeSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.START_VALUE, enabled: true},
-          {type: ColumnHeaderType.END_VALUE, enabled: true},
-          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
-          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.START_VALUE,
+            name: 'startValue',
+            displayName: 'Start Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.END_VALUE,
+            name: 'endValue',
+            displayName: 'End Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.MIN_VALUE,
+            name: 'minValue',
+            displayName: 'Min',
+            enabled: false,
+          },
         ]);
       });
     });
@@ -1670,11 +1970,36 @@ describe('metrics reducers', () => {
       it('moves header down to the disabled headers when toggling to disabled', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.START_VALUE, enabled: true},
-            {type: ColumnHeaderType.END_VALUE, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.START_VALUE,
+              name: 'startValue',
+              displayName: 'Start Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.END_VALUE,
+              name: 'endValue',
+              displayName: 'End Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: false,
+            },
+            {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: false,
+            },
           ],
         });
 
@@ -1687,22 +2012,72 @@ describe('metrics reducers', () => {
         );
 
         expect(nextState.rangeSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.START_VALUE, enabled: true},
-          {type: ColumnHeaderType.END_VALUE, enabled: true},
-          {type: ColumnHeaderType.RUN, enabled: false},
-          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          {
+            type: ColumnHeaderType.START_VALUE,
+            name: 'startValue',
+            displayName: 'Start Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.END_VALUE,
+            name: 'endValue',
+            displayName: 'End Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.MIN_VALUE,
+            name: 'minValue',
+            displayName: 'Min',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: false,
+          },
         ]);
       });
 
       it('moves header up to the enabled headers when toggling to enabled', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.START_VALUE, enabled: true},
-            {type: ColumnHeaderType.END_VALUE, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.START_VALUE,
+              name: 'startValue',
+              displayName: 'Start Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.END_VALUE,
+              name: 'endValue',
+              displayName: 'End Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: false,
+            },
+            {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: false,
+            },
           ],
         });
 
@@ -1715,28 +2090,98 @@ describe('metrics reducers', () => {
         );
 
         expect(nextState.rangeSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.START_VALUE, enabled: true},
-          {type: ColumnHeaderType.END_VALUE, enabled: true},
-          {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.START_VALUE,
+            name: 'startValue',
+            displayName: 'Start Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.END_VALUE,
+            name: 'endValue',
+            displayName: 'End Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MIN_VALUE,
+            name: 'minValue',
+            displayName: 'Min',
+            enabled: false,
+          },
         ]);
       });
 
       it('only changes range selection headers when dataTableMode is RANGE', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.START_VALUE, enabled: true},
-            {type: ColumnHeaderType.END_VALUE, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.START_VALUE,
+              name: 'startValue',
+              displayName: 'Start Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.END_VALUE,
+              name: 'endValue',
+              displayName: 'End Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: false,
+            },
+            {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: false,
+            },
           ],
           singleSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.STEP, enabled: true},
-            {type: ColumnHeaderType.VALUE, enabled: true},
-            {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.STEP,
+              name: 'step',
+              displayName: 'Step',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.VALUE,
+              name: 'value',
+              displayName: 'Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RELATIVE_TIME,
+              name: 'relativeTime',
+              displayName: 'Relative',
+              enabled: false,
+            },
           ],
         });
 
@@ -1749,34 +2194,124 @@ describe('metrics reducers', () => {
         );
 
         expect(nextState.rangeSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.START_VALUE, enabled: true},
-          {type: ColumnHeaderType.END_VALUE, enabled: true},
-          {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.START_VALUE,
+            name: 'startValue',
+            displayName: 'Start Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.END_VALUE,
+            name: 'endValue',
+            displayName: 'End Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MIN_VALUE,
+            name: 'minValue',
+            displayName: 'Min',
+            enabled: false,
+          },
         ]);
         expect(nextState.singleSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.STEP, enabled: true},
-          {type: ColumnHeaderType.VALUE, enabled: true},
-          {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.STEP,
+            name: 'step',
+            displayName: 'Step',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.RELATIVE_TIME,
+            name: 'relativeTime',
+            displayName: 'Relative',
+            enabled: false,
+          },
         ]);
       });
 
       it('only changes single selection headers when dataTableMode is SINGLE', () => {
         const beforeState = buildMetricsState({
           rangeSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.START_VALUE, enabled: true},
-            {type: ColumnHeaderType.END_VALUE, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-            {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.START_VALUE,
+              name: 'startValue',
+              displayName: 'Start Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.END_VALUE,
+              name: 'endValue',
+              displayName: 'End Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: false,
+            },
+            {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: false,
+            },
           ],
           singleSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.STEP, enabled: true},
-            {type: ColumnHeaderType.VALUE, enabled: true},
-            {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.STEP,
+              name: 'step',
+              displayName: 'Step',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.VALUE,
+              name: 'value',
+              displayName: 'Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RELATIVE_TIME,
+              name: 'relativeTime',
+              displayName: 'Relative',
+              enabled: false,
+            },
           ],
         });
 
@@ -1789,17 +2324,62 @@ describe('metrics reducers', () => {
         );
 
         expect(nextState.rangeSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.START_VALUE, enabled: true},
-          {type: ColumnHeaderType.END_VALUE, enabled: true},
-          {type: ColumnHeaderType.MIN_VALUE, enabled: false},
-          {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.START_VALUE,
+            name: 'startValue',
+            displayName: 'Start Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.END_VALUE,
+            name: 'endValue',
+            displayName: 'End Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MIN_VALUE,
+            name: 'minValue',
+            displayName: 'Min',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: false,
+          },
         ]);
         expect(nextState.singleSelectionHeaders).toEqual([
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.VALUE, enabled: true},
-          {type: ColumnHeaderType.STEP, enabled: false},
-          {type: ColumnHeaderType.RELATIVE_TIME, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.STEP,
+            name: 'step',
+            displayName: 'Step',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.RELATIVE_TIME,
+            name: 'relativeTime',
+            displayName: 'Relative',
+            enabled: false,
+          },
         ]);
       });
     });
@@ -2808,9 +3388,24 @@ describe('metrics reducers', () => {
     it('loads singleSelectionHeaders setting into the next state', () => {
       const beforeState = buildMetricsState({
         singleSelectionHeaders: [
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.SMOOTHED, enabled: true},
-          {type: ColumnHeaderType.VALUE, enabled: true},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.SMOOTHED,
+            name: 'smoothed',
+            displayName: 'Smoothed',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: true,
+          },
         ],
       });
 
@@ -2819,28 +3414,78 @@ describe('metrics reducers', () => {
         globalSettingsLoaded({
           partialSettings: {
             singleSelectionHeaders: [
-              {type: ColumnHeaderType.SMOOTHED, enabled: true},
-              {type: ColumnHeaderType.RUN, enabled: true},
-              {type: ColumnHeaderType.VALUE, enabled: false},
+              {
+                type: ColumnHeaderType.SMOOTHED,
+                name: 'smoothed',
+                displayName: 'Smoothed',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.RUN,
+                name: 'run',
+                displayName: 'Run',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.VALUE,
+                name: 'value',
+                displayName: 'Value',
+                enabled: false,
+              },
             ],
           },
         })
       );
 
       expect(nextState.singleSelectionHeaders).toEqual([
-        {type: ColumnHeaderType.SMOOTHED, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.VALUE, enabled: false},
+        {
+          type: ColumnHeaderType.SMOOTHED,
+          name: 'smoothed',
+          displayName: 'Smoothed',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: false,
+        },
       ]);
     });
 
     it('loads rangeSelectionHeaders setting into the next state', () => {
       const beforeState = buildMetricsState({
         rangeSelectionHeaders: [
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.MIN_VALUE, enabled: true},
-          {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-          {type: ColumnHeaderType.MEAN, enabled: false},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MIN_VALUE,
+            name: 'minValue',
+            displayName: 'Min',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.MEAN,
+            name: 'mean',
+            displayName: 'Mean',
+            enabled: false,
+          },
         ],
       });
 
@@ -2849,20 +3494,60 @@ describe('metrics reducers', () => {
         globalSettingsLoaded({
           partialSettings: {
             rangeSelectionHeaders: [
-              {type: ColumnHeaderType.RUN, enabled: true},
-              {type: ColumnHeaderType.MEAN, enabled: true},
-              {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-              {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+              {
+                type: ColumnHeaderType.RUN,
+                name: 'run',
+                displayName: 'Run',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.MEAN,
+                name: 'mean',
+                displayName: 'Mean',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.MAX_VALUE,
+                name: 'maxValue',
+                displayName: 'Max',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.MIN_VALUE,
+                name: 'minValue',
+                displayName: 'Min',
+                enabled: false,
+              },
             ],
           },
         })
       );
 
       expect(nextState.rangeSelectionHeaders).toEqual([
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.MEAN, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: false},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MEAN,
+          name: 'mean',
+          displayName: 'Mean',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'maxValue',
+          displayName: 'Max',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min',
+          enabled: false,
+        },
       ]);
     });
   });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2659,26 +2659,116 @@ describe('scalar card', () => {
     beforeEach(() => {
       store.overrideSelector(getMetricsLinkedTimeEnabled, true);
       store.overrideSelector(getSingleSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.SMOOTHED, enabled: true},
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
-        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.SMOOTHED,
+          name: 'smoothed',
+          displayName: 'Smoothed',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RELATIVE_TIME,
+          name: 'relativeTime',
+          displayName: 'Relative',
+          enabled: true,
+        },
       ]);
       store.overrideSelector(getRangeSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-        {type: ColumnHeaderType.START_VALUE, enabled: true},
-        {type: ColumnHeaderType.END_VALUE, enabled: true},
-        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
-        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
-        {type: ColumnHeaderType.START_STEP, enabled: true},
-        {type: ColumnHeaderType.END_STEP, enabled: true},
-        {type: ColumnHeaderType.STEP_AT_MAX, enabled: true},
-        {type: ColumnHeaderType.STEP_AT_MIN, enabled: true},
-        {type: ColumnHeaderType.MEAN, enabled: true},
-        {type: ColumnHeaderType.RAW_CHANGE, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'maxValue',
+          displayName: 'Max Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.START_VALUE,
+          name: 'startValue',
+          displayName: 'Start Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.END_VALUE,
+          name: 'endValue',
+          displayName: 'End Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE_CHANGE,
+          name: 'valueChange',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.PERCENTAGE_CHANGE,
+          name: 'percentageChange',
+          displayName: '%',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.START_STEP,
+          name: 'startStep',
+          displayName: 'Start Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.END_STEP,
+          name: 'endStep',
+          displayName: 'End Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP_AT_MAX,
+          name: 'stepAtMax',
+          displayName: 'Step At Max',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP_AT_MIN,
+          name: 'stepAtMin',
+          displayName: 'Step At Min',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MEAN,
+          name: 'mean',
+          displayName: 'Mean',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RAW_CHANGE,
+          name: 'rawChange',
+          displayName: 'Raw',
+          enabled: true,
+        },
       ]);
       store.overrideSelector(getCardStateMap, {
         card1: {
@@ -3480,12 +3570,32 @@ describe('scalar card', () => {
     beforeEach(() => {
       store.overrideSelector(getMetricsLinkedTimeEnabled, true);
       store.overrideSelector(getSingleSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.SMOOTHED, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.SMOOTHED,
+          name: 'smoothed',
+          displayName: 'Smoothed',
+          enabled: true,
+        },
       ]);
       store.overrideSelector(getRangeSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min Value',
+          enabled: true,
+        },
       ]);
 
       const runToSeries = {
@@ -3981,8 +4091,18 @@ describe('scalar card', () => {
         );
 
         const headers = [
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.VALUE, enabled: true},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: true,
+          },
         ];
         scalarCardDataTable.componentInstance.orderColumns(headers);
 
@@ -4015,8 +4135,18 @@ describe('scalar card', () => {
         );
 
         const headers = [
-          {type: ColumnHeaderType.RUN, enabled: true},
-          {type: ColumnHeaderType.VALUE, enabled: true},
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: true,
+          },
         ];
         scalarCardDataTable.componentInstance.orderColumns(headers);
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -100,6 +100,8 @@ export enum ColumnHeaderType {
 
 export interface ColumnHeader {
   type: ColumnHeaderType;
+  name: string;
+  displayName: string;
   enabled: boolean;
 }
 

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -94,8 +94,18 @@ describe('scalar column editor', () => {
 
   it('renders single selection headers when selectedTab is set to SINGLE', fakeAsync(() => {
     store.overrideSelector(getSingleSelectionHeaders, [
-      {type: ColumnHeaderType.RUN, enabled: true},
-      {type: ColumnHeaderType.VALUE, enabled: true},
+      {
+        type: ColumnHeaderType.RUN,
+        name: 'run',
+        displayName: 'Run',
+        enabled: true,
+      },
+      {
+        type: ColumnHeaderType.VALUE,
+        name: 'value',
+        displayName: 'Value',
+        enabled: true,
+      },
     ]);
     const fixture = createComponent();
 
@@ -111,8 +121,18 @@ describe('scalar column editor', () => {
 
   it('renders range selection headers when selectedTab is set to RANGE', fakeAsync(() => {
     store.overrideSelector(getRangeSelectionHeaders, [
-      {type: ColumnHeaderType.RUN, enabled: true},
-      {type: ColumnHeaderType.VALUE, enabled: true},
+      {
+        type: ColumnHeaderType.RUN,
+        name: 'run',
+        displayName: 'Run',
+        enabled: true,
+      },
+      {
+        type: ColumnHeaderType.VALUE,
+        name: 'value',
+        displayName: 'Value',
+        enabled: true,
+      },
     ]);
     const fixture = createComponent();
     switchTabs(fixture, DataTableMode.RANGE);
@@ -128,8 +148,18 @@ describe('scalar column editor', () => {
 
   it('checkboxes reflect enabled state', fakeAsync(() => {
     store.overrideSelector(getSingleSelectionHeaders, [
-      {type: ColumnHeaderType.RUN, enabled: true},
-      {type: ColumnHeaderType.VALUE, enabled: false},
+      {
+        type: ColumnHeaderType.RUN,
+        name: 'run',
+        displayName: 'Run',
+        enabled: true,
+      },
+      {
+        type: ColumnHeaderType.VALUE,
+        name: 'value',
+        displayName: 'Value',
+        enabled: false,
+      },
     ]);
     const fixture = createComponent();
 
@@ -154,8 +184,18 @@ describe('scalar column editor', () => {
 
     it('dispatches dataTableColumnToggled action with singe selection when checkbox is clicked', fakeAsync(() => {
       store.overrideSelector(getSingleSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.VALUE, enabled: false},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: false,
+        },
       ]);
       const fixture = createComponent();
       switchTabs(fixture, DataTableMode.SINGLE);
@@ -176,8 +216,18 @@ describe('scalar column editor', () => {
 
     it('dispatches dataTableColumnToggled action with range selection when checkbox is clicked', fakeAsync(() => {
       store.overrideSelector(getRangeSelectionHeaders, [
-        {type: ColumnHeaderType.SMOOTHED, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: false},
+        {
+          type: ColumnHeaderType.SMOOTHED,
+          name: 'smoothed',
+          displayName: 'Smoothed',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'maxValue',
+          displayName: 'Max',
+          enabled: false,
+        },
       ]);
       const fixture = createComponent();
 
@@ -208,9 +258,24 @@ describe('scalar column editor', () => {
 
     it('dispatches dataTableColumnEdited action with singe selection when header is dragged', fakeAsync(() => {
       store.overrideSelector(getSingleSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
       ]);
       const fixture = createComponent();
       switchTabs(fixture, DataTableMode.SINGLE);
@@ -228,9 +293,24 @@ describe('scalar column editor', () => {
         dataTableColumnEdited({
           dataTableMode: DataTableMode.SINGLE,
           headers: [
-            {type: ColumnHeaderType.VALUE, enabled: true},
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.STEP, enabled: true},
+            {
+              type: ColumnHeaderType.VALUE,
+              name: 'value',
+              displayName: 'Value',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.STEP,
+              name: 'step',
+              displayName: 'Step',
+              enabled: true,
+            },
           ],
         })
       );
@@ -238,9 +318,24 @@ describe('scalar column editor', () => {
 
     it('dispatches dataTableColumnEdited action with range selection when header is dragged', fakeAsync(() => {
       store.overrideSelector(getRangeSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'maxValue',
+          displayName: 'Max',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min',
+          enabled: true,
+        },
       ]);
       const fixture = createComponent();
       switchTabs(fixture, DataTableMode.RANGE);
@@ -258,9 +353,24 @@ describe('scalar column editor', () => {
         dataTableColumnEdited({
           dataTableMode: DataTableMode.RANGE,
           headers: [
-            {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+            {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: true,
+            },
           ],
         })
       );
@@ -268,9 +378,24 @@ describe('scalar column editor', () => {
 
     it('highlights item with bottom edge when dragging below item being dragged', fakeAsync(() => {
       store.overrideSelector(getRangeSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'maxValue',
+          displayName: 'Max',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min',
+          enabled: true,
+        },
       ]);
       const fixture = createComponent();
       switchTabs(fixture, DataTableMode.RANGE);
@@ -289,9 +414,24 @@ describe('scalar column editor', () => {
 
     it('highlights item with top edge when dragging above item being dragged', fakeAsync(() => {
       store.overrideSelector(getRangeSelectionHeaders, [
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'maxValue',
+          displayName: 'Max',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min',
+          enabled: true,
+        },
       ]);
       const fixture = createComponent();
       switchTabs(fixture, DataTableMode.RANGE);

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -187,8 +187,18 @@ describe('persistent_settings data_source test', () => {
         getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
           JSON.stringify({
             singleSelectionHeaders: [
-              {type: ColumnHeaderType.RUN, enabled: true},
-              {type: ColumnHeaderType.VALUE, enabled: false},
+              {
+                type: ColumnHeaderType.RUN,
+                name: 'run',
+                displayName: 'Run',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.VALUE,
+                name: 'value',
+                displayName: 'Value',
+                enabled: false,
+              },
             ],
           })
         );
@@ -197,8 +207,18 @@ describe('persistent_settings data_source test', () => {
 
         expect(actual).toEqual({
           singleSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.VALUE, enabled: false},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.VALUE,
+              name: 'value',
+              displayName: 'Value',
+              enabled: false,
+            },
           ],
         });
       });
@@ -206,8 +226,18 @@ describe('persistent_settings data_source test', () => {
         getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
           JSON.stringify({
             rangeSelectionHeaders: [
-              {type: ColumnHeaderType.RUN, enabled: true},
-              {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+              {
+                type: ColumnHeaderType.RUN,
+                name: 'run',
+                displayName: 'Run',
+                enabled: true,
+              },
+              {
+                type: ColumnHeaderType.MIN_VALUE,
+                name: 'minValue',
+                displayName: 'Min',
+                enabled: true,
+              },
             ],
           })
         );
@@ -216,8 +246,18 @@ describe('persistent_settings data_source test', () => {
 
         expect(actual).toEqual({
           rangeSelectionHeaders: [
-            {type: ColumnHeaderType.RUN, enabled: true},
-            {type: ColumnHeaderType.MIN_VALUE, enabled: true},
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min',
+              enabled: true,
+            },
           ],
         });
       });

--- a/tensorboard/webapp/widgets/data_table/data_table_header_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_component.ts
@@ -13,12 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnDestroy,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {
   ColumnHeaderType,
   ColumnHeader,

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -101,19 +101,84 @@ describe('data table', () => {
   it('displays given headers in order', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
-        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
-        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
-        {type: ColumnHeaderType.START_STEP, enabled: true},
-        {type: ColumnHeaderType.END_STEP, enabled: true},
-        {type: ColumnHeaderType.START_VALUE, enabled: true},
-        {type: ColumnHeaderType.END_VALUE, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
-        {type: ColumnHeaderType.SMOOTHED, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RELATIVE_TIME,
+          name: 'relativeTime',
+          displayName: 'Relative',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE_CHANGE,
+          name: 'valueChanged',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.START_STEP,
+          name: 'startStep',
+          displayName: 'Start Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.END_STEP,
+          name: 'endStep',
+          displayName: 'End Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.START_VALUE,
+          name: 'startValue',
+          displayName: 'Start Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.END_VALUE,
+          name: 'endValue',
+          displayName: 'End Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'maxValue',
+          displayName: 'Max',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.PERCENTAGE_CHANGE,
+          name: 'percentageChanged',
+          displayName: '%',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.SMOOTHED,
+          name: 'smoothed',
+          displayName: 'Smoothed',
+          enabled: true,
+        },
       ],
     });
     fixture.detectChanges();
@@ -149,19 +214,84 @@ describe('data table', () => {
   it('displays data in order', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
-        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
-        {type: ColumnHeaderType.VALUE_CHANGE, enabled: true},
-        {type: ColumnHeaderType.START_STEP, enabled: true},
-        {type: ColumnHeaderType.END_STEP, enabled: true},
-        {type: ColumnHeaderType.START_VALUE, enabled: true},
-        {type: ColumnHeaderType.END_VALUE, enabled: true},
-        {type: ColumnHeaderType.MIN_VALUE, enabled: true},
-        {type: ColumnHeaderType.MAX_VALUE, enabled: true},
-        {type: ColumnHeaderType.PERCENTAGE_CHANGE, enabled: true},
-        {type: ColumnHeaderType.SMOOTHED, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RELATIVE_TIME,
+          name: 'relativeTime',
+          displayName: 'Relative',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.VALUE_CHANGE,
+          name: 'valueChanged',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.START_STEP,
+          name: 'startStep',
+          displayName: 'Start Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.END_STEP,
+          name: 'endStep',
+          displayName: 'End Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.START_VALUE,
+          name: 'startValue',
+          displayName: 'Start Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.END_VALUE,
+          name: 'endValue',
+          displayName: 'End Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.MAX_VALUE,
+          name: 'maxValue',
+          displayName: 'max',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.PERCENTAGE_CHANGE,
+          name: 'percentageChanged',
+          displayName: '%',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.SMOOTHED,
+          name: 'smoothed',
+          displayName: 'Smoothed',
+          enabled: true,
+        },
       ],
       data: [
         {
@@ -217,9 +347,24 @@ describe('data table', () => {
   it('does not displays headers or data when header is disabled', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: false},
-        {type: ColumnHeaderType.STEP, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: false,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
       ],
       data: [
         {
@@ -248,10 +393,30 @@ describe('data table', () => {
   it('displays nothing when no data is available', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
-        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RELATIVE_TIME,
+          name: 'relativeTime',
+          displayName: 'Relative',
+          enabled: true,
+        },
       ],
       data: [{id: 'someid'}],
     });
@@ -269,10 +434,30 @@ describe('data table', () => {
   it('emits sortDataBy event when header clicked', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
-        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RELATIVE_TIME,
+          name: 'relativeTime',
+          displayName: 'Relative',
+          enabled: true,
+        },
       ],
     });
     fixture.detectChanges();
@@ -288,10 +473,30 @@ describe('data table', () => {
   it('emits sortDataBy event with DESCENDING when header that is currently sorted is clicked', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
-        {type: ColumnHeaderType.RELATIVE_TIME, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RELATIVE_TIME,
+          name: 'relativeTime',
+          displayName: 'Relative',
+          enabled: true,
+        },
       ],
       sortingInfo: {
         header: ColumnHeaderType.STEP,
@@ -311,9 +516,24 @@ describe('data table', () => {
   it('keeps sorting arrow invisible unless sorting on that header', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
       ],
       sortingInfo: {
         header: ColumnHeaderType.VALUE,
@@ -358,9 +578,24 @@ describe('data table', () => {
   it('shows downward arrow when order is DESCENDING', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
       ],
       sortingInfo: {
         header: ColumnHeaderType.STEP,
@@ -405,9 +640,24 @@ describe('data table', () => {
   it('emits orderColumns with new order when dragged left', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
       ],
       sortingInfo: {
         header: ColumnHeaderType.STEP,
@@ -433,18 +683,48 @@ describe('data table', () => {
     headerElements[2].query(By.css('.cell')).triggerEventHandler('dragend');
 
     expect(orderColumnsSpy).toHaveBeenCalledOnceWith([
-      {type: ColumnHeaderType.RUN, enabled: true},
-      {type: ColumnHeaderType.VALUE, enabled: true},
-      {type: ColumnHeaderType.STEP, enabled: true},
+      {
+        type: ColumnHeaderType.RUN,
+        name: 'run',
+        displayName: 'Run',
+        enabled: true,
+      },
+      {
+        type: ColumnHeaderType.VALUE,
+        name: 'value',
+        displayName: 'Value',
+        enabled: true,
+      },
+      {
+        type: ColumnHeaderType.STEP,
+        name: 'step',
+        displayName: 'Step',
+        enabled: true,
+      },
     ]);
   });
 
   it('emits orderColumns with new order when dragged right', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
       ],
       sortingInfo: {
         header: ColumnHeaderType.STEP,
@@ -470,19 +750,54 @@ describe('data table', () => {
     headerElements[2].query(By.css('.cell')).triggerEventHandler('dragend');
 
     expect(orderColumnsSpy).toHaveBeenCalledOnceWith([
-      {type: ColumnHeaderType.VALUE, enabled: true},
-      {type: ColumnHeaderType.STEP, enabled: true},
-      {type: ColumnHeaderType.RUN, enabled: true},
+      {
+        type: ColumnHeaderType.VALUE,
+        name: 'value',
+        displayName: 'Value',
+        enabled: true,
+      },
+      {
+        type: ColumnHeaderType.STEP,
+        name: 'step',
+        displayName: 'Step',
+        enabled: true,
+      },
+      {
+        type: ColumnHeaderType.RUN,
+        name: 'run',
+        displayName: 'Run',
+        enabled: true,
+      },
     ]);
   });
 
   it('does not display Smoothed column when smoothingEnabled is false', () => {
     const fixture = createComponent({
       headers: [
-        {type: ColumnHeaderType.VALUE, enabled: true},
-        {type: ColumnHeaderType.RUN, enabled: true},
-        {type: ColumnHeaderType.SMOOTHED, enabled: true},
-        {type: ColumnHeaderType.STEP, enabled: true},
+        {
+          type: ColumnHeaderType.VALUE,
+          name: 'value',
+          displayName: 'Value',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.SMOOTHED,
+          name: 'smoothed',
+          displayName: 'Smoothed',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.STEP,
+          name: 'step',
+          displayName: 'Step',
+          enabled: true,
+        },
       ],
       data: [
         {


### PR DESCRIPTION
## Motivation for features / changes
The goals is to allow for dynamic HParam columns in the data table. This means that we cannot have an enum like ColumnHeaderType be the unique identifier for the column headers because we cannot encapsulate all possible hparams into an enum.

## Technical description of changes
This change adds a name and displayName field to the ColumnHeader interface. The goal here is to make name be the unique identifier for columns. However, this PR does not use these fields at all. It simply adds them. THERE IS NO FUNCTIONAL CHANGE in this PR.

Upcoming changes will switch the code over to start using the name as the unique identifier and display the displayName. 

(For POC to see how this change fits in googlers see cl/526767686)

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)
POC works

## Alternate designs / implementations considered (or N/A)
There were many alternatives considered. In fact I do not believe this is going to be the final structure.

One option is to remove the type and add a category field
export interface ColumnHeader {
  name: string;
  displayName: string;
  Category: ColumnCategory(STATIC, HPARAM, METRIC)
  enabled: boolean;
}

However, deciding how to calculate the value based on hardcoded name strings does not seem ideal.

Another option is to have a hierarchy. I expect it to look like this:
Interface ColumnHeaderBase {
  name: string;
  displayName: string;
  type: ColumnHeaderType;
  enabled: boolean;
}

export interface StaticColumnHeader extends ColumnHeaderBase{
	category: “STATIC”
}

export interface HParamColumnHeader extends ColumnHeaderBase{
	category: “HParam”
        source: enum(data, config,....);
        differs:boolean;
}

ColumnHeader = StaticColumnHeader | HParamColumnHeader

This may be the final form that we go with however, we are not sure the source and differs attributes need to go here or somewhere else yet. All code which works with the type defined in this PR will work with this proposal as well.

Lastly, there is the option which is the same as the hierarchy option above but with StaticColumnHeader being the only interface with a "type" attribute. This is a valid possibility but, I have decided that it just adds unnecessary complexity by requiring a type check in many more places. 

