### PR TITLE
Access class property in acceptable way for internal TS compiler

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -360,10 +360,10 @@ describe('scalar column editor', () => {
       const tabs = fixture.debugElement.queryAll(By.css('.mat-tab-label'));
 
       expect(
-        tabs[0].attributes.class?.includes('mat-tab-label-active')
+        tabs[0].attributes['class']?.includes('mat-tab-label-active')
       ).toBeTrue();
       expect(
-        tabs[1].attributes.class?.includes('mat-tab-label-active')
+        tabs[1].attributes['class']?.includes('mat-tab-label-active')
       ).toBeFalse();
 
       store.overrideSelector(getTableEditorSelectedTab, DataTableMode.RANGE);
@@ -371,10 +371,10 @@ describe('scalar column editor', () => {
       fixture.detectChanges();
 
       expect(
-        tabs[0].attributes.class?.includes('mat-tab-label-active')
+        tabs[0].attributes['class']?.includes('mat-tab-label-active')
       ).toBeFalse();
       expect(
-        tabs[1].attributes.class?.includes('mat-tab-label-active')
+        tabs[1].attributes['class']?.includes('mat-tab-label-active')
       ).toBeTrue();
     });
   });


### PR DESCRIPTION
## Motivation for features / changes
Internal TS compiler threw error "Property 'class' comes from an index signature, so it must be accessed with ['class']." This change fixes those errors.

## Detailed steps to verify changes work correctly (as executed by you)
tested internally. (googlers see cl/526813276)