### PR TITLE
Chore: Remove markdown freewisdom reference.

### DIFF
--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -18,9 +18,6 @@
 import threading
 
 from bleach.sanitizer import Cleaner
-
-# pylint: disable=g-bad-import-order
-# Google-only: import markdown_freewisdom
 import markdown
 
 from tensorboard import context as _context


### PR DESCRIPTION
Followup to https://github.com/tensorflow/tensorboard/pull/6634, which references b/303850407 (Googlers only).

The PR was incomplete and also required removal of a reference to markdown_freewisdom.