### PR TITLE
HParams: Stop passing controlsEnabled boolean to DataTable

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
@@ -30,7 +30,6 @@ limitations under the License.
         [header]="header"
         [sortingInfo]="sortingInfo"
         [hparamsEnabled]="hparamsEnabled"
-        [controlsEnabled]="header.type !== ColumnHeaderType.COLOR"
       ></tb-data-table-header-cell> </ng-container
   ></ng-container>
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -40,7 +40,6 @@ limitations under the License.
         [header]="header"
         [sortingInfo]="sortingInfo"
         [hparamsEnabled]="true"
-        [controlsEnabled]="header.type !== ColumnHeaderType.COLOR && header.type !== ColumnHeaderType.CUSTOM"
         (contextmenu)="openContextMenu($event, header)"
       >
         <ng-container [ngSwitch]="header.name">


### PR DESCRIPTION
## Motivation for features / changes
This boolean was removed in #6463. However, I forgot to remove it from being passed in the ScalarCardDataTable. This was caught in an internal build.