### PR TITLE
HParams: Update remove header to use header name

### DIFF
--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -100,7 +100,7 @@ export interface HeaderEditInfo {
 }
 
 export interface HeaderToggleInfo {
-  headerType: ColumnHeaderType;
+  header: ColumnHeader;
   cardId?: CardId;
   dataTableMode?: DataTableMode;
 }

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1375,7 +1375,7 @@ const reducer = createReducer(
   }),
   on(
     actions.dataTableColumnToggled,
-    (state, {dataTableMode, headerType, cardId}) => {
+    (state, {dataTableMode, header, cardId}) => {
       const {cardStateMap, rangeSelectionEnabled, linkedTimeEnabled} = state;
       const rangeEnabled = cardId
         ? cardRangeSelectionEnabled(
@@ -1391,7 +1391,7 @@ const reducer = createReducer(
         : state.singleSelectionHeaders;
 
       const currentToggledHeaderIndex = targetedHeaders.findIndex(
-        (element) => element.type === headerType
+        (element) => element.name === header.name
       );
 
       // If the header is being enabled it goes at the bottom of the currently

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -2034,7 +2034,12 @@ describe('metrics reducers', () => {
           beforeState,
           actions.dataTableColumnToggled({
             dataTableMode: DataTableMode.RANGE,
-            headerType: ColumnHeaderType.RUN,
+            header: {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: false,
+            },
           })
         );
 
@@ -2077,7 +2082,12 @@ describe('metrics reducers', () => {
           beforeState,
           actions.dataTableColumnToggled({
             dataTableMode: DataTableMode.RANGE,
-            headerType: ColumnHeaderType.MAX_VALUE,
+            header: {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: true,
+            },
           })
         );
 
@@ -2120,7 +2130,12 @@ describe('metrics reducers', () => {
           beforeState,
           actions.dataTableColumnToggled({
             dataTableMode: DataTableMode.RANGE,
-            headerType: ColumnHeaderType.MAX_VALUE,
+            header: {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: true,
+            },
           })
         );
 
@@ -2190,7 +2205,12 @@ describe('metrics reducers', () => {
           beforeState,
           actions.dataTableColumnToggled({
             dataTableMode: DataTableMode.SINGLE,
-            headerType: ColumnHeaderType.STEP,
+            header: {
+              type: ColumnHeaderType.STEP,
+              name: 'step',
+              displayName: 'Step',
+              enabled: false,
+            },
           })
         );
 
@@ -2269,7 +2289,12 @@ describe('metrics reducers', () => {
           beforeState,
           actions.dataTableColumnToggled({
             cardId: 'card1',
-            headerType: ColumnHeaderType.RUN,
+            header: {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
           })
         );
 
@@ -2292,7 +2317,12 @@ describe('metrics reducers', () => {
           beforeState,
           actions.dataTableColumnToggled({
             cardId: 'card1',
-            headerType: ColumnHeaderType.MAX_VALUE,
+            header: {
+              type: ColumnHeaderType.MAX_VALUE,
+              name: 'maxValue',
+              displayName: 'Max',
+              enabled: true,
+            },
           })
         );
 
@@ -2371,7 +2401,12 @@ describe('metrics reducers', () => {
           beforeState,
           actions.dataTableColumnToggled({
             cardId: 'card1',
-            headerType: ColumnHeaderType.STEP,
+            header: {
+              type: ColumnHeaderType.STEP,
+              name: 'step',
+              displayName: 'Step',
+              enabled: false,
+            },
           })
         );
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -203,7 +203,7 @@ limitations under the License.
       [hparamsEnabled]="hparamsEnabled"
       (sortDataBy)="sortDataBy($event)"
       (editColumnHeaders)="editColumnHeaders.emit($event)"
-      (removeColumn)="removeColumn($event)"
+      (removeColumn)="removeColumn.emit($event)"
     >
     </scalar-card-data-table>
   </div>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -44,12 +44,7 @@ import {
   TooltipDatum,
 } from '../../../widgets/line_chart_v2/types';
 import {CardState} from '../../store';
-import {
-  HeaderEditInfo,
-  HeaderToggleInfo,
-  TooltipSort,
-  XAxisType,
-} from '../../types';
+import {HeaderEditInfo, TooltipSort, XAxisType} from '../../types';
 import {
   MinMaxStep,
   ScalarCardDataSeries,
@@ -58,7 +53,6 @@ import {
 } from './scalar_card_types';
 import {
   ColumnHeader,
-  ColumnHeaderType,
   DataTableMode,
   SortingInfo,
   SortingOrder,
@@ -120,7 +114,7 @@ export class ScalarCardComponent<Downloader> {
   @Output() onDataTableSorting = new EventEmitter<SortingInfo>();
   @Output() editColumnHeaders = new EventEmitter<HeaderEditInfo>();
   @Output() openTableEditMenuToMode = new EventEmitter<DataTableMode>();
-  @Output() onRemoveColumn = new EventEmitter<HeaderToggleInfo>();
+  @Output() removeColumn = new EventEmitter<ColumnHeader>();
 
   @Output() onLineChartZoom = new EventEmitter<Extent | null>();
 
@@ -150,13 +144,6 @@ export class ScalarCardComponent<Downloader> {
   sortDataBy(sortingInfo: SortingInfo) {
     this.sortingInfo = sortingInfo;
     this.onDataTableSorting.emit(sortingInfo);
-  }
-
-  removeColumn(headerToggleInfo: HeaderToggleInfo) {
-    this.onRemoveColumn.emit({
-      headerType: headerToggleInfo.headerType,
-      cardId: this.cardId,
-    });
   }
 
   resetDomain() {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -196,7 +196,7 @@ function isMinMaxStepValid(minMax: MinMaxStep | undefined): boolean {
       (editColumnHeaders)="editColumnHeaders($event)"
       (onCardStateChanged)="onCardStateChanged($event)"
       (openTableEditMenuToMode)="openTableEditMenuToMode($event)"
-      (onRemoveColumn)="onRemoveColumn($event)"
+      (removeColumn)="onRemoveColumn($event)"
     ></scalar-card-component>
   `,
   styles: [
@@ -695,7 +695,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.store.dispatch(metricsSlideoutMenuOpened({mode: tableMode}));
   }
 
-  onRemoveColumn(headerToggleInfo: HeaderToggleInfo) {
-    this.store.dispatch(dataTableColumnToggled(headerToggleInfo));
+  onRemoveColumn(header: ColumnHeader) {
+    this.store.dispatch(dataTableColumnToggled({header, cardId: this.cardId}));
   }
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -4502,14 +4502,21 @@ describe('scalar card', () => {
         fixture.detectChanges();
 
         fixture.componentInstance.onRemoveColumn({
-          cardId: 'card1',
-          headerType: ColumnHeaderType.RUN,
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
         });
 
         expect(dispatchedActions).toEqual([
           dataTableColumnToggled({
             cardId: 'card1',
-            headerType: ColumnHeaderType.RUN,
+            header: {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
           }),
         ]);
       }));
@@ -4538,14 +4545,21 @@ describe('scalar card', () => {
         fixture.detectChanges();
 
         fixture.componentInstance.onRemoveColumn({
-          cardId: 'card1',
-          headerType: ColumnHeaderType.MIN_VALUE,
+          type: ColumnHeaderType.MIN_VALUE,
+          name: 'minValue',
+          displayName: 'Min Value',
+          enabled: true,
         });
 
         expect(dispatchedActions).toEqual([
           dataTableColumnToggled({
             cardId: 'card1',
-            headerType: ColumnHeaderType.MIN_VALUE,
+            header: {
+              type: ColumnHeaderType.MIN_VALUE,
+              name: 'minValue',
+              displayName: 'Min Value',
+              enabled: true,
+            },
           }),
         ]);
       }));

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_component.ts
@@ -46,9 +46,9 @@ const moveHeader = (
   return newHeaders;
 };
 
-const getIndexOfType = (type: ColumnHeaderType, headers: ColumnHeader[]) => {
+const getIndexOfColumn = (column: ColumnHeader, headers: ColumnHeader[]) => {
   return headers.findIndex((header) => {
-    return header.type === type;
+    return header.name === column.name;
   });
 };
 
@@ -65,8 +65,8 @@ enum Edge {
 })
 export class ScalarColumnEditorComponent implements OnDestroy {
   DataTableMode = DataTableMode;
-  draggingHeaderType: ColumnHeaderType | undefined;
-  highlightedHeaderType: ColumnHeaderType | undefined;
+  draggingHeader: ColumnHeader | undefined;
+  highlightedHeader: ColumnHeader | undefined;
   highlightEdge: Edge = Edge.TOP;
   @Input() rangeHeaders!: ColumnHeader[];
   @Input() singleHeaders!: ColumnHeader[];
@@ -78,7 +78,7 @@ export class ScalarColumnEditorComponent implements OnDestroy {
   }>();
   @Output() onScalarTableColumnToggled = new EventEmitter<{
     dataTableMode: DataTableMode;
-    headerType: ColumnHeaderType;
+    header: ColumnHeader;
   }>();
   @Output() onScalarTableColumnEditorClosed = new EventEmitter<void>();
   @Output() onTabChange = new EventEmitter<DataTableMode>();
@@ -99,25 +99,25 @@ export class ScalarColumnEditorComponent implements OnDestroy {
   }
 
   dragStart(header: ColumnHeader) {
-    this.draggingHeaderType = header.type;
+    this.draggingHeader = header;
     this.hostElement.nativeElement.addEventListener('dragover', preventDefault);
   }
 
   dragEnd(dataTableMode: DataTableMode) {
-    if (!this.draggingHeaderType || !this.highlightedHeaderType) {
+    if (!this.draggingHeader || !this.highlightedHeader) {
       return;
     }
     const headers = this.getHeadersForMode(dataTableMode);
     this.onScalarTableColumnEdit.emit({
       dataTableMode: dataTableMode,
       headers: moveHeader(
-        getIndexOfType(this.draggingHeaderType, headers),
-        getIndexOfType(this.highlightedHeaderType, headers),
+        getIndexOfColumn(this.draggingHeader, headers),
+        getIndexOfColumn(this.highlightedHeader, headers),
         headers
       ),
     });
-    this.draggingHeaderType = undefined;
-    this.highlightedHeaderType = undefined;
+    this.draggingHeader = undefined;
+    this.highlightedHeader = undefined;
     this.hostElement.nativeElement.removeEventListener(
       'dragover',
       preventDefault
@@ -125,33 +125,33 @@ export class ScalarColumnEditorComponent implements OnDestroy {
   }
 
   dragEnter(header: ColumnHeader, dataTableMode: DataTableMode) {
-    if (!this.draggingHeaderType) {
+    if (!this.draggingHeader) {
       return;
     }
 
     // Highlight the position which the dragging header will go when dropped.
     const headers = this.getHeadersForMode(dataTableMode);
     if (
-      getIndexOfType(header.type, headers) <
-      getIndexOfType(this.draggingHeaderType, headers)
+      getIndexOfColumn(header, headers) <
+      getIndexOfColumn(this.draggingHeader, headers)
     ) {
       this.highlightEdge = Edge.TOP;
     } else {
       this.highlightEdge = Edge.BOTTOM;
     }
 
-    this.highlightedHeaderType = header.type;
+    this.highlightedHeader = header;
   }
 
   toggleHeader(header: ColumnHeader, dataTableMode: DataTableMode) {
     this.onScalarTableColumnToggled.emit({
       dataTableMode: dataTableMode,
-      headerType: header.type,
+      header,
     });
   }
 
   getHighlightClasses(header: ColumnHeader) {
-    if (header.type !== this.highlightedHeaderType) {
+    if (header.name !== this.highlightedHeader?.name) {
       return {};
     }
 

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -209,7 +209,12 @@ describe('scalar column editor', () => {
       expect(dispatchedActions[0]).toEqual(
         dataTableColumnToggled({
           dataTableMode: DataTableMode.SINGLE,
-          headerType: ColumnHeaderType.RUN,
+          header: {
+            type: ColumnHeaderType.RUN,
+            name: 'run',
+            displayName: 'Run',
+            enabled: true,
+          },
         })
       );
     }));
@@ -241,7 +246,12 @@ describe('scalar column editor', () => {
       expect(dispatchedActions[0]).toEqual(
         dataTableColumnToggled({
           dataTableMode: DataTableMode.RANGE,
-          headerType: ColumnHeaderType.MAX_VALUE,
+          header: {
+            type: ColumnHeaderType.MAX_VALUE,
+            name: 'maxValue',
+            displayName: 'Max',
+            enabled: false,
+          },
         })
       );
     }));

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -67,9 +67,7 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
 
   @Output() sortDataBy = new EventEmitter<SortingInfo>();
   @Output() orderColumns = new EventEmitter<ColumnHeader[]>();
-  @Output() removeColumn = new EventEmitter<{
-    headerType: ColumnHeaderType;
-  }>();
+  @Output() removeColumn = new EventEmitter<ColumnHeader>();
 
   readonly ColumnHeaders = ColumnHeaderType;
   readonly SortingOrder = SortingOrder;
@@ -202,8 +200,6 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
   }
 
   deleteButtonClicked(header: ColumnHeader) {
-    this.removeColumn.emit({
-      headerType: header.type,
-    });
+    this.removeColumn.emit(header);
   }
 }


### PR DESCRIPTION
## Motivation for features / changes
With the addition of hparam columns header type is no longer guaranteed to be unique, thus we are changing everything to use header name instead.

While making the change I also made some small refactors to remove usage of header type from the column editor as well.

## Screenshots of UI changes (or N/A)
I can still remove columns
![36a4c291-dc08-4d92-81fd-bb7c7a8ed1e4](https://github.com/tensorflow/tensorboard/assets/78179109/97214125-9bac-4e47-852c-dabd213fb68f)

I can still add columns
![bf0c15ec-a1a7-46aa-948a-aadd40af87de](https://github.com/tensorflow/tensorboard/assets/78179109/bdcd5e9e-3c9e-48ca-ba47-a78f8be808fe)
