### PR TITLE
Remove requirement that metricInfos are present to show Hparams main view.

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
@@ -565,9 +565,7 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
     const result = Boolean(
       this._experiment &&
         this._experiment.hparamInfos &&
-        this._experiment.hparamInfos.length > 0 &&
-        this._experiment.metricInfos &&
-        this._experiment.metricInfos.length > 0
+        this._experiment.hparamInfos.length > 0
     );
     this.set('dataLoadedWithNonEmptyHparams', result);
     this.set('dataLoadedWithEmptyHparams', !result);


### PR DESCRIPTION
## Motivation for features / changes

We are building some new hparams-related functionality internally. It is early stages and the data we return to the UI does not contain metrics. The hparams dashboard, however, requires `metricInfos` to be non-empty in order to show the main view of the dashboard. We want to show the main view despite not having metric data.

More generally, though, it doesn't seem like metric data should be a requirement to show hparam dashboard information. The hparams fields can still be valuable on their own.

## Technical description of changes

Remove a UI-level check for non-empty metricInfos.

