### PR TITLE
Release notes for TensorBoard 2.16.1.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+# Release 2.16.1
+
+## Bug Fixes
+- Depend on tf-keras instead of tf-keras-nightly.
+
 # Release 2.16.0
 
 The 2.16 minor series tracks TensorFlow 2.16.


### PR DESCRIPTION
Cherry-picks release notes from TensorBoard 2.16.1  from 2.16 branch to master branch.