### PR TITLE
data: define interface for `read_last_scalars`

### DIFF
--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -153,7 +153,7 @@ class FakeDataProvider(provider.DataProvider):
     def read_scalars(self, ctx=None, *, experiment_id):
         raise NotImplementedError()
 
-    def read_last_scalars(self, ctx=None, *, experiment_id):
+    def read_last_scalars(self, ctx=None, *, experiment_id, plugin_name):
         raise NotImplementedError()
 
 

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -153,6 +153,9 @@ class FakeDataProvider(provider.DataProvider):
     def read_scalars(self, ctx=None, *, experiment_id):
         raise NotImplementedError()
 
+    def read_last_scalars(self, ctx=None, *, experiment_id):
+        raise NotImplementedError()
+
 
 class HandlingErrorsTest(tb_test.TestCase):
     def test_successful_response_passes_through(self):

--- a/tensorboard/data/grpc_provider.py
+++ b/tensorboard/data/grpc_provider.py
@@ -155,11 +155,13 @@ class GrpcDataProvider(provider.DataProvider):
         ctx,
         *,
         experiment_id,
+        plugin_name,
         run_tag_filter=None,
     ):
         with timing.log_latency("build request"):
             req = data_provider_pb2.ReadScalarsRequest()
             req.experiment_id = experiment_id
+            req.plugin_filter.plugin_name = plugin_name
             _populate_rtf(run_tag_filter, req.run_tag_filter)
             # `ReadScalars` always includes the most recent datum, therefore
             # downsampling to one means fetching the latest value.

--- a/tensorboard/data/grpc_provider.py
+++ b/tensorboard/data/grpc_provider.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """A data provider that talks to a gRPC server."""
 
+import collections
 import contextlib
 
 import grpc
@@ -146,6 +147,42 @@ class GrpcDataProvider(provider.DataProvider):
                             value=value,
                         )
                         series.append(point)
+            return result
+
+    @timing.log_latency
+    def read_last_scalars(
+        self,
+        ctx,
+        *,
+        experiment_id,
+        run_tag_filter=None,
+    ):
+        with timing.log_latency("build request"):
+            req = data_provider_pb2.ReadScalarsRequest()
+            req.experiment_id = experiment_id
+            _populate_rtf(run_tag_filter, req.run_tag_filter)
+            # `ReadScalars` always includes the most recent datum, therefore
+            # downsampling to one means fetching the latest value.
+            req.downsample.num_points = 1
+        with timing.log_latency("_stub.ReadScalars"):
+            with _translate_grpc_error():
+                res = self._stub.ReadScalars(req)
+        with timing.log_latency("build result"):
+            result = collections.defaultdict(dict)
+            for run_entry in res.runs:
+                run_name = run_entry.run_name
+                for tag_entry in run_entry.tags:
+                    d = tag_entry.data
+                    # There should be no more than one datum in
+                    # `tag_entry.data` since downsample was set to 1.
+                    for (step, wt, value) in zip(d.step, d.wall_time, d.value):
+                        result[run_name][
+                            tag_entry.tag_name
+                        ] = provider.ScalarDatum(
+                            step=step,
+                            wall_time=wt,
+                            value=value,
+                        )
             return result
 
     @timing.log_latency

