### PR TITLE
Pipe full experiment name to experiment alias component for tooltip

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -96,6 +96,7 @@ limitations under the License.
                 <span *ngSwitchCase="'experimentAlias'">
                   <tb-experiment-alias
                     [alias]="dataRow['experimentAlias']"
+                    [title]="dataRow['experimentName']"
                   ></tb-experiment-alias>
                 </span>
               </ng-container>

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -165,6 +165,7 @@ export class RunsTableContainer implements OnInit, OnDestroy {
           ...Object.fromEntries(runTableItem.hparams.entries()),
           id: runTableItem.run.id,
           run: runTableItem.run.name,
+          experimentName: runTableItem.experimentName,
           experimentAlias: runTableItem.experimentAlias,
           selected: runTableItem.selected,
           color: runTableItem.runColor,

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -265,6 +265,7 @@ describe('runs_table', () => {
             run: buildRun({id: 'book1', name: "The Philosopher's Stone"}),
             runColor: '#000',
             experimentAlias: {aliasText: 'book', aliasNumber: 1},
+            experimentName: 'Harry Potter',
             selected: true,
             hparams: new Map(),
           },
@@ -272,6 +273,7 @@ describe('runs_table', () => {
             run: buildRun({id: 'book2', name: 'The Chamber Of Secrets'}),
             runColor: '#111',
             experimentAlias: {aliasText: 'book', aliasNumber: 1},
+            experimentName: 'Harry Potter',
             selected: false,
             hparams: new Map(),
           },
@@ -290,6 +292,7 @@ describe('runs_table', () => {
           color: '#000',
           run: "The Philosopher's Stone",
           experimentAlias: {aliasNumber: 1, aliasText: 'book'},
+          experimentName: 'Harry Potter',
           selected: true,
         },
         {
@@ -297,6 +300,7 @@ describe('runs_table', () => {
           color: '#111',
           run: 'The Chamber Of Secrets',
           experimentAlias: {aliasNumber: 1, aliasText: 'book'},
+          experimentName: 'Harry Potter',
           selected: false,
         },
       ]);


### PR DESCRIPTION
## Motivation for features / changes
The experiment name tooltip broke when we migrated to the new RunsDataTable. This fixes that tooltip

## Screenshots of UI changes (or N/A)
Screenshot not available in OSS.