### PR TITLE
HParams: Bug fix when adding table columns copy them rather than mutate them

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -817,7 +817,9 @@ export class RunsTableContainer implements OnInit, OnDestroy {
 
   addColumn({header, index}: {header: ColumnHeader; index: number}) {
     header.enabled = true;
-    this.store.dispatch(runsTableHeaderAdded({header, index}));
+    this.store.dispatch(
+      runsTableHeaderAdded({header: {...header, enabled: true}, index})
+    );
   }
 
   removeColumn(header: ColumnHeader) {


### PR DESCRIPTION
## Motivation for features / changes
There was a bug when readding columns because the column was getting set to readonly when written to redux. Making a copy of the column as it is added resolves this issue.

## Screenshots of UI changes (or N/A)
![1bb533b4-5c98-4b4a-bed4-e5468600714e](https://github.com/tensorflow/tensorboard/assets/78179109/55128429-658d-4c84-992a-4d3434bb2888)

## Detailed steps to verify changes work correctly (as executed by you)
1) Start tensorboard
2) Navigate to localhost:6006?enableHparamsInTimeseries
3) Add a column to the runs table
4) Remove that column
5) Add the column again
