### PR TITLE
Revert "Chore: Pin `tf-nightly` (#6350)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  # See https://github.com/tensorflow/tensorboard/pull/6350.
-  TENSORFLOW_VERSION: 'tf-nightly==2.13.0.dev20230426'
+  TENSORFLOW_VERSION: 'tf-nightly'
 
 jobs:
   build:


### PR DESCRIPTION
This reverts commit e75d5b9adaae36d06e142964610d769f59c1963e.

The pinned version of tf-nightly has been deleted and ci is now failing. We once again allow ci to use latest 'tf-nightly'.
