### PR TITLE
MDCMigration: fix readme button color

### DIFF
--- a/tensorboard/webapp/header/header_component.scss
+++ b/tensorboard/webapp/header/header_component.scss
@@ -44,3 +44,7 @@ settings-button {
   height: 100%;
   overflow: hidden;
 }
+
+.readme mat-icon {
+  color: #fff;
+}


### PR DESCRIPTION
## Motivation for features / changes
Make the readme link mat-icon look like all the other buttons by forcing the color to be white instead of the color of the anchor tag. Note: the header keeps all the same colors in dark mode.

## Screenshots of UI changes (or N/A)
Before this change:
<img width="177" alt="Screenshot 2023-10-04 at 3 54 40 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/07535873-94b2-4bbf-a283-7ef66078318b">

After this change: 
<img width="183" alt="Screenshot 2023-10-04 at 3 54 18 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/946508f5-c0d5-420c-9f34-b13db936b8be">