### PR TITLE
Revert HParams: Stop fetching hparams data using run effects (#6561)

### DIFF
--- a/tensorboard/webapp/app_routing/types.ts
+++ b/tensorboard/webapp/app_routing/types.ts
@@ -38,21 +38,6 @@ export enum RouteKind {
   NOT_SET,
 }
 
-export type DashboardRoute =
-  | RouteKind.EXPERIMENT
-  | RouteKind.COMPARE_EXPERIMENT
-  | RouteKind.CARD;
-
-export function isDashboardRoute(
-  routeKind: RouteKind
-): routeKind is DashboardRoute {
-  return (
-    routeKind === RouteKind.EXPERIMENT ||
-    routeKind === RouteKind.COMPARE_EXPERIMENT ||
-    routeKind === RouteKind.CARD
-  );
-}
-
 export const DEFAULT_EXPERIMENT_ID = 'defaultExperimentId';
 
 /**

--- a/tensorboard/webapp/runs/effects/runs_effects_test.ts
+++ b/tensorboard/webapp/runs/effects/runs_effects_test.ts
@@ -28,9 +28,7 @@ import {State} from '../../app_state';
 import * as coreActions from '../../core/actions';
 import {
   getActiveRoute,
-  getEnableHparamsInTimeSeries,
   getExperimentIdsFromRoute,
-  getRouteKind,
   getRuns,
   getRunsLoadState,
 } from '../../selectors';
@@ -64,7 +62,6 @@ describe('runs_effects', () => {
   let dispatchSpy: jasmine.Spy;
   let actualActions: Action[];
   let selectSpy: jasmine.Spy;
-  let fetchHparamsSpy: jasmine.Spy;
 
   function flushFetchRuns(requestIndex: number, runs: Run[]) {
     expect(fetchRunsSubjects.length).toBeGreaterThan(requestIndex);
@@ -116,8 +113,7 @@ describe('runs_effects', () => {
     });
 
     fetchHparamsMetadataSubjects = [];
-    fetchHparamsSpy = spyOn(runsDataSource, 'fetchHparamsMetadata');
-    fetchHparamsSpy.and.callFake(() => {
+    spyOn(runsDataSource, 'fetchHparamsMetadata').and.callFake(() => {
       const subject = new ReplaySubject<HparamsAndMetadata>(1);
       fetchHparamsMetadataSubjects.push(subject);
       return subject;
@@ -233,15 +229,6 @@ describe('runs_effects', () => {
 
         expect(actualActions).toEqual([]);
       });
-    });
-
-    it('does not fetch hparam data when enableHparamsInTimeSeries is true when on a dashboard route', () => {
-      store.overrideSelector(getEnableHparamsInTimeSeries, true);
-      store.overrideSelector(getRouteKind, RouteKind.EXPERIMENT);
-      store.refreshState();
-
-      action.next(actions.runTableShown({experimentIds: ['a']}));
-      expect(fetchHparamsSpy).not.toHaveBeenCalled();
     });
 
     it('fires FAILED action when failed to fetch runs', () => {


### PR DESCRIPTION
## Motivation for features / changes
#6561 created issues when syncing internally. When we discovered the problem we tried to patch forward twice
 * #6566 
 * #6568

There was a couple of issues.
 * Improper support for tuples internally.
 * Internally `forkJoin` and `zip` work differently, it's not document how though.
 * The unapproved screenshot changes in [cl/563231334](http://cl/563231334)

Googlers see [cl/563516101](http://cl/563516101) for confidence this ACTUALLY fixes the sync.