### PR TITLE
Change return type of list_hyperparameters() operation.

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -388,8 +388,8 @@ class DataProvider(metaclass=abc.ABCMeta):
             experiments.
 
         Returns:
-          A Collection[Hyperparameter] describing the hyperparameter metadata
-          for the experiments.
+          A ListHyperparametersResult describing the hyperparameter-related
+          metadata for the experiments.
 
         Raises:
           tensorboard.errors.PublicError: See `DataProvider` class docstring.
@@ -735,6 +735,21 @@ class HyperparameterSort:
 
     hyperparameter_name: str
     sort_direction: HyperparameterSortDirection
+
+
+@dataclasses.dataclass(frozen=True)
+class ListHyperparametersResult:
+    """The result from calling list_hyperparameters().
+
+    Attributes:
+      hyperparameters: The hyperparameteres belonging to the experiments in the
+        request.
+      session_groups: The session groups present in the experiments in the
+        request.
+    """
+
+    hyperparameters: Collection[Hyperparameter]
+    session_groups: Collection[HyperparameterSessionGroup]
 
 
 class _TimeSeries:

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -81,7 +81,7 @@ class Context:
             summary metadata content for the keyed time series.
           data_provider_hparams: The ouput from an hparams_from_data_provider()
             call, corresponding to DataProvider.list_hyperparameters().
-            A Collection[provider.Hyperparameter].
+            A provider.ListHyperpararametersResult.
 
         Returns:
           The experiment proto. If no data is found for an experiment proto to
@@ -323,18 +323,27 @@ class Context:
         Args:
           data_provider_hparams: The ouput from an hparams_from_data_provider()
             call, corresponding to DataProvider.list_hyperparameters().
-            A Collection[provider.Hyperparameter].
+            A provider.ListHyperparametersResult.
 
         Returns:
           The experiment proto. If there are no hyperparameters in the input,
           returns None.
         """
-        if not data_provider_hparams:
+        if isinstance(data_provider_hparams, list):
+            # TODO: Support old return value of Collection[provider.Hyperparameters]
+            # until all internal implementations of DataProvider can be
+            # migrated to use new return value of provider.ListHyperparametersResult.
+            hyperparameters = data_provider_hparams
+        else:
+            # Is instance of provider.ListHyperparametersResult
+            hyperparameters = data_provider_hparams.hyperparameters
+
+        if not hyperparameters:
             return None
 
         hparam_infos = [
             self._convert_data_provider_hparam(dp_hparam)
-            for dp_hparam in data_provider_hparams
+            for dp_hparam in hyperparameters
         ]
         return api_pb2.Experiment(hparam_infos=hparam_infos)
 

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -378,18 +378,21 @@ class BackendContextTest(tf.test.TestCase):
         self.assertProtoEquals("", actual_exp)
 
     def test_experiment_from_data_provider_differs(self):
-        self._hyperparameters = [
-            provider.Hyperparameter(
-                hyperparameter_name="hparam1_name",
-                hyperparameter_display_name="hparam1_display_name",
-                differs=True,
-            ),
-            provider.Hyperparameter(
-                hyperparameter_name="hparam2_name",
-                hyperparameter_display_name="hparam2_display_name",
-                differs=False,
-            ),
-        ]
+        self._hyperparameters = provider.ListHyperparametersResult(
+            hyperparameters=[
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam1_name",
+                    hyperparameter_display_name="hparam1_display_name",
+                    differs=True,
+                ),
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam2_name",
+                    hyperparameter_display_name="hparam2_display_name",
+                    differs=False,
+                ),
+            ],
+            session_groups=[],
+        )
         self._mock_tb_context.data_provider.list_tensors.side_effect = None
         actual_exp = self._experiment_from_metadata()
         expected_exp = """
@@ -407,14 +410,17 @@ class BackendContextTest(tf.test.TestCase):
         self.assertProtoEquals(expected_exp, actual_exp)
 
     def test_experiment_from_data_provider_interval_hparam(self):
