### PR TITLE
Update data server build step to run with ubuntu 20.04 and change platform tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,11 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-22.04', 'macos-12']
+        platform: ['ubuntu-20.04', 'macos-12']
         rust_version: ['1.65.0']
         include:
           - mode: 'universal'
-            platform: 'ubuntu-22.04'
+            platform: 'ubuntu-20.04'
             rust_version: '1.65.0'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/tensorboard/data/server/pip_package/build.py
+++ b/tensorboard/data/server/pip_package/build.py
@@ -37,8 +37,9 @@ def main():
     if cpu_name == "arm64":
         mac_platform = "macosx_11_0"
     platform_name = {
-        # using platform tag values from TensorFlow releases
-        "Linux": "manylinux2014",
+        # We build on an Ubuntu 20.04 (Focal Fossa) image, which ships with
+        # glibc 2.31 (https://launchpad.net/ubuntu/focal/+source/glibc).
+        "Linux": "manylinux_2_31",
         "Darwin": mac_platform,
     }.get(platform.system())
 


### PR DESCRIPTION
This should ensure that the generated wheels are compatible with the `manylinux_2_31` platform tag, since that's the version of `glibc` shipped with ubuntu 20.04. This aligns us with https://peps.python.org/pep-0600/ instead of reconfiguring our CI workflow to build on a system with `glibc<=2.17` to keep supporting the `manylinux2014` tag (https://peps.python.org/pep-0599/).