### PR TITLE
Fix graph rendering issue for tensors with zero dimension size

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -879,7 +879,10 @@ function extractOutputShapes(
         // into a number.
         return shape.dim.map((dim) => {
           // Size can be -1 if this particular dimension is unknown.
-          return dim.size;
+          // If we actually have a 0-dimension tensor `dim.size` returns null,
+          // so we default to 0 in this case to avoid upstream null-handling
+          // issues.
+          return dim.size || 0;
         });
       });
       // Since we already processed it, remove the entry from the attribute


### PR DESCRIPTION
A zero dimension tensor results in a proto with an empty `size` field, as seen below:

```
node {
  name: "input/b"
  op: "IO Node"
  attr {
    key: "attr"
    value {
      s: ""
    }
  }
  attr {
    key: "_output_shapes"
    value {
      list {
        shape {
          dim {
            size: 1
          }
          dim { <<<
          }
        }
      }
    }
  }
}
```

This results in `dim.size` returning null for these particular cases, breaking graph rendering. We update to default the null case to 0.

Fixes #6418
