### PR TITLE
Chore: Remove wheel from requirements.txt

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -33,4 +33,3 @@ requests >= 2.21.0, < 3
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 tensorboard-data-server >= 0.7.0, < 0.8.0
 werkzeug >= 1.0.1
-wheel >= 0.26


### PR DESCRIPTION
## Motivation for features / changes
This package is no longer needed in newer versions of python. It comes as a seed package where needed. It is even causing some users problems(#6567)