### PR TITLE
Hparams: Set interval domain fields for float summary hparams.

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -337,7 +337,7 @@ class Context:
             result.domain_discrete.extend([True, False])
 
         if result.type == api_pb2.DATA_TYPE_FLOAT64:
-            # Always uses interval domain type for nuemric values.
+            # Always uses interval domain type for numeric hparam values.
             distinct_float_values = sorted(
                 [v.number_value for v in values if v.HasField("number_value")]
             )

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -338,9 +338,7 @@ class Context:
 
         if result.type == api_pb2.DATA_TYPE_FLOAT64:
             # Always uses interval domain type for numeric hparam values.
-            distinct_float_values = sorted(
-                [v.number_value for v in values if v.HasField("number_value")]
-            )
+            distinct_float_values = sorted([v.number_value for v in values])
             if distinct_float_values:
                 result.domain_interval.min_value = distinct_float_values[0]
                 result.domain_interval.max_value = distinct_float_values[-1]

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -326,15 +326,24 @@ class Context:
             return None
 
         if result.type == api_pb2.DATA_TYPE_STRING:
-            distinct_values = set(
+            distinct_string_values = set(
                 _protobuf_value_to_string(v)
                 for v in values
                 if _can_be_converted_to_string(v)
             )
-            result.domain_discrete.extend(distinct_values)
+            result.domain_discrete.extend(distinct_string_values)
 
         if result.type == api_pb2.DATA_TYPE_BOOL:
             result.domain_discrete.extend([True, False])
+
+        if result.type == api_pb2.DATA_TYPE_FLOAT64:
+            # Always uses interval domain type for nuemric values.
+            distinct_float_values = sorted(
+                [v.number_value for v in values if v.HasField("number_value")]
+            )
+            if distinct_float_values:
+                result.domain_interval.min_value = distinct_float_values[0]
+                result.domain_interval.max_value = distinct_float_values[-1]
 
         return result
 

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -247,10 +247,18 @@ class BackendContextTest(tf.test.TestCase):
             hparam_infos: {
               name: 'batch_size'
               type: DATA_TYPE_FLOAT64
+              domain_interval {
+                min_value: 100.0
+                max_value: 300.0
+              }
             },
             hparam_infos: {
               name: 'lr'
               type: DATA_TYPE_FLOAT64
+              domain_interval {
+                min_value: 0.01
+                max_value: 0.05
+              }
             },
             hparam_infos: {
               name: 'model_type'


### PR DESCRIPTION
Currently TF summary written hparams with `DATA_TYPE_FLOAT64` value type have no domain types.

#hparams
