### PR TITLE
Add new package to check for when re-exporting tf.summary.

### DIFF
--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -132,6 +132,7 @@ def reexport_tf_summary():
         "tensorflow._api.v2",
         "tensorflow._api.v2.compat.v2",
         "tensorflow._api.v1.compat.v2",
+        "tensorflow._api.compat.v2",
     ]
 
     def dynamic_wildcard_import(module):


### PR DESCRIPTION
## Motivation for features / changes
In the next few weeks TensorFlow will switch over to a new API generation binary, and will cleanup some of its API generation logic. This adds the new module to check for the generated TF API when re-exporting tf.summary. 

## Technical description of changes
Add new module path to check for the generated TF API when re-exporting TF summary. 

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)
`bazel test //tensorboard/...`

## Alternate designs / implementations considered (or N/A)
N/A
