### PR TITLE
Bug Fix: Update the port scanning logic to properly skip ports in use

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -205,7 +205,7 @@ class TensorBoard:
             # any positional arguments to `serve`.
             serve_parser = serve_subparser
 
-        for (name, subcommand) in self.subcommands.items():
+        for name, subcommand in self.subcommands.items():
             subparser = subparsers.add_parser(
                 name,
                 help=subcommand.help(),
@@ -647,9 +647,15 @@ def with_port_scanning(cls):
         max_attempts = 100 if should_scan else 1
         base_port = min(base_port + max_attempts, 0x10000) - max_attempts
 
+        def is_port_in_use(port):
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                return s.connect_ex(("localhost", port)) == 0
+
         for port in range(base_port, base_port + max_attempts):
             subflags = argparse.Namespace(**vars(flags))
             subflags.port = port
+            if is_port_in_use(port):
+                continue
             try:
                 return cls(wsgi_app=wsgi_app, flags=subflags)
             except TensorBoardPortInUseError:


### PR DESCRIPTION
## Motivation for features / changes
#6552

## Technical description of changes
The port scanning logic originally added in #1851 does not seem to work anymore. WerkzeugServer no longer raises an Error when attempting to bind to a port which is in used and instead handles the issue silently.

The current Werkzeug version is 2.3.7 but I had 2.3.4 installed when I first verified this. I tried installing 2.2.0 and the issues was not present so I assume it was introduced in 2.3.0.
https://pypi.org/project/Werkzeug

## Detailed steps to verify changes work correctly (as executed by you)
1) Start TensorBoard, note the port it is bound to (it should be 6006)
2) In a separate terminal start TensorBoard again.
3) TensorBoard should successfully bind to a different port (this time 6007)
