### PR TITLE
HParams: Add custom modal widget

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -293,6 +293,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/widgets:resize_detector_testing",
         "//tensorboard/webapp/widgets/card_fob:card_fob_test",
         "//tensorboard/webapp/widgets/content_wrapping_input:content_wrapping_input_tests",
+        "//tensorboard/webapp/widgets/custom_modal:custom_modal_test",
         "//tensorboard/webapp/widgets/data_table:data_table_test",
         "//tensorboard/webapp/widgets/dropdown:dropdown_tests",
         "//tensorboard/webapp/widgets/experiment_alias:experiment_alias_test",

--- a/tensorboard/webapp/widgets/custom_modal/BUILD
+++ b/tensorboard/webapp/widgets/custom_modal/BUILD
@@ -1,0 +1,31 @@
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_ng_module(
+    name = "custom_modal",
+    srcs = [
+        "custom_modal_component.ts",
+        "custom_modal_module.ts",
+    ],
+    deps = [
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "custom_modal_test",
+    testonly = True,
+    srcs = [
+        "custom_modal_test.ts",
+    ],
+    deps = [
+        ":custom_modal",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal_component.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal_component.ts
@@ -61,7 +61,7 @@ export class CustomModalComponent implements OnInit {
   @ViewChild('content', {static: false})
   private readonly content!: ElementRef;
 
-  private clickListener: any = this.close.bind(this);
+  private clickListener: () => void = this.close.bind(this);
 
   ngOnInit() {
     this.visible$.subscribe((visible) => {

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal_component.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal_component.ts
@@ -1,0 +1,91 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  Component,
+  EventEmitter,
+  Output,
+  ViewChild,
+  ElementRef,
+  HostListener,
+  ContentChild,
+  OnInit,
+} from '@angular/core';
+import {BehaviorSubject, tap} from 'rxjs';
+
+export interface ModalContent {
+  onRender?: () => void;
+}
+
+@Component({
+  selector: 'custom-modal',
+  template: `
+    <div class="content" #content (click)="$event.stopPropagation()">
+      <ng-container *ngIf="visible$ | async">
+        <ng-content></ng-content>
+      </ng-container>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        position: fixed;
+        top: -64px; /* The height of the top bar */
+        left: 0;
+        z-index: 9001;
+      }
+
+      .content {
+        position: absolute;
+      }
+    `,
+  ],
+})
+export class CustomModalComponent implements OnInit {
+  @Output() onOpen = new EventEmitter<void>();
+  @Output() onClose = new EventEmitter<void>();
+
+  readonly visible$ = new BehaviorSubject(false);
+
+  @ViewChild('content', {static: false})
+  private readonly content!: ElementRef;
+
+  private clickListener: any = this.close.bind(this);
+
+  ngOnInit() {
+    this.visible$.subscribe((visible) => {
+      // Wait until after the next browser frame.
+      window.requestAnimationFrame(() => {
+        if (visible) {
+          this.onOpen.emit();
+        } else {
+          this.onClose.emit();
+        }
+      });
+    });
+  }
+
+  public openAtPosition(position: {x: number; y: number}) {
+    this.content.nativeElement.style.left = position.x + 'px';
+    this.content.nativeElement.style.top = position.y + 'px';
+    this.visible$.next(true);
+    document.addEventListener('click', this.clickListener);
+  }
+
+  @HostListener('document:keydown.escape', ['$event'])
+  public close() {
+    document.removeEventListener('click', this.clickListener);
+    this.visible$.next(false);
+  }
+}

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal_module.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal_module.ts
@@ -1,0 +1,25 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {CustomModalComponent} from './custom_modal_component';
+
+@NgModule({
+  declarations: [CustomModalComponent],
+  imports: [CommonModule],
+  exports: [CustomModalComponent],
+})
+export class CustomModalModule {}

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal_test.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal_test.ts
@@ -1,0 +1,138 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {CustomModalComponent} from './custom_modal_component';
+import {CommonModule} from '@angular/common';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Output,
+  ViewChild,
+} from '@angular/core';
+
+function waitFrame() {
+  return new Promise((resolve) => window.requestAnimationFrame(resolve));
+}
+
+@Component({
+  selector: 'testable-modal',
+  template: `<custom-modal #modal (onOpen)="setOpen()" (onClose)="setClosed()">
+    <div>My great content</div>
+  </custom-modal> `,
+})
+class TestableComponent {
+  @ViewChild('modal', {static: false})
+  modalComponent!: CustomModalComponent;
+
+  @ViewChild('content', {static: false})
+  content!: ElementRef;
+
+  isOpen = false;
+
+  @Output() onOpen = new EventEmitter();
+  @Output() onClose = new EventEmitter();
+
+  setOpen() {
+    this.isOpen = true;
+    this.onOpen.emit();
+  }
+
+  setClosed() {
+    this.isOpen = false;
+    this.onClose.emit();
+  }
+
+  close() {
+    this.modalComponent.close();
+  }
+
+  getContentStyle() {
+    return (this.modalComponent as any).content.nativeElement.style;
+  }
+
+  public openAtPosition(position: {x: number; y: number}) {
+    this.modalComponent.openAtPosition(position);
+  }
+}
+
+describe('custom modal', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestableComponent, CustomModalComponent],
+      imports: [CommonModule],
+    }).compileComponents();
+  });
+
+  it('waits a frame before emitting onOpen or onClose', async () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.detectChanges();
+    fixture.componentInstance.openAtPosition({x: 0, y: 0});
+    expect(fixture.componentInstance.isOpen).toBeFalse();
+    await waitFrame();
+    expect(fixture.componentInstance.isOpen).toBeTrue();
+    fixture.componentInstance.close();
+    fixture.detectChanges();
+    await waitFrame();
+    expect(fixture.componentInstance.isOpen).toBeFalse();
+  });
+
+  describe('openAtPosition', () => {
+    it('applies top and left offsets', () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.detectChanges();
+      fixture.componentInstance.openAtPosition({x: 20, y: 10});
+      expect(fixture.componentInstance.getContentStyle().top).toEqual('10px');
+      expect(fixture.componentInstance.getContentStyle().left).toEqual('20px');
+    });
+
+    it('emits onOpen', async () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      const spy = spyOn(fixture.componentInstance.onOpen, 'emit');
+      fixture.detectChanges();
+      fixture.componentInstance.openAtPosition({x: 20, y: 10});
+      expect(spy).not.toHaveBeenCalled();
+      await waitFrame();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('closing behavior', () => {
+    let fixture: ComponentFixture<TestableComponent>;
+    beforeEach(async () => {
+      fixture = TestBed.createComponent(TestableComponent);
+      fixture.detectChanges();
+      fixture.componentInstance.openAtPosition({x: 0, y: 0});
+      await waitFrame();
+    });
+
+    it('closes when escape key is pressed', async () => {
+      expect(fixture.componentInstance.isOpen).toBeTrue();
+      const event = new KeyboardEvent('keydown', {key: 'escape'});
+      document.dispatchEvent(event);
+      await waitFrame();
+
+      expect(fixture.componentInstance.isOpen).toBeFalse();
+    });
+
+    it('closes when user clicks outside modal', async () => {
+      expect(fixture.componentInstance.isOpen).toBeTrue();
+      document.body.click();
+      await waitFrame();
+
+      expect(fixture.componentInstance.isOpen).toBeFalse();
+    });
+  });
+});


### PR DESCRIPTION
## Motivation for features / changes
This is intended to be used with #6412 and the custom context menu we intend to build in the future.

## Screenshots of UI changes (or N/A)
See #6412 for screenshots of a component being projected inside this.

## Alternate designs / implementations considered (or N/A)
### Why build it this way rather than use `MatDialog`?
 * `MatDialog` does not have all the built in logic to handle closing when clicking outside if the background is not enabled.
 * `MatDialog` seems to have issues with form components? (I consistently get errors related to property changes when I open it)
 * Content projection provides a nice declarative way of showcasing the what should appear in the modal.

### What are the downsides of doing it this way?
 * This is additional code we have to maintain
 * Clicking someplace else where event propagation is disabled will not result in the modal being closed.