### PR TITLE
hparams: Add regex filter control to RunsDataTable

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -15,6 +15,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<div class="filter-row">
+  <tb-filter-input
+    class="run-filter"
+    value="{{ regexFilter }}"
+    (keyup)="onFilterKeyUp($event)"
+    placeholder="Filter runs (regex)"
+  ></tb-filter-input>
+</div>
 <tb-data-table
   [headers]="headers"
   [sortingInfo]="sortingInfo"

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -37,6 +37,7 @@ export class RunsDataTable {
   @Input() data!: TableData[];
   @Input() sortingInfo!: SortingInfo;
   @Input() experimentIds!: string[];
+  @Input() regexFilter!: string;
 
   ColumnHeaderType = ColumnHeaderType;
 
@@ -44,6 +45,7 @@ export class RunsDataTable {
   @Output() orderColumns = new EventEmitter<ColumnHeader[]>();
   @Output() onSelectionToggle = new EventEmitter<string>();
   @Output() onAllSelectionToggle = new EventEmitter<string[]>();
+  @Output() onRegexFilterChange = new EventEmitter<string>();
   @Output() onRunColorChange = new EventEmitter<{
     runId: string;
     newColor: string;
@@ -88,5 +90,10 @@ export class RunsDataTable {
 
   someRowsSelected() {
     return this.data.some((row) => row.selected);
+  }
+
+  onFilterKeyUp(event: KeyboardEvent) {
+    const input = event.target! as HTMLInputElement;
+    this.onRegexFilterChange.emit(input.value);
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
@@ -30,6 +30,8 @@ import {By} from '@angular/platform-browser';
 import {HeaderCellComponent} from '../../../widgets/data_table/header_cell_component';
 import {DataTableComponent} from '../../../widgets/data_table/data_table_component';
 import {ContentCellComponent} from '../../../widgets/data_table/content_cell_component';
+import {FilterInputModule} from '../../../widgets/filter_input/filter_input_module';
+import {sendKeys} from '../../../testing/dom';
 
 @Component({
   selector: 'testable-comp',
@@ -42,6 +44,7 @@ import {ContentCellComponent} from '../../../widgets/data_table/content_cell_com
       (orderColumns)="orderColumns($event)"
       (onSelectionToggle)="onSelectionToggle($event)"
       (onAllSelectionToggle)="onAllSelectionToggle($event)"
+      (onRegexFilterChange)="onRegexFilterChange($event)"
     ></runs-data-table>
   `,
 })
@@ -55,11 +58,13 @@ class TestableComponent {
 
   @Input() onSelectionToggle!: (runId: string) => void;
   @Input() onAllSelectionToggle!: (runIds: string[]) => void;
+  @Input() onRegexFilterChange!: (regex: string) => void;
 }
 
 describe('runs_data_table', () => {
   let onSelectionToggleSpy: jasmine.Spy;
   let onAllSelectionToggleSpy: jasmine.Spy;
+  let onRegexFilterChangeSpy: jasmine.Spy;
   function createComponent(input: {
     data?: TableData[];
     headers?: ColumnHeader[];
@@ -102,13 +107,21 @@ describe('runs_data_table', () => {
     onAllSelectionToggleSpy = jasmine.createSpy();
     fixture.componentInstance.onAllSelectionToggle = onAllSelectionToggleSpy;
 
+    onRegexFilterChangeSpy = jasmine.createSpy();
+    fixture.componentInstance.onRegexFilterChange = onRegexFilterChangeSpy;
+
     fixture.detectChanges();
     return fixture;
   }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [DataTableModule, MatIconTestingModule, MatCheckboxModule],
+      imports: [
+        DataTableModule,
+        FilterInputModule,
+        MatIconTestingModule,
+        MatCheckboxModule,
+      ],
       declarations: [TestableComponent, RunsDataTable],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -304,5 +317,16 @@ describe('runs_data_table', () => {
     firstCheckbox.nativeElement.dispatchEvent(new Event('change'));
 
     expect(onSelectionToggleSpy).toHaveBeenCalledWith('runid');
+  });
+
+  it('fire onRegexFilterChange when input is entered into the tb-filter-input', () => {
+    const fixture = createComponent({});
+    const filterInput = fixture.debugElement.query(By.css('tb-filter-input'));
+
+    expect(filterInput).toBeTruthy();
+
+    sendKeys(fixture, filterInput.query(By.css('input')), 'myRegex');
+
+    expect(onRegexFilterChangeSpy).toHaveBeenCalledWith('myRegex');
   });
 });

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -238,11 +238,13 @@ function matchFilter(
       [data]="allRunsTableData$ | async"
       [sortingInfo]="sortingInfo$ | async"
       [experimentIds]="experimentIds"
+      [regexFilter]="regexFilter$ | async"
       (sortDataBy)="sortDataBy($event)"
       (orderColumns)="orderColumns($event)"
       (onSelectionToggle)="onRunSelectionToggle($event)"
       (onAllSelectionToggle)="onAllSelectionToggle($event)"
       (onRunColorChange)="onRunColorChange($event)"
+      (onRegexFilterChange)="onRegexFilterChange($event)"
     ></runs-data-table>
   `,
   host: {


### PR DESCRIPTION
## Motivation for features / changes
We will soon replace the RunsTableComponent with the RunsDataTable which will allow for more customization in the columns. However, we first need to reach feature parity with the current component. We are missing the regex filter. This adds that filter.  There is still more work needed to filter out the runs which are deselected from this filter. That will come in a later PR.

## Technical description of changes
I just copied the component from the RunsTableComponent and used the same inputs and outputs.

I think the current testing for the component is sufficient. The only thing we could test is that the filter renders in the RunsDataTable. It does not seem like a valuable test to me.

## Screenshots of UI changes (or N/A)
<img width="281" alt="Screenshot 2023-06-26 at 9 49 55 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/826573f2-ae47-4958-bb3c-c41a8160f11c">
<img width="268" alt="Screenshot 2023-06-26 at 9 49 45 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/2ca9f13e-49d7-4da3-929a-e7202f7a959d">
<img width="281" alt="Screenshot 2023-06-26 at 9 49 34 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/ccb26ab0-4835-42a5-8c41-efc88f3f6365">
