### PR TITLE
Remove markdown test for deprecated behavior.

### DIFF
--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -206,13 +206,6 @@ class MarkdownsToSafeHTMLTest(tb_test.TestCase):
         expected = "&lt;script&gt;alert('unsafe!')&lt;/script&gt;<p>safe</p>"
         self.assertEqual(actual, expected)
 
-    def test_sanitization_can_have_collateral_damage(self):
-        inputs = ['<table title="*chuckles* ', "I'm in danger", '<table>">']
-        combine = lambda xs: "".join(xs)
-        actual = plugin_util.markdowns_to_safe_html(inputs, combine)
-        expected = "<table></table>"
-        self.assertEqual(actual, expected)
-
 
 class ContextTest(tb_test.TestCase):
     def test_context(self):


### PR DESCRIPTION
Googlers, see b/303850407

## Motivation for features / changes
Update to google-internal package markdown_freewisdom no longer has this behavior.

## Technical description of changes
Removes test that was testing a behavior that has been removed in the new version


