### PR TITLE
MDCMigration: Style alert snackbar for MDC migration.

### DIFF
--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.scss
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.scss
@@ -33,6 +33,7 @@ limitations under the License.
   margin-left: auto;
 }
 
-button {
+button.mat-mdc-button {
+  color: inherit;
   text-transform: uppercase;
 }


### PR DESCRIPTION
Style the alert snackbar buttons for MDC migration.

They were appearing a dark color at all times. Now we ask it to inherit its color.

Sample screenshots:
![image](https://github.com/tensorflow/tensorboard/assets/17152369/e84fd2aa-5c34-4afd-bc5e-da77188b34ed)

![image](https://github.com/tensorflow/tensorboard/assets/17152369/90dc905b-d6f4-4c74-aca5-2c396c503413)
