### PR TITLE
Chore: Upgrade to use TypeScript 4.9.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prettier-plugin-organize-imports": "2.3.4",
     "requirejs": "^2.3.6",
     "tslib": "^2.3.0",
-    "typescript": "4.8.4",
+    "typescript": "4.9.5",
     "yarn-deduplicate": "^5.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10436,7 +10436,12 @@ typed-assert@^1.0.8:
   resolved "https://registry.yarnpkg.com/typed-assert/-/typed-assert-1.0.9.tgz#8af9d4f93432c4970ec717e3006f33f135b06213"
   integrity sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==
 
-typescript@4.8.4, typescript@^4.6.2, typescript@~4.8.0:
+typescript@4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^4.6.2, typescript@~4.8.0:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==


### PR DESCRIPTION
This upgrades our npm typescript dependency to "4.9.5", the latest 4-series release on npm.

No code changes required. I audited our usage of ts-ignore but none of our usage would be impacted by this upgrade.

Note: I attempted to upgrade to TypeScript 5.1 but it was non-trivial. This is my consolation prize.
