### PR TITLE
Restricts protobuf dependency to < 4.24 due to protocolbuffers/protobuf#13485

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,6 +26,8 @@ numpy >= 1.12.0
 # At the same time, any constraints we specify here must allow at least some
 # version to be installed that is also compatible with TensorFlow's constraints:
 # https://github.com/tensorflow/tensorflow/blob/9d22f4a0a9499c8e10a4312503e63e0da35ccd94/tensorflow/tools/pip_package/setup.py#L100-L107
+# We needed to add an upper bound restriction due to issue reported in:
+# https://github.com/protocolbuffers/protobuf/issues/13485
 protobuf >= 3.19.6, < 4.24
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,7 +26,7 @@ numpy >= 1.12.0
 # At the same time, any constraints we specify here must allow at least some
 # version to be installed that is also compatible with TensorFlow's constraints:
 # https://github.com/tensorflow/tensorflow/blob/9d22f4a0a9499c8e10a4312503e63e0da35ccd94/tensorflow/tools/pip_package/setup.py#L100-L107
-protobuf >= 3.19.6
+protobuf >= 3.19.6, < 4.24
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 tensorboard-data-server >= 0.7.0, < 0.8.0


### PR DESCRIPTION
We currently don't have an upper bound on the protobuf dependency, but the new release broke our CI.