### PR TITLE
HParams: Prevent select allheckbox from its default behavior

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -46,7 +46,7 @@ limitations under the License.
             <mat-checkbox
               [checked]="allRowsSelected()"
               [indeterminate]="!allRowsSelected() && someRowsSelected()"
-              (click)="onAllSelectionToggle.emit(getRunIds())"
+              (click)="handleSelectAll($event)"
             ></mat-checkbox>
           </div>
           <span class="group-menu-container" *ngSwitchCase="'color'">

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -88,10 +88,6 @@ export class RunsDataTable {
     );
   }
 
-  getRunIds() {
-    return this.data.map((row) => row.id);
-  }
-
   allRowsSelected() {
     return this.data.every((row) => row['selected']);
   }

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -100,6 +100,11 @@ export class RunsDataTable {
     return this.data.some((row) => row['selected']);
   }
 
+  handleSelectAll(event: MouseEvent) {
+    event.preventDefault();
+    this.onAllSelectionToggle.emit(this.data.map((row) => row.id));
+  }
+
   onFilterKeyUp(event: KeyboardEvent) {
     const input = event.target! as HTMLInputElement;
     this.onRegexFilterChange.emit(input.value);


### PR DESCRIPTION
## Motivation for features / changes
The select all checkbox very often got into a bad state where it showed checked when it should show unchecked and vice versa.  This fixes that bug.  I could not get the tests to reproduce the issue so I could not write a test to ensure it does not happen again.

## Technical description of changes
I could not completely nail down why this was happening. This does fix it though.

## Screenshots of UI changes (or N/A)
Before:
<img width="50" alt="Screenshot 2023-06-30 at 2 33 35 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/dd394644-2760-4e0a-881f-07c360d33ed6">
<img width="51" alt="Screenshot 2023-06-30 at 2 33 27 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/c0664111-4a1a-4f5d-aa38-acc35681a108">

After: 
<img width="66" alt="Screenshot 2023-06-30 at 2 21 03 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/26544174-7aac-45a4-95a1-6b2a1de3a756">
<img width="56" alt="Screenshot 2023-06-30 at 2 20 56 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/4f2733d6-eb02-430f-8db9-71d22d54a8d4">
