### PR TITLE
Revert "Embedded Single Card: export card Id list"

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -69,12 +69,9 @@ export const getMetricsTagMetadata = createSelector(
 /**
  * Cards
  */
-export const getCardIds = createSelector(
-  selectMetricsState,
-  (state): CardId[] => {
-    return state.cardList;
-  }
-);
+const getCardIds = createSelector(selectMetricsState, (state): CardId[] => {
+  return state.cardList;
+});
 
 export const getCardLoadState = createSelector(
   selectMetricsState,


### PR DESCRIPTION
Reverts tensorflow/tensorboard#6499. Creating new card state to fetch card Id instead.

Googlers, please see cl/549111524 to see how the card Id will be linked in the card state. 