### PR TITLE
Update feature flag directive to fix internal tests

### DIFF
--- a/tensorboard/webapp/feature_flag/directives/feature_flag_directive.ts
+++ b/tensorboard/webapp/feature_flag/directives/feature_flag_directive.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Directive, ElementRef, HostBinding, Input} from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  HostBinding,
+  Input,
+  OnChanges,
+} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {firstValueFrom} from 'rxjs';
 import {map, tap} from 'rxjs/operators';
@@ -22,15 +28,28 @@ import {getFeatureFlagsToSendToServer} from '../store/feature_flag_selectors';
 import {State as FeatureFlagState} from '../store/feature_flag_types';
 
 @Directive({selector: 'a[includeFeatureFlags], img[includeFeatureFlags]'})
-export class FeatureFlagDirective {
-  @HostBinding('attr.href') hrefAttr: string | undefined = undefined;
-  @HostBinding('attr.src') srcAttr: string | undefined = undefined;
+export class FeatureFlagDirective implements OnChanges {
   // The selector applies if [includeFeatureFlags] is present at all. Supplying
   // [includeFeatureFlags]="true"/"false" has no impact on the actual logic and
   // will behave the same as though [includeFeatureFlags] is unset.
   @Input() includeFeatureFlags: boolean = true;
+  @Input() @HostBinding('attr.src') src: string | undefined;
+  @Input() @HostBinding('attr.href') href: string | undefined;
 
   constructor(private readonly store: Store<FeatureFlagState>) {}
+
+  ngOnChanges() {
+    if (this.src) {
+      firstValueFrom(this.getUrlWithFeatureFlags(this.src)).then((value) => {
+        this.src = value;
+      });
+    }
+    if (this.href) {
+      firstValueFrom(this.getUrlWithFeatureFlags(this.href)).then((value) => {
+        this.href = value;
+      });
+    }
+  }
 
   private getUrlWithFeatureFlags(url: string) {
     return this.store.select(getFeatureFlagsToSendToServer).pipe(
@@ -46,23 +65,5 @@ export class FeatureFlagDirective {
         }
       })
     );
-  }
-
-  @Input()
-  set href(href: string | null) {
-    if (href) {
-      firstValueFrom(this.getUrlWithFeatureFlags(href)).then((value) => {
-        this.hrefAttr = value;
-      });
-    }
-  }
-
-  @Input()
-  set src(src: string | null) {
-    if (src) {
-      firstValueFrom(this.getUrlWithFeatureFlags(src)).then((value) => {
-        this.srcAttr = value;
-      });
-    }
   }
 }


### PR DESCRIPTION
Internal end-to-end tests are failing due to the async nature of the directive leading to attributes not being set before validation occurs. This forces change detection to occur after the href/src are updated.