### PR TITLE
Hparams: Fix internal Builder failure for test.

### DIFF
--- a/tensorboard/webapp/hparams/_redux/BUILD
+++ b/tensorboard/webapp/hparams/_redux/BUILD
@@ -170,6 +170,7 @@ tf_ts_library(
         "//tensorboard/webapp/testing:utils",
         "//tensorboard/webapp/webapp_data_source:http_client_testing",
         "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
         "@npm//@types/jasmine",
         "@npm//rxjs",
     ],


### PR DESCRIPTION
Googlers, see cl/557139147 for failure.

The CL's presubmit passes because the tests are not run but fixing the Builder failures seems like good hygiene.