### PR TITLE
HParams: Make experiment name column sortable and movable

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -355,6 +355,8 @@ const {initialState: uiInitialState, reducers: uiNamespaceContextedReducers} =
               name: 'experimentName',
               displayName: 'Experiment',
               enabled: true,
+              movable: true,
+              sortable: true,
             },
           ];
 


### PR DESCRIPTION
## Motivation for features / changes
The experiment name column should always have been movable and sortable but it was created before those properties existed and didn't get updated until now.