### PR TITLE
Refactor backend_context_test to use DataProvider mock.

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -111,10 +111,7 @@ py_test(
         "//tensorboard:context",
         "//tensorboard:expect_protobuf_installed",
         "//tensorboard:expect_tensorflow_installed",
-        "//tensorboard/backend/event_processing:data_provider",
-        "//tensorboard/backend/event_processing:event_multiplexer",
-        "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/plugins/scalar:metadata",
+        "//tensorboard/data:provider",
     ],
 )
 


### PR DESCRIPTION
The backend_context_test.py has, for historical reasons, mocked its data dependencies at the "multiplexer" level. When backend_context.py was migrated to use DataProvider interface in 2020 (See #3425), its tests weren't fully converted to mock data dependencies at the "DataProvider" level.

We will soon be adding more logic to hparams/backend_context.py and it would be convenient to mock data dependencies at the "DataProvider" level instead of the "multiplexer" level. This PR updates existing backend_context_test tests so that they mock at the "DataProvider" level.

The refactor can be done fairly cleanly - only one of the tests need to be updated directly. Otherwise it is just the helper functions that need to change.
