### PR TITLE
HParams: Add new state property to store hparam and metric filters

### DIFF
--- a/tensorboard/webapp/hparams/_redux/BUILD
+++ b/tensorboard/webapp/hparams/_redux/BUILD
@@ -157,6 +157,7 @@ tf_ts_library(
         ":hparams_reducers",
         ":hparams_selectors",
         ":testing",
+        ":types",
         ":utils",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",

--- a/tensorboard/webapp/hparams/_redux/BUILD
+++ b/tensorboard/webapp/hparams/_redux/BUILD
@@ -10,6 +10,7 @@ tf_ts_library(
         "utils.ts",
     ],
     deps = [
+        ":types",
         "//tensorboard/webapp/hparams:types",
     ],
 )
@@ -47,6 +48,7 @@ tf_ts_library(
         "hparams_actions.ts",
     ],
     deps = [
+        ":types",
         "//tensorboard/webapp/hparams:types",
         "@npm//@ngrx/store",
     ],

--- a/tensorboard/webapp/hparams/_redux/hparams_actions.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_actions.ts
@@ -22,6 +22,7 @@ import {
   HparamAndMetricSpec,
   SessionGroup,
 } from '../types';
+import {HparamFilter, MetricFilter} from './types';
 
 export const hparamsDiscreteHparamFilterChanged = createAction(
   '[Hparams] Hparams Discrete Hparam Filter Changed',
@@ -61,4 +62,14 @@ export const hparamsFetchSessionGroupsSucceeded = createAction(
     hparamsAndMetricsSpecs: HparamAndMetricSpec;
     sessionGroups: SessionGroup[];
   }>()
+);
+
+export const dashboardHparamFilterAdded = createAction(
+  '[Hparams] Dashboard Hparam Filter Added',
+  props<{name: string; filter: HparamFilter}>()
+);
+
+export const dashboardMetricFilterAdded = createAction(
+  '[Hparams] Dashboard Metric Filter Added',
+  props<{name: string; filter: MetricFilter}>()
 );

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
@@ -375,26 +375,26 @@ const reducer: ActionReducer<HparamsState, Action> = createReducer(
     };
   }),
   on(actions.dashboardHparamFilterAdded, (state, action) => {
+    const nextHparamFilters = new Map(state.dashboardFilters.hparams);
+    nextHparamFilters.set(action.name, action.filter);
+
     return {
       ...state,
       dashboardFilters: {
         ...state.dashboardFilters,
-        hparams: {
-          ...state.dashboardFilters.hparams,
-          [action.name]: action.filter,
-        },
+        hparams: nextHparamFilters,
       },
     };
   }),
   on(actions.dashboardMetricFilterAdded, (state, action) => {
+    const nextMetricFilters = new Map(state.dashboardFilters.metrics);
+    nextMetricFilters.set(action.name, action.filter);
+
     return {
       ...state,
       dashboardFilters: {
         ...state.dashboardFilters,
-        metrics: {
-          ...state.dashboardFilters.metrics,
-          [action.name]: action.filter,
-        },
+        metrics: nextMetricFilters,
       },
     };
   })

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
@@ -37,6 +37,10 @@ const initialState: HparamsState = {
     metrics: [],
   },
   dashboardSessionGroups: [],
