### PR TITLE
LSC: Add load() statements for Blaze-builtin Python rules/providers.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,18 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories(omit_bazel_skylib = True)
 
+# rules_python has to be placed before load("@io_bazel_rules_closure//closure:repositories.bzl")
+# in the dependencies list, otherwise we get "cannot load '@rules_python//python:py_xxx.bzl': no such file"
+http_archive(
+    name = "rules_python",
+    sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578",
+    strip_prefix = "rules_python-0.24.0",
+    urls = [
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_python/releases/download/0.24.0/rules_python-0.24.0.tar.gz",
+        "https://github.com/bazelbuild/rules_python/releases/download/0.24.0/rules_python-0.24.0.tar.gz",  # 2023-07-11
+    ],
+)
+
 load("@io_bazel_rules_webtesting//web:py_repositories.bzl", "py_repositories")
 
 py_repositories()

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -4,6 +4,9 @@
 load("//tensorboard/defs:py_repl.bzl", "py_repl")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:zipper.bzl", "tensorboard_zip_file")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = [":internal"])
 

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -1,6 +1,9 @@
 # Description:
 # TensorBoard, a dashboard for investigating TensorFlow
 
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -1,5 +1,7 @@
 # Description:
 # Event processing logic for TensorBoard
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/compat/BUILD
+++ b/tensorboard/compat/BUILD
@@ -1,5 +1,6 @@
 # Description:
 # Compatibility interfaces for TensorBoard.
+load("@rules_python//python:py_library.bzl", "py_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -1,6 +1,7 @@
 # Description:
 # TensorBoard, a dashboard for investigating TensorFlow
 
+load("@rules_python//python:py_test.bzl", "py_test")
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])

--- a/tensorboard/compat/tensorflow_stub/BUILD
+++ b/tensorboard/compat/tensorflow_stub/BUILD
@@ -1,5 +1,7 @@
 # Description:
 # TensorBoard, a dashboard for investigating TensorFlow
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/data/BUILD
+++ b/tensorboard/data/BUILD
@@ -1,6 +1,9 @@
 # Description:
 # Experimental framework for generic TensorBoard data providers.
 
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/data/experimental/BUILD
+++ b/tensorboard/data/experimental/BUILD
@@ -1,5 +1,8 @@
 # Description:
 # Experiment Data Access API.
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/data/server/BUILD
+++ b/tensorboard/data/server/BUILD
@@ -1,3 +1,5 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc", "rust_doc_test", "rust_library", "rust_test")
 
 package(default_visibility = ["//tensorboard:internal"])

--- a/tensorboard/data/server/pip_package/BUILD
+++ b/tensorboard/data/server/pip_package/BUILD
@@ -1,3 +1,6 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])

--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -1,4 +1,6 @@
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@npm//@bazel/concatjs:index.bzl", "ts_library")
 

