### PR TITLE
Migrate hparams plugin to Keras 3 and remove Keras 2 from requirements.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,8 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install "${TENSORFLOW_VERSION}"
+          pip install "${TF_KERAS_VERSION}"
         if: matrix.tf_version_id != 'notf'
-      # Replace the `tf-keras` with `tf-keras-nightly` in the requirements.txt
-      # to avoid incompatibilities when using alongside `tf-nightly`.
-      # TODO: Remove this after migrating to Keras 3.
-      - name: 'Make user to use tf-keras-nightly with tf-nightly'
-        run: |
-          sed -i "s/^tf-keras.*/${TF_KERAS_VERSION}/g" ./tensorboard/pip_package/requirements.txt
       - name: 'Install Python dependencies'
         run: |
           python -m pip install -U pip

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -33,7 +33,4 @@ setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # requirement, and likely this will not disrupt existing users of the package.
 six > 1.9
 tensorboard-data-server >= 0.7.0, < 0.8.0
-# Stay on Keras 2 for now: https://github.com/keras-team/keras/issues/18467.
-# TODO: Remove this after migrating to Keras 3.
-tf-keras >= 2.15.0
 werkzeug >= 1.0.1

--- a/tensorboard/plugins/hparams/_keras.py
+++ b/tensorboard/plugins/hparams/_keras.py
@@ -24,15 +24,8 @@ from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import summary
 from tensorboard.plugins.hparams import summary_v2
 
-# Stay on Keras 2 for now: https://github.com/keras-team/keras/issues/18467.
-version_fn = getattr(tf.keras, "version", None)
-if version_fn and version_fn().startswith("3."):
-    import tf_keras as keras  # Keras 2
-else:
-    keras = tf.keras  # Keras 2
 
-
-class Callback(keras.callbacks.Callback):
+class Callback(tf.keras.callbacks.Callback):
     """Callback for logging hyperparameters to TensorBoard.
 
     NOTE: This callback only works in TensorFlow eager mode.
@@ -41,7 +34,7 @@ class Callback(keras.callbacks.Callback):
     def __init__(self, writer, hparams, trial_id=None):
         """Create a callback for logging hyperparameters to TensorBoard.
 
-        As with the standard `keras.callbacks.TensorBoard` class, each
+        As with the standard `tf.keras.callbacks.TensorBoard` class, each
         callback object is valid for only one call to `model.fit`.
 
         Args:


### PR DESCRIPTION
We must still install keras 2 as part of CI in order to successfully run graph plugin tests.