### PR TITLE
HParams: Do not scroll regex filter in the horizontal direction

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<!-- <div clas="runs-data-table-container"> -->
 <div class="filter-row">
   <tb-filter-input
     class="run-filter"

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<!-- <div clas="runs-data-table-container"> -->
 <div class="filter-row">
   <tb-filter-input
     class="run-filter"
@@ -26,84 +27,86 @@ limitations under the License.
 <div *ngIf="loading" class="loading">
   <mat-spinner mode="indeterminate" diameter="28"></mat-spinner>
 </div>
-<tb-data-table
-  *ngIf="!loading"
-  [headers]="headers"
-  [sortingInfo]="sortingInfo"
-  [columnCustomizationEnabled]="true"
-  [selectableColumns]="selectableColumns"
-  [columnFilters]="columnFilters"
-  (sortDataBy)="sortDataBy.emit($event)"
-  (orderColumns)="orderColumns.emit($event)"
-  (addColumn)="addColumn.emit($event)"
-  (removeColumn)="removeColumn.emit($event)"
-  (addFilter)="addFilter.emit($event)"
->
-  <ng-container header>
-    <ng-container *ngFor="let header of getHeaders()">
-      <tb-data-table-header-cell
-        *ngIf="header.enabled"
-        [header]="header"
-        [sortingInfo]="sortingInfo"
-        [hparamsEnabled]="true"
-      >
-        <ng-container [ngSwitch]="header.name">
-          <div *ngSwitchCase="'selected'">
-            <mat-checkbox
-              [checked]="allRowsSelected()"
-              [indeterminate]="!allRowsSelected() && someRowsSelected()"
-              (click)="handleSelectAll($event)"
-            ></mat-checkbox>
-          </div>
-          <span class="group-menu-container" *ngSwitchCase="'color'">
-            <runs-group-menu-button
-              [experimentIds]="experimentIds"
-            ></runs-group-menu-button>
-          </span>
-        </ng-container>
-      </tb-data-table-header-cell> </ng-container
-  ></ng-container>
+<div class="table-container">
+  <tb-data-table
+    *ngIf="!loading"
+    [headers]="headers"
+    [sortingInfo]="sortingInfo"
+    [columnCustomizationEnabled]="true"
+    [selectableColumns]="selectableColumns"
+    [columnFilters]="columnFilters"
+    (sortDataBy)="sortDataBy.emit($event)"
+    (orderColumns)="orderColumns.emit($event)"
+    (addColumn)="addColumn.emit($event)"
+    (removeColumn)="removeColumn.emit($event)"
+    (addFilter)="addFilter.emit($event)"
+  >
+    <ng-container header>
+      <ng-container *ngFor="let header of getHeaders()">
+        <tb-data-table-header-cell
+          *ngIf="header.enabled"
+          [header]="header"
+          [sortingInfo]="sortingInfo"
+          [hparamsEnabled]="true"
+        >
+          <ng-container [ngSwitch]="header.name">
+            <div *ngSwitchCase="'selected'">
+              <mat-checkbox
+                [checked]="allRowsSelected()"
+                [indeterminate]="!allRowsSelected() && someRowsSelected()"
+                (click)="handleSelectAll($event)"
+              ></mat-checkbox>
+            </div>
+            <span class="group-menu-container" *ngSwitchCase="'color'">
+              <runs-group-menu-button
+                [experimentIds]="experimentIds"
+              ></runs-group-menu-button>
+            </span>
+          </ng-container>
+        </tb-data-table-header-cell> </ng-container
+    ></ng-container>
 
