### PR TITLE
Post-release 2.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         tf_version_id: ['tf', 'notf']
-        python_version: ['3.8']
+        python_version: ['3.9']
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
-          python-version: '3.8'
+          python-version: '3.9'
           architecture: 'x64'
       - name: 'Cache Cargo artifacts'
         if: matrix.mode == 'native'
@@ -217,7 +217,7 @@ jobs:
         # flake8 should run on each Python version that we target,
         # because the errors and warnings can differ due to language
         # changes, and we want to catch them all.
-        python_version: ['3.8', '3.9', '3.10', '3.11']
+        python_version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,23 @@
+# Release 2.14.0
+
+The 2.14 minor series tracks TensorFlow 2.14.
+
+## Features
+
+- Small data table and step selector usability and accessibility improvements (#6372, #6409, #6410, #6431)
+
+## Bug Fixes
+
+- Embedding Projector plugin improvements
+  - Fix tSNE tweaking hyperparams (#6320, thanks @alicialics)
+  - Some visualization and usability improvements (#6373, #6326, #6325, #6429, thanks @alicialics)
+- Graph plugin: Fix rendering issue for tensors with zero dimension size (#6420)
+- HParams plugin: A couple fixes related to boolean and NaN values (#6393, #6496)
+
+## Breaking Changes
+
+- Drops support for Python 3.8.
+
 # Release 2.13.0
 
 The 2.13 minor series tracks TensorFlow 2.13

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -64,7 +64,7 @@ setup(
     },
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     # PyPI package information.
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -73,7 +73,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,7 +15,7 @@
 
 """Contains the version string."""
 
-VERSION = "2.14.0a0"
+VERSION = "2.15.0a0"
 
 if __name__ == "__main__":
     print(VERSION)


### PR DESCRIPTION
- Cherry-pick the drop for support for Python 3.8
- Cherry-pick the relnotes
- Update version for our nightly builds to the next number: 2.15.0a0