### PR TITLE
Hparams: Change `read_hyperparameters()` return type

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -411,7 +411,7 @@ class DataProvider(metaclass=abc.ABCMeta):
             should be sorted.
 
         Returns:
-          A Collection[HyperparameterSessionGroup] describing the groups and
+          A Sequence[HyperparameterSessionGroup] describing the groups and
           their hyperparameter values.
 
         Raises:


### PR DESCRIPTION
Resultant session groups would be sorted if `sort` is specified.

#hparams