### PR TITLE
HParams: Stop fetching hparams data using run effects

### DIFF
--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -38,6 +38,21 @@ export enum RouteKind {
   NOT_SET,
 }
 
+export type DashboardRoute =
+  | RouteKind.EXPERIMENT
+  | RouteKind.COMPARE_EXPERIMENT
+  | RouteKind.CARD;
+
+export function isDashboardRoute(
+  routeKind: RouteKind
+): routeKind is DashboardRoute {
+  return (
+    routeKind === RouteKind.EXPERIMENT ||
+    routeKind === RouteKind.COMPARE_EXPERIMENT ||
+    routeKind === RouteKind.CARD
+  );
+}
+
 export const DEFAULT_EXPERIMENT_ID = 'defaultExperimentId';
 
 /**

--- a/tensorboard/webapp/runs/effects/runs_effects.ts
+++ b/tensorboard/webapp/runs/effects/runs_effects.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
 import {Store} from '@ngrx/store';
-import {forkJoin, merge, Observable, of, throwError} from 'rxjs';
+import {forkJoin, merge, Observable, of, throwError, zip} from 'rxjs';
 import {
   catchError,
   distinctUntilChanged,
@@ -267,7 +267,9 @@ export class RunsEffects {
     );
   }
 
-  private maybeFetchHparamsMetadata(experimentId: string) {
+  private maybeFetchHparamsMetadata(
+    experimentId: string
+  ): Observable<HparamsAndMetadata> {
     return this.store.select(getEnableHparamsInTimeSeries).pipe(
       withLatestFrom(this.store.select(getRouteKind)),
       switchMap(([hparamsInTimeSeries, routeKind]) => {
@@ -289,7 +291,7 @@ export class RunsEffects {
     runs: Run[];
     metadata: HparamsAndMetadata;
   }> {
-    return forkJoin([
+    return zip([
       this.runsDataSource.fetchRuns(experimentId),
       this.maybeFetchHparamsMetadata(experimentId),
     ]).pipe(


### PR DESCRIPTION
## Motivation for features / changes
Now that we are fetching the hparams data using the newly created hparams_effects (#6540) we no longer need to fetch them using the old method.

Note that the experiment list SHOULD still use the old method.
