### PR TITLE
Change icon size value to override material CSS value instead

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_component.scss
@@ -16,7 +16,6 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 
 ::ng-deep .run-table-color-group-by {
-  $_icon-size: 20px;
   font-size: 16px;
 
   .label {
@@ -28,8 +27,7 @@ limitations under the License.
   }
 
   mat-icon {
-    height: $_icon-size;
-    width: $_icon-size;
+    --mat-menu-item-icon-size: 20px;
   }
 
   .display-regex-string {


### PR DESCRIPTION
## Motivation for features / changes
Override the CSS variable (part of M3 work done here: https://github.com/angular/components/pull/28470) that now exists for icon size in menu, the correct way of overriding this value.

## Technical description of changes

## Screenshots of UI changes (or N/A)
Slight padding changes will show in screenshots, the menu is now closer to the M2 spec.

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
