### PR TITLE
HParams: Order RunsDataTable Columns on drag

### DIFF
--- a/tensorboard/webapp/runs/actions/runs_actions.ts
+++ b/tensorboard/webapp/runs/actions/runs_actions.ts
@@ -115,6 +115,14 @@ export const runsTableHeaderRemoved = createAction(
 );
 
 /**
+ * Users requested to change the order of the columns in the runs table.
+ */
+export const runsTableHeaderOrderChanged = createAction(
+  '[Runs] Runs Table Header Order Changed',
+  props<{newHeaderOrder: ColumnHeader[]}>()
+);
+
+/**
  * Updates the sorting logic used by the runs data tabe.
  */
 export const runsTableSortingInfoChanged = createAction(

--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -449,6 +449,12 @@ const uiReducer: ActionReducer<RunsUiState, Action> = createReducer(
       runsTableHeaders: newRunsTableHeaders,
     };
   }),
+  on(runsActions.runsTableHeaderOrderChanged, (state, {newHeaderOrder}) => {
+    return {
+      ...state,
+      runsTableHeaders: newHeaderOrder,
+    };
+  }),
   on(runsActions.runsTableSortingInfoChanged, (state, {sortingInfo}) => {
     return {
       ...state,

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -1468,6 +1468,65 @@ describe('runs_reducers', () => {
     });
   });
 
+  describe('runsTableHeaderOrderChanged', () => {
+    it('sets the new headers as the runsTableHeaders', () => {
+      const state = buildRunsState(
+        {},
+        {
+          runsTableHeaders: [
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.COLOR,
+              name: 'color',
+              displayName: 'Color',
+              enabled: true,
+            },
+          ],
+        }
+      );
+
+      const nextState = runsReducers.reducers(
+        state,
+        actions.runsTableHeaderOrderChanged({
+          newHeaderOrder: [
+            {
+              type: ColumnHeaderType.COLOR,
+              name: 'color',
+              displayName: 'Color',
+              enabled: true,
+            },
+            {
+              type: ColumnHeaderType.RUN,
+              name: 'run',
+              displayName: 'Run',
+              enabled: true,
+            },
+          ],
+        })
+      );
+
+      expect(nextState.ui.runsTableHeaders).toEqual([
+        {
+          type: ColumnHeaderType.COLOR,
+          name: 'color',
+          displayName: 'Color',
+          enabled: true,
+        },
+        {
+          type: ColumnHeaderType.RUN,
+          name: 'run',
+          displayName: 'Run',
+          enabled: true,
+        },
+      ]);
+    });
+  });
+
   describe('runsTableSortingInfoChanged', () => {
     it('returns the current runs table sorting info', () => {
       const state = buildRunsState(

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -82,6 +82,7 @@ import {
   runSelectorSortChanged,
   runTableShown,
   runsTableHeaderAdded,
+  runsTableHeaderOrderChanged,
   runsTableHeaderRemoved,
   runsTableSortingInfoChanged,
   singleRunSelected,
@@ -852,6 +853,10 @@ export class RunsTableContainer implements OnInit, OnDestroy {
 
   removeColumn(header: ColumnHeader) {
     this.store.dispatch(runsTableHeaderRemoved({header}));
+  }
+
+  orderColumns(newHeaderOrder: ColumnHeader[]) {
+    this.store.dispatch(runsTableHeaderOrderChanged({newHeaderOrder}));
   }
 }
 


### PR DESCRIPTION
## Motivation for features / changes
The dragging functionality was all in place except it never fired an action to actually change the order. This PR creates the reordering action/reducer and hooks up the orderColumns event with that action.

## Technical description of changes
As in the Scalar Table be re-ordering we actually just replace the entire list of headers with a new one. I am not a huge fan of this. I would like to change how this works sometime but that is beyond the scope of this PR.

## Screenshots of UI changes (or N/A)
![2023-06-27_15-21-09 (1)](https://github.com/tensorflow/tensorboard/assets/8672809/9df1e85d-bb74-42ab-8282-0a28ff8137e0)

## Alternate designs / implementations considered (or N/A)
I considered refactoring the orderColumns events to just return source and destination indexes. However, I decided that was too big a change ATM. I think it should be done sometime in the future.
