### PR TITLE
Continue moving to use name in SortingInfo

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -123,7 +123,6 @@ export class ScalarCardComponent<Downloader> {
   @ViewChild(LineChartComponent)
   lineChart?: LineChartComponent;
   sortingInfo: SortingInfo = {
-    header: ColumnHeaderType.RUN, //This is no longer used but the type needs it or it will break sync. TODO(jameshollyer): remove this once internal code all uses name.
     name: 'run',
     order: SortingOrder.ASCENDING,
   };

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -118,14 +118,12 @@ export class DataTableComponent implements OnDestroy {
       this.sortingInfo.order === SortingOrder.ASCENDING
     ) {
       this.sortDataBy.emit({
-        header: ColumnHeaderType.RUN, //This is no longer used but the sortingInfo interface needs it or it will break sync. TODO(jameshollyer): remove this once internal code all uses name.
         name,
         order: SortingOrder.DESCENDING,
       });
       return;
     }
     this.sortDataBy.emit({
-      header: ColumnHeaderType.RUN, //This is no longer used but the sortingInfo interface needs it or it will break sync. TODO(jameshollyer): remove this once internal code all uses name.
       name,
       order: SortingOrder.ASCENDING,
     });

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -75,7 +75,6 @@ describe('data table', () => {
     fixture.componentInstance.headers = input.headers || [];
     fixture.componentInstance.data = input.data || [];
     fixture.componentInstance.sortingInfo = input.sortingInfo || {
-      header: ColumnHeaderType.RUN,
       name: 'run',
       order: SortingOrder.ASCENDING,
     };
@@ -416,7 +415,6 @@ describe('data table', () => {
 
     headerElements[3].triggerEventHandler('click', {});
     expect(sortDataBySpy).toHaveBeenCalledOnceWith({
-      header: jasmine.any(String), // This attribute is no longer used but temporarily left here to no break internal syncs
       name: 'step',
       order: SortingOrder.ASCENDING,
     });
@@ -451,7 +449,6 @@ describe('data table', () => {
         },
       ],
       sortingInfo: {
-        header: ColumnHeaderType.STEP,
         name: 'step',
         order: SortingOrder.ASCENDING,
       },
@@ -463,7 +460,6 @@ describe('data table', () => {
 
     headerElements[3].triggerEventHandler('click', {});
     expect(sortDataBySpy).toHaveBeenCalledOnceWith({
-      header: jasmine.any(String), // This attribute is no longer used but temporarily left here to no break internal syncs
       name: 'step',
       order: SortingOrder.DESCENDING,
     });
@@ -492,7 +488,6 @@ describe('data table', () => {
         },
       ],
       sortingInfo: {
-        header: ColumnHeaderType.VALUE,
         name: 'value',
         order: SortingOrder.ASCENDING,
       },
@@ -557,7 +552,6 @@ describe('data table', () => {
         },
       ],
       sortingInfo: {
-        header: ColumnHeaderType.STEP,
         name: 'step',
         order: SortingOrder.DESCENDING,
       },
@@ -622,7 +616,6 @@ describe('data table', () => {
         },
       ],
       sortingInfo: {
-        header: ColumnHeaderType.STEP,
         name: 'step',
         order: SortingOrder.DESCENDING,
       },
@@ -692,7 +685,6 @@ describe('data table', () => {
         },
       ],
       sortingInfo: {
-        header: ColumnHeaderType.STEP,
         name: 'step',
         order: SortingOrder.DESCENDING,
       },

--- a/tensorboard/webapp/widgets/data_table/types.ts
+++ b/tensorboard/webapp/widgets/data_table/types.ts
@@ -56,9 +56,9 @@ export interface SortingInfo {
   // Currently in the process of moving from header to name.
   // Header is no longer used but is required as to not break sync
   // TODO(jameshollyer): Remove header once all internal code is switched
-  // to using name and make name required.
-  header: ColumnHeaderType;
-  name?: string;
+  // to using name.
+  header?: ColumnHeaderType;
+  name: string;
   order: SortingOrder;
 }
 


### PR DESCRIPTION
## Motivation for features / changes
For the HParam work that is being done we are now using the name field as the unique identifier for columns. Therefore the SortingInfo interface needs to use name and not header. However, making the hard swap to using name would break sync so it is happening in stages. The name switch to using names happened in #6362. However, we had to make name optional for sync reasons. Googlers see cl/534097086 to see where name was added. Now this PR makes header optional. I will then make an internal change to remove it. Then I can finally submit a final PR which removes the property entirely. 