### PR TITLE
Migrate hparams to use gtag.js-based logging for Google Analytics.

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
@@ -196,16 +196,20 @@ class TfHparamsSessionsPane extends PolymerElement {
     action: string,
     tabName?: string
   ) => {
-    // If window['ga'] is defined, use it, otherwise any logging calls will be
-    // no-ops. window['ga'] is only defined in the hosted TensorBoard.
+    // If window['dataLayer'] is defined, use it, otherwise any logging calls
+    // will be no-ops. window['dataLayer'] is only defined in the hosted
+    // TensorBoard.
     // @ts-ignore
-    const analytics = window['ga'] || function () {};
+    const dataLayer = window['dataLayer'] || [];
     // @ts-ignore
-    analytics('send', {
-      hitType: 'event',
-      eventCategory: 'HParams',
-      eventAction: action,
-      eventLabel: tabName,
+
+    function gtag(...ignore: unknown[]) {
+      dataLayer.push(arguments);
+    }
+
+    gtag('event', action, {
+      'event_category': 'HParams',
+      'event_label': tabName,
     });
   };
 }

--- a/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
@@ -201,15 +201,17 @@ class TfHparamsSessionsPane extends PolymerElement {
     // TensorBoard.
     // @ts-ignore
     const dataLayer = window['dataLayer'] || [];
-    // @ts-ignore
 
-    function gtag(...ignore: unknown[]) {
+    // Define gtag() function similar to how it is documented in
+    // https://developers.google.com/tag-platform/gtagjs/install.
+    function gtag() {
       dataLayer.push(arguments);
     }
+    // @ts-ignore
 
     gtag('event', action, {
-      'event_category': 'HParams',
-      'event_label': tabName,
+      event_category: 'HParams',
+      event_label: tabName,
     });
   };
 }


### PR DESCRIPTION
Internally we have migrated our GA logging implementation to use the "gtag.js"-based method instead of the "analytics.js" method.  We want to update this bit of hparams GA logging to do the same.

Tested:
* Compiled and ran the program and noticed that no logging is performed (because GA is not configured by default)
* Imported the code internally and ran and noticed that logging is performed.
