### PR TITLE
MDCMigration: Restyle all plugins selector component for MDC migration.

### DIFF
--- a/tensorboard/webapp/header/plugin_selector_component.ng.html
+++ b/tensorboard/webapp/header/plugin_selector_component.ng.html
@@ -19,7 +19,7 @@ limitations under the License.
   [selectedIndex]="getActivePluginIndex()"
   animationDuration="100ms"
 >
-  <mat-tab *ngFor="let plugin of activePlugins">
+  <mat-tab *ngFor="let plugin of activePlugins" [disabled]="!plugin.enabled">
     <ng-template mat-tab-label>
       <!-- Manually subscribe to the click event on the tab content element.
       Cannot trust the selectedTabChange event since it is async and can cause
@@ -34,11 +34,7 @@ limitations under the License.
     </ng-template>
   </mat-tab>
 </mat-tab-group>
-<mat-form-field
-  floatLabel="never"
-  *ngIf="disabledPlugins.length"
-  subscriptSizing="dynamic"
->
+<mat-form-field floatLabel="never" *ngIf="disabledPlugins.length > 0">
   <mat-label>Inactive</mat-label>
   <mat-select
     [value]="selectedPlugin"

--- a/tensorboard/webapp/header/plugin_selector_component.ng.html
+++ b/tensorboard/webapp/header/plugin_selector_component.ng.html
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <mat-tab-group
+  mat-stretch-tabs="false"
   class="active-plugin-list"
   [selectedIndex]="getActivePluginIndex()"
   animationDuration="100ms"
@@ -34,10 +35,15 @@ limitations under the License.
     </ng-template>
   </mat-tab>
 </mat-tab-group>
-<mat-form-field floatLabel="never" *ngIf="disabledPlugins.length > 0">
+<mat-form-field
+  floatLabel="never"
+  *ngIf="disabledPlugins.length > 0"
+  subscriptSizing="dynamic"
+>
   <mat-label>Inactive</mat-label>
   <mat-select
     [value]="selectedPlugin"
+    [hideSingleSelectionIndicator]="true"
     (selectionChange)="onDisabledPluginSelectionChanged($event)"
   >
     <mat-option

--- a/tensorboard/webapp/header/plugin_selector_component.scss
+++ b/tensorboard/webapp/header/plugin_selector_component.scss
@@ -14,59 +14,154 @@ limitations under the License.
 ==============================================================================*/
 @import 'tensorboard/webapp/theme/tb_theme';
 
-@mixin plugin-text {
-  color: map-get($tb-dark-foreground, text);
-  font-weight: 500;
-  text-transform: uppercase;
-}
-
 :host {
   align-items: center;
   display: flex;
   flex: 1 1 auto;
   font-size: 14px;
   height: 100%;
-  justify-content: space-between;
   overflow: hidden;
+}
 
