### PR TITLE
Embedded Single Card: get loadable time series selector

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -117,30 +117,30 @@ export const getCardLoadState = createSelector(
   }
 );
 
-export const getLoadableTimeSeries = (
-  cardMetadata: CardMetadata,
-  timeSeriesData: TimeSeriesData
-) => {
-  const {plugin, tag, sample} = cardMetadata;
-  const loadable = storeUtils.getTimeSeriesLoadable(
-    timeSeriesData,
-    plugin,
-    tag,
-    sample
+export const getLoadableTimeSeries = memoize((cardMetadata: CardMetadata) => {
+  return createSelector(
+    (state: MetricsState): MetricsState => state,
+    (state: MetricsState): DeepReadonly<RunToSeries> | null => {
+      const {plugin, tag, sample} = cardMetadata;
+      const loadable = storeUtils.getTimeSeriesLoadable(
+        state.timeSeriesData,
+        plugin,
+        tag,
+        sample
+      );
+      return loadable ? loadable.runToSeries : null;
+    }
   );
-  return loadable ? loadable.runToSeries : null;
-};
+});
 
 export const getCardTimeSeries = createSelector(
   selectMetricsState,
-  (state: MetricsState, cardId: CardId) => {
+  (state: MetricsState, cardId: CardId): DeepReadonly<RunToSeries> | null => {
     if (!state.cardMetadataMap.hasOwnProperty(cardId)) {
       return null;
     }
-    return getLoadableTimeSeries(
-      state.cardMetadataMap[cardId],
-      state.timeSeriesData
-    );
+
+    return getLoadableTimeSeries(state.cardMetadataMap[cardId])(state);
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -46,7 +46,6 @@ import {
   METRICS_FEATURE_KEY,
   RunToSeries,
   TagMetadata,
-  TimeSeriesData,
 } from './metrics_types';
 import {ColumnHeader, DataTableMode} from '../../widgets/data_table/types';
 import {Extent} from '../../widgets/line_chart_v2/lib/public_types';

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -46,6 +46,7 @@ import {
   METRICS_FEATURE_KEY,
   RunToSeries,
   TagMetadata,
+  TimeSeriesData,
 } from './metrics_types';
 import {ColumnHeader, DataTableMode} from '../../widgets/data_table/types';
 import {Extent} from '../../widgets/line_chart_v2/lib/public_types';
@@ -116,20 +117,30 @@ export const getCardLoadState = createSelector(
   }
 );
 
+export const getLoadableTimeSeries = (
+  cardMetadata: CardMetadata,
+  timeSeriesData: TimeSeriesData
+) => {
+  const {plugin, tag, sample} = cardMetadata;
+  const loadable = storeUtils.getTimeSeriesLoadable(
+    timeSeriesData,
+    plugin,
+    tag,
+    sample
+  );
+  return loadable ? loadable.runToSeries : null;
+};
+
 export const getCardTimeSeries = createSelector(
   selectMetricsState,
-  (state: MetricsState, cardId: CardId): DeepReadonly<RunToSeries> | null => {
+  (state: MetricsState, cardId: CardId) => {
     if (!state.cardMetadataMap.hasOwnProperty(cardId)) {
       return null;
     }
-    const {plugin, tag, sample} = state.cardMetadataMap[cardId];
-    const loadable = storeUtils.getTimeSeriesLoadable(
-      state.timeSeriesData,
-      plugin,
-      tag,
-      sample
+    return getLoadableTimeSeries(
+      state.cardMetadataMap[cardId],
+      state.timeSeriesData
     );
-    return loadable ? loadable.runToSeries : null;
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -448,7 +448,7 @@ describe('metrics selectors', () => {
           tag: 'tagA',
           runId: null,
         })(state)
-      ).toEqual(null);
+      ).toBeNull();
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -348,7 +348,7 @@ describe('metrics selectors', () => {
     });
   });
 
-  describe('getCardTimeSeries', () => {
+  describe('getLoadableTimeSeries', () => {
     it('getCardTimeSeries', () => {
       selectors.getCardTimeSeries.release();
 
@@ -401,6 +401,35 @@ describe('metrics selectors', () => {
         sampleImageRunToSeries
       );
       expect(selectors.getCardTimeSeries(state, 'card-nonexistent')).toBe(null);
+    });
+
+    it('returns time series with direct metadata input', () => {
+      const sampleScalarRunToSeries = {
+        run1: createScalarStepData(),
+        run2: createScalarStepData(),
+      };
+      const state = buildMetricsState({
+        timeSeriesData: {
+          ...createTimeSeriesData(),
+          scalars: {
+            tagA: {
+              runToLoadState: {
+                run1: DataLoadState.LOADED,
+                run2: DataLoadState.LOADED,
+              },
+              runToSeries: sampleScalarRunToSeries,
+            },
+          },
+        },
+      });
+
+      expect(
+        selectors.getLoadableTimeSeries({
+          plugin: PluginType.SCALARS,
+          tag: 'tagA',
+          runId: null,
+        })(state)
+      ).toEqual(sampleScalarRunToSeries);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -348,7 +348,7 @@ describe('metrics selectors', () => {
     });
   });
 
-  describe('getLoadableTimeSeries', () => {
+  describe('getCardTimeSeries', () => {
     it('getCardTimeSeries', () => {
       selectors.getCardTimeSeries.release();
 
@@ -402,8 +402,10 @@ describe('metrics selectors', () => {
       );
       expect(selectors.getCardTimeSeries(state, 'card-nonexistent')).toBe(null);
     });
+  });
 
-    it('returns time series with direct metadata input', () => {
+  describe('getLoadableTimeSeries', () => {
+    it('getLoadableTimeSeries', () => {
       const sampleScalarRunToSeries = {
         run1: createScalarStepData(),
         run2: createScalarStepData(),
@@ -430,6 +432,23 @@ describe('metrics selectors', () => {
           runId: null,
         })(state)
       ).toEqual(sampleScalarRunToSeries);
+    });
+
+    it('returns null when plugin data does not contain tag', () => {
+      const state = buildMetricsState({
+        timeSeriesData: {
+          ...createTimeSeriesData(),
+          scalars: {},
+        },
+      });
+
+      expect(
+        selectors.getLoadableTimeSeries({
+          plugin: PluginType.SCALARS,
+          tag: 'tagA',
+          runId: null,
+        })(state)
+      ).toEqual(null);
     });
   });
 


### PR DESCRIPTION
## Motivation for features / changes
Create a separate selector so that the single card fetch the time series data with a given card Id. 

## Technical description of changes
Separate the existing time series selector to have card metadata as input so that the single card can pass in parsed metadata. 

Googlers, please see cl/547536441 for the usage of the decomposed selector. 
