### PR TITLE
Fixes sync errors

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,13 +15,13 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check(
-    # Keep this version in sync with:
-    #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
-    minimum_bazel_version = "4.2.2",
     # Preemptively assume the next Bazel major version will break us, since historically they do,
     # and provide a clean error message in that case. Since the maximum version is inclusive rather
     # than exclusive, we set it to the 999th patch release of the current major version.
     maximum_bazel_version = "6.999.0",
+    # Keep this version in sync with:
+    #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
+    minimum_bazel_version = "4.2.2",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,13 +15,13 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check(
+    # Keep this version in sync with:
+    #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
+    minimum_bazel_version = "4.2.2",
     # Preemptively assume the next Bazel major version will break us, since historically they do,
     # and provide a clean error message in that case. Since the maximum version is inclusive rather
     # than exclusive, we set it to the 999th patch release of the current major version.
     maximum_bazel_version = "6.999.0",
-    # Keep this version in sync with:
-    #  * The BAZEL environment variable defined in .github/workflows/ci.yml, which is used for CI and nightly builds.
-    minimum_bazel_version = "4.2.2",
 )
 
 http_archive(

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, ActionReducer, createReducer, on} from '@ngrx/store';
-import {DataTableUtils} from '../../widgets/data_table/utils';
+import {dataTableUtils} from '../../widgets/data_table/utils';
 import {persistentSettingsLoaded} from '../../persistent_settings';
 import {Side} from '../../widgets/data_table/types';
 import * as actions from './hparams_actions';
@@ -153,7 +153,7 @@ const reducer: ActionReducer<HparamsState, Action> = createReducer(
     actions.dashboardHparamColumnOrderChanged,
     (state, {source, destination, side}) => {
       const {dashboardDisplayedHparamColumns: columns} = state;
-      const newColumns = DataTableUtils.moveColumn(
+      const newColumns = dataTableUtils.moveColumn(
         columns,
         source,
         destination,

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
@@ -18,8 +18,8 @@ import * as actions from './hparams_actions';
 import {reducers} from './hparams_reducers';
 import {buildHparamSpec, buildHparamsState, buildMetricSpec} from './testing';
 import {ColumnHeaderType, Side} from '../../widgets/data_table/types';
-import {DataTableUtils} from '../../widgets/data_table/utils';
 import {persistentSettingsLoaded} from '../../persistent_settings';
+import {dataTableUtils} from '../../widgets/data_table/utils';
 
 describe('hparams/_redux/hparams_reducers_test', () => {
   describe('#persistentSettingsLoaded', () => {
@@ -673,7 +673,7 @@ describe('hparams/_redux/hparams_reducers_test', () => {
         dashboardDisplayedHparamColumns: fakeColumns,
       });
       const moveColumnSpy = spyOn(
-        DataTableUtils,
+        dataTableUtils,
         'moveColumn'
       ).and.callThrough();
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -78,7 +78,7 @@ import {
   TimeSeriesData,
   TimeSeriesLoadable,
 } from './metrics_types';
-import {DataTableUtils} from '../../widgets/data_table/utils';
+import {dataTableUtils} from '../../widgets/data_table/utils';
 
 function buildCardMetadataList(tagMetadata: TagMetadata): CardMetadata[] {
   const results: CardMetadata[] = [];
@@ -1438,7 +1438,7 @@ const reducer = createReducer(
         dataTableMode === DataTableMode.RANGE
           ? [...state.rangeSelectionHeaders]
           : [...state.singleSelectionHeaders];
-      headers = DataTableUtils.moveColumn(headers, source, destination, side);
+      headers = dataTableUtils.moveColumn(headers, source, destination, side);
 
       if (dataTableMode === DataTableMode.RANGE) {
         return {

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -51,7 +51,7 @@ import {ColumnHeader, DataTableMode} from '../../widgets/data_table/types';
 import {Extent} from '../../widgets/line_chart_v2/lib/public_types';
 import {memoize} from '../../util/memoize';
 import {getDashboardDisplayedHparamColumns} from '../../hparams/_redux/hparams_selectors';
-import {DataTableUtils} from '../../widgets/data_table/utils';
+import {dataTableUtils} from '../../widgets/data_table/utils';
 
 const selectMetricsState =
   createFeatureSelector<MetricsState>(METRICS_FEATURE_KEY);
@@ -669,6 +669,6 @@ export const getGroupedHeadersForCard = memoize((cardId: string) =>
     getColumnHeadersForCard(cardId),
     getDashboardDisplayedHparamColumns,
     (standardColumns, hparamColumns) =>
-      DataTableUtils.groupColumns([...standardColumns, ...hparamColumns])
+      dataTableUtils.groupColumns([...standardColumns, ...hparamColumns])
   )
 );

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -31,7 +31,7 @@ import {
   ColumnHeader,
   DataTableMode,
 } from '../../../../widgets/data_table/types';
-import {map} from 'rxjs';
+import {map} from 'rxjs/operators';
 
 function headersWithoutRuns(headers: ColumnHeader[]) {
   return headers.filter((header) => header.type !== 'RUN');

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -340,6 +340,6 @@ export const getGroupedRunsTableHeaders = createSelector(
       }
       return newColumn;
     });
-    return DataTableUtils.groupColumns(columns);
+    return dataTableUtils.groupColumns(columns);
   }
 );

--- a/tensorboard/webapp/runs/store/runs_selectors.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors.ts
@@ -32,7 +32,7 @@ import {
 } from '../../hparams/_redux/hparams_selectors';
 import {HparamValue, RunToHparamsAndMetrics} from '../../hparams/types';
 import {ColumnHeader, SortingInfo} from '../../widgets/data_table/types';
-import {DataTableUtils} from '../../widgets/data_table/utils';
+import {dataTableUtils} from '../../widgets/data_table/utils';
 
 const getRunsState = createFeatureSelector<RunsState>(RUNS_FEATURE_KEY);
 

--- a/tensorboard/webapp/widgets/data_table/utils.ts
+++ b/tensorboard/webapp/widgets/data_table/utils.ts
@@ -80,7 +80,7 @@ function groupColumns(columns: ColumnHeader[]): ColumnHeader[] {
   return Array.from(headerGroups.values()).flat();
 }
 
-export const DataTableUtils = {
+export const dataTableUtils = {
   moveColumn,
   groupColumns,
 };

--- a/tensorboard/webapp/widgets/data_table/utils_test.ts
+++ b/tensorboard/webapp/widgets/data_table/utils_test.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {ColumnHeaderType, Side} from './types';
-import {DataTableUtils} from './utils';
+import {dataTableUtils} from './utils';
 
 describe('data table utils', () => {
   describe('groupColumns', () => {
@@ -58,7 +58,7 @@ describe('data table utils', () => {
         },
       ];
 
-      expect(DataTableUtils.groupColumns(inputColumns)).toEqual([
+      expect(dataTableUtils.groupColumns(inputColumns)).toEqual([
         {
           type: ColumnHeaderType.RUN,
           name: 'run',
@@ -128,7 +128,7 @@ describe('data table utils', () => {
     ];
 
     it('returns original headers if source is not found', () => {
-      const moveResult = DataTableUtils.moveColumn(
+      const moveResult = dataTableUtils.moveColumn(
         fakeColumns,
         {
           type: ColumnHeaderType.HPARAM,
@@ -149,7 +149,7 @@ describe('data table utils', () => {
     });
 
     it('returns original headers if source equals dest', () => {
-      const moveResult = DataTableUtils.moveColumn(
+      const moveResult = dataTableUtils.moveColumn(
         fakeColumns,
         {
           type: ColumnHeaderType.HPARAM,
@@ -190,7 +190,7 @@ describe('data table utils', () => {
       },
     ].forEach(({testDesc, side, expectedResult}) => {
       it(`if destination not found, moves source ${testDesc}`, () => {
-        const moveResult = DataTableUtils.moveColumn(
+        const moveResult = dataTableUtils.moveColumn(
           fakeColumns,
           fakeColumns[1],
           {
@@ -207,7 +207,7 @@ describe('data table utils', () => {
     });
 
     it('swaps source and destination positions if destination is found', () => {
-      const moveResult = DataTableUtils.moveColumn(
+      const moveResult = dataTableUtils.moveColumn(
         fakeColumns,
         fakeColumns[1],
         fakeColumns[0],


### PR DESCRIPTION
## Motivation for features / changes
Recently merged hparam column PRs (#6732, #6733, #6736) will cause build and lint errors during 1p sync.

## Technical description of changes
- import map from rxjs/operators instead of rxjs
- `DataTableUtils` -> `dataTableUtils`
- use proper string signature on CardStateMap in tests