### PR TITLE
MDC Migration: Adjust image slider styling to get rid of card horizontal scroll bar.

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -145,7 +145,6 @@ $_title-to-heading-gap: 12px;
 
   mat-slider {
     margin-left: 6px;
-    margin-right: 6px;
   }
 }
 


### PR DESCRIPTION
The additional right margin on the image slider from #6666 adds an unnecessary horizontal scrollbar to the image card. I don't think the margin is necessary so I've just removed it.

Screenshot of changes:
![image](https://github.com/tensorflow/tensorboard/assets/17152369/e103706c-528c-442b-ba95-68911dbff567)
