### PR TITLE
Removes obsolete entryComponents from ngModules

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_module.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_module.ts
@@ -52,6 +52,5 @@ import {TimelineModule} from './views/timeline/timeline_module';
     PluginRegistryModule.forPlugin(PLUGIN_ID, DebuggerContainer),
   ],
   exports: [DebuggerContainer],
-  entryComponents: [DebuggerContainer],
 })
 export class DebuggerModule {}

--- a/tensorboard/webapp/alert/views/alert_snackbar_module.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_module.ts
@@ -26,9 +26,5 @@ import {AlertSnackbarContainer} from './alert_snackbar_container';
   declarations: [AlertSnackbarContainer, AlertDisplaySnackbarContainer],
   exports: [AlertSnackbarContainer],
   imports: [CommonModule, MatButtonModule, MatSnackBarModule],
-  entryComponents: [
-    // Required for non-Ivy Angular apps.
-    AlertDisplaySnackbarContainer,
-  ],
 })
 export class AlertSnackbarModule {}

--- a/tensorboard/webapp/app_routing/route_registry_module.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module.ts
@@ -92,7 +92,6 @@ export class RouteRegistryModule {
    *   imports: [
    *     RouteRegistryModule.registerRoutes(routesProvider),
    *   ],
-   *   entryComponents: [ScalarsDashboard]
    * })
    */
   static registerRoutes(

--- a/tensorboard/webapp/app_routing/views/router_outlet_test.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_test.ts
@@ -59,13 +59,7 @@ describe('router_outlet', () => {
         SecondTestableComponent,
       ],
       schemas: [NO_ERRORS_SCHEMA],
-    })
-      .overrideModule(BrowserDynamicTestingModule, {
-        set: {
-          entryComponents: [FirstTestableComponent, SecondTestableComponent],
-        },
-      })
-      .compileComponents();
+    }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getActiveRoute, null);

--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -67,7 +67,6 @@ import {
  *
  *    @NgModule({
  *      declarations: [MyCustomButtonComponent],
- *      entryComponents: [MyCustomButtonComponent],
  *      providers: [{
  *        provide: CustomizableButton,
  *        useClass: MyCustomButtonComponent,

--- a/tensorboard/webapp/customization/customization_test.ts
+++ b/tensorboard/webapp/customization/customization_test.ts
@@ -46,7 +46,6 @@ export class ParentComponent {
 @NgModule({
   imports: [CustomizationModule],
   declarations: [ParentComponent],
-  entryComponents: [ParentComponent],
 })
 export class ParentComponentModule {}
 
@@ -65,7 +64,6 @@ export class CustomizableComponent {}
  */
 @NgModule({
   declarations: [CustomizableComponent],
-  entryComponents: [CustomizableComponent],
   providers: [
     {
       provide: CustomizableComponentType,

--- a/tensorboard/webapp/feature_flag/views/feature_flag_dialog_module.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_dialog_module.ts
@@ -26,6 +26,5 @@ import {FeatureFlagDialogContainer} from './feature_flag_dialog_container';
   declarations: [FeatureFlagDialogComponent, FeatureFlagDialogContainer],
   imports: [CommonModule, MatButtonModule, MatSelectModule],
   exports: [FeatureFlagDialogContainer],
-  entryComponents: [FeatureFlagDialogContainer],
 })
 export class FeatureFlagDialogModule {}

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_module.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_module.ts
@@ -25,6 +25,6 @@ import {FeatureFlagDialogModule} from './feature_flag_dialog_module';
   declarations: [FeatureFlagModalTriggerContainer],
   imports: [CommonModule, FeatureFlagDialogModule],
   exports: [FeatureFlagModalTriggerContainer],
-  entryComponents: [FeatureFlagModalTriggerContainer],
 })
-export class FeatureFlagModalTriggerModule {}
+export class FeatureFlagModalTriggerModule {
+}

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_module.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_module.ts
@@ -26,5 +26,4 @@ import {FeatureFlagDialogModule} from './feature_flag_dialog_module';
   imports: [CommonModule, FeatureFlagDialogModule],
   exports: [FeatureFlagModalTriggerContainer],
 })
-export class FeatureFlagModalTriggerModule {
-}
+export class FeatureFlagModalTriggerModule {}

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -189,6 +189,5 @@ export function getRangeSelectionHeadersFactory() {
       useValue: METRICS_SETTINGS_DEFAULT,
     },
   ],
-  entryComponents: [MetricsDashboardContainer],
 })
 export class MetricsModule {}

--- a/tensorboard/webapp/metrics/views/card_renderer/data_download_module.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/data_download_module.ts
@@ -37,6 +37,5 @@ import {DataDownloadDialogContainer} from './data_download_dialog_container';
     MatSelectModule,
     MetricsDataSourceModule,
   ],
