### PR TITLE
Avoids bad protobuf version 4.24.0

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -25,7 +25,7 @@ numpy >= 1.12.0
 # version to be installed that is also compatible with TensorFlow's constraints:
 # https://github.com/tensorflow/tensorflow/blob/25adc4fccb4b0bb5a933eba1d246380e7b87d7f7/tensorflow/tools/pip_package/setup.py#L101
 # 4.24.0 had an issue that broke our tests, so we should avoid that release:
-# protocolbuffers/protobuf#13485
+# https://github.com/protocolbuffers/protobuf/issues/13485
 protobuf >= 3.19.6, != 4.24.0
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # A dependency of our vendored packages. This lower bound has not been correctly

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -24,6 +24,8 @@ numpy >= 1.12.0
 # At the same time, any constraints we specify here must allow at least some
 # version to be installed that is also compatible with TensorFlow's constraints:
 # https://github.com/tensorflow/tensorflow/blob/25adc4fccb4b0bb5a933eba1d246380e7b87d7f7/tensorflow/tools/pip_package/setup.py#L101
+# 4.24.0 had an issue that broke our tests, so we should avoid that release:
+# protocolbuffers/protobuf#13485
 protobuf >= 3.19.6, != 4.24.0
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # A dependency of our vendored packages. This lower bound has not been correctly

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -34,5 +34,4 @@ tensorboard-data-server >= 0.7.0, < 0.8.0
 # Stay on Keras 2 for now: https://github.com/keras-team/keras/issues/18467.
 # TODO: Remove this after migrating to Keras 3.
 tf-keras >= 2.15.0
-werkzeug >= 1.0.1
-
+werkzeug >= 1.0.1 

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -24,7 +24,7 @@ numpy >= 1.12.0
 # At the same time, any constraints we specify here must allow at least some
 # version to be installed that is also compatible with TensorFlow's constraints:
 # https://github.com/tensorflow/tensorflow/blob/9d22f4a0a9499c8e10a4312503e63e0da35ccd94/tensorflow/tools/pip_package/setup.py#L100-L107
-protobuf >= 3.19.6
+protobuf >= 3.19.6, != 4.24.0
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # A dependency of our vendored packages. This lower bound has not been correctly
 # vetted, but I wanted to be the least restrictive we can, since it's not a new

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -34,4 +34,4 @@ tensorboard-data-server >= 0.7.0, < 0.8.0
 # Stay on Keras 2 for now: https://github.com/keras-team/keras/issues/18467.
 # TODO: Remove this after migrating to Keras 3.
 tf-keras >= 2.15.0
-werkzeug >= 1.0.1 
+werkzeug >= 1.0.1

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -23,7 +23,7 @@ numpy >= 1.12.0
 # NOTE: this version must be >= the protoc version in our WORKSPACE file.
 # At the same time, any constraints we specify here must allow at least some
 # version to be installed that is also compatible with TensorFlow's constraints:
-# https://github.com/tensorflow/tensorflow/blob/9d22f4a0a9499c8e10a4312503e63e0da35ccd94/tensorflow/tools/pip_package/setup.py#L100-L107
+# https://github.com/tensorflow/tensorflow/blob/25adc4fccb4b0bb5a933eba1d246380e7b87d7f7/tensorflow/tools/pip_package/setup.py#L101
 protobuf >= 3.19.6, != 4.24.0
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # A dependency of our vendored packages. This lower bound has not been correctly

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -35,3 +35,4 @@ tensorboard-data-server >= 0.7.0, < 0.8.0
 # TODO: Remove this after migrating to Keras 3.
 tf-keras >= 2.15.0
 werkzeug >= 1.0.1
+


### PR DESCRIPTION
I should have added this condition in #6660. At the time I thought it wouldn't matter much, as I assumed users would most likely get a newer version installed, but on second thought, it would be better to have this check, just in case.