### PR TITLE
Hparams: Apply limit to hparams retrieved from protos with `_hparams_/experiment` tag.

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -104,7 +104,8 @@ class Context:
             ctx, experiment_id, include_metrics, hparams_run_to_tag_to_content
         )
         if experiment_from_runs:
-            _reduce_to_hparams_limit(experiment_from_runs, hparams_limit)
+            # YTODO: Apply `hparams_limit` to `experiment_from_runs` after `differs`
+            # fields are populated in `_compute_hparam_info_from_values()`.
             return experiment_from_runs
 
         experiment_from_data_provider_hparams = (
@@ -330,6 +331,7 @@ class Context:
         if result.type == api_pb2.DATA_TYPE_UNSET:
             return None
 
+        # YTODO: Populate `differs` fields for hparams once go/tbpr/6574 is merged.
         if result.type == api_pb2.DATA_TYPE_STRING:
             distinct_string_values = set(
                 _protobuf_value_to_string(v)

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -97,14 +97,14 @@ class Context:
             hparams_run_to_tag_to_content, include_metrics
         )
         if experiment:
-            _reduce_to_hparams_limit(experiment, hparams_limit)
+            _sort_and_reduce_to_hparams_limit(experiment, hparams_limit)
             return experiment
 
         experiment_from_runs = self._compute_experiment_from_runs(
             ctx, experiment_id, include_metrics, hparams_run_to_tag_to_content
         )
         if experiment_from_runs:
-            # YTODO: Apply `hparams_limit` to `experiment_from_runs` after `differs`
+            # TODO(yatbear): Apply `hparams_limit` to `experiment_from_runs` after `differs`
             # fields are populated in `_compute_hparam_info_from_values()`.
             return experiment_from_runs
 
@@ -331,7 +331,7 @@ class Context:
         if result.type == api_pb2.DATA_TYPE_UNSET:
             return None
 
-        # YTODO: Populate `differs` fields for hparams once go/tbpr/6574 is merged.
+        # TODO(yatbear): Populate `differs` fields for hparams once go/tbpr/6574 is merged.
         if result.type == api_pb2.DATA_TYPE_STRING:
             distinct_string_values = set(
                 _protobuf_value_to_string(v)
@@ -585,19 +585,19 @@ def _protobuf_value_to_string(value):
     return value_in_json
 
 
-def _reduce_to_hparams_limit(experiment, hparams_limit=None):
-    """Reduces the number of hparams in the given experiment proto to `hparams_limit`.
+def _sort_and_reduce_to_hparams_limit(experiment, hparams_limit=None):
+    """Sorts and applies limit to the hparams in the given experiment proto.
 
     Args:
         experiment: An api_pb2.Experiment proto, which will be modified in place.
         hparams_limit: Optional number of hyperparameter metadata to include in the
-            result. If unset or zero, no changes will be made.
+            result. If unset or zero, no limit will be applied.
 
     Returns:
         None. `experiment` proto will be modified in place.
     """
     if not hparams_limit:
-        return
+        hparams_limit = -1
 
     # Prioritizes returning HParamInfo protos with `differed` values.
     limited_hparam_infos = sorted(

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -936,7 +936,7 @@ class BackendContextTest(tf.test.TestCase):
         )
         self._mock_tb_context.data_provider.list_tensors.side_effect = None
         self._mock_tb_context.data_provider.list_tensors.return_value = {
-            'train': {metadata.EXPERIMENT_TAG: t}
+            "train": {metadata.EXPERIMENT_TAG: t}
         }
         expected_exp = """
             name: 'Test experiment'

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -153,7 +153,9 @@ class BackendContextTest(tf.test.TestCase):
     ):
         return self._hyperparameters
 
-    def _experiment_from_metadata(self, *, include_metrics=True):
+    def _experiment_from_metadata(
+        self, *, include_metrics=True, hparams_limit=None
+    ):
         """Calls the expected operations for generating an Experiment proto."""
         ctxt = backend_context.Context(self._mock_tb_context)
         request_ctx = context.RequestContext()
@@ -162,7 +164,10 @@ class BackendContextTest(tf.test.TestCase):
             "123",
             include_metrics,
             ctxt.hparams_metadata(request_ctx, "123"),
-            ctxt.hparams_from_data_provider(request_ctx, "123", limit=None),
+            ctxt.hparams_from_data_provider(
+                request_ctx, "123", limit=hparams_limit
+            ),
+            hparams_limit,
         )
 
     def test_experiment_with_experiment_tag(self):
@@ -895,6 +900,61 @@ class BackendContextTest(tf.test.TestCase):
               }
             }
         """
+        self.assertProtoEquals(expected_exp, actual_exp)
+
+    def test_experiment_from_tags_with_hparams_limit_returns_differed_hparams_first(
+        self,
+    ):
+        experiment = """
+            name: 'Test experiment'
+            hparam_infos: [
+              {
+                name: 'batch_size'
+                type: DATA_TYPE_FLOAT64
+                differs: false
+              },
+             {
+              name: 'lr'
+              type: DATA_TYPE_FLOAT64
+              differs: true
+            },
+            {
+              name: 'model_type'
+              type: DATA_TYPE_STRING
+              differs: true
+            }
+            ]
+        """
+        t = provider.TensorTimeSeries(
+            max_step=0,
+            max_wall_time=0,
+            plugin_content=self._serialized_plugin_data(
+                DATA_TYPE_EXPERIMENT, experiment
+            ),
+            description="",
+            display_name="",
+        )
+        self._mock_tb_context.data_provider.list_tensors.side_effect = None
+        self._mock_tb_context.data_provider.list_tensors.return_value = {
+            'train': {metadata.EXPERIMENT_TAG: t}
+        }
+        expected_exp = """
+            name: 'Test experiment'
+            hparam_infos: {
+              name: 'lr'
+              type: DATA_TYPE_FLOAT64
+              differs: true
+            },
+            hparam_infos: {
+              name: 'model_type'
+              type: DATA_TYPE_STRING
+              differs: true
+            }
+        """
+        actual_exp = self._experiment_from_metadata(
+            include_metrics=False, hparams_limit=2
+        )
+        _canonicalize_experiment(actual_exp)
         self.assertProtoEquals(expected_exp, actual_exp)
 
     def _serialized_plugin_data(self, data_oneof_field, text_protobuffer):

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -46,6 +46,13 @@ class Handler:
         Returns:
           An Experiment object.
         """
+        data_provider_hparams = (
+            self._backend_context.hparams_from_data_provider(
+                self._request_context,
+                self._experiment_id,
+                limit=self._hparams_limit,
+            )
+        )
         return self._backend_context.experiment_from_metadata(
             self._request_context,
             self._experiment_id,
@@ -53,9 +60,6 @@ class Handler:
             self._backend_context.hparams_metadata(
                 self._request_context, self._experiment_id
             ),
-            self._backend_context.hparams_from_data_provider(
-                self._request_context,
-                self._experiment_id,
-                limit=self._hparams_limit,
-            ),
+            data_provider_hparams,
+            self._hparams_limit,
         )


### PR DESCRIPTION
Limit for summary hparams fetched from `data_provider.list_tensors` will be applied later (see `TODO` for details).

#hparams
