### PR TITLE
Post-release 2.15.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,19 @@
+# Release 2.15.0
+
+The 2.15 minor series tracks TensorFlow 2.15.
+
+## Features
+
+- Scalar chart data tables are shown by default. This can be disabled from the general settings panel. (#6563)
+- Hparams support in timeseries. Allows sorting and filtering the Runs Table in the Time Series dashboard using values logged with the Hparams plugin. (#6565)
+- Better default sorting of Hparams in the Hparams plugin. Sort the ones that have multiple values to the top of the list. (#6601)
+- New material components across the UI. (#6631)
+
+## Bug Fixes
+
+- Restricts protobuf dependency to < 4.24 due to protocolbuffers/protobuf#13485 (#6538)
+- Relaxes dependency on google-auth-oauthlib to allow versions 1.x < 2.0 (#6609, thanks @elgalu)
+
 # Release 2.14.1
 
 ## Bug Fixes

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,7 +15,7 @@
 
 """Contains the version string."""
 
-VERSION = "2.15.0a0"
+VERSION = "2.16.0a0"
 
 if __name__ == "__main__":
     print(VERSION)


### PR DESCRIPTION
- Cherry-pick the relnotes
- Update version for our nightly builds to the next number: 2.16.0a0
