### PR TITLE
mat-dialog style fix

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
@@ -28,11 +28,11 @@ $padding-size: 16px;
       @include tb-theme-foreground-prop(color, link-visited);
     }
   }
-  padding-bottom: $padding-size;
+  padding: $padding-size;
 }
 
 .group-container {
-  margin: $padding-size 0;
+  margin: $padding-size;
 
   h4 {
     margin-bottom: $padding-size;

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.css
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.css
@@ -22,6 +22,7 @@ limitations under the License.
 
 h3 {
   font-size: 20px;
+  margin: 0;
 }
 
 .reload-toggle {

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.ng.html
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.ng.html
@@ -42,7 +42,7 @@ limitations under the License.
   </div>
 </div>
 <div>
-  <mat-form-field>
+  <mat-form-field subscriptSizing="dynamic">
     <mat-label>Pagination Limit</mat-label>
     <input
       class="page-size"


### PR DESCRIPTION
## Motivation for features / changes
In #6690 I made some styling changes to a few dialogs. On closer inspection we did not like the way they looked. This fixes them to look a bit better.

## Technical description of changes
Most of this is just css. However, I did add a subscriptSizing="dynamic" to a mat-form-field. This is because without it the mat-form-field adds a div underneath which essentially was just unwanted padding.

## Screenshots of UI changes (or N/A)
Before:
![Screenshot 2023-12-07 at 3 06 01 PM](https://github.com/tensorflow/tensorboard/assets/8672809/e54b0bf9-37b9-46cd-962a-19d5a681f469)

![Screenshot 2023-12-07 at 3 06 16 PM](https://github.com/tensorflow/tensorboard/assets/8672809/cb3a565f-8a71-4ed7-9703-77b6d52acb6e)

After: 
![Screenshot 2023-12-07 at 3 01 00 PM](https://github.com/tensorflow/tensorboard/assets/8672809/f1bfb0e8-6d65-4b0f-9ee7-5d981f8d4536)

![Screenshot 2023-12-07 at 3 00 52 PM](https://github.com/tensorflow/tensorboard/assets/8672809/61fd0a76-af83-4417-9d68-35611b015ded)
