### PR TITLE
Hparams: Populate `differs` field for TF summary hparams.

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -342,8 +342,8 @@ class Context:
             result.differs = len(distinct_string_values) > 1
 
         if result.type == api_pb2.DATA_TYPE_BOOL:
+            result.domain_discrete.extend([True, False])
             distinct_bool_values = set(v.bool_value for v in values)
-            result.domain_discrete.extend(distinct_bool_values)
             result.differs = len(distinct_bool_values) > 1
 
         if result.type == api_pb2.DATA_TYPE_FLOAT64:

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -342,8 +342,8 @@ class Context:
             result.differs = len(distinct_string_values) > 1
 
         if result.type == api_pb2.DATA_TYPE_BOOL:
-            result.domain_discrete.extend([True, False])
             distinct_bool_values = set(v.bool_value for v in values)
+            result.domain_discrete.extend(distinct_bool_values)
             result.differs = len(distinct_bool_values) > 1
 
         if result.type == api_pb2.DATA_TYPE_FLOAT64:

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -104,8 +104,7 @@ class Context:
             ctx, experiment_id, include_metrics, hparams_run_to_tag_to_content
         )
         if experiment_from_runs:
-            # TODO(yatbear): Apply `hparams_limit` to `experiment_from_runs` after `differs`
-            # fields are populated in `_compute_hparam_info_from_values()`.
+            # TODO(yatbear): Apply `hparams_limit` to `experiment_from_runs`.
             return experiment_from_runs
 
         experiment_from_data_provider_hparams = (
@@ -331,7 +330,6 @@ class Context:
         if result.type == api_pb2.DATA_TYPE_UNSET:
             return None
 
-        # TODO(yatbear): Populate `differs` fields for hparams once go/tbpr/6574 is merged.
         if result.type == api_pb2.DATA_TYPE_STRING:
             distinct_string_values = set(
                 _protobuf_value_to_string(v)

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -339,9 +339,12 @@ class Context:
                 if _can_be_converted_to_string(v)
             )
             result.domain_discrete.extend(distinct_string_values)
+            result.differs = len(distinct_string_values) > 1
 
         if result.type == api_pb2.DATA_TYPE_BOOL:
-            result.domain_discrete.extend([True, False])
+            distinct_bool_values = set(v.bool_value for v in values)
+            result.domain_discrete.extend(distinct_bool_values)
+            result.differs = len(distinct_bool_values) > 1
 
         if result.type == api_pb2.DATA_TYPE_FLOAT64:
             # Always uses interval domain type for numeric hparam values.
@@ -349,6 +352,7 @@ class Context:
             if distinct_float_values:
                 result.domain_interval.min_value = distinct_float_values[0]
                 result.domain_interval.max_value = distinct_float_values[-1]
+                result.differs = len(set(distinct_float_values)) > 1
 
         return result
 

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -230,6 +230,7 @@ class BackendContextTest(tf.test.TestCase):
         self.session_1_start_info_ = """
             hparams: [
               {key: 'batch_size' value: {number_value: 100}},
+              {key: 'eval.timeout' value: {bool_value: false}},
               {key: 'lr' value: {number_value: 0.01}},
               {key: 'model_type' value: {string_value: 'CNN'}}
             ]
@@ -237,6 +238,7 @@ class BackendContextTest(tf.test.TestCase):
         self.session_2_start_info_ = """
             hparams:[
               {key: 'batch_size' value: {number_value: 200}},
+              {key: 'eval.timeout' value: {bool_value: false}},
               {key: 'lr' value: {number_value: 0.02}},
               {key: 'model_type' value: {string_value: 'LATTICE'}}
             ]
@@ -244,6 +246,7 @@ class BackendContextTest(tf.test.TestCase):
         self.session_3_start_info_ = """
             hparams:[
               {key: 'batch_size' value: {number_value: 300}},
+              {key: 'eval.timeout' value: {bool_value: false}},
               {key: 'lr' value: {number_value: 0.05}},
               {key: 'model_type' value: {string_value: 'CNN'}}
             ]
@@ -256,7 +259,16 @@ class BackendContextTest(tf.test.TestCase):
                 min_value: 100.0
                 max_value: 300.0
               }
-            },
+              differs: true
+            }
+            hparam_infos: {
+              name: 'eval.timeout'
+              type: DATA_TYPE_BOOL
+              domain_discrete: {
+                values: [{bool_value: false}]
+              }
+              differs: false
+            }
             hparam_infos: {
               name: 'lr'
               type: DATA_TYPE_FLOAT64
@@ -264,7 +276,8 @@ class BackendContextTest(tf.test.TestCase):
                 min_value: 0.01
                 max_value: 0.05
               }
-            },
+              differs: true
+            }
             hparam_infos: {
               name: 'model_type'
               type: DATA_TYPE_STRING
@@ -272,6 +285,7 @@ class BackendContextTest(tf.test.TestCase):
                 values: [{string_value: 'CNN'},
                          {string_value: 'LATTICE'}]
               }
+              differs: true
             }
             metric_infos: {
               name: {group: '', tag: 'accuracy'}
@@ -317,6 +331,7 @@ class BackendContextTest(tf.test.TestCase):
                 values: [{string_value: '100.0'},
                          {string_value: 'true'}]
               }
+              differs: true
             }
             hparam_infos: {
               name: 'lr'
@@ -325,6 +340,7 @@ class BackendContextTest(tf.test.TestCase):
                 values: [{string_value: '0.01'},
                          {string_value: '0.02'}]
               }
+              differs: true
             }
             hparam_infos: {
               name: 'model_type'
@@ -333,6 +349,7 @@ class BackendContextTest(tf.test.TestCase):
                 values: [{string_value: 'CNN'},
                          {string_value: 'LATTICE'}]
               }
+              differs: true
             }
             metric_infos: {
               name: {group: '', tag: 'accuracy'}
@@ -371,8 +388,9 @@ class BackendContextTest(tf.test.TestCase):
               name: 'batch_size'
               type: DATA_TYPE_BOOL
               domain_discrete: {
-                values: [{bool_value: true}, {bool_value: false}]
+                values: [{bool_value: true}]
               }
+              differs: false
             }
             metric_infos: {
               name: {group: '', tag: 'accuracy'}

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -301,7 +301,7 @@ class BackendContextTest(tf.test.TestCase):
               {key: 'float_hparam_differs_false' value: {number_value: 1024}},
               {key: 'float_hparam_differs_true' value: {number_value: 0.01}},
               {key: 'string_hparams_differs_false' value: {string_value: 'momentum'}},
-              {key: 'string_hparams_differs_true' value: {string_value: 'CNN'}} 
+              {key: 'string_hparams_differs_true' value: {string_value: 'CNN'}}
             ]
         """
         self.session_2_start_info_ = """

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -229,26 +229,31 @@ class BackendContextTest(tf.test.TestCase):
     def test_experiment_with_session_tags(self):
         self.session_1_start_info_ = """
             hparams: [
-              {key: 'batch_size' value: {number_value: 100}},
+              {key: 'batch_size' value: {number_value: 1024}},
               {key: 'eval.timeout' value: {bool_value: false}},
               {key: 'lr' value: {number_value: 0.01}},
-              {key: 'model_type' value: {string_value: 'CNN'}}
+              {key: 'model_type' value: {string_value: 'CNN'}},
+              {key: 'optimizer_type' value: {string_value: 'momentum'}},
+              {key: 'use_batch_norm' value: {bool_value: true}}
             ]
         """
         self.session_2_start_info_ = """
             hparams:[
-              {key: 'batch_size' value: {number_value: 200}},
+              {key: 'batch_size' value: {number_value: 1024}},
               {key: 'eval.timeout' value: {bool_value: false}},
               {key: 'lr' value: {number_value: 0.02}},
-              {key: 'model_type' value: {string_value: 'LATTICE'}}
+              {key: 'model_type' value: {string_value: 'LATTICE'}},
+              {key: 'optimizer_type' value: {string_value: 'momentum'}}
             ]
         """
         self.session_3_start_info_ = """
             hparams:[
-              {key: 'batch_size' value: {number_value: 300}},
+              {key: 'batch_size' value: {number_value: 1024}},
               {key: 'eval.timeout' value: {bool_value: false}},
               {key: 'lr' value: {number_value: 0.05}},
-              {key: 'model_type' value: {string_value: 'CNN'}}
+              {key: 'model_type' value: {string_value: 'CNN'}},
+              {key: 'optimizer_type' value: {string_value: 'momentum'}},
+              {key: 'use_batch_norm' value: {bool_value: false}}
             ]
         """
         expected_exp = """
@@ -256,16 +261,16 @@ class BackendContextTest(tf.test.TestCase):
               name: 'batch_size'
               type: DATA_TYPE_FLOAT64
               domain_interval {
-                min_value: 100.0
-                max_value: 300.0
+                min_value: 1024
+                max_value: 1024
               }
-              differs: true
+              differs: false
             }
             hparam_infos: {
               name: 'eval.timeout'
               type: DATA_TYPE_BOOL
               domain_discrete: {
-                values: [{bool_value: false}]
+                values: [{bool_value: true}, {bool_value: false}]
               }
               differs: false
             }