--- a/tensorboard/defs/internal/BUILD
+++ b/tensorboard/defs/internal/BUILD
@@ -1,3 +1,6 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/defs/protos.bzl
+++ b/tensorboard/defs/protos.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@com_google_protobuf//:protobuf.bzl", "proto_gen")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 # TODO(#6185): try to reduce the complexity in this rule.
 def tb_proto_library(
@@ -63,7 +64,7 @@ def tb_proto_library(
     )
 
     py_deps = [s + "_py_pb2" for s in deps] + [runtime]
-    native.py_library(
+    py_library(
         name = name + "_py_pb2",
         srcs = outs_proto,
         imports = [],
@@ -73,7 +74,7 @@ def tb_proto_library(
         visibility = visibility,
     )
     if has_services:
-        native.py_library(
+        py_library(
             name = name + "_py_pb2_grpc",
             srcs = outs_grpc,
             imports = [],

--- a/tensorboard/defs/py_repl.bzl
+++ b/tensorboard/defs/py_repl.bzl
@@ -16,6 +16,8 @@
 
 # Minimal wrapper over ctx.actions.write to write a string to a file.
 # Simpler than the genrule equivalent since we don't need to escape.
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
 def _write_file_impl(ctx):
     ctx.actions.write(ctx.outputs.out, ctx.attr.content, ctx.attr.is_executable)
 
@@ -82,7 +84,7 @@ def py_repl(name, preamble = None, deps = None, **kwargs):
         content = full_preamble,
     )
 
-    native.py_binary(
+    py_binary(
         name = name + "_py",
         srcs = [name + ".py"],
         main = name + ".py",

--- a/tensorboard/examples/plugins/example_raw_scalars/BUILD
+++ b/tensorboard/examples/plugins/example_raw_scalars/BUILD
@@ -5,6 +5,8 @@
 # demonstrate that Bazel is not required); we use this BUILD file only
 # to define integration tests for TensorBoard itself.
 
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -1,6 +1,9 @@
 # Description:
 #  Tools for building the TensorBoard pip package.
 
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])

--- a/tensorboard/plugins/BUILD
+++ b/tensorboard/plugins/BUILD
@@ -1,5 +1,7 @@
 # Description:
 # A plugin system for TensorBoard
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -1,6 +1,8 @@
 # Description:
 # TensorBoard plugin for audio
-
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -1,5 +1,7 @@
 # Description:
 #   TensorBoard core plugin.
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -1,6 +1,8 @@
 # Description:
 # TensorBoard plugin for custom scalars plots
-
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])

--- a/tensorboard/plugins/debugger_v2/BUILD
+++ b/tensorboard/plugins/debugger_v2/BUILD
@@ -2,6 +2,8 @@
 # TensorBoard Debugger V2 Plugin: A plugin for inspecting and debugging
 # the internals of a TensorFlow program (e.g., graphs, functions and tensors),
 # with a focus on TensorFlow 2.x.
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -1,4 +1,5 @@
 load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_ts_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -1,5 +1,7 @@
 # Description:
 # TensorBoard plugin for distributions
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -1,5 +1,9 @@
 # Description:
 # TensorBoard plugin for graphs
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -2,6 +2,9 @@
 # TensorBoard plugin for histograms
 
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -4,6 +4,9 @@
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -2,6 +2,9 @@
 # TensorBoard plugin for images
 
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/mesh/BUILD
+++ b/tensorboard/plugins/mesh/BUILD
@@ -1,4 +1,7 @@
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/metrics/BUILD
+++ b/tensorboard/plugins/metrics/BUILD
@@ -1,6 +1,9 @@
 # Description:
 # TensorBoard plugin for metrics (scalars, images, histograms, distributions)
 
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -2,6 +2,9 @@
 # TensorBoard plugin for precision-recall curves.
 
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/profile_redirect/BUILD
+++ b/tensorboard/plugins/profile_redirect/BUILD
@@ -1,6 +1,9 @@
 # Description:
 # Plugin with installation instructions for dynamic profile plugin
 
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -1,6 +1,9 @@
 # Embedding Projector plugin.
 
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -2,6 +2,9 @@
 # TensorBoard plugin for scalars
 
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -2,6 +2,9 @@
 # TensorBoard plugin for the Text
 
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/scripts/BUILD
+++ b/tensorboard/scripts/BUILD
@@ -1,5 +1,6 @@
 # Description:
 # Some useful scripts that are bundled with TensorBoard.
+load("@rules_python//python:py_binary.bzl", "py_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -2,6 +2,8 @@
 # Summary API for TensorBoard.
 
 load("//tensorboard/defs:py_repl.bzl", "py_repl")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/summary/writer/BUILD
+++ b/tensorboard/summary/writer/BUILD
@@ -1,5 +1,8 @@
 # Description:
 # Writer interfaces for TensorBoard if tensorflow is not present
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/tools/BUILD
+++ b/tensorboard/tools/BUILD
@@ -1,3 +1,6 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -1,6 +1,9 @@
 # Description:
 # Uploader for TensorBoard.dev
 
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -1,4 +1,6 @@
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/third_party/bleach.BUILD
+++ b/third_party/bleach.BUILD
@@ -2,6 +2,8 @@
 #   Build file for Bleach.
 # License:
 #   Apache 2.0
+load("@rules_python//python:py_library.bzl", "py_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/third_party/html5lib.BUILD
+++ b/third_party/html5lib.BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Import of html5lib library.
 
+load("@rules_python//python:py_library.bzl", "py_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # BSD-like notice-style license, see LICENSE file

--- a/third_party/markdown.BUILD
+++ b/third_party/markdown.BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Markdown processor
 
+load("@rules_python//python:py_library.bzl", "py_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # This software says they use a BSD license.

--- a/third_party/six.BUILD
+++ b/third_party/six.BUILD
@@ -2,6 +2,8 @@
 #   Six provides simple utilities for wrapping over differences between Python 2
 #   and Python 3.
 
+load("@rules_python//python:py_library.bzl", "py_library")
+
 licenses(["notice"])  # MIT
 
 exports_files(["LICENSE"])

--- a/third_party/urllib3.BUILD
+++ b/third_party/urllib3.BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   urllib3, another url library
 
+load("@rules_python//python:py_library.bzl", "py_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # MIT

--- a/third_party/webencodings.BUILD
+++ b/third_party/webencodings.BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Character encoding aliases for legacy web content
 
+load("@rules_python//python:py_library.bzl", "py_library")
+
 licenses(["notice"])  # BSD
 
 exports_files(["LICENSE"])

--- a/third_party/werkzeug.BUILD
+++ b/third_party/werkzeug.BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Werkzeug provides utilities for making WSGI applications
 
+load("@rules_python//python:py_library.bzl", "py_library")
+
 licenses(["notice"])  # BSD 3-Clause
 
 exports_files(["LICENSE"])


### PR DESCRIPTION
LSC: Add load() statements for Blaze-builtin Python rules/providers.

load()s are being added in preparation for moving the rule implementations out of Blaze itself.

More information: [go/py-add-loads-lsc](https://goto.google.com/py-add-loads-lsc)

example CL: https://critique.corp.google.com/cl/518105787

Tests done:

```
bazel build //tensorboard
```
Build completed successfully

```
bazel run //tensorboard -- --logdir /google/data/ro/teams/tensorboard/logfiles --bind_all
```
Started up standalone TensorBoard successfully. Verified that the dashboard works as expected.

