### PR TITLE
Bug Fix: Always fire rangeValueChanged event when thumb is dragged

### DIFF
--- a/tensorboard/webapp/widgets/range_input/range_input_component.ng.html
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ng.html
@@ -32,12 +32,12 @@ limitations under the License.
 <mat-slider class="slider" [min]="min" [max]="max" [step]="calculateStepSize()">
   <input
     matSliderStartThumb
-    (valueChange)="startThumbDrag($event)"
+    (valueChange)="thumbDrag()"
     [(ngModel)]="lowerValue"
   />
   <input
     matSliderEndThumb
-    (valueChange)="endThumbDrag($event)"
+    (valueChange)="thumbDrag()"
     [(ngModel)]="upperValue"
   />
 </mat-slider>

--- a/tensorboard/webapp/widgets/range_input/range_input_component.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_component.ts
@@ -113,18 +113,12 @@ export class RangeInputComponent {
 
   readonly Position = Position;
 
-  startThumbDrag(value: number) {
-    this.maybeNotifyNextRangeValues(
-      [value, this.upperValue],
-      RangeInputSource.SLIDER
-    );
-  }
-
-  endThumbDrag(value: number) {
-    this.maybeNotifyNextRangeValues(
-      [this.lowerValue, value],
-      RangeInputSource.SLIDER
-    );
+  thumbDrag() {
+    this.rangeValuesChanged.emit({
+      lowerValue: this.lowerValue,
+      upperValue: this.upperValue,
+      source: RangeInputSource.SLIDER,
+    });
   }
 
   calculateStepSize() {

--- a/tensorboard/webapp/widgets/range_input/range_input_test.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_test.ts
@@ -120,7 +120,7 @@ describe('range input test', () => {
       );
     });
 
-    it('dispatches actions when making range step change', () => {
+    it('dispatches actions when slider emits valueChange event', () => {
       const {fixture, onRangeValuesChanged} = createComponent({
         lowerValue: -1,
         upperValue: 1,
@@ -130,9 +130,9 @@ describe('range input test', () => {
         By.css('mat-slider input')
       )[0];
 
-      sliderThumb.triggerEventHandler('valueChange', -4);
+      sliderThumb.triggerEventHandler('valueChange');
       expect(onRangeValuesChanged).toHaveBeenCalledWith({
-        lowerValue: -4,
+        lowerValue: -1,
         upperValue: 1,
         source: RangeInputSource.SLIDER,
       });
@@ -151,20 +151,6 @@ describe('range input test', () => {
       expect(slider.nativeElement.getAttribute('ng-reflect-step')).toEqual(
         '0.5'
       );
-    });
-
-    it('does not trigger change when value does not change', () => {
-      const {fixture, onRangeValuesChanged} = createComponent({
-        lowerValue: -5,
-        upperValue: 1,
-        tickCount: 10,
-      });
-      const sliderThumb = fixture.debugElement.queryAll(
-        By.css('mat-slider input')
-      )[0];
-
-      sliderThumb.triggerEventHandler('valueChange', -5);
-      expect(onRangeValuesChanged).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Motivation for features / changes
The rangeInputComponent was not triggering the rangeValueChanged event when dragging the slider thumb. This fixes that bug.

## Technical description of changes
The slider changes the value of lowerValue and upperValue while the thumb is being dragged. When dragging is stopped the component used to ensure the value sent in the event was different from the previous values by comparing it to the lowerValue and upperValue. This check always failed as the component now keeps these values up to date. It should be noted that if these values are not kept up to date the input fields do not update while dragging.

To solve I simply call the event every time without doing the check. If the value has not changed we update the state to the same value. This does cause an unnecessary repaint but that seems reasonable for when I user clicks the thumb and does not move it.

I decided I could simply ignore the value in the event as the lowerValue and upperValue properties are already updated. This simplifies the code by having one place to call no matter which thumb is dragged.