### PR TITLE
Bug Fix: Make the runs data table only show a scrollbar when needed

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.scss
@@ -22,7 +22,7 @@ $_arrow_size: 16px;
 }
 
 :host {
-  overflow-y: scroll;
+  overflow-y: auto;
   width: 100%;
 }
 


### PR DESCRIPTION
## Motivation for features / changes
The runs table previously always showed the scroll bar. Now it only shows when there are enough runs.

## Screenshots of UI changes (or N/A)
Before (no scroll):
![image](https://github.com/tensorflow/tensorboard/assets/78179109/ab6f197e-1494-4c3a-b11d-88e181860e8b)

Before (with scroll):
![image](https://github.com/tensorflow/tensorboard/assets/78179109/ff5908ee-5a75-4153-9a93-d541c5980d51)

After (no scroll):
![image](https://github.com/tensorflow/tensorboard/assets/78179109/e287cf02-8cc2-4386-baee-505a5b406266)

After (with scroll):
![image](https://github.com/tensorflow/tensorboard/assets/78179109/78c45e94-38aa-4997-971d-d7148d548bda)

