### PR TITLE
Add types for metrics data source

### DIFF
--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -22,12 +22,29 @@ export declare interface Experiment {
   hparams?: string;
   tags?: string[];
   related_links?: Array<{name: string; url: string}>;
+  // The resource name of the default table serving the metrics data of the
+  // experiment, as in https://google.aip.dev/122. Format:
+  // repos/{repo-id}/tables/{table-id}
+  default_metrics_data_source?: string;
+  metrics_data_sources?: MetricsDataSource[];
   // These state values were chosen to follow these AIPs
   // https://google.aip.dev/164 and https://google.aip.dev/216.
   // However, we replaced 'delete' with 'hidden' as this feature is different
   // from the soft delete described in the AIP. In this case 'hidden' simply
   // means that the experiment is not shown in the experiment list.
   state?: 'active' | 'hidden' | 'unspecified';
+}
+
+export declare interface MetricsDataSource {
+  // The resource name of the table serving the metrics data of the
+  // experiment, as in https://google.aip.dev/122. Format:
+  // repos/{repo-id}/tables/{table-id}
+  name: string;
+  repo_id: string;
+  table_id: string;
+  // The Datatable UI url for for Datatable data source. Format:
+  // https://datatable/xid/{xid}/{table_path}
+  datatable_uri?: string;
 }
 
 export interface ExperimentAlias {


### PR DESCRIPTION
## Motivation for features / changes
Add the type and its corresponding fields of metrics data source to the Experiment type

## Technical description of changes
TB.corp backend already includes metrics data source in the HTTP response of Experiment related GET request. This PR adds the corresponding type and fields to the FE Experiment type to make metrics data source available in the Ngrx store.
## Screenshots of UI changes (or N/A)
This PR is the prerequisite of the Data Source Selector UI in TB.corp 

<img width="1062" alt="image" src="https://github.com/tensorflow/tensorboard/assets/88216042/b1c3a983-ebd3-4de3-8d75-260af8e351b8">

Googlers see cl/575344506 for implementation of this feature.