### PR TITLE
TensorBoard 2.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  # See https://github.com/tensorflow/tensorboard/pull/6350.
-  TENSORFLOW_VERSION: 'tf-nightly==2.13.0.dev20230426'
+  TENSORFLOW_VERSION: 'tf-nightly==2.13.0.dev20230501'
 
 jobs:
   build:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,15 @@
+# Release 2.13.0
+
+The 2.13 minor series tracks TensorFlow 2.13
+
+## Bug Fixes
+
+- Several improvements to the projector plugin (thank you @alicialics)
+  - Embedding Projector: fix regex suffix css (#6329)
+  - Embedding Projector: fix bookmark projection state (#6328)
+  - Embedding Projector: fix dark mode button contrast (#6327)
+  - Embedding Projector: update tsne learning rate during iteration (#6319)
+
 # Release 2.12.3
 
 ## Bug Fixes

--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -127,10 +127,16 @@ tb_proto_library(
 )
 
 tb_proto_library(
+    name = "graph_debug_info",
+    srcs = ["graph_debug_info.proto"],
+)
+
+tb_proto_library(
     name = "graph",
     srcs = ["graph.proto"],
     deps = [
         ":function",
+        ":graph_debug_info",
         ":node_def",
         ":versions",
     ],
@@ -326,6 +332,7 @@ tb_proto_library(
         ":full_type",
         ":function",
         ":graph",
+        ":graph_debug_info",
         ":histogram",
         ":meta_graph",
         ":node_def",

--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -691,7 +691,9 @@ message ConfigProto {
     // aims to negate its value.
     bool disable_optimize_for_static_graph = 24;
 
-    // Next: 25
+    reserved 25;
+
+    // Next: 26
   }
 
   Experimental experimental = 16;

--- a/tensorboard/compat/proto/coordination_config.proto
+++ b/tensorboard/compat/proto/coordination_config.proto
@@ -56,4 +56,9 @@ message CoordinationServiceConfig {
   // If empty, no jobs will be recoverable and every task failure will cause
   // error propagation to other tasks.
   repeated string recoverable_jobs = 9;
+
+  // If a task restarts with a new incarnation, we may allow it to reconnect
+  // silently. This is useful when we know that a task can immediately resume
+  // work upon re-connecting to the service.
+  bool allow_new_incarnation_to_reconnect = 11;
 }

--- a/tensorboard/compat/proto/graph.proto
+++ b/tensorboard/compat/proto/graph.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package tensorboard;
 
 import "tensorboard/compat/proto/function.proto";
+import "tensorboard/compat/proto/graph_debug_info.proto";
 import "tensorboard/compat/proto/node_def.proto";
 import "tensorboard/compat/proto/versions.proto";
 
@@ -53,4 +54,7 @@ message GraphDef {
   //     consumer does not start until all return values of the callee
   //     function are ready.
   FunctionDefLibrary library = 2;
+
+  // Stack traces for the nodes in this graph.
+  GraphDebugInfo debug_info = 5;
 }

--- a/tensorboard/compat/proto/graph_debug_info.proto
+++ b/tensorboard/compat/proto/graph_debug_info.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package tensorboard;
+
+option cc_enable_arenas = true;
+option java_outer_classname = "GraphDebugInfoProtos";
+option java_multiple_files = true;
+option java_package = "org.tensorflow.framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
+
+message GraphDebugInfo {
+  // This represents a file/line location in the source code.
+  message FileLineCol {
+    // File name index, which can be used to retrieve the file name string from
+    // `files`. The value should be between 0 and (len(files)-1)
+    int32 file_index = 1;
+
+    // Line number in the file.
+    int32 line = 2;
+
+    // Col number in the file line.
+    int32 col = 3;
+
+    // Name of function contains the file line.
+    string func = 4;
+
+    // Source code contained in this file line.
+    string code = 5;
+  }
+
+  // This represents a stack trace which is a ordered list of `FileLineCol`.
+  message StackTrace {
+    // Each line in the stack trace.
+    repeated FileLineCol file_line_cols = 1;
+  }
+
+  // This stores all the source code file names and can be indexed by the
+  // `file_index`.
+  repeated string files = 1;
+
+  // This maps a node name to a stack trace in the source code.
+  // The map key is a mangling of the containing function and op name with
+  // syntax:
+  //   op.name '@' func_name
+  // For ops in the top-level graph, the func_name is the empty string.
+  // Note that op names are restricted to a small number of characters which
+  // exclude '@', making it impossible to collide keys of this form. Function
+  // names accept a much wider set of characters.
+  // It would be preferable to avoid mangling and use a tuple key of (op.name,
+  // func_name), but this is not supported with protocol buffers.
+  map<string, StackTrace> traces = 2;
+}

--- a/tensorboard/compat/proto/proto_test.py
+++ b/tensorboard/compat/proto/proto_test.py
@@ -67,6 +67,10 @@ PROTO_IMPORTS = [
         "tensorboard.compat.proto.function_pb2",
     ),
     (
+        "tensorflow.core.framework.graph_debug_info_pb2",
+        "tensorboard.compat.proto.graph_debug_info_pb2",
+    ),
+    (
         "tensorflow.core.framework.graph_pb2",
         "tensorboard.compat.proto.graph_pb2",
     ),

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -72,6 +72,8 @@ message StructuredValue {
     DictValue dict_value = 53;
     // Represents Python's namedtuple.
     NamedTupleValue named_tuple_value = 54;
+    // Represents a value for tf.Tensor.
+    tensorboard.TensorProto tensor_value = 55;
   }
 }
 

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,7 +15,7 @@
 
 """Contains the version string."""
 
-VERSION = "2.13.0a0"
+VERSION = "2.13.0"
 
 if __name__ == "__main__":
     print(VERSION)


### PR DESCRIPTION
## Motivation for features / changes
The TensorBoard release that tracks the TF 2.13 release.

## Technical description of changes
* Update TensorFlow protos as part of the 2.13 release.
* Pin the TF version for CI (to `tf-nightly=2.13.0.dev20230501`)

The proto updates were made by manually copying and editing the new file then updating the remaining files according to  [these intructions](https://github.com/tensorflow/tensorboard/blob/b6afe57af75636eaa61081f8f0e9636036aad4c8/tensorboard/compat/proto/proto_test.py)
