### PR TITLE
HParams: Close the context menu after a column is removed

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -287,6 +287,7 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
       return;
     }
     this.removeColumn.emit(this.contextMenuHeader);
+    this.contextMenu.close();
   }
 
   private getInsertIndex() {

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -715,7 +715,7 @@ describe('data table', () => {
       });
     });
 
-    it('removes column when Remove button is clicked', fakeAsync(() => {
+    it('removes column when Remove button is clicked', () => {
       const fixture = createComponent({
         headers: mockHeaders,
         data: mockTableData,
@@ -727,19 +727,16 @@ describe('data table', () => {
       cell.nativeElement.dispatchEvent(new MouseEvent('contextmenu'));
       fixture.detectChanges();
 
-      let columnRemoved: ColumnHeader | undefined = undefined;
-      fixture.componentInstance.removeColumn.subscribe((event) => {
-        columnRemoved = event;
-      });
-
+      spyOn(fixture.componentInstance.removeColumn, 'emit');
       fixture.debugElement
         .queryAll(By.css('.context-menu button'))
         .find((btn) => btn.nativeElement.innerHTML.includes('Remove'))!
         .nativeElement.click();
-      flush();
+      fixture.detectChanges();
 
-      expect(columnRemoved).toBeDefined();
-    }));
+      expect(fixture.componentInstance.removeColumn.emit).toHaveBeenCalled();
+      expect(fixture.debugElement.query(By.css('.context-menu'))).toBeNull();
+    });
 
     it('does not include add buttons when there are no selectable columns', () => {
       const fixture = createComponent({


### PR DESCRIPTION
## Motivation for features / changes
This is a bug fix. When removing a column via the context menu the context menu should immediately close.

## Screenshots of UI changes (or N/A)
It closes now
![21dfb5be-cf29-4c10-ae55-0de19e284166](https://github.com/tensorflow/tensorboard/assets/78179109/b41061db-b972-46be-afaf-a5f4bcb13fec)
