### PR TITLE
Change Hyperparameter to a dataclass.

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -15,7 +15,9 @@
 """Experimental framework for generic TensorBoard data providers."""
 
 
+from typing import Collection, Tuple
 import abc
+import dataclasses
 import enum
 
 import numpy as np
@@ -530,6 +532,7 @@ class HyperparameterDomainType(enum.Enum):
     DISCRETE_BOOL = "discrete_bool"
 
 
+@dataclasses.dataclass(frozen=True)
 class Hyperparameter:
     """Metadata about a hyperparameter.
 
@@ -552,40 +555,16 @@ class Hyperparameter:
           finite set of bool values.
     """
 
-    __slots__ = (
-        "_hyperparameter_name",
-        "_hyperparameter_display_name",
-        "_domain_type",
-        "_domain",
-    )
-
-    def __init__(
-        self,
-        hyperparameter_name,
-        hyperparameter_display_name,
-        domain_type,
-        domain,
-    ):
-        self._hyperparameter_name = hyperparameter_name
-        self._hyperparameter_display_name = hyperparameter_display_name
-        self._domain_type = domain_type
-        self._domain = domain
-
-    @property
-    def hyperparameter_name(self):
-        return self._hyperparameter_name
-
-    @property
-    def hyperparameter_display_name(self):
-        return self._hyperparameter_display_name
-
-    @property
-    def domain_type(self):
-        return self._domain_type
-
-    @property
-    def domain(self):
-        return self._domain
+    hyperparameter_name: str = ""
+    hyperparameter_display_name: str = ""
+    domain_type: HyperparameterDomainType | None = None
+    domain: (
+        Tuple[float, float]
+        | Collection[float]
+        | Collection[str]
+        | Collection[bool]
+        | None
+    ) = None
 
 
 class _TimeSeries:


### PR DESCRIPTION
Change Hyperparameter to a dataclass so we can get special methods like __repr__  and __eq__ and to simplify the code. We can do this now that we only target versions of python > 3.7.

This also requires typing the Hyperparameter class in order for the dataclass to be properly generated. I therefore considered also typing the list_hyperparameters() function but there is mixed value since the py_library() rule does not run a pytype checker.