### PR TITLE
Embedding Projector: Upload dialog example delimiter fix

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html.ts
@@ -479,15 +479,12 @@ export const template = html`
               <div class="data-step-contents-contents">
                 Example of 3 vectors with dimension 4:
                 <div class="code">
-                  0.1<span class="delimiter"> </span>0.2<span class="delimiter">
-                  </span
-                  >0.5<span class="delimiter"> </span>0.9<br />
-                  0.2<span class="delimiter"> </span>0.1<span class="delimiter">
-                  </span
-                  >5.0<span class="delimiter"> </span>0.2<br />
-                  0.4<span class="delimiter"> </span>0.1<span class="delimiter">
-                  </span
-                  >7.0<span class="delimiter"> </span>0.8
+                  0.1<span class="delimiter">&#92;t</span>0.2<span class="delimiter">&#92;t</span
+                  >0.5<span class="delimiter">&#92;t</span>0.9<br />
+                  0.2<span class="delimiter">&#92;t</span>0.1<span class="delimiter">&#92;t</span
+                  >5.0<span class="delimiter">&#92;t</span>0.2<br />
+                  0.4<span class="delimiter">&#92;t</span>0.1<span class="delimiter">&#92;t</span
+                  >7.0<span class="delimiter">&#92;t</span>0.8
                 </div>
               </div>
               <div class="data-step-contents-upload">
@@ -517,10 +514,10 @@ export const template = html`
                   parsed as column labels.</i
                 >
                 <div class="code">
-                  <b>Pokémon<span class="delimiter"> </span>Species</b><br />
-                  Wartortle<span class="delimiter"> </span>Turtle<br />
-                  Venusaur<span class="delimiter"> </span>Seed<br />
-                  Charmeleon<span class="delimiter"> </span>Flame
+                  <b>Pokémon<span class="delimiter">&#92;t</span>Species</b><br />
+                  Wartortle<span class="delimiter">&#92;t</span>Turtle<br />
+                  Venusaur<span class="delimiter">&#92;t</span>Seed<br />
+                  Charmeleon<span class="delimiter">&#92;t</span>Flame
                 </div>
               </div>
               <div class="data-step-contents-upload">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html.ts
@@ -479,11 +479,17 @@ export const template = html`
               <div class="data-step-contents-contents">
                 Example of 3 vectors with dimension 4:
                 <div class="code">
-                  0.1<span class="delimiter">&#92;t</span>0.2<span class="delimiter">&#92;t</span
+                  0.1<span class="delimiter">&#92;t</span>0.2<span
+                    class="delimiter"
+                    >&#92;t</span
                   >0.5<span class="delimiter">&#92;t</span>0.9<br />
-                  0.2<span class="delimiter">&#92;t</span>0.1<span class="delimiter">&#92;t</span
+                  0.2<span class="delimiter">&#92;t</span>0.1<span
+                    class="delimiter"
+                    >&#92;t</span
                   >5.0<span class="delimiter">&#92;t</span>0.2<br />
-                  0.4<span class="delimiter">&#92;t</span>0.1<span class="delimiter">&#92;t</span
+                  0.4<span class="delimiter">&#92;t</span>0.1<span
+                    class="delimiter"
+                    >&#92;t</span
                   >7.0<span class="delimiter">&#92;t</span>0.8
                 </div>
               </div>
@@ -514,7 +520,8 @@ export const template = html`
                   parsed as column labels.</i
                 >
                 <div class="code">
-                  <b>Pokémon<span class="delimiter">&#92;t</span>Species</b><br />
+                  <b>Pokémon<span class="delimiter">&#92;t</span>Species</b
+                  ><br />
                   Wartortle<span class="delimiter">&#92;t</span>Turtle<br />
                   Venusaur<span class="delimiter">&#92;t</span>Seed<br />
                   Charmeleon<span class="delimiter">&#92;t</span>Flame


### PR DESCRIPTION
## Motivation for features / changes
The delimiter got lost compared to projector.tensorflow.org

## Technical description of changes
In the upload dialog example, show tab delimiters correctly

## Screenshots of UI changes (or N/A)
![image](https://github.com/tensorflow/tensorboard/assets/31378877/50189639-9cec-469c-b13d-44b61d26ce05)


## Detailed steps to verify changes work correctly (as executed by you)
Click on Upload to see this

## Alternate designs / implementations considered (or N/A)
