### PR TITLE
Handle null hparam values in table view.

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_utils/tf-hparams-utils.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_utils/tf-hparams-utils.ts
@@ -302,7 +302,7 @@ export function prettyPrint(value) {
     // TODO(erez):Make the precision user-configurable.
     return value.toPrecision(5);
   }
-  if (value === undefined) {
+  if (value === null || value === undefined) {
     return '';
   }
   return value.toString();


### PR DESCRIPTION
Hparams from data provider can return null for some hparam values. The Hparams dashboard code does not yet expect this and would call toString() on null values, resulting in error and stopping the table from rendering properly.

The fix is simple, render empty string '' for null values just as we already do for undefined values.
