### PR TITLE
Chore: Remove header attribute of sortingInfo interface

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -333,7 +333,6 @@ const {initialState: uiInitialState, reducers: uiNamespaceContextedReducers} =
         },
       ],
       sortingInfo: {
-        header: ColumnHeaderType.RUN,
         name: 'run',
         order: SortingOrder.DESCENDING,
       },

--- a/tensorboard/webapp/runs/store/runs_reducers_test.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers_test.ts
@@ -1624,7 +1624,6 @@ describe('runs_reducers', () => {
         {},
         {
           sortingInfo: {
-            header: ColumnHeaderType.RUN,
             name: 'run',
             order: SortingOrder.ASCENDING,
           },
@@ -1634,14 +1633,12 @@ describe('runs_reducers', () => {
         state,
         actions.runsTableSortingInfoChanged({
           sortingInfo: {
-            header: ColumnHeaderType.HPARAM,
             name: 'lr',
             order: SortingOrder.DESCENDING,
           },
         })
       );
       expect(nextState.ui.sortingInfo).toEqual({
-        header: ColumnHeaderType.HPARAM,
         name: 'lr',
         order: SortingOrder.DESCENDING,
       });

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -633,7 +633,6 @@ describe('runs_selectors', () => {
           {},
           {
             sortingInfo: {
-              header: ColumnHeaderType.RUN,
               name: 'run',
               order: SortingOrder.ASCENDING,
             },
@@ -641,7 +640,6 @@ describe('runs_selectors', () => {
         )
       );
       expect(selectors.getRunsTableSortingInfo(state)).toEqual({
-        header: ColumnHeaderType.RUN,
         name: 'run',
         order: SortingOrder.ASCENDING,
       });

--- a/tensorboard/webapp/runs/store/testing.ts
+++ b/tensorboard/webapp/runs/store/testing.ts
@@ -71,7 +71,6 @@ export function buildRunsState(
       selectionState: new Map(),
       runsTableHeaders: [],
       sortingInfo: {
-        header: ColumnHeaderType.RUN,
         name: 'run',
         order: SortingOrder.DESCENDING,
       },

--- a/tensorboard/webapp/widgets/data_table/types.ts
+++ b/tensorboard/webapp/widgets/data_table/types.ts
@@ -60,11 +60,6 @@ export enum SortingOrder {
 }
 
 export interface SortingInfo {
-  // Currently in the process of moving from header to name.
-  // Header is no longer used but is required as to not break sync
-  // TODO(jameshollyer): Remove header once all internal code is switched
-  // to using name.
-  header?: ColumnHeaderType;
   name: string;
   order: SortingOrder;
 }


### PR DESCRIPTION
## Motivation for features / changes
This is the final change in a long line of changes to move to using name. The original and functional change is #6362. This had to add name as an optional parameter only in order to avoid internal breakages. Now that we had name we could add the use of name internally(Googlers see cl/534191646) . Then we could switch to make the header optional and the name required which was done here: #6400. After header was optional we removed the use of headers internally(googlers see cl/552643471). Finally in this PR we removed the header attribute.