+  dashboardFilters: {
+    hparams: new Map(),
+    metrics: new Map(),
+  },
 };
 
 const reducer: ActionReducer<HparamsState, Action> = createReducer(
@@ -368,6 +372,30 @@ const reducer: ActionReducer<HparamsState, Action> = createReducer(
       ...state,
       dashboardSpecs: nextDashboardSpecs,
       dashboardSessionGroups: nextDashboardSessionGroups,
+    };
+  }),
+  on(actions.dashboardHparamFilterAdded, (state, action) => {
+    return {
+      ...state,
+      dashboardFilters: {
+        ...state.dashboardFilters,
+        hparams: {
+          ...state.dashboardFilters.hparams,
+          [action.name]: action.filter,
+        },
+      },
+    };
+  }),
+  on(actions.dashboardMetricFilterAdded, (state, action) => {
+    return {
+      ...state,
+      dashboardFilters: {
+        ...state.dashboardFilters,
+        metrics: {
+          ...state.dashboardFilters.metrics,
+          [action.name]: action.filter,
+        },
+      },
     };
   })
 );

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
@@ -633,7 +633,23 @@ describe('hparams/_redux/hparams_reducers_test', () => {
 
   describe('dashboardHparamFilterAdded', () => {
     it('adds entry dashboardFilters', () => {
-      const state = buildHparamsState();
+      const state = buildHparamsState({
+        dashboardFilters: {
+          hparams: new Map([
+            [
+              'hparam2',
+              {
+                type: DomainType.INTERVAL,
+                includeUndefined: true,
+                minValue: 2,
+                maxValue: 20,
+                filterLowerBound: 2,
+                filterUpperBound: 20,
+              },
+            ],
+          ]),
+        },
+      });
       const state2 = reducers(
         state,
         actions.dashboardHparamFilterAdded({
@@ -657,6 +673,17 @@ describe('hparams/_redux/hparams_reducers_test', () => {
               possibleValues: [5, 7, 8],
             },
           ],
+          [
+            'hparam2',
+            {
+              type: DomainType.INTERVAL,
+              includeUndefined: true,
+              minValue: 2,
+              maxValue: 20,
+              filterLowerBound: 2,
+              filterUpperBound: 20,
+            },
+          ],
         ]),
         metrics: new Map(),
       });
@@ -665,7 +692,23 @@ describe('hparams/_redux/hparams_reducers_test', () => {
 
   describe('dashboardMetricFilterAdded', () => {
     it('adds entry dashboardFilters', () => {
-      const state = buildHparamsState();
+      const state = buildHparamsState({
+        dashboardFilters: {
+          metrics: new Map([
+            [
+              'metric 2',
+              {
+                type: DomainType.INTERVAL,
+                includeUndefined: true,
+                minValue: 1,
+                maxValue: 50,
+                filterLowerValue: 1,
+                filterUpperValue: 51,
+              },
+            ],
+          ]),
+        },
+      });
       const state2 = reducers(
         state,
         actions.dashboardMetricFilterAdded({
@@ -692,6 +735,17 @@ describe('hparams/_redux/hparams_reducers_test', () => {
               maxValue: 42,
               filterLowerValue: -2,
               filterUpperValue: 40,
+            },
+          ],
+          [
+            'metric 2',
+            {
+              type: DomainType.INTERVAL,
+              includeUndefined: true,
+              minValue: 1,
+              maxValue: 50,
+              filterLowerValue: 1,
+              filterUpperValue: 51,
             },
           ],
         ]),

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
@@ -630,4 +630,72 @@ describe('hparams/_redux/hparams_reducers_test', () => {
       expect(state2.dashboardSessionGroups).toEqual([mockSessionGroup]);
     });
   });
+
+  describe('dashboardHparamFilterAdded', () => {
+    it('adds entry dashboardFilters', () => {
+      const state = buildHparamsState();
+      const state2 = reducers(
+        state,
+        actions.dashboardHparamFilterAdded({
+          name: 'hparam1',
+          filter: {
+            type: DomainType.DISCRETE,
+            includeUndefined: true,
+            filterValues: [5],
+            possibleValues: [5, 7, 8],
+          },
+        })
+      );
+      expect(state2.dashboardFilters).toEqual({
+        hparams: new Map([
+          [
+            'hparam1',
+            {
+              type: DomainType.DISCRETE,
+              includeUndefined: true,
+              filterValues: [5],
+              possibleValues: [5, 7, 8],
+            },
+          ],
+        ]),
+        metrics: new Map(),
+      });
+    });
+  });
+
+  describe('dashboardMetricFilterAdded', () => {
+    it('adds entry dashboardFilters', () => {
+      const state = buildHparamsState();
+      const state2 = reducers(
+        state,
+        actions.dashboardMetricFilterAdded({
+          name: 'metric 1',
+          filter: {
+            type: DomainType.INTERVAL,
+            includeUndefined: true,
+            minValue: -2,
+            maxValue: 42,
+            filterLowerValue: -2,
+            filterUpperValue: 40,
+          },
+        })
+      );
+      expect(state2.dashboardFilters).toEqual({
+        hparams: new Map(),
+        metrics: new Map([
+          [
+            'metric 1',
+            {
+              type: DomainType.INTERVAL,
+              includeUndefined: true,
+              minValue: -2,
+              maxValue: 42,
+              filterLowerValue: -2,
+              filterUpperValue: 40,
+            },
+          ],
+        ]),
+      });
+    });
+  });
 });

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
@@ -21,11 +21,17 @@ import {
   RunToHparamsAndMetrics,
 } from '../types';
 import {combineHparamAndMetricSpecs} from './hparams_selectors_utils';
-import {HparamsState, HPARAMS_FEATURE_KEY} from './types';
+import {
+  HparamsState,
+  HPARAMS_FEATURE_KEY,
+  HparamsAndMetricsFilters,
+} from './types';
 import {
   combineDefaultHparamFilters,
   combineDefaultMetricFilters,
   getIdFromExperimentIds,
+  hparamSpecToDefaultFilter,
+  metricSpecToDefaultFilter,
 } from './utils';
 
 const getHparamsState =
@@ -230,5 +236,41 @@ export const getDashboardRunsToHparamsAndMetrics = createSelector(
       }
     }
     return runToHparamsAndMetrics;
+  }
+);
+
+export const getDashboardDefaultFilters = createSelector(
+  getDashboardHparamsAndMetricsSpecs,
+  (specs): HparamsAndMetricsFilters => {
+    const hparams = new Map(
+      specs.hparams.map((hparamSpec) => {
+        return [hparamSpec.name, hparamSpecToDefaultFilter(hparamSpec)];
+      })
+    );
+
+    const metrics = new Map(
+      specs.metrics.map((metricSpec) => {
+        return [metricSpec.name.tag, metricSpecToDefaultFilter(metricSpec)];
+      })
+    );
+
+    return {
+      hparams,
+      metrics,
+    };
+  }
+);
+
+export const getDashboardHparamFilterMap = createSelector(
+  getHparamsState,
+  (state) => {
+    return state.dashboardFilters.hparams;
+  }
+);
+
+export const getDashboardMetricsFilterMap = createSelector(
+  getHparamsState,
+  (state) => {
+    return state.dashboardFilters.metrics;
   }
 );

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
@@ -21,17 +21,12 @@ import {
   RunToHparamsAndMetrics,
 } from '../types';
 import {combineHparamAndMetricSpecs} from './hparams_selectors_utils';
-import {
-  HparamsState,
-  HPARAMS_FEATURE_KEY,
-  HparamsAndMetricsFilters,
-} from './types';
+import {HparamsState, HPARAMS_FEATURE_KEY, HparamFilter} from './types';
 import {
   combineDefaultHparamFilters,
   combineDefaultMetricFilters,
   getIdFromExperimentIds,
   hparamSpecToDefaultFilter,
-  metricSpecToDefaultFilter,
 } from './utils';
 
 const getHparamsState =
@@ -239,25 +234,16 @@ export const getDashboardRunsToHparamsAndMetrics = createSelector(
   }
 );
 
-export const getDashboardDefaultFilters = createSelector(
+export const getDashboardDefaultHparamFilters = createSelector(
   getDashboardHparamsAndMetricsSpecs,
-  (specs): HparamsAndMetricsFilters => {
+  (specs): Map<string, HparamFilter> => {
     const hparams = new Map(
       specs.hparams.map((hparamSpec) => {
         return [hparamSpec.name, hparamSpecToDefaultFilter(hparamSpec)];
       })
     );
 
-    const metrics = new Map(
-      specs.metrics.map((metricSpec) => {
-        return [metricSpec.name.tag, metricSpecToDefaultFilter(metricSpec)];
-      })
-    );
-
-    return {
-      hparams,
-      metrics,
-    };
+    return hparams;
   }
 );
 

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {DomainType} from '../types';
 import * as selectors from './hparams_selectors';
 import {
   buildDiscreteFilter,
@@ -698,6 +699,58 @@ describe('hparams/_redux/hparams_selectors_test', () => {
           ],
         },
       });
+    });
+  });
+
+  describe('#getDashboardDefaultHparamFilters', () => {
+    it('generates default filters for all hparam specs', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          dashboardSpecs: {
+            hparams: [
+              buildHparamSpec({
+                name: 'interval hparam',
+                domain: {
+                  type: DomainType.INTERVAL,
+                  minValue: 2,
+                  maxValue: 5,
+                },
+              }),
+              buildHparamSpec({
+                name: 'discrete hparam',
+                domain: {
+                  type: DomainType.DISCRETE,
+                  values: [2, 4, 6, 8],
+                },
+              }),
+            ],
+          },
+        })
+      );
+      expect(selectors.getDashboardDefaultHparamFilters(state)).toEqual(
+        new Map([
+          [
+            'interval hparam',
+            {
+              type: DomainType.INTERVAL,
+              includeUndefined: true,
+              minValue: 2,
+              maxValue: 5,
+              filterLowerValue: 2,
+              filterUpperValue: 5,
+            },
+          ],
+          [
+            'discrete hparam',
+            {
+              type: DomainType.DISCRETE,
+              includeUndefined: true,
+              possibleValues: [2, 4, 6, 8],
+              filterValues: [2, 4, 6, 8],
+            },
+          ],
+        ])
+      );
     });
   });
 

