### PR TITLE
Removing missing image reference

### DIFF
--- a/docs/tensorboard_projector_plugin.ipynb
+++ b/docs/tensorboard_projector_plugin.ipynb
@@ -65,8 +65,6 @@
         "\n",
         "Using the **TensorBoard Embedding Projector**, you can graphically represent high dimensional embeddings. This can be helpful in visualizing, examining, and understanding your embedding layers.\n",
         "\n",
-        "<img src=\"https://github.com/tensorflow/docs/blob/master/site/en/tutorials/text/images/embedding.jpg?raw=\\\" alt=\"Screenshot of the embedding projector\" width=\"400\"/>\n",
-        "\n",
         "In this tutorial, you will learn how visualize this type of trained layer."
       ]
     },


### PR DESCRIPTION
## Motivation for features / changes

There is a broken image link.

## Technical description of changes

Removing the reference.

## Screenshots of UI changes (or N/A)

N/A.

## Detailed steps to verify changes work correctly (as executed by you)

The original image:
https://github.com/tensorflow/docs/blob/f957ee6185e5b2135da5c3d3f8ba0c429794ebe1/site/en/tutorials/text/images/embedding.jpg

Was removed as part of: 
https://github.com/tensorflow/docs/commit/d16e549c837c7a268c9e8d866e886164aac86d2d#diff-31e6e93b3e0ec43331ea20072ef374ae4fe5c86f6600c794fd3ae333dd789f20


## Alternate designs / implementations considered (or N/A)

Considered copying over the old image, but I see the new docs use a different image format, and that the examples in the current notebook are very similar to the initial image.
