### PR TITLE
MDCMigration: Style readme button for MDC migration.

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -283,7 +283,7 @@ $tb-dark-theme: map_merge(
     contain: strict;
   }
 
-  a:not(.mat-button, .mat-icon-button) {
+  a:not(.mdc-button, .mdc-icon-button) {
     color: map-get($tb-foreground, link);
 
     &:visited {
@@ -327,7 +327,7 @@ $tb-dark-theme: map_merge(
   body.dark-mode {
     background-color: map-get($tb-dark-background, background);
 
-    a:not(.mat-button, .mat-icon-button) {
+    a:not(.mdc-button, .mdc-icon-button) {
       color: map-get($tb-dark-foreground, link);
 
       &:visited {


### PR DESCRIPTION
Style the readme button for MDC Migration.

In global theme we change the rules that ensure a read `<a>` link remains white.

Screenshots:
![image](https://github.com/tensorflow/tensorboard/assets/17152369/2121935f-94ed-4a53-bedb-d08afb1c7b47)

![image](https://github.com/tensorflow/tensorboard/assets/17152369/d7db8706-2059-4f5d-a12c-a156b2e57bda)
