### PR TITLE
Set Token Permissions for github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
   pull_request: {}
   workflow_call: {}
 
+permissions:
+  contents: read
+
 env:
   # Keep this Bazel version in sync with the `versions.check` directive
   # in our WORKSPACE file.

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -7,6 +7,9 @@ on:
     # (cron syntax: minute hour day-of-month month day-of-week)
     - cron: '0 11 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
## Motivation for features / changes

GitHub grants, by default, write-all permission for the GITHUB_TOKEN, which is shared by the actions used and, in case of any action got compromised, can be exploited by a malicious attacker.

Considering this, it is both an [OpenSSF Scorecard](https://github.com/ossf/scorecard) and [GitHub](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets) recommendation to use permissions minimally scoped.

## Technical description of changes

To minimally scope the permissions, it is a good practice to set a read-only basic permission (such as contents: read) and grant any additional permission on job level. In tensorboard case, only the contents: read on top level is enough for both workflows.

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)
I've checked the CI.yml workflow at https://github.com/joycebrum/tensorboard/actions/runs/6190658790 and it is working fine. 

The nightly-release does not need any permission from GITHUB_TOKEN other than contents: read (for the ci.yml to run)

## Alternate designs / implementations considered (or N/A)
N/A
