### PR TITLE
HParams: Add selected checkbox column to Runs table

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -302,7 +302,9 @@ export class ScalarCardDataTable {
   }
 }
 
-function makeValueSortable(value: number | string | null | undefined) {
+function makeValueSortable(
+  value: number | string | boolean | null | undefined
+) {
   if (
     Number.isNaN(value) ||
     value === 'NaN' ||

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -29,8 +29,16 @@ limitations under the License.
         [header]="header"
         [sortingInfo]="sortingInfo"
         [hparamsEnabled]="true"
-        [controlsEnabled]="header.type !== ColumnHeaderType.COLOR"
-      ></tb-data-table-header-cell> </ng-container
+        [controlsEnabled]="header.type !== ColumnHeaderType.COLOR && header.type !== ColumnHeaderType.CUSTOM"
+      >
+        <div *ngIf="header.name === 'selected'">
+          <mat-checkbox
+            [checked]="allRowsSelected()"
+            [indeterminate]="!allRowsSelected() && someRowsSelected()"
+            (click)="onAllSelectionToggle.emit(getRunIds())"
+          ></mat-checkbox>
+        </div>
+      </tb-data-table-header-cell> </ng-container
   ></ng-container>
 
   <ng-container content>
@@ -42,12 +50,17 @@ limitations under the License.
             [header]="header"
             [datum]="dataRow[header.name]"
           >
-            <div
-              *ngIf="header.type === ColumnHeaderType.COLOR"
-              class="row-circle"
-            >
-              <span [style.backgroundColor]="dataRow['color']"></span>
-            </div>
+            <ng-container [ngSwitch]="header.name">
+              <div *ngSwitchCase="'color'" class="row-circle">
+                <span [style.backgroundColor]="dataRow['color']"></span>
+              </div>
+              <div *ngSwitchCase="'selected'">
+                <mat-checkbox
+                  [checked]="dataRow['selected']"
+                  (change)="onSelectionToggle.emit(dataRow.id)"
+                ></mat-checkbox>
+              </div>
+            </ng-container>
           </tb-data-table-content-cell>
         </ng-container>
       </tb-data-table-content-row>

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -41,15 +41,38 @@ export class RunsDataTable {
 
   @Output() sortDataBy = new EventEmitter<SortingInfo>();
   @Output() orderColumns = new EventEmitter<ColumnHeader[]>();
+  @Output() onSelectionToggle = new EventEmitter<string>();
+  @Output() onAllSelectionToggle = new EventEmitter<string[]>();
 
   getHeaders() {
-    return this.headers.concat([
+    return [
       {
-        name: 'color',
+        name: 'selected',
         displayName: '',
-        type: ColumnHeaderType.COLOR,
+        type: ColumnHeaderType.CUSTOM,
         enabled: true,
       },
-    ]);
+    ].concat(
+      this.headers.concat([
+        {
+          name: 'color',
+          displayName: '',
+          type: ColumnHeaderType.COLOR,
+          enabled: true,
+        },
+      ])
+    );
+  }
+
+  getRunIds() {
+    return this.data.map((row) => row.id);
+  }
+
+  allRowsSelected() {
+    return this.data.every((row) => row.selected);
+  }
+
+  someRowsSelected() {
+    return this.data.some((row) => row.selected);
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -590,7 +590,7 @@ export class RunsTableContainer implements OnInit, OnDestroy {
           const tableData: TableData = {
             id: run.id,
             color: colorMap[run.id],
-            selected: (selectionMap && selectionMap.get(run.id)) ?? false,
+            selected: Boolean(selectionMap?.get(run.id)),
           };
 
           runsColumns.forEach((column) => {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -221,7 +221,7 @@ function matchFilter(
       [regexFilter]="regexFilter$ | async"
       [sortOption]="sortOption$ | async"
       [usePagination]="usePagination"
-      (onSelectionToggle)="onRunSelectionToggle($event)"
+      (onSelectionToggle)="onRunItemSelectionToggle($event)"
       (onSelectionDblClick)="onRunSelectionDblClick($event)"
       (onPageSelectionToggle)="onPageSelectionToggle($event)"
       (onPaginationChange)="onPaginationChange($event)"
@@ -239,6 +239,8 @@ function matchFilter(
       [sortingInfo]="sortingInfo$ | async"
       (sortDataBy)="sortDataBy($event)"
       (orderColumns)="orderColumns($event)"
+      (onSelectionToggle)="onRunSelectionToggle($event)"
+      (onAllSelectionToggle)="onAllSelectionToggle($event)"
     ></runs-data-table>
   `,
   host: {
@@ -579,15 +581,18 @@ export class RunsTableContainer implements OnInit, OnDestroy {
     return combineLatest([
       this.store.select(getRuns, {experimentId}),
       this.store.select(getRunColorMap),
+      this.store.select(getCurrentRouteRunSelection),
       this.runsColumns$,
       this.runToHParamValues$,
     ]).pipe(
-      map(([runs, colorMap, runsColumns, runToHParamValues]) => {
+      map(([runs, colorMap, selectionMap, runsColumns, runToHParamValues]) => {
         return runs.map((run) => {
           const tableData: TableData = {
             id: run.id,
             color: colorMap[run.id],
+            selected: (selectionMap && selectionMap.get(run.id)) ?? false,
           };
+
           runsColumns.forEach((column) => {
             switch (column.type) {
               case ColumnHeaderType.RUN:
@@ -646,10 +651,18 @@ export class RunsTableContainer implements OnInit, OnDestroy {
     );
   }
 
-  onRunSelectionToggle(item: RunTableItem) {
+  onRunItemSelectionToggle(item: RunTableItem) {
     this.store.dispatch(
       runSelectionToggled({
         runId: item.run.id,
+      })
+    );
+  }
+
+  onRunSelectionToggle(id: string) {
+    this.store.dispatch(
+      runSelectionToggled({
+        runId: id,
       })
     );
   }
@@ -670,6 +683,14 @@ export class RunsTableContainer implements OnInit, OnDestroy {
     this.store.dispatch(
       singleRunSelected({
         runId: item.run.id,
+      })
+    );
+  }
+
+  onAllSelectionToggle(runIds: string[]) {
+    this.store.dispatch(
+      runPageSelectionToggled({
+        runIds,
       })
     );
   }

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -3194,7 +3194,7 @@ describe('runs_table', () => {
       ).toBeFalsy();
     });
 
-    it('passes run name and color to data table', () => {
+    it('passes run name, selected value, and color to data table', () => {
       // To make sure we only return the runs when called with the right props.
       const selectSpy = spyOn(store, 'select').and.callThrough();
       selectSpy
@@ -3221,6 +3221,8 @@ describe('runs_table', () => {
         book2: '#111',
       });
 
+      store.overrideSelector(getCurrentRouteRunSelection, new Map([['book1', true], ['book2', false]]));
+
       const fixture = createComponent(['book']);
       fixture.detectChanges();
       const runsDataTable = fixture.debugElement.query(
@@ -3228,9 +3230,31 @@ describe('runs_table', () => {
       );
 
       expect(runsDataTable.componentInstance.data).toEqual([
-        {id: 'book1', color: '#000', run: "The Philosopher's Stone"},
-        {id: 'book2', color: '#111', run: 'The Chamber Of Secrets'},
+        {id: 'book1', color: '#000', run: "The Philosopher's Stone", selected: true},
+        {id: 'book2', color: '#111', run: 'The Chamber Of Secrets', selected: false},
       ]);
+    });
+
+    it('passes selected value of false if run is not in selectionMap', () => {
+      // To make sure we only return the runs when called with the right props.
+      const selectSpy = spyOn(store, 'select').and.callThrough();
+      selectSpy
+        .withArgs(getRuns, {experimentId: 'book'})
+        .and.returnValue(
+          of([
+            buildRun({id: 'book1'}),
+          ])
+        );
+
+      store.overrideSelector(getCurrentRouteRunSelection, new Map([['otherbook', true]]));
+
+      const fixture = createComponent(['book']);
+      fixture.detectChanges();
+      const runsDataTable = fixture.debugElement.query(
+        By.directive(RunsDataTable)
+      );
+
+      expect(runsDataTable.componentInstance.data[0].selected).toEqual(false);
     });
 
     it('passes hparam values to data table', () => {
@@ -3277,10 +3301,8 @@ describe('runs_table', () => {
         By.directive(RunsDataTable)
       );
 
-      expect(runsDataTable.componentInstance.data).toEqual([
-        {id: 'book1', color: '#000', batch_size: 1},
-        {id: 'book2', color: '#111', batch_size: 2},
-      ]);
+      expect(runsDataTable.componentInstance.data[0].batch_size).toEqual(1);
+      expect(runsDataTable.componentInstance.data[1].batch_size).toEqual(2);
     });
   });
 });

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -3221,7 +3221,13 @@ describe('runs_table', () => {
         book2: '#111',
       });
 
-      store.overrideSelector(getCurrentRouteRunSelection, new Map([['book1', true], ['book2', false]]));
+      store.overrideSelector(
+        getCurrentRouteRunSelection,
+        new Map([
+          ['book1', true],
+          ['book2', false],
+        ])
+      );
 
       const fixture = createComponent(['book']);
       fixture.detectChanges();
@@ -3230,8 +3236,18 @@ describe('runs_table', () => {
       );
 
       expect(runsDataTable.componentInstance.data).toEqual([
-        {id: 'book1', color: '#000', run: "The Philosopher's Stone", selected: true},
-        {id: 'book2', color: '#111', run: 'The Chamber Of Secrets', selected: false},
+        {
+          id: 'book1',
+          color: '#000',
+          run: "The Philosopher's Stone",
+          selected: true,
+        },
+        {
+          id: 'book2',
+          color: '#111',
+          run: 'The Chamber Of Secrets',
+          selected: false,
+        },
       ]);
     });
 
@@ -3240,13 +3256,12 @@ describe('runs_table', () => {
       const selectSpy = spyOn(store, 'select').and.callThrough();
       selectSpy
         .withArgs(getRuns, {experimentId: 'book'})
-        .and.returnValue(
-          of([
-            buildRun({id: 'book1'}),
-          ])
-        );
+        .and.returnValue(of([buildRun({id: 'book1'})]));
 
-      store.overrideSelector(getCurrentRouteRunSelection, new Map([['otherbook', true]]));
+      store.overrideSelector(
+        getCurrentRouteRunSelection,
+        new Map([['otherbook', true]])
+      );
 
       const fixture = createComponent(['book']);
       fixture.detectChanges();

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -27,10 +27,6 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
     display: table-row;
   }
 
-  .col {
-    display: table-cell;
-  }
-
   .header {
     background-color: mat.get-color-from-palette($tb-background, background);
     position: sticky;

--- a/tensorboard/webapp/widgets/data_table/types.ts
+++ b/tensorboard/webapp/widgets/data_table/types.ts
@@ -39,6 +39,7 @@ export enum ColumnHeaderType {
   MEAN = 'MEAN',
   RAW_CHANGE = 'RAW_CHANGE',
   HPARAM = 'HPARAM',
+  CUSTOM = 'CUSTOM',
 }
 
 export interface ColumnHeader {
@@ -68,7 +69,7 @@ export interface SortingInfo {
  * DataTable. It will have a value for each required ColumnHeader for a given
  * run.
  */
-export type TableData = Record<string, string | number> & {
+export type TableData = Record<string, string | number | boolean> & {
   id: string;
 };
 


### PR DESCRIPTION
## Motivation for features / changes
In #6438 we rewrote the Runs Data Table to use the new projection Data Table structure(Created in #6427 and #6422). This allows us to project custom controls such as the run selection check boxes. This PR implements those checkboxes.

## Technical description of changes
Pretty straight forward use of projection. The weird part was that the projected checkbox in the header did not fire the "change" event while the header itself had a subscription to a "click" event for sorting. The solution was to subscribe to the "click" event and that seems to work just fine.

## Screenshots of UI changes (or N/A)
All selected:
<img width="230" alt="Screenshot 2023-06-20 at 2 40 19 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/164ab4c2-b2bd-47ad-b46d-9dbcf78c976a">
Some selected:
<img width="228" alt="Screenshot 2023-06-20 at 2 40 27 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/0822e363-ac08-45a3-9102-4c1959192c9f">
None selected:
<img width="211" alt="Screenshot 2023-06-20 at 2 40 35 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/9ce0b8aa-182d-4796-a59b-5e05fc655f2e">

