### PR TITLE
Hparams: Fix repainting bug

### DIFF
--- a/tensorboard/webapp/hparams/_redux/hparams_effects.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_effects.ts
@@ -67,7 +67,7 @@ export class HparamsEffects {
     distinctUntilChanged((prev, cur) => prev.join('') === cur.join(''))
   );
 
-  private readonly loadHparamsOnNavigationOrReload$: Observable<string[]> =
+  private readonly loadHparamsOnReload$: Observable<string[]> =
     this.actions$.pipe(
       ofType(coreActions.reload, coreActions.manualReload),
       withLatestFrom(this.store.select(getExperimentIdsFromRoute)),
@@ -80,7 +80,7 @@ export class HparamsEffects {
     return merge(
       this.navigated$,
       this.runTableShown$,
-      this.loadHparamsOnNavigationOrReload$
+      this.loadHparamsOnReload$
     ).pipe(
       withLatestFrom(
         this.store.select(getEnableHparamsInTimeSeries),

--- a/tensorboard/webapp/hparams/_redux/hparams_effects.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_effects.ts
@@ -23,7 +23,7 @@ import {
   switchMap,
   withLatestFrom,
   throttleTime,
-  combineLatestWith,
+  distinctUntilChanged,
 } from 'rxjs/operators';
 
 import {navigated} from '../../app_routing/actions';
@@ -72,7 +72,8 @@ export class HparamsEffects {
       this.runTableShown$,
       this.loadHparamsOnNavigationOrReload$
     ).pipe(
-      combineLatestWith(
+      distinctUntilChanged((prev, cur) => prev.join('') === cur.join('')),
+      withLatestFrom(
         this.store.select(getEnableHparamsInTimeSeries),
         this.store.select(getActiveRoute)
       ),

--- a/tensorboard/webapp/hparams/_redux/hparams_effects_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_effects_test.ts
@@ -160,6 +160,17 @@ describe('hparams effects', () => {
       ]);
     });
 
+    it('does not refetch data if experiments have not changed', () => {
+      action.next(runsActions.runTableShown({experimentIds: ['exp1']}));
+      action.next(runsActions.runTableShown({experimentIds: ['exp1']}));
+      expect(actualActions).toEqual([
+        hparamsActions.hparamsFetchSessionGroupsSucceeded({
+          hparamsAndMetricsSpecs: mockHparamsAndMetricsSpecs,
+          sessionGroups: mockSessionGroups,
+        }),
+      ]);
+    });
+
     it('fetches data after navigation', () => {
       action.next(appRoutingActions.navigated({} as any));
       expect(dataSource.fetchExperimentInfo).toHaveBeenCalledWith([
@@ -172,6 +183,17 @@ describe('hparams effects', () => {
           metrics: [buildMetricSpec({tag: 'm1'})],
         }
       );
+      expect(actualActions).toEqual([
+        hparamsActions.hparamsFetchSessionGroupsSucceeded({
+          hparamsAndMetricsSpecs: mockHparamsAndMetricsSpecs,
+          sessionGroups: mockSessionGroups,
+        }),
+      ]);
+    });
+
+    it('does not fetch data when navigating to the same experiment', () => {
+      action.next(appRoutingActions.navigated({} as any));
+      action.next(appRoutingActions.navigated({} as any));
       expect(actualActions).toEqual([
         hparamsActions.hparamsFetchSessionGroupsSucceeded({
           hparamsAndMetricsSpecs: mockHparamsAndMetricsSpecs,

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -486,22 +486,23 @@ export const getTableEditorSelectedTab = createSelector(
   (state): DataTableMode => state.tableEditorSelectedTab
 );
 
-export const getMetricsCardRangeSelectionEnabled = createSelector(
-  getCardStateMap,
-  getMetricsRangeSelectionEnabled,
-  getMetricsLinkedTimeEnabled,
-  (
-    cardStateMap: CardStateMap,
-    globalRangeSelectionEnabled: boolean,
-    linkedTimeEnabled: boolean,
-    cardId: CardId
-  ) =>
-    cardRangeSelectionEnabled(
-      cardStateMap,
-      globalRangeSelectionEnabled,
-      linkedTimeEnabled,
-      cardId
-    )
+export const getMetricsCardRangeSelectionEnabled = memoize((cardId) =>
+  createSelector(
+    getCardStateMap,
+    getMetricsRangeSelectionEnabled,
+    getMetricsLinkedTimeEnabled,
+    (
+      cardStateMap: CardStateMap,
+      globalRangeSelectionEnabled: boolean,
+      linkedTimeEnabled: boolean
+    ) =>
+      cardRangeSelectionEnabled(
+        cardStateMap,
+        globalRangeSelectionEnabled,
+        linkedTimeEnabled,
+        cardId
+      )
+  )
 );
 
 /**
@@ -639,11 +640,15 @@ export const getRangeSelectionHeaders = createSelector(
 
 export const getColumnHeadersForCard = memoize((cardId: string) => {
   return createSelector(
-    (state) => state,
+    getMetricsCardRangeSelectionEnabled(cardId),
     getSingleSelectionHeaders,
     getRangeSelectionHeaders,
-    (state, singleSelectionHeaders, rangeSelectionHeaders) => {
-      return getMetricsCardRangeSelectionEnabled(state, cardId)
+    (
+      cardRangeSelectionEnabled,
+      singleSelectionHeaders,
+      rangeSelectionHeaders
+    ) => {
+      return cardRangeSelectionEnabled
         ? rangeSelectionHeaders
         : singleSelectionHeaders;
     }

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -1344,7 +1344,7 @@ describe('metrics selectors', () => {
   describe('getMetricsCardRangeSelectionEnabled', () => {
     it('returns card specific value when defined', () => {
       expect(
-        selectors.getMetricsCardRangeSelectionEnabled(
+        selectors.getMetricsCardRangeSelectionEnabled('card1')(
           appStateFromMetricsState(
             buildMetricsState({
               rangeSelectionEnabled: false,
@@ -1355,12 +1355,11 @@ describe('metrics selectors', () => {
                 },
               },
             })
-          ),
-          'card1'
+          )
         )
       ).toBeTrue();
       expect(
-        selectors.getMetricsCardRangeSelectionEnabled(
+        selectors.getMetricsCardRangeSelectionEnabled('card1')(
           appStateFromMetricsState(
             buildMetricsState({
               rangeSelectionEnabled: true,
@@ -1371,15 +1370,14 @@ describe('metrics selectors', () => {
                 },
               },
             })
-          ),
-          'card1'
+          )
         )
       ).toBeFalse();
     });
 
     it('returns global value when card specific value is not defined', () => {
       expect(
-        selectors.getMetricsCardRangeSelectionEnabled(
+        selectors.getMetricsCardRangeSelectionEnabled('card1')(
           appStateFromMetricsState(
             buildMetricsState({
               rangeSelectionEnabled: true,
@@ -1387,25 +1385,23 @@ describe('metrics selectors', () => {
                 card1: {},
               },
             })
-          ),
-          'card1'
+          )
         )
       ).toBeTrue();
       expect(
-        selectors.getMetricsCardRangeSelectionEnabled(
+        selectors.getMetricsCardRangeSelectionEnabled('card1')(
           appStateFromMetricsState(
             buildMetricsState({
               rangeSelectionEnabled: false,
             })
-          ),
-          'card1'
+          )
         )
       ).toBeFalse();
     });
 
     it('returns global value when linked time is enabled', () => {
       expect(
-        selectors.getMetricsCardRangeSelectionEnabled(
+        selectors.getMetricsCardRangeSelectionEnabled('card1')(
           appStateFromMetricsState(
             buildMetricsState({
               rangeSelectionEnabled: true,
@@ -1417,13 +1413,12 @@ describe('metrics selectors', () => {
                 },
               },
             })
-          ),
-          'card1'
+          )
         )
       ).toBeTrue();
 
       expect(
-        selectors.getMetricsCardRangeSelectionEnabled(
+        selectors.getMetricsCardRangeSelectionEnabled('card1')(
           appStateFromMetricsState(
             buildMetricsState({
               rangeSelectionEnabled: false,
@@ -1435,8 +1430,7 @@ describe('metrics selectors', () => {
                 },
               },
             })
-          ),
-          'card1'
+          )
         )
       ).toBeFalse();
     });

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -596,8 +596,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.isPinned$ = this.store.select(getCardPinnedState, this.cardId);
 
     this.rangeEnabled$ = this.store.select(
-      getMetricsCardRangeSelectionEnabled,
-      this.cardId
+      getMetricsCardRangeSelectionEnabled(this.cardId)
     );
 
     this.hparamsEnabled$ = this.store.select(getEnableHparamsInTimeSeries);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_container.ts
@@ -160,8 +160,7 @@ export class ScalarCardLineChartContainer
     this.loadState$ = this.store.select(getCardLoadState, this.cardId);
 
     this.rangeEnabled$ = this.store.select(
-      getMetricsCardRangeSelectionEnabled,
-      this.cardId
+      getMetricsCardRangeSelectionEnabled(this.cardId)
     );
   }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
@@ -453,7 +453,7 @@ describe('scalar card line chart', () => {
     );
     store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
     store.overrideSelector(
-      selectors.getMetricsCardRangeSelectionEnabled,
+      selectors.getMetricsCardRangeSelectionEnabled('card1'),
       false
     );
     store.overrideSelector(selectors.getMetricsCardUserViewBox, null);
@@ -1794,7 +1794,10 @@ describe('scalar card line chart', () => {
           start: {step: 10},
           end: {step: 25},
         };
-        store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+        store.overrideSelector(
+          getMetricsCardRangeSelectionEnabled('card1'),
+          true
+        );
         store.refreshState();
         fixture.detectChanges();
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -386,7 +386,7 @@ describe('scalar card', () => {
     );
     store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
     store.overrideSelector(
-      selectors.getMetricsCardRangeSelectionEnabled,
+      selectors.getMetricsCardRangeSelectionEnabled('card1'),
       false
     );
     store.overrideSelector(selectors.getMetricsCardUserViewBox, null);
@@ -864,7 +864,10 @@ describe('scalar card', () => {
         selectors.getIsScalarColumnCustomizationEnabled,
         true
       );
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, false);
+      store.overrideSelector(
+        getMetricsCardRangeSelectionEnabled('card1'),
+        false
+      );
       const fixture = createComponent('card1');
 
       openOverflowMenu(fixture);
@@ -882,7 +885,10 @@ describe('scalar card', () => {
         selectors.getIsScalarColumnCustomizationEnabled,
         true
       );
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(
+        getMetricsCardRangeSelectionEnabled('card1'),
+        true
+      );
       const fixture = createComponent('card1');
 
       openOverflowMenu(fixture);
@@ -3054,7 +3060,10 @@ describe('scalar card', () => {
         runToSeries
       );
       store.overrideSelector(getMetricsRangeSelectionEnabled, true);
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(
+        getMetricsCardRangeSelectionEnabled('card1'),
+        true
+      );
       store.overrideSelector(
         selectors.getCurrentRouteRunSelection,
         new Map([
@@ -3136,7 +3145,10 @@ describe('scalar card', () => {
         runToSeries
       );
       store.overrideSelector(getMetricsRangeSelectionEnabled, true);
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(
+        getMetricsCardRangeSelectionEnabled('card1'),
+        true
+      );
       store.overrideSelector(
         selectors.getCurrentRouteRunSelection,
         new Map([['run1', true]])
@@ -3202,7 +3214,10 @@ describe('scalar card', () => {
         runToSeries
       );
       store.overrideSelector(getMetricsRangeSelectionEnabled, true);
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(
+        getMetricsCardRangeSelectionEnabled('card1'),
+        true
+      );
       store.overrideSelector(
         selectors.getCurrentRouteRunSelection,
         new Map([['run1', true]])
@@ -3318,7 +3333,10 @@ describe('scalar card', () => {
         runToSeries
       );
       store.overrideSelector(getMetricsRangeSelectionEnabled, true);
-      store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+      store.overrideSelector(
+        getMetricsCardRangeSelectionEnabled('card1'),
+        true
+      );
       store.overrideSelector(
         selectors.getCurrentRouteRunSelection,
         new Map([
@@ -4156,7 +4174,10 @@ describe('scalar card', () => {
           start: {step: 10},
           end: {step: 25},
         });
-        store.overrideSelector(getMetricsCardRangeSelectionEnabled, true);
+        store.overrideSelector(
+          getMetricsCardRangeSelectionEnabled('card1'),
+          true
+        );
         store.refreshState();
         fixture.detectChanges();
 

--- a/tensorboard/webapp/util/ui_selectors.ts
+++ b/tensorboard/webapp/util/ui_selectors.ts
@@ -87,7 +87,7 @@ const getRunMatchableMap = createSelector(
   (aliasMap, runs) => {
     const runMatchableMap = new Map<string, RunMatchable>();
     for (const run of runs) {
-      runMatchableMap.set(run.experimentId, {
+      runMatchableMap.set(run.id, {
         runName: run.name,
         experimentAlias: aliasMap[run.experimentId],
       });

--- a/tensorboard/webapp/util/ui_selectors.ts
+++ b/tensorboard/webapp/util/ui_selectors.ts
@@ -39,6 +39,7 @@ import {
   getRunColorOverride,
   getRunIdToExperimentId,
   getRuns,
+  getDashboardRuns,
   getRunSelectionMap,
   getRunSelectorRegexFilter,
 } from '../runs/store/runs_selectors';
@@ -80,6 +81,21 @@ const getRunSelectionMapFilteredToCurrentRoute = createSelector<
   }
 );
 
+const getRunMatchableMap = createSelector(
+  getExperimentIdToExperimentAliasMap,
+  getDashboardRuns,
+  (aliasMap, runs) => {
+    const runMatchableMap = new Map<string, RunMatchable>();
+    for (const run of runs) {
+      runMatchableMap.set(run.experimentId, {
+        runName: run.name,
+        experimentAlias: aliasMap[run.experimentId],
+      });
+    }
+    return runMatchableMap;
+  }
+);
+
 /**
  * Selects the run selection (runId to boolean) of current set of experiments.
  *
@@ -89,22 +105,7 @@ export const getCurrentRouteRunSelection = createSelector(
   getExperimentIdsFromRoute,
   getRunSelectionMapFilteredToCurrentRoute,
   getRunSelectorRegexFilter,
-  (state: State): Map<string, RunMatchable> => {
-    const experimentIds = getExperimentIdsFromRoute(state) ?? [];
-    const aliasMap = getExperimentIdToExperimentAliasMap(state);
-
-    const runMatchableMap = new Map<string, RunMatchable>();
-    for (const experimentId of experimentIds) {
-      const runs = getRuns(state, {experimentId});
-      for (const run of runs) {
-        runMatchableMap.set(run.id, {
-          runName: run.name,
-          experimentAlias: aliasMap[experimentId],
-        });
-      }
-    }
-    return runMatchableMap;
-  },
+  getRunMatchableMap,
   getRouteKind,
   (experimentIds, runSelection, regexFilter, runMatchableMap, routeKind) => {
     if (!experimentIds) {


### PR DESCRIPTION
## Motivation for features / changes
Previously any changes to the metrics state would result in the runs table being redrawn. This was happening for two reasons both related to selectors with dependencies on `state`. Whenever any value on state changed these selectors would reflow.

While testing this I discovered that entering a value into the tag filter triggered a `navigated` event which would in turn re-fetch the session_groups data. I have chosen to fix this by deduplicating events at the effect layer.

## Screenshots of UI changes (or N/A)
Before
![12fa591b-6846-4f9d-a12f-8b3ce21c2e18](https://github.com/tensorflow/tensorboard/assets/78179109/e2c02b63-b353-44a2-8189-2bf6acab3de0)

After
![f18b30d5-0156-4b24-85f9-8c3ba930919c](https://github.com/tensorflow/tensorboard/assets/78179109/9bfb6c0e-4bc3-40a5-87d6-998bcb6ccee6)

