### PR TITLE
HParams: Default Runs table sorting to ascending

### DIFF
--- a/tensorboard/webapp/runs/store/runs_reducers.ts
+++ b/tensorboard/webapp/runs/store/runs_reducers.ts
@@ -335,7 +335,7 @@ const {initialState: uiInitialState, reducers: uiNamespaceContextedReducers} =
       ],
       sortingInfo: {
         name: 'run',
-        order: SortingOrder.DESCENDING,
+        order: SortingOrder.ASCENDING,
       },
     },
     {},


### PR DESCRIPTION
## Motivation for features / changes
The new runs data table was sorting the runs in a different order than the older runs table. We want to keep the sorting the same when we make the switch to the new table for users.