### PR TITLE
Data Table: refactor data table to use divs instead of html table

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -13,7 +13,7 @@ limitations under the License.
 -->
 
 <div class="data-table">
-  <header>
+  <div class="header">
     <div class="col"></div>
     <ng-container *ngFor="let header of headers;">
       <div
@@ -46,7 +46,7 @@ limitations under the License.
         </div>
       </div>
     </ng-container>
-  </header>
+  </div>
   <ng-container *ngFor="let runData of data;">
     <div class="row">
       <div class="col row-circle">

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -12,74 +12,67 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div>
-  <table class="data-table">
-    <thead>
-      <tr>
-        <th>
-          <!-- This header is intentionally left blank for the color column -->
-        </th>
-        <ng-container *ngFor="let header of headers;">
-          <th *ngIf="showColumn(header)" (click)="headerClicked(header.name)">
-            <div
-              [draggable]="columnCustomizationEnabled"
-              (dragstart)="dragStart(header)"
-              (dragend)="dragEnd()"
-              (dragenter)="dragEnter(header)"
-              class="cell"
-              [ngClass]="getHeaderHighlightStyle(header.name)"
-            >
-              <tb-data-table-header [header]="header"></tb-data-table-header>
+<div class="data-table">
+  <header>
+    <div class="col"></div>
+    <ng-container *ngFor="let header of headers;">
+      <div
+        class="col"
+        *ngIf="showColumn(header)"
+        (click)="headerClicked(header.name)"
+      >
+        <div
+          [draggable]="columnCustomizationEnabled"
+          (dragstart)="dragStart(header)"
+          (dragend)="dragEnd()"
+          (dragenter)="dragEnter(header)"
+          class="cell"
+          [ngClass]="getHeaderHighlightStyle(header.name)"
+        >
+          <tb-data-table-header [header]="header"></tb-data-table-header>
 
-              <div class="sorting-icon-container">
-                <mat-icon
-                  *ngIf="sortingInfo.order === SortingOrder.ASCENDING || header.name !== sortingInfo.name"
-                  [ngClass]="header.name === sortingInfo.name ? 'show' : 'show-on-hover'"
-                  svgIcon="arrow_upward_24px"
-                ></mat-icon>
-                <mat-icon
-                  *ngIf="sortingInfo.order === SortingOrder.DESCENDING && header.name === sortingInfo.name"
-                  [ngClass]="header.name === sortingInfo.name ? 'show' : 'show-on-hover'"
-                  svgIcon="arrow_downward_24px"
-                ></mat-icon>
-              </div>
-            </div>
-          </th>
-        </ng-container>
-      </tr>
-    </thead>
-    <tbody>
-      <ng-container *ngFor="let runData of data;">
-        <tr class="row">
-          <td class="row-circle">
-            <span [style.backgroundColor]="runData['color']"></span>
-          </td>
-          <ng-container *ngFor="let header of headers;">
-            <td *ngIf="showColumn(header)" [ngSwitch]="header.type">
-              <div *ngSwitchCase="ColumnHeaders.VALUE_CHANGE" class="cell">
-                <ng-container
-                  *ngTemplateOutlet="arrow; context: {$implicit:runData[header.name]}"
-                ></ng-container>
-                {{ getFormattedDataForColumn(header.type, runData[header.name])
-                }}
-              </div>
-              <div *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE" class="cell">
-                <ng-container
-                  *ngTemplateOutlet="arrow; context: {$implicit:runData[header.name]}"
-                ></ng-container>
-                {{ getFormattedDataForColumn(header.type, runData[header.name])
-                }}
-              </div>
-              <div *ngSwitchDefault class="cell extra-right-padding">
-                {{ getFormattedDataForColumn(header.type, runData[header.name])
-                }}
-              </div>
-            </td>
-          </ng-container>
-        </tr>
+          <div class="sorting-icon-container">
+            <mat-icon
+              *ngIf="sortingInfo.order === SortingOrder.ASCENDING || header.name !== sortingInfo.name"
+              [ngClass]="header.name === sortingInfo.name ? 'show' : 'show-on-hover'"
+              svgIcon="arrow_upward_24px"
+            ></mat-icon>
+            <mat-icon
+              *ngIf="sortingInfo.order === SortingOrder.DESCENDING && header.name === sortingInfo.name"
+              [ngClass]="header.name === sortingInfo.name ? 'show' : 'show-on-hover'"
+              svgIcon="arrow_downward_24px"
+            ></mat-icon>
+          </div>
+        </div>
+      </div>
+    </ng-container>
+  </header>
+  <ng-container *ngFor="let runData of data;">
+    <div class="row">
+      <div class="col row-circle">
+        <span [style.backgroundColor]="runData['color']"></span>
+      </div>
+      <ng-container *ngFor="let header of headers;">
+        <div class="col" *ngIf="showColumn(header)" [ngSwitch]="header.type">
+          <div *ngSwitchCase="ColumnHeaders.VALUE_CHANGE" class="cell">
+            <ng-container
+              *ngTemplateOutlet="arrow; context: {$implicit:runData[header.name]}"
+            ></ng-container>
+            {{ getFormattedDataForColumn(header.type, runData[header.name]) }}
+          </div>
+          <div *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE" class="cell">
+            <ng-container
+              *ngTemplateOutlet="arrow; context: {$implicit:runData[header.name]}"
+            ></ng-container>
+            {{ getFormattedDataForColumn(header.type, runData[header.name]) }}
+          </div>
+          <div *ngSwitchDefault class="cell extra-right-padding">
+            {{ getFormattedDataForColumn(header.type, runData[header.name]) }}
+          </div>
+        </div>
       </ng-container>
