### PR TITLE
HParams: Header Button Styling and Context Menu updates

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
@@ -30,6 +30,7 @@ limitations under the License.
         [header]="header"
         [sortingInfo]="sortingInfo"
         [hparamsEnabled]="hparamsEnabled"
+        hideContextMenu="true"
       ></tb-data-table-header-cell> </ng-container
   ></ng-container>
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
@@ -30,7 +30,7 @@ limitations under the License.
         [header]="header"
         [sortingInfo]="sortingInfo"
         [hparamsEnabled]="hparamsEnabled"
-        hideContextMenu="true"
+        disableContextMenu="true"
       ></tb-data-table-header-cell> </ng-container
   ></ng-container>
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -40,7 +40,6 @@ limitations under the License.
         [header]="header"
         [sortingInfo]="sortingInfo"
         [hparamsEnabled]="true"
-        (contextmenu)="openContextMenu($event, header)"
       >
         <ng-container [ngSwitch]="header.name">
           <div *ngSwitchCase="'selected'">

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -34,17 +34,17 @@ limitations under the License.
       mat-button
       (click)="sortByHeader(contextMenuHeader?.name)"
     >
-      <mat-icon
+      <ng-container
         *ngIf="
           sortingInfo.order === SortingOrder.ASCENDING &&
           sortingInfo.name === contextMenuHeader?.name;
           else descending"
-        svgIcon="arrow_upward_24px"
-      ></mat-icon>
+      >
+        <mat-icon svgIcon="arrow_downward_24px"></mat-icon>Sort Descending
+      </ng-container>
       <ng-template #descending>
-        <mat-icon svgIcon="arrow_downward_24px"></mat-icon>
+        <mat-icon svgIcon="arrow_upward_24px"></mat-icon>Sort Ascending
       </ng-template>
-      Sort
     </button>
     <button
       mat-button

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -15,18 +15,36 @@ limitations under the License.
 <custom-modal #contextMenu>
   <div class="context-menu">
     <div
-      *ngIf="!canContextMenuRemoveColumn() && !(selectableColumns && selectableColumns.length)"
+      *ngIf="!contextMenuHeader?.removable && !contextMenuHeader?.sortable && !canContextMenuInsert()"
       class="no-actions-message"
     >
       No Actions Available
     </div>
     <button
-      *ngIf="canContextMenuRemoveColumn()"
+      *ngIf="contextMenuHeader?.removable"
       class="context-menu-button"
       mat-button
       (click)="contextMenuRemoveColumn()"
     >
       <mat-icon svgIcon="close_24px"></mat-icon>Remove
+    </button>
+    <button
+      *ngIf="contextMenuHeader?.sortable"
+      class="context-menu-button sort-button"
+      mat-button
+      (click)="sortByHeader(contextMenuHeader?.name)"
+    >
+      <mat-icon
+        *ngIf="
+          sortingInfo.order === SortingOrder.ASCENDING &&
+          sortingInfo.name === contextMenuHeader?.name;
+          else descending"
+        svgIcon="arrow_upward_24px"
+      ></mat-icon>
+      <ng-template #descending>
+        <mat-icon svgIcon="arrow_downward_24px"></mat-icon>
+      </ng-template>
+      Sort
     </button>
     <button
       mat-button

--- a/tensorboard/webapp/widgets/data_table/data_table_component.scss
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.scss
@@ -73,4 +73,10 @@ $_accent: map-get(mat.get-color-config($tb-theme), accent);
     padding: 8px;
     text-wrap: nowrap;
   }
+
+  .sort-button {
+    ::ng-deep path {
+      fill: unset;
+    }
+  }
 }

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -120,10 +120,7 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
         headerCell.dragStart.subscribe(this.dragStart.bind(this)),
         headerCell.dragEnter.subscribe(this.dragEnter.bind(this)),
         headerCell.dragEnd.subscribe(this.dragEnd.bind(this)),
-        headerCell.headerClicked.subscribe(this.headerClicked.bind(this)),
-        headerCell.deleteButtonClicked.subscribe(
-          this.deleteButtonClicked.bind(this)
-        ),
+        headerCell.headerClicked.subscribe(this.sortByHeader.bind(this)),
         headerCell.contextMenuOpened.subscribe(
           this.openContextMenu.bind(this, headerCell.header)
         )
@@ -144,7 +141,7 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
       .flat();
   }
 
