### PR TITLE
HParams: Reduce Header Cell padding

### DIFF
--- a/tensorboard/webapp/widgets/data_table/header_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.scss
@@ -20,7 +20,7 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
 
 :host {
   display: table-cell;
-  padding: 4px;
+  padding: 2px;
   vertical-align: bottom;
 }
 .sorting-icon-container {


### PR DESCRIPTION
## Motivation for features / changes
The padding between cells is supposed to be 4px. So 2 px from each cell.

## Technical description of changes

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
