### PR TITLE
HParams: Align sub context menus to the top of the button which opened them

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -274,10 +274,12 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
     }
     this.filterModal?.close();
     this.insertColumnTo = options?.insertTo;
-    const rect = (event.target as HTMLElement).getBoundingClientRect();
+    const rect = (
+      (event.target as HTMLElement).closest('button') as HTMLButtonElement
+    ).getBoundingClientRect();
     this.columnSelectorModal.openAtPosition({
       x: rect.x + rect.width,
-      y: rect.y + rect.height,
+      y: rect.y,
     });
     this.columnSelector.activate();
   }
@@ -348,7 +350,7 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
     this.columnSelectorModal?.close();
     this.filterModal.openAtPosition({
       x: rect.x + rect.width,
-      y: rect.y + rect.height,
+      y: rect.y,
     });
   }
 


### PR DESCRIPTION
## Motivation for features / changes
The context menus were being aligned to the bottom of the button which opened them. This was wrong.

## Screenshots of UI changes (or N/A)
![aeb15622-1951-4033-a3bb-10dd9eed3509](https://github.com/tensorflow/tensorboard/assets/78179109/243d2b61-05fa-4787-8151-652616fc7551)

## Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Navigate to localhost:6006?enableHparamsInTimeseries
3) Right click on the runs table
4) Add a column
5) Note that the column selector opens aligned to the top of the "Add Left / Right" button
6) Try the same thing with the filter menu