### PR TITLE
Improve styling of context menus

### DIFF
--- a/tensorboard/webapp/widgets/data_table/column_selector_component.scss
+++ b/tensorboard/webapp/widgets/data_table/column_selector_component.scss
@@ -53,8 +53,8 @@ limitations under the License.
     flex-direction: column;
     width: 100%;
 
-    max-height: 200px;
-    overflow-y: scroll;
+    max-height: 300px;
+    overflow-y: auto;
   }
 
   .column-button {

--- a/tensorboard/webapp/widgets/data_table/filter_dialog_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/filter_dialog_component.ng.html
@@ -15,38 +15,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="filter-dialog">
-  <div
-    *ngIf="filter.type === DomainType.DISCRETE"
-    class="discrete-filters-area"
-  >
-    <tb-filter-input
-      *ngIf="filter.possibleValues"
-      [value]="discreteValueFilter"
-      (keyup)="discreteValueKeyUp($event)"
-      placeholder="Filter Discrete Values (regex)"
-    ></tb-filter-input>
+  <div *ngIf="filter.type === DomainType.DISCRETE" class="filter-container">
+    <div class="input-container">
+      <tb-filter-input
+        *ngIf="filter.possibleValues"
+        [value]="discreteValueFilter"
+        (keyup)="discreteValueKeyUp($event)"
+        placeholder="Filter Discrete Values (regex)"
+      ></tb-filter-input>
+    </div>
     <div *ngIf="!getPossibleValues().length" class="no-matches">
       No Matching Values
     </div>
-    <div
-      *ngFor="let value of getPossibleValues(); index"
-      (click)="$event.stopPropagation()"
-    >
-      <mat-checkbox
-        [checked]="filter.filterValues.includes(value)"
-        (change)="discreteFilterChanged.emit(value)"
-        ><span>{{ value }}</span></mat-checkbox
+
+    <div *ngIf="getPossibleValues().length" class="discrete-filters-container">
+      <div
+        *ngFor="let value of getPossibleValues(); index"
+        (click)="$event.stopPropagation()"
+        class="discrete-value"
       >
+        <mat-checkbox
+          [checked]="filter.filterValues.includes(value)"
+          (change)="discreteFilterChanged.emit(value)"
+          ><span>{{ value }}</span></mat-checkbox
+        >
+      </div>
     </div>
   </div>
 
   <div
     *ngIf="filter.type === DomainType.INTERVAL"
     (click)="$event.stopPropagation()"
-    class="range-input-container"
+    class="filter-container"
     disableRipple
   >
     <tb-range-input
+      class="range-input"
       [min]="filter.minValue"
       [max]="filter.maxValue"
       [lowerValue]="filter.filterLowerValue"

--- a/tensorboard/webapp/widgets/data_table/filter_dialog_component.scss
+++ b/tensorboard/webapp/widgets/data_table/filter_dialog_component.scss
@@ -68,6 +68,8 @@ limitations under the License.
 .discrete-value {
   overflow: hidden;
 
+  // This stretches the width of the mat-checkbox label to 100% so that
+  // the entire row is clickable.
   ::ng-deep {
     mat-checkbox,
     .mdc-form-field,

--- a/tensorboard/webapp/widgets/data_table/filter_dialog_component.scss
+++ b/tensorboard/webapp/widgets/data_table/filter_dialog_component.scss
@@ -16,7 +16,7 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .filter-dialog {
-  padding: 8px;
+  padding: 16px 8px;
   border-radius: 4px;
   border: 1px solid;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
@@ -30,15 +30,49 @@ limitations under the License.
       'background'
     );
   }
+}
 
-  .discrete-filters-area {
-    max-height: 100px;
-    overflow-y: auto;
+.input-container {
+  margin-bottom: 8px;
+}
+
+.discrete-filters-container {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.no-matches {
+  // 12px is the width of the checkbox so the text should match the
+  // indentation of the selectable filters.
+  padding: 8px 12px;
+}
+
+.filter-container {
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid mat.get-color-from-palette($tb-foreground, border);
+
+  @include tb-dark-theme {
+    border-bottom-color: mat.get-color-from-palette(
+      $tb-dark-foreground,
+      border
+    );
   }
+}
 
-  .no-matches {
-    // 12px is the width of the checkbox so the text should match the
-    // indentation of the selectable filters.
-    padding: 8px 12px;
+.range-input {
+  padding: 4px 8px;
+  width: 200px;
+}
+
+.discrete-value {
+  overflow: hidden;
+
+  ::ng-deep {
+    mat-checkbox,
+    .mdc-form-field,
+    label {
+      width: 100%;
+    }
   }
 }


### PR DESCRIPTION
## Motivation for features / changes
These modals felt pretty cramped sow were' adding more space. Additionally more items should fit in the scroll container prior to the scroll bar appearing.

## Screenshots of UI changes (or N/A)
### Interval Filter Modal
Before
![image](https://github.com/tensorflow/tensorboard/assets/78179109/95efd039-ab62-4929-9831-90a0c2523b59)

After
![image](https://github.com/tensorflow/tensorboard/assets/78179109/257cdc04-d838-40dc-88b6-b8b7024f6677)

### Discrete Filter Modal
Before
![image](https://github.com/tensorflow/tensorboard/assets/78179109/08278e9c-e371-4d20-81d5-e3d315f0a5c5)

After
![image](https://github.com/tensorflow/tensorboard/assets/78179109/2de6b030-faac-45e5-b39b-425c6859de61)

### Click Target
Before
![image](https://github.com/tensorflow/tensorboard/assets/78179109/3b766fee-0461-4958-9af9-8a98556dda58)

After
![image](https://github.com/tensorflow/tensorboard/assets/78179109/a6af3ec5-5479-4a8f-8e37-b5bba5c7e15b)
