### PR TITLE
Hparams: fix documentation of session and session group

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -109,11 +109,14 @@ class DataProvider(metaclass=abc.ABCMeta):
     execution.
 
     Each run within an experiment may specify its own value for a
-    hyperparameter. Runs that were logically executed together with the same set
-    of hyperparameter values form a hyperparameter session group. When querying
-    for hyperparameter values for a set of experiments, the result will group
-    runs by hyperparameter session group and provide one set of hyperparameter
-    values for each group.
+    hyperparameter. Runs that were logically executed together with the same
+    set of hyperparameter values form a hyperparameter session. Often a session
+    group will contain only a single session. However, in some scenarios, the
+    same hyperparameters will be used to execute multiple jobs with the idea to
+    aggregate the metrics across those jobs and analyze non-deterministic
+    factors. In that case, a session group will contain multiple sessions.
+    The result will group runs by hyperparameter session group and provide one
+    set of hyperparameter values for each group.
 
     All methods on this class take a `RequestContext` parameter as the
     first positional argument. This argument is temporarily optional to
@@ -652,10 +655,17 @@ class HyperparameterSessionRun:
 
 @dataclasses.dataclass(frozen=True)
 class HyperparameterSessionGroup:
-    """A group of runs logically executed together with the same hparam values.
+    """A group of sessions logically executed together with the same hparam values.
 
-    The group of runs may have, for example, combined to generate and test a
-    single model or other artifacts.
+    A session generally represents a particular execution of a job with a given
+    set of hyperparameter values. A session may contain multiple related runs
+    executed together to train and validate a model.
+
+    Often a session group will contain only a single session. However, in some
+    scenarios, the same hyperparameters will be used to execute multiple jobs
+    with the idea to aggregate the metrics across those jobs and analyze
+    non-deterministic factors. In that case, a session group will contain multiple
+    sessions.
 
     We assume these groups of runs were executed with the same set of
     hyperparameter values. However, having the same set of hyperparameter values


### PR DESCRIPTION
A session may contain multiple runs instead of just one run. 

Googlers, see cl/555481552 for more details.

#hparams 