### PR TITLE
HParams: Add new selector factory to get runs from experiment ids

### DIFF
--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -79,6 +79,25 @@ export const getRuns = createSelector(
   }
 );
 
+export const getRunsFromExperimentIds = (experimentIds: string[]) =>
+  createSelector(
+    getDataState,
+    (state: RunsDataState): Array<Run & {experimentId: string}> => {
+      return experimentIds.reduce((runs, experimentId) => {
+        const runsIdsForExperiment = (state.runIds[experimentId] || []).filter(
+          (id) => Boolean(state.runMetadata[id])
+        );
+        runsIdsForExperiment.forEach((runId) => {
+          runs.push({
+            ...state.runMetadata[runId],
+            experimentId,
+          });
+        });
+        return runs;
+      }, [] as Array<Run & {experimentId: string}>);
+    }
+  );
+
 /**
  * Returns Observable that emits runs list for an experiment.
  */

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -84,15 +84,12 @@ export const getRunsFromExperimentIds = (experimentIds: string[]) =>
     getDataState,
     (state: RunsDataState): Array<Run & {experimentId: string}> => {
       return experimentIds.reduce((runs, experimentId) => {
-        const runsIdsForExperiment = (state.runIds[experimentId] || []).filter(
-          (id) => Boolean(state.runMetadata[id])
-        );
-        runsIdsForExperiment.forEach((runId) => {
-          runs.push({
-            ...state.runMetadata[runId],
-            experimentId,
+        (state.runIds[experimentId] || [])
+          .filter((id) => Boolean(state.runMetadata[id]))
+          .forEach((runId) => {
+            runs.push({...state.runMetadata[runId], experimentId});
           });
-        });
+
         return runs;
       }, [] as Array<Run & {experimentId: string}>);
     }

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -176,6 +176,57 @@ describe('runs_selectors', () => {
     });
   });
 
+  describe('#getRunsFromExperimentIds', () => {
+    it('returns runs', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          runIds: {
+            eid: ['run1'],
+          },
+          runMetadata: {
+            run1: buildRun({id: 'run1'}),
+          },
+        })
+      );
+      expect(selectors.getRunsFromExperimentIds(['eid'])(state)).toEqual([
+        {
+          ...buildRun({
+            id: 'run1',
+          }),
+          experimentId: 'eid',
+        },
+      ]);
+    });
+
+    it('returns runs for the ones that has metadata', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          runIds: {
+            eid: ['run1', 'run2'],
+          },
+          runMetadata: {
+            run1: buildRun({id: 'run1'}),
+          },
+        })
+      );
+      expect(selectors.getRunsFromExperimentIds(['eid'])(state)).toEqual([
+        {
+          ...buildRun({
+            id: 'run1',
+          }),
+          experimentId: 'eid',
+        },
+      ]);
+    });
+
+    it('returns empty list if experiment id does not exist', () => {
+      const state = buildStateFromRunsState(buildRunsState());
+      expect(
+        selectors.getRunsFromExperimentIds(['i_do_not_exist'])(state)
+      ).toEqual([]);
+    });
+  });
+
   describe('#getRunIdsForExperiment', () => {
     beforeEach(() => {
       // Clear the memoization.


### PR DESCRIPTION
## Motivation for features / changes
As part of the effort to bring hparams to the time series dashboard a handful of new selectors need to be created. In particular I will be creating a new one to handle runs filtering by moving the logic out of the runs_table_container into the selector layer.
This will ensure filtered runs are consistent across the dashboard.

## Technical description of changes
This new selector is not meaningfully different from the existing one but the factory allows it to be called with an encapsulated experiment id.
