### PR TITLE
Cleanup: rename globalSettings to persistentSettings

### DIFF
--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
 import {createNamespaceContextedState} from '../../app_routing/namespaced_state_reducer_helper';
-import {globalSettingsLoaded} from '../../persistent_settings';
+import {persistentSettingsLoaded} from '../../persistent_settings';
 import {DataLoadState} from '../../types/data';
 import {composeReducers} from '../../util/ngrx';
 import * as actions from '../actions';
@@ -154,7 +154,7 @@ const reducer = createReducer(
       sideBarWidthInPercent: Math.min(Math.max(0, widthInPercent), 100),
     };
   }),
-  on(globalSettingsLoaded, (state, {partialSettings}) => {
+  on(persistentSettingsLoaded, (state, {partialSettings}) => {
     const nextState = {...state};
 
     const sideBarWidthInPercent = partialSettings.sideBarWidthInPercent;

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
-import {globalSettingsLoaded, ThemeValue} from '../../persistent_settings';
+import {persistentSettingsLoaded, ThemeValue} from '../../persistent_settings';
 import * as actions from '../actions/feature_flag_actions';
 import {FeatureFlags} from '../types';
 import {initialState} from './feature_flag_store_config_provider';
@@ -72,7 +72,7 @@ const reducer = createReducer<FeatureFlagState>(
       flagOverrides: {},
     };
   }),
-  on(globalSettingsLoaded, (state, {partialSettings}) => {
+  on(persistentSettingsLoaded, (state, {partialSettings}) => {
     if (!partialSettings.themeOverride) {
       return state;
     }

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -18,7 +18,7 @@ import {stateRehydratedFromUrl} from '../../app_routing/actions';
 import {createNamespaceContextedState} from '../../app_routing/namespaced_state_reducer_helper';
 import {RouteKind} from '../../app_routing/types';
 import * as coreActions from '../../core/actions';
-import {globalSettingsLoaded} from '../../persistent_settings';
+import {persistentSettingsLoaded} from '../../persistent_settings';
 import {DataLoadState} from '../../types/data';
 import {ElementId} from '../../util/dom';
 import {mapObjectValues} from '../../util/lang';
@@ -526,7 +526,7 @@ const reducer = createReducer(
     }
     return newState;
   }),
-  on(globalSettingsLoaded, (state, {partialSettings}) => {
+  on(persistentSettingsLoaded, (state, {partialSettings}) => {
     const metricsSettings: Partial<MetricsSettings> = {};
     if (
       partialSettings.tooltipSort &&

--- a/tensorboard/webapp/notification_center/_redux/notification_center_reducers.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_reducers.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
-import {globalSettingsLoaded} from '../../persistent_settings';
+import {persistentSettingsLoaded} from '../../persistent_settings';
 import * as actions from './notification_center_actions';
 import {Notification, NotificationState} from './notification_center_types';
 
@@ -43,7 +43,7 @@ const reducer = createReducer(
     }
   ),
   on(
-    globalSettingsLoaded,
+    persistentSettingsLoaded,
     (state: NotificationState, {partialSettings}): NotificationState => {
       if (
         typeof partialSettings.notificationLastReadTimeInMs === 'undefined' ||

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
@@ -27,9 +27,4 @@ export const persistentSettingsLoaded = createAction(
 );
 
 // TODO(b/279035032): Removes this function once internal import are renamed.
-export const globalSettingsLoaded = createAction(
-  '[Persistent Settings] Global Settings Loaded',
-  props<{
-    partialSettings: Partial<PersistableSettings>;
-  }>()
-);
+export const globalSettingsLoaded = persistentSettingsLoaded;

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
@@ -19,6 +19,14 @@ import {PersistableSettings} from '../_data_source/types';
  * Describes settings loaded from a global settings storage. Dispatched once
  * when the application bootstraps.
  */
+export const persistentSettingsLoaded = createAction(
+  '[Persistent Settings] Global Settings Loaded',
+  props<{
+    partialSettings: Partial<PersistableSettings>;
+  }>()
+);
+
+// TODO(b/279035032): Removes this function once internal import are renamed.
 export const globalSettingsLoaded = createAction(
   '[Persistent Settings] Global Settings Loaded',
   props<{

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects.ts
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
-import {Actions, createEffect, ofType, OnInitEffects} from '@ngrx/effects';
-import {Action, createAction, Store} from '@ngrx/store';
-import {EMPTY, merge, Observable} from 'rxjs';
+import {Actions, createEffect, ofType} from '@ngrx/effects';
+import {Store} from '@ngrx/store';
+import {EMPTY, Observable, merge} from 'rxjs';
 import {
   buffer,
   debounceTime,
@@ -29,12 +29,12 @@ import {
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
-import {PersistentSettingsConfigModule} from '../persistent_settings_config_module';
+import * as appRoutingActions from '../../app_routing/actions';
 import {PersistentSettingsDataSource} from '../_data_source/persistent_settings_data_source';
 import {PersistableSettings} from '../_data_source/types';
-import {globalSettingsLoaded} from './persistent_settings_actions';
+import {PersistentSettingsConfigModule} from '../persistent_settings_config_module';
+import {persistentSettingsLoaded} from './persistent_settings_actions';
 import {getShouldPersistSettings} from './persistent_settings_selectors';
-import * as appRoutingActions from '../../app_routing/actions';
 
 const DEBOUNCE_PERIOD_IN_MS = 500;
 
@@ -55,7 +55,7 @@ export class PersistentSettingsEffects {
         filter(([, shouldPersistSettings]) => shouldPersistSettings),
         mergeMap(() => this.dataSource.getSettings()),
         tap((partialSettings) => {
-          this.store.dispatch(globalSettingsLoaded({partialSettings}));
+          this.store.dispatch(persistentSettingsLoaded({partialSettings}));
         }),
         // Give time for reducers to react to the action in a microtask.
         delay(0),

--- a/tensorboard/webapp/persistent_settings/index.ts
+++ b/tensorboard/webapp/persistent_settings/index.ts
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+export {PersistableSettings, ThemeValue} from './_data_source/types';
+// TODO(b/279035032): Removes globalSettingsLoaded export after internal import are renamed.
+export {
+  persistentSettingsLoaded,
+  globalSettingsLoaded,
+} from './_redux/persistent_settings_actions';
 export {PersistentSettingsConfigModule} from './persistent_settings_config_module';
 export {PersistentSettingsModule} from './persistent_settings_module';
-export {PersistableSettings, ThemeValue} from './_data_source/types';
-export {globalSettingsLoaded} from './_redux/persistent_settings_actions';

--- a/tensorboard/webapp/settings/_redux/settings_reducers.ts
+++ b/tensorboard/webapp/settings/_redux/settings_reducers.ts
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
-import {globalSettingsLoaded} from '../../persistent_settings';
+import {persistentSettingsLoaded} from '../../persistent_settings';
 import {DataLoadState} from '../../types/data';
 import * as actions from './settings_actions';
-import {initialState, Settings, SettingsState} from './settings_types';
+import {Settings, SettingsState, initialState} from './settings_types';
 
 /**
  * Check if settings are ready to modify. We want to reject modifications to
@@ -82,7 +82,7 @@ const reducer = createReducer(
       },
     };
   }),
-  on(globalSettingsLoaded, (state, {partialSettings}) => {
+  on(persistentSettingsLoaded, (state, {partialSettings}) => {
     const nextSettings: Partial<Settings> = {};
 
     if (


### PR DESCRIPTION
## Motivation for features / changes
The current action name "globalSettingsLoaded" is actually about persistent settings, rename to make it clear.

## Technical description of changes
Still preserves an extra export of "globalSettings" to not break sync and fix everything all at once.