### PR TITLE
Add load() statements for Blaze-builtin Python rules/providers

### DIFF
--- a/tensorboard/plugins/wit_redirect/BUILD
+++ b/tensorboard/plugins/wit_redirect/BUILD
@@ -1,5 +1,7 @@
 # Description:
 # Plugin with installation instructions for dynamic interpretability plugin
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 


### PR DESCRIPTION
## Motivation for features / changes

This is a follow up PR for [#6495](https://github.com/tensorflow/tensorboard/pull/6495) to add load() statements for Blaze-builtin Python rules/providers. 

More information: [go/py-add-loads-lsc](https://goto.google.com/py-add-loads-lsc)