### PR TITLE
Change to facilitate Angular Material theming API update

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.scss
@@ -42,6 +42,15 @@ limitations under the License.
   }
 }
 
+// TODO(tensorboard-team): this component currently uses `mat-button-toggle-group` without
+// projecting `mat-button-toggle` into it. This is an unsupported configuration that breaks
+// with some upcoming Angular Material changes. The following patch aims to preserve the old
+// appearance. Either the buttons should be replaced with `mat-button-toggle` or the
+// `mat-button-toggle-group` should be removed.
+mat-button-toggle-group.filter-view {
+  @include tb-theme-foreground-prop(border, border, 1px solid);
+}
+
 .filter-view {
   border-radius: 4px;
   flex: none;


### PR DESCRIPTION
We're in the process of adding design tokens to the button toggle component in https://github.com/angular/components/pull/27509. This involves moving styles from the theme into the component's base styles.

The changes revealed an unsupported configuration that is being used by Tensorboard: a `mat-button-toggle-group` is used without `mat-button-togle`. Previously this looked okay, because the border of the group came from the theme. Now that the border is in the component styles and because `mat-button-toggle` is the one responsible for pulling in the button toggle group's styles, it ends up without a border.

These changes add a temporary patch to unblock the change in Angular Material.

**Note:** these changes may require some screenshot updates, because the border generated by `tb-theme-foreground-prop` isn't exactly the same as the one coming from Angular Material. Previously it was `#595959` and now it's `#555` which is identical, but not exactly the same.