### PR TITLE
Chore: Add placeholder for internal import of deprecated styles.

### DIFF
--- a/tensorboard/webapp/theme/_variable.scss
+++ b/tensorboard/webapp/theme/_variable.scss
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 @use '@angular/material' as mat;
+// INTERNAL-ONLY: Import of deprecated legacy Angular Material styles
 @import 'tensorboard/webapp/theme/tb_palette';
 
 $tb-primary: mat.define-palette($tf-orange, 700, 400, 800);

--- a/tensorboard/webapp/theme/_variable.scss
+++ b/tensorboard/webapp/theme/_variable.scss
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-@use '@angular/material' as mat;
 // INTERNAL-ONLY: Import of deprecated legacy Angular Material styles
+@use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_palette';
 
 $tb-primary: mat.define-palette($tf-orange, 700, 400, 800);


### PR DESCRIPTION
Googlers, see cl/537831311, which requires a placeholder be added to the code to _variable.scss in order for a new import transform to be applied.