--- a/tensorboard/data/grpc_provider_test.py
+++ b/tensorboard/data/grpc_provider_test.py
@@ -255,6 +255,7 @@ class GrpcDataProviderTest(tb_test.TestCase):
         actual = self.provider.read_last_scalars(
             self.ctx,
             experiment_id="123",
+            plugin_name="scalars",
             run_tag_filter=provider.RunTagFilter(
                 runs=["train", "test", "nope"]
             ),
@@ -276,6 +277,7 @@ class GrpcDataProviderTest(tb_test.TestCase):
 
         req = data_provider_pb2.ReadScalarsRequest()
         req.experiment_id = "123"
+        req.plugin_filter.plugin_name = "scalars"
         req.run_tag_filter.runs.names.extend(
             ["nope", "test", "train"]
         )  # sorted

--- a/tensorboard/data/grpc_provider_test.py
+++ b/tensorboard/data/grpc_provider_test.py
@@ -275,14 +275,17 @@ class GrpcDataProviderTest(tb_test.TestCase):
 
         self.assertEqual(actual, expected)
 
-        req = data_provider_pb2.ReadScalarsRequest()
-        req.experiment_id = "123"
-        req.plugin_filter.plugin_name = "scalars"
-        req.run_tag_filter.runs.names.extend(
-            ["nope", "test", "train"]
-        )  # sorted
-        req.downsample.num_points = 1
-        self.stub.ReadScalars.assert_called_once_with(req)
+        expected_req = data_provider_pb2.ReadScalarsRequest(
+            experiment_id="123",
+            plugin_filter=data_provider_pb2.PluginFilter(plugin_name="scalars"),
+            run_tag_filter=data_provider_pb2.RunTagFilter(
+                runs=data_provider_pb2.RunFilter(
+                    names=["nope", "test", "train"]  # sorted
+                )
+            ),
+            downsample=data_provider_pb2.Downsample(num_points=1),
+        )
+        self.stub.ReadScalars.assert_called_once_with(expected_req)
 
     def test_list_tensors(self):
         res = data_provider_pb2.ListTensorsResponse()

--- a/tensorboard/data/grpc_provider_test.py
+++ b/tensorboard/data/grpc_provider_test.py
@@ -230,6 +230,58 @@ class GrpcDataProviderTest(tb_test.TestCase):
         req.downsample.num_points = 4
         self.stub.ReadScalars.assert_called_once_with(req)
 
+    def test_read_last_scalars(self):
+        tag1 = data_provider_pb2.ReadScalarsResponse.TagEntry(
+            tag_name="tag1",
+            data=data_provider_pb2.ScalarData(
+                step=[10000], wall_time=[1234.0], value=[1]
+            ),
+        )
+        tag2 = data_provider_pb2.ReadScalarsResponse.TagEntry(
+            tag_name="tag2",
+            data=data_provider_pb2.ScalarData(
+                step=[10000], wall_time=[1235.0], value=[0.50]
+            ),
+        )
+        run1 = data_provider_pb2.ReadScalarsResponse.RunEntry(
+            run_name="run1", tags=[tag1]
+        )
+        run2 = data_provider_pb2.ReadScalarsResponse.RunEntry(
+            run_name="run2", tags=[tag2]
+        )
+        res = data_provider_pb2.ReadScalarsResponse(runs=[run1, run2])
+        self.stub.ReadScalars.return_value = res
+
+        actual = self.provider.read_last_scalars(
+            self.ctx,
+            experiment_id="123",
+            run_tag_filter=provider.RunTagFilter(
+                runs=["train", "test", "nope"]
+            ),
+        )
+        expected = {
+            "run1": {
+                "tag1": provider.ScalarDatum(
+                    step=10000, wall_time=1234.0, value=1
+                ),
+            },
+            "run2": {
+                "tag2": provider.ScalarDatum(
+                    step=10000, wall_time=1235.0, value=0.50
+                ),
+            },
+        }
+
+        self.assertEqual(actual, expected)
+
+        req = data_provider_pb2.ReadScalarsRequest()
+        req.experiment_id = "123"
+        req.run_tag_filter.runs.names.extend(
+            ["nope", "test", "train"]
+        )  # sorted
+        req.downsample.num_points = 1
+        self.stub.ReadScalars.assert_called_once_with(req)
+
     def test_list_tensors(self):
         res = data_provider_pb2.ListTensorsResponse()
         run1 = res.runs.add(run_name="val")

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -259,6 +259,9 @@ class DataProvider(metaclass=abc.ABCMeta):
     ):
         """Read the most recent values from scalar time series.
 
+        The most recent scalar value for each tag under each run is retrieved
+        from the latest event (at the latest step).
+
         Args:
           ctx: A TensorBoard `RequestContext` value.
           experiment_id: ID of enclosing experiment.

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -215,7 +215,6 @@ class DataProvider(metaclass=abc.ABCMeta):
         ctx=None,
         *,
         experiment_id,
-        plugin_name,
         downsample=None,
         run_tag_filter=None,
     ):
@@ -224,8 +223,6 @@ class DataProvider(metaclass=abc.ABCMeta):
         Args:
           ctx: A TensorBoard `RequestContext` value.
           experiment_id: ID of enclosing experiment.
-          plugin_name: String name of the TensorBoard plugin that created
-            the data to be queried. Required.
           downsample: Integer number of steps to which to downsample the
             results (e.g., `1000`). The most recent datum (last scalar)
             should always be included. See `DataProvider` class docstring

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -259,8 +259,6 @@ class DataProvider(metaclass=abc.ABCMeta):
     ):
         """Read the most recent values from scalar time series.
 
