### PR TITLE
Fixing broken link in projector dashboard

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.ts
@@ -31,7 +31,8 @@ class VzProjectorDashboard extends PolymerElement {
 
           <li>
             You are not saving any checkpoint. To save your model, create a
-            <a href="https://www.tensorflow.org/api_docs/python/tf/train/Saver"
+            <a
+              href="https://www.tensorflow.org/api_docs/python/tf/compat/v1/train/Saver"
               ><code>tf.train.Saver</code></a
             >
             and save your model periodically by calling


### PR DESCRIPTION
## Motivation for features / changes

There is a broken link on the projector dashboard page.

## Technical description of changes

Updating it with the newest version.

## Screenshots of UI changes (or N/A)

N/A.

## Detailed steps to verify changes work correctly (as executed by you)

Accessing an empty projector dashboard page.

## Alternate designs / implementations considered (or N/A)

Instead of using the `compat` link, figure out what the new way should be and link in there.
