### PR TITLE
HParam: Implement new Data Table projection architecture in Runs Table

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -124,6 +124,7 @@ tf_ts_library(
     testonly = True,
     srcs = [
         "regex_edit_dialog_test.ts",
+        "runs_data_table_test.ts",
         "runs_table_test.ts",
     ],
     deps = [

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -31,6 +31,12 @@ tf_sass_binary(
     deps = ["//tensorboard/webapp/theme"],
 )
 
+tf_sass_binary(
+    name = "runs_data_table_styles",
+    src = "runs_data_table.scss",
+    strict_deps = False,
+)
+
 tf_ts_library(
     name = "types",
     srcs = [
@@ -48,6 +54,7 @@ tf_ng_module(
     srcs = [
         "regex_edit_dialog_component.ts",
         "regex_edit_dialog_container.ts",
+        "runs_data_table.ts",
         "runs_group_menu_button_component.ts",
         "runs_group_menu_button_container.ts",
         "runs_table_component.ts",
@@ -56,9 +63,11 @@ tf_ng_module(
     ],
     assets = [
         ":regex_edit_dialog_styles",
+        ":runs_data_table_styles",
         ":runs_group_menu_button_styles",
         ":runs_table_styles",
         "regex_edit_dialog.ng.html",
+        "runs_data_table.ng.html",
         "runs_table_component.ng.html",
         "runs_group_menu_button_component.ng.html",
     ],

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -1,0 +1,56 @@
+<!--
+@license
+Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<tb-data-table
+  [headers]="headers"
+  [sortingInfo]="sortingInfo"
+  [columnCustomizationEnabled]="true"
+  (sortDataBy)="sortDataBy.emit($event)"
+  (orderColumns)="orderColumns.emit($event)"
+>
+  <ng-container header>
+    <ng-container *ngFor="let header of getHeaders()">
+      <tb-data-table-header-cell
+        *ngIf="header.enabled"
+        [header]="header"
+        [sortingInfo]="sortingInfo"
+        [hparamsEnabled]="true"
+        [controlsEnabled]="header.type !== ColumnHeaderType.COLOR"
+      ></tb-data-table-header-cell> </ng-container
+  ></ng-container>
+
+  <ng-container content>
+    <ng-container *ngFor="let dataRow of data">
+      <tb-data-table-content-row>
+        <ng-container *ngFor="let header of getHeaders()">
+          <tb-data-table-content-cell
+            *ngIf="header.enabled"
+            [header]="header"
+            [datum]="dataRow[header.name]"
+          >
+            <div
+              *ngIf="header.type === ColumnHeaderType.COLOR"
+              class="row-circle"
+            >
+              <span [style.backgroundColor]="dataRow['color']"></span>
+            </div>
+          </tb-data-table-content-cell>
+        </ng-container>
+      </tb-data-table-content-row>
+    </ng-container>
+  </ng-container>
+</tb-data-table>

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -1,0 +1,28 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+$_circle-size: 12px;
+
+.row-circle {
+  height: $_circle-size;
+  width: $_circle-size;
+}
+.row-circle > span {
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  display: inline-block;
+  height: $_circle-size - 2px; // size minus border
+  width: $_circle-size - 2px; // size minus border
+  vertical-align: middle;
+}

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -1,4 +1,4 @@
-/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -1,0 +1,55 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import {
+  ColumnHeader,
+  TableData,
+  SortingInfo,
+  ColumnHeaderType,
+} from '../../../widgets/data_table/types';
+
+@Component({
+  selector: 'runs-data-table',
+  templateUrl: 'runs_data_table.ng.html',
+  styleUrls: ['runs_data_table.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RunsDataTable {
+  @Input() headers!: ColumnHeader[];
+  @Input() data!: TableData[];
+  @Input() sortingInfo!: SortingInfo;
+
+  ColumnHeaderType = ColumnHeaderType;
+
+  @Output() sortDataBy = new EventEmitter<SortingInfo>();
+  @Output() orderColumns = new EventEmitter<ColumnHeader[]>();
+
+  getHeaders() {
+    return this.headers.concat([
+      {
+        name: 'color',
+        displayName: '',
+        type: ColumnHeaderType.COLOR,
+        enabled: true,
+      },
+    ]);
+  }
+}

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class TestableComponent {
   @Input() sortingInfo!: SortingInfo;
 }
 
-fdescribe('runs_data_table', () => {
+describe('runs_data_table', () => {
   function createComponent(input: {
     data?: TableData[];
     headers?: ColumnHeader[];

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
@@ -1,0 +1,152 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, Input, ViewChild} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {RunsDataTable} from './runs_data_table';
+import {DataTableModule} from '../../../widgets/data_table/data_table_module';
+import {MatIconTestingModule} from '../../../testing/mat_icon_module';
+import {
+  SortingOrder,
+  SortingInfo,
+  TableData,
+  ColumnHeader,
+  ColumnHeaderType,
+} from '../../../widgets/data_table/types';
+import {By} from '@angular/platform-browser';
+import {HeaderCellComponent} from '../../../widgets/data_table/header_cell_component';
+import {DataTableComponent} from '../../../widgets/data_table/data_table_component';
+import {ContentCellComponent} from '../../../widgets/data_table/content_cell_component';
+
+@Component({
+  selector: 'testable-comp',
+  template: `
+    <runs-data-table
+      [data]="data"
+      [headers]="headers"
+      [sortingInfo]="sortingInfo"
+      (sortDataBy)="sortDataBy($event)"
+      (orderColumns)="orderColumns($event)"
+    ></runs-data-table>
+  `,
+})
+class TestableComponent {
+  @ViewChild('RunsDataTable')
+  dataTable!: RunsDataTable;
+
+  @Input() headers!: ColumnHeader[];
+  @Input() data!: TableData[];
+  @Input() sortingInfo!: SortingInfo;
+}
+
+fdescribe('runs_data_table', () => {
+  function createComponent(input: {
+    data?: TableData[];
+    headers?: ColumnHeader[];
+    sortingInfo?: SortingInfo;
+  }) {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.componentInstance.data = input.data || [
+      {id: 'runid', run: 'run name'},
+    ];
+
+    fixture.componentInstance.headers = input.headers || [
+      {
+        name: 'run',
+        type: ColumnHeaderType.RUN,
+        displayName: 'Run',
+        enabled: true,
+      },
+      {
+        name: 'disabled_header',
+        type: ColumnHeaderType.MAX_VALUE,
+        displayName: 'disabled',
+        enabled: false,
+      },
+      {
+        name: 'other_header',
+        type: ColumnHeaderType.HPARAM,
+        displayName: 'Display This',
+        enabled: true,
+      },
+    ];
+
+    fixture.componentInstance.sortingInfo = input.sortingInfo || {
+      name: 'test',
+      order: SortingOrder.ASCENDING,
+    };
+
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DataTableModule, MatIconTestingModule],
+      declarations: [TestableComponent, RunsDataTable],
+      //   schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  });
+
+  it('renders', () => {
+    const fixture = createComponent({});
+    expect(
+      fixture.debugElement.query(By.directive(RunsDataTable))
+    ).toBeTruthy();
+  });
+
+  it('projects enabled headers plus color column', () => {
+    const fixture = createComponent({});
+    const dataTable = fixture.debugElement.query(
+      By.directive(DataTableComponent)
+    );
+    const headers = dataTable.queryAll(By.directive(HeaderCellComponent));
+
+    expect(headers.length).toBe(3);
+    expect(headers[0].componentInstance.header.name).toEqual('run');
+    expect(headers[1].componentInstance.header.name).toEqual('other_header');
+    expect(headers[2].componentInstance.header.name).toEqual('color');
+  });
+
+  it('projects content for each enabled header and color column', () => {
+    const fixture = createComponent({
+      data: [{id: 'runid', run: 'run name', color: 'red', other_header: 'foo'}],
+    });
+    const dataTable = fixture.debugElement.query(
+      By.directive(DataTableComponent)
+    );
+    const cells = dataTable.queryAll(By.directive(ContentCellComponent));
+
+    expect(cells.length).toBe(3);
+    expect(cells[0].componentInstance.header.name).toEqual('run');
+    expect(cells[1].componentInstance.header.name).toEqual('other_header');
+    expect(cells[2].componentInstance.header.name).toEqual('color');
+  });
+
+  it('disables controls for color header', () => {
+    const fixture = createComponent({});
+
+    const dataTable = fixture.debugElement.query(
+      By.directive(DataTableComponent)
+    );
+    const headers = dataTable.queryAll(By.directive(HeaderCellComponent));
+
+    const colorHeader = headers.find(
+      (h) => h.componentInstance.header.name === 'color'
+    )!;
+
+    expect(colorHeader.componentInstance.controlsEnabled).toBe(false);
+  });
+});

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
@@ -96,7 +96,6 @@ describe('runs_data_table', () => {
     await TestBed.configureTestingModule({
       imports: [DataTableModule, MatIconTestingModule],
       declarations: [TestableComponent, RunsDataTable],
-      //   schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -237,8 +237,6 @@ function matchFilter(
       [headers]="runsColumns$ | async"
       [data]="allRunsTableData$ | async"
       [sortingInfo]="sortingInfo$ | async"
-      columnCustomizationEnabled="true"
-      smoothingEnabled="false"
       (sortDataBy)="sortDataBy($event)"
       (orderColumns)="orderColumns($event)"
     ></runs-data-table>
@@ -590,6 +588,7 @@ export class RunsTableContainer implements OnInit, OnDestroy {
             id: run.id,
             color: colorMap[run.id],
           };
+
           runsColumns.forEach((column) => {
             switch (column.type) {
               case ColumnHeaderType.RUN:

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -180,7 +180,7 @@ function matchFilter(
   }
   if (filter.type === DomainType.DISCRETE) {
     // (upcast to work around bad TypeScript libdefs)
-    const values: Readonly<Array<(typeof filter.filterValues)[number]>> =
+    const values: Readonly<Array<typeof filter.filterValues[number]>> =
       filter.filterValues;
     return values.includes(value);
   } else if (filter.type === DomainType.INTERVAL) {
@@ -588,7 +588,6 @@ export class RunsTableContainer implements OnInit, OnDestroy {
             id: run.id,
             color: colorMap[run.id],
           };
-
           runsColumns.forEach((column) => {
             switch (column.type) {
               case ColumnHeaderType.RUN:

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -180,7 +180,7 @@ function matchFilter(
   }
   if (filter.type === DomainType.DISCRETE) {
     // (upcast to work around bad TypeScript libdefs)
-    const values: Readonly<Array<typeof filter.filterValues[number]>> =
+    const values: Readonly<Array<(typeof filter.filterValues)[number]>> =
       filter.filterValues;
     return values.includes(value);
   } else if (filter.type === DomainType.INTERVAL) {
@@ -232,7 +232,7 @@ function matchFilter(
       (onHparamDiscreteFilterChanged)="onHparamDiscreteFilterChanged($event)"
       (onMetricFilterChanged)="onMetricFilterChanged($event)"
     ></runs-table-component>
-    <tb-data-table
+    <runs-data-table
       *ngIf="HParamsEnabled.value"
       [headers]="runsColumns$ | async"
       [data]="allRunsTableData$ | async"
@@ -241,7 +241,7 @@ function matchFilter(
       smoothingEnabled="false"
       (sortDataBy)="sortDataBy($event)"
       (orderColumns)="orderColumns($event)"
-    ></tb-data-table>
+    ></runs-data-table>
   `,
   host: {
     '[class.flex-layout]': 'useFlexibleLayout',

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_module.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_module.ts
@@ -39,6 +39,7 @@ import {RegexEditDialogComponent} from './regex_edit_dialog_component';
 import {RegexEditDialogContainer} from './regex_edit_dialog_container';
 import {RunsGroupMenuButtonComponent} from './runs_group_menu_button_component';
 import {RunsGroupMenuButtonContainer} from './runs_group_menu_button_container';
+import {RunsDataTable} from './runs_data_table';
 import {RunsTableComponent} from './runs_table_component';
 import {RunsTableContainer} from './runs_table_container';
 
@@ -68,6 +69,7 @@ import {RunsTableContainer} from './runs_table_container';
   declarations: [
     RegexEditDialogComponent,
     RegexEditDialogContainer,
+    RunsDataTable,
     RunsGroupMenuButtonComponent,
     RunsGroupMenuButtonContainer,
     RunsTableComponent,

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -81,8 +81,6 @@ import {MatIconTestingModule} from '../../../testing/mat_icon_module';
 import {provideMockTbStore} from '../../../testing/utils';
 import {DataLoadState} from '../../../types/data';
 import {SortDirection} from '../../../types/ui';
-import {DataTableModule} from '../../../widgets/data_table/data_table_module';
-import {DataTableComponent} from '../../../widgets/data_table/data_table_component';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
 import {FilterInputModule} from '../../../widgets/filter_input/filter_input_module';
 import {RangeInputModule} from '../../../widgets/range_input/range_input_module';
@@ -101,6 +99,7 @@ import {DomainType} from '../../data_source/runs_data_source_types';
 import {MAX_NUM_RUNS_TO_ENABLE_BY_DEFAULT, Run} from '../../store/runs_types';
 import {buildRun} from '../../store/testing';
 import {GroupByKey, SortType} from '../../types';
+import {RunsDataTable} from './runs_data_table';
 import {RunsGroupMenuButtonComponent} from './runs_group_menu_button_component';
 import {RunsGroupMenuButtonContainer} from './runs_group_menu_button_container';
 import {RunsTableComponent} from './runs_table_component';
@@ -245,9 +244,9 @@ describe('runs_table', () => {
         FilterInputModule,
         RangeInputModule,
         ExperimentAliasModule,
-        DataTableModule,
       ],
       declarations: [
+        RunsDataTable,
         RunsGroupMenuButtonComponent,
         RunsGroupMenuButtonContainer,
         RunsTableComponent,
@@ -3188,105 +3187,100 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       expect(
-        fixture.debugElement.query(By.directive(DataTableComponent))
+        fixture.debugElement.query(By.directive(RunsDataTable))
       ).toBeTruthy();
       expect(
         fixture.nativeElement.querySelector('runs-table-component')
       ).toBeFalsy();
     });
 
-    // Currently nothing is passed to the data table from the runs table. This
-    // is because of a data table refactor.
-    // TODO(JamesHollyer): reenable and fix tests once runs table implements new
-    // data table structure.
+    it('passes run name and color to data table', () => {
+      // To make sure we only return the runs when called with the right props.
+      const selectSpy = spyOn(store, 'select').and.callThrough();
+      selectSpy
+        .withArgs(getRuns, {experimentId: 'book'})
+        .and.returnValue(
+          of([
+            buildRun({id: 'book1', name: "The Philosopher's Stone"}),
+            buildRun({id: 'book2', name: 'The Chamber Of Secrets'}),
+          ])
+        );
+      selectSpy.withArgs(getRunsTableHeaders).and.returnValue(
+        of([
+          {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
+        ])
+      );
 
-    // it('passes run name and color to data table', () => {
-    //   // To make sure we only return the runs when called with the right props.
-    //   const selectSpy = spyOn(store, 'select').and.callThrough();
-    //   selectSpy
-    //     .withArgs(getRuns, {experimentId: 'book'})
-    //     .and.returnValue(
-    //       of([
-    //         buildRun({id: 'book1', name: "The Philosopher's Stone"}),
-    //         buildRun({id: 'book2', name: 'The Chamber Of Secrets'}),
-    //       ])
-    //     );
-    //   selectSpy.withArgs(getRunsTableHeaders).and.returnValue(
-    //     of([
-    //       {
-    //         type: ColumnHeaderType.RUN,
-    //         name: 'run',
-    //         displayName: 'Run',
-    //         enabled: true,
-    //       },
-    //     ])
-    //   );
+      store.overrideSelector(getRunColorMap, {
+        book1: '#000',
+        book2: '#111',
+      });
 
-    //   store.overrideSelector(getRunColorMap, {
-    //     book1: '#000',
-    //     book2: '#111',
-    //   });
+      const fixture = createComponent(['book']);
+      fixture.detectChanges();
+      const runsDataTable = fixture.debugElement.query(
+        By.directive(RunsDataTable)
+      );
 
-    //   const fixture = createComponent(['book']);
-    //   fixture.detectChanges();
-    //   const dataTableComponent = fixture.debugElement.query(
-    //     By.directive(DataTableComponent)
-    //   );
+      expect(runsDataTable.componentInstance.data).toEqual([
+        {id: 'book1', color: '#000', run: "The Philosopher's Stone"},
+        {id: 'book2', color: '#111', run: 'The Chamber Of Secrets'},
+      ]);
+    });
 
-    //   expect(dataTableComponent.componentInstance.data).toEqual([
-    //     {id: 'book1', color: '#000', run: "The Philosopher's Stone"},
-    //     {id: 'book2', color: '#111', run: 'The Chamber Of Secrets'},
-    //   ]);
-    // });
+    it('passes hparam values to data table', () => {
+      const run1 = buildRun({id: 'book1', name: "The Philosopher's Stone"});
+      const run2 = buildRun({id: 'book2', name: 'The Chamber Of Secrets'});
+      // To make sure we only return the runs when called with the right props.
+      const selectSpy = spyOn(store, 'select').and.callThrough();
+      selectSpy
+        .withArgs(getRuns, {experimentId: 'book'})
+        .and.returnValue(of([run1, run2]));
 
-    // it('passes hparam values to data table', () => {
-    //   const run1 = buildRun({id: 'book1', name: "The Philosopher's Stone"});
-    //   const run2 = buildRun({id: 'book2', name: 'The Chamber Of Secrets'});
-    //   // To make sure we only return the runs when called with the right props.
-    //   const selectSpy = spyOn(store, 'select').and.callThrough();
-    //   selectSpy
-    //     .withArgs(getRuns, {experimentId: 'book'})
-    //     .and.returnValue(of([run1, run2]));
+      selectSpy.withArgs(getRunsTableHeaders).and.returnValue(
+        of([
+          {
+            type: ColumnHeaderType.HPARAM,
+            name: 'batch_size',
+            displayName: 'Batch Size',
+            enabled: true,
+          },
+        ])
+      );
 
-    //   selectSpy.withArgs(getRunsTableHeaders).and.returnValue(
-    //     of([
-    //       {
-    //         type: ColumnHeaderType.HPARAM,
-    //         name: 'batch_size',
-    //         displayName: 'Batch Size',
-    //         enabled: true,
-    //       },
-    //     ])
-    //   );
+      selectSpy.withArgs(getFilteredRenderableRunsFromRoute).and.returnValue(
+        of([
+          {
+            run: run1,
+            hparams: new Map([['batch_size', 1]]),
+          } as RunTableItem,
+          {
+            run: run2,
+            hparams: new Map([['batch_size', 2]]),
+          } as RunTableItem,
+        ])
+      );
 
-    //   selectSpy.withArgs(getFilteredRenderableRunsFromRoute).and.returnValue(
-    //     of([
-    //       {
-    //         run: run1,
-    //         hparams: new Map([['batch_size', 1]]),
-    //       } as RunTableItem,
-    //       {
-    //         run: run2,
-    //         hparams: new Map([['batch_size', 2]]),
-    //       } as RunTableItem,
-    //     ])
-    //   );
+      store.overrideSelector(getRunColorMap, {
+        book1: '#000',
+        book2: '#111',
+      });
 
-    //   store.overrideSelector(getRunColorMap, {
-    //     book1: '#000',
-    //     book2: '#111',
-    //   });
+      const fixture = createComponent(['book']);
+      fixture.detectChanges();
+      const runsDataTable = fixture.debugElement.query(
+        By.directive(RunsDataTable)
+      );
 
-    //   const fixture = createComponent(['book']);
-    //   fixture.detectChanges();
-    //   const dataTableComponent = fixture.debugElement.query(
-    //     By.directive(DataTableComponent)
-    //   );
-
-    //   expect(dataTableComponent.componentInstance.data).toEqual([
-    //     {id: 'book1', color: '#000', batch_size: 1},
-    //     {id: 'book2', color: '#111', batch_size: 2},
-    //   ]);
-    // });
+      expect(runsDataTable.componentInstance.data).toEqual([
+        {id: 'book1', color: '#000', batch_size: 1},
+        {id: 'book2', color: '#111', batch_size: 2},
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## Motivation for features / changes
We preparation for adding HParam functionality to both the Scalar Table and the Runs Table we have refactored the Data Table to be more flexible. This refactoring was done in #6422 and #6427 and was only implemented in the Scalar Table because the Runs Table only uses the Data Table behind a flag. This PR implements the new Data Table Structure in the Runs Table.

## Technical description of changes
Basically just followed the same structure as the Scalar Table.

## Screenshots of UI changes (or N/A)
Runs Table specific styling still needs to be done. It currently looks like this.
<img width="392" alt="Screenshot 2023-06-15 at 7 21 46 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/2dd13003-ad93-4b66-89eb-579a497d6708">


We still need to add a column for check boxes and add styling. 