-  headerClicked(name: string) {
+  sortByHeader(name: string) {
     if (
       this.sortingInfo.name === name &&
       this.sortingInfo.order === SortingOrder.ASCENDING
@@ -234,10 +231,6 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
     return this.headers.findIndex((element) => {
       return name === element.name;
     });
-  }
-
-  deleteButtonClicked(header: ColumnHeader) {
-    this.removeColumn.emit(header);
   }
 
   focusColumnSelector() {

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -552,6 +552,7 @@ describe('data table', () => {
           displayName: 'Run',
           enabled: true,
           movable: true,
+          sortable: true,
         },
         {
           name: 'disabled_header',
@@ -576,6 +577,12 @@ describe('data table', () => {
           enabled: true,
           removable: true,
           movable: false,
+        },
+        {
+          name: 'some static column',
+          type: ColumnHeaderType.HPARAM,
+          displayName: 'cant touch this',
+          enabled: true,
         },
       ];
       mockTableData = [
@@ -697,7 +704,7 @@ describe('data table', () => {
         By.directive(ContentCellComponent)
       );
 
-      expect(cells.length).toBe(3);
+      expect(cells.length).toBe(4);
 
       cells.forEach((cell) => {
         cell.nativeElement.dispatchEvent(new MouseEvent('contextmenu'));
@@ -775,7 +782,7 @@ describe('data table', () => {
         By.directive(ContentCellComponent)
       );
 
-      expect(cells.length).toBe(3);
+      expect(cells.length).toBe(4);
 
       cells.forEach((cell) => {
         cell.nativeElement.dispatchEvent(new MouseEvent('contextmenu'));
@@ -798,6 +805,70 @@ describe('data table', () => {
           expect(addRight).toBeUndefined();
         }
       });
+    });
+
+    it('renders an upwards arrow when the sort direction is ascending', () => {
+      const fixture = createComponent({
+        headers: mockHeaders,
+        data: mockTableData,
+        potentialColumns: mockPotentialColumns,
+        sortingInfo: {
+          name: 'run',
+          order: SortingOrder.ASCENDING,
+        },
+      });
+      const header = fixture.debugElement.query(
+        By.directive(HeaderCellComponent)
+      );
+      header.nativeElement.dispatchEvent(new MouseEvent('contextmenu'));
+      fixture.detectChanges();
+
+      expect(
+        fixture.debugElement
+          .query(By.css('.context-menu-button.sort-button mat-icon'))
+          .nativeElement.getAttribute('svgIcon')
+      ).toBe('arrow_downward_24px');
+    });
+
+    it('renders a downwards arrow when the sort direction is descending', () => {
+      const fixture = createComponent({
+        headers: mockHeaders,
+        data: mockTableData,
+        potentialColumns: mockPotentialColumns,
+        sortingInfo: {
+          name: 'run',
+          order: SortingOrder.DESCENDING,
+        },
+      });
+      const header = fixture.debugElement.query(
+        By.directive(HeaderCellComponent)
+      );
+      header.nativeElement.dispatchEvent(new MouseEvent('contextmenu'));
+      fixture.detectChanges();
+
+      expect(
+        fixture.debugElement
+          .query(By.css('.context-menu-button.sort-button mat-icon'))
+          .nativeElement.getAttribute('svgIcon')
+      ).toBe('arrow_upward_24px');
+    });
+
+    it('displays a message when empty', () => {
+      const fixture = createComponent({
+        headers: mockHeaders,
+        data: mockTableData,
+        potentialColumns: mockPotentialColumns,
+      });
+      const fixedHeader = fixture.debugElement.queryAll(
+        By.directive(HeaderCellComponent)
+      )[4];
+      fixedHeader.nativeElement.dispatchEvent(new MouseEvent('contextmenu'));
+      fixture.detectChanges();
+
+      const contextMenu = fixture.debugElement.query(By.css('.context-menu'));
+      expect(
+        contextMenu.nativeElement.innerHTML.includes('No Actions Available')
+      ).toBeTrue();
     });
   });
 });

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.ng.html
@@ -46,7 +46,7 @@ limitations under the License.
     ></mat-icon>
   </div>
   <div
-    *ngIf="(header.removable || header.sortable) && !hideContextMenu"
+    *ngIf="(header.removable || header.sortable) && !disableContextMenu"
     class="context-menu-container show-on-hover"
   >
     <mat-icon

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.ng.html
@@ -22,20 +22,6 @@ limitations under the License.
   [ngClass]="highlightStyle$ | async"
 >
   <ng-content></ng-content>
-  <div
-    *ngIf="hparamsEnabled && header.removable"
-    class="delete-button-container"
-  >
-    <button
-      class="delete-button"
-      mat-icon-button
-      i18n-aria-label="A button to delete a data table column."
-      aria-label="Delete column"
-      (click)="deleteButtonClicked.emit(header)"
-    >
-      <mat-icon svgIcon="close_24px"> </mat-icon>
-    </button>
-  </div>
   <tb-data-table-header [header]="header"></tb-data-table-header>
   <div *ngIf="header.sortable" class="sorting-icon-container">
     <mat-icon
@@ -60,15 +46,12 @@ limitations under the License.
     ></mat-icon>
   </div>
   <div
-    *ngIf="header.removable || header.sortable"
-    class="context-menu-container"
+    *ngIf="(header.removable || header.sortable) && !hideContextMenu"
+    class="context-menu-container show-on-hover"
   >
-    <button
-      mat-icon-button
-      class="context-menu-trigger"
+    <mat-icon
       (click)="onContextMenuOpened($event)"
-    >
-      <mat-icon svgIcon="more_vert_24px"></mat-icon>
-    </button>
+      svgIcon="more_vert_24px"
+    ></mat-icon>
   </div>
 </div>

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.scss
@@ -25,17 +25,20 @@ $_icon_size: 12px;
   vertical-align: bottom;
 
   &:hover {
-    .context-menu-container {
-      opacity: 0.8;
-    }
-
     .show-on-hover {
       opacity: 0.3;
     }
   }
+
+  .show-on-hover {
+    &:hover {
+      opacity: 1;
+    }
+  }
 }
 
-.sorting-icon-container {
+.sorting-icon-container,
+.context-menu-container {
   width: $_icon_size;
   height: $_icon_size;
   border-radius: 5px;
@@ -44,12 +47,6 @@ $_icon_size: 12px;
 .cell {
   align-items: center;
   display: flex;
-
-  &:hover {
-    .delete-button-container {
-      opacity: 1;
-    }
-  }
 
   mat-icon {
     height: $_icon_size;
@@ -61,30 +58,6 @@ $_icon_size: 12px;
       fill: unset;
     }
   }
-}
-
-.delete-button {
-  display: flex;
-  align-items: center;
-  color: #fff;
-  font-size: $_icon_size;
-  height: $_icon_size;
-  width: $_icon_size;
-  line-height: $_icon_size;
-  cursor: pointer;
-
-  .mat-icon {
-    line-height: $_icon_size;
-  }
-}
-
-.delete-button-container {
-  border-radius: 50%;
-  background-color: mat.get-color-from-palette(mat.$gray-palette, 400);
-  margin-left: -$_icon_size;
-  height: $_icon_size;
-  opacity: 0;
-  position: absolute;
 }
 
 .show {
@@ -105,16 +78,4 @@ $_icon_size: 12px;
 
 .highlight-border-left {
   border-left: 2px solid mat.get-color-from-palette($_accent);
-}
-
-.context-menu-container {
-  opacity: 0;
-
-  .context-menu-trigger {
-    width: 12px;
-
-    mat-icon {
-      height: unset;
-    }
-  }
 }

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.ts
@@ -34,7 +34,7 @@ export class HeaderCellComponent {
   @Input() header!: ColumnHeader;
   @Input() sortingInfo!: SortingInfo;
   @Input() hparamsEnabled?: boolean = false;
-  @Input() hideContextMenu?: boolean = false;
+  @Input() disableContextMenu?: boolean = false;
 
   @Output() dragStart = new EventEmitter<ColumnHeader>();
   @Output() dragEnd = new EventEmitter<void>();
@@ -48,6 +48,9 @@ export class HeaderCellComponent {
 
   @HostListener('contextmenu', ['$event'])
   onContextMenuOpened(event: MouseEvent) {
+    if (this.disableContextMenu) {
+      return;
+    }
     this.contextMenuOpened.emit(event);
   }
 

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.ts
@@ -21,12 +21,7 @@ import {
   Input,
   Output,
 } from '@angular/core';
-import {
-  ColumnHeader,
-  ColumnHeaderType,
-  SortingInfo,
-  SortingOrder,
-} from './types';
+import {ColumnHeader, SortingInfo, SortingOrder} from './types';
 import {BehaviorSubject} from 'rxjs';
 
 @Component({
@@ -39,14 +34,12 @@ export class HeaderCellComponent {
   @Input() header!: ColumnHeader;
   @Input() sortingInfo!: SortingInfo;
   @Input() hparamsEnabled?: boolean = false;
+  @Input() hideContextMenu?: boolean = false;
 
   @Output() dragStart = new EventEmitter<ColumnHeader>();
   @Output() dragEnd = new EventEmitter<void>();
   @Output() dragEnter = new EventEmitter<ColumnHeader>();
   @Output() headerClicked = new EventEmitter<string>();
-  @Output() deleteButtonClicked = new EventEmitter<{
-    headerType: ColumnHeaderType;
-  }>();
   @Output() contextMenuOpened = new EventEmitter<MouseEvent>();
 
   highlightStyle$: BehaviorSubject<Object> = new BehaviorSubject<Object>({});

--- a/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
@@ -13,8 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input, ViewChild} from '@angular/core';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component, EventEmitter, Input, Output, ViewChild} from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  flush,
+} from '@angular/core/testing';
 import {MatIconTestingModule} from '../../testing/mat_icon_module';
 import {By} from '@angular/platform-browser';
 import {
@@ -34,8 +39,10 @@ import {HeaderCellComponent} from './header_cell_component';
       [sortingInfo]="sortingInfo"
       [hparamsEnabled]="hparamsEnabled"
       [controlsEnabled]="controlsEnabled"
+      [disableContextMenu]="disableContextMenu"
       (headerClicked)="headerClicked($event)"
       (deleteButtonClicked)="deleteButtonClicked($event)"
+      (contextMenuOpened)="contextMenuOpened.emit($event)"
     ></tb-data-table-header-cell>
   `,
 })
@@ -47,9 +54,12 @@ class TestableComponent {
   @Input() sortingInfo!: SortingInfo;
   @Input() hparamsEnabled!: boolean;
   @Input() controlsEnabled!: boolean;
+  @Input() disableContextMenu!: boolean;
 
   @Input() headerClicked!: (sortingInfo: SortingInfo) => void;
   @Input() deleteButtonClicked!: (header: ColumnHeader) => void;
+
+  @Output() contextMenuOpened = new EventEmitter<MouseEvent>();
 }
 
 describe('header cell', () => {
@@ -66,6 +76,7 @@ describe('header cell', () => {
     header?: ColumnHeader;
     sortingInfo?: SortingInfo;
     hparamsEnabled?: boolean;
+    disableContextMenu?: boolean;
   }): ComponentFixture<TestableComponent> {
     const fixture = TestBed.createComponent(TestableComponent);
 
@@ -83,6 +94,8 @@ describe('header cell', () => {
       order: SortingOrder.ASCENDING,
     };
     fixture.componentInstance.hparamsEnabled = input.hparamsEnabled ?? true;
+    fixture.componentInstance.disableContextMenu =
+      input.disableContextMenu ?? false;
 
     headerClickedSpy = jasmine.createSpy();
     fixture.componentInstance.headerClicked = headerClickedSpy;
@@ -124,54 +137,6 @@ describe('header cell', () => {
       .componentInstance.headerClicked.subscribe();
     fixture.debugElement.query(By.css('.cell')).nativeElement.click();
     expect(headerClickedSpy).not.toHaveBeenCalled();
-  });
-
-  describe('delete column button', () => {
-    it('emits removeColumn event when delete button clicked', () => {
-      const fixture = createComponent({hparamsEnabled: true});
-      fixture.debugElement
-        .query(By.directive(HeaderCellComponent))
-        .componentInstance.deleteButtonClicked.subscribe();
-      fixture.debugElement
-        .query(By.css('.delete-button'))
-        .triggerEventHandler('click', {});
-
-      expect(deleteButtonClickedSpy).toHaveBeenCalledOnceWith({
-        name: 'run',
-        displayName: 'Run',
-        type: ColumnHeaderType.RUN,
-        enabled: true,
-        sortable: true,
-        removable: true,
-        movable: true,
-      });
-    });
-
-    it('renders delete button when hparamsEnabled is true', () => {
-      const fixture = createComponent({hparamsEnabled: true});
-
-      expect(fixture.debugElement.query(By.css('.delete-button'))).toBeTruthy();
-    });
-
-    it('does not render delete button when hparamsEnabled is false', () => {
-      const fixture = createComponent({hparamsEnabled: false});
-
-      expect(fixture.debugElement.query(By.css('.delete-button'))).toBeFalsy();
-    });
-
-    it('does not render delete button when removable is false', () => {
-      const fixture = createComponent({
-        header: {
-          name: 'run',
-          displayName: 'Run',
-          type: ColumnHeaderType.RUN,
-          enabled: true,
-          removable: false,
-        },
-      });
-
-      expect(fixture.debugElement.query(By.css('.delete-button'))).toBeFalsy();
-    });
   });
 
   describe('sorting icon', () => {
@@ -275,6 +240,62 @@ describe('header cell', () => {
       expect(
         fixture.debugElement.query(By.css('.cell')).nativeElement.draggable
       ).toBe(false);
+    });
+  });
+
+  describe('context menu', () => {
+    it('context menu dispatches event', () => {
+      const fixture = createComponent({});
+      const component = fixture.debugElement.query(
+        By.directive(HeaderCellComponent)
+      );
+      spyOn(component.componentInstance.contextMenuOpened, 'emit');
+      expect(
+        component.componentInstance.contextMenuOpened.emit
+      ).not.toHaveBeenCalled();
+      component.nativeElement.dispatchEvent(new MouseEvent('contextmenu'));
+      expect(
+        component.componentInstance.contextMenuOpened.emit
+      ).toHaveBeenCalled();
+    });
+
+    it('does not render the context menu icon when disableContextMenu is true', () => {
+      const fixture = createComponent({disableContextMenu: true});
+      const contextMenuBtn = fixture.debugElement.query(
+        By.css('.context-menu-container mat-icon')
+      );
+      expect(contextMenuBtn).toBeNull();
+    });
+
+    it('clicking context menu button dispatches event', () => {
+      const fixture = createComponent({});
+      const component = fixture.debugElement.query(
+        By.directive(HeaderCellComponent)
+      );
+      spyOn(component.componentInstance.contextMenuOpened, 'emit');
+      expect(
+        component.componentInstance.contextMenuOpened.emit
+      ).not.toHaveBeenCalled();
+
+      const contextMenuBtn = fixture.debugElement.query(
+        By.css('.context-menu-container mat-icon')
+      );
+      contextMenuBtn.nativeElement.click();
+      expect(
+        component.componentInstance.contextMenuOpened.emit
+      ).toHaveBeenCalled();
+    });
+
+    it('disableContextMenu prevents openContextMenu from emitting', () => {
+      const fixture = createComponent({disableContextMenu: true});
+      const component = fixture.debugElement.query(
+        By.directive(HeaderCellComponent)
+      );
+      spyOn(component.componentInstance.contextMenuOpened, 'emit');
+      component.nativeElement.dispatchEvent(new MouseEvent('contextmenu'));
+      expect(
+        component.componentInstance.contextMenuOpened.emit
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
@@ -244,7 +244,7 @@ describe('header cell', () => {
   });
 
   describe('context menu', () => {
-    it('context menu dispatches event', () => {
+    it('dispatches event', () => {
       const fixture = createComponent({});
       const component = fixture.debugElement.query(
         By.directive(HeaderCellComponent)


### PR DESCRIPTION
## Motivation for features / changes
While testing the new hparams in time series feature we got a lot of feedback about the styling and placement of the header buttons.

The main takeaways are:
- Remove the "Delete Column" button
- Ensure the icons are the same height and color
- The 3dot button ripple was weird

We also noticed that the sort button was missing from the context menu and discovered that right clicking a header cell logged an error to the console

## Screenshots of UI changes (or N/A)

Header Buttons (Dark Mode)
![image](https://github.com/tensorflow/tensorboard/assets/78179109/cd26c82d-12ad-4915-b476-8bf72a2c34bb)

Header Buttons (Light Mode)
![image](https://github.com/tensorflow/tensorboard/assets/78179109/e33e6dd8-ff0e-4ae8-9726-dd931353ffcc)

Context Menu (Dark Mode)
![image](https://github.com/tensorflow/tensorboard/assets/78179109/5fcb762a-539b-43f0-b044-b73f0e55aa79)

Context Menu (Light Mode)
![image](https://github.com/tensorflow/tensorboard/assets/78179109/4a050bc9-6465-48db-8c7b-fb2348c85e74)

No context menu in scalar card
![image](https://github.com/tensorflow/tensorboard/assets/78179109/6f0220a9-5213-4cca-aab7-832be9f4f5a6)

