### PR TITLE
Update BUILD to include deprecated_angular_disable_strict_deps for 1P…

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
@@ -23,6 +23,7 @@ tf_ng_module(
         ":scalar_column_editor_styles",
         "scalar_column_editor_component.ng.html",
     ],
+    deprecated_angular_disable_strict_deps = True,
     deps = [
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",


### PR DESCRIPTION
… compatibility

This target needs fix for its deps. For now I added deprecated_angular_disable_strict_deps attribute to get around. Ideally its deps should be fixed and then we can remove this attr.

## Motivation for features / changes

## Technical description of changes

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
