### PR TITLE
tensorboard-data-server 0.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  # See https://github.com/tensorflow/tensorboard/pull/6350.
-  TENSORFLOW_VERSION: 'tf-nightly==2.13.0.dev20230426'
+  TENSORFLOW_VERSION: 'tf-nightly==2.13.0.dev20230501'
 
 jobs:
   build:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,15 @@
+# Release 2.13.0
+
+The 2.13 minor series tracks TensorFlow 2.13
+
+## Bug Fixes
+
+- Several improvements to the projector plugin (thank you @alicialics)
+  - Embedding Projector: fix regex suffix css (#6329)
+  - Embedding Projector: fix bookmark projection state (#6328)
+  - Embedding Projector: fix dark mode button contrast (#6327)
+  - Embedding Projector: update tsne learning rate during iteration (#6319)
+
 # Release 2.12.3
 
 ## Bug Fixes

--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -127,10 +127,16 @@ tb_proto_library(
 )
 
 tb_proto_library(
+    name = "graph_debug_info",
+    srcs = ["graph_debug_info.proto"],
+)
+
+tb_proto_library(
     name = "graph",
     srcs = ["graph.proto"],
     deps = [
         ":function",
+        ":graph_debug_info",
         ":node_def",
         ":versions",
     ],
@@ -326,6 +332,7 @@ tb_proto_library(
         ":full_type",
         ":function",
         ":graph",
+        ":graph_debug_info",
         ":histogram",
         ":meta_graph",
         ":node_def",

--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -691,7 +691,9 @@ message ConfigProto {
     // aims to negate its value.
     bool disable_optimize_for_static_graph = 24;
 
-    // Next: 25
+    reserved 25;
+
+    // Next: 26
   }
 
   Experimental experimental = 16;

--- a/tensorboard/compat/proto/coordination_config.proto
+++ b/tensorboard/compat/proto/coordination_config.proto
@@ -56,4 +56,9 @@ message CoordinationServiceConfig {
   // If empty, no jobs will be recoverable and every task failure will cause
   // error propagation to other tasks.
   repeated string recoverable_jobs = 9;
+
+  // If a task restarts with a new incarnation, we may allow it to reconnect
+  // silently. This is useful when we know that a task can immediately resume
+  // work upon re-connecting to the service.
+  bool allow_new_incarnation_to_reconnect = 11;
 }

--- a/tensorboard/compat/proto/graph.proto
+++ b/tensorboard/compat/proto/graph.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package tensorboard;
 
 import "tensorboard/compat/proto/function.proto";
+import "tensorboard/compat/proto/graph_debug_info.proto";
 import "tensorboard/compat/proto/node_def.proto";
 import "tensorboard/compat/proto/versions.proto";
 
@@ -53,4 +54,7 @@ message GraphDef {
   //     consumer does not start until all return values of the callee
   //     function are ready.
   FunctionDefLibrary library = 2;
+
+  // Stack traces for the nodes in this graph.
+  GraphDebugInfo debug_info = 5;
 }

--- a/tensorboard/compat/proto/graph_debug_info.proto
+++ b/tensorboard/compat/proto/graph_debug_info.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package tensorboard;
+
+option cc_enable_arenas = true;
+option java_outer_classname = "GraphDebugInfoProtos";
+option java_multiple_files = true;
+option java_package = "org.tensorflow.framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
+
+message GraphDebugInfo {
+  // This represents a file/line location in the source code.
+  message FileLineCol {
+    // File name index, which can be used to retrieve the file name string from
+    // `files`. The value should be between 0 and (len(files)-1)
+    int32 file_index = 1;
+
+    // Line number in the file.
+    int32 line = 2;
+
+    // Col number in the file line.
+    int32 col = 3;
+
+    // Name of function contains the file line.
+    string func = 4;
+
+    // Source code contained in this file line.
+    string code = 5;
+  }
+
+  // This represents a stack trace which is a ordered list of `FileLineCol`.
+  message StackTrace {
+    // Each line in the stack trace.
+    repeated FileLineCol file_line_cols = 1;
+  }
+
+  // This stores all the source code file names and can be indexed by the
+  // `file_index`.
+  repeated string files = 1;
+
+  // This maps a node name to a stack trace in the source code.
+  // The map key is a mangling of the containing function and op name with
+  // syntax:
+  //   op.name '@' func_name
+  // For ops in the top-level graph, the func_name is the empty string.
+  // Note that op names are restricted to a small number of characters which
+  // exclude '@', making it impossible to collide keys of this form. Function
+  // names accept a much wider set of characters.
+  // It would be preferable to avoid mangling and use a tuple key of (op.name,
+  // func_name), but this is not supported with protocol buffers.
+  map<string, StackTrace> traces = 2;
+}

--- a/tensorboard/compat/proto/proto_test.py
+++ b/tensorboard/compat/proto/proto_test.py
@@ -67,6 +67,10 @@ PROTO_IMPORTS = [
         "tensorboard.compat.proto.function_pb2",
     ),
     (
+        "tensorflow.core.framework.graph_debug_info_pb2",
+        "tensorboard.compat.proto.graph_debug_info_pb2",
+    ),
+    (
         "tensorflow.core.framework.graph_pb2",
         "tensorboard.compat.proto.graph_pb2",
     ),

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -72,6 +72,8 @@ message StructuredValue {
     DictValue dict_value = 53;
     // Represents Python's namedtuple.
     NamedTupleValue named_tuple_value = 54;
+    // Represents a value for tf.Tensor.
+    tensorboard.TensorProto tensor_value = 55;
   }
 }
 

--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "rustboard"
-version = "0.8.0-alpha.0"
+version = "0.7.1-alpha.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "rustboard"
-version = "0.8.0-alpha.0"
+version = "0.7.1-alpha.0"
 authors = ["The TensorFlow Authors <tensorboard-gardener@google.com>"]
 # Keep in sync with `edition` in rustfmt.toml.
 edition = "2018"

--- a/tensorboard/data/server/lib.rs
+++ b/tensorboard/data/server/lib.rs
@@ -19,7 +19,7 @@ limitations under the License.
 
 /// Package version. Keep in sync with `Cargo.toml`. We don't use `env!("CARGO_PKG_VERSION")`
 /// because of <https://github.com/bazelbuild/rules_rust/issues/573>.
-pub(crate) const VERSION: &str = "0.8.0-alpha.0";
+pub(crate) const VERSION: &str = "0.7.1-alpha.0";
 
 pub mod blob_key;
 pub mod cli;

--- a/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
+++ b/tensorboard/data/server/pip_package/tensorboard_data_server/__init__.py
@@ -19,7 +19,7 @@ import os
 
 # Version of this Python package. This may differ from the versions of
 # both TensorBoard and the data server.
-__version__ = "0.8.0a0"
+__version__ = "0.7.1"
 
 
 def server_binary():

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,7 +15,7 @@
 
 """Contains the version string."""
 
-VERSION = "2.13.0a0"
+VERSION = "2.13.0"
 
 if __name__ == "__main__":
     print(VERSION)

--- a/tensorboard/webapp/feature_flag/directives/feature_flag_directive.ts
+++ b/tensorboard/webapp/feature_flag/directives/feature_flag_directive.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Directive, ElementRef, HostBinding, Input} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Directive,
+  ElementRef,
+  HostBinding,
+  Input,
+} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {firstValueFrom} from 'rxjs';
 import {map, tap} from 'rxjs/operators';
@@ -30,7 +36,10 @@ export class FeatureFlagDirective {
   // will behave the same as though [includeFeatureFlags] is unset.
   @Input() includeFeatureFlags: boolean = true;
 
-  constructor(private readonly store: Store<FeatureFlagState>) {}
+  constructor(
+    private readonly store: Store<FeatureFlagState>,
+    private readonly changeDetectorRef: ChangeDetectorRef
+  ) {}
 
   private getUrlWithFeatureFlags(url: string) {
     return this.store.select(getFeatureFlagsToSendToServer).pipe(
@@ -53,6 +62,7 @@ export class FeatureFlagDirective {
     if (href) {
       firstValueFrom(this.getUrlWithFeatureFlags(href)).then((value) => {
         this.hrefAttr = value;
+        this.changeDetectorRef.detectChanges();
       });
     }
   }
@@ -62,6 +72,7 @@ export class FeatureFlagDirective {
     if (src) {
       firstValueFrom(this.getUrlWithFeatureFlags(src)).then((value) => {
         this.srcAttr = value;
+        this.changeDetectorRef.detectChanges();
       });
     }
   }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -100,8 +100,8 @@ export enum ColumnHeaderType {
 
 export interface ColumnHeader {
   type: ColumnHeaderType;
-  name: string;
-  displayName: string;
+  name?: string; // TODO(jameshollyer): make required after internal changes are made
+  displayName?: string; // TODO(jameshollyer): make required after internal changes are made
   enabled: boolean;
 }
 

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -79,6 +79,22 @@ export const getRuns = createSelector(
   }
 );
 
+export const getRunsFromExperimentIds = (experimentIds: string[]) =>
+  createSelector(
+    getDataState,
+    (state: RunsDataState): Array<Run & {experimentId: string}> => {
+      return experimentIds.reduce((runs, experimentId) => {
+        (state.runIds[experimentId] || [])
+          .filter((id) => Boolean(state.runMetadata[id]))
+          .forEach((runId) => {
+            runs.push({...state.runMetadata[runId], experimentId});
+          });
+
+        return runs;
+      }, [] as Array<Run & {experimentId: string}>);
+    }
+  );
+
 /**
  * Returns Observable that emits runs list for an experiment.
  */

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -176,6 +176,57 @@ describe('runs_selectors', () => {
     });
   });
 
+  describe('#getRunsFromExperimentIds', () => {
+    it('returns runs', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          runIds: {
+            eid: ['run1'],
+          },
+          runMetadata: {
+            run1: buildRun({id: 'run1'}),
+          },
+        })
+      );
+      expect(selectors.getRunsFromExperimentIds(['eid'])(state)).toEqual([
+        {
+          ...buildRun({
+            id: 'run1',
+          }),
+          experimentId: 'eid',
+        },
+      ]);
+    });
+
+    it('returns runs for the ones that has metadata', () => {
+      const state = buildStateFromRunsState(
+        buildRunsState({
+          runIds: {
+            eid: ['run1', 'run2'],
+          },
+          runMetadata: {
+            run1: buildRun({id: 'run1'}),
+          },
+        })
+      );
+      expect(selectors.getRunsFromExperimentIds(['eid'])(state)).toEqual([
+        {
+          ...buildRun({
+            id: 'run1',
+          }),
+          experimentId: 'eid',
+        },
+      ]);
+    });
+
+    it('returns empty list if experiment id does not exist', () => {
+      const state = buildStateFromRunsState(buildRunsState());
+      expect(
+        selectors.getRunsFromExperimentIds(['i_do_not_exist'])(state)
+      ).toEqual([]);
+    });
+  });
+
   describe('#getRunIdsForExperiment', () => {
     beforeEach(() => {
       // Clear the memoization.

--- a/tensorboard/webapp/widgets/data_table/data_table_header_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_component.ng.html
@@ -28,6 +28,6 @@ limitations under the License.
   <div *ngSwitchDefault class="extra-right-padding"></div>
 
   <span [ngClass]="getSpecialTypeClasses(header.type)"
-    >{{ getHeaderTextColumn(header.type) }}</span
+    >{{ header.displayName }}</span
   >
 </div>

--- a/tensorboard/webapp/widgets/data_table/data_table_header_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_header_component.ts
@@ -29,49 +29,6 @@ export class DataTableHeaderComponent {
   @Input() header!: ColumnHeader;
   ColumnHeaderType = ColumnHeaderType;
 
-  getHeaderTextColumn(columnHeader: ColumnHeaderType): string {
-    switch (columnHeader) {
-      case ColumnHeaderType.RUN:
-        return 'Run';
-      case ColumnHeaderType.VALUE:
-        return 'Value';
-      case ColumnHeaderType.STEP:
-        return 'Step';
-      case ColumnHeaderType.TIME:
-        return 'Time';
-      case ColumnHeaderType.RELATIVE_TIME:
-        return 'Relative';
-      case ColumnHeaderType.SMOOTHED:
-        return 'Smoothed';
-      case ColumnHeaderType.VALUE_CHANGE:
-        return 'Value';
-      case ColumnHeaderType.START_STEP:
-        return 'Start Step';
-      case ColumnHeaderType.END_STEP:
-        return 'End Step';
-      case ColumnHeaderType.START_VALUE:
-        return 'Start Value';
-      case ColumnHeaderType.END_VALUE:
-        return 'End Value';
-      case ColumnHeaderType.MIN_VALUE:
-        return 'Min';
-      case ColumnHeaderType.MAX_VALUE:
-        return 'Max';
-      case ColumnHeaderType.PERCENTAGE_CHANGE:
-        return '%';
-      case ColumnHeaderType.STEP_AT_MAX:
-        return 'Step at Max';
-      case ColumnHeaderType.STEP_AT_MIN:
-        return 'Step at Min';
-      case ColumnHeaderType.MEAN:
-        return 'Mean';
-      case ColumnHeaderType.RAW_CHANGE:
-        return 'Real Value';
-      default:
-        return '';
-    }
-  }
-
   getSpecialTypeClasses(columnHeader: ColumnHeaderType) {
     switch (columnHeader) {
       case ColumnHeaderType.STEP_AT_MIN:

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -114,57 +114,9 @@ describe('data table', () => {
           enabled: true,
         },
         {
-          type: ColumnHeaderType.STEP,
-          name: 'step',
-          displayName: 'Step',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.RELATIVE_TIME,
-          name: 'relativeTime',
-          displayName: 'Relative',
-          enabled: true,
-        },
-        {
           type: ColumnHeaderType.VALUE_CHANGE,
           name: 'valueChanged',
           displayName: 'Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.START_STEP,
-          name: 'startStep',
-          displayName: 'Start Step',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.END_STEP,
-          name: 'endStep',
-          displayName: 'End Step',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.START_VALUE,
-          name: 'startValue',
-          displayName: 'Start Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.END_VALUE,
-          name: 'endValue',
-          displayName: 'End Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.MIN_VALUE,
-          name: 'minValue',
-          displayName: 'Min',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.MAX_VALUE,
-          name: 'maxValue',
-          displayName: 'Max',
           enabled: true,
         },
         {
@@ -188,27 +140,19 @@ describe('data table', () => {
     expect(headerElements[0].nativeElement.innerText).toBe('');
     expect(headerElements[1].nativeElement.innerText).toBe('Value');
     expect(headerElements[2].nativeElement.innerText).toBe('Run');
-    expect(headerElements[3].nativeElement.innerText).toBe('Step');
-    expect(headerElements[4].nativeElement.innerText).toBe('Relative');
-    expect(headerElements[5].nativeElement.innerText).toBe('Value');
+    expect(headerElements[3].nativeElement.innerText).toBe('Value');
     expect(
-      headerElements[5]
+      headerElements[3]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.getAttribute('svgIcon')
     ).toBe('change_history_24px');
-    expect(headerElements[6].nativeElement.innerText).toBe('Start Step');
-    expect(headerElements[7].nativeElement.innerText).toBe('End Step');
-    expect(headerElements[8].nativeElement.innerText).toBe('Start Value');
-    expect(headerElements[9].nativeElement.innerText).toBe('End Value');
-    expect(headerElements[10].nativeElement.innerText).toBe('Min');
-    expect(headerElements[11].nativeElement.innerText).toBe('Max');
-    expect(headerElements[12].nativeElement.innerText).toBe('%');
+    expect(headerElements[4].nativeElement.innerText).toBe('%');
     expect(
-      headerElements[12]
+      headerElements[4]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.getAttribute('svgIcon')
     ).toBe('change_history_24px');
-    expect(headerElements[13].nativeElement.innerText).toBe('Smoothed');
+    expect(headerElements[5].nativeElement.innerText).toBe('Smoothed');
   });
 
   it('displays data in order', () => {


### PR DESCRIPTION
## Motivation for features / changes
We just released tensorboard 2.13.0 yesterday in #6270 and would like to also release some small changes made to rustboard. Because these changes are all bug fixes, we are going to release a patch release rather than a minor release.

## Detailed steps to verify changes work correctly (as executed by you)
```sh
> cargo build
> RUST_LOG=debug TB_GCS_BUFFER_SIZE_KB=1024 cargo run -- --logdir=gs://PATH/TO/MANY/FILE --reload-once
```

## Alternate designs / implementations considered (or N/A)
We could do a full release of tensorboard-data-server and then a corresponding patch release to tensorboard
