### PR TITLE
HParams: Bug fix - removing a column closes the filter modal

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -314,6 +314,7 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
     }
     this.removeColumn.emit(this.contextMenuHeader);
     this.contextMenu.close();
+    this.filterModal?.close();
   }
 
   private getInsertIndex() {


### PR DESCRIPTION
## Motivation for features / changes
There are a lot of funky interactions revolving around interactions in nested context menus. This is one of them. Essentially we don't always want to close context menus when you click in them, but there are a couple of edge cases where we actually do want it closed, such as removing the subject of the context menu.

## Screenshots of UI changes (or N/A)
![5d66b89e-7d59-4b02-ae4d-2b7e8af322ad](https://github.com/tensorflow/tensorboard/assets/78179109/129b98cc-7ac4-4071-9b85-7c13844826fc)

## Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Nagivate to localhost:6006?enableHparamsInTimeSeries=true
3) Add an hparam column to the runs table
4) Using the context menu open the filter dialog
5) Without closing anything click the remove button in the context menu
6) Assert the filter dialog disappears