### PR TITLE
Updates import and BUILD dependency in test from example

### DIFF
--- a/tensorboard/examples/plugins/example_raw_scalars/BUILD
+++ b/tensorboard/examples/plugins/example_raw_scalars/BUILD
@@ -43,5 +43,6 @@ py_test(
     tags = ["support_notf"],
     deps = [
         "//tensorboard",
+        "//tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars:plugin",
     ],
 )

--- a/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/BUILD
+++ b/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/BUILD
@@ -1,0 +1,14 @@
+# Description:
+# An example plugin.
+load("@rules_python//python:py_library.bzl", "py_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])
+
+py_library(
+    name = "plugin",
+    srcs = ["plugin.py"],
+    srcs_version = "PY3",
+    visibility = ["//visibility:public"],
+)

--- a/tensorboard/examples/plugins/example_raw_scalars/test.py
+++ b/tensorboard/examples/plugins/example_raw_scalars/test.py
@@ -23,7 +23,9 @@ from werkzeug import test
 from werkzeug import wrappers
 
 from tensorboard.plugins import base_plugin
-from tensorboard.examples.plugins.example_raw_scalars.tensorboard_plugin_example_raw_scalars import plugin
+from tensorboard.examples.plugins.example_raw_scalars.tensorboard_plugin_example_raw_scalars import (
+    plugin,
+)
 
 
 def is_path_safe(path):

--- a/tensorboard/examples/plugins/example_raw_scalars/test.py
+++ b/tensorboard/examples/plugins/example_raw_scalars/test.py
@@ -23,7 +23,7 @@ from werkzeug import test
 from werkzeug import wrappers
 
 from tensorboard.plugins import base_plugin
-from tensorboard_plugin_example_raw_scalars import plugin
+from tensorboard.examples.plugins.example_raw_scalars.tensorboard_plugin_example_raw_scalars import plugin
 
 
 def is_path_safe(path):


### PR DESCRIPTION
## Motivation for features / changes

I expect the behavior for relative imports changed after the python rule changed in #6495, and made this test fail, so it now needs to be an absolute import. (Unsure of why this was not making CI fail... maybe this particular target is not run as part of CI, since it's just an example.)

## Technical description of changes

Adds a BUILD target for the submodule that was previously imported with a relative import. With the BUILD target and the dependency, the module can now be referenced as an absolute import.

## Screenshots of UI changes (or N/A)

N/A

## Detailed steps to verify changes work correctly (as executed by you)

Tests that were previously failing now pass.

## Alternate designs / implementations considered (or N/A)

N/A