### PR TITLE
Add a frame-ancestors allow list option to Content-Security-Policy

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -37,6 +37,7 @@ _DISALLOWED_CHAR_IN_DOMAIN = re.compile(r"\s")
 # loading font icons.
 _CSP_FONT_DOMAINS_WHITELIST = ["data:"]
 _CSP_FRAME_DOMAINS_WHITELIST = []
+_CSP_FRAME_ANCESTORS_DOMAINS_ALLOWLIST = []
 _CSP_IMG_DOMAINS_WHITELIST = []
 _CSP_SCRIPT_DOMAINS_WHITELIST = []
 _CSP_CONNECT_DOMAINS_WHITELIST = []
@@ -219,6 +220,8 @@ def Respond(
                 # Dynamic plugins are rendered inside an iframe.
                 "frame-src %s"
                 % _create_csp_string("'self'", *_CSP_FRAME_DOMAINS_WHITELIST),
+                "frame-ancestors %s"
+                % _create_csp_string(*_CSP_FRAME_ANCESTORS_DOMAINS_ALLOWLIST),
                 "img-src %s"
                 % _create_csp_string(
                     "'self'",

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -229,8 +229,8 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=["abcdefghi"]
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
+            "default-src 'self';font-src 'self' data:;frame-src 'self';"
+            "frame-ancestors 'none';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'self' 'unsafe-eval' 'sha256-abcdefghi'"
         )
@@ -243,8 +243,8 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
+            "default-src 'self';font-src 'self' data:;frame-src 'self';"
+            "frame-ancestors 'none';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'unsafe-eval'"
         )
@@ -258,8 +258,8 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
+            "default-src 'self';font-src 'self' data:;frame-src 'self';"
+            "frame-ancestors 'none';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'none'"
         )
@@ -273,8 +273,8 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
+            "default-src 'self';font-src 'self' data:;frame-src 'self';"
+            "frame-ancestors 'none';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'self'"
         )
@@ -287,8 +287,8 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=["abcdefghi"]
         )
         expected_csp = (
-            "default-src 'self';font-src 'self' data:;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
+            "default-src 'self';font-src 'self' data:;frame-src 'self';"
+            "frame-ancestors 'none';img-src 'self' data: blob:;object-src 'none';"
             "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
             "connect-src 'self';script-src 'self' 'sha256-abcdefghi'"
         )
@@ -308,6 +308,9 @@ class RespondTest(tb_test.TestCase):
     @mock.patch.object(
         http_util, "_CSP_FRAME_DOMAINS_WHITELIST", ["https://myframe.com"]
     )
+    @mock.patch.object(
+        http_util, "_CSP_FRAME_ANCESTORS_DOMAINS_ALLOWLIST", ["https://foo.bar"]
+    )
     def testCsp_globalDomainWhiteList(self):
         q = wrappers.Request(wtest.EnvironBuilder().get_environ())
         r = http_util.Respond(
@@ -316,6 +319,7 @@ class RespondTest(tb_test.TestCase):
         expected_csp = (
             "default-src 'self';font-src 'self' data:;"
             "frame-src 'self' https://myframe.com;"
+            "frame-ancestors https://foo.bar;"
             "img-src 'self' data: blob: https://example.com;"
             "object-src 'none';style-src 'self' https://www.gstatic.com data: "
             "'unsafe-inline' https://googol.com;connect-src 'self';script-src "


### PR DESCRIPTION
## Motivation for features / changes
Add an allowlist to allow TensorBoard to embedded as an iframe in other apps

## Technical description of changes
By default, browsers disallow any webpages to be iframed in other external apps unless a `Content-Security-Policy frame-ancestors` header is set. This change exposes an option to customize that header.

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)
Added unit test and verified headers show up as expected.

## Alternate designs / implementations considered (or N/A)
N/A
