### PR TITLE
tbdev turndown: Remove references to TensorBoard.dev in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ Documentation on how to use TensorBoard to work with images, graphs, hyper
 parameters, and more are linked from there, along with tutorial walk-throughs in
 Colab.
 
-You may also be interested in the hosted TensorBoard solution at
-[TensorBoard.dev][]. You can use TensorBoard.dev to easily host, track, and
-share your ML experiments for free. For example, [this experiment][] shows a
-working example featuring the scalars, graphs, histograms, distributions, and
-hparams dashboards.
-
 TensorBoard is designed to run entirely offline, without requiring any access
 to the Internet. For instance, this may be on your local machine, behind a
 corporate firewall, or in a datacenter.


### PR DESCRIPTION
Continuing #6639 

tensorboard.dev is being shut down, removing the remaining reference in README.md following Commit 7cb91184 / PR #6639

## Motivation for features / changes

Tensorboard.dev is being shut down, PR #6639 updated the relevant documentations but didn't update README.md.

## Technical description of changes

Removed tensorboard.dev from README.md

## Screenshots of UI changes (or N/A)

N/A

## Detailed steps to verify changes work correctly (as executed by you)

N/A

## Alternate designs / implementations considered (or N/A)

N/A