-  // Mat tabs use the theme primary color as their text color.
-  mat-tab-group ::ng-deep {
-    .mat-mdc-tab {
-      padding: 0 8px;
-      margin: 0 16px;
-      height: 64px;
+mat-form-field {
+  flex: 0 0;
+  /* visually center align with _text_ of the select to the center. */
+  margin-top: 5px;
+  /* default width is 180px */
+  width: 130px;
+}
 
-      .mdc-tab-indicator__content {
-        border-color: currentColor;
-      }
-    }
+mat-label,
+mat-select,
+mat-option {
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.active-plugin-list {
+  align-self: stretch;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.plugin-name {
+  align-items: center;
+  display: inline-flex;
+  height: 100%;
+  justify-content: center;
+  padding: 0 12px;
+  width: 100%;
+}
+
+// TODO(tensorboard-team): Can probably remove after migrating away from Legacy Material components.
+// These styles exist in `mat-toolbar` already, but the combination of the
+// dark theme selector being `body.dark-theme` and the legacy select component
+// being used causes the styles to be overwritten in a dark theme.
+:host ::ng-deep .mat-form-field.mat-form-field.mat-form-field {
+  .mat-form-field-underline,
+  .mat-form-field-ripple,
+  &.mat-focused .mat-form-field-ripple {
+    background-color: currentColor;
   }
 
-  mat-form-field ::ng-deep {
-    // There are only two appearance options
-    //   1) "filled" - with a background
-    //   2) "outline" - with a border
-    // Both will require a restyle like this. I'm opting for filled
-    // because it is the default.
-    .mdc-text-field--filled {
-      background: none;
-    }
-
-    // The bottom border of the select menu.
-    .mdc-text-field--filled {
-      ::before {
-        border-bottom-color: map-get($tb-dark-foreground, text);
-      }
-    }
-
-    mat-label,
-    .mat-mdc-select-arrow {
-      @include plugin-text;
-    }
+  .mat-select-value,
+  .mat-select-arrow,
+  &.mat-focused .mat-form-field-label,
+  &.mat-focused .mat-select-arrow {
+    color: inherit;
   }
 }
 
-mat-option,
-.plugin-name {
-  @include plugin-text;
+:host ::ng-deep .active-plugin-list {
+  // Override mat-tab styling. By default, mat-tab has the right styling but,
+  // here, we are using it under dark header background. Must invert the color.
+
+  &.mat-primary .mat-tab-list .mat-ink-bar {
+    background-color: currentColor;
+  }
+
+  .mat-tab-label,
+  .mat-tab-link {
+    // Inherit from `color` on the toolbar.
+    color: inherit;
+    // default is .6 and it is too dark against dark background.
+    opacity: 0.7;
+
+    &.mat-tab-label-active {
+      opacity: 1;
+    }
+  }
+
+  .mat-tab-header-pagination-chevron {
+    border-color: currentColor;
+  }
+
+  .mat-tab-header-pagination-disabled {
+    visibility: hidden;
+  }
+
+  .mat-tab-disabled {
+    display: none;
+  }
+
+  mat-tab-list,
+  .mat-tab-header,
+  .mat-tab-labels,
+  .mat-tab-label {
+    height: 100%;
+  }
+
+  .mat-tab-label {
+    min-width: 48px; /* default is 160px which is too big for us */
+    padding: 0; /* default is 24px */
+    text-transform: uppercase;
+  }
+
+  .mat-tab-label-content {
+    height: 100%;
+  }
+
+  mat-tab-header {
+    .mat-tab-list {
+      // 36px is the size of the chevron. Please see [1] for the reason.
+      padding: 0 36px;
+    }
+
+    > {
+      :first-child,
+      .mat-tab-label-container,
+      :last-child {
+        // [1]: Reason for customizing the mat-tab-header.
+        //
+        // Default mat-tab only renders the directional overflow chevron when
+        // width of the label container is smaller than mat-tab-header. This
+        // causes visual jank when user resizes the screen as the mat-tab with
+        // the chevron appears to have more padding (visually; directional
+        // chevron can have `visibility: hidden` in case it is not needed and
+        // appear as padding). To have the same experience as the Polymer based
+        // Material tab header, we always set the padding of 36px on each sides
+        // but that causes the scroll calculation to be incorrect and causes a
+        // bug [2].
+        // To work around it, we make everything `position: absolute`.
+        // [2]: https://github.com/tensorflow/tensorboard/issues/4841
+        bottom: 0;
+        position: absolute;
+        top: 0;
+      }
+
+      :first-child,
+      .mat-tab-label-container {
+        left: 0;
+      }
+
+      :last-child,
+      .mat-tab-label-container {
+        right: 0;
+      }
+
+      .mat-tab-header-pagination {
+        @include tb-theme-background-prop(background-color, app-bar);
+      }
+    }
+  }
 }

--- a/tensorboard/webapp/header/plugin_selector_component.scss
+++ b/tensorboard/webapp/header/plugin_selector_component.scss
@@ -23,17 +23,40 @@ limitations under the License.
   overflow: hidden;
 }
 
-mat-form-field {
-  flex: 0 0;
-  /* visually center align with _text_ of the select to the center. */
-  margin-top: 5px;
-  /* default width is 180px */
-  width: 130px;
+:host mat-form-field ::ng-deep {
+  // Default width is calculated by the contents of the longest value in the
+  // select. We override both the trigger and panel widths to be a bit shorter
+  // than what we see in practice.
+  // TODO: In Angular 16+ use the panelWidth attribute to set the width of the
+  //       panel to be different than the trigger. (We would likely want the
+  //       trigger to be shorter and the panel to be longer).
+  width: 144px;
+
+  .mdc-text-field {
+    @include tb-theme-background-prop(background-color, app-bar);
+    // Default padding is "0 16px".
+    padding: 0 4px;
+  }
+
+  label.mdc-floating-label.mat-mdc-floating-label,
+  .mat-mdc-select,
+  .mat-mdc-select-value,
+  .mat-mdc-select-arrow {
+    // Inherit from `color` on the toolbar.
+    color: inherit;
+  }
+
+  .mdc-text-field--filled:not(.mdc-text-field--disabled)
+    .mdc-line-ripple::before {
+    // Inherit from `border-color` on the toolbar.
+    border-color: inherit;
+  }
 }
 
 mat-label,
 mat-select,
 mat-option {
+  font-size: 14px;
   font-weight: 500;
   text-transform: uppercase;
 }
@@ -53,83 +76,64 @@ mat-option {
   width: 100%;
 }
 
-// TODO(tensorboard-team): Can probably remove after migrating away from Legacy Material components.
-// These styles exist in `mat-toolbar` already, but the combination of the
-// dark theme selector being `body.dark-theme` and the legacy select component
-// being used causes the styles to be overwritten in a dark theme.
-:host ::ng-deep .mat-form-field.mat-form-field.mat-form-field {
-  .mat-form-field-underline,
-  .mat-form-field-ripple,
-  &.mat-focused .mat-form-field-ripple {
-    background-color: currentColor;
-  }
-
-  .mat-select-value,
-  .mat-select-arrow,
-  &.mat-focused .mat-form-field-label,
-  &.mat-focused .mat-select-arrow {
-    color: inherit;
-  }
-}
-
 :host ::ng-deep .active-plugin-list {
   // Override mat-tab styling. By default, mat-tab has the right styling but,
   // here, we are using it under dark header background. Must invert the color.
 
-  &.mat-primary .mat-tab-list .mat-ink-bar {
-    background-color: currentColor;
+  .mat-mdc-tab:not(.mat-mdc-tab-disabled)
+    .mdc-tab-indicator__content--underline {
+    border-color: currentColor;
   }
 
-  .mat-tab-label,
-  .mat-tab-link {
-    // Inherit from `color` on the toolbar.
-    color: inherit;
-    // default is .6 and it is too dark against dark background.
-    opacity: 0.7;
+  .mat-mdc-tab:not(.mat-mdc-tab-disabled) {
+    .mdc-tab__text-label {
+      // Inherit from `color` on the toolbar.
+      color: inherit;
+      // default is .6 and it is too dark against dark background.
+      opacity: 0.7;
+    }
 
-    &.mat-tab-label-active {
+    &.mdc-tab--active .mdc-tab__text-label {
+      // Repeat color with more-specific selector to override dark-mode styling.
+      // Inherit from `color` on the toolbar.
+      color: inherit;
       opacity: 1;
     }
   }
 
-  .mat-tab-header-pagination-chevron {
-    border-color: currentColor;
-  }
-
-  .mat-tab-header-pagination-disabled {
+  .mat-mdc-tab-header-pagination-disabled {
     visibility: hidden;
   }
 
-  .mat-tab-disabled {
+  .mat-mdc-tab-disabled {
     display: none;
   }
 
-  mat-tab-list,
-  .mat-tab-header,
-  .mat-tab-labels,
-  .mat-tab-label {
+  mat-mdc-tab-list,
+  .mat-mdc-tab-header,
+  .mat-mdc-tab-labels,
+  // Extra-specific selector to override dark-mode styling.
+  .mat-mdc-tab-header .mat-mdc-tab,
+  .mdc-tab__text-label {
     height: 100%;
   }
 
-  .mat-tab-label {
-    min-width: 48px; /* default is 160px which is too big for us */
+  .mat-mdc-tab {
+    letter-spacing: 0.25px;
+    min-width: 48px; /* default is 90px which is too big for us */
     padding: 0; /* default is 24px */
     text-transform: uppercase;
   }
 
-  .mat-tab-label-content {
-    height: 100%;
-  }
-
   mat-tab-header {
-    .mat-tab-list {
+    .mat-mdc-tab-list {
       // 36px is the size of the chevron. Please see [1] for the reason.
       padding: 0 36px;
     }
 
     > {
       :first-child,
-      .mat-tab-label-container,
+      .mat-mdc-tab-label-container,
       :last-child {
         // [1]: Reason for customizing the mat-tab-header.
         //
@@ -150,16 +154,16 @@ mat-option {
       }
 
       :first-child,
-      .mat-tab-label-container {
+      .mat-mdc-tab-label-container {
         left: 0;
       }
 
       :last-child,
-      .mat-tab-label-container {
+      .mat-mdc-tab-label-container {
         right: 0;
       }
 
-      .mat-tab-header-pagination {
+      .mat-mdc-tab-header-pagination {
         @include tb-theme-background-prop(background-color, app-bar);
       }
     }

--- a/tensorboard/webapp/header/plugin_selector_component.scss
+++ b/tensorboard/webapp/header/plugin_selector_component.scss
@@ -101,6 +101,14 @@ mat-option {
     }
   }
 
+  .mat-mdc-tab-header-pagination {
+    color: inherit;
+  }
+
+  .mat-mdc-tab-header-pagination-chevron {
+    border-color: currentColor;
+  }
+
   .mat-mdc-tab-header-pagination-disabled {
     visibility: hidden;
   }

--- a/tensorboard/webapp/header/plugin_selector_container.ts
+++ b/tensorboard/webapp/header/plugin_selector_container.ts
@@ -23,11 +23,6 @@ const getUiPlugins = createSelector(getPlugins, (listing): UiPluginMetadata[] =>
   Object.keys(listing).map((key) => Object.assign({}, {id: key}, listing[key]))
 );
 
-const getActivePlugins = createSelector(
-  getUiPlugins,
-  (plugins): UiPluginMetadata[] => plugins.filter((plugin) => plugin.enabled)
-);
-
 const getDisabledPlugins = createSelector(
   getUiPlugins,
   (plugins): UiPluginMetadata[] => plugins.filter((plugin) => !plugin.enabled)
@@ -37,7 +32,7 @@ const getDisabledPlugins = createSelector(
   selector: 'plugin-selector',
   template: `
     <plugin-selector-component
-      [activePlugins]="activePlugins$ | async"
+      [activePlugins]="plugins$ | async"
       [disabledPlugins]="disabledPlugins$ | async"
       [selectedPlugin]="activePlugin$ | async"
       (onPluginSelectionChanged)="onPluginSelectionChange($event)"
@@ -46,7 +41,7 @@ const getDisabledPlugins = createSelector(
 })
 export class PluginSelectorContainer {
   readonly activePlugin$ = this.store.pipe(select(getActivePlugin));
-  readonly activePlugins$ = this.store.pipe(select(getActivePlugins));
+  readonly plugins$ = this.store.pipe(select(getUiPlugins));
   readonly disabledPlugins$ = this.store.pipe(select(getDisabledPlugins));
 
   constructor(private readonly store: Store<State>) {}


### PR DESCRIPTION
This is another attempt at restyling the plugins selector component for MDC Migration.

We start by reverting the previous attempt so that we have a good base for the conversion.
(See b846aae50da844a62f44c1fb0d08a89fa5f3d538)

We then take the approach of attempting to adjust the current styling to mdc components as much as possible, in order to preserve current styling and current behavior.
(See 4012cae19d433eeb254a61a9f9658a606868f1bf for the clean diff compared to original)

The end result is:
* The header plugin tabs appear and behave almost identically to current.
* The inactive plugin selector is styled slightly differently but still, in spirit, is similar to current.

Some sample screenshots but please patch it locally to play with it:

![image](https://github.com/tensorflow/tensorboard/assets/17152369/e2a5c499-f17c-4539-92f9-c904cfcbb794)

![image](https://github.com/tensorflow/tensorboard/assets/17152369/740db4f3-ecf9-4f48-9f0a-4ade3db0cc3d)