@@ -284,6 +289,22 @@ class BackendContextTest(tf.test.TestCase):
               domain_discrete: {
                 values: [{string_value: 'CNN'},
                          {string_value: 'LATTICE'}]
+              }
+              differs: true
+            }
+            hparam_infos: {
+              name: 'optimizer_type'
+              type: DATA_TYPE_STRING
+              domain_discrete: {
+                values: [{string_value: 'momentum'}]
+              }
+              differs: false
+            }
+            hparam_infos: {
+              name: 'use_batch_norm'
+              type: DATA_TYPE_BOOL
+              domain_discrete: {
+                values: [{bool_value: true}, {bool_value: false}]
               }
               differs: true
             }
@@ -371,12 +392,12 @@ class BackendContextTest(tf.test.TestCase):
     def test_experiment_with_session_tags_bool_types(self):
         self.session_1_start_info_ = """
             hparams:[
-              {key: 'batch_size' value: {bool_value: true}}
+              {key: 'use_batch_norm' value: {bool_value: true}}
             ]
         """
         self.session_2_start_info_ = """
             hparams:[
-              {key: 'batch_size' value: {bool_value: true}}
+              {key: 'use_batch_norm' value: {bool_value: true}}
             ]
         """
         self.session_3_start_info_ = """
@@ -385,10 +406,10 @@ class BackendContextTest(tf.test.TestCase):
         """
         expected_exp = """
             hparam_infos: {
-              name: 'batch_size'
+              name: 'use_batch_norm'
               type: DATA_TYPE_BOOL
               domain_discrete: {
-                values: [{bool_value: true}]
+                values: [{bool_value: true}, {bool_value: false}]
               }
               differs: false
             }


### PR DESCRIPTION
Currently `differs` fields are not populated for hparams written by TF summary API. 

Also changed the boolean hparam domain discrete values to be the actual values used in the sessions rather than both True and False.

#hparams