### PR TITLE
Remove `strict_deps = False` from some sass rules, that are no longer necessary

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -246,7 +246,7 @@ def tf_svg_bundle(name, srcs, out):
         ],
     )
 
-def tf_sass_binary(deps = [], include_paths = [], strict_deps = True, **kwargs):
+def tf_sass_binary(deps = [], include_paths = [], **kwargs):
     """TensorBoard wrap for declaring SASS binary.
 
     It adds dependency on theme by default then add include Angular material

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -251,12 +251,7 @@ def tf_sass_binary(deps = [], include_paths = [], strict_deps = True, **kwargs):
 
     It adds dependency on theme by default then add include Angular material
     theme library paths for better node_modules library resolution.
-
-    strict_deps is included here and intentionally ignored so it can be used
-    internally.
     """
-    if (strict_deps):
-        fail("all tf_sass_binary calls need to have the strict_deps = False override for internal calls");
     sass_binary(
         deps = deps,
         include_paths = include_paths + [

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -246,11 +246,14 @@ def tf_svg_bundle(name, srcs, out):
         ],
     )
 
-def tf_sass_binary(deps = [], include_paths = [], **kwargs):
+def tf_sass_binary(deps = [], include_paths = [], strict_deps = True, **kwargs):
     """TensorBoard wrap for declaring SASS binary.
 
     It adds dependency on theme by default then add include Angular material
     theme library paths for better node_modules library resolution.
+
+    strict_deps is included here and intentionally ignored so it can be used
+    internally.
     """
     sass_binary(
         deps = deps,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -8,7 +8,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "debugger_component_style",
     src = "debugger_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "execution_data_styles",
     src = "execution_data_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
@@ -16,6 +16,7 @@ tf_sass_binary(
 tf_sass_binary(
     name = "graph_op_styles",
     src = "graph_op_component.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp/theme",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "graph_styles",
     src = "graph_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp/theme",
@@ -17,7 +16,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "graph_op_styles",
     src = "graph_op_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp/theme",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "graph_executions_styles",
     src = "graph_executions_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp/theme",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "source_files_component_style",
     src = "source_files_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "stack_trace_styles",
     src = "stack_trace_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -88,7 +88,6 @@ tf_ts_library(
 tf_sass_binary(
     name = "app_styles",
     src = "app_container.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 
@@ -385,6 +384,5 @@ tf_external_sass_libray(
 tf_sass_binary(
     name = "styles",
     src = "styles.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )

--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "alert_display_snackbar_styles",
     src = "alert_display_snackbar_container.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "alert_display_snackbar_styles",
     src = "alert_display_snackbar_container.scss",
+    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/core/views/BUILD
+++ b/tensorboard/webapp/core/views/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "layout_styles",
     src = "layout_container.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/feature_flag/views/BUILD
+++ b/tensorboard/webapp/feature_flag/views/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "style",
     src = "feature_flag_dialog_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/header/BUILD
+++ b/tensorboard/webapp/header/BUILD
@@ -7,14 +7,12 @@ licenses(["notice"])
 tf_sass_binary(
     name = "plugin_selector_styles",
     src = "plugin_selector_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 
 tf_sass_binary(
     name = "header_styles",
     src = "header_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/metrics/views/BUILD
+++ b/tensorboard/webapp/metrics/views/BUILD
@@ -12,7 +12,6 @@ tf_sass_library(
 tf_sass_binary(
     name = "metrics_container_styles",
     src = "metrics_container.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -79,6 +79,7 @@ tf_ng_module(
 tf_sass_binary(
     name = "histogram_card_styles",
     src = "histogram_card_component.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -255,6 +256,7 @@ tf_ts_library(
 tf_sass_binary(
     name = "scalar_card_styles",
     src = "scalar_card_component.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -264,6 +266,7 @@ tf_sass_binary(
 tf_sass_binary(
     name = "scalar_card_fob_controller_styles",
     src = "scalar_card_fob_controller.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -273,6 +276,7 @@ tf_sass_binary(
 tf_sass_binary(
     name = "scalar_card_data_table_styles",
     src = "scalar_card_data_table.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -366,6 +370,7 @@ tf_ng_module(
 tf_sass_binary(
     name = "scalar_card_line_chart_styles",
     src = "scalar_card_line_chart_component.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "card_view_styles",
     src = "card_view_container.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 
@@ -43,7 +42,6 @@ tf_ng_module(
 tf_sass_binary(
     name = "data_download_dialog_styles",
     src = "data_download_dialog_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 
@@ -81,7 +79,6 @@ tf_ng_module(
 tf_sass_binary(
     name = "histogram_card_styles",
     src = "histogram_card_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -131,7 +128,6 @@ tf_ng_module(
 tf_sass_binary(
     name = "image_card_styles",
     src = "image_card_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -179,7 +175,6 @@ tf_ng_module(
 tf_sass_binary(
     name = "run_name_styles",
     src = "run_name_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 
@@ -209,7 +204,6 @@ tf_ng_module(
 tf_sass_binary(
     name = "vis_linked_time_selection_warning_styles",
     src = "vis_linked_time_selection_warning_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -261,7 +255,6 @@ tf_ts_library(
 tf_sass_binary(
     name = "scalar_card_styles",
     src = "scalar_card_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -271,7 +264,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "scalar_card_fob_controller_styles",
     src = "scalar_card_fob_controller.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -281,7 +273,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "scalar_card_data_table_styles",
     src = "scalar_card_data_table.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -375,7 +366,6 @@ tf_ng_module(
 tf_sass_binary(
     name = "scalar_card_line_chart_styles",
     src = "scalar_card_line_chart_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "main_view_styles",
     src = "main_view_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -16,7 +15,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "filter_input_component_styles",
     src = "filter_input_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -26,7 +24,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "filtered_view_component_styles",
     src = "filtered_view_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -37,7 +34,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "pinned_view_component_styles",
     src = "pinned_view_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -48,7 +44,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "card_grid_component_styles",
     src = "card_grid_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -58,7 +53,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "card_groups_component_styles",
     src = "card_groups_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -68,7 +62,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "card_group_toolbar_component_styles",
     src = "card_group_toolbar_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -24,6 +24,7 @@ tf_sass_binary(
 tf_sass_binary(
     name = "filtered_view_component_styles",
     src = "filtered_view_component.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",

--- a/tensorboard/webapp/metrics/views/right_pane/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "settings_view_styles",
     src = "settings_view_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "scalar_column_editor_styles",
     src = "scalar_column_editor_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/notification_center/_views/BUILD
+++ b/tensorboard/webapp/notification_center/_views/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "notification_center_styles",
     src = "notification_center_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "plugins_component_styles",
     src = "plugins_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "runs_group_menu_button_styles",
     src = "runs_group_menu_button_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -17,21 +16,18 @@ tf_sass_binary(
 tf_sass_binary(
     name = "regex_edit_dialog_styles",
     src = "regex_edit_dialog_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 
 tf_sass_binary(
     name = "filterbar_styles",
     src = "filterbar_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 
 tf_sass_binary(
     name = "runs_data_table_styles",
     src = "runs_data_table.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/card_fob/BUILD
+++ b/tensorboard/webapp/widgets/card_fob/BUILD
@@ -14,6 +14,7 @@ tf_sass_binary(
 tf_sass_binary(
     name = "card_fob_controller_styles",
     src = "card_fob_controller_component.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/card_fob/BUILD
+++ b/tensorboard/webapp/widgets/card_fob/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "card_fob_styles",
     src = "card_fob_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -15,7 +14,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "card_fob_controller_styles",
     src = "card_fob_controller_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/content_wrapping_input/BUILD
+++ b/tensorboard/webapp/widgets/content_wrapping_input/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "content_wrapping_input_component_styles",
     src = "content_wrapping_input_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -23,6 +23,7 @@ tf_sass_binary(
 tf_sass_binary(
     name = "content_cell_styles",
     src = "content_cell_component.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
     ],
@@ -31,6 +32,7 @@ tf_sass_binary(
 tf_sass_binary(
     name = "data_table_header_styles",
     src = "data_table_header_component.scss",
+    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "data_table_styles",
     src = "data_table_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -15,7 +14,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "header_cell_styles",
     src = "header_cell_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -25,7 +23,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "content_cell_styles",
     src = "content_cell_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
     ],
@@ -34,7 +31,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "data_table_header_styles",
     src = "data_table_header_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -44,7 +40,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "column_selector_component_styles",
     src = "column_selector_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -54,7 +49,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "filter_dialog_styles",
     src = "filter_dialog_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "dropdown_styles",
     src = "dropdown_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/experiment_alias/BUILD
+++ b/tensorboard/webapp/widgets/experiment_alias/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "experiment_alias_component_styles",
     src = "experiment_alias_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/filter_input/BUILD
+++ b/tensorboard/webapp/widgets/filter_input/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "filter_input_component_styles",
     src = "filter_input_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "histogram_styles",
     src = "histogram_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "line_chart_styles",
     src = "line_chart_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -14,6 +14,7 @@ tf_sass_binary(
 tf_sass_binary(
     name = "line_chart_interactive_view_styles",
     src = "line_chart_interactive_view.scss",
+    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "line_chart_axis_view_styles",
     src = "line_chart_axis_view.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -15,7 +14,6 @@ tf_sass_binary(
 tf_sass_binary(
     name = "line_chart_interactive_view_styles",
     src = "line_chart_interactive_view.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/range_input/BUILD
+++ b/tensorboard/webapp/widgets/range_input/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 tf_sass_binary(
     name = "range_input_styles",
     src = "range_input_component.scss",
-    strict_deps = False,
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/text/BUILD
+++ b/tensorboard/webapp/widgets/text/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 tf_sass_binary(
     name = "truncated_path_styles",
     src = "truncated_path_component.scss",
-    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/text/BUILD
+++ b/tensorboard/webapp/widgets/text/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 tf_sass_binary(
     name = "truncated_path_styles",
     src = "truncated_path_component.scss",
+    strict_deps = False,
     deps = ["//tensorboard/webapp/theme"],
 )
 


### PR DESCRIPTION
`strict_deps = False` in sass rules were originally added due to requirements from internal code base in #6184, but *some of them* are now being removed.

Googlers, see b/323361346.

This should be a no-op for OSS.