-        self._hyperparameters = [
-            provider.Hyperparameter(
-                hyperparameter_name="hparam1_name",
-                hyperparameter_display_name="hparam1_display_name",
-                domain_type=provider.HyperparameterDomainType.INTERVAL,
-                domain=(-10.0, 15),
-            )
-        ]
+        self._hyperparameters = provider.ListHyperparametersResult(
+            hyperparameters=[
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam1_name",
+                    hyperparameter_display_name="hparam1_display_name",
+                    domain_type=provider.HyperparameterDomainType.INTERVAL,
+                    domain=(-10.0, 15),
+                )
+            ],
+            session_groups=[],
+        )
         self._mock_tb_context.data_provider.list_tensors.side_effect = None
         actual_exp = self._experiment_from_metadata()
         expected_exp = """
@@ -431,32 +437,35 @@ class BackendContextTest(tf.test.TestCase):
         self.assertProtoEquals(expected_exp, actual_exp)
 
     def test_experiment_from_data_provider_discrete_bool_hparam(self):
-        self._hyperparameters = [
-            provider.Hyperparameter(
-                hyperparameter_name="hparam1_name",
-                hyperparameter_display_name="hparam1_display_name",
-                domain_type=provider.HyperparameterDomainType.DISCRETE_BOOL,
-                domain=[True],
-            ),
-            provider.Hyperparameter(
-                hyperparameter_name="hparam2_name",
-                hyperparameter_display_name="hparam2_display_name",
-                domain_type=provider.HyperparameterDomainType.DISCRETE_BOOL,
-                domain=[True, False],
-            ),
-            provider.Hyperparameter(
-                hyperparameter_name="hparam3_name",
-                hyperparameter_display_name="hparam3_display_name",
-                domain_type=provider.HyperparameterDomainType.DISCRETE_BOOL,
-                domain=[False],
-            ),
-            provider.Hyperparameter(
-                hyperparameter_name="hparam4_name",
-                hyperparameter_display_name="hparam4_display_name",
-                domain_type=provider.HyperparameterDomainType.DISCRETE_BOOL,
-                domain=[],
-            ),
-        ]
+        self._hyperparameters = provider.ListHyperparametersResult(
+            hyperparameters=[
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam1_name",
+                    hyperparameter_display_name="hparam1_display_name",
+                    domain_type=provider.HyperparameterDomainType.DISCRETE_BOOL,
+                    domain=[True],
+                ),
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam2_name",
+                    hyperparameter_display_name="hparam2_display_name",
+                    domain_type=provider.HyperparameterDomainType.DISCRETE_BOOL,
+                    domain=[True, False],
+                ),
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam3_name",
+                    hyperparameter_display_name="hparam3_display_name",
+                    domain_type=provider.HyperparameterDomainType.DISCRETE_BOOL,
+                    domain=[False],
+                ),
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam4_name",
+                    hyperparameter_display_name="hparam4_display_name",
+                    domain_type=provider.HyperparameterDomainType.DISCRETE_BOOL,
+                    domain=[],
+                ),
+            ],
+            session_groups=[],
+        )
         self._mock_tb_context.data_provider.list_tensors.side_effect = None
         actual_exp = self._experiment_from_metadata()
         expected_exp = """
@@ -493,14 +502,17 @@ class BackendContextTest(tf.test.TestCase):
         self.assertProtoEquals(expected_exp, actual_exp)
 
     def test_experiment_from_data_provider_discrete_float_hparam(self):
-        self._hyperparameters = [
-            provider.Hyperparameter(
-                hyperparameter_name="hparam1_name",
-                hyperparameter_display_name="hparam1_display_name",
-                domain_type=provider.HyperparameterDomainType.DISCRETE_FLOAT,
-                domain=[-1.0, 1.5, 0.0],
-            ),
-        ]
+        self._hyperparameters = provider.ListHyperparametersResult(
+            hyperparameters=[
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam1_name",
+                    hyperparameter_display_name="hparam1_display_name",
+                    domain_type=provider.HyperparameterDomainType.DISCRETE_FLOAT,
+                    domain=[-1.0, 1.5, 0.0],
+                ),
+            ],
+            session_groups=[],
+        )
         self._mock_tb_context.data_provider.list_tensors.side_effect = None
         actual_exp = self._experiment_from_metadata()
         expected_exp = """
@@ -520,14 +532,17 @@ class BackendContextTest(tf.test.TestCase):
         self.assertProtoEquals(expected_exp, actual_exp)
 
     def test_experiment_from_data_provider_discrete_string_hparam(self):
-        self._hyperparameters = [
-            provider.Hyperparameter(
-                hyperparameter_name="hparam1_name",
-                hyperparameter_display_name="hparam1_display_name",
-                domain_type=provider.HyperparameterDomainType.DISCRETE_STRING,
-                domain=["one", "two", "aaaa"],
-            ),
-        ]
+        self._hyperparameters = provider.ListHyperparametersResult(
+            hyperparameters=[
+                provider.Hyperparameter(
+                    hyperparameter_name="hparam1_name",
+                    hyperparameter_display_name="hparam1_display_name",
+                    domain_type=provider.HyperparameterDomainType.DISCRETE_STRING,
+                    domain=["one", "two", "aaaa"],
+                ),
+            ],
+            session_groups=[],
+        )
         self._mock_tb_context.data_provider.list_tensors.side_effect = None
         actual_exp = self._experiment_from_metadata()
         expected_exp = """
@@ -541,6 +556,30 @@ class BackendContextTest(tf.test.TestCase):
                   {string_value: 'two'},
                   {string_value: 'aaaa'}
                 ]
+              }
+            }
+        """
+        self.assertProtoEquals(expected_exp, actual_exp)
+
+    def test_experiment_from_data_provider_old_response_type(self):
+        self._hyperparameters = [
+            provider.Hyperparameter(
+                hyperparameter_name="hparam1_name",
+                hyperparameter_display_name="hparam1_display_name",
+                domain_type=provider.HyperparameterDomainType.INTERVAL,
+                domain=(-10.0, 15),
+            )
+        ]
+        self._mock_tb_context.data_provider.list_tensors.side_effect = None
+        actual_exp = self._experiment_from_metadata()
+        expected_exp = """
+            hparam_infos: {
+              name: 'hparam1_name'
+              display_name: 'hparam1_display_name'
+              type: DATA_TYPE_FLOAT64
+              domain_interval: {
+                min_value: -10.0
+                max_value: 15
               }
             }
         """


### PR DESCRIPTION
Change the return type of DataProvider.list_hyperparameters() to be a complex "Result" type that can contain multiple pieces of information.

Where previously it was a Collection[Hyperparameter], it is now a ListHyperparametersResult. It contains a "hyperparameters" field that contains the same data as the previous return type. We also add a "session_groups" field for future usage.

We change the hparams plugin to be able to handle both the old and the new return types.
