### PR TITLE
Data Table: enable data table by default

### DIFF
--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -267,7 +267,7 @@ const {initialState, reducers: namespaceContextedReducer} =
       tagGroupExpanded: new Map<string, boolean>(),
       linkedTimeSelection: null,
       linkedTimeEnabled: false,
-      stepSelectorEnabled: false,
+      stepSelectorEnabled: true,
       rangeSelectionEnabled: false,
       singleSelectionHeaders: [
         {


### PR DESCRIPTION
## Motivation for features / changes
This feature has been out for awhile and we have had good feedback. However, based on the number we believe many user who would find this useful have not discovered it. This change turns the table on by default.

It is worth noting that if users have enabled/disabled this in the past their choices are stored and then will not see any changes unless they delete their local storage or move to a new computer.

## Detailed steps to verify changes work correctly (as executed by you)
I deleted localStorage, reloaded the page, and observed that is was enabled. Then disabled, reloaded the page, and observed that it was still disabled. All is working as expected.