### PR TITLE
HParams: Refactor how runs and hparams metadata is fetched

### DIFF
--- a/tensorboard/webapp/runs/data_source/runs_data_source.ts
+++ b/tensorboard/webapp/runs/data_source/runs_data_source.ts
@@ -99,13 +99,20 @@ export class TBRunsDataSource implements RunsDataSource {
       );
   }
 
-  fetchHparamsMetadata(experimentId: string): Observable<HparamsAndMetadata> {
+  fetchHparamsMetadata(
+    experimentIds: string[]
+  ): Observable<HparamsAndMetadata> {
+    const experimentName =
+      experimentIds.length === 1
+        ? experimentIds[0]
+        : experimentIds.map((eid) => `:${eid}`).join(',');
     const requestPayload: GetExperimentHparamRequestPayload = {
-      experimentName: experimentId,
+      experimentName,
     };
+    const prefix = experimentIds.length === 1 ? 'experiment' : 'compare';
     return this.http
       .post<backendTypes.BackendHparamsExperimentResponse>(
-        `/experiment/${experimentId}/${HPARAMS_HTTP_PATH_PREFIX}/experiment`,
+        `/${prefix}/${experimentName}/${HPARAMS_HTTP_PATH_PREFIX}/experiment`,
         requestPayload,
         {},
         'request'
@@ -124,7 +131,7 @@ export class TBRunsDataSource implements RunsDataSource {
 
           const listSessionRequestParams: backendTypes.BackendListSessionGroupRequest =
             {
-              experimentName: experimentId,
+              experimentName,
               allowedStatuses: [
                 backendTypes.RunStatus.STATUS_FAILURE,
                 backendTypes.RunStatus.STATUS_RUNNING,
@@ -145,7 +152,7 @@ export class TBRunsDataSource implements RunsDataSource {
         mergeMap(({experimentHparamsInfo, listSessionRequestParams}) => {
           return this.http
             .post<backendTypes.BackendListSessionGroupResponse>(
-              `/experiment/${experimentId}/${HPARAMS_HTTP_PATH_PREFIX}/session_groups`,
+              `/${prefix}/${experimentName}/${HPARAMS_HTTP_PATH_PREFIX}/session_groups`,
               listSessionRequestParams,
               {},
               'request'
@@ -174,7 +181,7 @@ export class TBRunsDataSource implements RunsDataSource {
                 const runName = metricValue.name.group
                   ? `${session.name}/${metricValue.name.group}`
                   : session.name;
-                const runId = `${experimentId}/${runName}`;
+                const runId = `${experimentName}/${runName}`;
                 const hparamsAndMetrics = runToHparamsAndMetrics[runId] || {
                   metrics: [],
                   hparams,

--- a/tensorboard/webapp/runs/data_source/runs_data_source_types.ts
+++ b/tensorboard/webapp/runs/data_source/runs_data_source_types.ts
@@ -81,9 +81,9 @@ export interface Run {
 
 @Injectable({providedIn: 'root'})
 export abstract class RunsDataSource {
-  abstract fetchRuns(experimentId: string): Observable<Run[]>;
+  abstract fetchRuns(experimentIds: string): Observable<Run[]>;
   abstract fetchHparamsMetadata(
-    experimentId: string
+    experimentIds: string[] // DO_NOT_SUBMIT this will cause an issue when syncing.
   ): Observable<HparamsAndMetadata>;
 }
 


### PR DESCRIPTION
Note: I have deliberately not update the tests as I expect to need to make changes to my overall approach.

## Motivation for features / changes
Previously when in a comparison view a call would be made to `/experiment/{eid}/data/runs` endpoint for each experiment. This was kinda fine but weird. However, the same was true for the `/experiment/{eid}/data/session_groups` endpoint. This was NOT fine because it lead to mismatched domains when two experiments had an hparam with the same name.

Following this same paradigm our strategy for only fetching some experiments is no longer valid so I am removing it and always fetching all experiments. In doing this I exposed some redundancy where both the route change and the runs table being shown triggered metadata fetches. I'm opting to remove one of these but am open to combining the effects instead to prevent duplicate fetches.

## Screenshots of UI changes (or N/A)
Previously duplicate requests were made
![image](https://github.com/tensorflow/tensorboard/assets/78179109/9d35db66-d48b-423b-98ec-68078b3f4a73)

Only a single fetch is being made now
![image](https://github.com/tensorflow/tensorboard/assets/78179109/a87e0a9f-4626-4ff3-adec-efa0337ceca6)

### The hparams in time series feature works now too!
This error was being shown before
![image](https://github.com/tensorflow/tensorboard/assets/78179109/81ba6b8f-eaf8-4d3c-a4c9-00391c4ebe00)

Previously no potential columns existed because of the error
![image](https://github.com/tensorflow/tensorboard/assets/78179109/4f7b0c6c-1f5b-46de-95b1-5c7f766a1c31)

Now
![image](https://github.com/tensorflow/tensorboard/assets/78179109/3b3a825f-bef0-4b9a-9e0c-19076df64cca)