-  <ng-container content>
-    <ng-container *ngFor="let dataRow of data">
-      <tb-data-table-content-row>
-        <ng-container *ngFor="let header of getHeaders()">
-          <tb-data-table-content-cell
-            *ngIf="header.enabled"
-            [header]="header"
-            [datum]="dataRow[header.name]"
-          >
-            <ng-container [ngSwitch]="header.name">
-              <span *ngSwitchCase="'color'" class="color-container">
-                <button
-                  class="run-color-swatch"
-                  [style.background]="dataRow['color']"
-                  [colorPicker]="dataRow['color']"
-                  [cpDialogDisplay]="'popup'"
-                  [cpPositionOffset]="-20"
-                  [cpUseRootViewContainer]="true"
-                  [cpOutputFormat]="'hex'"
-                  (colorPickerChange)="onRunColorChange.emit({runId: dataRow.id, newColor: $event})"
-                ></button>
-              </span>
-              <div *ngSwitchCase="'selected'">
-                <mat-checkbox
-                  [checked]="dataRow['selected']"
-                  (click)="selectionClick($event, dataRow['id'])"
-                ></mat-checkbox>
-              </div>
-              <span *ngSwitchCase="'experimentAlias'">
-                <tb-experiment-alias
-                  [alias]="dataRow['experimentAlias']"
-                ></tb-experiment-alias>
-              </span>
-            </ng-container>
-          </tb-data-table-content-cell>
-        </ng-container>
-      </tb-data-table-content-row>
+    <ng-container content>
+      <ng-container *ngFor="let dataRow of data">
+        <tb-data-table-content-row>
+          <ng-container *ngFor="let header of getHeaders()">
+            <tb-data-table-content-cell
+              *ngIf="header.enabled"
+              [header]="header"
+              [datum]="dataRow[header.name]"
+            >
+              <ng-container [ngSwitch]="header.name">
+                <span *ngSwitchCase="'color'" class="color-container">
+                  <button
+                    class="run-color-swatch"
+                    [style.background]="dataRow['color']"
+                    [colorPicker]="dataRow['color']"
+                    [cpDialogDisplay]="'popup'"
+                    [cpPositionOffset]="-20"
+                    [cpUseRootViewContainer]="true"
+                    [cpOutputFormat]="'hex'"
+                    (colorPickerChange)="onRunColorChange.emit({runId: dataRow.id, newColor: $event})"
+                  ></button>
+                </span>
+                <div *ngSwitchCase="'selected'">
+                  <mat-checkbox
+                    [checked]="dataRow['selected']"
+                    (click)="selectionClick($event, dataRow['id'])"
+                  ></mat-checkbox>
+                </div>
+                <span *ngSwitchCase="'experimentAlias'">
+                  <tb-experiment-alias
+                    [alias]="dataRow['experimentAlias']"
+                  ></tb-experiment-alias>
+                </span>
+              </ng-container>
+            </tb-data-table-content-cell>
+          </ng-container>
+        </tb-data-table-content-row>
+      </ng-container>
     </ng-container>
-  </ng-container>
-</tb-data-table>
+  </tb-data-table>
+</div>
 <div class="full-screen-toggle" [ngClass]="{'full-screen': isFullScreen}">
   <button
     mat-button

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -115,11 +115,15 @@ tb-data-table-header-cell:last-of-type {
   display: flex;
   align-items: center;
   height: 48px;
-  padding: 0 16px;
+  width: 100%;
 
   tb-filter-input {
+    padding-left: 16px;
     flex-grow: 1;
   }
+}
+.table-container {
+  overflow-x: scroll;
 }
 
 .loading {

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -123,7 +123,7 @@ tb-data-table-header-cell:last-of-type {
   }
 }
 .table-container {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .loading {


### PR DESCRIPTION
## Motivation for features / changes
I originally started to fix a bug where the bottom border in the regex did not stretch to the end of the table once scrolled. However, I decided there is no reason to scroll the regex at all and it can actually be kind of annoying. So I change the x scroll to just be the table

## Screenshots of UI changes 
![2023-09-22_16-57-36 (1)](https://github.com/tensorflow/tensorboard/assets/8672809/049cc341-6787-48d8-bb21-1e894434cf47)
(or N/A)
