### PR TITLE
TensorBoard 2.16.1 release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+# Release 2.16.1
+
+## Bug Fixes
+- Depend on tf-keras instead of tf-keras-nightly.
+
 # Release 2.16.0
 
 The 2.16 minor series tracks TensorFlow 2.16.

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,7 +15,7 @@
 
 """Contains the version string."""
 
-VERSION = "2.16.0"
+VERSION = "2.16.1"
 
 if __name__ == "__main__":
     print(VERSION)


### PR DESCRIPTION
The TensorBoard 2.16.0 release depends on tf-keras-nightly, which is bad.
I will perform a TensorBoard 2.16.1 release that depends on tf-keras instead.

These commits prepare for the release. I will rebase and merge them.
