### PR TITLE
Bump webtesting rules version.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ http_archive(
     name = "io_bazel_rules_webtesting",
     sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
     urls = [
-#        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz",
+        #        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz",
         "https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ http_archive(
     name = "io_bazel_rules_webtesting",
     sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
     urls = [
-        #        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz",
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz",
         "https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,11 +55,11 @@ py_repositories()
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "b2ead8bdcf6d2d56b9cb797699a0ea707d33998edb9067825a588d9ccd3805e0",
-    strip_prefix = "rules_closure-c56b953045c883b393d6f0f5dbf9900df71949c1",
+    sha256 = "6a900831c1eb8dbfc9d6879b5820fd614d4ea1db180eb5ff8aedcb75ee747c1f",
+    strip_prefix = "rules_closure-db4683a2a1836ac8e265804ca5fa31852395185b",
     urls = [
-        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_closure/archive/c56b953045c883b393d6f0f5dbf9900df71949c1.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/c56b953045c883b393d6f0f5dbf9900df71949c1.tar.gz", # 2024-02-28
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_closure/archive/db4683a2a1836ac8e265804ca5fa31852395185b.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/db4683a2a1836ac8e265804ca5fa31852395185b.tar.gz",  # 2020-01-15
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,10 +26,10 @@ versions.check(
 
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
+    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
     urls = [
-        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz",
-        "https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz",
+#        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz",
+        "https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,11 +55,11 @@ py_repositories()
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "6a900831c1eb8dbfc9d6879b5820fd614d4ea1db180eb5ff8aedcb75ee747c1f",
-    strip_prefix = "rules_closure-db4683a2a1836ac8e265804ca5fa31852395185b",
+    sha256 = "b2ead8bdcf6d2d56b9cb797699a0ea707d33998edb9067825a588d9ccd3805e0",
+    strip_prefix = "rules_closure-c56b953045c883b393d6f0f5dbf9900df71949c1",
     urls = [
-        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_closure/archive/db4683a2a1836ac8e265804ca5fa31852395185b.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/db4683a2a1836ac8e265804ca5fa31852395185b.tar.gz",  # 2020-01-15
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_closure/archive/c56b953045c883b393d6f0f5dbf9900df71949c1.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/c56b953045c883b393d6f0f5dbf9900df71949c1.tar.gz", # 2024-02-28
     ],
 )
 

--- a/third_party/chromium/BUILD
+++ b/third_party/chromium/BUILD
@@ -1,5 +1,3 @@
-load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_archive")
-
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
@@ -14,25 +12,22 @@ config_setting(
     values = {"cpu": "k8"},
 )
 
-web_test_archive(
+alias(
     name = "chromium",
-    archive = "@org_chromium_chromium//file",
-    extract = "build",
-    named_files = select({
-        ":linux": {
-            "CHROMIUM": "chrome-linux/chrome",
-        },
-        ":mac": {
-            "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/chromium",
-        },
+    testonly = True,
+    actual = select({
+        ":linux": "@org_chromium_chromium_linux_x64//:metadata",
+        ":mac": "@org_chromium_chromium_macos//:metadata",
     }),
     visibility = ["//tensorboard/functionaltests/browsers:__pkg__"],
 )
 
-web_test_archive(
+alias(
     name = "chromedriver",
-    archive = "@org_chromium_chromedriver//file",
-    extract = "build",
-    named_files = {"CHROMEDRIVER": "chromedriver"},
+    testonly = True,
+    actual = select({
+        ":linux": "@org_chromium_chromedriver_linux_x64//:metadata",
+        ":mac": "@org_chromium_chromedriver_macos//:metadata",
+    }),
     visibility = ["//tensorboard/functionaltests/browsers:__pkg__"],
 )

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -18,6 +18,7 @@ TensorBoard external dependencies that can be loaded in WORKSPACE files.
 
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@io_bazel_rules_webtesting//web:web.bzl", "platform_archive")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 load("//third_party:fonts.bzl", "tensorboard_fonts_workspace")
 load("//third_party:python.bzl", "tensorboard_python_workspace")
 load("//third_party:js.bzl", "tensorboard_js_workspace")
@@ -45,6 +46,10 @@ def tensorboard_workspace(name = ""):
         name = "grpc_python_plugin",
         actual = "@com_github_grpc_grpc//src/compiler:grpc_python_plugin",
     )
+
+    # We use our own browser definition below, but this seems to be required by
+    # bazel if we want to reference the new version of rules_webtesting.
+    browser_repositories(chromium = True)
 
     # Chromium browser for multiple platforms, pinned to Chromium 84.0.4147.0.
     platform_archive(

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -48,7 +48,7 @@ def tensorboard_workspace(name = ""):
     )
 
     # We use our own browser definition below, but this seems to be required by
-    # bazel if we want to reference the new version of rules_webtesting.
+    # the rules_webtesting dependency.
     browser_repositories(chromium = True)
 
     # Chromium browser for multiple platforms, pinned to Chromium 84.0.4147.0.

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -17,7 +17,7 @@ TensorBoard external dependencies that can be loaded in WORKSPACE files.
 """
 
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
-load("@io_bazel_rules_webtesting//web/internal:platform_http_file.bzl", "platform_http_file")  # buildifier: disable=bzl-visibility
+load("@io_bazel_rules_webtesting//web:web.bzl", "platform_archive")
 load("//third_party:fonts.bzl", "tensorboard_fonts_workspace")
 load("//third_party:python.bzl", "tensorboard_python_workspace")
 load("//third_party:js.bzl", "tensorboard_js_workspace")
@@ -46,44 +46,72 @@ def tensorboard_workspace(name = ""):
         actual = "@com_github_grpc_grpc//src/compiler:grpc_python_plugin",
     )
 
-    platform_http_file(
-        name = "org_chromium_chromium",  # pinned to Chromium 84.0.4147.0
+    # Chromium browser for multiple platforms, pinned to Chromium 84.0.4147.0.
+    platform_archive(
+        name = "org_chromium_chromium_linux_x64",
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
-        amd64_sha256 =
-            "49b25bf32b797558eb7957ac7c60e065433bdef278f669291f71edd329505e27",
-        amd64_urls = [
+        sha256 = "49b25bf32b797558eb7957ac7c60e065433bdef278f669291f71edd329505e27",
+        urls = [
             "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/768959/chrome-linux.zip",
         ],
-        macos_sha256 =
-            "f0c7dc5c26061e2f179d1cb9819cb786d2c37cca9f53155e57ac2b6ab60c5cbc",
-        macos_urls = [
-            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/768938/chrome-mac.zip",
-        ],
-        windows_sha256 =
-            "f441a079046a35afc249a95d29356f33945c0a60b59236b9cf6db532c69dba6f",
-        windows_urls = [
-            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/768952/chrome-win.zip",
-        ],
+        named_files = {
+            "CHROMIUM": "chrome-linux/chrome",
+        },
     )
 
-    platform_http_file(
-        name = "org_chromium_chromedriver",
+    platform_archive(
+        name = "org_chromium_chromium_macos",
+        licenses = ["notice"],  # BSD 3-clause (maybe more?)
+        sha256 = "f0c7dc5c26061e2f179d1cb9819cb786d2c37cca9f53155e57ac2b6ab60c5cbc",
+        urls = [
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/768938/chrome-mac.zip",
+        ],
+        named_files = {
+            "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/chromium",
+        },
+    )
+
+    platform_archive(
+        name = "org_chromium_chromium_windows",
+        licenses = ["notice"],  # BSD 3-clause (maybe more?)
+        sha256 = "f441a079046a35afc249a95d29356f33945c0a60b59236b9cf6db532c69dba6f",
+        urls = [
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/768952/chrome-win.zip",
+        ],
+        named_files = {
+            "CHROMIUM": "chrome-win/chrome.exe",
+        },
+    )
+
+    # Chromium webdriver for multiple platforms.
+    platform_archive(
+        name = "org_chromium_chromedriver_linux_x64",
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-        amd64_sha256 =
-            "71eafe087900dbca4bc0b354a1d172df48b31a4a502e21f7c7b156d7e76c95c7",
-        amd64_urls = [
+        sha256 = "71eafe087900dbca4bc0b354a1d172df48b31a4a502e21f7c7b156d7e76c95c7",
+        urls = [
             "https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip",
         ],
-        macos_sha256 =
-            "fd32a27148f44796a55f5ce3397015c89ebd9f600d9dda2bcaca54575e2497ae",
-        macos_urls = [
+        named_files = {"CHROMEDRIVER": "chromedriver"},
+    )
+
+    platform_archive(
+        name = "org_chromium_chromedriver_macos",
+        licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
+        sha256 = "fd32a27148f44796a55f5ce3397015c89ebd9f600d9dda2bcaca54575e2497ae",
+        urls = [
             "https://chromedriver.storage.googleapis.com/2.41/chromedriver_mac64.zip",
         ],
-        windows_sha256 =
-            "a8fa028acebef7b931ef9cb093f02865f9f7495e49351f556e919f7be77f072e",
-        windows_urls = [
+        named_files = {"CHROMEDRIVER": "chromedriver"},
+    )
+
+    platform_archive(
+        name = "org_chromium_chromedriver_windows",
+        licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
+        sha256 = "a8fa028acebef7b931ef9cb093f02865f9f7495e49351f556e919f7be77f072e",
+        urls = [
             "https://chromedriver.storage.googleapis.com/2.38/chromedriver_win32.zip",
         ],
+        named_files = {"CHROMEDRIVER": "chromedriver"},
     )
 
     java_import_external(

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -47,8 +47,8 @@ def tensorboard_workspace(name = ""):
         actual = "@com_github_grpc_grpc//src/compiler:grpc_python_plugin",
     )
 
-    # We use our own browser definition below, but this seems to be required by
-    # the rules_webtesting dependency.
+    # We use our own browser definition based on the archives defined below, but
+    # this seems to be required by the rules_webtesting dependency.
     browser_repositories(chromium = True)
 
     # Chromium browser for multiple platforms, pinned to Chromium 84.0.4147.0.


### PR DESCRIPTION
We haven't updated this dependency on the bazel webtesting rules for a while, and it looks like we need to do it to be able to also update our reference to the rules_closure target, to unblock #6721.

To be clear, this PR is a prerequisite to pin the rules_closure version in a separate PR, which in turn will unblock #6721. (Or at least that's the expectation. It is yet to be confirmed that the rules_closure version we want to pin is compatible with this one).

An attempt to use the versioned browsers provided by the rules_webtesting dependency was created in #6772, but some tests were failing. It seems that some components or tests were written in a way that depends on the specific browser (?), so to be able to update this dependency, this continues to use the same browser version, only updating the rules we use to define our testing browser, to be compatible with a newer version of rules_webtesting.
