### PR TITLE
MDC Migration: Fix styling for runs_group_menu

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.ng.html
@@ -31,13 +31,11 @@ limitations under the License.
     [attr.aria-checked]="selectedGroupBy.key === GroupByKey.EXPERIMENT"
     (click)="onGroupByChange.emit({key: GroupByKey.EXPERIMENT})"
   >
-    <span>
-      <mat-icon
-        *ngIf="selectedGroupBy.key === GroupByKey.EXPERIMENT"
-        svgIcon="done_24px"
-      ></mat-icon>
-    </span>
-    <label>Experiment</label>
+    <mat-icon
+      *ngIf="selectedGroupBy.key === GroupByKey.EXPERIMENT"
+      svgIcon="done_24px"
+    ></mat-icon>
+    <span>Experiment</span>
   </button>
   <button
     mat-menu-item
@@ -46,13 +44,11 @@ limitations under the License.
     [attr.aria-checked]="selectedGroupBy.key === GroupByKey.RUN"
     (click)="onGroupByChange.emit({key: GroupByKey.RUN})"
   >
-    <span>
-      <mat-icon
-        *ngIf="selectedGroupBy.key === GroupByKey.RUN"
-        svgIcon="done_24px"
-      ></mat-icon>
-    </span>
-    <label>Run</label>
+    <mat-icon
+      *ngIf="selectedGroupBy.key === GroupByKey.RUN"
+      svgIcon="done_24px"
+    ></mat-icon>
+    <span>Run</span>
   </button>
   <button
     mat-menu-item
@@ -61,13 +57,11 @@ limitations under the License.
     [attr.aria-checked]="selectedGroupBy.key === GroupByKey.REGEX"
     (click)="onGroupByRegexClick()"
   >
-    <span>
-      <mat-icon
-        *ngIf="selectedGroupBy.key === GroupByKey.REGEX"
-        svgIcon="done_24px"
-      ></mat-icon>
-    </span>
-    <label>Regex</label>
+    <mat-icon
+      *ngIf="selectedGroupBy.key === GroupByKey.REGEX"
+      svgIcon="done_24px"
+    ></mat-icon>
+    <span>Regex</span>
   </button>
   <button
     mat-menu-item
@@ -76,10 +70,8 @@ limitations under the License.
     (click)="onRegexStringEdit()"
     class="display-regex-string"
   >
-    <span>
-      <mat-icon svgIcon="edit_24px"></mat-icon>
-    </span>
-    <label *ngIf="regexString">{{regexString}}</label>
-    <label *ngIf="!regexString" class="none-set-string">(none set)</label>
+    <mat-icon svgIcon="edit_24px"></mat-icon>
+    <span *ngIf="regexString">{{regexString}}</span>
+    <span *ngIf="!regexString" class="none-set-string">(none set)</span>
   </button>
 </mat-menu>

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
@@ -27,12 +27,6 @@ limitations under the License.
     pointer-events: none;
   }
 
-  button {
-    display: grid;
-    gap: 2px 10px;
-    grid-template-columns: $_icon-size auto;
-  }
-
   mat-icon {
     height: $_icon-size;
     width: $_icon-size;

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -638,7 +638,7 @@ describe('runs_table', () => {
         const items = getOverlayMenuItems();
 
         expect(
-          items.map((element) => element.querySelector('label')!.textContent)
+          items.map((element) => element.querySelector('span')!.textContent)
         ).toEqual(['Experiment', 'Run', 'Regex', '(none set)']);
       });
 
@@ -655,9 +655,10 @@ describe('runs_table', () => {
 
         openColorGroupDialog(fixture);
         const items = getOverlayMenuItems();
+        console.log('items', items);
 
         expect(
-          items.map((element) => element.querySelector('label')!.textContent)
+          items.map((element) => element.querySelector('span')!.textContent)
         ).toEqual(['Run', 'Regex', '(none set)']);
       });
 


### PR DESCRIPTION
## Motivation for features / changes
Updating the style of this menu after update to new MDC components. T
## Technical description of changes
The new MDC mat-menu no longer uses `<label>` and can also handle mat-icons on its own.

## Screenshots of UI changes (or N/A)
<img width="173" alt="Screenshot 2023-09-28 at 12 02 41 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/57b3d6c7-4b43-484e-8668-03dc43081e27">

<img width="170" alt="Screenshot 2023-09-28 at 12 04 19 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/cd1ec903-9c05-463f-ac93-c97cdea8b0ee">