### PR TITLE
HParams: Add runs data table color controls

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -35,6 +35,10 @@ tf_sass_binary(
     name = "runs_data_table_styles",
     src = "runs_data_table.scss",
     strict_deps = False,
+    deps = [
+        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/theme",
+    ],
 )
 
 tf_ts_library(

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -31,13 +31,20 @@ limitations under the License.
         [hparamsEnabled]="true"
         [controlsEnabled]="header.type !== ColumnHeaderType.COLOR && header.type !== ColumnHeaderType.CUSTOM"
       >
-        <div *ngIf="header.name === 'selected'">
-          <mat-checkbox
-            [checked]="allRowsSelected()"
-            [indeterminate]="!allRowsSelected() && someRowsSelected()"
-            (click)="onAllSelectionToggle.emit(getRunIds())"
-          ></mat-checkbox>
-        </div>
+        <ng-container [ngSwitch]="header.name">
+          <div *ngSwitchCase="'selected'">
+            <mat-checkbox
+              [checked]="allRowsSelected()"
+              [indeterminate]="!allRowsSelected() && someRowsSelected()"
+              (click)="onAllSelectionToggle.emit(getRunIds())"
+            ></mat-checkbox>
+          </div>
+          <span *ngSwitchCase="'color'">
+            <runs-group-menu-button
+              [experimentIds]="experimentIds"
+            ></runs-group-menu-button>
+          </span>
+        </ng-container>
       </tb-data-table-header-cell> </ng-container
   ></ng-container>
 
@@ -50,28 +57,26 @@ limitations under the License.
             [header]="header"
             [datum]="dataRow[header.name]"
           >
-          <ng-container [ngSwitch]="header.name">
-            <span *ngSwitchCase="'color'">
+            <ng-container [ngSwitch]="header.name">
+              <span *ngSwitchCase="'color'" class="color-container">
                 <button
-                  [ngClass]="{'run-color-swatch': true}"
+                  class="run-color-swatch"
                   [style.background]="dataRow['color']"
                   [colorPicker]="dataRow['color']"
-                  [cpToggle]="true"
                   [cpDialogDisplay]="'popup'"
                   [cpPositionOffset]="-20"
                   [cpUseRootViewContainer]="true"
                   [cpOutputFormat]="'hex'"
-                  (colorPickerChange)="onRunColorChange.emit($event)"
-                  (click)="test()"
+                  (colorPickerChange)="onRunColorChange.emit({runId: dataRow.id, newColor: $event})"
                 ></button>
               </span>
-            <div *ngSwitchCase="'selected'">
-              <mat-checkbox
-                [checked]="dataRow['selected']"
-                (change)="onSelectionToggle.emit(dataRow.id)"
-              ></mat-checkbox>
-            </div>
-          </ng-container>
+              <div *ngSwitchCase="'selected'">
+                <mat-checkbox
+                  [checked]="dataRow['selected']"
+                  (change)="onSelectionToggle.emit(dataRow.id)"
+                ></mat-checkbox>
+              </div>
+            </ng-container>
           </tb-data-table-content-cell>
         </ng-container>
       </tb-data-table-content-row>

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -50,17 +50,28 @@ limitations under the License.
             [header]="header"
             [datum]="dataRow[header.name]"
           >
-            <ng-container [ngSwitch]="header.name">
-              <div *ngSwitchCase="'color'" class="row-circle">
-                <span [style.backgroundColor]="dataRow['color']"></span>
-              </div>
-              <div *ngSwitchCase="'selected'">
-                <mat-checkbox
-                  [checked]="dataRow['selected']"
-                  (change)="onSelectionToggle.emit(dataRow.id)"
-                ></mat-checkbox>
-              </div>
-            </ng-container>
+          <ng-container [ngSwitch]="header.name">
+            <span *ngSwitchCase="'color'">
+                <button
+                  [ngClass]="{'run-color-swatch': true}"
+                  [style.background]="dataRow['color']"
+                  [colorPicker]="dataRow['color']"
+                  [cpToggle]="true"
+                  [cpDialogDisplay]="'popup'"
+                  [cpPositionOffset]="-20"
+                  [cpUseRootViewContainer]="true"
+                  [cpOutputFormat]="'hex'"
+                  (colorPickerChange)="onRunColorChange.emit($event)"
+                  (click)="test()"
+                ></button>
+              </span>
+            <div *ngSwitchCase="'selected'">
+              <mat-checkbox
+                [checked]="dataRow['selected']"
+                (change)="onSelectionToggle.emit(dataRow.id)"
+              ></mat-checkbox>
+            </div>
+          </ng-container>
           </tb-data-table-content-cell>
         </ng-container>
       </tb-data-table-content-row>

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -14,32 +14,18 @@ limitations under the License.
 ==============================================================================*/
 @use '@angular/material' as mat;
 @import 'tensorboard/webapp/theme/tb_theme';
-$_circle-size: 12px;
+$_circle-size: 20px;
 
-.row-circle {
-  height: $_circle-size;
-  width: $_circle-size;
-}
-.row-circle > span {
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  display: inline-block;
-  height: $_circle-size - 2px; // size minus border
-  width: $_circle-size - 2px; // size minus border
-  vertical-align: middle;
+.color-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
 }
 
 .run-color-swatch {
-  $_swatch-size: 20px;
-
   border-radius: 100%;
   border: 1px solid mat.get-color-from-palette($tb-foreground, border);
   height: $_circle-size;
   width: $_circle-size;
   outline: none;
-
-  &.no-color {
-    border-color: mat.get-color-from-palette($tf-slate, 300);
-    border-width: 2px;
-  }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+@use '@angular/material' as mat;
+@import 'tensorboard/webapp/theme/tb_theme';
 $_circle-size: 12px;
 
 .row-circle {
@@ -25,4 +27,19 @@ $_circle-size: 12px;
   height: $_circle-size - 2px; // size minus border
   width: $_circle-size - 2px; // size minus border
   vertical-align: middle;
+}
+
+.run-color-swatch {
+  $_swatch-size: 20px;
+
+  border-radius: 100%;
+  border: 1px solid mat.get-color-from-palette($tb-foreground, border);
+  height: $_circle-size;
+  width: $_circle-size;
+  outline: none;
+
+  &.no-color {
+    border-color: mat.get-color-from-palette($tf-slate, 300);
+    border-width: 2px;
+  }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -36,6 +36,7 @@ export class RunsDataTable {
   @Input() headers!: ColumnHeader[];
   @Input() data!: TableData[];
   @Input() sortingInfo!: SortingInfo;
+  @Input() experimentIds!: string[];
 
   ColumnHeaderType = ColumnHeaderType;
 
@@ -43,25 +44,31 @@ export class RunsDataTable {
   @Output() orderColumns = new EventEmitter<ColumnHeader[]>();
   @Output() onSelectionToggle = new EventEmitter<string>();
   @Output() onAllSelectionToggle = new EventEmitter<string[]>();
+  @Output() onRunColorChange = new EventEmitter<{
+    runId: string;
+    newColor: string;
+  }>();
+
+  beforeColumns = [
+    {
+      name: 'selected',
+      displayName: '',
+      type: ColumnHeaderType.CUSTOM,
+      enabled: true,
+    },
+  ];
+
+  afterColumns = [
+    {
+      name: 'color',
+      displayName: '',
+      type: ColumnHeaderType.COLOR,
+      enabled: true,
+    },
+  ];
 
   getHeaders() {
-    return [
-      {
-        name: 'selected',
-        displayName: '',
-        type: ColumnHeaderType.CUSTOM,
-        enabled: true,
-      },
-    ].concat(
-      this.headers.concat([
-        {
-          name: 'color',
-          displayName: '',
-          type: ColumnHeaderType.COLOR,
-          enabled: true,
-        },
-      ])
-    );
+    return this.beforeColumns.concat(this.headers.concat(this.afterColumns));
   }
 
   getRunIds() {
@@ -74,13 +81,5 @@ export class RunsDataTable {
 
   someRowsSelected() {
     return this.data.some((row) => row.selected);
-  }
-
-  onRunColorChange(newColor: string) {
-    console.log('onRunColorChange')
-  }
-
-  test() {
-    console.log('clicked');
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -49,6 +49,9 @@ export class RunsDataTable {
     newColor: string;
   }>();
 
+  // These columns must be stored and reused to stop needless re-rendering of
+  // the content and headers in these columns. This has been known to cause
+  // problems with the controls in these columns, specifically the color picker.
   beforeColumns = [
     {
       name: 'selected',
@@ -68,7 +71,11 @@ export class RunsDataTable {
   ];
 
   getHeaders() {
-    return this.beforeColumns.concat(this.headers.concat(this.afterColumns));
+    return ([] as Array<ColumnHeader>).concat(
+      this.beforeColumns,
+      this.headers,
+      this.afterColumns
+    );
   }
 
   getRunIds() {

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -75,4 +75,12 @@ export class RunsDataTable {
   someRowsSelected() {
     return this.data.some((row) => row.selected);
   }
+
+  onRunColorChange(newColor: string) {
+    console.log('onRunColorChange')
+  }
+
+  test() {
+    console.log('clicked');
+  }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
@@ -200,8 +200,31 @@ describe('runs_data_table', () => {
         // This only tests that the button with the same class as the color
         // picker button is rendered. Technically there could be another button
         // with the same class here and it would still pass.
-        expect(cell.query(By.css('button .run-color-swatch'))).toBeFalsy();
+        expect(cell.query(By.css('button.run-color-swatch'))).toBeTruthy();
       });
+    });
+
+    // If the call to getHeaders produces a new color header on each call, then
+    // the content gets re-rendered when the color picker opens. This causes the
+    // color picker modal to close immediately. This test ensures that we keep
+    // the same reference to the color header and continue to use that reference
+    // instead of creating a new one on each call.
+    it('getHeaders does not produce new color header on each call', () => {
+      const fixture = createComponent({});
+
+      const runsDataTable = fixture.debugElement.query(
+        By.directive(RunsDataTable)
+      );
+
+      expect(
+        runsDataTable.componentInstance
+          .getHeaders()
+          .find((header: ColumnHeader) => header.name === 'color')
+      ).toBe(
+        runsDataTable.componentInstance
+          .getHeaders()
+          .find((header: ColumnHeader) => header.name === 'color')
+      );
     });
   });
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input, ViewChild} from '@angular/core';
+import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {RunsDataTable} from './runs_data_table';
 import {DataTableModule} from '../../../widgets/data_table/data_table_module';
@@ -110,6 +110,7 @@ describe('runs_data_table', () => {
     await TestBed.configureTestingModule({
       imports: [DataTableModule, MatIconTestingModule, MatCheckboxModule],
       declarations: [TestableComponent, RunsDataTable],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
 
@@ -150,19 +151,58 @@ describe('runs_data_table', () => {
     expect(cells[3].componentInstance.header.name).toEqual('color');
   });
 
-  it('disables controls for color header', () => {
-    const fixture = createComponent({});
+  describe('color column', () => {
+    it('disables controls for color header', () => {
+      const fixture = createComponent({});
 
-    const dataTable = fixture.debugElement.query(
-      By.directive(DataTableComponent)
-    );
-    const headers = dataTable.queryAll(By.directive(HeaderCellComponent));
+      const dataTable = fixture.debugElement.query(
+        By.directive(DataTableComponent)
+      );
+      const headers = dataTable.queryAll(By.directive(HeaderCellComponent));
 
-    const colorHeader = headers.find(
-      (h) => h.componentInstance.header.name === 'color'
-    )!;
+      const colorHeader = headers.find(
+        (h) => h.componentInstance.header.name === 'color'
+      )!;
 
-    expect(colorHeader.componentInstance.controlsEnabled).toBe(false);
+      expect(colorHeader.componentInstance.controlsEnabled).toBe(false);
+    });
+
+    it('renders group by control in color header', () => {
+      const fixture = createComponent({});
+
+      const dataTable = fixture.debugElement.query(
+        By.directive(DataTableComponent)
+      );
+      const headers = dataTable.queryAll(By.directive(HeaderCellComponent));
+
+      const colorHeader = headers.find(
+        (h) => h.componentInstance.header.name === 'color'
+      )!;
+
+      expect(colorHeader.query(By.css('runs-group-menu-button'))).toBeTruthy();
+    });
+
+    it('renders color picker button in color content cells', () => {
+      const fixture = createComponent({});
+
+      const dataTable = fixture.debugElement.query(
+        By.directive(DataTableComponent)
+      );
+      const cells = dataTable.queryAll(By.directive(ContentCellComponent));
+
+      const colorCells = cells.filter((cell) => {
+        return cell.componentInstance.header.name === 'color';
+      });
+
+      expect(colorCells.length).toBe(1);
+
+      colorCells.forEach((cell) => {
+        // This only tests that the button with the same class as the color
+        // picker button is rendered. Technically there could be another button
+        // with the same class here and it would still pass.
+        expect(cell.query(By.css('button .run-color-swatch'))).toBeFalsy();
+      });
+    });
   });
 
   it('disables controls for selected header', () => {
@@ -198,6 +238,8 @@ describe('runs_data_table', () => {
     });
 
     expect(selectedHeader.query(By.css('mat-checkbox'))).toBeTruthy();
+
+    expect(selectedContentCells.length).toBe(1);
     selectedContentCells.forEach((cell) => {
       expect(cell.query(By.css('mat-checkbox'))).toBeTruthy();
     });

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -237,10 +237,12 @@ function matchFilter(
       [headers]="runsColumns$ | async"
       [data]="allRunsTableData$ | async"
       [sortingInfo]="sortingInfo$ | async"
+      [experimentIds]="experimentIds"
       (sortDataBy)="sortDataBy($event)"
       (orderColumns)="orderColumns($event)"
       (onSelectionToggle)="onRunSelectionToggle($event)"
       (onAllSelectionToggle)="onAllSelectionToggle($event)"
+      (onRunColorChange)="onRunColorChange($event)"
     ></runs-data-table>
   `,
   host: {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -157,7 +157,7 @@ const Selector = {
   SELECT_ALL_ROW: '.select-all',
 };
 
-describe('runs_table', () => {
+fdescribe('runs_table', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;
   let overlayContainer: OverlayContainer;

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -157,7 +157,7 @@ const Selector = {
   SELECT_ALL_ROW: '.select-all',
 };
 
-fdescribe('runs_table', () => {
+describe('runs_table', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;
   let overlayContainer: OverlayContainer;


### PR DESCRIPTION
## Motivation for features / changes
We are trying to reach feature parity with the new RunsDataTable. This is a new table structure which will allow us to add many new custom columns and make the table more useful. This PR links up the color objects with the controls that were already there for the old runs table.

## Technical description of changes
Pretty straight forward copy of the old functionality in the RunsTableComponent.

## Screenshots of UI changes (or N/A)
<img width="487" alt="Screenshot 2023-06-22 at 5 10 27 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/b57bda37-2072-4788-9687-83ddcbf105e4">
<img width="394" alt="Screenshot 2023-06-22 at 5 10 18 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/517e9a8e-9267-4550-8f92-780060810f25">
