### PR TITLE
MDCMigration: fix settings modal style

### DIFF
--- a/tensorboard/webapp/settings/_views/settings_dialog_component.css
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.css
@@ -17,21 +17,14 @@ limitations under the License.
 }
 
 :host > div {
-  margin: 10px 0;
-}
-
-:host > :first-child {
-  margin-top: 0;
-}
-
-:host > :last-child {
-  margin-bottom: 0;
+  margin: 8px;
 }
 
 h3 {
   font-size: 20px;
+  margin: 8px;
 }
 
 .reload-toggle {
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.ng.html
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.ng.html
@@ -23,11 +23,11 @@ limitations under the License.
   </div>
   <div>
     <mat-form-field>
+      <mat-label>Reload Period (seconds)</mat-label>
       <input
         class="reload-period"
         matInput
         type="number"
-        placeholder="Reload Period (seconds)"
         [formControl]="reloadPeriodControl"
       />
     </mat-form-field>
@@ -43,11 +43,11 @@ limitations under the License.
 </div>
 <div>
   <mat-form-field>
+    <mat-label>Pagination Limit</mat-label>
     <input
       class="page-size"
       matInput
       type="number"
-      placeholder="Pagination Limit"
       [formControl]="paginationControl"
     />
   </mat-form-field>


### PR DESCRIPTION
## Motivation for features / changes
After migrating to the new MDC components many new components needed style fixes. This is that fix for the SettingsDialogComponent.
## Screenshots of UI changes (or N/A)
before:
<img width="409" alt="Screenshot 2023-10-06 at 3 58 41 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/5f91c6b0-3941-4a9e-a4a1-48a779ead69a">

after:
<img width="400" alt="Screenshot 2023-10-06 at 3 20 11 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/4420a432-0092-428e-a5af-21e84ba4e8cb">
