### PR TITLE
Hparams: Allow sessions without name to pull all run,tag combinations as metrics.

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -403,7 +403,7 @@ class Context:
         self, ctx, experiment_id, session_groups
     ):
         session_runs = set(
-            generate_data_provider_session_name(experiment_id, s)
+            generate_data_provider_session_name(s)
             for sg in session_groups
             for s in sg.sessions
         )
@@ -446,7 +446,7 @@ class Context:
         )
         for run, tags in scalars_run_to_tag_to_content.items():
             session = _find_longest_parent_path(session_runs, run)
-            if not session:
+            if session is None:
                 continue
             group = os.path.relpath(run, session)
             # relpath() returns "." for the 'session' directory, we use an empty
@@ -460,14 +460,14 @@ class Context:
         return metric_names_list
 
 
-def generate_data_provider_session_name(experiment_id, session):
+def generate_data_provider_session_name(session):
     """Generates a name from a HyperparameterSesssionRun.
 
     If the HyperparameterSessionRun contains no experiment or run information
     then the name is set to the original experiment_id.
     """
     if not session.experiment_id and not session.run:
-        return experiment_id
+        return ""
     elif not session.experiment_id:
         return session.run
     elif not session.run:

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -689,6 +689,106 @@ class BackendContextTest(tf.test.TestCase):
         """
         self.assertProtoEquals(expected_exp, actual_exp)
 
+    def test_experiment_from_data_provider_session_group_without_session_names(
+        self,
+    ):
+        self._mock_tb_context.data_provider.list_tensors.side_effect = None
+        self._hyperparameters = provider.ListHyperparametersResult(
+            hyperparameters=[],
+            session_groups=[
+                provider.HyperparameterSessionGroup(
+                    root=provider.HyperparameterSessionRun(
+                        experiment_id="", run=""
+                    ),
+                    sessions=[
+                        provider.HyperparameterSessionRun(
+                            experiment_id="", run=""
+                        ),
+                    ],
+                    hyperparameter_values=[],
+                ),
+            ],
+        )
+        actual_exp = self._experiment_from_metadata()
+        # The result specifies a single session without explicit identifier. It
+        # therefore represents a session that includes all run/tag combinations
+        # as separate metric values.
+        expected_exp = """
+            metric_infos {
+              name {
+                group: "exp/session_1"
+                tag: "accuracy"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_2"
+                tag: "accuracy"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_3"
+                tag: "accuracy"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_1"
+                tag: "loss"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_1/eval"
+                tag: "loss"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_1/train"
+                tag: "loss"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_2"
+                tag: "loss"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_2/eval"
+                tag: "loss"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_2/train"
+                tag: "loss"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_3"
+                tag: "loss"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_3/eval"
+                tag: "loss"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_3xyz"
+                tag: "loss2"
+              }
+            }
+        """
+        self.assertProtoEquals(expected_exp, actual_exp)
+
     def test_experiment_from_data_provider_old_response_type(self):
         self._hyperparameters = [
             provider.Hyperparameter(

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -136,7 +136,7 @@ class Handler:
             for session in provider_group.sessions:
                 session_name = (
                     backend_context_lib.generate_data_provider_session_name(
-                        self._experiment_id, session
+                        session
                     )
                 )
                 sessions.append(
@@ -150,8 +150,10 @@ class Handler:
                 )
 
             name = backend_context_lib.generate_data_provider_session_name(
-                self._experiment_id, provider_group.root
+                provider_group.root
             )
+            if not name:
+                name = self._experiment_id
             session_group = api_pb2.SessionGroup(
                 name=name,
                 sessions=sessions,


### PR DESCRIPTION
Motivation: Sometimes a user is viewing a single experiment and the DataProvider determines that experiment contains exactly one session. In this case the DataProvider will return a session with both empty experiment_id and empty run.

We want this "empty-name session" to represent all runs in the experiment. But we have a bug where the /experiment and /session_group responses do not contain any metrics for the session. We want to instead designate all (run,tag) combinations as separate metrics to include in the /experiment and /session_groups responses.

The first change to get this to work:

* When generating session names, a session with experiment_id="" and run="" should generate an empty session_name "" (instead of using the somewhat-meaningless input experiment id as the session_name).
 
The side-effect of the first change is that calls to _find_longest_parent_path() will return "" for all runs passed into it - effectively saying that all runs belong to the "empty-name session".  So the second change to get this to work:

* When _find_longest_parent_path() returns "" instead of None, treat this as a match with "empty-name session" instead of ignoring it.
