### PR TITLE
Chore: Fix CI breakage

### DIFF
--- a/tensorboard/webapp/runs/effects/runs_effects_test.ts
+++ b/tensorboard/webapp/runs/effects/runs_effects_test.ts
@@ -29,6 +29,7 @@ import * as coreActions from '../../core/actions';
 import * as hparamsActions from '../../hparams/_redux/hparams_actions';
 import {
   getActiveRoute,
+  getEnableHparamsInTimeSeries,
   getExperimentIdsFromRoute,
   getRuns,
   getRunsLoadState,


### PR DESCRIPTION
## Motivation for features / changes
I let #6565 sit for a long time, then merged without rebasing. The result broke CI. This should fix it.

When the PR was created the `enableHparamsInTimeSeries` was already imported, but between the PR creation and merge it was removed.

https://github.com/rileyajones/tensorboard/blob/3cd4ce2e00a4e5fb0bb92e82a44d2fcdc8a7f13b/tensorboard/webapp/runs/effects/runs_effects_test.ts