### PR TITLE
Add a placeholder dependency for angular material progress spinner

### DIFF
--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -85,6 +85,7 @@ tf_ng_module(
         ":types",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
+        "//tensorboard/webapp/angular:expect_angular_material_progress_spinner",
         "//tensorboard/webapp/metrics/views/card_renderer:scalar_card_types",
         "//tensorboard/webapp/widgets/custom_modal",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:formatter",


### PR DESCRIPTION
## Motivation for features / changes
This spinner was added to the Data Table in #6658. However, I forgot to add the placeholder dependency which is required for internal syncs. This adds that dependency to fix the sync.