### PR TITLE
Add ➕ icon

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -319,6 +319,7 @@ tf_svg_bundle(
     # //tensorboard/webapp/testing/mat_icon_module.ts.
     # 'com_google_material_design_icon' in third_party/js.bzl
     srcs = [
+        "@com_google_material_design_icon//:add_24px.svg",
         "@com_google_material_design_icon//:arrow_downward_24px.svg",
         "@com_google_material_design_icon//:arrow_upward_24px.svg",
         "@com_google_material_design_icon//:brightness_6_24px.svg",

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -202,6 +202,10 @@ def tensorboard_js_workspace():
                 "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_change_history_24px.svg",
                 "https://raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_change_history_24px.svg",
             ],
+            "475c29758b4a689598f80099714362c0340ad3a4bc111e2d88807bbf4b0f817e": [
+                "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/b3f05bfbf4329a5b63f50a720f867c2bac163f98/src/content/add/materialicons/24px.svg",
+                "https://raw.githubusercontent.com/google/material-design-icons/b3f05bfbf4329a5b63f50a720f867c2bac163f98/src/content/add/materialicons/24px.svg",
+            ],
         },
         rename = {
             "ic_arrow_downward_24px.svg": "arrow_downward_24px.svg",
@@ -266,5 +270,7 @@ def tensorboard_js_workspace():
             "https://raw.githubusercontent.com/google/material-design-icons/d3d4aca5a7cf50bc68bbd401cefa708e364194e8/src/image/brightness_6/materialicons/24px.svg": "brightness_6_24px.svg",
             "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/d3d4aca5a7cf50bc68bbd401cefa708e364194e8/src/action/drag_indicator/materialicons/24px.svg": "drag_indicator_24px.svg",
             "https://raw.githubusercontent.com/google/material-design-icons/d3d4aca5a7cf50bc68bbd401cefa708e364194e8/src/action/drag_indicator/materialicons/24px.svg": "drag_indicator_24px.svg",
+            "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/b3f05bfbf4329a5b63f50a720f867c2bac163f98/src/content/add/materialicons/24px.svg": "add_24px.svg",
+            "https://raw.githubusercontent.com/google/material-design-icons/b3f05bfbf4329a5b63f50a720f867c2bac163f98/src/content/add/materialicons/24px.svg": "add_24px.svg",
         },
     )


### PR DESCRIPTION
## Motivation for features / changes
The hparams in time series project needs a plus icon for the add column button.

## Technical description of changes
### How do you add icons?

1) Find the icon you want to add here https://github.com/google/material-design-icons
2) Get the raw icon you want to add by clicking the "Raw" button
3) Download the file and get the checksum `wget -O output.svg $FILE && sha256sum output.svg`
4) Finally a googler must follow the instructions here to update the tensorflow mirror [go/tensorboard-tf-mirror](go/tensorboard-tf-mirror)

## Screenshots of UI changes (or N/A)
Look! There's an icon?
![image](https://github.com/tensorflow/tensorboard/assets/78179109/e270fb83-4180-406e-bf9a-f38511357bba)