-    </tbody>
-  </table>
+    </div>
+  </ng-container>
 </div>
 <ng-template #arrow let-value>
   <mat-icon *ngIf="value >= 0" svgIcon="arrow_upward_24px"></mat-icon>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -23,7 +23,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
   display: table;
   width: 100%;
 
-  header,
+  .header,
   .row {
     display: table-row;
   }
@@ -32,7 +32,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
     display: table-cell;
   }
 
-  header {
+  .header {
     background-color: mat.get-color-from-palette($tb-background, background);
     position: sticky;
     text-align: left;

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -20,13 +20,24 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 .data-table {
   border-spacing: 4px;
   font-size: 13px;
+  display: table;
   width: 100%;
 
-  th {
+  header,
+  .row {
+    display: table-row;
+  }
+
+  .col {
+    display: table-cell;
+  }
+
+  header {
     background-color: mat.get-color-from-palette($tb-background, background);
     position: sticky;
     text-align: left;
     top: 0;
+    font-weight: bold;
     vertical-align: bottom;
 
     &:hover {
@@ -36,11 +47,17 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
     @include tb-dark-theme {
       background-color: map-get($tb-dark-background, background);
     }
+    .col:hover .show-on-hover {
+      opacity: 0.3;
+    }
+
+    .col {
+      vertical-align: bottom;
+    }
   }
 
-  .cell {
-    align-items: center;
-    display: flex;
+  .col {
+    padding: 1px;
   }
 
   .extra-right-padding {
@@ -48,18 +65,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
     padding-right: 1px;
   }
 
-  .row {
-    white-space: nowrap;
-  }
-
   $_circle-size: 12px;
-
-  .row-circle {
-    align-items: center;
-    display: inline-flex;
-    height: $_circle-size;
-    width: $_circle-size;
-  }
 
   .row-circle > span {
     border-radius: 50%;
@@ -68,6 +74,12 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
     // Subtract by border width (1px on both sides)
     height: $_circle-size - 2px;
     width: $_circle-size - 2px;
+    vertical-align: middle;
+  }
+
+  .cell {
+    align-items: center;
+    display: flex;
   }
 
   .cell mat-icon {
@@ -87,10 +99,6 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 
   .show-on-hover {
     opacity: 0;
-  }
-
-  th:hover .show-on-hover {
-    opacity: 0.3;
   }
 
   .highlight {

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -135,7 +135,9 @@ describe('data table', () => {
       ],
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
 
     // The first header should always be blank as it is the run color column.
     expect(headerElements[0].nativeElement.innerText).toBe('');
@@ -258,7 +260,7 @@ describe('data table', () => {
       ],
     });
     fixture.detectChanges();
-    const dataElements = fixture.debugElement.queryAll(By.css('td'));
+    const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
 
     // The first header should always be blank as it is the run color column.
     expect(dataElements[0].nativeElement.innerText).toBe('');
@@ -321,8 +323,10 @@ describe('data table', () => {
       ],
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
-    const dataElements = fixture.debugElement.queryAll(By.css('td'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
+    const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
 
     // The first header should always be blank as it is the run color column.
     expect(headerElements[0].nativeElement.innerText).toBe('');
@@ -366,7 +370,7 @@ describe('data table', () => {
       data: [{id: 'someid'}],
     });
     fixture.detectChanges();
-    const dataElements = fixture.debugElement.queryAll(By.css('td'));
+    const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
 
     // The first header should always be blank as it is the run color column.
     expect(dataElements[0].nativeElement.innerText).toBe('');
@@ -406,7 +410,9 @@ describe('data table', () => {
       ],
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
 
     headerElements[3].triggerEventHandler('click', {});
     expect(sortDataBySpy).toHaveBeenCalledOnceWith({
@@ -451,7 +457,9 @@ describe('data table', () => {
       },
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
 
     headerElements[3].triggerEventHandler('click', {});
     expect(sortDataBySpy).toHaveBeenCalledOnceWith({
@@ -490,7 +498,9 @@ describe('data table', () => {
       },
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
 
     expect(
       headerElements[1]
@@ -553,7 +563,9 @@ describe('data table', () => {
       },
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
 
     expect(
       headerElements[1]
@@ -616,7 +628,9 @@ describe('data table', () => {
       },
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
 
     headerElements[2].query(By.css('.cell')).triggerEventHandler('dragstart');
     headerElements[1].query(By.css('.cell')).triggerEventHandler('dragenter');
@@ -684,7 +698,9 @@ describe('data table', () => {
       },
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
 
     headerElements[2].query(By.css('.cell')).triggerEventHandler('dragstart');
     headerElements[3].query(By.css('.cell')).triggerEventHandler('dragenter');
@@ -763,8 +779,10 @@ describe('data table', () => {
       smoothingEnabled: false,
     });
     fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(By.css('th'));
-    const dataElements = fixture.debugElement.queryAll(By.css('td'));
+    const headerElements = fixture.debugElement.queryAll(
+      By.css('header > .col')
+    );
+    const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
 
     // The first header should always be blank as it is the run color column.
     expect(headerElements[0].nativeElement.innerText).toBe('');

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -136,7 +136,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
 
     // The first header should always be blank as it is the run color column.
@@ -324,7 +324,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
     const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
 
@@ -411,7 +411,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
 
     headerElements[3].triggerEventHandler('click', {});
@@ -458,7 +458,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
 
     headerElements[3].triggerEventHandler('click', {});
@@ -499,7 +499,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
 
     expect(
@@ -564,7 +564,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
 
     expect(
@@ -629,7 +629,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
 
     headerElements[2].query(By.css('.cell')).triggerEventHandler('dragstart');
@@ -699,7 +699,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
 
     headerElements[2].query(By.css('.cell')).triggerEventHandler('dragstart');
@@ -780,7 +780,7 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('header > .col')
+      By.css('.header > .col')
     );
     const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
 


### PR DESCRIPTION
## Motivation for features / changes
This probably should have been done when the data table was created. html table is generally considered old technology. Building tables with divs is preferred as it allows for more flexibility. 

## Technical description of changes
Pretty straight forward swap to using display table, table-row, table-column instead of table, tr, td. For the header we use a \<header\> to wrap it and still use the .col. Because of this header specific logic for .col was moved inside the header object.

I also had to mess around with the row-circle class to get the color circle to align properly because the display is now table-cell instead of flex.

## Screenshots of UI changes (or N/A)
New table looks like this.
<img width="731" alt="Screenshot 2023-05-18 at 4 41 01 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/4e7eadc2-18c7-4320-919e-9d30573d72a5">

The only change is that the circle icon moves ever so slightly(to see the difference more clearly googlers can check the screenshot diffs here cl/529831620).

## Detailed steps to verify changes work correctly (as executed by you)
A couple CSS queries changes and all the tests pass. I also clicked around and tested functionality in local instance.

## Alternate designs / implementations considered (or N/A)
Considered leaving it as is.
