### PR TITLE
Adds declare statement to ColumnHeader interface to squelch 1p error

### DIFF
--- a/tensorboard/webapp/widgets/data_table/types.ts
+++ b/tensorboard/webapp/widgets/data_table/types.ts
@@ -75,7 +75,7 @@ export interface FilterAddedEvent {
   value: IntervalFilter | DiscreteFilter;
 }
 
-export interface ColumnHeader {
+export declare interface ColumnHeader {
   type: ColumnHeaderType;
   name: string;
   displayName: string;


### PR DESCRIPTION
## Motivation for features / changes
As-is, tslint will complain that "Type ColumnHeader should have the `declare` modifier because type BackendSettings has it."