### PR TITLE
Require some provider.Hyperparameter properties.

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -555,8 +555,8 @@ class Hyperparameter:
           finite set of bool values.
     """
 
-    hyperparameter_name: str = ""
-    hyperparameter_display_name: str = ""
+    hyperparameter_name: str
+    hyperparameter_display_name: str
     domain_type: Union[HyperparameterDomainType, None] = None
     domain: Union[
         Tuple[float, float],


### PR DESCRIPTION
provider.Hyperparameter's 'name' and 'display_name' properties should be required rather than defaulting to empty string "".