### PR TITLE
hparams: Style Runs Data Table

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -29,3 +29,26 @@ $_circle-size: 20px;
   width: $_circle-size;
   outline: none;
 }
+
+:host {
+  width: 100%;
+}
+
+tb-data-table-content-row,
+tb-data-table-header-cell {
+  height: 43px;
+}
+
+tb-data-table-content-cell,
+tb-data-table-header-cell {
+  vertical-align: middle;
+  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
+
+  &:first-child {
+    padding-left: 19px;
+  }
+
+  &:last-child {
+    padding-right: 19px;
+  }
+}

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -36,7 +36,7 @@ $_circle-size: 20px;
 
 tb-data-table-content-row,
 tb-data-table-header-cell {
-  height: 43px;
+  height: 44px;
 }
 
 tb-data-table-content-cell,
@@ -45,10 +45,10 @@ tb-data-table-header-cell {
   @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
 
   &:first-child {
-    padding-left: 19px;
+    padding-left: 16px;
   }
 
   &:last-child {
-    padding-right: 19px;
+    padding-right: 16px;
   }
 }

--- a/tensorboard/webapp/widgets/data_table/content_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component.scss
@@ -15,7 +15,7 @@ limitations under the License.
 
 :host {
   display: table-cell;
-  padding: 5px;
+  padding: 4px;
 }
 .cell {
   align-items: center;

--- a/tensorboard/webapp/widgets/data_table/content_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component.scss
@@ -15,7 +15,7 @@ limitations under the License.
 
 :host {
   display: table-cell;
-  padding: 1px;
+  padding: 5px;
 }
 .cell {
   align-items: center;

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -18,7 +18,6 @@ limitations under the License.
 $_accent: map-get(mat.get-color-config($tb-theme), accent);
 
 .data-table {
-  border-spacing: 4px;
   font-size: 13px;
   display: table;
   width: 100%;

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.scss
@@ -20,7 +20,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 
 :host {
   display: table-cell;
-  padding: 5px;
+  padding: 4px;
   vertical-align: bottom;
 }
 .sorting-icon-container {

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.scss
@@ -20,7 +20,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 
 :host {
   display: table-cell;
-  padding: 1px;
+  padding: 5px;
   vertical-align: bottom;
 }
 .sorting-icon-container {


### PR DESCRIPTION
## Motivation for features / changes
We are replacing the RunsTableComponent with a RunsDataTable which uses the DataTable Widget. We have been making it functional but this trying to style the table to look similar the original table.

## Technical description of changes

## Screenshots of UI changes (or N/A)
<img width="273" alt="Screenshot 2023-06-26 at 9 31 40 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/082430fd-d66b-405f-85ac-0143e733f0f5">
<img width="279" alt="Screenshot 2023-06-26 at 9 32 13 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/f41cd806-7142-470f-bfdb-9fd0dfa5995f">

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
