### PR TITLE
BUILD: strip for release build

### DIFF
--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -133,3 +133,6 @@ data_attr = "glob([\"src/**/*.der\"])"
 [package.metadata.raze.crates.webpki.'0.22.0']
 gen_buildrs = true
 data_attr = "glob([\"src/**/*.der\"])"
+
+[profile.release]
+strip = true


### PR DESCRIPTION
## Motivation for features / changes

Potential improvement to the build: reduce the binary size by ~5Mb

## Technical description of changes

Run `strip` on release build so that [whatever strip does to the binary] is not shipped in the production build.

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)

Run `cargo build --release`, with and without the change, to observe the binary size (as tested on M1 Mac) reducing from 14Mb to 9.5Mb

## Alternate designs / implementations considered (or N/A)
