### PR TITLE
MDC migration: Fix notifications menu rendering after MDC migration.

### DIFF
--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -30,10 +30,11 @@ limitations under the License.
   width: $_dim;
 }
 
-::ng-deep .notification-menu.mat-menu-panel {
-  font-size: 13px;
+::ng-deep .notification-menu.mat-mdc-menu-panel {
   max-width: 350px;
   width: 350px;
+  --mat-menu-item-label-text-size: 13px;
+  --mat-menu-item-label-text-line-height: 15px;
 }
 
 .menu-item {
@@ -58,7 +59,6 @@ limitations under the License.
 }
 
 .content-wrapper {
-  line-height: 15px;
   margin-left: 20px;
   margin-top: 15px;
 }


### PR DESCRIPTION
The styling of the notifications menu, which is only used internally, was broken after MDC migration. This fixes it up.

Screenshots below are only available to Googlers.

Before migration:
https://screenshot.googleplex.com/3GKSmvthNeMbSUq

After migration, broken:
https://screenshot.googleplex.com/3YUdd2PLRPcneQv

After migration, fixed:
https://screenshot.googleplex.com/3uvLB54yWzhVSoL

(Note that, in the screenshots, the position of the "fixed" notifications menu is higher than before migration because the new MDC menu shifts up to accomodate content that is taller than the current viewport.)
