### PR TITLE
Sync: remove untouched condition

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -584,9 +584,7 @@ export function getMinMaxStepFromCardState(cardState: Partial<CardState>) {
 
   const minStep = x[0] < x[1] ? x[0] : x[1];
   const maxStep = minStep === x[0] ? x[1] : x[0];
-  return (
-    {minStep: Math.ceil(minStep), maxStep: Math.floor(maxStep)} || dataMinMax
-  );
+  return {minStep: Math.ceil(minStep), maxStep: Math.floor(maxStep)};
 }
 
 export function getCardSelectionStateToBoolean(


### PR DESCRIPTION
## Motivation for features / changes
The code after `||` will not be touched since we have changed our "userViewBox" logic in this selector. Removed it.

Googlers, please see sync cl cl/488391097