### PR TITLE
Require new ColumnHeader attributes

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_types.ts
@@ -100,8 +100,8 @@ export enum ColumnHeaderType {
 
 export interface ColumnHeader {
   type: ColumnHeaderType;
-  name?: string; // TODO(jameshollyer): make required after internal changes are made
-  displayName?: string; // TODO(jameshollyer): make required after internal changes are made
+  name: string;
+  displayName: string;
   enabled: boolean;
 }
 


### PR DESCRIPTION
## Motivation for features / changes
These attributes were added in #6346. There were then made optional in #6369 to fix sync issues. The internal issues have now been resolved and this changes them back to required fields.