### PR TITLE
Fix regex dialog 'Save' text color

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_component.scss
@@ -115,7 +115,3 @@ mat-form-field {
     margin-top: $padding-size;
   }
 }
-
-.save-button {
-  color: inherit;
-}


### PR DESCRIPTION
The regex dialog "Save" button is rendered poorly internaly, dark text on dark background.

The color of the button text was changed to 'inherit' in go/tbpr/6631. It doesn't seem to have been necessary so I revert that particular change here.

It means in OSS TensorBoard the button text color will be slightly darker than previously. I didn't personally notice the difference but internal screenshot tests show a slight difference. Googlers, see cr/612557079.
