### PR TITLE
Chore: Update h2 version

### DIFF
--- a/tensorboard/data/server/Cargo.lock
+++ b/tensorboard/data/server/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes 1.0.1",
  "fnv",

--- a/tensorboard/data/server/data_compat.rs
+++ b/tensorboard/data/server/data_compat.rs
@@ -368,7 +368,7 @@ impl SummaryValue {
                 };
                 Box::new(md)
             }
-            (None, _) => Box::new(pb::SummaryMetadata::default()),
+            (None, _) => Box::<pb::SummaryMetadata>::default(),
         }
     }
 }

--- a/tensorboard/data/server/server.rs
+++ b/tensorboard/data/server/server.rs
@@ -452,7 +452,7 @@ impl TensorBoardDataProvider for DataProviderHandler {
                 let mut steps = Vec::with_capacity(n);
                 let mut wall_times = Vec::with_capacity(n);
                 let mut values = Vec::with_capacity(n);
-                for (step, wall_time, &BlobSequenceValue(ref value)) in points {
+                for (step, wall_time, BlobSequenceValue(value)) in points {
                     steps.push(step.into());
                     wall_times.push(wall_time.into());
                     let eid = req.experiment_id.as_str();


### PR DESCRIPTION
## Motivation for features / changes
Dependabot decided we needed this update here #6392. However, that did not pass our linter. So I am made the update myself and fixed the lint issues

## Technical description of changes
I did this by running 
`cargo update --package h2`
Then
`cargo build --release`

I then checked the lint issues by running
`cargo clippy`

I could not get cargo clippy --fix to work so I manually made the changes that clippy recommended.

## Detailed steps to verify changes work correctly (as executed by you)
cargo clippy now passes and then I ran oss tensorboard and it all worked.

## Alternate designs / implementations considered (or N/A)
I first tried just running cargo update instead of specifying which package. That turned out to be a really big change as it update a lot of packages. There were lots of errors after that update so I just decided to fix h2 as dependabot said.
