### PR TITLE
Bug Fix: update hparams plugin to generate domains for boolean hparams

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -311,6 +311,10 @@ class Context:
         ):
             result.domain_discrete.extend(distinct_values)
 
+        # If the result is a boolean, domain should be True and False
+        if result.type == api_pb2.DATA_TYPE_BOOL:
+            result.domain_discrete.extend([True, False])
+
         return result
 
     def _experiment_from_data_provider_hparams(

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -311,7 +311,6 @@ class Context:
         ):
             result.domain_discrete.extend(distinct_values)
 
-        # If the result is a boolean, domain should be True and False
         if result.type == api_pb2.DATA_TYPE_BOOL:
             result.domain_discrete.extend([True, False])
 

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -366,7 +366,7 @@ class BackendContextTest(tf.test.TestCase):
         """
         self.session_2_start_info_ = """
             hparams:[
-              {key: 'batch_size' value: {bool_value: false}}
+              {key: 'batch_size' value: {bool_value: true}}
             ]
         """
         self.session_3_start_info_ = """
@@ -394,16 +394,7 @@ class BackendContextTest(tf.test.TestCase):
               name: {group: 'train', tag: 'loss'}
             }
         """
-        ctxt = backend_context.Context(
-            self._mock_tb_context, max_domain_discrete_len=1
-        )
-        request_ctx = context.RequestContext()
-        actual_exp = ctxt.experiment_from_metadata(
-            request_ctx,
-            "123",
-            ctxt.hparams_metadata(request_ctx, "123"),
-            ctxt.hparams_from_data_provider(request_ctx, "123"),
-        )
+        actual_exp = self._experiment_from_metadata()
         _canonicalize_experiment(actual_exp)
         self.assertProtoEquals(expected_exp, actual_exp)
 


### PR DESCRIPTION
## Motivation for features / changes
This has been a bug for a while that we only noticed now that hparams are being used to filter runs in the time series dashboard.

Googlers see https://chat.google.com/room/AAAA03izhrk/VyyPgojcNvY for context on how this was discovered

## Technical description of changes
Boolean HParams were not having a domain set. This lead to the ui treating them as intervals, however, this lead to incorrect filter conditions. We currently treat all non number values being filtered this way as not matching (the alternative would be to treat them all as being true which also seems wrong). This leads to all runs with a value for a boolean hparam being filtered out.

## Screenshots of UI changes (or N/A)

Googlers see cl/532932348

## Alternate designs / implementations considered (or N/A)
This could have been done on the client but ideally the bug would be fixed in other places where the api is being used.