### PR TITLE
Cleanup: remove globalSettingsLoaded action

### DIFF
--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {globalSettingsLoaded} from '../../persistent_settings';
+import {persistentSettingsLoaded} from '../../persistent_settings';
 import {DataLoadState} from '../../types/data';
 import * as actions from '../actions';
 import {
@@ -591,14 +591,14 @@ describe('core reducer', () => {
     });
   });
 
-  describe('#globalSettingsLoaded', () => {
+  describe('#persistentSettingsLoaded', () => {
     it('loads sideBarWidthInPercent from settings when present', () => {
       const state = createCoreState({
         sideBarWidthInPercent: 0,
       });
       const nextState = reducers(
         state,
-        globalSettingsLoaded({partialSettings: {sideBarWidthInPercent: 40}})
+        persistentSettingsLoaded({partialSettings: {sideBarWidthInPercent: 40}})
       );
 
       expect(nextState.sideBarWidthInPercent).toBe(40);
@@ -610,7 +610,7 @@ describe('core reducer', () => {
       });
       const nextState = reducers(
         state,
-        globalSettingsLoaded({partialSettings: {}})
+        persistentSettingsLoaded({partialSettings: {}})
       );
 
       expect(nextState.sideBarWidthInPercent).toBe(0);
@@ -622,19 +622,23 @@ describe('core reducer', () => {
       });
       const state2 = reducers(
         state1,
-        globalSettingsLoaded({partialSettings: {sideBarWidthInPercent: 101}})
+        persistentSettingsLoaded({
+          partialSettings: {sideBarWidthInPercent: 101},
+        })
       );
       expect(state2.sideBarWidthInPercent).toBe(0);
 
       const state3 = reducers(
         state2,
-        globalSettingsLoaded({partialSettings: {sideBarWidthInPercent: -1}})
+        persistentSettingsLoaded({partialSettings: {sideBarWidthInPercent: -1}})
       );
       expect(state3.sideBarWidthInPercent).toBe(0);
 
       const state4 = reducers(
         state3,
-        globalSettingsLoaded({partialSettings: {sideBarWidthInPercent: NaN}})
+        persistentSettingsLoaded({
+          partialSettings: {sideBarWidthInPercent: NaN},
+        })
       );
       expect(state4.sideBarWidthInPercent).toBe(0);
     });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {globalSettingsLoaded, ThemeValue} from '../../persistent_settings';
+import {persistentSettingsLoaded, ThemeValue} from '../../persistent_settings';
 import * as actions from '../actions/feature_flag_actions';
 import {buildFeatureFlag} from '../testing';
 import {reducers} from './feature_flag_reducers';
@@ -221,7 +221,7 @@ describe('feature_flag_reducers', () => {
     });
   });
 
-  describe('#globalSettingsLoaded', () => {
+  describe('#persistentSettingsLoaded', () => {
     it('sets dark mode overrides when global settings include it', () => {
       const prevState = buildFeatureFlagState({
         isFeatureFlagsLoaded: true,
@@ -232,7 +232,7 @@ describe('feature_flag_reducers', () => {
 
       const state1 = reducers(
         prevState,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {},
         })
       );
@@ -240,7 +240,7 @@ describe('feature_flag_reducers', () => {
 
       const state2 = reducers(
         prevState,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {themeOverride: ThemeValue.LIGHT},
         })
       );
@@ -248,7 +248,7 @@ describe('feature_flag_reducers', () => {
 
       const state3 = reducers(
         prevState,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {themeOverride: ThemeValue.DARK},
         })
       );
@@ -256,7 +256,7 @@ describe('feature_flag_reducers', () => {
 
       const state4 = reducers(
         prevState,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {themeOverride: ThemeValue.BROWSER_DEFAULT},
         })
       );

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -16,7 +16,7 @@ import * as routingActions from '../../app_routing/actions';
 import {buildNavigatedAction, buildRoute} from '../../app_routing/testing';
 import {RouteKind} from '../../app_routing/types';
 import * as coreActions from '../../core/actions';
-import {globalSettingsLoaded} from '../../persistent_settings';
+import {persistentSettingsLoaded} from '../../persistent_settings';
 import {buildDeserializedState} from '../../routes/testing';
 import {DataLoadState} from '../../types/data';
 import {nextElementId} from '../../util/dom';
@@ -3309,7 +3309,7 @@ describe('metrics reducers', () => {
     });
   });
 
-  describe('#globalSettingsLoaded', () => {
+  describe('#persistentSettingsLoaded', () => {
     it('adds partial state from loading the settings to the (alphabetical) settings', () => {
       const beforeState = buildMetricsState({
         settings: buildMetricsSettingsState({
@@ -3325,7 +3325,7 @@ describe('metrics reducers', () => {
 
       const nextState = reducers(
         beforeState,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {
             ignoreOutliers: true,
             tooltipSort: TooltipSort.DESCENDING,
@@ -3354,7 +3354,7 @@ describe('metrics reducers', () => {
 
         const nextState = reducers(
           beforeState,
-          globalSettingsLoaded({
+          persistentSettingsLoaded({
             partialSettings: {
               tooltipSort: 'yo' as TooltipSort,
             },
@@ -3372,7 +3372,7 @@ describe('metrics reducers', () => {
 
       const nextState = reducers(
         beforeState,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {
             timeSeriesSettingsPaneOpened: false,
           },
@@ -3408,7 +3408,7 @@ describe('metrics reducers', () => {
 
       const nextState = reducers(
         beforeState,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {
             singleSelectionHeaders: [
               {
@@ -3488,7 +3488,7 @@ describe('metrics reducers', () => {
 
       const nextState = reducers(
         beforeState,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {
             rangeSelectionHeaders: [
               {
@@ -3558,7 +3558,7 @@ describe('metrics reducers', () => {
 
     const nextState = reducers(
       beforeState,
-      globalSettingsLoaded({
+      persistentSettingsLoaded({
         partialSettings: {
           stepSelectorEnabled: true,
         },
@@ -3579,7 +3579,7 @@ describe('metrics reducers', () => {
 
     const nextState = reducers(
       beforeState,
-      globalSettingsLoaded({
+      persistentSettingsLoaded({
         partialSettings: {
           rangeSelectionEnabled: true,
         },
@@ -3600,7 +3600,7 @@ describe('metrics reducers', () => {
 
     const nextState = reducers(
       beforeState,
-      globalSettingsLoaded({
+      persistentSettingsLoaded({
         partialSettings: {
           linkedTimeEnabled: true,
         },

--- a/tensorboard/webapp/notification_center/_redux/notification_center_reducers_test.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_reducers_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {globalSettingsLoaded} from '../../persistent_settings';
+import {persistentSettingsLoaded} from '../../persistent_settings';
 import * as notificationActions from './notification_center_actions';
 import * as notificationReducers from './notification_center_reducers';
 import {buildNotification, buildNotificationState} from './testing';
@@ -53,7 +53,7 @@ describe('notification reducers', () => {
     });
   });
 
-  describe('#globalSettingsLoaded', () => {
+  describe('#persistentSettingsLoaded', () => {
     it('sets lastReadTimestampInMs if its related state is present', () => {
       const state1 = buildNotificationState({
         lastReadTimestampInMs: 0,
@@ -61,7 +61,7 @@ describe('notification reducers', () => {
 
       const state2 = notificationReducers.reducers(
         state1,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {
             notificationLastReadTimeInMs: 500,
           },
@@ -77,7 +77,7 @@ describe('notification reducers', () => {
 
       const state2 = notificationReducers.reducers(
         state1,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {
             notificationLastReadTimeInMs: NaN,
           },
@@ -87,7 +87,7 @@ describe('notification reducers', () => {
 
       const state3 = notificationReducers.reducers(
         state2,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {},
         })
       );

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_actions.ts
@@ -25,6 +25,3 @@ export const persistentSettingsLoaded = createAction(
     partialSettings: Partial<PersistableSettings>;
   }>()
 );
-
-// TODO(b/279035032): Removes this function once internal import are renamed.
-export const globalSettingsLoaded = persistentSettingsLoaded;

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
@@ -28,7 +28,7 @@ import {
   PersistentSettingsTestingDataSource,
   PersistentSettingsTestingDataSourceModule,
 } from '../_data_source/testing';
-import {globalSettingsLoaded} from './persistent_settings_actions';
+import {persistentSettingsLoaded} from './persistent_settings_actions';
 import {
   PersistentSettingsEffects,
   TEST_ONLY,
@@ -107,7 +107,7 @@ describe('persistent_settings effects test', () => {
         action.next(appRoutingActions.navigating({after: buildRoute()}));
 
         expect(actualActions).toEqual([
-          globalSettingsLoaded({
+          persistentSettingsLoaded({
             partialSettings: {
               ignoreOutliers: false,
             },
@@ -138,7 +138,7 @@ describe('persistent_settings effects test', () => {
 
         action.next(appRoutingActions.navigating({after: buildRoute()}));
         expect(actualActions).toEqual([
-          globalSettingsLoaded({
+          persistentSettingsLoaded({
             partialSettings: {
               ignoreOutliers: false,
             },

--- a/tensorboard/webapp/persistent_settings/index.ts
+++ b/tensorboard/webapp/persistent_settings/index.ts
@@ -14,10 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 export {PersistableSettings, ThemeValue} from './_data_source/types';
-// TODO(b/279035032): Removes globalSettingsLoaded export after internal import are renamed.
-export {
-  persistentSettingsLoaded,
-  globalSettingsLoaded,
-} from './_redux/persistent_settings_actions';
+export {persistentSettingsLoaded} from './_redux/persistent_settings_actions';
 export {PersistentSettingsConfigModule} from './persistent_settings_config_module';
 export {PersistentSettingsModule} from './persistent_settings_module';

--- a/tensorboard/webapp/settings/_redux/settings_reducers_test.ts
+++ b/tensorboard/webapp/settings/_redux/settings_reducers_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {globalSettingsLoaded} from '../../persistent_settings';
+import {persistentSettingsLoaded} from '../../persistent_settings';
 import {DataLoadState} from '../../types/data';
 import {createSettings, createSettingsState} from '../testing';
 import * as actions from './settings_actions';
@@ -158,7 +158,7 @@ describe('settings reducer', () => {
     });
   });
 
-  describe('#globalSettingsLoaded', () => {
+  describe('#persistentSettingsLoaded', () => {
     it('loads settings from the persistent settings storage', () => {
       const state = createSettingsState({
         state: DataLoadState.LOADING,
@@ -171,7 +171,7 @@ describe('settings reducer', () => {
 
       const nextState = reducers(
         state,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {
             autoReloadPeriodInMs: 50000,
             pageSize: 10,
@@ -195,7 +195,7 @@ describe('settings reducer', () => {
 
       const nextState = reducers(
         state,
-        globalSettingsLoaded({
+        persistentSettingsLoaded({
           partialSettings: {
             autoReloadPeriodInMs: 10,
             pageSize: NaN,


### PR DESCRIPTION
Remove globalSettingsLoaded action export once all internal actions have been renamed.

Googlers, see cl/532908969