### PR TITLE
Hparams: Treat Nan/Infinity numeric hparam values as unset values.

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -29,6 +29,7 @@ py_library(
         "download_data.py",
         "get_experiment.py",
         "hparams_plugin.py",
+        "json_format_compat.py",
         "list_metric_evals.py",
         "list_session_groups.py",
         "metrics.py",
@@ -113,6 +114,15 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/data:provider",
     ],
+)
+
+py_test(
+    name = "json_format_compat_test",
+    size = "small",
+    srcs = [
+        "json_format_compat_test.py",
+    ],
+    deps = [":hparams_plugin"],
 )
 
 py_binary(

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -22,6 +22,7 @@ import os
 
 from tensorboard.data import provider
 from tensorboard.plugins.hparams import api_pb2
+from tensorboard.plugins.hparams import json_format_compat
 from tensorboard.plugins.hparams import metadata
 from google.protobuf import json_format
 from tensorboard.plugins.scalar import metadata as scalar_metadata
@@ -282,11 +283,6 @@ class Context:
         # If all values have the same type, then that is the type used.
         # Otherwise, the returned type is DATA_TYPE_STRING.
         result = api_pb2.HParamInfo(name=name, type=api_pb2.DATA_TYPE_UNSET)
-        distinct_values = set(
-            _protobuf_value_to_string(v)
-            for v in values
-            if _protobuf_value_type(v)
-        )
         for v in values:
             v_type = _protobuf_value_type(v)
             if not v_type:
@@ -304,6 +300,11 @@ class Context:
             return None
 
         if result.type == api_pb2.DATA_TYPE_STRING:
+            distinct_values = set()
+            for value in values:
+                if _protobuf_value_type(value):
+                    if json_format_compat.is_serializable_value(value):
+                        distinct_values.add(_protobuf_value_to_string(value))
             result.domain_discrete.extend(distinct_values)
 
         if result.type == api_pb2.DATA_TYPE_BOOL:

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -300,11 +300,11 @@ class Context:
             return None
 
         if result.type == api_pb2.DATA_TYPE_STRING:
-            distinct_values = set()
-            for value in values:
-                if _protobuf_value_type(value):
-                    if json_format_compat.is_serializable_value(value):
-                        distinct_values.add(_protobuf_value_to_string(value))
+            distinct_values = set(
+                _protobuf_value_to_string(v)
+                for v in values
+                if _can_be_converted_to_string(v)
+            )
             result.domain_discrete.extend(distinct_values)
 
         if result.type == api_pb2.DATA_TYPE_BOOL:
@@ -451,6 +451,12 @@ def _find_longest_parent_path(path_set, path):
             return None
         path = os.path.dirname(path)
     return path
+
+
+def _can_be_converted_to_string(value):
+    if not _protobuf_value_type(value):
+        return False
+    return json_format_compat.is_serializable_value(value)
 
 
 def _protobuf_value_type(value):

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -344,6 +344,33 @@ class BackendContextTest(tf.test.TestCase):
         _canonicalize_experiment(actual_exp)
         self.assertProtoEquals(expected_exp, actual_exp)
 
+    def test_experiment_with_string_domain_and_invalid_number_values(self):
+        self.session_1_start_info_ = """
+            hparams:[
+              {key: 'maybe_invalid' value: {string_value: 'force_to_string_type'}}
+            ]
+        """
+        self.session_2_start_info_ = """
+            hparams:[
+              {key: 'maybe_invalid' value: {number_value: NaN}}
+            ]
+        """
+        self.session_3_start_info_ = """
+            hparams:[
+              {key: 'maybe_invalid' value: {number_value: Infinity}}
+            ]
+        """
+        expected_hparam_info = """
+            name: 'maybe_invalid'
+            type: DATA_TYPE_STRING
+            domain_discrete: {
+              values: [{string_value: 'force_to_string_type'}]
+            }
+        """
+        actual_exp = self._experiment_from_metadata()
+        self.assertLen(actual_exp.hparam_infos, 1)
+        self.assertProtoEquals(expected_hparam_info, actual_exp.hparam_infos[0])
+
     def test_experiment_without_any_hparams(self):
         request_ctx = context.RequestContext()
         actual_exp = self._experiment_from_metadata()

--- a/tensorboard/plugins/hparams/json_format_compat.py
+++ b/tensorboard/plugins/hparams/json_format_compat.py
@@ -1,0 +1,37 @@
+# Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import math
+
+
+def is_serializable_value(value):
+    """Returns whether a protobuf Value will be serializable by MessageToJson.
+
+    The json_format documentation states that "attempting to serialize NaN or
+    Infinity results in error."
+
+    https://protobuf.dev/reference/protobuf/google.protobuf/#value
+
+    Args:
+      value: A value of type protobuf.Value.
+
+    Returns:
+      True if the Value should be serializable without error by MessageToJson.
+      False, otherwise.
+    """
+    return not value.HasField("number_value") or (
+        not math.isnan(value.number_value)
+        and not math.isinf(value.number_value)
+    )

--- a/tensorboard/plugins/hparams/json_format_compat.py
+++ b/tensorboard/plugins/hparams/json_format_compat.py
@@ -31,7 +31,8 @@ def is_serializable_value(value):
       True if the Value should be serializable without error by MessageToJson.
       False, otherwise.
     """
-    return not value.HasField("number_value") or (
-        not math.isnan(value.number_value)
-        and not math.isinf(value.number_value)
-    )
+    if not value.HasField("number_value"):
+        return True
+
+    number_value = value.number_value
+    return not math.isnan(number_value) and not math.isinf(number_value)

--- a/tensorboard/plugins/hparams/json_format_compat_test.py
+++ b/tensorboard/plugins/hparams/json_format_compat_test.py
@@ -1,0 +1,64 @@
+# Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from google.protobuf import struct_pb2
+from tensorboard.plugins.hparams import json_format_compat
+
+
+class TestCase(absltest.TestCase):
+    def test_real_value_is_serializable(self):
+        self.assertTrue(
+            json_format_compat.is_serializable_value(
+                struct_pb2.Value(number_value=1.0)
+            )
+        )
+        self.assertTrue(
+            json_format_compat.is_serializable_value(
+                struct_pb2.Value(string_value="nan")
+            )
+        )
+        self.assertTrue(
+            json_format_compat.is_serializable_value(
+                struct_pb2.Value(bool_value=False)
+            )
+        )
+
+    def test_empty_value_is_serializable(self):
+        self.assertTrue(
+            json_format_compat.is_serializable_value(struct_pb2.Value())
+        )
+
+    def test_nan_value_is_not_serializable(self):
+        self.assertFalse(
+            json_format_compat.is_serializable_value(
+                struct_pb2.Value(number_value=float("nan"))
+            )
+        )
+
+    def test_infinity_value_is_not_serializable(self):
+        self.assertFalse(
+            json_format_compat.is_serializable_value(
+                struct_pb2.Value(number_value=float("inf"))
+            )
+        )
+        self.assertFalse(
+            json_format_compat.is_serializable_value(
+                struct_pb2.Value(number_value=float("-inf"))
+            )
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
## Motivation for features / changes

There are cases where users might log hparam numeric values that are NaN or Infinity. Recall, we use proto's Value message for logging and storing hparam values. While processing these values in the python layer of the Hparams plugin, we may run these Value message through json_format.MessageToJson, at which point the json_format library raises an error.

The limitation is documented at https://protobuf.dev/reference/protobuf/google.protobuf/#value. "[A]ttempting to serialize NaN or Infinity results in error."

## Technical description of changes

We now will try to avoid calling MessageToJson on these problematic hparam values. We instead chose to treat these as "unset" values -- equivalent to having not set an hparam value at all. It will mean the values will not contribute to the calculation of discrete domains. And it means that the values will appear blank in the hparams UI rather than appearing as "NaN".

## Alternate designs / implementations considered (or N/A)

Given infinite amount of time:
* Fix json_format to handle NaN and Infinity :O.
* Change the hparams api.proto to use something other than proto's Value for representing hparam values.

Other reasonable options:
* Change the NaN numeric value to "NaN" string. This was my first choice but it unfortunately leads to other complications - for instance the plugin will raise errors when it encounters a "NaN" string for an hparam that is supposed to have a numeric value.