### PR TITLE
Hparams: Avoid retrieving metrics when populating timeseries runs table with hparams.

### DIFF
--- a/tensorboard/webapp/hparams/_redux/hparams_data_source.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_data_source.ts
@@ -20,6 +20,7 @@ import {
   Domain,
   DomainType,
   BackendListSessionGroupRequest,
+  BackendHparamsExperimentRequest,
   BackendHparamsExperimentResponse,
   BackendHparamSpec,
   DiscreteDomainHparamSpec,
@@ -90,12 +91,20 @@ export class HparamsDataSource {
     experimentIds: string[]
   ): Observable<HparamAndMetricSpec> {
     const formattedExperimentIds = this.formatExperimentIds(experimentIds);
+
+    const experimentRequest: BackendHparamsExperimentRequest = {
+      experimentName: formattedExperimentIds,
+      // The hparams feature generates its own metric data and does not require
+      // the backend to calculate it.
+      includeMetrics: false,
+    };
+
     return this.http
       .post<BackendHparamsExperimentResponse>(
         `/${this.getPrefix(
           experimentIds
         )}/${formattedExperimentIds}/${HPARAMS_HTTP_PATH_PREFIX}/experiment`,
-        {experimentName: formattedExperimentIds},
+        experimentRequest,
         {},
         'request'
       )
@@ -151,6 +160,9 @@ export class HparamsDataSource {
       startIndex: 0,
       // arbitrary large number so it does not get clipped.
       sliceSize: 1e6,
+      // The hparams feature generates its own metric data and does not require
+      // the backend to calculate it.
+      includeMetrics: false,
     };
 
     return this.http

--- a/tensorboard/webapp/hparams/_types.ts
+++ b/tensorboard/webapp/hparams/_types.ts
@@ -36,6 +36,7 @@ export {
   HparamSpec as BackendHparamSpec,
   DiscreteDomainHparamSpec,
   IntervalDomainHparamSpec,
+  BackendHparamsExperimentRequest,
   BackendHparamsExperimentResponse,
   BackendListSessionGroupResponse,
   BackendListSessionGroupRequest,

--- a/tensorboard/webapp/runs/data_source/runs_backend_types.ts
+++ b/tensorboard/webapp/runs/data_source/runs_backend_types.ts
@@ -85,6 +85,11 @@ export function isDiscreteDomainHparamSpec(
   return spec.hasOwnProperty('domainDiscrete');
 }
 
+export interface BackendHparamsExperimentRequest {
+  experimentName: string;
+  includeMetrics?: boolean;
+}
+
 export interface BackendHparamsExperimentResponse {
   description: string;
   hparamInfos: HparamSpec[];
@@ -108,6 +113,7 @@ export interface BackendListSessionGroupRequest {
   colParams: Array<HparamsColFilterParams | MetricsColFilterParams>;
   startIndex: number;
   sliceSize: number;
+  includeMetrics?: boolean;
 }
 
 export interface Session {


### PR DESCRIPTION
The runs table does not display any of the metric fields/data returned by the hparams plugin. We want to avoid unnecessarily calculating this data on the backend.

The hparams plugin allows requests to specify an include_metrics parameter (added in https://github.com/tensorflow/tensorboard/pull/6556). We set this flag to false for all hparams-related requests coming from the "hparams_data_source".

Testing:
* Observed in both OSS and internal TensorBoard that setting this flag to False results in responses that do not include the metric data.
* Observed that hparams in timeseries runs table still works.
* Observed that hparams in experiment list runs table still works.