### PR TITLE
MDCMigration: Style run table and right pane checkboxes.

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -34,7 +34,10 @@ section {
   margin: 0 0 12px 0;
 }
 
-section .control-row:not(:last-child) {
+// Add additional margin between most control elements. The exception is when
+// the second control row is a checkbox, in which case we just rely on the
+// padding that is already included in the checkbox.
+section .control-row:not(:has(+ .control-row > mat-checkbox)):not(:last-child) {
   margin-bottom: 12px;
 }
 
@@ -89,6 +92,20 @@ section .control-row:not(:last-child) {
   }
 }
 
+mat-checkbox {
+  // Counteract the padding of the checkbox in order to align it vertically
+  // with other items in the pane.
+  margin-left: -11px;
+
+  ::ng-deep label {
+    @include tb-theme-foreground-prop(color, secondary-text);
+    font-size: 12px;
+    letter-spacing: normal;
+    padding-left: 0px;
+    white-space: nowrap;
+  }
+}
+
 mat-slider {
   flex: 1;
   // Reset mat-slider's internal extra space on left/right sides
@@ -125,12 +142,8 @@ tb-dropdown {
   display: block;
 }
 
-.linked-time {
-  padding: 5px 0;
-}
-
 .control-row {
   .indent {
-    margin-left: 25px;
+    margin-left: 28px;
   }
 }

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -56,10 +56,6 @@ tb-data-table-header-cell {
   vertical-align: middle;
   @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
 
-  &:first-child {
-    padding-left: 16px;
-  }
-
   &:last-child {
     @include tb-theme-foreground-prop(border-right, border, 1px solid);
   }

--- a/tensorboard/webapp/widgets/data_table/header_cell_component.scss
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component.scss
@@ -21,7 +21,7 @@ $_icon_size: 12px;
 
 :host {
   display: table-cell;
-  padding: 2px;
+  padding: 4px;
   vertical-align: bottom;
 
   &:hover {


### PR DESCRIPTION
Restyle the checkboxes in both the runs table and right pane.

For runs table this is mostly just about removing and adjusting padding.

For right pane this:
* adds negative margin to account for checkbox padding - aligning the checkboxes with other elements in the pane.
* adjusting the text of checkbox labels to look more like the current style.

Here are some sample screenshots but please patch it in locally to play with it:

![image](https://github.com/tensorflow/tensorboard/assets/17152369/9f09d7b5-f708-469c-8eea-76b0ea1129a3)

![image](https://github.com/tensorflow/tensorboard/assets/17152369/fb35c457-e2c1-47e7-a03d-5d088a6cfbdb)

