### PR TITLE
MDC Migration: remove padding to individual dialogs in favor of global padding setting

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
@@ -28,11 +28,11 @@ $padding-size: 16px;
       @include tb-theme-foreground-prop(color, link-visited);
     }
   }
-  padding: $padding-size;
+  padding-bottom: $padding-size;
 }
 
 .group-container {
-  margin: $padding-size;
+  margin: $padding-size 0;
 
   h4 {
     margin-bottom: $padding-size;

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.css
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.css
@@ -17,12 +17,11 @@ limitations under the License.
 }
 
 :host > div {
-  margin: 16px;
+  margin: 16px 0;
 }
 
 h3 {
   font-size: 20px;
-  margin: 16px;
 }
 
 .reload-toggle {

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -287,7 +287,7 @@ $tb-dark-theme: map_merge(
     // new dialog this padding was added to avoid adding it to them all
     // individually.
     .mat-mdc-dialog-surface {
-      padding: 24px;
+      padding: 16px;
     }
   }
 


### PR DESCRIPTION
## Motivation for features / changes
For consistency it would be better to have a global padding setting. The old mat-dialog had a default padding. During migration we added padding to a few components but we missed one. Internally we also have many more dialogs which look broken after migration. The global setting is less code to maintain and gives our dialogs consistency.

I added the global setting in #6689 but realized the stacking of the previously added padding during migration made some of the dialogs look bad.

## Screenshots of UI changes (or N/A)
![Screenshot 2023-12-01 at 3 38 31 PM](https://github.com/tensorflow/tensorboard/assets/8672809/bc288a0d-e495-4a0d-bad7-e7600ddbc916)

<img width="427" alt="Screenshot 2023-12-04 at 3 00 08 PM" src="https://github.com/tensorflow/tensorboard/assets/8672809/524ec2c4-3d66-49ef-a681-4cb26c5cab56">


![Screenshot 2023-12-01 at 3 40 41 PM](https://github.com/tensorflow/tensorboard/assets/8672809/9d417abb-4103-4d82-bec8-38dc475f7f34)
