### PR TITLE
Embedded Single Card: disable tooltip on line chart

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_component.ng.html
@@ -26,6 +26,7 @@ limitations under the License.
   [ignoreYOutliers]="ignoreOutliers"
   [useDarkMode]="useDarkMode"
   [userViewBox]="userViewBox"
+  [disableTooltip]="disableTooltip"
   (onViewBoxOverridden)="isViewBoxOverridden = $event"
   (viewBoxChanged)="onLineChartZoom.emit($event)"
   [customVisTemplate]="lineChartCustomVis"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_component.ts
@@ -72,6 +72,7 @@ export class ScalarCardLineChartComponent {
   @Input() minMaxStep!: MinMaxStep;
   @Input() userViewBox!: Extent | null;
   @Input() tooltipTemplate!: TooltipTemplate | null;
+  @Input() disableTooltip!: boolean;
 
   @Output()
   onTimeSelectionChanged = new EventEmitter<{

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_container.ts
@@ -78,6 +78,7 @@ import {ScalarCardLineChartComponent} from './scalar_card_line_chart_component';
       [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection"
       [forceSvg]="forceSvg$ | async"
       [userViewBox]="userViewBox$ | async"
+      [disableTooltip]="disableTooltip"
       (onTimeSelectionChanged)="onTimeSelectionChanged($event)"
       (onStepSelectorToggled)="onStepSelectorToggled($event)"
       (onLineChartZoom)="onLineChartZoom($event)"
@@ -109,6 +110,7 @@ export class ScalarCardLineChartContainer
   @Input() ignoreOutliers?: boolean;
   @Input() disableUpdate?: boolean = false;
   @Input() tooltipTemplate?: TooltipTemplate;
+  @Input() disableTooltip?: boolean = false;
 
   @ViewChild(ScalarCardLineChartComponent)
   scalarCardLineChart?: ScalarCardLineChartComponent;

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ng.html
@@ -50,6 +50,7 @@ limitations under the License.
       [tooltipOriginEl]="overlayTarget"
       [domDim]="domDimensions.main"
       [tooltipTemplate]="tooltipTemplate"
+      [disableTooltip]="disableTooltip"
       (onViewExtentChange)="onViewBoxChanged($event)"
       (onViewExtentReset)="viewBoxReset()"
       (onInteractionStateChange)="onInteractionStateChange($event)"

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component.ts
@@ -142,6 +142,8 @@ export class LineChartComponent
   @Input()
   lineOnly?: boolean = false;
 
+  @Input() disableTooltip?: boolean = false;
+
   @Output()
   viewBoxChanged = new EventEmitter<Extent | null>();
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ng.html
@@ -52,6 +52,7 @@ limitations under the License.
   #tooltipOrigin="cdkOverlayOrigin"
 ></div>
 <ng-template
+  *ngIf="!disableTooltip"
   cdkConnectedOverlay
   [cdkConnectedOverlayOrigin]="tooltipOriginEl"
   [cdkConnectedOverlayOpen]="tooltipDisplayAttached && state.getValue() === InteractionState.NONE"

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view.ts
@@ -132,6 +132,8 @@ export class LineChartInteractiveViewComponent
   @Input()
   tooltipTemplate?: TooltipTemplate;
 
+  @Input() disableTooltip?: boolean;
+
   @Output()
   onViewExtentChange = new EventEmitter<{dataExtent: Extent}>();
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view_test.ts
@@ -48,6 +48,7 @@ interface Coord {
       [yScale]="yScale"
       [domDim]="domDim"
       [tooltipOriginEl]="tooltipOrigin"
+      [disableTooltip]="disableTooltip"
       (onViewExtentChange)="onViewExtentChange($event)"
       (onViewExtentReset)="onViewExtentReset()"
       (onInteractionStateChange)="onInteractionStateChange($event)"
@@ -82,6 +83,9 @@ class TestableComponent {
 
   @Input()
   domDim!: Dimension;
+
+  @Input()
+  disableTooltip: boolean = false;
 
   @Input()
   onViewExtentChange!: (extent: Extent) => void;
@@ -266,6 +270,17 @@ describe('line_chart_v2/sub_view/interactive_view test', () => {
       fixture.componentInstance.seriesMetadataMap = {
         foo: buildMetadata({id: 'foo', displayName: 'Foo', visible: false}),
       };
+      fixture.detectChanges();
+
+      emitEvent(fixture, 'mouseenter', {clientX: 10, clientY: 10});
+      fixture.detectChanges();
+
+      expect(overlayContainer.getContainerElement().childElementCount).toBe(0);
+    });
+
+    it('does not render tooltip when disableTooltip is true', () => {
+      const fixture = createComponent();
+      fixture.componentInstance.disableTooltip = true;
       fixture.detectChanges();
 
       emitEvent(fixture, 'mouseenter', {clientX: 10, clientY: 10});


### PR DESCRIPTION
## Motivation for features / changes
The internal embedded single card will not render the tooltip, so the line chart needs to handle that behavior. 

## Technical description of changes
Add in a flag to disable the tooltip.

## Screenshots of UI changes (or N/A)
Demo - disabled tooltip on single card
[single card.webm](https://github.com/tensorflow/tensorboard/assets/70195566/1da09258-951e-4e23-96ea-9fbad6244817)

Demo - scalar card tooltip working normally (renders tooltip)
[scalar card.webm](https://github.com/tensorflow/tensorboard/assets/70195566/c89cc3cd-0327-456b-87a1-838f22f7b556)


