### PR TITLE
Hparams: Adds sort argument to DataProvider.read_hyperparameters().

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -396,7 +396,9 @@ class DataProvider(metaclass=abc.ABCMeta):
         """
         return []
 
-    def read_hyperparameters(self, ctx=None, *, experiment_ids, filters=None):
+    def read_hyperparameters(
+        self, ctx=None, *, experiment_ids, filters=None, sort=None
+    ):
         """Read hyperparameter values.
 
         Args:
@@ -405,6 +407,8 @@ class DataProvider(metaclass=abc.ABCMeta):
             experiments.
           filters: A Collection[HyperparameterFilter] that constrain the
             returned session groups based on hyperparameter value.
+          sort: A Sequence[HyperparameterSort] that specify how the results
+            should be sorted.
 
         Returns:
           A Collection[HyperparameterSessionGroup] describing the groups and
@@ -707,6 +711,30 @@ class HyperparameterFilter:
         Tuple[float, float],
         Collection[Union[float, str, bool]],
     ]
+
+
+class HyperparameterSortDirection(enum.Enum):
+    """Describes which direction to sort a value."""
+
+    # Sort values ascending.
+    ASCENDING = "ascending"
+    # Sort values descending.
+    DESCENDING = "descending"
+
+
+@dataclasses.dataclass(frozen=True)
+class HyperparameterSort:
+    """A sort criterium based on hyperparameter value.
+
+    Attributes:
+      hyperparameter_name: A string identifier for the hyperparameter to use for
+        the sort. It corresponds to the hyperparameter_name field in the
+        Hyperparameter class.
+      sort_direction: The direction to sort.
+    """
+
+    hyperparameter_name: str
+    sort_direction: HyperparameterSortDirection
 
 
 class _TimeSeries:

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -192,10 +192,12 @@ class Context:
             ctx, experiment_ids=[experiment_id]
         )
 
-    def session_groups_from_data_provider(self, ctx, experiment_id, filters):
+    def session_groups_from_data_provider(
+        self, ctx, experiment_id, filters, sort
+    ):
         """Calls DataProvider.read_hyperparameters() and returns the result."""
         return self._tb_context.data_provider.read_hyperparameters(
-            ctx, experiment_ids=[experiment_id], filters=filters
+            ctx, experiment_ids=[experiment_id], filters=filters, sort=sort
         )
 
     def _find_experiment_tag(self, hparams_run_to_tag_to_content):


### PR DESCRIPTION
Adds support for specifying sort in
DataProvider.read_hyperparameters(), represented as keyword argument
`filters: Sequence[HyperparameterSort]`.

Updates list_session_groups.py to translate ColParams from the HTTP
request into HyperparameterSort objects and include it in the request
to the DataProvider implementation.