--- a/tensorboard/webapp/hparams/_redux/testing.ts
+++ b/tensorboard/webapp/hparams/_redux/testing.ts
@@ -85,6 +85,10 @@ export function buildHparamsState(
       metrics: overrides.dashboardSpecs?.metrics ?? [],
     },
     dashboardSessionGroups: overrides.dashboardSessionGroups ?? [],
+    dashboardFilters: {
+      hparams: overrides.dashboardFilters?.hparams ?? new Map(),
+      metrics: overrides.dashboardFilters?.metrics ?? new Map(),
+    },
   } as HparamsState;
 }
 

--- a/tensorboard/webapp/hparams/_redux/types.ts
+++ b/tensorboard/webapp/hparams/_redux/types.ts
@@ -24,11 +24,6 @@ import {
 export type HparamFilter = DiscreteFilter | IntervalFilter;
 export type MetricFilter = IntervalFilter;
 
-export interface HparamsAndMetricsFilters {
-  hparams: Map<string, HparamFilter>;
-  metrics: Map<string, MetricFilter>;
-}
-
 export interface HparamsMetricsAndFilters {
   hparam: {
     specs: HparamSpec[];
@@ -55,7 +50,10 @@ export interface HparamsState {
   specs: ExperimentToHparams;
   dashboardSpecs: HparamAndMetricSpec;
   dashboardSessionGroups: SessionGroup[];
-  dashboardFilters: HparamsAndMetricsFilters;
+  dashboardFilters: {
+    hparams: Map<string, HparamFilter>;
+    metrics: Map<string, MetricFilter>;
+  };
   /**
    * RATIONALE: we do not use the NamespaceContextedState because of the following reasons.
    * - RunsTable which uses the state renders both on the dashboard view and the
@@ -70,7 +68,10 @@ export interface HparamsState {
    *    separate for the list and the dashboard views, but them shared is not too bad.
    */
   filters: {
-    [id: string]: HparamsAndMetricsFilters;
+    [id: string]: {
+      hparams: Map<string, HparamFilter>;
+      metrics: Map<string, MetricFilter>;
+    };
   };
 }
 

--- a/tensorboard/webapp/hparams/_redux/types.ts
+++ b/tensorboard/webapp/hparams/_redux/types.ts
@@ -21,14 +21,22 @@ import {
   SessionGroup,
 } from '../_types';
 
+export type HparamFilter = DiscreteFilter | IntervalFilter;
+export type MetricFilter = IntervalFilter;
+
+export interface HparamsAndMetricsFilters {
+  hparams: Map<string, HparamFilter>;
+  metrics: Map<string, MetricFilter>;
+}
+
 export interface HparamsMetricsAndFilters {
   hparam: {
     specs: HparamSpec[];
-    defaultFilters: Map<string, DiscreteFilter | IntervalFilter>;
+    defaultFilters: Map<string, HparamFilter>;
   };
   metric: {
     specs: MetricSpec[];
-    defaultFilters: Map<string, IntervalFilter>;
+    defaultFilters: Map<string, MetricFilter>;
   };
 }
 
@@ -47,6 +55,7 @@ export interface HparamsState {
   specs: ExperimentToHparams;
   dashboardSpecs: HparamAndMetricSpec;
   dashboardSessionGroups: SessionGroup[];
+  dashboardFilters: HparamsAndMetricsFilters;
   /**
    * RATIONALE: we do not use the NamespaceContextedState because of the following reasons.
    * - RunsTable which uses the state renders both on the dashboard view and the
@@ -61,10 +70,7 @@ export interface HparamsState {
    *    separate for the list and the dashboard views, but them shared is not too bad.
    */
   filters: {
-    [id: string]: {
-      hparams: Map<string, DiscreteFilter | IntervalFilter>;
-      metrics: Map<string, IntervalFilter>;
-    };
+    [id: string]: HparamsAndMetricsFilters;
   };
 }
 

--- a/tensorboard/webapp/hparams/_redux/utils.ts
+++ b/tensorboard/webapp/hparams/_redux/utils.ts
@@ -170,14 +170,3 @@ export function hparamSpecToDefaultFilter(spec: HparamSpec): HparamFilter {
     filterUpperValue: spec.domain.maxValue,
   };
 }
-
-export function metricSpecToDefaultFilter(spec: MetricSpec): MetricFilter {
-  return {
-    type: DomainType.INTERVAL,
-    includeUndefined: true,
-    minValue: -Infinity,
-    maxValue: Infinity,
-    filterLowerValue: -Infinity,
-    filterUpperValue: Infinity,
-  };
-}

--- a/tensorboard/webapp/hparams/_redux/utils.ts
+++ b/tensorboard/webapp/hparams/_redux/utils.ts
@@ -18,8 +18,11 @@ import {
   DiscreteHparamValue,
   DiscreteHparamValues,
   DomainType,
+  HparamSpec,
   IntervalFilter,
+  MetricSpec,
 } from '../types';
+import {HparamFilter, MetricFilter} from './types';
 
 export function getIdFromExperimentIds(experimentIds: string[]): string {
   return JSON.stringify([...experimentIds].sort());
@@ -146,4 +149,35 @@ export function combineDefaultMetricFilters(
   }
 
   return intervalMetrics;
+}
+
+export function hparamSpecToDefaultFilter(spec: HparamSpec): HparamFilter {
+  if (spec.domain.type === DomainType.DISCRETE) {
+    return {
+      type: DomainType.DISCRETE,
+      includeUndefined: true,
+      possibleValues: spec.domain.values,
+      filterValues: spec.domain.values,
+    };
+  }
+
+  return {
+    type: DomainType.INTERVAL,
+    includeUndefined: true,
+    minValue: spec.domain.minValue,
+    maxValue: spec.domain.maxValue,
+    filterLowerValue: spec.domain.minValue,
+    filterUpperValue: spec.domain.maxValue,
+  };
+}
+
+export function metricSpecToDefaultFilter(spec: MetricSpec): MetricFilter {
+  return {
+    type: DomainType.INTERVAL,
+    includeUndefined: true,
+    minValue: -Infinity,
+    maxValue: Infinity,
+    filterLowerValue: -Infinity,
+    filterUpperValue: Infinity,
+  };
 }

--- a/tensorboard/webapp/hparams/_redux/utils_test.ts
+++ b/tensorboard/webapp/hparams/_redux/utils_test.ts
@@ -12,12 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {DiscreteFilter, IntervalFilter} from '../types';
-import {buildDiscreteFilter, buildIntervalFilter} from './testing';
+import {DiscreteFilter, DomainType, IntervalFilter} from '../types';
+import {
+  buildDiscreteFilter,
+  buildHparamSpec,
+  buildIntervalFilter,
+} from './testing';
 import {
   combineDefaultHparamFilters,
   combineDefaultMetricFilters,
   getIdFromExperimentIds,
+  hparamSpecToDefaultFilter,
 } from './utils';
 
 describe('hparams/_redux/utils test', () => {
@@ -357,6 +362,47 @@ describe('hparams/_redux/utils test', () => {
           ],
         ])
       );
+    });
+  });
+
+  describe('hparamSpecToDefaultFilter', () => {
+    it('creates discrete filter when domain type is discrete', () => {
+      expect(
+        hparamSpecToDefaultFilter(
+          buildHparamSpec({
+            domain: {
+              type: DomainType.DISCRETE,
+              values: [2, 4, 6],
+            },
+          })
+        )
+      ).toEqual({
+        type: DomainType.DISCRETE,
+        includeUndefined: true,
+        possibleValues: [2, 4, 6],
+        filterValues: [2, 4, 6],
+      });
+    });
+
+    it('creates interval filter when domain type is interval', () => {
+      expect(
+        hparamSpecToDefaultFilter(
+          buildHparamSpec({
+            domain: {
+              type: DomainType.INTERVAL,
+              minValue: 2,
+              maxValue: 4,
+            },
+          })
+        )
+      ).toEqual({
+        type: DomainType.INTERVAL,
+        includeUndefined: true,
+        minValue: 2,
+        maxValue: 4,
+        filterLowerValue: 2,
+        filterUpperValue: 4,
+      });
     });
   });
 });


### PR DESCRIPTION
## Motivation for features / changes
Now that the filter dialog is merged #6493 we need to add support for filtering by hparams. However, #6544 changed the way hparam values are read. This change adds a new property to state in which to store dashboard related hparam and metric filters.

See #6488 for the WIP integration with the runs_table_container + tb_data_table -> common_selectors + hparam_selectors.

