### PR TITLE
MDC Migration: Add padding to all new mdc dialog

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -280,7 +280,15 @@ $tb-dark-theme: map_merge(
   // Prevent color-picker from briefly showing scrollbar when calculating its
   // position.
   .cdk-overlay-container {
+    // Prevent color-picker from briefly showing scrollbar when calculating its
+    // position.
     contain: strict;
+    // The old dialog had a default 24px padding. When migrating to the
+    // new dialog this padding was added to avoid adding it to them all
+    // individually.
+    .mat-mdc-dialog-surface {
+      padding: 24px;
+    }
   }
 
   a:not(.mdc-button, .mdc-icon-button) {


### PR DESCRIPTION
## Motivation for features / changes
We missed some style issues in the MDC migration. This fixes those style issues. It is done inside the theme file to help facilitate the internal migration as well.

## Technical description of changes
The new mdc dialog does not have this 24px padding. The old one did. Therefore, all of our dialogs are built to assume it is there. Adding this padding keeps the dialogs from changes their design during the upgrade.
(Googlers see cl/580652255 for internal migration)

## Screenshots of UI changes (or N/A)
Before:
<img width="414" alt="Screenshot 2023-11-30 at 11 36 44 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/6780a147-a948-4da8-ac71-e8ce6cb35348">

After:
<img width="455" alt="Screenshot 2023-11-30 at 11 37 49 AM" src="https://github.com/tensorflow/tensorboard/assets/8672809/64f81c99-55a6-4608-9775-d3e0620859e1">

## Alternate designs / implementations considered (or N/A)
I considered adding the padding to individual dialogs.
