### PR TITLE
Bug fix: Do not pass all data points as parameters

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -389,12 +389,19 @@ export function generateNextCardStepIndex(
 export function generateScalarCardMinMaxStep(
   runsToSeries: RunToSeries<PluginType.SCALARS>
 ): MinMaxStep {
-  const allData = Object.values(runsToSeries)
+  let minStep = Infinity;
+  let maxStep = -Infinity;
+
+  Object.values(runsToSeries)
     .flat()
-    .map((stepDatum) => stepDatum.step);
+    .forEach((stepDatum) => {
+      minStep = Math.min(minStep, stepDatum.step);
+      maxStep = Math.max(maxStep, stepDatum.step);
+    });
+
   return {
-    minStep: Math.min(...allData),
-    maxStep: Math.max(...allData),
+    minStep,
+    maxStep,
   };
 }
 


### PR DESCRIPTION
## Motivation for features / changes
This was causing "Maximum call stack size" errors when we received too many data points.

## Technical description of changes
I am simply looping over the data points and getting the min and max instead of passing them all to Math.min and Math.max

## Detailed steps to verify changes work correctly (as executed by you)
I ran internally hardcoding the backend to return 300,000 data points. This caused the "Maximum call stack size" error. Then I made this change and the data loaded. I increased the number of data points to over 1 million(timeseries call was 7mb) and the data still loaded. When I went to 10 million data points the call failed after waiting 5 minutes.