-  entryComponents: [DataDownloadDialogContainer],
 })
 export class DataDownloadModule {}

--- a/tensorboard/webapp/plugins/plugin_registry_module.ts
+++ b/tensorboard/webapp/plugins/plugin_registry_module.ts
@@ -53,7 +53,6 @@ export class PluginRegistryModule {
    *   imports: [
    *     PluginRegistryModule.forPlugin('scalars', ScalarsDashboard)
    *   ],
-   *   entryComponents: [ScalarsDashboard]
    * })
    */
   static forPlugin(

--- a/tensorboard/webapp/plugins/testing/index.ts
+++ b/tensorboard/webapp/plugins/testing/index.ts
@@ -26,6 +26,5 @@ export class ExtraDashboardComponent {}
   imports: [
     PluginRegistryModule.forPlugin('extra-plugin', ExtraDashboardComponent),
   ],
-  entryComponents: [ExtraDashboardComponent],
 })
 export class ExtraDashboardModule {}

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_module.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_module.ts
@@ -65,7 +65,6 @@ import {RunsTableContainer} from './runs_table_container';
     AlertModule,
   ],
   exports: [RunsTableContainer],
-  entryComponents: [RegexEditDialogContainer],
   declarations: [
     RegexEditDialogComponent,
     RegexEditDialogContainer,

--- a/tensorboard/webapp/settings/_views/settings_module.ts
+++ b/tensorboard/webapp/settings/_views/settings_module.ts
@@ -40,7 +40,6 @@ import {SettingsDialogContainer} from './settings_dialog_container';
     SettingsDialogContainer,
     SettingsPolymerInteropContainer,
   ],
-  entryComponents: [SettingsDialogContainer],
   imports: [
     CommonModule,
     FormsModule,

--- a/tensorboard/webapp/settings/_views/settings_test.ts
+++ b/tensorboard/webapp/settings/_views/settings_test.ts
@@ -72,13 +72,7 @@ describe('settings test', () => {
         SettingsButtonComponent,
         SettingsButtonContainer,
       ],
-    })
-      .overrideModule(BrowserDynamicTestingModule, {
-        set: {
-          entryComponents: [SettingsDialogContainer],
-        },
-      })
-      .compileComponents();
+    }).compileComponents();
     store = TestBed.inject<Store>(Store) as MockStore;
     dispatchSpy = spyOn(store, 'dispatch');
     overlayContainer = TestBed.inject(OverlayContainer);

--- a/tensorboard/webapp/tb_wrapper/tb_wrapper_module.ts
+++ b/tensorboard/webapp/tb_wrapper/tb_wrapper_module.ts
@@ -25,6 +25,5 @@ import {TensorBoardWrapperComponent} from './tb_wrapper_component';
   declarations: [TensorBoardWrapperComponent],
   imports: [CommonModule, PluginsModule, ReloaderModule],
   exports: [TensorBoardWrapperComponent],
-  entryComponents: [TensorBoardWrapperComponent],
 })
 export class TensorBoardWrapperModule {}


### PR DESCRIPTION
## Motivation for features / changes
As of Angular 12 the entryComponents aren't required anymore.

## Technical description of changes
Removes entryComponents properties fields from all ngModules calls.

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
