### PR TITLE
Hparams: Return empty lists for DataProvider hyperparameter operations.

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -394,7 +394,7 @@ class DataProvider(metaclass=abc.ABCMeta):
         Raises:
           tensorboard.errors.PublicError: See `DataProvider` class docstring.
         """
-        pass
+        return []
 
     def read_hyperparameters(self, ctx=None, *, experiment_ids):
         """Read hyperparameter values.
@@ -411,7 +411,7 @@ class DataProvider(metaclass=abc.ABCMeta):
         Raises:
           tensorboard.errors.PublicError: See `DataProvider` class docstring.
         """
-        pass
+        return []
 
 
 class ExperimentMetadata:


### PR DESCRIPTION
The DataProvider abstract base class is changed to have simple implementations of both list_hyperparameters() and read_hyperparameters(). This is to accomodate TensorBoards' DataProvider implementations that do not currently implement these operations. We return empty lists in both operations.