### PR TITLE
MDCMigration: 2 dialog style changes

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog.ng.html
@@ -91,6 +91,7 @@ limitations under the License.
   <div mat-dialog-actions align="end">
     <button mat-button mat-dialog-close>Cancel</button>
     <button
+      class="save-button"
       mat-raised-button
       color="primary"
       mat-dialog-close

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
@@ -115,3 +115,7 @@ mat-form-field {
     margin-top: $padding-size;
   }
 }
+
+.save-button {
+  color: inherit;
+}

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.css
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.css
@@ -17,14 +17,14 @@ limitations under the License.
 }
 
 :host > div {
-  margin: 8px;
+  margin: 16px;
 }
 
 h3 {
   font-size: 20px;
-  margin: 8px;
+  margin: 16px;
 }
 
 .reload-toggle {
-  margin-bottom: 8px;
+  margin-bottom: 16px;
 }


### PR DESCRIPTION
## Motivation for features / changes
Some last minute fix ups before the MDC Migration feature branch merge.

## Screenshots of UI changes (or N/A)
Before(note save button color): 
<img width="820" alt="Screenshot 2023-10-10 at 3 57 25 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/deccac08-422a-4924-b770-c391b1086b08">
<img width="830" alt="Screenshot 2023-10-10 at 3 58 38 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/e07ae31a-df7c-4773-a12b-9e853e736457">

After:
<img width="825" alt="Screenshot 2023-10-10 at 3 56 52 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/53eae7c1-fa00-4203-b3a5-e10cc6bccee7">
<img width="819" alt="Screenshot 2023-10-10 at 3 49 40 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/129e27b8-1141-4822-baaf-709723fccb47">

Before:
<img width="416" alt="Screenshot 2023-10-10 at 3 59 32 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/ed247a41-7437-4732-a4ec-6b4ad3360d9d">

After:
<img width="420" alt="Screenshot 2023-10-10 at 3 57 47 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/1af6c0b7-0aba-4e38-a2a3-b4c643d74668">
