### PR TITLE
Give fixed width to runs table's checkbox and color columns.

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -47,6 +47,7 @@ limitations under the License.
           [header]="header"
           [sortingInfo]="sortingInfo"
           [hparamsEnabled]="true"
+          [ngClass]="['table-column-' + header.name]"
         >
           <ng-container [ngSwitch]="header.name">
             <div *ngSwitchCase="'selected'">
@@ -73,6 +74,7 @@ limitations under the License.
               *ngIf="header.enabled"
               [header]="header"
               [datum]="dataRow[header.name]"
+              [ngClass]="['table-column-' + header.name]"
             >
               <ng-container [ngSwitch]="header.name">
                 <span *ngSwitchCase="'color'" class="color-container">

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -67,6 +67,11 @@ tb-data-table-header-cell:last-of-type {
   @include tb-theme-foreground-prop(border-right, border, 1px solid);
 }
 
+.table-column-selected,
+.table-column-color {
+  width: 40px;
+}
+
 .full-screen-toggle {
   opacity: 0;
   position: absolute;


### PR DESCRIPTION
## Motivation for features / changes

The checkbox (aka 'selected') and color icon columns in the new runs data table would have variable width in the table's flex layout. This led to some awkward looking spacing for these columns.

We want to fix the width of these columns.

## Technical description of changes

Similar to strategies for other tables (mat-table and the old runs table, for example), add a column-specific class to each cell and customize the width of the 'selected' and 'color' columns using these classes.


