### PR TITLE
Hparams: Support `limit` when fetching hparam metadata.

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -379,13 +379,15 @@ class DataProvider(metaclass=abc.ABCMeta):
         """
         pass
 
-    def list_hyperparameters(self, ctx=None, *, experiment_ids):
+    def list_hyperparameters(self, ctx=None, *, experiment_ids, limit=0):
         """List hyperparameters metadata.
 
         Args:
           ctx: A TensorBoard `RequestContext` value.
           experiment_ids: A Collection[string] of IDs of the enclosing
             experiments.
+          limit: Optional number of hyperparameter metadata to include in the
+            result. If zero, all metadata will be included.
 
         Returns:
           A ListHyperparametersResult describing the hyperparameter-related

--- a/tensorboard/plugins/hparams/api.proto
+++ b/tensorboard/plugins/hparams/api.proto
@@ -254,13 +254,17 @@ enum Status {
 
 // Parameters for a GetExperiment API call.
 // Each experiment is scoped by a unique global id.
-// NEXT_TAG: 3
+// NEXT_TAG: 4
 message GetExperimentRequest {
   // REQUIRED
   string experiment_name = 1;
 
   // Whether to fetch metrics and include them in the results. Defaults to true.
   optional bool include_metrics = 2;
+
+  // Number of hyperparameter metadata to include in the result. If zero, all
+  // hyperparameter metadata will be returned.
+  optional int32 hparams_limit = 3;
 }
 
 // Parameters for a ListSessionGroups API call.

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -193,10 +193,10 @@ class Context:
             for (run, tag_to_data) in data_provider_output.items()
         }
 
-    def hparams_from_data_provider(self, ctx, experiment_id):
+    def hparams_from_data_provider(self, ctx, experiment_id, limit):
         """Calls DataProvider.list_hyperparameters() and returns the result."""
         return self._tb_context.data_provider.list_hyperparameters(
-            ctx, experiment_ids=[experiment_id]
+            ctx, experiment_ids=[experiment_id], limit=limit
         )
 
     def session_groups_from_data_provider(

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -149,6 +149,7 @@ class BackendContextTest(tf.test.TestCase):
         ctx,
         *,
         experiment_ids,
+        limit,
     ):
         return self._hyperparameters
 
@@ -161,7 +162,7 @@ class BackendContextTest(tf.test.TestCase):
             "123",
             include_metrics,
             ctxt.hparams_metadata(request_ctx, "123"),
-            ctxt.hparams_from_data_provider(request_ctx, "123"),
+            ctxt.hparams_from_data_provider(request_ctx, "123", limit=0),
         )
 
     def test_experiment_with_experiment_tag(self):

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -38,6 +38,7 @@ class Handler:
             not request.HasField("include_metrics")
             or request.include_metrics
         )
+        self._hparams_limit = request.hparams_limit
 
     def run(self):
         """Handles the request specified on construction.
@@ -53,6 +54,8 @@ class Handler:
                 self._request_context, self._experiment_id
             ),
             self._backend_context.hparams_from_data_provider(
-                self._request_context, self._experiment_id
+                self._request_context,
+                self._experiment_id,
+                limit=self._hparams_limit,
             ),
         )


### PR DESCRIPTION
Support `limit` for `DataProvider.list_hyperparameters()`.

Googlers, see cl/563165193 for more context.

#hparams