### PR TITLE
Added compatibility for dark theme

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -489,7 +489,7 @@ export const template = html`
     }
     .expandbutton,
     .collapsebutton {
-      stroke: white;
+      stroke: #444;
     }
     /* Do not let the path elements in the button take pointer focus */
     .node > .nodeshape > .buttoncontainer > .expandbutton,

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -382,7 +382,7 @@ class TfGraphControls extends LegacyElementMixin(
       }
 
       .legend-clarifier {
-        color: #266236;
+        color: var(--tb-graph-controls-text-color);
         cursor: help;
         display: inline-block;
         text-decoration: underline;


### PR DESCRIPTION
## Motivation for features / changes
Issue #6276 
## Technical description of changes
The plus button and help icon were not visible in dark theme. Changed the color to the same color as name text.

## Screenshots of UI changes (or N/A)
Changed design for black
<img width="264" alt="Screenshot 2023-12-03 at 6 44 53 PM" src="https://github.com/tensorflow/tensorboard/assets/51014362/6703993b-114b-433c-9c5b-806e33c87dc1">

Working for all colors.
<img width="473" alt="Screenshot 2023-12-03 at 6 44 38 PM" src="https://github.com/tensorflow/tensorboard/assets/51014362/846a1e04-01d3-4d07-a95a-fe1af42d9df6">

Light theme:
<img width="329" alt="Screenshot 2023-12-03 at 6 44 57 PM" src="https://github.com/tensorflow/tensorboard/assets/51014362/39cd5f60-b4ae-4863-b10d-9b778d51e359">


Help icon
<img width="647" alt="Screenshot 2023-12-03 at 6 43 32 PM" src="https://github.com/tensorflow/tensorboard/assets/51014362/301bdabb-6333-474a-a7c5-36a55f202282">

## Detailed steps to verify changes work correctly (as executed by you)
Go to the graphs tab and select dark theme.

## Alternate designs / implementations considered (or N/A)
N/A