### PR TITLE
HParams: project header cell components

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -48,7 +48,16 @@ import {isDatumVisible} from './utils';
       [smoothingEnabled]="smoothingEnabled"
       (sortDataBy)="sortDataBy.emit($event)"
       (orderColumns)="orderColumns($event)"
-    ></tb-data-table>
+    >
+      <ng-container header>
+        <ng-container *ngFor="let header of columnHeaders">
+          <tb-data-table-header-cell
+            *ngIf="header.enabled"
+            [header]="header"
+            [sortingInfo]="sortingInfo"
+          ></tb-data-table-header-cell> </ng-container
+      ></ng-container>
+    </tb-data-table>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -121,6 +121,7 @@ tf_ts_library(
     srcs = [
         "column_selector_test.ts",
         "data_table_test.ts",
+        "header_cell_component_test.ts",
     ],
     deps = [
         ":column_selector",

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -13,6 +13,16 @@ tf_sass_binary(
 )
 
 tf_sass_binary(
+    name = "header_cell_styles",
+    src = "header_cell_component.scss",
+    strict_deps = False,
+    deps = [
+        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/theme",
+    ],
+)
+
+tf_sass_binary(
     name = "data_table_header_styles",
     src = "data_table_header_component.scss",
     strict_deps = False,
@@ -36,11 +46,14 @@ tf_ng_module(
     name = "data_table",
     srcs = [
         "data_table_component.ts",
+        "header_cell_component.ts",
         "data_table_module.ts",
     ],
     assets = [
         "data_table_component.ng.html",
+        "header_cell_component.ng.html",
         ":data_table_styles",
+        ":header_cell_styles"
     ],
     deps = [
         ":data_table_header",
@@ -50,6 +63,7 @@ tf_ng_module(
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//rxjs",
     ],
 )
 

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -53,7 +53,7 @@ tf_ng_module(
         "data_table_component.ng.html",
         "header_cell_component.ng.html",
         ":data_table_styles",
-        ":header_cell_styles"
+        ":header_cell_styles",
     ],
     deps = [
         ":data_table_header",

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -46,8 +46,8 @@ tf_ng_module(
     name = "data_table",
     srcs = [
         "data_table_component.ts",
-        "header_cell_component.ts",
         "data_table_module.ts",
+        "header_cell_component.ts",
     ],
     assets = [
         "data_table_component.ng.html",

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -15,37 +15,7 @@ limitations under the License.
 <div class="data-table">
   <div class="header">
     <div class="col"></div>
-    <ng-container *ngFor="let header of headers;">
-      <div
-        class="col"
-        *ngIf="showColumn(header)"
-        (click)="headerClicked(header.name)"
-      >
-        <div
-          [draggable]="columnCustomizationEnabled"
-          (dragstart)="dragStart(header)"
-          (dragend)="dragEnd()"
-          (dragenter)="dragEnter(header)"
-          class="cell"
-          [ngClass]="getHeaderHighlightStyle(header.name)"
-        >
-          <tb-data-table-header [header]="header"></tb-data-table-header>
-
-          <div class="sorting-icon-container">
-            <mat-icon
-              *ngIf="sortingInfo.order === SortingOrder.ASCENDING || header.name !== sortingInfo.name"
-              [ngClass]="header.name === sortingInfo.name ? 'show' : 'show-on-hover'"
-              svgIcon="arrow_upward_24px"
-            ></mat-icon>
-            <mat-icon
-              *ngIf="sortingInfo.order === SortingOrder.DESCENDING && header.name === sortingInfo.name"
-              [ngClass]="header.name === sortingInfo.name ? 'show' : 'show-on-hover'"
-              svgIcon="arrow_downward_24px"
-            ></mat-icon>
-          </div>
-        </div>
-      </div>
-    </ng-container>
+    <ng-content select="[header]"></ng-content>
   </div>
   <ng-container *ngFor="let runData of data;">
     <div class="row">

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -47,13 +47,6 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
     @include tb-dark-theme {
       background-color: map-get($tb-dark-background, background);
     }
-    .col:hover .show-on-hover {
-      opacity: 0.3;
-    }
-
-    .col {
-      vertical-align: bottom;
-    }
   }
 
   .col {
@@ -89,31 +82,5 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
     ::ng-deep path {
       fill: unset;
     }
-  }
-
-  .sorting-icon-container {
-    width: 12px;
-    height: 12px;
-    border-radius: 5px;
-  }
-
-  .show {
-    opacity: 1;
-  }
-
-  .show-on-hover {
-    opacity: 0;
-  }
-
-  .highlight {
-    background-color: mat.get-color-from-palette(mat.$gray-palette, 200);
-  }
-
-  .highlight-border-right {
-    border-right: 2px solid mat.get-color-from-palette($_accent);
-  }
-
-  .highlight-border-left {
-    border-left: 2px solid mat.get-color-from-palette($_accent);
   }
 }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -80,6 +80,9 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
 
   ngOnDestroy() {
     document.removeEventListener('dragover', preventDefault);
+    this.headerCellSubscriptions.forEach((subscription) => {
+      subscription.unsubscribe();
+    });
   }
 
   ngAfterContentInit() {

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -14,12 +14,15 @@ limitations under the License.
 ==============================================================================*/
 
 import {
+  AfterContentInit,
   ChangeDetectionStrategy,
   Component,
+  ContentChildren,
   EventEmitter,
   Input,
   OnDestroy,
   Output,
+  QueryList,
 } from '@angular/core';
 import {
   ColumnHeader,
@@ -33,6 +36,8 @@ import {
   numberFormatter,
   relativeTimeFormatter,
 } from '../line_chart_v2/lib/formatter';
+import {HeaderCellComponent} from './header_cell_component';
+import {Subscription} from 'rxjs';
 
 enum Side {
   RIGHT,
@@ -49,7 +54,7 @@ const preventDefault = function (e: MouseEvent) {
   styleUrls: ['data_table_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DataTableComponent implements OnDestroy {
+export class DataTableComponent implements OnDestroy, AfterContentInit {
   // The order of this array of headers determines the order which they are
   // displayed in the table.
   @Input() headers!: ColumnHeader[];
@@ -57,6 +62,10 @@ export class DataTableComponent implements OnDestroy {
   @Input() sortingInfo!: SortingInfo;
   @Input() columnCustomizationEnabled!: boolean;
   @Input() smoothingEnabled!: boolean;
+
+  @ContentChildren(HeaderCellComponent)
+  headerCells!: QueryList<HeaderCellComponent>;
+  headerCellSubscriptions: Subscription[] = [];
 
   @Output() sortDataBy = new EventEmitter<SortingInfo>();
   @Output() orderColumns = new EventEmitter<ColumnHeader[]>();
@@ -71,6 +80,26 @@ export class DataTableComponent implements OnDestroy {
 
   ngOnDestroy() {
     document.removeEventListener('dragover', preventDefault);
+  }
+
+  ngAfterContentInit() {
+    this.syncHeaders();
+    this.headerCells.changes.subscribe(this.syncHeaders.bind(this));
+  }
+
+  syncHeaders() {
+    this.headerCellSubscriptions.forEach((subscription) => {
+      subscription.unsubscribe();
+    });
+    this.headerCellSubscriptions = [];
+    this.headerCells.forEach((headerCell) => {
+      this.headerCellSubscriptions.push(
+        headerCell.dragStart.subscribe(this.dragStart.bind(this)),
+        headerCell.dragEnter.subscribe(this.dragEnter.bind(this)),
+        headerCell.dragEnd.subscribe(this.dragEnd.bind(this)),
+        headerCell.headerClicked.subscribe(this.headerClicked.bind(this))
+      );
+    });
   }
 
   getFormattedDataForColumn(
@@ -154,6 +183,9 @@ export class DataTableComponent implements OnDestroy {
     this.draggingHeaderName = undefined;
     this.highlightedColumnName = undefined;
     document.removeEventListener('dragover', preventDefault);
+    this.headerCells.forEach((headerCell) => {
+      headerCell.highlightStyle$.next({});
+    });
   }
 
   dragEnter(header: ColumnHeader) {
@@ -169,6 +201,12 @@ export class DataTableComponent implements OnDestroy {
       this.highlightSide = Side.RIGHT;
     }
     this.highlightedColumnName = header.name;
+
+    this.headerCells.forEach((headerCell) => {
+      headerCell.highlightStyle$.next(
+        this.getHeaderHighlightStyle(headerCell.header.name)
+      );
+    });
   }
 
   // Move the item at sourceIndex to destinationIndex

--- a/tensorboard/webapp/widgets/data_table/data_table_module.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_module.ts
@@ -17,11 +17,12 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {MatIconModule} from '@angular/material/icon';
 import {DataTableComponent} from './data_table_component';
+import {HeaderCellComponent} from './header_cell_component';
 import {DataTableHeaderModule} from './data_table_header_module';
 
 @NgModule({
-  declarations: [DataTableComponent],
-  exports: [DataTableComponent],
+  declarations: [DataTableComponent, HeaderCellComponent],
+  exports: [DataTableComponent, HeaderCellComponent],
   imports: [CommonModule, MatIconModule, DataTableHeaderModule],
 })
 export class DataTableModule {}

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import {Component, Input, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatIconTestingModule} from '@angular/material/icon/testing';
+import {MatIconModule} from '@angular/material/icon';
 import {By} from '@angular/platform-browser';
 import {
   ColumnHeader,
@@ -80,7 +80,7 @@ describe('data table', () => {
         DataTableComponent,
         HeaderCellComponent,
       ],
-      imports: [MatIconTestingModule, DataTableModule],
+      imports: [MatIconModule, DataTableModule],
     }).compileComponents();
   });
 

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import {Component, Input, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatIconModule} from '@angular/material/icon';
+import {MatIconTestingModule} from '@angular/material/icon/testing';
 import {By} from '@angular/platform-browser';
 import {
   ColumnHeader,
@@ -26,6 +26,7 @@ import {
 } from './types';
 import {DataTableComponent} from './data_table_component';
 import {DataTableModule} from './data_table_module';
+import {HeaderCellComponent} from './header_cell_component';
 
 @Component({
   selector: 'testable-comp',
@@ -38,7 +39,22 @@ import {DataTableModule} from './data_table_module';
       [smoothingEnabled]="smoothingEnabled"
       (sortDataBy)="sortDataBy($event)"
       (orderColumns)="orderColumns($event)"
-    ></tb-data-table>
+    >
+      <ng-container header>
+        <ng-container *ngFor="let header of headers">
+          <!-- Smoothing and enabled logic is still handled by the table for
+          the content. Soon that logic will all be hanled by the parent. Once
+          moved this ngIf can be removed along with many tests around enabling
+          and disabling columns. -->
+          <tb-data-table-header-cell
+            *ngIf="
+              header.enabled && (header.type !== 'SMOOTHED' || smoothingEnabled)
+            "
+            [header]="header"
+            [sortingInfo]="sortingInfo"
+          ></tb-data-table-header-cell> </ng-container
+      ></ng-container>
+    </tb-data-table>
   `,
 })
 class TestableComponent {
@@ -59,8 +75,12 @@ describe('data table', () => {
   let orderColumnsSpy: jasmine.Spy;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TestableComponent, DataTableComponent],
-      imports: [MatIconModule, DataTableModule],
+      declarations: [
+        TestableComponent,
+        DataTableComponent,
+        HeaderCellComponent,
+      ],
+      imports: [MatIconTestingModule, DataTableModule],
     }).compileComponents();
   });
 
@@ -135,26 +155,24 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
 
-    // The first header should always be blank as it is the run color column.
-    expect(headerElements[0].nativeElement.innerText).toBe('');
-    expect(headerElements[1].nativeElement.innerText).toBe('Value');
-    expect(headerElements[2].nativeElement.innerText).toBe('Run');
-    expect(headerElements[3].nativeElement.innerText).toBe('Value');
+    expect(headerElements[0].nativeElement.innerText).toBe('Value');
+    expect(headerElements[1].nativeElement.innerText).toBe('Run');
+    expect(headerElements[2].nativeElement.innerText).toBe('Value');
+    expect(
+      headerElements[2]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.getAttribute('svgIcon')
+    ).toBe('change_history_24px');
+    expect(headerElements[3].nativeElement.innerText).toBe('%');
     expect(
       headerElements[3]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.getAttribute('svgIcon')
     ).toBe('change_history_24px');
-    expect(headerElements[4].nativeElement.innerText).toBe('%');
-    expect(
-      headerElements[4]
-        .queryAll(By.css('mat-icon'))[0]
-        .nativeElement.getAttribute('svgIcon')
-    ).toBe('change_history_24px');
-    expect(headerElements[5].nativeElement.innerText).toBe('Smoothed');
+    expect(headerElements[4].nativeElement.innerText).toBe('Smoothed');
   });
 
   it('displays data in order', () => {
@@ -323,14 +341,14 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
     const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
 
-    // The first header should always be blank as it is the run color column.
-    expect(headerElements[0].nativeElement.innerText).toBe('');
-    expect(headerElements[1].nativeElement.innerText).toBe('Value');
-    expect(headerElements[2].nativeElement.innerText).toBe('Step');
+    // The color column is currently hard coded into the data table and is not a
+    // HeaderCellComponent.
+    expect(headerElements[0].nativeElement.innerText).toBe('Value');
+    expect(headerElements[1].nativeElement.innerText).toBe('Step');
 
     // The first column should always be blank as it is the run color column.
     expect(dataElements[0].nativeElement.innerText).toBe('');
@@ -379,7 +397,7 @@ describe('data table', () => {
     expect(dataElements[4].nativeElement.innerText).toBe('');
   });
 
-  it('emits sortDataBy event when header clicked', () => {
+  it('emits sortDataBy event when header emits headerClicked event', () => {
     const fixture = createComponent({
       headers: [
         {
@@ -410,17 +428,17 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
 
-    headerElements[3].triggerEventHandler('click', {});
+    headerElements[3].componentInstance.headerClicked.emit('step');
     expect(sortDataBySpy).toHaveBeenCalledOnceWith({
       name: 'step',
       order: SortingOrder.ASCENDING,
     });
   });
 
-  it('emits sortDataBy event with DESCENDING when header that is currently sorted is clicked', () => {
+  it('emits sortDataBy event with DESCENDING when header that is currently sorted emits headerClick event', () => {
     const fixture = createComponent({
       headers: [
         {
@@ -455,10 +473,10 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
 
-    headerElements[3].triggerEventHandler('click', {});
+    headerElements[3].componentInstance.headerClicked.emit('step');
     expect(sortDataBySpy).toHaveBeenCalledOnceWith({
       name: 'step',
       order: SortingOrder.DESCENDING,
@@ -494,36 +512,36 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
 
     expect(
-      headerElements[1]
+      headerElements[0]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.classList.contains('show')
     ).toBe(true);
     expect(
-      headerElements[1]
+      headerElements[0]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.getAttribute('svgIcon')
     ).toBe('arrow_upward_24px');
     expect(
-      headerElements[2]
+      headerElements[1]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.classList.contains('show')
     ).toBe(false);
     expect(
-      headerElements[2]
+      headerElements[1]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.classList.contains('show-on-hover')
     ).toBe(true);
     expect(
-      headerElements[3]
+      headerElements[2]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.classList.contains('show')
     ).toBe(false);
     expect(
-      headerElements[3]
+      headerElements[2]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.classList.contains('show-on-hover')
     ).toBe(true);
@@ -558,10 +576,20 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
 
     expect(
+      headerElements[0]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.classList.contains('show')
+    ).toBe(false);
+    expect(
+      headerElements[0]
+        .queryAll(By.css('mat-icon'))[0]
+        .nativeElement.classList.contains('show-on-hover')
+    ).toBe(true);
+    expect(
       headerElements[1]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.classList.contains('show')
@@ -575,19 +603,9 @@ describe('data table', () => {
       headerElements[2]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.classList.contains('show')
-    ).toBe(false);
+    ).toBe(true);
     expect(
       headerElements[2]
-        .queryAll(By.css('mat-icon'))[0]
-        .nativeElement.classList.contains('show-on-hover')
-    ).toBe(true);
-    expect(
-      headerElements[3]
-        .queryAll(By.css('mat-icon'))[0]
-        .nativeElement.classList.contains('show')
-    ).toBe(true);
-    expect(
-      headerElements[3]
         .queryAll(By.css('mat-icon'))[0]
         .nativeElement.getAttribute('svgIcon')
     ).toBe('arrow_downward_24px');
@@ -622,23 +640,23 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
 
-    headerElements[2].query(By.css('.cell')).triggerEventHandler('dragstart');
-    headerElements[1].query(By.css('.cell')).triggerEventHandler('dragenter');
+    headerElements[1].query(By.css('.cell')).triggerEventHandler('dragstart');
+    headerElements[0].query(By.css('.cell')).triggerEventHandler('dragenter');
     fixture.detectChanges();
     expect(
-      headerElements[1]
+      headerElements[0]
         .query(By.css('.cell'))
         .nativeElement.classList.contains('highlight')
     ).toBe(true);
     expect(
-      headerElements[1]
+      headerElements[0]
         .query(By.css('.cell'))
         .nativeElement.classList.contains('highlight-border-left')
     ).toBe(true);
-    headerElements[2].query(By.css('.cell')).triggerEventHandler('dragend');
+    headerElements[1].query(By.css('.cell')).triggerEventHandler('dragend');
 
     expect(orderColumnsSpy).toHaveBeenCalledOnceWith([
       {
@@ -691,23 +709,23 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
 
-    headerElements[2].query(By.css('.cell')).triggerEventHandler('dragstart');
-    headerElements[3].query(By.css('.cell')).triggerEventHandler('dragenter');
+    headerElements[1].query(By.css('.cell')).triggerEventHandler('dragstart');
+    headerElements[2].query(By.css('.cell')).triggerEventHandler('dragenter');
     fixture.detectChanges();
     expect(
-      headerElements[3]
+      headerElements[2]
         .query(By.css('.cell'))
         .nativeElement.classList.contains('highlight')
     ).toBe(true);
     expect(
-      headerElements[3]
+      headerElements[2]
         .query(By.css('.cell'))
         .nativeElement.classList.contains('highlight-border-right')
     ).toBe(true);
-    headerElements[2].query(By.css('.cell')).triggerEventHandler('dragend');
+    headerElements[1].query(By.css('.cell')).triggerEventHandler('dragend');
 
     expect(orderColumnsSpy).toHaveBeenCalledOnceWith([
       {
@@ -772,17 +790,18 @@ describe('data table', () => {
     });
     fixture.detectChanges();
     const headerElements = fixture.debugElement.queryAll(
-      By.css('.header > .col')
+      By.directive(HeaderCellComponent)
     );
     const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
 
-    // The first header should always be blank as it is the run color column.
-    expect(headerElements[0].nativeElement.innerText).toBe('');
-    expect(headerElements[1].nativeElement.innerText).toBe('Value');
-    expect(headerElements[2].nativeElement.innerText).toBe('Run');
-    expect(headerElements[3].nativeElement.innerText).toBe('Step');
-    expect(headerElements.length).toBe(4);
+    // The color column in the header is currently hard coded in and is not a
+    // HeaderCellComponent.
+    expect(headerElements[0].nativeElement.innerText).toBe('Value');
+    expect(headerElements[1].nativeElement.innerText).toBe('Run');
+    expect(headerElements[2].nativeElement.innerText).toBe('Step');
+    expect(headerElements.length).toBe(3);
 
+    // The first header should always be blank as it is the run color column.
     expect(dataElements[0].nativeElement.innerText).toBe('');
     expect(dataElements[1].nativeElement.innerText).toBe('3');
     expect(dataElements[2].nativeElement.innerText).toBe('run name');

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.ng.html
@@ -1,3 +1,17 @@
+<!--
+@license
+Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <div
   class="cell"
   [draggable]="sortable"

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.ng.html
@@ -1,0 +1,34 @@
+<div
+  class="cell"
+  [draggable]="sortable"
+  (dragstart)="dragStart.emit(header)"
+  (dragend)="dragEnd.emit()"
+  (dragenter)="dragEnter.emit(header)"
+  (click)="headerClicked.emit(header.name)"
+  [ngClass]="highlightStyle$ | async"
+>
+  <ng-content></ng-content>
+  <tb-data-table-header [header]="header"></tb-data-table-header>
+  <div *ngIf="sortable" class="sorting-icon-container">
+    <mat-icon
+      *ngIf="
+            sortingInfo.order === SortingOrder.ASCENDING ||
+            header.name !== sortingInfo.name
+          "
+      [ngClass]="
+            header.name === sortingInfo.name ? 'show' : 'show-on-hover'
+          "
+      svgIcon="arrow_upward_24px"
+    ></mat-icon>
+    <mat-icon
+      *ngIf="
+            sortingInfo.order === SortingOrder.DESCENDING &&
+            header.name === sortingInfo.name
+          "
+      [ngClass]="
+            header.name === sortingInfo.name ? 'show' : 'show-on-hover'
+          "
+      svgIcon="arrow_downward_24px"
+    ></mat-icon>
+  </div>
+</div>

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.scss
@@ -1,3 +1,18 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
 @use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
 

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.scss
@@ -1,0 +1,51 @@
+@use '@angular/material' as mat;
+@import 'tensorboard/webapp/theme/tb_theme';
+
+$_accent: map-get(mat.get-color-config($tb-theme), accent);
+
+:host {
+  display: table-cell;
+  padding: 1px;
+  vertical-align: bottom;
+}
+.sorting-icon-container {
+  width: 12px;
+  height: 12px;
+  border-radius: 5px;
+}
+.cell mat-icon {
+  height: 12px;
+  width: 12px;
+
+  ::ng-deep path {
+    fill: unset;
+  }
+}
+.cell {
+  align-items: center;
+  display: flex;
+}
+
+.show {
+  opacity: 1;
+}
+
+:host:hover .show-on-hover {
+  opacity: 0.3;
+}
+
+.show-on-hover {
+  opacity: 0;
+}
+
+.highlight {
+  background-color: mat.get-color-from-palette(mat.$gray-palette, 200);
+}
+
+.highlight-border-right {
+  border-right: 2px solid mat.get-color-from-palette($_accent);
+}
+
+.highlight-border-left {
+  border-left: 2px solid mat.get-color-from-palette($_accent);
+}

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.ts
@@ -1,0 +1,44 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import {ColumnHeader, SortingInfo, SortingOrder} from './types';
+import {BehaviorSubject} from 'rxjs';
+
+@Component({
+  selector: 'tb-data-table-header-cell',
+  templateUrl: 'header_cell_component.ng.html',
+  styleUrls: ['header_cell_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HeaderCellComponent {
+  @Input() header!: ColumnHeader;
+  @Input() sortingInfo!: SortingInfo;
+  @Input() sortable: boolean = true;
+
+  @Output() dragStart = new EventEmitter<ColumnHeader>();
+  @Output() dragEnd = new EventEmitter<void>();
+  @Output() dragEnter = new EventEmitter<ColumnHeader>();
+  @Output() headerClicked = new EventEmitter<string>();
+
+  highlightStyle$: BehaviorSubject<Object> = new BehaviorSubject<Object>({});
+
+  SortingOrder = SortingOrder;
+}

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
 import {
   ChangeDetectionStrategy,
   Component,

--- a/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
@@ -1,0 +1,99 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, Input, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatIconTestingModule} from '@angular/material/icon/testing';
+import {By} from '@angular/platform-browser';
+import {
+  ColumnHeader,
+  ColumnHeaderType,
+  TableData,
+  SortingInfo,
+  SortingOrder,
+} from './types';
+import {DataTableComponent} from './data_table_component';
+import {DataTableModule} from './data_table_module';
+import {HeaderCellComponent} from './header_cell_component';
+
+@Component({
+  selector: 'testable-comp',
+  template: `
+    <tb-data-table-header-cell
+      [header]="header"
+      [sortingInfo]="sortingInfo"
+      (headerClicked)="headerClicked($event)"
+    ></tb-data-table-header-cell>
+  `,
+})
+class TestableComponent {
+  @ViewChild('DataTable')
+  headerCell!: HeaderCellComponent;
+
+  @Input() header!: ColumnHeader;
+  @Input() sortingInfo!: SortingInfo;
+
+  @Input() headerClicked!: (sortingInfo: SortingInfo) => void;
+}
+
+describe('header cell', () => {
+  let headerClickedSpy: jasmine.Spy;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestableComponent, HeaderCellComponent],
+      imports: [MatIconTestingModule, DataTableModule],
+    }).compileComponents();
+  });
+
+  function createComponent(input: {
+    header?: ColumnHeader;
+    sortingInfo?: SortingInfo;
+  }): ComponentFixture<TestableComponent> {
+    const fixture = TestBed.createComponent(TestableComponent);
+
+    fixture.componentInstance.header = input.header || {
+      name: 'run',
+      displayName: 'Run',
+      type: ColumnHeaderType.RUN,
+      enabled: true,
+    };
+    fixture.componentInstance.sortingInfo = input.sortingInfo || {
+      name: 'run',
+      order: SortingOrder.ASCENDING,
+    };
+
+    headerClickedSpy = jasmine.createSpy();
+    fixture.componentInstance.headerClicked = headerClickedSpy;
+
+    return fixture;
+  }
+
+  it('renders', () => {
+    const fixture = createComponent({});
+    fixture.detectChanges();
+    const cell = fixture.debugElement.query(By.css('.cell'));
+    expect(cell).toBeTruthy();
+  });
+
+  it('emits headerClicked event when cell element is clicked', () => {
+    const fixture = createComponent({});
+    fixture.detectChanges();
+    fixture.debugElement
+      .query(By.directive(HeaderCellComponent))
+      .componentInstance.headerClicked.subscribe();
+    fixture.debugElement.query(By.css('.cell')).nativeElement.click();
+    expect(headerClickedSpy).toHaveBeenCalledOnceWith('run');
+  });
+});


### PR DESCRIPTION
## Motivation for features / changes
This refactoring allows more customization of the data table which will be used by both the runs table and scalar card. This allows the parents(like the runs table) to add functionality to the header component such as the color pallet and select all checkbox. 

## Technical description of changes
This change pulls out the header cells from the DataTable and allows the parent component to project them back down. We add a HeaderCellComponent which is used keep consistency and allow the DataTable to still keep the logic which should be on all tables such as dragging and sorting. This is done by using event emitters in the HeaderCellComponent which the DataTable subscribes to.

## Screenshots of UI changes (or N/A)
The Scalar table has no changes.
<img width="358" alt="Screenshot 2023-06-07 at 9 38 21 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/7afd8a70-bfec-4707-a15c-f6abc28ec533">

This does break the runs data table which is still behind a flag. This will be fixed in a follow up.
<img width="420" alt="Screenshot 2023-06-07 at 9 39 40 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/22f856aa-1921-442d-9342-f423f4db5b6e">

## Detailed steps to verify changes work correctly (as executed by you)
Ran it and clicked a round a lot to try and break it.

## Alternate designs / implementations considered (or N/A)
We considered a more config based solution where we add lots of options for functionality in the header objects being passed down to the table.
