### PR TITLE
Import Fix: Remove DebuggerState from AppState.

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -142,7 +142,6 @@ tf_ng_module(
         "app_state.ts",
     ],
     deps = [
-        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
         "//tensorboard/webapp/alert/store:types",
         "//tensorboard/webapp/app_routing/store:types",
         "//tensorboard/webapp/core/store",

--- a/tensorboard/webapp/app_state.ts
+++ b/tensorboard/webapp/app_state.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {State as DebuggerState} from '../plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types';
 import {State as AlertState} from './alert/store/alert_types';
 import {State as AppRoutingState} from './app_routing/store/app_routing_types';
 import {State as CoreState} from './core/store/core_types';
@@ -35,6 +34,5 @@ export type State = AppRoutingState &
   RunsState &
   SettingsState &
   NotificationState &
-  DebuggerState &
   AlertState &
   PersistentSettingsState;

--- a/tensorboard/webapp/testing/utils.ts
+++ b/tensorboard/webapp/testing/utils.ts
@@ -67,7 +67,6 @@ import {ALERT_FEATURE_KEY} from '../alert/store/alert_types';
 import {PERSISTENT_SETTINGS_FEATURE_KEY} from '../persistent_settings/_redux/persistent_settings_types';
 import {SETTINGS_FEATURE_KEY} from '../settings/_redux/settings_types';
 import {CORE_FEATURE_KEY} from '../core/store/core_types';
-import {DEBUGGER_FEATURE_KEY} from '../../plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types';
 
 type PartialOverrides = {
   [K in keyof State]?: Partial<State[K]>;
@@ -75,9 +74,6 @@ type PartialOverrides = {
 
 export function buildMockState(overrides: PartialOverrides = {}): State {
   return {
-    ...buildStateFromDebuggerState(
-      createDebuggerState(overrides[DEBUGGER_FEATURE_KEY] ?? {})
-    ),
     ...buildStateFromAlertState(
       buildAlertState(overrides[ALERT_FEATURE_KEY] ?? {})
     ),


### PR DESCRIPTION
In https://github.com/tensorflow/tensorboard/pull/6544 we introduced a dependency on AppState on DebuggerState. This unfortunately fails some internal tests, where certain TensorBoard products do not want to unnecessarily depend on plugin state that they don't use.

I've removed DebuggerState from AppState. Fortunately there are no tests or features that require this dependency.