### PR TITLE
Hparams: Support excluding metric information in HTTP requests.

### DIFF
--- a/tensorboard/plugins/hparams/api.proto
+++ b/tensorboard/plugins/hparams/api.proto
@@ -254,17 +254,20 @@ enum Status {
 
 // Parameters for a GetExperiment API call.
 // Each experiment is scoped by a unique global id.
-// NEXT_TAG: 2
+// NEXT_TAG: 3
 message GetExperimentRequest {
   // REQUIRED
   string experiment_name = 1;
+
+  // Whether to fetch metrics and include them in the results. Defaults to true.
+  optional bool include_metrics = 2;
 }
 
 // Parameters for a ListSessionGroups API call.
 // Computes a list of the current session groups allowing for filtering and
 // sorting by metrics and hyperparameter values. Returns a "slice" of
 // that list specified by start_index and slice_size.
-// NEXT_TAG: 8
+// NEXT_TAG: 9
 message ListSessionGroupsRequest {
   string experiment_name = 6;
 
@@ -314,6 +317,9 @@ message ListSessionGroupsRequest {
   // sorted and filtered by the parameters above (if start_index > total_size
   // no session groups are returned).
   int32 slice_size = 5;
+
+  // Whether to fetch metrics and include them in the results. Defaults to true.
+  optional bool include_metrics = 8;
 }
 
 // Defines parmeters for a ListSessionGroupsRequest for a specific column.

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -18,17 +18,21 @@
 class Handler:
     """Handles a GetExperiment request."""
 
-    def __init__(self, request_context, backend_context, experiment_id):
+    def __init__(
+        self, request_context, backend_context, experiment_id, request
+    ):
         """Constructor.
 
         Args:
           request_context: A tensorboard.context.RequestContext.
           backend_context: A backend_context.Context instance.
           experiment_id: A string, as from `plugin_util.experiment_id`.
+          request: A api_pb2.GetExperimentRequest instance.
         """
         self._request_context = request_context
         self._backend_context = backend_context
         self._experiment_id = experiment_id
+        self._request = request
 
     def run(self):
         """Handles the request specified on construction.
@@ -37,9 +41,15 @@ class Handler:
           An Experiment object.
         """
         experiment_id = self._experiment_id
+        include_metrics = (
+            not self._request.HasField("include_metrics")
+            or self._request.include_metrics
+        )
+
         return self._backend_context.experiment_from_metadata(
             self._request_context,
             experiment_id,
+            include_metrics,
             self._backend_context.hparams_metadata(
                 self._request_context, experiment_id
             ),

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -113,15 +113,14 @@ class HParamsPlugin(base_plugin.TBPlugin):
         ctx = plugin_util.context(request.environ)
         experiment_id = plugin_util.experiment_id(request.environ)
         try:
-            # This backend currently ignores the request parameters, but (for a POST)
-            # we must advance the input stream to skip them -- otherwise the next HTTP
-            # request will be parsed incorrectly.
-            _ = _parse_request_argument(request, api_pb2.GetExperimentRequest)
+            request_proto = _parse_request_argument(
+                request, api_pb2.GetExperimentRequest
+            )
             return http_util.Respond(
                 request,
                 json_format.MessageToJson(
                     get_experiment.Handler(
-                        ctx, self._context, experiment_id
+                        ctx, self._context, experiment_id, request_proto
                     ).run(),
                     including_default_value_fields=True,
                 ),

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -51,6 +51,10 @@ class Handler:
         self._backend_context = backend_context
         self._experiment_id = experiment_id
         self._request = request
+        self._include_metrics = (
+            not self._request.HasField("include_metrics")
+            or self._request.include_metrics
+        )
 
     def run(self):
         """Handles the request specified on construction.
@@ -92,6 +96,7 @@ class Handler:
         experiment = self._backend_context.experiment_from_metadata(
             self._request_context,
             self._experiment_id,
+            self._include_metrics,
             hparams_run_to_tag_to_content,
             # Don't pass any information from the DataProvider since we are only
             # examining session groups based on tag metadata
@@ -120,14 +125,22 @@ class Handler:
             sort,
         )
 
-        metric_infos = self._backend_context.compute_metric_infos_from_data_provider_session_groups(
-            self._request_context, self._experiment_id, response
+        metric_infos = (
+            self._backend_context.compute_metric_infos_from_data_provider_session_groups(
+                self._request_context, self._experiment_id, response
+            )
+            if self._include_metrics
+            else []
         )
 
-        all_metric_evals = self._backend_context.read_last_scalars(
-            self._request_context,
-            self._experiment_id,
-            run_tag_filter=None,
+        all_metric_evals = (
+            self._backend_context.read_last_scalars(
+                self._request_context,
+                self._experiment_id,
+                run_tag_filter=None,
+            )
+            if self._include_metrics
+            else {}
         )
 
         session_groups = []
@@ -228,12 +241,16 @@ class Handler:
                 )
                 metric_runs.add(run)
                 metric_tags.add(tag)
-        all_metric_evals = self._backend_context.read_last_scalars(
-            self._request_context,
-            self._experiment_id,
-            run_tag_filter=provider.RunTagFilter(
-                runs=metric_runs, tags=metric_tags
-            ),
+        all_metric_evals = (
+            self._backend_context.read_last_scalars(
+                self._request_context,
+                self._experiment_id,
+                run_tag_filter=provider.RunTagFilter(
+                    runs=metric_runs, tags=metric_tags
+                ),
+            )
+            if self._include_metrics
+            else {}
         )
         for (
             session_name,

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -52,6 +52,8 @@ class Handler:
         self._experiment_id = experiment_id
         self._request = request
         self._include_metrics = (
+            # Metrics are included by default if include_metrics is not
+            # specified in the request.
             not self._request.HasField("include_metrics")
             or self._request.include_metrics
         )


### PR DESCRIPTION
There are some clients of the Hparams HTTP API that do not require the metric information. This includes the metric_infos usually returned in the /experiments request and the metric_values usually returned in the /session_groups request. Since these can be expensive to calculate, we want the option to not calculate and return them in the response.

Add option `include_metrics` to both GetExperimentRequest and ListSessionGroupsRequest. If unspecified we treat `include_metrics` as True, for backward compatibility. Honor the `include_metrics` property in all three major cases: When experiment metadata is defined by Experiment tags, by Session tags, or by the DataProvider.