### PR TITLE
MDCMigration: Fix prev and next buttons for dark mode

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_component.scss
@@ -92,10 +92,8 @@ card-view {
 }
 
 .pagination-button {
-  @include tb-theme-foreground-prop(color, secondary-text);
   background-color: $metrics-button-background-color-on-gray;
-
-  &:disabled {
-    @include tb-theme-foreground-prop(color, disabled-text);
+  @include tb-dark-theme {
+    background-color: transparent;
   }
 }


### PR DESCRIPTION
## Motivation for features / changes
The new mat-button uses different colors in it's styling. This caused a readability problem with our Next and Prev buttons when enabled. This fixes the buttons to be readable and look nice. We decided the transparent background looked nice in dark mode but not in light mode. 

This was brought to our attention in #6651.

## Screenshots of UI changes (or N/A)
Before:
<img width="905" alt="Screenshot 2023-10-20 at 11 22 09 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/ffad969c-4fa0-4f45-af80-0975a5ad2756">
<img width="897" alt="Screenshot 2023-10-20 at 11 22 17 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/5fc01f59-7e6c-407d-929b-aac6bdcf0ac6">

After:
<img width="868" alt="Screenshot 2023-10-20 at 11 00 38 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/e8000574-910e-4fef-bb44-26b4faeb5966">
<img width="887" alt="Screenshot 2023-10-20 at 11 13 09 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/18b821d0-1942-43cd-a501-5d5b7549a8a6">

## Alternate designs / implementations considered (or N/A)
Also considered having a transparent background in light mode.