### PR TITLE
Embedded Single Card View: add card route type

### DIFF
--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -178,6 +178,7 @@ export function getDeepLinkGroup(routeKind: RouteKind): DeepLinkGroup | null {
     case RouteKind.COMPARE_EXPERIMENT:
       return DeepLinkGroup.DASHBOARD;
     case RouteKind.UNKNOWN:
+    case RouteKind.CARD:
     case RouteKind.NOT_SET:
       return null;
   }

--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -175,10 +175,10 @@ export function getDeepLinkGroup(routeKind: RouteKind): DeepLinkGroup | null {
     case RouteKind.EXPERIMENTS:
       return DeepLinkGroup.EXPERIMENTS;
     case RouteKind.EXPERIMENT:
+    case RouteKind.CARD:
     case RouteKind.COMPARE_EXPERIMENT:
       return DeepLinkGroup.DASHBOARD;
     case RouteKind.UNKNOWN:
-    case RouteKind.CARD:
     case RouteKind.NOT_SET:
       return null;
   }

--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -31,6 +31,7 @@ export enum RouteKind {
   EXPERIMENTS,
   EXPERIMENT,
   COMPARE_EXPERIMENT,
+  CARD,
   // Router has not yet bootstrapped and RouteKind is not set yet.
   // Temporary enum values until we can remove special cases in core_effects to
   // handle TensorBoard applications with no routes defined.


### PR DESCRIPTION
## Motivation for features / changes
Adds a new route which will be used later for internal embedded card project.
Googlers, please see cl/540654482 for the internal route CL.

## Technical description of changes
This change adds a new route type CARD. 
