### PR TITLE
Clean Up: Use MatIconTestingModule in data table test

### DIFF
--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -127,7 +127,7 @@ tf_ts_library(
         ":data_table",
         ":types",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
-        "//tensorboard/webapp/angular:expect_angular_material_icon",
+        "//tensorboard/webapp/testing:mat_icon",
         "@npm//@angular/core",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import {Component, Input, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatIconModule} from '@angular/material/icon';
+import {MatIconTestingModule} from '../../testing/mat_icon_module';
 import {By} from '@angular/platform-browser';
 import {
   ColumnHeader,
@@ -80,7 +80,7 @@ describe('data table', () => {
         DataTableComponent,
         HeaderCellComponent,
       ],
-      imports: [MatIconModule, DataTableModule],
+      imports: [MatIconTestingModule, DataTableModule],
     }).compileComponents();
   });
 

--- a/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
@@ -15,16 +15,14 @@ limitations under the License.
 
 import {Component, Input, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatIconTestingModule} from '@angular/material/icon/testing';
+import {MatIconTestingModule} from '../../testing/mat_icon_module';
 import {By} from '@angular/platform-browser';
 import {
   ColumnHeader,
   ColumnHeaderType,
-  TableData,
   SortingInfo,
   SortingOrder,
 } from './types';
-import {DataTableComponent} from './data_table_component';
 import {DataTableModule} from './data_table_module';
 import {HeaderCellComponent} from './header_cell_component';
 


### PR DESCRIPTION
## Motivation for features / changes
The errors from using the regular MatIconModule in the test file does not effect the test. However, they do produce a lot of error logs. This eliminates those error logs which helps a lot when debugging.

## Technical description of changes
Just a simple swap for our internal MatIconTestingModule which is used elsewhere and should have been used here from teh start.