### PR TITLE
Embedded Single Card: non-global experiment for card route

### DIFF
--- a/tensorboard/webapp/app_routing/internal_utils.ts
+++ b/tensorboard/webapp/app_routing/internal_utils.ts
@@ -77,6 +77,9 @@ export function getExperimentIdsFromRouteParams(
     case RouteKind.CARD: {
       const experimentIds = (params as CompareRouteParams).experimentIds;
       if (experimentIds.indexOf(',') < 0) {
+        if (Object.prototype.hasOwnProperty.call(params, 'experimentId')) {
+          return [(params as ExperimentRouteParams).experimentId];
+        }
         return [experimentIds];
       }
       return parseCompareExperimentStr(experimentIds).map(({id}) => id);


### PR DESCRIPTION
## Motivation for features / changes
The internal single card needs to handle non-global experiments in the parsed experiment Id from the URL. 
