### PR TITLE
Remove unused timeSelectionCleared() action.

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -220,10 +220,6 @@ export const cardViewBoxChanged = createAction(
   props<{cardId: CardId; userViewBox: Extent | null}>()
 );
 
-export const timeSelectionCleared = createAction(
-  '[Metrics] Linked Time Selection Cleared'
-);
-
 export const linkedTimeToggled = createAction(
   '[Metrics] Linked Time Enable Toggle',
   props<{

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1341,12 +1341,6 @@ const reducer = createReducer(
       cardStateMap: nextCardStateMap,
     };
   }),
-  on(actions.timeSelectionCleared, (state) => {
-    return {
-      ...state,
-      linkedTimeSelection: null,
-    };
-  }),
   on(actions.tableEditorTabChanged, (state, {tab}) => {
     return {
       ...state,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3967,18 +3967,6 @@ describe('metrics reducers', () => {
       });
     });
 
-    describe('#timeSelectionCleared', () => {
-      it('clears linked time selection', () => {
-        const beforeState = buildMetricsState({
-          linkedTimeSelection: {start: {step: 4}, end: {step: 4}},
-        });
-
-        const nextState = reducers(beforeState, actions.timeSelectionCleared());
-
-        expect(nextState.linkedTimeSelection).toBeNull();
-      });
-    });
-
     describe('#rangeSelectionToggled', () => {
       it('toggles whether stepSelectorRange is enabled or not', () => {
         const state1 = buildMetricsState({


### PR DESCRIPTION
The timeSelectionCleared() action is unused except by the reducers.