### PR TITLE
Hparams: Add `include_in_result` field and implement support for `hparams_to_include`

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -397,7 +397,13 @@ class DataProvider(metaclass=abc.ABCMeta):
         return ListHyperparametersResult(hyperparameters=[], session_groups=[])
 
     def read_hyperparameters(
-        self, ctx=None, *, experiment_ids, filters=None, sort=None
+        self,
+        ctx=None,
+        *,
+        experiment_ids,
+        filters=None,
+        sort=None,
+        hparams_to_include=None,
     ):
         """Read hyperparameter values.
 
@@ -409,6 +415,10 @@ class DataProvider(metaclass=abc.ABCMeta):
             returned session groups based on hyperparameter value.
           sort: A Sequence[HyperparameterSort] that specify how the results
             should be sorted.
+          hparams_to_include: An optional Collection[str] of the full names of
+            hyperparameters to include in the results. This collection will be
+            augmented to include all the hyperparameters specified in `filters`
+            and `sort`. If None, all hyperparameters will be returned.
 
         Returns:
           A Sequence[HyperparameterSessionGroup] describing the groups and

--- a/tensorboard/plugins/hparams/api.proto
+++ b/tensorboard/plugins/hparams/api.proto
@@ -322,9 +322,9 @@ message ListSessionGroupsRequest {
   optional bool include_metrics = 8;
 }
 
-// Defines parmeters for a ListSessionGroupsRequest for a specific column.
+// Defines parameters for a ListSessionGroupsRequest for a specific column.
 // See the comment for "ListSessionGroupsRequest" above for more details.
-// NEXT_TAG: 9
+// NEXT_TAG: 10
 message ColParams {
   oneof name {
     MetricName metric = 1;
@@ -373,6 +373,12 @@ message ColParams {
   // Specifies whether to exclude session groups whose column value is missing
   // from the response.
   bool exclude_missing_values = 8;
+
+  // Specifies whether to include the values for the field in the operation
+  // result. Defaults to True.
+  // Note: Hparams and metrics that do not appear in any `ColParams` in a request
+  // will also not be included in the result.
+  optional bool include_in_result = 9;
 }
 
 enum SortOrder {

--- a/tensorboard/plugins/hparams/api.proto
+++ b/tensorboard/plugins/hparams/api.proto
@@ -376,8 +376,8 @@ message ColParams {
 
   // Specifies whether to include the values for the field in the operation
   // result. Defaults to True.
-  // Note: Hparams and metrics that do not appear in any `ColParams` in a request
-  // will also not be included in the result.
+  // Note: Hparams and metrics that do not appear in any `ColParams` in a
+  // request will also not be included in the result.
   optional bool include_in_result = 9;
 }
 

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -200,11 +200,15 @@ class Context:
         )
 
     def session_groups_from_data_provider(
-        self, ctx, experiment_id, filters, sort
+        self, ctx, experiment_id, filters, sort, hparams_to_include
     ):
         """Calls DataProvider.read_hyperparameters() and returns the result."""
         return self._tb_context.data_provider.read_hyperparameters(
-            ctx, experiment_ids=[experiment_id], filters=filters, sort=sort
+            ctx,
+            experiment_ids=[experiment_id],
+            filters=filters,
+            sort=sort,
+            hparams_to_include=hparams_to_include,
         )
 
     def _find_experiment_tag(

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -114,6 +114,9 @@ class Handler:
         )
         session_groups = self._filter(session_groups, filters)
         self._sort(session_groups, extractors)
+
+        _reduce_to_hparams_to_include(session_groups, self._request.col_params)
+
         return session_groups
 
     def _session_groups_from_data_provider(self):
@@ -125,6 +128,7 @@ class Handler:
             self._experiment_id,
             filters,
             sort,
+            _get_hparams_to_include(self._request.col_params),
         )
 
         metric_infos = (
@@ -968,3 +972,59 @@ def _build_data_provider_sort_item(col_param):
         hyperparameter_name=col_param.hparam,
         sort_direction=sort_direction,
     )
+
+
+def _get_hparams_to_include(col_params):
+    """Generates the list of hparams to include in the response.
+
+    The determination is based on the `include_in_result` field in ColParam. If
+    a ColParam either has `include_in_result: True` or does not specify the
+    field at all, then it should be included in the result.
+
+    Args:
+      col_params: A collection of `ColParams` protos.
+
+    Returns:
+      A list of names of hyperparameters to include in the response. If None,
+      all hyperparameters will be included.
+    """
+    # If none of the col_params contains `include_in_result` field, all hparams should be included in the response.
+    if all(
+        not col_param.HasField("include_in_result") for col_param in col_params
+    ):
+        return None
+
+    hparams_to_include = []
+    for col_param in col_params:
+        if (
+            col_param.HasField("include_in_result")
+            and not col_param.include_in_result
+        ):
+            # Explicitly set to exclude this hparam.
+            continue
+        if col_param.hparam:
+            hparams_to_include.append(col_param.hparam)
+    return hparams_to_include
+
+
+def _reduce_to_hparams_to_include(session_groups, col_params):
+    """Removes hparams from session_groups that should not be included in the response.
+
+    Args:
+      session_groups: A collection of `SessionGroup` protos, which will be modified in place.
+      col_params: A collection of `ColParams` protos.
+    """
+    hparams_to_include = _get_hparams_to_include(col_params)
+    if hparams_to_include is None:
+        return
+
+    for i, session_group in enumerate(session_groups):
+        new_hparams = {
+            hparam: value
+            for (hparam, value) in session_group.hparams.items()
+            if hparam in hparams_to_include
+        }
+
+        session_group.ClearField("hparams")
+        for (hparam, value) in new_hparams.items():
+            session_group.hparams[hparam].CopyFrom(value)

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -1020,17 +1020,16 @@ def _get_hparams_to_include(col_params):
 
 
 def _reduce_to_hparams_to_include(session_groups, col_params):
-    """Removes hparams from session_groups that should not be included in the response.
+    """Removes hparams from session_groups that should not be included.
 
     Args:
-      session_groups: A collection of `SessionGroup` protos, which will be modified in place.
+      session_groups: A collection of `SessionGroup` protos, which will be
+        modified in place.
       col_params: A collection of `ColParams` protos.
     """
     hparams_to_include = _get_hparams_to_include(col_params)
-    if hparams_to_include is None:
-        return
 
-    for i, session_group in enumerate(session_groups):
+    for session_group in session_groups:
         new_hparams = {
             hparam: value
             for (hparam, value) in session_group.hparams.items()


### PR DESCRIPTION
This PR extracts the filtering logic for hparams only (metrics filtering will be done later) from bmd3k's [commit](https://github.com/bmd3k/tensorboard/commit/ab75cd1812097f5ca54085e68a34a8cfa346a60b). 

Googlers, see comments in cl/559852837 for more context.

Test internally at cl/563163418.

#hparams
