### PR TITLE
HParams: Enable `hparamsInTimeSeries` by default

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -111,7 +111,7 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       parseValue: parseBoolean,
     },
     enableHparamsInTimeSeries: {
-      defaultValue: false,
+      defaultValue: true,
       queryParamOverride: 'enableHparamsInTimeSeries',
       parseValue: parseBoolean,
     },

--- a/tensorboard/webapp/runs/effects/runs_effects_test.ts
+++ b/tensorboard/webapp/runs/effects/runs_effects_test.ts
@@ -129,6 +129,7 @@ describe('runs_effects', () => {
     });
     store.overrideSelector(getExperimentIdsFromRoute, null);
     store.overrideSelector(getActiveRoute, buildRoute());
+    store.overrideSelector(getEnableHparamsInTimeSeries, false);
   });
 
   afterEach(() => {

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -111,16 +111,16 @@ export class RunsDataTable {
   }
 
   allRowsSelected() {
-    return this.data.every((row) => row['selected']);
+    return this.data?.every((row) => row['selected']);
   }
 
   someRowsSelected() {
-    return this.data.some((row) => row['selected']);
+    return this.data?.some((row) => row['selected']);
   }
 
   handleSelectAll(event: MouseEvent) {
     event.preventDefault();
-    this.onAllSelectionToggle.emit(this.data.map((row) => row.id));
+    this.onAllSelectionToggle.emit(this.data?.map((row) => row.id));
   }
 
   onFilterKeyUp(event: KeyboardEvent) {


### PR DESCRIPTION
## Motivation for features / changes
This PR will launch the hparams in timeseries feature.

## Screenshots of UI changes (or N/A)
### Light Mode
![image](https://github.com/tensorflow/tensorboard/assets/78179109/57c6c1bd-4584-41e7-83b3-cea67be170a3)

### Dark Mode
![image](https://github.com/tensorflow/tensorboard/assets/78179109/170c61ca-d892-4dde-aee9-597c6c443c10)

### Adding a column
![image](https://github.com/tensorflow/tensorboard/assets/78179109/f95a8e78-142a-457e-bde4-67bee0a1e9fa)

### Runs Table with additional columns
![image](https://github.com/tensorflow/tensorboard/assets/78179109/2ffd77f9-7476-4ea8-bcfd-7c5153c960e5)

### Applying an Interval Filter
![image](https://github.com/tensorflow/tensorboard/assets/78179109/0d9a5ff7-38a5-464d-90d5-a0864ac71b88)
![image](https://github.com/tensorflow/tensorboard/assets/78179109/32bd62cb-c0f5-47d7-aa47-895efd9690cf)

### Applying a Discrete Filter
![image](https://github.com/tensorflow/tensorboard/assets/78179109/1504f871-223f-463c-80de-20866687324c)
![image](https://github.com/tensorflow/tensorboard/assets/78179109/28c25dec-0788-40a8-a98c-9f6af15af1f8)

