### PR TITLE
Add new memoize utility and use it to memoize selector factories

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -2416,7 +2416,6 @@ describe('scalar card', () => {
           end: null,
         });
         store.refreshState();
-        tick();
         fixture.detectChanges();
 
         testController.stopDrag();
@@ -2439,7 +2438,6 @@ describe('scalar card', () => {
           end: null,
         });
         store.refreshState();
-        tick();
         fixture.detectChanges();
 
         testController.stopDrag();
@@ -3895,7 +3893,6 @@ describe('scalar card', () => {
           end: null,
         });
         store.refreshState();
-        tick();
         fixture.detectChanges();
 
         // One start fob
@@ -3918,7 +3915,6 @@ describe('scalar card', () => {
         });
         store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
         store.refreshState();
-        tick();
         fixture.detectChanges();
 
         // One start fob, one end fob
@@ -3994,7 +3990,6 @@ describe('scalar card', () => {
           end: null,
         });
         store.refreshState();
-        tick();
         fixture.detectChanges();
 
         testController.stopDrag();
@@ -4055,7 +4050,6 @@ describe('scalar card', () => {
           end: null,
         });
         store.refreshState();
-        tick();
         fixture.detectChanges();
 
         testController.stopDrag();

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -92,6 +92,7 @@ tf_ts_library(
         "//tensorboard/webapp/runs:types",
         "//tensorboard/webapp/runs/views/runs_table:types",
         "//tensorboard/webapp/util:matcher",
+        "//tensorboard/webapp/util:memoize",
         "//tensorboard/webapp/util:types",
         "@npm//@ngrx/store",
     ],

--- a/tensorboard/webapp/metrics/views/main_view/common_selectors.ts
+++ b/tensorboard/webapp/metrics/views/main_view/common_selectors.ts
@@ -47,6 +47,7 @@ import {getNonEmptyCardIdsWithMetadata, TagMetadata} from '../../store';
 import {compareTagNames} from '../../utils';
 import {CardIdWithMetadata} from '../metrics_view_types';
 import {RouteKind} from '../../../app_routing/types';
+import {memoize} from '../../../util/memoize';
 
 export const getScalarTagsForRunSelection = createSelector(
   getMetricsTagMetadata,
@@ -178,7 +179,7 @@ const utils = {
   },
 };
 
-function getRenderableRuns(experimentIds: string[]) {
+const getRenderableRuns = memoize((experimentIds: string[]) => {
   return createSelector(
     getRunsFromExperimentIds(experimentIds),
     getExperimentNames(experimentIds),
@@ -213,9 +214,9 @@ function getRenderableRuns(experimentIds: string[]) {
       });
     }
   );
-}
+});
 
-function getFilteredRenderableRuns(experimentIds: string[]) {
+const getFilteredRenderableRuns = memoize((experimentIds: string[]) => {
   return createSelector(
     getRunSelectorRegexFilter,
     getRenderableRuns(experimentIds),
@@ -236,7 +237,7 @@ function getFilteredRenderableRuns(experimentIds: string[]) {
       );
     }
   );
-}
+});
 
 export const getFilteredRenderableRunsFromRoute = createSelector(
   (state) => state,

--- a/tensorboard/webapp/util/BUILD
+++ b/tensorboard/webapp/util/BUILD
@@ -66,6 +66,13 @@ tf_ts_library(
 )
 
 tf_ts_library(
+    name = "memoize",
+    srcs = [
+        "memoize.ts",
+    ],
+)
+
+tf_ts_library(
     name = "ui_selectors",
     srcs = [
         "ui_selectors.ts",
@@ -92,6 +99,7 @@ tf_ts_library(
     srcs = [
         "lang_test.ts",
         "matcher_test.ts",
+        "memoize_test.ts",
         "ngrx_test.ts",
         "string_test.ts",
         "ui_selectors_test.ts",
@@ -101,6 +109,7 @@ tf_ts_library(
         ":colors",
         ":lang",
         ":matcher",
+        ":memoize",
         ":ngrx",
         ":string",
         ":ui_selectors",

--- a/tensorboard/webapp/util/memoize.ts
+++ b/tensorboard/webapp/util/memoize.ts
@@ -1,0 +1,29 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+export function memoize<T extends Array<any>, R>(
+  fn: (...args: T) => R
+): (...args: T) => R {
+  const cache = new Map<string, R>();
+  return (...args: T): R => {
+    const key = JSON.stringify(args);
+    if (cache.has(key)) {
+      return cache.get(key)!;
+    } else {
+      const result = fn(...args);
+      cache.set(key, result);
+      return result;
+    }
+  };
+}

--- a/tensorboard/webapp/util/memoize_test.ts
+++ b/tensorboard/webapp/util/memoize_test.ts
@@ -1,0 +1,47 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {memoize} from './memoize';
+
+describe('memoize', () => {
+  let add: (a: number, b: number, c: number) => number;
+  let sum: (numbers: number[]) => number;
+  let createNumArray: (
+    a: number,
+    b: number,
+    c: number
+  ) => [number, number, number];
+
+  beforeEach(() => {
+    add = memoize((a: number, b: number, c: number) => a + b + c);
+    sum = memoize((numbers: number[]) =>
+      numbers.reduce((sum, num) => sum + num, 0)
+    );
+    createNumArray = memoize((a: number, b: number, c: number) => [a, b, c]);
+  });
+
+  it('generates a new result when arguments change', () => {
+    expect(add(1, 2, 3)).toEqual(6);
+    expect(add(4, 5, 6)).toEqual(15);
+
+    expect(sum([1, 2, 3])).toEqual(6);
+    expect(sum([4, 5, 6])).toEqual(15);
+
+    expect(createNumArray(1, 2, 3)).not.toBe(createNumArray(3, 2, 1));
+  });
+
+  it('reuses existing result when arguments are the same', () => {
+    expect(createNumArray(1, 2, 3)).toBe(createNumArray(1, 2, 3));
+  });
+});


### PR DESCRIPTION
## Motivation for features / changes
Using non memoized selector factories can lead to awkwardness in tests and slightly lower performance in general.

## Screenshots of UI changes (or N/A)
None

## Alternate designs / implementations considered (or N/A)
We could have used a library instead (for example lodash) but the typing wasn't as good.