### PR TITLE
Fixes hparam columns from breaking multi-experiment scalar cards

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -270,7 +270,7 @@ export class ScalarCardDataTable {
                 (metadata as SmoothedSeriesMetadata).originalSeriesId ||
                 metadata.id;
               selectedStepData[header.name] =
-                this.runToHparamMap?.[runId].get(header.name) ?? '';
+                this.runToHparamMap?.[runId]?.get(header.name) ?? '';
               continue;
             default:
               continue;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -4091,6 +4091,35 @@ describe('scalar card', () => {
         ]);
       }));
 
+      // This can easily happen in multi-experiment Time Series dashboards.
+      it('shows empty cells for runs that do not have given hparams', fakeAsync(() => {
+        store.overrideSelector(
+          commonSelectors.getFilteredRenderableRunsIds,
+          new Set(['run1', 'run2'])
+        );
+        store.overrideSelector(runsSelectors.getRunToHparamMap, {});
+        const fixture = createComponent('card1');
+        const scalarCardDataTable = fixture.debugElement.query(
+          By.directive(ScalarCardDataTable)
+        );
+
+        const data =
+          scalarCardDataTable.componentInstance.getTimeSelectionTableData();
+
+        expect(data).toEqual([
+          jasmine.objectContaining({
+            id: 'run1',
+            conv_layers: '',
+            conv_kernel_size: '',
+          }),
+          jasmine.objectContaining({
+            id: 'run2',
+            conv_layers: '',
+            conv_kernel_size: '',
+          }),
+        ]);
+      }));
+
       it('shows hparam values with smoothing enabled', fakeAsync(() => {
         store.overrideSelector(
           commonSelectors.getFilteredRenderableRunsIds,


### PR DESCRIPTION
## Motivation for features / changes
Currently [scalar_card_data_table.ts:273](https://github.com/tensorflow/tensorboard/blob/5033fef6cf89f5f539b6ec56e193689d98daa6cf/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts#L273) will throw an error if the scalar card table does not contain the corresponding hparam column data - this will happen often for multi-experiment dashboards.

## Technical description of changes
- Extends the optional chaining to the get() call (this was the original intent)
- Adds test to prevent regression