### PR TITLE
Clean Up: Fix sync breakage due to import inconsistencies

### DIFF
--- a/tensorboard/webapp/widgets/custom_modal/BUILD
+++ b/tensorboard/webapp/widgets/custom_modal/BUILD
@@ -23,6 +23,7 @@ tf_ts_library(
     ],
     deps = [
         ":custom_modal",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal_component.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal_component.ts
@@ -19,10 +19,9 @@ import {
   ViewChild,
   ElementRef,
   HostListener,
-  ContentChild,
   OnInit,
 } from '@angular/core';
-import {BehaviorSubject, tap} from 'rxjs';
+import {BehaviorSubject} from 'rxjs';
 
 export interface ModalContent {
   onRender?: () => void;

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -84,7 +84,6 @@ tf_ng_module(
     deps = [
         ":types",
         "//tensorboard/webapp/angular:expect_angular_material_button",
-        "//tensorboard/webapp/angular:expect_angular_material_dialog",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_material_input",
         "@npm//@angular/common",

--- a/tensorboard/webapp/widgets/data_table/column_selector_module.ts
+++ b/tensorboard/webapp/widgets/data_table/column_selector_module.ts
@@ -20,7 +20,6 @@ import {MatInputModule} from '@angular/material/input';
 import {MatButtonModule} from '@angular/material/button';
 import {ColumnSelectorComponent} from './column_selector_component';
 import {FormsModule} from '@angular/forms';
-import {MatDialogModule} from '@angular/material/dialog';
 
 @NgModule({
   declarations: [ColumnSelectorComponent],
@@ -29,7 +28,6 @@ import {MatDialogModule} from '@angular/material/dialog';
     MatIconModule,
     MatInputModule,
     MatButtonModule,
-    MatDialogModule,
     FormsModule,
   ],
   exports: [ColumnSelectorComponent],


### PR DESCRIPTION
## Technical Description of Changes
It seems like the linter is no longer catching unused variables so that part was easy.
There was also an issue with the a missing build rule remapping

~Sync should pass after cl/538963303 is submitted. See example sync cl/538963353~
It really did pass cl/539096814