### PR TITLE
Chore: Bring back RateLimiter.

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -211,6 +211,7 @@ py_test(
     name = "util_test",
     srcs = ["util_test.py"],
     deps = [
+        ":test_util",
         ":util",
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_protobuf_installed",

--- a/tensorboard/uploader/util.py
+++ b/tensorboard/uploader/util.py
@@ -19,6 +19,28 @@ import datetime
 import errno
 import os
 import os.path
+import time
+
+
+class RateLimiter:
+    """Helper class for rate-limiting using a fixed minimum interval."""
+
+    def __init__(self, interval_secs):
+        """Constructs a RateLimiter that permits a tick() every
+        `interval_secs`."""
+        self._time = time  # Use property for ease of testing.
+        self._interval_secs = interval_secs
+        self._last_called_secs = 0
+
+    def tick(self):
+        """Blocks until it has been at least `interval_secs` since last
+        tick()."""
+        wait_secs = (
+            self._last_called_secs + self._interval_secs - self._time.time()
+        )
+        if wait_secs > 0:
+            self._time.sleep(wait_secs)
+        self._last_called_secs = self._time.time()
 
 
 def get_user_config_directory():


### PR DESCRIPTION
We deleted the tensorboard.uploader.util.RateLImiter in #6638. However it is used internally and needs to be returned. This is therefore a partial rollback of #6638.