-        Note that some impementations might not support all scalar types.
-
         Args:
           ctx: A TensorBoard `RequestContext` value.
           experiment_id: ID of enclosing experiment.

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -215,6 +215,7 @@ class DataProvider(metaclass=abc.ABCMeta):
         ctx=None,
         *,
         experiment_id,
+        plugin_name,
         downsample=None,
         run_tag_filter=None,
     ):
@@ -223,6 +224,8 @@ class DataProvider(metaclass=abc.ABCMeta):
         Args:
           ctx: A TensorBoard `RequestContext` value.
           experiment_id: ID of enclosing experiment.
+          plugin_name: String name of the TensorBoard plugin that created
+            the data to be queried. Required.
           downsample: Integer number of steps to which to downsample the
             results (e.g., `1000`). The most recent datum (last scalar)
             should always be included. See `DataProvider` class docstring

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -259,7 +259,7 @@ class DataProvider(metaclass=abc.ABCMeta):
     ):
         """Read the most recent values from scalar time series.
 
-        Note that some impementations might not support not all scalar types.
+        Note that some impementations might not support all scalar types.
 
         Args:
           ctx: A TensorBoard `RequestContext` value.

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -248,6 +248,42 @@ class DataProvider(metaclass=abc.ABCMeta):
         """
         pass
 
+    @abc.abstractmethod
+    def read_last_scalars(
+        self,
+        ctx=None,
+        *,
+        experiment_id,
+        plugin_name,
+        run_tag_filter=None,
+    ):
+        """Read the most recent values from scalar time series.
+
+        Note that some impementations might not support not all scalar types.
+
+        Args:
+          ctx: A TensorBoard `RequestContext` value.
+          experiment_id: ID of enclosing experiment.
+          plugin_name: String name of the TensorBoard plugin that created
+            the data to be queried. Required.
+          run_tag_filter: Optional `RunTagFilter` value. If provided, a datum
+            series will only be included in the result if its run and tag
+            both pass this filter. If `None`, all time series will be
+            included.
+
+        The result will only contain keys for run-tag combinations that
+        actually exist, which may not include all entries in the
+        `run_tag_filter`.
+
+        Returns:
+          A nested map `d` such that `d[run][tag]` is a `ScalarDatum`
+          representing the latest scalar in the time series.
+
+        Raises:
+          tensorboard.errors.PublicError: See `DataProvider` class docstring.
+        """
+        pass
+
     def list_tensors(
         self, ctx=None, *, experiment_id, plugin_name, run_tag_filter=None
     ):

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -522,6 +522,17 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
         del experiment_id, plugin_name, downsample, run_tag_filter
         raise TypeError("Debugger V2 DataProvider doesn't support scalars.")
 
+    def read_last_scalars(
+        self,
+        ctx=None,
+        *,
+        experiment_id,
+        plugin_name,
+        run_tag_filter=None,
+    ):
+        del experiment_id, plugin_name, run_tag_filter
+        raise TypeError("Debugger V2 DataProvider doesn't support scalars.")
+
     def list_blob_sequences(
         self, ctx=None, *, experiment_id, plugin_name, run_tag_filter=None
     ):


### PR DESCRIPTION
This will be used for `hparams.backend_context.read_last_scalars`.

Googlers, see b/292102513 for more context.

Tested internally at cl/577906864.

#hparams