### PR TITLE
Enable isolatedModules.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "inlineSourceMap": true,
+    // Transpile each file as a separate module (similar to 'ts.transpileModule').
+    "isolatedModules": true,
     "lib": ["dom", "es2021", "dom.iterable"],
     "moduleResolution": "node",
     "module": "es2022",


### PR DESCRIPTION
Internal only, opt out from go/fast-tsjs-transpilation.

Googlers, see cl/599115946.

#oncall