### PR TITLE
Temporarily make new ColumnHeader properties optional for sync

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -100,8 +100,8 @@ export enum ColumnHeaderType {
 
 export interface ColumnHeader {
   type: ColumnHeaderType;
-  name: string;
-  displayName: string;
+  name?: string; // TODO: make required after internal changes are make
+  displayName?: string; // TODO: make required after internal changes are make
   enabled: boolean;
 }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -100,8 +100,8 @@ export enum ColumnHeaderType {
 
 export interface ColumnHeader {
   type: ColumnHeaderType;
-  name?: string; // TODO: make required after internal changes are make
-  displayName?: string; // TODO: make required after internal changes are make
+  name?: string; // TODO(jameshollyer): make required after internal changes are made
+  displayName?: string; // TODO(jameshollyer): make required after internal changes are made
   enabled: boolean;
 }
 


### PR DESCRIPTION
## Motivation for features / changes
These new properties break internal sync as the components which use ColumnHeader do not have these properties.
I will make them required again once internal uses are changed.

Googlers see cl/508442178 for sync test.