### PR TITLE
ci: update pip to latest before installing TF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
             "common --remote_upload_local_results=true" \
             ;
       - name: 'Install TensorFlow'
-        run: pip install "${TENSORFLOW_VERSION}"
+        run: |
+          python -m pip install -U pip
+          pip install "${TENSORFLOW_VERSION}"
         if: matrix.tf_version_id != 'notf'
       - name: 'Install Python dependencies'
         run: |


### PR DESCRIPTION
We're seeing issues in CI with pip's hash-checking logic failing on `tf-nightly`, and that same error mentions that pip is stale (see example error at end). There are a few mentions of hash-checking in the release notes so it seems plausible that the old pip version is somehow incompatible with how pip downloads are resolving in our CI environment.

This PR resolves that by upgrading pip before installing TF, the same as we do before installing our own requirements.txt file (we still keep that upgrade to handle the no-TF case; I could conditionally omit it but it'd be more complex and I expect the second pip upgrade will be a fairly quick no-op).


```
Collecting tf-nightly==2.13.0.dev20230426
  Downloading tf_nightly-2.13.0.dev20230426-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (524.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━          406.8/524.6 MB 8.4 MB/s eta 0:00:14
ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    tf-nightly==2.13.0.dev20230426 from https://files.pythonhosted.org/packages/a7/c6/c6da1ad13c3c4b76ccf5b2afc8ed199f677a59169806349e7b62df96dd21/tf_nightly-2.13.0.dev20230426-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl:
        Expected sha256 f2d547cc2af11f9ea1060c07296c27d37e8b146b063ed3b3d5e1d38384725252
             Got        9839e5ea2be29cd2f82c57f92440e3a6a3869a34130cf9759e8929567cf8cd4a


Notice:  A new release of pip is available: 23.0.1 -> 23.1.2
Notice:  To update, run: pip install --upgrade pip
```