### PR TITLE
fix mat-button letter spacing style override

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -311,7 +311,10 @@ $tb-dark-theme: map_merge(
     a,
     button.mat-mdc-button-base {
       --tb-icon-size: 24px;
-      --mdc-typography-button-letter-spacing: normal;
+      --mdc-text-button-label-text-tracking: normal;
+      --mdc-filled-button-label-text-tracking: normal;
+      --mdc-outlined-button-label-text-tracking: normal;
+      --mdc-protected-button-label-text-tracking: normal;
 
       &[mat-icon-button].mat-mdc-icon-button {
         width: 40px;


### PR DESCRIPTION
- Angular Material is splitting the mat-button tokens into separate tokens for each button variant. This change is needed to land cl/586440723