### PR TITLE
Throttle tags request

### DIFF
--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -18,6 +18,7 @@ import {Action, createAction, createSelector, Store} from '@ngrx/store';
 import {forkJoin, merge, Observable, of} from 'rxjs';
 import {
   catchError,
+  debounceTime,
   filter,
   map,
   mergeMap,
@@ -126,6 +127,7 @@ export class MetricsEffects implements OnInitEffects {
       this.store.select(getMetricsTagMetadataLoadState),
       this.store.select(selectors.getExperimentIdsFromRoute)
     ),
+    debounceTime(10),
     filter(([, tagLoadState, experimentIds]) => {
       /**
        * When `experimentIds` is null, the actual ids have not

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -18,7 +18,7 @@ import {Action, createAction, createSelector, Store} from '@ngrx/store';
 import {forkJoin, merge, Observable, of} from 'rxjs';
 import {
   catchError,
-  debounceTime,
+  throttleTime,
   filter,
   map,
   mergeMap,
@@ -127,7 +127,6 @@ export class MetricsEffects implements OnInitEffects {
       this.store.select(getMetricsTagMetadataLoadState),
       this.store.select(selectors.getExperimentIdsFromRoute)
     ),
-    debounceTime(10),
     filter(([, tagLoadState, experimentIds]) => {
       /**
        * When `experimentIds` is null, the actual ids have not
@@ -137,6 +136,7 @@ export class MetricsEffects implements OnInitEffects {
         tagLoadState.state !== DataLoadState.LOADING && experimentIds !== null
       );
     }),
+    throttleTime(10),
     tap(() => {
       this.store.dispatch(actions.metricsTagMetadataRequested());
     }),


### PR DESCRIPTION
## Motivation for features / changes
For years we have been making two requests to fetch tags then canceling the first one. This occurs because the request is dispatched when either the dashboard is shown without data or a new plugin is loaded. When the dashboard is initially loaded both of these conditions are true.

## Screenshots of UI changes (or N/A)
Before:
![image](https://github.com/tensorflow/tensorboard/assets/78179109/cbaffa77-4388-4222-bf84-fd93494f00b6)

After:
![image](https://github.com/tensorflow/tensorboard/assets/78179109/78f13434-c0ee-402f-bf7c-5dc5ea05d0d1)
