### PR TITLE
HParams: Add experiment name column

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -336,7 +336,30 @@ const {initialState: uiInitialState, reducers: uiNamespaceContextedReducers} =
         order: SortingOrder.DESCENDING,
       },
     },
-    {}
+    {},
+    /* onNavigated() */
+    (state, oldRoute, newRoute) => {
+      if (
+        !areSameRouteKindAndExperiments(oldRoute, newRoute) &&
+        newRoute.routeKind === RouteKind.COMPARE_EXPERIMENT
+      ) {
+        const newRunsTableHeaders = state.runsTableHeaders.filter(
+          (header) => header.name !== 'experimentName'
+        );
+        newRunsTableHeaders.push({
+          type: ColumnHeaderType.EXPERIMENT,
+          name: 'experimentName',
+          displayName: 'Experiment',
+          enabled: true,
+        });
+
+        return {
+          ...state,
+          runsTableHeaders: newRunsTableHeaders,
+        };
+      }
+      return state;
+    }
   );
 
 const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -341,17 +341,20 @@ const {initialState: uiInitialState, reducers: uiNamespaceContextedReducers} =
     (state, oldRoute, newRoute) => {
       if (
         !areSameRouteKindAndExperiments(oldRoute, newRoute) &&
-        newRoute.routeKind === RouteKind.COMPARE_EXPERIMENT
+        newRoute.routeKind === RouteKind.COMPARE_EXPERIMENT &&
+        !state.runsTableHeaders.find(
+          (header) => header.name === 'experimentName'
+        )
       ) {
-        const newRunsTableHeaders = state.runsTableHeaders.filter(
-          (header) => header.name !== 'experimentName'
-        );
-        newRunsTableHeaders.push({
-          type: ColumnHeaderType.EXPERIMENT,
-          name: 'experimentName',
-          displayName: 'Experiment',
-          enabled: true,
-        });
+        const newRunsTableHeaders = [
+          ...state.runsTableHeaders,
+          {
+            type: ColumnHeaderType.EXPERIMENT,
+            name: 'experimentName',
+            displayName: 'Experiment',
+            enabled: true,
+          },
+        ];
 
         return {
           ...state,

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -339,27 +339,41 @@ const {initialState: uiInitialState, reducers: uiNamespaceContextedReducers} =
     {},
     /* onNavigated() */
     (state, oldRoute, newRoute) => {
-      if (
-        !areSameRouteKindAndExperiments(oldRoute, newRoute) &&
-        newRoute.routeKind === RouteKind.COMPARE_EXPERIMENT &&
-        !state.runsTableHeaders.find(
-          (header) => header.name === 'experimentName'
-        )
-      ) {
-        const newRunsTableHeaders = [
-          ...state.runsTableHeaders,
-          {
-            type: ColumnHeaderType.EXPERIMENT,
-            name: 'experimentName',
-            displayName: 'Experiment',
-            enabled: true,
-          },
-        ];
+      if (!areSameRouteKindAndExperiments(oldRoute, newRoute)) {
+        if (
+          newRoute.routeKind === RouteKind.COMPARE_EXPERIMENT &&
+          !state.runsTableHeaders.find(
+            (header) => header.name === 'experimentName'
+          )
+        ) {
+          const newRunsTableHeaders = [
+            ...state.runsTableHeaders,
+            {
+              type: ColumnHeaderType.EXPERIMENT,
+              name: 'experimentName',
+              displayName: 'Experiment',
+              enabled: true,
+            },
+          ];
 
-        return {
-          ...state,
-          runsTableHeaders: newRunsTableHeaders,
-        };
+          return {
+            ...state,
+            runsTableHeaders: newRunsTableHeaders,
+          };
+        }
+        if (
+          oldRoute?.routeKind === RouteKind.COMPARE_EXPERIMENT &&
+          newRoute.routeKind !== RouteKind.COMPARE_EXPERIMENT
+        ) {
+          const newRunsTableHeaders = state.runsTableHeaders.filter(
+            (column) => column.name !== 'experimentName'
+          );
+
+          return {
+            ...state,
+            runsTableHeaders: newRunsTableHeaders,
+          };
+        }
       }
       return state;
     }

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -1354,7 +1354,7 @@ describe('runs_reducers', () => {
       expect(nextState.data.initialGroupBy.key).toBe(GroupByKey.RUN);
     });
 
-    it('adds the experiment name column to the end of the runs table columns list', () => {
+    it('adds the experiment name column to the runs table columns list', () => {
       const state = buildRunsState(
         {},
         {
@@ -1410,6 +1410,39 @@ describe('runs_reducers', () => {
       expect(
         nextState.ui.runsTableHeaders.map((column) => column.name)
       ).toEqual(['experimentName', 'run']);
+    });
+
+    it('removes the experiment name column when changing away comparison view', () => {
+      const state = buildRunsState(
+        {},
+        {
+          runsTableHeaders: [
+            {
+              type: ColumnHeaderType.EXPERIMENT,
+              name: 'experimentName',
+              displayName: 'ExperimentName',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+          ],
+        }
+      );
+
+      const nextState = runsReducers.reducers(
+        state,
+        buildNavigatedAction({
+          before: buildCompareRoute(['eid1:run1', 'eid1:run2']),
+          after: buildRoute({routeKind: RouteKind.EXPERIMENT}),
+        })
+      );
+      expect(
+        nextState.ui.runsTableHeaders.map((column) => column.name)
+      ).toEqual(['run']);
     });
   });
 

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -1353,6 +1353,64 @@ describe('runs_reducers', () => {
 
       expect(nextState.data.initialGroupBy.key).toBe(GroupByKey.RUN);
     });
+
+    it('adds the experiment name column to the end of the runs table columns list', () => {
+      const state = buildRunsState(
+        {},
+        {
+          runsTableHeaders: [
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+          ],
+        }
+      );
+      const nextState = runsReducers.reducers(
+        state,
+        buildNavigatedAction({
+          before: buildRoute({routeKind: RouteKind.EXPERIMENT}),
+          after: buildCompareRoute(['eid1:run1', 'eid1:run2']),
+        })
+      );
+      expect(
+        nextState.ui.runsTableHeaders.map((column) => column.name)
+      ).toEqual(['run', 'experimentName']);
+    });
+
+    it('does not add duplicate experiment name columns', () => {
+      const state = buildRunsState(
+        {},
+        {
+          runsTableHeaders: [
+            {
+              type: ColumnHeaderType.EXPERIMENT,
+              name: 'experimentName',
+              displayName: 'ExperimentName',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+          ],
+        }
+      );
+      const nextState = runsReducers.reducers(
+        state,
+        buildNavigatedAction({
+          before: buildRoute({routeKind: RouteKind.EXPERIMENT}),
+          after: buildCompareRoute(['eid1:run1', 'eid1:run2']),
+        })
+      );
+      expect(
+        nextState.ui.runsTableHeaders.map((column) => column.name)
+      ).toEqual(['experimentName', 'run']);
+    });
   });
 
   describe('runsTableHeaderAdded', () => {

--- a/tensorboard/webapp/widgets/data_table/content_cell_component.ts
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component.ts
@@ -47,6 +47,7 @@ export class ContentCellComponent {
     }
     switch (this.header.type) {
       case ColumnHeaderType.RUN:
+      case ColumnHeaderType.EXPERIMENT:
         return this.datum as string;
       case ColumnHeaderType.VALUE:
       case ColumnHeaderType.STEP:
@@ -61,7 +62,6 @@ export class ContentCellComponent {
       case ColumnHeaderType.STEP_AT_MIN:
       case ColumnHeaderType.MEAN:
       case ColumnHeaderType.HPARAM:
-      case ColumnHeaderType.EXPERIMENT:
         if (typeof this.datum === 'number') {
           return intlNumberFormatter.formatShort(this.datum as number);
         }

--- a/tensorboard/webapp/widgets/data_table/content_cell_component.ts
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component.ts
@@ -61,6 +61,7 @@ export class ContentCellComponent {
       case ColumnHeaderType.STEP_AT_MIN:
       case ColumnHeaderType.MEAN:
       case ColumnHeaderType.HPARAM:
+      case ColumnHeaderType.EXPERIMENT:
         if (typeof this.datum === 'number') {
           return intlNumberFormatter.formatShort(this.datum as number);
         }

--- a/tensorboard/webapp/widgets/data_table/types.ts
+++ b/tensorboard/webapp/widgets/data_table/types.ts
@@ -23,6 +23,7 @@ export enum ColumnHeaderType {
   RELATIVE_TIME = 'RELATIVE_TIME',
   RUN = 'RUN',
   STEP = 'STEP',
+  EXPERIMENT = 'EXPERIMENT',
   TIME = 'TIME',
   VALUE = 'VALUE',
   SMOOTHED = 'SMOOTHED',


### PR DESCRIPTION
## Motivation for features / changes
When comparing two experiments another column should be added showing the experiments name. This is a feature that we had not implemented in our replacement for the runs table.

## Technical description of changes
I added an additional reducer which is called upon navigation which checks if the current route is a comparison route and then potentially adds an experiment name column.

## Screenshots of UI changes (or N/A)
Screenshot from internal
![image](https://github.com/tensorflow/tensorboard/assets/78179109/233399ac-b6a9-4ff5-9ba9-5825027c0d82)
