### PR TITLE
Fix scenario where session does not specify a run name.

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -403,7 +403,7 @@ class Context:
         self, ctx, experiment_id, session_groups
     ):
         session_runs = set(
-            f"{s.experiment_id}/{s.run}"
+            f"{s.experiment_id}/{s.run}" if s.run else s.experiment_id
             for sg in session_groups
             for s in sg.sessions
         )

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -561,7 +561,7 @@ class BackendContextTest(tf.test.TestCase):
         """
         self.assertProtoEquals(expected_exp, actual_exp)
 
-    def test_experiment_from_data_provider_session_group(self):
+    def test_experiment_from_data_provider_session_groups(self):
         self._mock_tb_context.data_provider.list_tensors.side_effect = None
         # The sessions chosen here mimic those returned in the implementation
         # of _mock_list_tensors. These work nicely with the scalars returned
@@ -591,6 +591,41 @@ class BackendContextTest(tf.test.TestCase):
                     sessions=[
                         provider.HyperparameterSessionRun(
                             experiment_id="exp", run="session_3"
+                        ),
+                    ],
+                    hyperparameter_values=[],
+                ),
+            ],
+        )
+        actual_exp = self._experiment_from_metadata()
+        expected_exp = """
+            metric_infos: {
+              name: {group: '', tag: 'accuracy'}
+            }
+            metric_infos: {
+              name: {group: '', tag: 'loss'}
+            }
+            metric_infos: {
+              name: {group: 'eval', tag: 'loss'}
+            }
+            metric_infos: {
+              name: {group: 'train', tag: 'loss'}
+            }
+        """
+        self.assertProtoEquals(expected_exp, actual_exp)
+
+    def test_experiment_from_data_provider_session_group_without_run_name(self):
+        self._mock_tb_context.data_provider.list_tensors.side_effect = None
+        self._hyperparameters = provider.ListHyperparametersResult(
+            hyperparameters=[],
+            session_groups=[
+                provider.HyperparameterSessionGroup(
+                    root=provider.HyperparameterSessionRun(
+                        experiment_id="exp/session_1", run=""
+                    ),
+                    sessions=[
+                        provider.HyperparameterSessionRun(
+                            experiment_id="exp/session_1", run=""
                         ),
                     ],
                     hyperparameter_values=[],


### PR DESCRIPTION
Fix a bug where sessions without run names do not match with the runs generated by scalars_metadata().

As an example:

When a HyperparameterSessionRun does not contain `run` field, we were generating session_names of the form 'exp1/', 'exp2/', etc.. with a trailing `/`. Meanwhile, runs would be just of the form 'exp1/run_name'.
The logic to match paths in _find_longest_parent_path() would first try to find 'exp1/run_name' in session_names and then 'exp1' in session_names. Both comparisons would fail because of the trailing slashes in session_names.

So, instead, when there is no `run` field in a HyperparameterSessionRun, we drop the final '/' and just generate names like 'exp1', 'exp2', etc...