### PR TITLE
Hparams: Add differs field.

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -559,13 +559,14 @@ class Hyperparameter:
     """Metadata about a hyperparameter.
 
     Attributes:
-      hyperparameter_name: A string identifier for the hyperparameter that should be unique
-        in any result set of Hyperparameter objects.
+      hyperparameter_name: A string identifier for the hyperparameter that
+        should be unique in any result set of Hyperparameter objects.
       hyperparameter_display_name: A displayable name for the hyperparameter.
         Unlike hyperparameter_name, there is no uniqueness constraint.
       domain_type: A HyperparameterDomainType describing how we represent the
         set of known values in the `domain` attribute.
-      domain: A representation of the set of known values for the hyperparameter.
+      domain: A representation of the set of known values for the
+        hyperparameter.
 
         If domain_type is INTERVAL, a Tuple[float, float] describing the
           range of numeric values.
@@ -575,6 +576,11 @@ class Hyperparameter:
           finite set of string values.
         If domain_type is DISCRETE_BOOL, a Collection[bool] describing the
           finite set of bool values.
+
+      differs: Describes whether there are two or more known values for the
+        hyperparameter for the set of experiments specified in the
+        list_hyperparameters() request. Hyperparameters for which this is
+        true are made more prominent or easier to discover in the UI.
     """
 
     hyperparameter_name: str
@@ -587,6 +593,7 @@ class Hyperparameter:
         Collection[bool],
         None,
     ] = None
+    differs: bool = False
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tensorboard/plugins/hparams/api.proto
+++ b/tensorboard/plugins/hparams/api.proto
@@ -69,7 +69,7 @@ message Experiment {
   repeated MetricInfo metric_infos = 5;
 }
 
-// NEXT_TAG: 7
+// NEXT_TAG: 8
 message HParamInfo {
   // An id for the hyperparameter.
   string name = 1;
@@ -96,6 +96,11 @@ message HParamInfo {
     // hyperparameter are taken.
     Interval domain_interval = 6;
   }
+
+  // Describes whether there are two or more known values for the HParam
+  // in the specified Experiment. HParams for which this is true are made more
+  // prominent or easier to discover in the UI.
+  bool differs = 7;
 }
 
 enum DataType {

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -348,6 +348,7 @@ class Context:
         hparam_info = api_pb2.HParamInfo(
             name=dp_hparam.hyperparameter_name,
             display_name=dp_hparam.hyperparameter_display_name,
+            differs=dp_hparam.differs,
         )
         if dp_hparam.domain_type == provider.HyperparameterDomainType.INTERVAL:
             hparam_info.type = api_pb2.DATA_TYPE_FLOAT64

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -361,7 +361,7 @@ class BackendContextTest(tf.test.TestCase):
                 hyperparameter_name="hparam2_name",
                 hyperparameter_display_name="hparam2_display_name",
                 differs=False,
-            )
+            ),
         ]
         self._mock_tb_context.data_provider.list_tensors.side_effect = None
         actual_exp = self._experiment_from_metadata()

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -350,6 +350,35 @@ class BackendContextTest(tf.test.TestCase):
         self.assertIsInstance(actual_exp, api_pb2.Experiment)
         self.assertProtoEquals("", actual_exp)
 
+    def test_experiment_from_data_provider_differs(self):
+        self._hyperparameters = [
+            provider.Hyperparameter(
+                hyperparameter_name="hparam1_name",
+                hyperparameter_display_name="hparam1_display_name",
+                differs=True,
+            ),
+            provider.Hyperparameter(
+                hyperparameter_name="hparam2_name",
+                hyperparameter_display_name="hparam2_display_name",
+                differs=False,
+            )
+        ]
+        self._mock_tb_context.data_provider.list_tensors.side_effect = None
+        actual_exp = self._experiment_from_metadata()
+        expected_exp = """
+            hparam_infos: {
+              name: 'hparam1_name'
+              display_name: 'hparam1_display_name'
+              differs: true
+            }
+            hparam_infos: {
+              name: 'hparam2_name'
+              display_name: 'hparam2_display_name'
+              differs: false
+            }
+        """
+        self.assertProtoEquals(expected_exp, actual_exp)
+
     def test_experiment_from_data_provider_interval_hparam(self):
         self._hyperparameters = [
             provider.Hyperparameter(

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
@@ -628,8 +628,10 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
     });
     // Choose to display the first 5 hparams in the main view initially.
     const kNumHParamsToDisplayByDefault = 5;
-    const numHparamsToDisplay =
-        Math.min(kNumHParamsToDisplayByDefault, result.length);
+    const numHparamsToDisplay = Math.min(
+      kNumHParamsToDisplayByDefault,
+      result.length
+    );
     for (let i = 0; i < numHparamsToDisplay; i++) {
       result[i].displayed = true;
     }

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
@@ -575,11 +575,12 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
   // Updates the _hparams property from the _experiment property.
   _computeHParams() {
     const result: any[] = [];
-    const kNumHParamsToDisplayByDefault = 5;
-    this._experiment.hparamInfos.forEach((anInfo, index) => {
+    this._experiment.hparamInfos.forEach((anInfo) => {
       const hparam = {
         info: anInfo as any,
-        displayed: index < kNumHParamsToDisplayByDefault,
+        // Controls whether the hparam is chosen for display in the main view.
+        // Set later.
+        displayed: false,
         filter: {} as any,
       };
       if (hparam.info.hasOwnProperty('domainDiscrete')) {
@@ -617,6 +618,21 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
       }
       result.push(hparam);
     });
+    // Reorder by moving hparams with 'differs === true' to the top of the list.
+    result.sort((x, y) => {
+      if (x.info.differs === y.info.differs) {
+        return 0;
+      }
+
+      return x.info.differs ? -1 : 1;
+    });
+    // Choose to display the first 5 hparams in the main view initially.
+    const kNumHParamsToDisplayByDefault = 5;
+    const numHparamsToDisplay =
+        Math.min(kNumHParamsToDisplayByDefault, result.length);
+    for (let i = 0; i < numHparamsToDisplay; i++) {
+      result[i].displayed = true;
+    }
     this.set('_hparams', result);
   }
   // Updates the _metrics property from the _experiment property.


### PR DESCRIPTION
Add a `differs` field at both the DataProvider level (in Hyperparameter) and at the hparams API level (in HParamInfo).

Also write logic to consume it in the hparams dashboard by sorting the hparams that differ to the top.

There are, unfortunately, no tests in the repo for UI changes so I had to test the changes manually. I tested that an experiment with < 5 hparams renders all hparams and selects all hparams. I tested that an internal experiment (from an internal data provider implementation) that has > 5 hparams sorts hparams with `differs===true` to the top and that the first five are selected. I checked that attempts to set the order and to set filters succeed.