### PR TITLE
Embedded Single Card: fix modules for scalar card line chart 

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -316,17 +316,16 @@ tf_ng_module(
     srcs = [
         "scalar_card_component.ts",
         "scalar_card_container.ts",
-        "scalar_card_fob_controller.ts",
         "scalar_card_module.ts",
     ],
     assets = [
         ":scalar_card_styles",
-        ":scalar_card_fob_controller_styles",
         "scalar_card_component.ng.html",
     ],
     deps = [
         ":data_download_dialog",
         ":scalar_card_data_table",
+        ":scalar_card_line_chart",
         ":scalar_card_types",
         ":utils",
         ":vis_linked_time_selection_warning",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -395,7 +395,6 @@ tf_ng_module(
         "scalar_card_line_chart_component.ng.html",
     ],
     deps = [
-        ":scalar_card",
         ":scalar_card_types",
         ":utils",
         "//tensorboard/webapp:app_state",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -316,17 +316,16 @@ tf_ng_module(
     srcs = [
         "scalar_card_component.ts",
         "scalar_card_container.ts",
-        "scalar_card_fob_controller.ts",
         "scalar_card_module.ts",
     ],
     assets = [
         ":scalar_card_styles",
-        ":scalar_card_fob_controller_styles",
         "scalar_card_component.ng.html",
     ],
     deps = [
         ":data_download_dialog",
         ":scalar_card_data_table",
+        ":scalar_card_line_chart",
         ":scalar_card_types",
         ":utils",
         ":vis_linked_time_selection_warning",
@@ -384,16 +383,17 @@ tf_sass_binary(
 tf_ng_module(
     name = "scalar_card_line_chart",
     srcs = [
+        "scalar_card_fob_controller.ts",
         "scalar_card_line_chart_component.ts",
         "scalar_card_line_chart_container.ts",
         "scalar_card_line_chart_module.ts",
     ],
     assets = [
         ":scalar_card_line_chart_styles",
+        ":scalar_card_fob_controller_styles",
         "scalar_card_line_chart_component.ng.html",
     ],
     deps = [
-        ":scalar_card",
         ":scalar_card_types",
         ":utils",
         "//tensorboard/webapp:app_state",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -316,16 +316,17 @@ tf_ng_module(
     srcs = [
         "scalar_card_component.ts",
         "scalar_card_container.ts",
+        "scalar_card_fob_controller.ts",
         "scalar_card_module.ts",
     ],
     assets = [
         ":scalar_card_styles",
+        ":scalar_card_fob_controller_styles",
         "scalar_card_component.ng.html",
     ],
     deps = [
         ":data_download_dialog",
         ":scalar_card_data_table",
-        ":scalar_card_line_chart",
         ":scalar_card_types",
         ":utils",
         ":vis_linked_time_selection_warning",
@@ -394,6 +395,7 @@ tf_ng_module(
         "scalar_card_line_chart_component.ng.html",
     ],
     deps = [
+        ":scalar_card",
         ":scalar_card_types",
         ":utils",
         "//tensorboard/webapp:app_state",

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_module.ts
@@ -26,6 +26,7 @@ import {ScalarCardFobController} from './scalar_card_fob_controller';
     ScalarCardLineChartComponent,
     ScalarCardFobController,
   ],
+  // TO-DO(@brendahuang b/288573332): Remove ScalarCardFobController from exports when replacing line chart with ScalarCardLineChart for ScalarCard
   exports: [ScalarCardLineChartContainer, ScalarCardFobController],
   imports: [CardFobModule, CommonModule, LineChartV2Module],
 })

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_module.ts
@@ -26,7 +26,7 @@ import {ScalarCardFobController} from './scalar_card_fob_controller';
     ScalarCardLineChartComponent,
     ScalarCardFobController,
   ],
-  exports: [ScalarCardLineChartContainer],
+  exports: [ScalarCardLineChartContainer, ScalarCardFobController],
   imports: [CardFobModule, CommonModule, LineChartV2Module],
 })
 export class ScalarCardLineChartModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_module.ts
@@ -14,14 +14,19 @@ limitations under the License.
 ==============================================================================*/
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {CardFobModule} from '../../../widgets/card_fob/card_fob_module';
 import {LineChartModule as LineChartV2Module} from '../../../widgets/line_chart_v2/line_chart_module';
 import {ScalarCardLineChartComponent} from './scalar_card_line_chart_component';
 import {ScalarCardLineChartContainer} from './scalar_card_line_chart_container';
-import {ScalarCardModule} from './scalar_card_module';
+import {ScalarCardFobController} from './scalar_card_fob_controller';
 
 @NgModule({
-  declarations: [ScalarCardLineChartContainer, ScalarCardLineChartComponent],
+  declarations: [
+    ScalarCardLineChartContainer,
+    ScalarCardLineChartComponent,
+    ScalarCardFobController,
+  ],
   exports: [ScalarCardLineChartContainer],
-  imports: [CommonModule, LineChartV2Module, ScalarCardModule],
+  imports: [CardFobModule, CommonModule, LineChartV2Module],
 })
 export class ScalarCardLineChartModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
@@ -391,7 +391,7 @@ describe('scalar card line chart', () => {
     );
     const lineChartComponent = fixture.debugElement.query(Selector.LINE_CHART);
 
-    // HACK: we are using viewChild in ScalarCardComponent and there is
+    // HACK: we are using viewChild in ScalarCardLineChartComponent and there is
     // no good way to provide a stub implementation. Manually set what
     // would be populated by ViewChild decorator.
     scalarCardLineChartComponent.componentInstance.lineChart =

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -18,6 +18,7 @@ import {MatLegacyButtonModule} from '@angular/material/legacy-button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatLegacyMenuModule} from '@angular/material/legacy-menu';
 import {MatLegacyProgressSpinnerModule} from '@angular/material/legacy-progress-spinner';
+import {CardFobModule} from '../../../widgets/card_fob/card_fob_module';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
 import {IntersectionObserverModule} from '../../../widgets/intersection_observer/intersection_observer_module';
 import {LineChartModule as LineChartV2Module} from '../../../widgets/line_chart_v2/line_chart_module';
@@ -27,13 +28,18 @@ import {DataDownloadModule} from './data_download_module';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
 import {ScalarCardDataTableModule} from './scalar_card_data_table_module';
+import {ScalarCardFobController} from './scalar_card_fob_controller';
 import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_warning_module';
-import {ScalarCardLineChartModule} from './scalar_card_line_chart_module';
 
 @NgModule({
-  declarations: [ScalarCardContainer, ScalarCardComponent],
+  declarations: [
+    ScalarCardContainer,
+    ScalarCardComponent,
+    ScalarCardFobController,
+  ],
   exports: [ScalarCardContainer],
   imports: [
+    CardFobModule,
     CommonModule,
     DataDownloadModule,
     ExperimentAliasModule,
@@ -45,7 +51,6 @@ import {ScalarCardLineChartModule} from './scalar_card_line_chart_module';
     MatLegacyProgressSpinnerModule,
     ResizeDetectorModule,
     ScalarCardDataTableModule,
-    ScalarCardLineChartModule,
     TruncatedPathModule,
     VisLinkedTimeSelectionWarningModule,
   ],

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -18,7 +18,6 @@ import {MatLegacyButtonModule} from '@angular/material/legacy-button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatLegacyMenuModule} from '@angular/material/legacy-menu';
 import {MatLegacyProgressSpinnerModule} from '@angular/material/legacy-progress-spinner';
-import {CardFobModule} from '../../../widgets/card_fob/card_fob_module';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
 import {IntersectionObserverModule} from '../../../widgets/intersection_observer/intersection_observer_module';
 import {LineChartModule as LineChartV2Module} from '../../../widgets/line_chart_v2/line_chart_module';
@@ -28,18 +27,13 @@ import {DataDownloadModule} from './data_download_module';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
 import {ScalarCardDataTableModule} from './scalar_card_data_table_module';
-import {ScalarCardFobController} from './scalar_card_fob_controller';
+import {ScalarCardLineChartModule} from './scalar_card_line_chart_module';
 import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_warning_module';
 
 @NgModule({
-  declarations: [
-    ScalarCardContainer,
-    ScalarCardComponent,
-    ScalarCardFobController,
-  ],
+  declarations: [ScalarCardContainer, ScalarCardComponent],
   exports: [ScalarCardContainer],
   imports: [
-    CardFobModule,
     CommonModule,
     DataDownloadModule,
     ExperimentAliasModule,
@@ -51,6 +45,7 @@ import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_w
     MatLegacyProgressSpinnerModule,
     ResizeDetectorModule,
     ScalarCardDataTableModule,
+    ScalarCardLineChartModule,
     TruncatedPathModule,
     VisLinkedTimeSelectionWarningModule,
   ],

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_module.ts
@@ -18,7 +18,6 @@ import {MatLegacyButtonModule} from '@angular/material/legacy-button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatLegacyMenuModule} from '@angular/material/legacy-menu';
 import {MatLegacyProgressSpinnerModule} from '@angular/material/legacy-progress-spinner';
-import {CardFobModule} from '../../../widgets/card_fob/card_fob_module';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
 import {IntersectionObserverModule} from '../../../widgets/intersection_observer/intersection_observer_module';
 import {LineChartModule as LineChartV2Module} from '../../../widgets/line_chart_v2/line_chart_module';
@@ -28,18 +27,13 @@ import {DataDownloadModule} from './data_download_module';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
 import {ScalarCardDataTableModule} from './scalar_card_data_table_module';
-import {ScalarCardFobController} from './scalar_card_fob_controller';
 import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_warning_module';
+import {ScalarCardLineChartModule} from './scalar_card_line_chart_module';
 
 @NgModule({
-  declarations: [
-    ScalarCardContainer,
-    ScalarCardComponent,
-    ScalarCardFobController,
-  ],
+  declarations: [ScalarCardContainer, ScalarCardComponent],
   exports: [ScalarCardContainer],
   imports: [
-    CardFobModule,
     CommonModule,
     DataDownloadModule,
     ExperimentAliasModule,
@@ -51,6 +45,7 @@ import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_w
     MatLegacyProgressSpinnerModule,
     ResizeDetectorModule,
     ScalarCardDataTableModule,
+    ScalarCardLineChartModule,
     TruncatedPathModule,
     VisLinkedTimeSelectionWarningModule,
   ],


### PR DESCRIPTION
## Motivation for features / changes
The scalar card line chart will be a separate module that we want independent of the scalar card. This aims to resolve build errors in the previous scalar card line chart changes.
Googlers, see cl/547304448 to see that these changes build. 

## Technical description of changes
Move ScalarCardFobController from Scalar Card to Scalar Card Line Chart. 


Demo that current scalar card with fob still works
[demo.webm](https://github.com/tensorflow/tensorboard/assets/70195566/7a0828df-5c65-4989-8746-70da632b4411)
