### PR TITLE
tbdev turndown: replace dev subcommand with shim

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -29,12 +29,12 @@ py_binary(
         ":assets_lib",  # link dep for webfiles assets
         ":default",
         ":dynamic_plugins",  # loads internal dynamic plugin like projector
+        ":legacy_tbdev_subcommand",
         ":lib",
         ":main_lib",
         ":program",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins:base_plugin",
-        "//tensorboard/uploader:uploader_subcommand",
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:timing",  # non-strict dep, for patching convenience
     ],
@@ -59,10 +59,10 @@ py_binary(
     deps = [
         ":default",
         ":dynamic_plugins",  # loads internal dynamic plugin like projector
+        ":legacy_tbdev_subcommand",
         ":lib",
         ":main_lib",
         ":program",
-        "//tensorboard/uploader:uploader_subcommand",
     ],
 )
 
@@ -646,4 +646,10 @@ py_test(
     srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [":lazy"],
+)
+
+py_library(
+    name = "legacy_tbdev_subcommand",
+    srcs = ["legacy_tbdev_subcommand.py"],
+    srcs_version = "PY3",
 )

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -25,10 +25,10 @@ import sys
 
 from absl import app
 from tensorboard import default
+from tensorboard import legacy_tbdev_subcommand
 from tensorboard import main_lib
 from tensorboard import program
 from tensorboard.plugins import base_plugin
-from tensorboard.uploader import uploader_subcommand
 from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
@@ -40,7 +40,7 @@ def run_main():
 
     tensorboard = program.TensorBoard(
         plugins=default.get_plugins(),
-        subcommands=[uploader_subcommand.UploaderSubcommand()],
+        subcommands=[legacy_tbdev_subcommand.LegacyTbdevSubcommand()],
     )
     try:
         app.run(tensorboard.main, flags_parser=tensorboard.configure)

--- a/tensorboard/main_dev.py
+++ b/tensorboard/main_dev.py
@@ -19,10 +19,10 @@ import sys
 
 from absl import app
 from tensorboard import default
+from tensorboard import legacy_tbdev_subcommand
 from tensorboard import main_lib
 from tensorboard import program
 from tensorboard.plugins import base_plugin
-from tensorboard.uploader import uploader_subcommand
 
 
 def run_main():
@@ -33,7 +33,7 @@ def run_main():
     tensorboard = program.TensorBoard(
         plugins=default.get_plugins(),
         assets_zip_provider=lambda: open(path, "rb"),
-        subcommands=[uploader_subcommand.UploaderSubcommand()],
+        subcommands=[legacy_tbdev_subcommand.LegacyTbdevSubcommand()],
     )
 
     try:


### PR DESCRIPTION
This replaces the `dev` subcommand with a shim that prints out a message about the turndown.

Unfortunately, the actual uploader code can't quite be deleted yet because Cloud AI Platform is depending on it still:
https://github.com/googleapis/python-aiplatform/blob/cd31c1306a9a00a01fbc1dda56fe99ed567a4cfb/google/cloud/aiplatform/tensorboard/uploader.py#L62-L65
