### PR TITLE
TensorBoard 2.15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ env:
   BUILDTOOLS_VERSION: '3.0.0'
   BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
   BUILDOZER_SHA256SUM: '3d58a0b6972e4535718cdd6c12778170ea7382de7c75bc3728f5719437ffb84d'
-  TENSORFLOW_VERSION: 'tf-nightly==2.15.0.dev20231011'
+  # By the time we created TB patch release 2.15.2 TF 2.15.0 had already been
+  # released, and there were no more nightly versions available.
+  # This is the latest release available for TF 2.15.x.
+  TENSORFLOW_VERSION: 'tensorflow==2.15.0.post1'
 
 jobs:
   build:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,15 @@
+# Release 2.15.2
+
+## Breaking Changes
+
+- Updates restriction on protobuf dependency to avoid bad version while still
+  allowing newer versions.(#6660 & #6746)
+
 # Release 2.15.1
 
 ## Breaking Changes
 
-- TensorBoard.dev is shutting down. See the FAQ at https://tensorboard.dev.
+  - TensorBoard.dev is shutting down. See the FAQ at https://tensorboard.dev.
   - No longer able to upload new data to TensorBoard.dev. The `tensorboard dev upload` command will fail. (#6638)
   - The experimental dataframe api has been deleted. (#6644)
 

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,9 +26,7 @@ numpy >= 1.12.0
 # At the same time, any constraints we specify here must allow at least some
 # version to be installed that is also compatible with TensorFlow's constraints:
 # https://github.com/tensorflow/tensorflow/blob/9d22f4a0a9499c8e10a4312503e63e0da35ccd94/tensorflow/tools/pip_package/setup.py#L100-L107
-# We needed to add an upper bound restriction due to issue reported in:
-# https://github.com/protocolbuffers/protobuf/issues/13485
-protobuf >= 3.19.6, < 4.24
+protobuf >= 3.19.6, != 4.24.0
 requests >= 2.21.0, < 3
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # A dependency of our vendored packages. This lower bound has not been correctly

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,7 +15,7 @@
 
 """Contains the version string."""
 
-VERSION = "2.15.1"
+VERSION = "2.15.2"
 
 if __name__ == "__main__":
     print(VERSION)


### PR DESCRIPTION
Patch release to relax the protobuf dependency restriction that we introduced when their release broke our CI workflow.