### PR TITLE
Add missing build dependency for internal import.

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -122,7 +122,10 @@ py_test(
     srcs = [
         "json_format_compat_test.py",
     ],
-    deps = [":hparams_plugin"],
+    deps = [
+        ":hparams_plugin",
+        "//tensorboard:expect_absl_testing_absltest_installed",
+    ],
 )
 
 py_binary(


### PR DESCRIPTION
#6496 broke the internal import due to missing BUILD dependency for json_format_compat_test.py.