### PR TITLE
Embedded Single Card: Add card route type to parse experiment IDs

### DIFF
--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -74,6 +74,7 @@ export function getExperimentIdsFromRouteParams(
       }
       return [DEFAULT_EXPERIMENT_ID];
     }
+    case RouteKind.CARD:
     case RouteKind.COMPARE_EXPERIMENT: {
       const typedParams = params as CompareRouteParams;
       return parseCompareExperimentStr(typedParams.experimentIds).map(

--- a/tensorboard/webapp/app_routing/internal_utils_test.ts
+++ b/tensorboard/webapp/app_routing/internal_utils_test.ts
@@ -108,6 +108,13 @@ describe('app_routing/utils', () => {
       expect(actual).toEqual(['1', '2']);
     });
 
+    it('returns ids from card route', () => {
+      const actual = utils.getExperimentIdsFromRouteParams(RouteKind.CARD, {
+        experimentIds: 'e1:1,e2:2',
+      });
+      expect(actual).toEqual(['1', '2']);
+    });
+
     it('returns id from experiment route', () => {
       const actual = utils.getExperimentIdsFromRouteParams(
         RouteKind.EXPERIMENT,


### PR DESCRIPTION
## Motivation for features / changes
The single card route will be formatted tb.corp/card/<exp_ids>/tag/<tag> so we need to add handling for the card routing to parse experiment IDs. 
Googlers, please see cl/544184799 for the internal time series data fetching by populating the experiment ids and tag from the card route. 

## Technical description of changes
Added CARD route kind to parse multiple IDs from the route. The COMPARE_EXPERIMENT has the same parsing logic so we can reuse that. 
