### PR TITLE
Hparams: fix the bug where the last hparam was discarded when there is no limit

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -599,7 +599,8 @@ def _sort_and_reduce_to_hparams_limit(experiment, hparams_limit=None):
         None. `experiment` proto will be modified in place.
     """
     if not hparams_limit:
-        hparams_limit = -1
+        # If limit is unset or zero, returns all hparams.
+        hparams_limit = len(experiment.hparam_infos)
 
     # Prioritizes returning HParamInfo protos with `differed` values.
     limited_hparam_infos = sorted(

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -1174,6 +1174,11 @@ class BackendContextTest(tf.test.TestCase):
               type: DATA_TYPE_FLOAT64
               differs: false
             }
+            hparam_infos: {
+              name: 'use_batch_norm'
+              type: DATA_TYPE_BOOL
+              differs: false
+            }
         """
         actual_exp = self._experiment_from_metadata(
             include_metrics=False, hparams_limit=None


### PR DESCRIPTION
Bug fixed by this PR: Currently when there is no limit, `_sort_and_reduce_to_hparams_limit()` truncates the last value. Corresponding unit test is wrong as well. 🤦 

Googlers, see internal test at: cl/563163418

#hparams
