### PR TITLE
HParams: project table content components

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -278,6 +278,16 @@ tf_sass_binary(
     ],
 )
 
+tf_sass_binary(
+    name = "scalar_card_data_table_styles",
+    src = "scalar_card_data_table.scss",
+    strict_deps = False,
+    deps = [
+        "//tensorboard/webapp/metrics/views:metrics_common_styles",
+        "//tensorboard/webapp/theme",
+    ],
+)
+
 tf_ng_module(
     name = "scalar_card",
     srcs = [
@@ -288,6 +298,7 @@ tf_ng_module(
         "scalar_card_module.ts",
     ],
     assets = [
+        ":scalar_card_data_table_styles",
         ":scalar_card_styles",
         ":scalar_card_fob_controller_styles",
         "scalar_card_component.ng.html",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -291,6 +291,7 @@ tf_ng_module(
         ":scalar_card_styles",
         ":scalar_card_fob_controller_styles",
         "scalar_card_component.ng.html",
+        "scalar_card_data_table.ng.html",
     ],
     deps = [
         ":data_download_dialog",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
@@ -1,0 +1,56 @@
+<!--
+@license
+Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<tb-data-table
+  [headers]="columnHeaders"
+  [sortingInfo]="sortingInfo"
+  [columnCustomizationEnabled]="columnCustomizationEnabled"
+  (sortDataBy)="sortDataBy.emit($event)"
+  (orderColumns)="orderColumns($event)"
+  (removeColumn)="removeColumn.emit($event)"
+>
+  <ng-container header>
+    <ng-container *ngFor="let header of columnHeaders">
+      <tb-data-table-header-cell
+        *ngIf="header.enabled"
+        [header]="header"
+        [sortingInfo]="sortingInfo"
+        [hparamsEnabled]="hparamsEnabled"
+      ></tb-data-table-header-cell> </ng-container
+  ></ng-container>
+
+  <ng-container content>
+    <ng-container *ngFor="let dataRow of getTimeSelectionTableData()">
+      <tb-data-table-content-row>
+        <ng-container *ngFor="let header of getHeaders()">
+          <tb-data-table-content-cell
+            *ngIf="header.enabled"
+            [header]="header"
+            [datum]="dataRow[header.name]"
+          >
+            <div
+              *ngIf="header.type === ColumnHeaderType.COLOR"
+              class="row-circle"
+            >
+              <span [style.backgroundColor]="dataRow['color']"></span>
+            </div>
+          </tb-data-table-content-cell>
+        </ng-container>
+      </tb-data-table-content-row>
+    </ng-container>
+  </ng-container>
+</tb-data-table>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
@@ -26,7 +26,7 @@ limitations under the License.
   <ng-container header>
     <ng-container *ngFor="let header of columnHeaders">
       <tb-data-table-header-cell
-        *ngIf="header.enabled"
+        *ngIf="header.enabled && (header.type !== ColumnHeaderType.SMOOTHED || smoothingEnabled)"
         [header]="header"
         [sortingInfo]="sortingInfo"
         [hparamsEnabled]="hparamsEnabled"
@@ -38,7 +38,7 @@ limitations under the License.
       <tb-data-table-content-row>
         <ng-container *ngFor="let header of getHeaders()">
           <tb-data-table-content-cell
-            *ngIf="header.enabled"
+            *ngIf="header.enabled && (header.type !== ColumnHeaderType.SMOOTHED || smoothingEnabled)"
             [header]="header"
             [datum]="dataRow[header.name]"
           >

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.scss
@@ -1,21 +1,28 @@
-<!--
-@license
-Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
+$_circle-size: 12px;
 
-<div class="data-table">
-  <div class="header">
-    <div class=".col"></div>
-    <ng-content select="[header]"></ng-content>
-  </div>
-  <ng-content select="[content]"></ng-content>
-</div>
+.row-circle {
+  height: $_circle-size;
+  width: $_circle-size;
+}
+.row-circle > span {
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  display: inline-block;
+  height: $_circle-size - 2px; // size minus border
+  width: $_circle-size - 2px; // size minus border
+  vertical-align: middle;
+}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -39,28 +39,23 @@ import {isDatumVisible} from './utils';
 
 @Component({
   selector: 'scalar-card-data-table',
-  template: `
-    <tb-data-table
-      [headers]="columnHeaders"
-      [data]="getTimeSelectionTableData()"
-      [sortingInfo]="sortingInfo"
-      [columnCustomizationEnabled]="columnCustomizationEnabled"
-      [smoothingEnabled]="smoothingEnabled"
-      (sortDataBy)="sortDataBy.emit($event)"
-      (orderColumns)="orderColumns($event)"
-      (removeColumn)="removeColumn.emit($event)"
-    >
-      <ng-container header>
-        <ng-container *ngFor="let header of columnHeaders">
-          <tb-data-table-header-cell
-            *ngIf="header.enabled"
-            [header]="header"
-            [sortingInfo]="sortingInfo"
-            [hparamsEnabled]="hparamsEnabled"
-          ></tb-data-table-header-cell> </ng-container
-      ></ng-container>
-    </tb-data-table>
-  `,
+  templateUrl: 'scalar_card_data_table.ng.html',
+  styles: [
+    `
+      .row-circle {
+        height: 12px;
+        width: 12px;
+      }
+      .row-circle > span {
+        border-radius: 50%;
+        border: 1px solid rgba(255, 255, 255, 0.4);
+        display: inline-block;
+        height: 10px;
+        width: 10px;
+        vertical-align: middle;
+      }
+    `,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScalarCardDataTable {
@@ -79,6 +74,18 @@ export class ScalarCardDataTable {
     headerType: ColumnHeaderType;
   }>();
 
+  ColumnHeaderType = ColumnHeaderType;
+
+  getHeaders(): ColumnHeader[] {
+    return [
+      {
+        name: 'color',
+        displayName: '',
+        type: ColumnHeaderType.COLOR,
+        enabled: true,
+      },
+    ].concat(this.columnHeaders);
+  }
   getMinPointInRange(
     points: ScalarCardPoint[],
     startPointIndex: number,
@@ -287,6 +294,7 @@ export class ScalarCardDataTable {
         return 0;
       });
     }
+    // console.log(JSON.parse(JSON.stringify(dataTableData)) as TableData[]);
     return dataTableData;
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -40,22 +40,7 @@ import {isDatumVisible} from './utils';
 @Component({
   selector: 'scalar-card-data-table',
   templateUrl: 'scalar_card_data_table.ng.html',
-  styles: [
-    `
-      .row-circle {
-        height: 12px;
-        width: 12px;
-      }
-      .row-circle > span {
-        border-radius: 50%;
-        border: 1px solid rgba(255, 255, 255, 0.4);
-        display: inline-block;
-        height: 10px;
-        width: 10px;
-        vertical-align: middle;
-      }
-    `,
-  ],
+  styleUrls: ['scalar_card_data_table.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScalarCardDataTable {
@@ -294,7 +279,6 @@ export class ScalarCardDataTable {
         return 0;
       });
     }
-    // console.log(JSON.parse(JSON.stringify(dataTableData)) as TableData[]);
     return dataTableData;
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -124,6 +124,9 @@ import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {provideMockTbStore} from '../../../testing/utils';
 import * as commonSelectors from '../main_view/common_selectors';
 import {CardFeatureOverride} from '../../store/metrics_types';
+import {ContentCellComponent} from '../../../widgets/data_table/content_cell_component';
+import {ContentRowComponent} from '../../../widgets/data_table/content_row_component';
+import {HeaderCellComponent} from '../../../widgets/data_table/header_cell_component';
 
 @Component({
   selector: 'line-chart',
@@ -2602,6 +2605,250 @@ describe('scalar card', () => {
         );
 
         expect(dataTableComponent).toBeFalsy();
+      }));
+
+      it('projects tb-data-table-header-cell for enabled headers', fakeAsync(() => {
+        store.overrideSelector(getMetricsLinkedTimeSelection, {
+          start: {step: 20},
+          end: null,
+        });
+        store.overrideSelector(getSingleSelectionHeaders, [
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.STEP,
+            name: 'step',
+            displayName: 'Step',
+            enabled: true,
+          },
+        ]);
+        const fixture = createComponent('card1');
+        fixture.detectChanges();
+
+        const dataTableComponentInstance = fixture.debugElement.query(
+          By.directive(DataTableComponent)
+        ).componentInstance;
+
+        expect(dataTableComponentInstance.headerCells.length).toEqual(2);
+
+        expect(
+          dataTableComponentInstance.headerCells.get(0).header.name
+        ).toEqual('run');
+        expect(
+          dataTableComponentInstance.headerCells.get(1).header.name
+        ).toEqual('step');
+      }));
+
+      it('projects tb-data-table-content-cell with data for enabled headers', fakeAsync(() => {
+        store.overrideSelector(getMetricsLinkedTimeSelection, {
+          start: {step: 20},
+          end: null,
+        });
+        store.overrideSelector(getSingleSelectionHeaders, [
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.VALUE,
+            name: 'value',
+            displayName: 'Value',
+            enabled: false,
+          },
+          {
+            type: ColumnHeaderType.STEP,
+            name: 'step',
+            displayName: 'Step',
+            enabled: true,
+          },
+        ]);
+        const runToSeries = {
+          run1: [
+            {wallTime: 1, value: 1, step: 1},
+            {wallTime: 2, value: 10, step: 2},
+            {wallTime: 3, value: 20, step: 3},
+          ],
+          run2: [
+            {wallTime: 1, value: 1, step: 1},
+            {wallTime: 2, value: 10, step: 2},
+            {wallTime: 3, value: 20, step: 3},
+          ],
+        };
+        provideMockCardRunToSeriesData(
+          selectSpy,
+          PluginType.SCALARS,
+          'card1',
+          null /* metadataOverride */,
+          runToSeries
+        );
+        store.overrideSelector(
+          selectors.getCurrentRouteRunSelection,
+          new Map([
+            ['run1', true],
+            ['run2', true],
+          ])
+        );
+        store.overrideSelector(
+          commonSelectors.getFilteredRenderableRunsIdsFromRoute,
+          new Set(['run1', 'run2'])
+        );
+
+        store.overrideSelector(getMetricsLinkedTimeSelection, {
+          start: {step: 2},
+          end: null,
+        });
+
+        const fixture = createComponent('card1');
+        const scalarCardDataTable = fixture.debugElement.query(
+          By.directive(ScalarCardDataTable)
+        );
+        fixture.detectChanges();
+
+        const data =
+          scalarCardDataTable.componentInstance.getTimeSelectionTableData();
+
+        const contentRowComponents = fixture.debugElement.queryAll(
+          By.directive(ContentRowComponent)
+        );
+
+        expect(contentRowComponents.length).toEqual(2);
+
+        const firstRowContentCells = contentRowComponents[0].queryAll(
+          By.directive(ContentCellComponent)
+        );
+
+        expect(firstRowContentCells.length).toEqual(3);
+
+        expect(firstRowContentCells[0].componentInstance.header.name).toEqual(
+          'color'
+        );
+        expect(firstRowContentCells[1].componentInstance.header.name).toEqual(
+          'run'
+        );
+        expect(firstRowContentCells[2].componentInstance.header.name).toEqual(
+          'step'
+        );
+
+        expect(firstRowContentCells[0].componentInstance.datum).toEqual(
+          data[0].color
+        );
+        expect(firstRowContentCells[1].componentInstance.datum).toEqual(
+          data[0].run
+        );
+        expect(firstRowContentCells[2].componentInstance.datum).toEqual(
+          data[0].step
+        );
+
+        const secondRowContentCells = contentRowComponents[1].queryAll(
+          By.directive(ContentCellComponent)
+        );
+
+        expect(secondRowContentCells.length).toEqual(3);
+
+        expect(secondRowContentCells[0].componentInstance.header.name).toEqual(
+          'color'
+        );
+        expect(secondRowContentCells[1].componentInstance.header.name).toEqual(
+          'run'
+        );
+        expect(secondRowContentCells[2].componentInstance.header.name).toEqual(
+          'step'
+        );
+
+        expect(secondRowContentCells[0].componentInstance.datum).toEqual(
+          data[1].color
+        );
+        expect(secondRowContentCells[1].componentInstance.datum).toEqual(
+          data[1].run
+        );
+        expect(secondRowContentCells[2].componentInstance.datum).toEqual(
+          data[1].step
+        );
+      }));
+
+      it('does not project smoothed column when smoothing is disabled', fakeAsync(() => {
+        store.overrideSelector(getMetricsLinkedTimeSelection, {
+          start: {step: 20},
+          end: null,
+        });
+        store.overrideSelector(getSingleSelectionHeaders, [
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+          {
+            type: ColumnHeaderType.SMOOTHED,
+            name: 'smoothed',
+            displayName: 'Smoothed',
+            enabled: true,
+          },
+        ]);
+        const runToSeries = {
+          run1: [
+            {wallTime: 1, value: 1, step: 1},
+            {wallTime: 2, value: 10, step: 2},
+            {wallTime: 3, value: 20, step: 3},
+          ],
+        };
+        provideMockCardRunToSeriesData(
+          selectSpy,
+          PluginType.SCALARS,
+          'card1',
+          null /* metadataOverride */,
+          runToSeries
+        );
+        store.overrideSelector(
+          selectors.getCurrentRouteRunSelection,
+          new Map([['run1', true]])
+        );
+        store.overrideSelector(
+          commonSelectors.getFilteredRenderableRunsIdsFromRoute,
+          new Set(['run1'])
+        );
+
+        store.overrideSelector(getMetricsLinkedTimeSelection, {
+          start: {step: 2},
+          end: null,
+        });
+        store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
+
+        const fixture = createComponent('card1');
+        const scalarCardDataTable = fixture.debugElement.query(
+          By.directive(ScalarCardDataTable)
+        );
+        fixture.detectChanges();
+
+        let dataTableComponentInstance = fixture.debugElement.query(
+          By.directive(DataTableComponent)
+        ).componentInstance;
+
+        let contentCells = scalarCardDataTable.queryAll(
+          By.directive(ContentCellComponent)
+        );
+
+        expect(dataTableComponentInstance.headerCells.length).toEqual(1);
+        expect(
+          dataTableComponentInstance.headerCells.find(
+            (cell: HeaderCellComponent) =>
+              cell.header.type === ColumnHeaderType.SMOOTHED
+          )
+        ).toBeFalsy();
+        // content cells automatically add the color column.
+        expect(contentCells.length).toEqual(2);
       }));
     });
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -16,7 +16,6 @@ import {OverlayContainer} from '@angular/cdk/overlay';
 import {
   ChangeDetectorRef,
   Component,
-  DebugElement,
   EventEmitter,
   Inject,
   Input,

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -3195,93 +3195,98 @@ describe('runs_table', () => {
       ).toBeFalsy();
     });
 
-    it('passes run name and color to data table', () => {
-      // To make sure we only return the runs when called with the right props.
-      const selectSpy = spyOn(store, 'select').and.callThrough();
-      selectSpy
-        .withArgs(getRuns, {experimentId: 'book'})
-        .and.returnValue(
-          of([
-            buildRun({id: 'book1', name: "The Philosopher's Stone"}),
-            buildRun({id: 'book2', name: 'The Chamber Of Secrets'}),
-          ])
-        );
-      selectSpy.withArgs(getRunsTableHeaders).and.returnValue(
-        of([
-          {
-            type: ColumnHeaderType.RUN,
-            name: 'run',
-            displayName: 'Run',
-            enabled: true,
-          },
-        ])
-      );
+    // Currently nothing is passed to the data table from the runs table. This
+    // is because of a data table refactor.
+    // TODO(JamesHollyer): reenable and fix tests once runs table implements new
+    // data table structure.
 
-      store.overrideSelector(getRunColorMap, {
-        book1: '#000',
-        book2: '#111',
-      });
+    // it('passes run name and color to data table', () => {
+    //   // To make sure we only return the runs when called with the right props.
+    //   const selectSpy = spyOn(store, 'select').and.callThrough();
+    //   selectSpy
+    //     .withArgs(getRuns, {experimentId: 'book'})
+    //     .and.returnValue(
+    //       of([
+    //         buildRun({id: 'book1', name: "The Philosopher's Stone"}),
+    //         buildRun({id: 'book2', name: 'The Chamber Of Secrets'}),
+    //       ])
+    //     );
+    //   selectSpy.withArgs(getRunsTableHeaders).and.returnValue(
+    //     of([
+    //       {
+    //         type: ColumnHeaderType.RUN,
+    //         name: 'run',
+    //         displayName: 'Run',
+    //         enabled: true,
+    //       },
+    //     ])
+    //   );
 
-      const fixture = createComponent(['book']);
-      fixture.detectChanges();
-      const dataTableComponent = fixture.debugElement.query(
-        By.directive(DataTableComponent)
-      );
+    //   store.overrideSelector(getRunColorMap, {
+    //     book1: '#000',
+    //     book2: '#111',
+    //   });
 
-      expect(dataTableComponent.componentInstance.data).toEqual([
-        {id: 'book1', color: '#000', run: "The Philosopher's Stone"},
-        {id: 'book2', color: '#111', run: 'The Chamber Of Secrets'},
-      ]);
-    });
+    //   const fixture = createComponent(['book']);
+    //   fixture.detectChanges();
+    //   const dataTableComponent = fixture.debugElement.query(
+    //     By.directive(DataTableComponent)
+    //   );
 
-    it('passes hparam values to data table', () => {
-      const run1 = buildRun({id: 'book1', name: "The Philosopher's Stone"});
-      const run2 = buildRun({id: 'book2', name: 'The Chamber Of Secrets'});
-      // To make sure we only return the runs when called with the right props.
-      const selectSpy = spyOn(store, 'select').and.callThrough();
-      selectSpy
-        .withArgs(getRuns, {experimentId: 'book'})
-        .and.returnValue(of([run1, run2]));
+    //   expect(dataTableComponent.componentInstance.data).toEqual([
+    //     {id: 'book1', color: '#000', run: "The Philosopher's Stone"},
+    //     {id: 'book2', color: '#111', run: 'The Chamber Of Secrets'},
+    //   ]);
+    // });
 
-      selectSpy.withArgs(getRunsTableHeaders).and.returnValue(
-        of([
-          {
-            type: ColumnHeaderType.HPARAM,
-            name: 'batch_size',
-            displayName: 'Batch Size',
-            enabled: true,
-          },
-        ])
-      );
+    // it('passes hparam values to data table', () => {
+    //   const run1 = buildRun({id: 'book1', name: "The Philosopher's Stone"});
+    //   const run2 = buildRun({id: 'book2', name: 'The Chamber Of Secrets'});
+    //   // To make sure we only return the runs when called with the right props.
+    //   const selectSpy = spyOn(store, 'select').and.callThrough();
+    //   selectSpy
+    //     .withArgs(getRuns, {experimentId: 'book'})
+    //     .and.returnValue(of([run1, run2]));
 
-      selectSpy.withArgs(getFilteredRenderableRunsFromRoute).and.returnValue(
-        of([
-          {
-            run: run1,
-            hparams: new Map([['batch_size', 1]]),
-          } as RunTableItem,
-          {
-            run: run2,
-            hparams: new Map([['batch_size', 2]]),
-          } as RunTableItem,
-        ])
-      );
+    //   selectSpy.withArgs(getRunsTableHeaders).and.returnValue(
+    //     of([
+    //       {
+    //         type: ColumnHeaderType.HPARAM,
+    //         name: 'batch_size',
+    //         displayName: 'Batch Size',
+    //         enabled: true,
+    //       },
+    //     ])
+    //   );
 
-      store.overrideSelector(getRunColorMap, {
-        book1: '#000',
-        book2: '#111',
-      });
+    //   selectSpy.withArgs(getFilteredRenderableRunsFromRoute).and.returnValue(
+    //     of([
+    //       {
+    //         run: run1,
+    //         hparams: new Map([['batch_size', 1]]),
+    //       } as RunTableItem,
+    //       {
+    //         run: run2,
+    //         hparams: new Map([['batch_size', 2]]),
+    //       } as RunTableItem,
+    //     ])
+    //   );
 
-      const fixture = createComponent(['book']);
-      fixture.detectChanges();
-      const dataTableComponent = fixture.debugElement.query(
-        By.directive(DataTableComponent)
-      );
+    //   store.overrideSelector(getRunColorMap, {
+    //     book1: '#000',
+    //     book2: '#111',
+    //   });
 
-      expect(dataTableComponent.componentInstance.data).toEqual([
-        {id: 'book1', color: '#000', batch_size: 1},
-        {id: 'book2', color: '#111', batch_size: 2},
-      ]);
-    });
+    //   const fixture = createComponent(['book']);
+    //   fixture.detectChanges();
+    //   const dataTableComponent = fixture.debugElement.query(
+    //     By.directive(DataTableComponent)
+    //   );
+
+    //   expect(dataTableComponent.componentInstance.data).toEqual([
+    //     {id: 'book1', color: '#000', batch_size: 1},
+    //     {id: 'book2', color: '#111', batch_size: 2},
+    //   ]);
+    // });
   });
 });

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -45,6 +45,8 @@ tf_sass_binary(
 tf_ng_module(
     name = "data_table",
     srcs = [
+        "content_cell_component.ts",
+        "content_row_component.ts",
         "data_table_component.ts",
         "data_table_module.ts",
         "header_cell_component.ts",

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -23,6 +23,15 @@ tf_sass_binary(
 )
 
 tf_sass_binary(
+    name = "content_cell_styles",
+    src = "content_cell_component.scss",
+    strict_deps = False,
+    deps = [
+        "//tensorboard/webapp:angular_material_sass_deps",
+    ],
+)
+
+tf_sass_binary(
     name = "data_table_header_styles",
     src = "data_table_header_component.scss",
     strict_deps = False,
@@ -52,8 +61,10 @@ tf_ng_module(
         "header_cell_component.ts",
     ],
     assets = [
+        "content_cell_component.ng.html",
         "data_table_component.ng.html",
         "header_cell_component.ng.html",
+        ":content_cell_styles",
         ":data_table_styles",
         ":header_cell_styles",
     ],
@@ -121,6 +132,7 @@ tf_ts_library(
     testonly = True,
     srcs = [
         "column_selector_test.ts",
+        "content_cell_component_test.ts",
         "data_table_test.ts",
         "header_cell_component_test.ts",
     ],

--- a/tensorboard/webapp/widgets/data_table/content_cell_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component.ng.html
@@ -1,0 +1,36 @@
+<!--
+@license
+Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<ng-container [ngSwitch]="header.type">
+  <div *ngSwitchCase="ColumnHeaderType.VALUE_CHANGE" class="cell">
+    <ng-container
+      *ngTemplateOutlet="arrow; context: {$implicit: datum}"
+    ></ng-container>
+    {{ getFormattedDataForColumn() }}
+  </div>
+  <div *ngSwitchCase="ColumnHeaderType.PERCENTAGE_CHANGE" class="cell">
+    <ng-container
+      *ngTemplateOutlet="arrow; context: {$implicit: datum}"
+    ></ng-container>
+    {{ getFormattedDataForColumn() }}
+  </div>
+  <div *ngSwitchDefault class="cell extra-right-padding">
+    {{ getFormattedDataForColumn() }}
+  </div>
+  <ng-content></ng-content>
+</ng-container>
+<ng-template #arrow let-value>
+  <mat-icon *ngIf="value >= 0" svgIcon="arrow_upward_24px"></mat-icon>
+  <mat-icon *ngIf="value < 0" svgIcon="arrow_downward_24px"></mat-icon>
+</ng-template>

--- a/tensorboard/webapp/widgets/data_table/content_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component.scss
@@ -1,21 +1,36 @@
-<!--
-@license
-Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
 
-<div class="data-table">
-  <div class="header">
-    <div class=".col"></div>
-    <ng-content select="[header]"></ng-content>
-  </div>
-  <ng-content select="[content]"></ng-content>
-</div>
+:host {
+  display: table-cell;
+  padding: 1px;
+}
+.cell {
+  align-items: center;
+  display: flex;
+}
+
+.cell mat-icon {
+  height: 12px;
+  width: 12px;
+
+  ::ng-deep path {
+    fill: unset;
+  }
+}
+
+.extra-right-padding {
+  padding-right: 1px;
+}

--- a/tensorboard/webapp/widgets/data_table/content_cell_component.ts
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component.ts
@@ -1,0 +1,121 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {ColumnHeader, ColumnHeaderType} from './types';
+import {
+  intlNumberFormatter,
+  numberFormatter,
+  relativeTimeFormatter,
+} from '../line_chart_v2/lib/formatter';
+
+@Component({
+  selector: 'tb-data-table-content-cell',
+  template: `
+    <ng-container [ngSwitch]="header.type">
+      <div *ngSwitchCase="ColumnHeaderType.VALUE_CHANGE" class="cell">
+        <ng-container
+          *ngTemplateOutlet="arrow; context: {$implicit: datum}"
+        ></ng-container>
+        {{ getFormattedDataForColumn() }}
+      </div>
+      <div *ngSwitchCase="ColumnHeaderType.PERCENTAGE_CHANGE" class="cell">
+        <ng-container
+          *ngTemplateOutlet="arrow; context: {$implicit: datum}"
+        ></ng-container>
+        {{ getFormattedDataForColumn() }}
+      </div>
+      <div *ngSwitchDefault class="cell extra-right-padding">
+        {{ getFormattedDataForColumn() }}
+      </div>
+      <ng-content></ng-content>
+    </ng-container>
+    <ng-template #arrow let-value>
+      <mat-icon *ngIf="value >= 0" svgIcon="arrow_upward_24px"></mat-icon>
+      <mat-icon *ngIf="value < 0" svgIcon="arrow_downward_24px"></mat-icon>
+    </ng-template>
+  `,
+  styles: [
+    `
+      :host {
+        display: table-cell;
+        padding: 1px;
+      }
+      .cell {
+        align-items: center;
+        display: flex;
+      }
+
+      .cell mat-icon {
+        height: 12px;
+        width: 12px;
+
+        ::ng-deep path {
+          fill: unset;
+        }
+      }
+
+      .extra-right-padding {
+        padding-right: 1px;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ContentCellComponent {
+  @Input() header!: ColumnHeader;
+  @Input() datum!: string | number;
+
+  ColumnHeaderType = ColumnHeaderType;
+
+  getFormattedDataForColumn(): string {
+    if (this.datum === undefined) {
+      return '';
+    }
+    switch (this.header.type) {
+      case ColumnHeaderType.RUN:
+        return this.datum as string;
+      case ColumnHeaderType.VALUE:
+      case ColumnHeaderType.STEP:
+      case ColumnHeaderType.SMOOTHED:
+      case ColumnHeaderType.START_STEP:
+      case ColumnHeaderType.END_STEP:
+      case ColumnHeaderType.START_VALUE:
+      case ColumnHeaderType.END_VALUE:
+      case ColumnHeaderType.MIN_VALUE:
+      case ColumnHeaderType.MAX_VALUE:
+      case ColumnHeaderType.STEP_AT_MAX:
+      case ColumnHeaderType.STEP_AT_MIN:
+      case ColumnHeaderType.MEAN:
+      case ColumnHeaderType.HPARAM:
+        if (typeof this.datum === 'number') {
+          return intlNumberFormatter.formatShort(this.datum as number);
+        }
+        return this.datum;
+      case ColumnHeaderType.TIME:
+        const time = new Date(this.datum!);
+        return time.toISOString();
+      case ColumnHeaderType.RELATIVE_TIME:
+        return relativeTimeFormatter.formatReadable(this.datum as number);
+      case ColumnHeaderType.VALUE_CHANGE:
+        return intlNumberFormatter.formatShort(Math.abs(this.datum as number));
+      case ColumnHeaderType.PERCENTAGE_CHANGE:
+        return Math.round((this.datum as number) * 100).toString() + '%';
+      case ColumnHeaderType.RAW_CHANGE:
+        return numberFormatter.formatShort(Math.abs(this.datum as number));
+      default:
+        return '';
+    }
+  }
+}

--- a/tensorboard/webapp/widgets/data_table/content_cell_component.ts
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,55 +22,8 @@ import {
 
 @Component({
   selector: 'tb-data-table-content-cell',
-  template: `
-    <ng-container [ngSwitch]="header.type">
-      <div *ngSwitchCase="ColumnHeaderType.VALUE_CHANGE" class="cell">
-        <ng-container
-          *ngTemplateOutlet="arrow; context: {$implicit: datum}"
-        ></ng-container>
-        {{ getFormattedDataForColumn() }}
-      </div>
-      <div *ngSwitchCase="ColumnHeaderType.PERCENTAGE_CHANGE" class="cell">
-        <ng-container
-          *ngTemplateOutlet="arrow; context: {$implicit: datum}"
-        ></ng-container>
-        {{ getFormattedDataForColumn() }}
-      </div>
-      <div *ngSwitchDefault class="cell extra-right-padding">
-        {{ getFormattedDataForColumn() }}
-      </div>
-      <ng-content></ng-content>
-    </ng-container>
-    <ng-template #arrow let-value>
-      <mat-icon *ngIf="value >= 0" svgIcon="arrow_upward_24px"></mat-icon>
-      <mat-icon *ngIf="value < 0" svgIcon="arrow_downward_24px"></mat-icon>
-    </ng-template>
-  `,
-  styles: [
-    `
-      :host {
-        display: table-cell;
-        padding: 1px;
-      }
-      .cell {
-        align-items: center;
-        display: flex;
-      }
-
-      .cell mat-icon {
-        height: 12px;
-        width: 12px;
-
-        ::ng-deep path {
-          fill: unset;
-        }
-      }
-
-      .extra-right-padding {
-        padding-right: 1px;
-      }
-    `,
-  ],
+  templateUrl: 'content_cell_component.ng.html',
+  styleUrls: ['content_cell_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ContentCellComponent {

--- a/tensorboard/webapp/widgets/data_table/content_cell_component_test.ts
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component_test.ts
@@ -1,0 +1,147 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, Input, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatIconTestingModule} from '../../testing/mat_icon_module';
+import {By} from '@angular/platform-browser';
+import {ColumnHeader, ColumnHeaderType} from './types';
+import {DataTableModule} from './data_table_module';
+import {ContentCellComponent} from './content_cell_component';
+
+@Component({
+  selector: 'testable-comp',
+  template: `
+    <tb-data-table-content-cell
+      [header]="header"
+      [datum]="datum"
+    ></tb-data-table-content-cell>
+  `,
+})
+class TestableComponent {
+  @ViewChild('DataTable')
+  contentCell!: ContentCellComponent;
+
+  @Input() header!: ColumnHeader;
+  @Input() datum!: string | number;
+}
+
+describe('header cell', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestableComponent, ContentCellComponent],
+      imports: [MatIconTestingModule, DataTableModule],
+    }).compileComponents();
+  });
+
+  function createComponent(input: {
+    header?: ColumnHeader;
+    datum?: string | number;
+  }): ComponentFixture<TestableComponent> {
+    const fixture = TestBed.createComponent(TestableComponent);
+
+    fixture.componentInstance.header = input.header || {
+      name: 'run',
+      displayName: 'Run',
+      type: ColumnHeaderType.RUN,
+      enabled: true,
+    };
+    fixture.componentInstance.datum = input.datum || '';
+
+    return fixture;
+  }
+
+  it('renders', () => {
+    const fixture = createComponent({});
+    fixture.detectChanges();
+    const cell = fixture.debugElement.query(By.css('.cell'));
+    expect(cell).toBeTruthy();
+  });
+
+  it('renders datum', () => {
+    const fixture = createComponent({datum: 'test datum'});
+    fixture.detectChanges();
+    const cell = fixture.debugElement.query(By.css('.cell'));
+    expect(cell.nativeElement.innerText).toEqual('test datum');
+  });
+
+  it('renders up arrow for cells with PercentageChange header type and positive datum', () => {
+    const fixture = createComponent({
+      header: {
+        name: 'percentageChange',
+        displayName: '%',
+        type: ColumnHeaderType.PERCENTAGE_CHANGE,
+        enabled: true,
+      },
+      datum: 1,
+    });
+    fixture.detectChanges();
+    const icon = fixture.debugElement.query(By.css('mat-icon'));
+    expect(icon.nativeElement.getAttribute('svgIcon')).toBe(
+      'arrow_upward_24px'
+    );
+  });
+
+  it('renders down arrow for cells with PercentageChange header type and negative datum', () => {
+    const fixture = createComponent({
+      header: {
+        name: 'percentageChange',
+        displayName: '%',
+        type: ColumnHeaderType.PERCENTAGE_CHANGE,
+        enabled: true,
+      },
+      datum: -1,
+    });
+    fixture.detectChanges();
+    const icon = fixture.debugElement.query(By.css('mat-icon'));
+    expect(icon.nativeElement.getAttribute('svgIcon')).toBe(
+      'arrow_downward_24px'
+    );
+  });
+
+  it('renders up arrow for cells with ValueChange header type and positive datum', () => {
+    const fixture = createComponent({
+      header: {
+        name: 'valueChange',
+        displayName: '%',
+        type: ColumnHeaderType.PERCENTAGE_CHANGE,
+        enabled: true,
+      },
+      datum: 1,
+    });
+    fixture.detectChanges();
+    const icon = fixture.debugElement.query(By.css('mat-icon'));
+    expect(icon.nativeElement.getAttribute('svgIcon')).toBe(
+      'arrow_upward_24px'
+    );
+  });
+
+  it('renders down arrow for cells with ValueChange header type and negative datum', () => {
+    const fixture = createComponent({
+      header: {
+        name: 'valueChange',
+        displayName: '%',
+        type: ColumnHeaderType.VALUE_CHANGE,
+        enabled: true,
+      },
+      datum: -1,
+    });
+    fixture.detectChanges();
+    const icon = fixture.debugElement.query(By.css('mat-icon'));
+    expect(icon.nativeElement.getAttribute('svgIcon')).toBe(
+      'arrow_downward_24px'
+    );
+  });
+});

--- a/tensorboard/webapp/widgets/data_table/content_row_component.ts
+++ b/tensorboard/webapp/widgets/data_table/content_row_component.ts
@@ -12,39 +12,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-@use '@angular/material' as mat;
-@import 'tensorboard/webapp/theme/tb_theme';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 
-$_accent: map-get(mat.get-color-config($tb-theme), accent);
-
-.data-table {
-  border-spacing: 4px;
-  font-size: 13px;
-  display: table;
-  width: 100%;
-
-  .header {
-    display: table-row;
-  }
-
-  .col {
-    display: table-cell;
-  }
-
-  .header {
-    background-color: mat.get-color-from-palette($tb-background, background);
-    position: sticky;
-    text-align: left;
-    top: 0;
-    font-weight: bold;
-    vertical-align: bottom;
-
-    &:hover {
-      cursor: pointer;
-    }
-
-    @include tb-dark-theme {
-      background-color: map-get($tb-dark-background, background);
-    }
-  }
-}
+@Component({
+  selector: 'tb-data-table-content-row',
+  template: ` <ng-content></ng-content> `,
+  styles: [
+    `
+      :host {
+        display: table-row;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ContentRowComponent {}

--- a/tensorboard/webapp/widgets/data_table/content_row_component.ts
+++ b/tensorboard/webapp/widgets/data_table/content_row_component.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,13 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'tb-data-table-content-row',

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -14,7 +14,7 @@ limitations under the License.
 
 <div class="data-table">
   <div class="header">
-    <div class=".col"></div>
+    <div class="col"></div>
     <ng-content select="[header]"></ng-content>
   </div>
   <ng-content select="[content]"></ng-content>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -17,34 +17,5 @@ limitations under the License.
     <div class="col"></div>
     <ng-content select="[header]"></ng-content>
   </div>
-  <ng-container *ngFor="let runData of data;">
-    <div class="row">
-      <div class="col row-circle">
-        <span [style.backgroundColor]="runData['color']"></span>
-      </div>
-      <ng-container *ngFor="let header of headers;">
-        <div class="col" *ngIf="showColumn(header)" [ngSwitch]="header.type">
-          <div *ngSwitchCase="ColumnHeaders.VALUE_CHANGE" class="cell">
-            <ng-container
-              *ngTemplateOutlet="arrow; context: {$implicit:runData[header.name]}"
-            ></ng-container>
-            {{ getFormattedDataForColumn(header.type, runData[header.name]) }}
-          </div>
-          <div *ngSwitchCase="ColumnHeaders.PERCENTAGE_CHANGE" class="cell">
-            <ng-container
-              *ngTemplateOutlet="arrow; context: {$implicit:runData[header.name]}"
-            ></ng-container>
-            {{ getFormattedDataForColumn(header.type, runData[header.name]) }}
-          </div>
-          <div *ngSwitchDefault class="cell extra-right-padding">
-            {{ getFormattedDataForColumn(header.type, runData[header.name]) }}
-          </div>
-        </div>
-      </ng-container>
-    </div>
-  </ng-container>
+  <ng-content select="[content]"></ng-content>
 </div>
-<ng-template #arrow let-value>
-  <mat-icon *ngIf="value >= 0" svgIcon="arrow_upward_24px"></mat-icon>
-  <mat-icon *ngIf="value < 0" svgIcon="arrow_downward_24px"></mat-icon>
-</ng-template>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -58,10 +58,8 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
   // The order of this array of headers determines the order which they are
   // displayed in the table.
   @Input() headers!: ColumnHeader[];
-  @Input() data!: TableData[];
   @Input() sortingInfo!: SortingInfo;
   @Input() columnCustomizationEnabled!: boolean;
-  @Input() smoothingEnabled!: boolean;
 
   @ContentChildren(HeaderCellComponent)
   headerCells!: QueryList<HeaderCellComponent>;
@@ -109,49 +107,6 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
         )
       );
     });
-  }
-
-  getFormattedDataForColumn(
-    columnHeader: ColumnHeaderType,
-    datum: string | number | undefined
-  ): string {
-    if (datum === undefined) {
-      return '';
-    }
-    switch (columnHeader) {
-      case ColumnHeaderType.RUN:
-        return datum as string;
-      case ColumnHeaderType.VALUE:
-      case ColumnHeaderType.STEP:
-      case ColumnHeaderType.SMOOTHED:
-      case ColumnHeaderType.START_STEP:
-      case ColumnHeaderType.END_STEP:
-      case ColumnHeaderType.START_VALUE:
-      case ColumnHeaderType.END_VALUE:
-      case ColumnHeaderType.MIN_VALUE:
-      case ColumnHeaderType.MAX_VALUE:
-      case ColumnHeaderType.STEP_AT_MAX:
-      case ColumnHeaderType.STEP_AT_MIN:
-      case ColumnHeaderType.MEAN:
-      case ColumnHeaderType.HPARAM:
-        if (typeof datum === 'number') {
-          return intlNumberFormatter.formatShort(datum as number);
-        }
-        return datum;
-      case ColumnHeaderType.TIME:
-        const time = new Date(datum!);
-        return time.toISOString();
-      case ColumnHeaderType.RELATIVE_TIME:
-        return relativeTimeFormatter.formatReadable(datum as number);
-      case ColumnHeaderType.VALUE_CHANGE:
-        return intlNumberFormatter.formatShort(Math.abs(datum as number));
-      case ColumnHeaderType.PERCENTAGE_CHANGE:
-        return Math.round((datum as number) * 100).toString() + '%';
-      case ColumnHeaderType.RAW_CHANGE:
-        return numberFormatter.formatShort(Math.abs(datum as number));
-      default:
-        return '';
-    }
   }
 
   headerClicked(name: string) {
@@ -238,13 +193,6 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
       'highlight-border-right': this.highlightSide === Side.RIGHT,
       'highlight-border-left': this.highlightSide === Side.LEFT,
     };
-  }
-
-  showColumn(header: ColumnHeader) {
-    return (
-      header.enabled &&
-      (this.smoothingEnabled || header.type !== ColumnHeaderType.SMOOTHED)
-    );
   }
 
   getIndexOfHeaderWithName(name: string) {

--- a/tensorboard/webapp/widgets/data_table/data_table_module.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_module.ts
@@ -19,10 +19,22 @@ import {MatIconModule} from '@angular/material/icon';
 import {DataTableComponent} from './data_table_component';
 import {HeaderCellComponent} from './header_cell_component';
 import {DataTableHeaderModule} from './data_table_header_module';
+import {ContentCellComponent} from './content_cell_component';
+import {ContentRowComponent} from './content_row_component';
 
 @NgModule({
-  declarations: [DataTableComponent, HeaderCellComponent],
-  exports: [DataTableComponent, HeaderCellComponent],
+  declarations: [
+    ContentCellComponent,
+    ContentRowComponent,
+    DataTableComponent,
+    HeaderCellComponent,
+  ],
+  exports: [
+    ContentCellComponent,
+    ContentRowComponent,
+    DataTableComponent,
+    HeaderCellComponent,
+  ],
   imports: [CommonModule, MatIconModule, DataTableHeaderModule],
 })
 export class DataTableModule {}

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -71,7 +71,7 @@ class TestableComponent {
   @Input() orderColumns!: (newOrder: ColumnHeaderType[]) => void;
 }
 
-describe('data table', () => {
+fdescribe('data table', () => {
   let sortDataBySpy: jasmine.Spy;
   let orderColumnsSpy: jasmine.Spy;
   beforeEach(async () => {

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -34,22 +34,13 @@ import {HeaderCellComponent} from './header_cell_component';
     <tb-data-table
       #DataTable
       [headers]="headers"
-      [data]="data"
       [sortingInfo]="sortingInfo"
-      [smoothingEnabled]="smoothingEnabled"
       (sortDataBy)="sortDataBy($event)"
       (orderColumns)="orderColumns($event)"
     >
       <ng-container header>
         <ng-container *ngFor="let header of headers">
-          <!-- Smoothing and enabled logic is still handled by the table for
-          the content. Soon that logic will all be hanled by the parent. Once
-          moved this ngIf can be removed along with many tests around enabling
-          and disabling columns. -->
           <tb-data-table-header-cell
-            *ngIf="
-              header.enabled && (header.type !== 'SMOOTHED' || smoothingEnabled)
-            "
             [header]="header"
             [sortingInfo]="sortingInfo"
             [hparamsEnabled]="hparamsEnabled"
@@ -71,7 +62,7 @@ class TestableComponent {
   @Input() orderColumns!: (newOrder: ColumnHeaderType[]) => void;
 }
 
-fdescribe('data table', () => {
+describe('data table', () => {
   let sortDataBySpy: jasmine.Spy;
   let orderColumnsSpy: jasmine.Spy;
   beforeEach(async () => {
@@ -87,22 +78,16 @@ fdescribe('data table', () => {
 
   function createComponent(input: {
     headers?: ColumnHeader[];
-    data?: TableData[];
     sortingInfo?: SortingInfo;
-    smoothingEnabled?: boolean;
     hparamsEnabled?: boolean;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
 
     fixture.componentInstance.headers = input.headers || [];
-    fixture.componentInstance.data = input.data || [];
     fixture.componentInstance.sortingInfo = input.sortingInfo || {
       name: 'run',
       order: SortingOrder.ASCENDING,
     };
-
-    fixture.componentInstance.smoothingEnabled =
-      input.smoothingEnabled === undefined ? true : input.smoothingEnabled;
 
     sortDataBySpy = jasmine.createSpy();
     fixture.componentInstance.sortDataBy = sortDataBySpy;
@@ -118,285 +103,6 @@ fdescribe('data table', () => {
     fixture.detectChanges();
     const dataTable = fixture.debugElement.query(By.css('.data-table'));
     expect(dataTable).toBeTruthy();
-  });
-
-  it('displays given headers in order', () => {
-    const fixture = createComponent({
-      headers: [
-        {
-          type: ColumnHeaderType.VALUE,
-          name: 'value',
-          displayName: 'Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.RUN,
-          name: 'run',
-          displayName: 'Run',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.VALUE_CHANGE,
-          name: 'valueChanged',
-          displayName: 'Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.PERCENTAGE_CHANGE,
-          name: 'percentageChanged',
-          displayName: '%',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.SMOOTHED,
-          name: 'smoothed',
-          displayName: 'Smoothed',
-          enabled: true,
-        },
-      ],
-    });
-    fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(
-      By.directive(HeaderCellComponent)
-    );
-
-    expect(headerElements[0].nativeElement.innerText).toBe('Value');
-    expect(headerElements[1].nativeElement.innerText).toBe('Run');
-    expect(headerElements[2].nativeElement.innerText).toBe('Value');
-    expect(
-      headerElements[2]
-        .queryAll(By.css('mat-icon'))[0]
-        .nativeElement.getAttribute('svgIcon')
-    ).toBe('change_history_24px');
-    expect(headerElements[3].nativeElement.innerText).toBe('%');
-    expect(
-      headerElements[3]
-        .queryAll(By.css('mat-icon'))[0]
-        .nativeElement.getAttribute('svgIcon')
-    ).toBe('change_history_24px');
-    expect(headerElements[4].nativeElement.innerText).toBe('Smoothed');
-  });
-
-  it('displays data in order', () => {
-    const fixture = createComponent({
-      headers: [
-        {
-          type: ColumnHeaderType.VALUE,
-          name: 'value',
-          displayName: 'Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.RUN,
-          name: 'run',
-          displayName: 'Run',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.STEP,
-          name: 'step',
-          displayName: 'Step',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.RELATIVE_TIME,
-          name: 'relativeTime',
-          displayName: 'Relative',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.VALUE_CHANGE,
-          name: 'valueChange',
-          displayName: 'Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.START_STEP,
-          name: 'startStep',
-          displayName: 'Start Step',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.END_STEP,
-          name: 'endStep',
-          displayName: 'End Step',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.START_VALUE,
-          name: 'startValue',
-          displayName: 'Start Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.END_VALUE,
-          name: 'endValue',
-          displayName: 'End Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.MIN_VALUE,
-          name: 'minValue',
-          displayName: 'Min',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.MAX_VALUE,
-          name: 'maxValue',
-          displayName: 'max',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.PERCENTAGE_CHANGE,
-          name: 'percentageChange',
-          displayName: '%',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.SMOOTHED,
-          name: 'smoothed',
-          displayName: 'Smoothed',
-          enabled: true,
-        },
-      ],
-      data: [
-        {
-          id: 'someid',
-          run: 'run name',
-          value: 31415926535,
-          step: 1,
-          relativeTime: 123,
-          valueChange: -20,
-          startStep: 5,
-          endStep: 30,
-          startValue: 13,
-          endValue: 23,
-          minValue: 0.12345,
-          maxValue: 89793238462,
-          percentageChange: 0.3,
-          smoothed: 3.14e10,
-        },
-      ],
-    });
-    fixture.detectChanges();
-    const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
-
-    // The first header should always be blank as it is the run color column.
-    expect(dataElements[0].nativeElement.innerText).toBe('');
-    expect(dataElements[1].nativeElement.innerText).toBe('31,415,926,535');
-    expect(dataElements[2].nativeElement.innerText).toBe('run name');
-    expect(dataElements[3].nativeElement.innerText).toBe('1');
-    expect(dataElements[4].nativeElement.innerText).toBe('123 ms');
-    expect(dataElements[5].nativeElement.innerText).toBe('20');
-    expect(dataElements[5].queryAll(By.css('mat-icon')).length).toBe(1);
-    expect(
-      dataElements[5]
-        .queryAll(By.css('mat-icon'))[0]
-        .nativeElement.getAttribute('svgIcon')
-    ).toBe('arrow_downward_24px');
-    expect(dataElements[6].nativeElement.innerText).toBe('5');
-    expect(dataElements[7].nativeElement.innerText).toBe('30');
-    expect(dataElements[8].nativeElement.innerText).toBe('13');
-    expect(dataElements[9].nativeElement.innerText).toBe('23');
-    expect(dataElements[10].nativeElement.innerText).toBe('0.1235');
-    expect(dataElements[11].nativeElement.innerText).toBe('89,793,238,462');
-    expect(dataElements[12].nativeElement.innerText).toBe('30%');
-    expect(dataElements[12].queryAll(By.css('mat-icon')).length).toBe(1);
-    expect(
-      dataElements[12]
-        .queryAll(By.css('mat-icon'))[0]
-        .nativeElement.getAttribute('svgIcon')
-    ).toBe('arrow_upward_24px');
-    expect(dataElements[13].nativeElement.innerText).toBe('31,400,000,000');
-  });
-
-  it('does not displays headers or data when header is disabled', () => {
-    const fixture = createComponent({
-      headers: [
-        {
-          type: ColumnHeaderType.VALUE,
-          name: 'value',
-          displayName: 'Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.RUN,
-          name: 'run',
-          displayName: 'Run',
-          enabled: false,
-        },
-        {
-          type: ColumnHeaderType.STEP,
-          name: 'step',
-          displayName: 'Step',
-          enabled: true,
-        },
-      ],
-      data: [
-        {
-          id: 'someid',
-          run: 'run name',
-          value: 3,
-          step: 1,
-        },
-      ],
-    });
-    fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(
-      By.directive(HeaderCellComponent)
-    );
-    const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
-
-    // The color column is currently hard coded into the data table and is not a
-    // HeaderCellComponent.
-    expect(headerElements[0].nativeElement.innerText).toBe('Value');
-    expect(headerElements[1].nativeElement.innerText).toBe('Step');
-
-    // The first column should always be blank as it is the run color column.
-    expect(dataElements[0].nativeElement.innerText).toBe('');
-    expect(dataElements[1].nativeElement.innerText).toBe('3');
-    expect(dataElements[2].nativeElement.innerText).toBe('1');
-  });
-
-  it('displays nothing when no data is available', () => {
-    const fixture = createComponent({
-      headers: [
-        {
-          type: ColumnHeaderType.VALUE,
-          name: 'value',
-          displayName: 'Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.RUN,
-          name: 'run',
-          displayName: 'Run',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.STEP,
-          name: 'step',
-          displayName: 'Step',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.RELATIVE_TIME,
-          name: 'relativeTime',
-          displayName: 'Relative',
-          enabled: true,
-        },
-      ],
-      data: [{id: 'someid'}],
-    });
-    fixture.detectChanges();
-    const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
-
-    // The first header should always be blank as it is the run color column.
-    expect(dataElements[0].nativeElement.innerText).toBe('');
-    expect(dataElements[1].nativeElement.innerText).toBe('');
-    expect(dataElements[2].nativeElement.innerText).toBe('');
-    expect(dataElements[3].nativeElement.innerText).toBe('');
-    expect(dataElements[4].nativeElement.innerText).toBe('');
   });
 
   it('emits sortDataBy event when header emits headerClicked event', () => {
@@ -749,65 +455,5 @@ fdescribe('data table', () => {
         enabled: true,
       },
     ]);
-  });
-
-  it('does not display Smoothed column when smoothingEnabled is false', () => {
-    const fixture = createComponent({
-      headers: [
-        {
-          type: ColumnHeaderType.VALUE,
-          name: 'value',
-          displayName: 'Value',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.RUN,
-          name: 'run',
-          displayName: 'Run',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.SMOOTHED,
-          name: 'smoothed',
-          displayName: 'Smoothed',
-          enabled: true,
-        },
-        {
-          type: ColumnHeaderType.STEP,
-          name: 'step',
-          displayName: 'Step',
-          enabled: true,
-        },
-      ],
-      data: [
-        {
-          id: 'someid',
-          run: 'run name',
-          value: 3,
-          step: 1,
-          smoothed: 2,
-        },
-      ],
-      smoothingEnabled: false,
-    });
-    fixture.detectChanges();
-    const headerElements = fixture.debugElement.queryAll(
-      By.directive(HeaderCellComponent)
-    );
-    const dataElements = fixture.debugElement.queryAll(By.css('.row > .col'));
-
-    // The color column in the header is currently hard coded in and is not a
-    // HeaderCellComponent.
-    expect(headerElements[0].nativeElement.innerText).toBe('Value');
-    expect(headerElements[1].nativeElement.innerText).toBe('Run');
-    expect(headerElements[2].nativeElement.innerText).toBe('Step');
-    expect(headerElements.length).toBe(3);
-
-    // The first header should always be blank as it is the run color column.
-    expect(dataElements[0].nativeElement.innerText).toBe('');
-    expect(dataElements[1].nativeElement.innerText).toBe('3');
-    expect(dataElements[2].nativeElement.innerText).toBe('run name');
-    expect(dataElements[3].nativeElement.innerText).toBe('1');
-    expect(dataElements.length).toBe(4);
   });
 });

--- a/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Motivation for features / changes
This is part of the effort to use the data table widget in the Runs table which will allow for lots of code reuse as we add HParam functionality to both tables. To allow more customization in each table this PR pulls all the table content out of the data_table_component and allows users to project it using the new content_row_component and content_cell_component.

## Technical description of changes
Created new content_row_component and content_cell_component. The row is extremely basic and basically just wraps the content inside a table-row. The content_cell_component take all the logic for formatting each cell. To customize the content users of this component can simply pass in no datum or a ColumnHeaderType that does not have a specified way to format in the getFormattedDataForColumn function and then put the custom content inside the cell as a child it will be projected in. This is currently shown in the way the ScalarCardDataTable handles the Color column.

## Screenshots of UI changes (or N/A)
This should result in no changes to the Scalar Data Table. However, the Runs Data Table is now empty as it has not implemented this new DataTable structure. It is behind a flag though and will be implemented in an upcoming PR.

<img width="398" alt="Screenshot 2023-06-09 at 2 24 42 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/28002f09-bc93-45a1-99d5-752e4f71b2ed">

## Detailed steps to verify changes work correctly (as executed by you)
Ran it and clicked around a lot to try breaking.

## Alternate designs / implementations considered (or N/A)
We considered some way to allow the data table to be highly configured instead of projecting the content.
I also considered not creating the content_row_component class and requiring parents to add their own div with class=table-row.
