### PR TITLE
Embedded Single Card: single fob removal

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -57,7 +57,7 @@ export class ScalarCardFobController {
   @Input() minMaxStep!: MinMaxStep;
   @Input() axisSize!: number;
   @Input() disableInteraction: boolean = false;
-  @Input() allowFobRemoval?: boolean;
+  @Input() allowFobRemoval?: boolean = true;
 
   @Output() onTimeSelectionChanged = new EventEmitter<{
     timeSelection: TimeSelection;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_fob_controller.ts
@@ -41,6 +41,7 @@ import {MinMaxStep} from './scalar_card_types';
       [prospectiveStep]="prospectiveStep"
       [cardFobHelper]="cardFobHelper"
       [showExtendedLine]="true"
+      [allowFobRemoval]="allowFobRemoval"
       (onProspectiveStepChanged)="onProspectiveStepChanged($event)"
       (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
       (onTimeSelectionToggled)="onTimeSelectionToggled.emit($event)"
@@ -56,6 +57,7 @@ export class ScalarCardFobController {
   @Input() minMaxStep!: MinMaxStep;
   @Input() axisSize!: number;
   @Input() disableInteraction: boolean = false;
+  @Input() allowFobRemoval?: boolean;
 
   @Output() onTimeSelectionChanged = new EventEmitter<{
     timeSelection: TimeSelection;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_component.ng.html
@@ -85,6 +85,7 @@ limitations under the License.
       [minMaxHorizontalViewExtend]="viewExtent.x"
       [minMaxStep]="minMaxStep"
       [axisSize]="domDim.width"
+      [allowFobRemoval]="allowFobRemoval"
       (onTimeSelectionChanged)="onTimeSelectionChanged.emit($event)"
       (onTimeSelectionToggled)="onFobRemoved()"
     ></scalar-card-fob-controller>

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_component.ts
@@ -72,6 +72,7 @@ export class ScalarCardLineChartComponent {
   @Input() minMaxStep!: MinMaxStep;
   @Input() userViewBox!: Extent | null;
   @Input() tooltipTemplate!: TooltipTemplate | null;
+  @Input() allowFobRemoval!: boolean;
 
   @Output()
   onTimeSelectionChanged = new EventEmitter<{

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_container.ts
@@ -78,6 +78,7 @@ import {ScalarCardLineChartComponent} from './scalar_card_line_chart_component';
       [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection"
       [forceSvg]="forceSvg$ | async"
       [userViewBox]="userViewBox$ | async"
+      [allowFobRemoval]="allowFobRemoval"
       (onTimeSelectionChanged)="onTimeSelectionChanged($event)"
       (onStepSelectorToggled)="onStepSelectorToggled($event)"
       (onLineChartZoom)="onLineChartZoom($event)"
@@ -109,6 +110,7 @@ export class ScalarCardLineChartContainer
   @Input() ignoreOutliers?: boolean;
   @Input() disableUpdate?: boolean = false;
   @Input() tooltipTemplate?: TooltipTemplate;
+  @Input() allowFobRemoval?: boolean = true;
 
   @ViewChild(ScalarCardLineChartComponent)
   scalarCardLineChart?: ScalarCardLineChartComponent;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
@@ -172,6 +172,7 @@ class TestableLineChart {
       [tooltipTemplate]="tooltip"
       [minMaxStep]="minMaxStep"
       [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection"
+      [allowFobRemoval]="allowFobRemoval"
     >
     </scalar-card-line-chart>
     <ng-template
@@ -248,6 +249,7 @@ class TestableScalarCardLineChart {
   @Input() dataPointForTesting: {x: number; y: number} = {x: 0, y: 0};
   @Input() smoothingEnabled: boolean = false;
   @Input() tooltipSort: TooltipSort = TooltipSort.ALPHABETICAL;
+  @Input() allowFobRemoval: boolean = true;
 
   readonly relativeXFormatter = relativeTimeFormatter;
   readonly valueFormatter = numberFormatter;
@@ -1589,6 +1591,66 @@ describe('scalar card line chart', () => {
         expect(fobController.endFobWrapper).toBeUndefined();
       }));
     });
+
+    it('does not allow for single fob removal when allowFobRemoval is false', fakeAsync(() => {
+      const fixture = createComponent();
+      fixture.componentInstance.cardId = 'card1';
+      fixture.componentInstance.minMaxStep = {
+        minStep: 0,
+        maxStep: 100,
+      };
+      fixture.componentInstance.stepOrLinkedTimeSelection = {
+        start: {step: 20},
+        end: null,
+      };
+      fixture.componentInstance.allowFobRemoval = false;
+      fixture.detectChanges();
+
+      expect(
+        fixture.debugElement.queryAll(By.css('[aria-label="Deselect fob"]'))
+          .length
+      ).toEqual(0);
+    }));
+
+    it('allows for single fob removal when allowFobRemoval is true', fakeAsync(() => {
+      const fixture = createComponent();
+      fixture.componentInstance.cardId = 'card1';
+      fixture.componentInstance.minMaxStep = {
+        minStep: 0,
+        maxStep: 100,
+      };
+      fixture.componentInstance.stepOrLinkedTimeSelection = {
+        start: {step: 20},
+        end: null,
+      };
+      fixture.componentInstance.allowFobRemoval = true;
+      fixture.detectChanges();
+
+      expect(
+        fixture.debugElement.queryAll(By.css('[aria-label="Deselect fob"]'))
+          .length
+      ).toEqual(1);
+    }));
+
+    it('allows for range fob removal even when allowFobRemoval is false', fakeAsync(() => {
+      const fixture = createComponent();
+      fixture.componentInstance.cardId = 'card1';
+      fixture.componentInstance.minMaxStep = {
+        minStep: 0,
+        maxStep: 100,
+      };
+      fixture.componentInstance.stepOrLinkedTimeSelection = {
+        start: {step: 20},
+        end: {step: 40},
+      };
+      fixture.componentInstance.allowFobRemoval = false;
+      fixture.detectChanges();
+
+      expect(
+        fixture.debugElement.queryAll(By.css('[aria-label="Deselect fob"]'))
+          .length
+      ).toEqual(2);
+    }));
   });
 
   describe('data table line chart integration', () => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
@@ -1580,7 +1580,7 @@ describe('scalar card line chart', () => {
       }));
     });
 
-    it('does not allow for single fob removal when allowFobRemoval is false', fakeAsync(() => {
+    it('does not render dismiss icon for single fob removal when allowFobRemoval is false', fakeAsync(() => {
       const fixture = createComponent();
       fixture.componentInstance.cardId = 'card1';
       fixture.componentInstance.minMaxStep = {
@@ -1600,7 +1600,7 @@ describe('scalar card line chart', () => {
       ).toEqual(0);
     }));
 
-    it('allows for single fob removal when allowFobRemoval is true', fakeAsync(() => {
+    it('renders dismiss icon for single fob removal when allowFobRemoval is true', fakeAsync(() => {
       const fixture = createComponent();
       fixture.componentInstance.cardId = 'card1';
       fixture.componentInstance.minMaxStep = {
@@ -1620,7 +1620,7 @@ describe('scalar card line chart', () => {
       ).toEqual(1);
     }));
 
-    it('allows for range fob removal even when allowFobRemoval is false', fakeAsync(() => {
+    it('renders dismiss icon for range fob removal even when allowFobRemoval is false', fakeAsync(() => {
       const fixture = createComponent();
       fixture.componentInstance.cardId = 'card1';
       fixture.componentInstance.minMaxStep = {

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ng.html
@@ -52,6 +52,7 @@ limitations under the License.
     ></div>
     <card-fob
       class="startFob"
+      [allowRemoval]="allowFobRemoval ? true : timeSelection.end"
       [ngClass]="isVertical() ? 'vertical-fob' : 'horizontal-fob'"
       [step]="timeSelection.start.step"
       (mousedown)="startDrag(Fob.START, TimeSelectionAffordance.FOB, $event)"

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_component.ts
@@ -63,6 +63,7 @@ export class CardFobControllerComponent {
   @Input() showExtendedLine?: Boolean = false;
   @Input() prospectiveStep: number | null = null;
   @Input() prospectiveStepAxisPosition?: number | null = null;
+  @Input() allowFobRemoval?: boolean = true;
 
   @Output() onTimeSelectionChanged =
     new EventEmitter<TimeSelectionWithAffordance>();


### PR DESCRIPTION
## Motivation for features / changes
For the internal new single card, we want to keep step selection toggled on at all times. 

## Technical description of changes
Prevent removal of the single fob when step selection is single selection. On range selection, allow removal of either fob. By default, the fob should allow removal, otherwise it will not allow removal when receiving specific input. 
