### PR TITLE
Remove MetricSpec and HparamAndMetricSpec types.

### DIFF
--- a/tensorboard/webapp/hparams/_redux/hparams_actions.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_actions.ts
@@ -21,13 +21,13 @@ import {
   AddColumnEvent,
   ReorderColumnEvent,
 } from '../../widgets/data_table/types';
-import {HparamAndMetricSpec, SessionGroup, ColumnHeader} from '../types';
+import {HparamSpec, SessionGroup, ColumnHeader} from '../types';
 import {HparamFilter, MetricFilter} from './types';
 
 export const hparamsFetchSessionGroupsSucceeded = createAction(
   '[Hparams] Hparams Fetch Session Groups Succeeded',
   props<{
-    hparamsAndMetricsSpecs: HparamAndMetricSpec;
+    hparamSpecs: HparamSpec[];
     sessionGroups: SessionGroup[];
   }>()
 );

--- a/tensorboard/webapp/hparams/_redux/hparams_data_source_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_data_source_test.ts
@@ -68,53 +68,29 @@ describe('HparamsDataSource Test', () => {
       httpMock
         .expectOne('/experiment/eid/data/plugin/hparams/experiment')
         .flush(createHparamsExperimentResponse());
-      expect(returnValue).toHaveBeenCalledWith({
-        hparams: [
-          {
-            description: 'describes hparams one',
-            displayName: 'hparams one',
-            name: 'hparams1',
-            type: BackendHparamsValueType.DATA_TYPE_STRING,
-            domain: {
-              type: DomainType.INTERVAL,
-              minValue: -100,
-              maxValue: 100,
-            },
+      expect(returnValue).toHaveBeenCalledWith([
+        {
+          description: 'describes hparams one',
+          displayName: 'hparams one',
+          name: 'hparams1',
+          type: BackendHparamsValueType.DATA_TYPE_STRING,
+          domain: {
+            type: DomainType.INTERVAL,
+            minValue: -100,
+            maxValue: 100,
           },
-          {
-            description: 'describes hparams two',
-            displayName: 'hparams two',
-            name: 'hparams2',
-            type: BackendHparamsValueType.DATA_TYPE_BOOL,
-            domain: {
-              type: DomainType.DISCRETE,
-              values: ['foo', 'bar', 'baz'],
-            },
+        },
+        {
+          description: 'describes hparams two',
+          displayName: 'hparams two',
+          name: 'hparams2',
+          type: BackendHparamsValueType.DATA_TYPE_BOOL,
+          domain: {
+            type: DomainType.DISCRETE,
+            values: ['foo', 'bar', 'baz'],
           },
-        ],
-        metrics: [
-          {
-            name: {
-              tag: 'metrics1',
-              group: '',
-            },
-            tag: 'metrics1',
-            displayName: 'Metrics One',
-            description: 'describe metrics one',
-            datasetType: DatasetType.DATASET_UNKNOWN,
-          },
-          {
-            name: {
-              tag: 'metrics2',
-              group: 'group',
-            },
-            tag: 'metrics2',
-            displayName: 'Metrics Two',
-            description: 'describe metrics two',
-            datasetType: DatasetType.DATASET_TRAINING,
-          },
-        ],
-      });
+        },
+      ]);
     });
 
     it('treats missing domains as discrete domains', () => {
@@ -123,41 +99,35 @@ describe('HparamsDataSource Test', () => {
       httpMock
         .expectOne('/experiment/eid/data/plugin/hparams/experiment')
         .flush(createHparamsExperimentNoDomainResponse());
-      expect(returnValue).toHaveBeenCalledWith(
-        jasmine.objectContaining({
-          hparams: [
-            {
-              description: 'describes hparams one',
-              displayName: 'hparams one',
-              name: 'hparams1',
-              type: BackendHparamsValueType.DATA_TYPE_STRING,
-              domain: {
-                type: DomainType.DISCRETE,
-                values: [],
-              },
-            },
-            {
-              description: 'describes hparams two',
-              displayName: 'hparams two',
-              name: 'hparams2',
-              type: BackendHparamsValueType.DATA_TYPE_BOOL,
-              domain: {
-                type: DomainType.DISCRETE,
-                values: ['foo', 'bar', 'baz'],
-              },
-            },
-          ],
-        })
-      );
+      expect(returnValue).toHaveBeenCalledWith([
+        {
+          description: 'describes hparams one',
+          displayName: 'hparams one',
+          name: 'hparams1',
+          type: BackendHparamsValueType.DATA_TYPE_STRING,
+          domain: {
+            type: DomainType.DISCRETE,
+            values: [],
+          },
+        },
+        {
+          description: 'describes hparams two',
+          displayName: 'hparams two',
+          name: 'hparams2',
+          type: BackendHparamsValueType.DATA_TYPE_BOOL,
+          domain: {
+            type: DomainType.DISCRETE,
+            values: ['foo', 'bar', 'baz'],
+          },
+        },
+      ]);
     });
   });
 
   describe('fetchSessionGroups', () => {
     it('uses /experiment when a single experiment id is provided', () => {
       const returnValue = jasmine.createSpy();
-      dataSource
-        .fetchSessionGroups(['eid'], {hparams: [], metrics: []})
-        .subscribe(returnValue);
+      dataSource.fetchSessionGroups(['eid'], []).subscribe(returnValue);
       httpMock
         .expectOne('/experiment/eid/data/plugin/hparams/session_groups')
         .flush(createHparamsListSessionGroupResponse());
@@ -167,7 +137,7 @@ describe('HparamsDataSource Test', () => {
     it('uses /compare when a multiple experiment ids are provided', () => {
       const returnValue = jasmine.createSpy();
       dataSource
-        .fetchSessionGroups(['eid1', 'eid2'], {hparams: [], metrics: []})
+        .fetchSessionGroups(['eid1', 'eid2'], [])
         .subscribe(returnValue);
       httpMock
         .expectOne('/compare/0:eid1,1:eid2/data/plugin/hparams/session_groups')
@@ -180,9 +150,7 @@ describe('HparamsDataSource Test', () => {
       const callback = (resp: SessionGroup[]) => {
         sessionGroups = resp;
       };
-      dataSource
-        .fetchSessionGroups(['eid'], {hparams: [], metrics: []})
-        .subscribe(callback);
+      dataSource.fetchSessionGroups(['eid'], []).subscribe(callback);
       httpMock
         .expectOne('/experiment/eid/data/plugin/hparams/session_groups')
         .flush(createHparamsListSessionGroupResponse());
@@ -195,9 +163,7 @@ describe('HparamsDataSource Test', () => {
       const callback = (resp: SessionGroup[]) => {
         sessionGroups = resp;
       };
-      dataSource
-        .fetchSessionGroups(['eid1', 'eid2'], {hparams: [], metrics: []})
-        .subscribe(callback);
+      dataSource.fetchSessionGroups(['eid1', 'eid2'], []).subscribe(callback);
 
       const response = createHparamsListSessionGroupResponse();
       // This is the format expected in comparison view.
@@ -333,26 +299,7 @@ export function createHparamsExperimentResponse(): BackendHparamsExperimentRespo
         domainDiscrete: ['foo', 'bar', 'baz'],
       },
     ],
-    metricInfos: [
-      {
-        name: {
-          group: '',
-          tag: 'metrics1',
-        },
-        displayName: 'Metrics One',
-        description: 'describe metrics one',
-        datasetType: DatasetType.DATASET_UNKNOWN,
-      },
-      {
-        name: {
-          group: 'group',
-          tag: 'metrics2',
-        },
-        displayName: 'Metrics Two',
-        description: 'describe metrics two',
-        datasetType: DatasetType.DATASET_TRAINING,
-      },
-    ],
+    metricInfos: [],
     name: 'experiment name',
     timeCreatedSecs: 1337,
     user: 'user name',
@@ -377,26 +324,7 @@ export function createHparamsExperimentNoDomainResponse(): BackendHparamsExperim
         domainDiscrete: ['foo', 'bar', 'baz'],
       },
     ],
-    metricInfos: [
-      {
-        name: {
-          group: '',
-          tag: 'metrics1',
-        },
-        displayName: 'Metrics One',
-        description: 'describe metrics one',
-        datasetType: DatasetType.DATASET_UNKNOWN,
-      },
-      {
-        name: {
-          group: 'group',
-          tag: 'metrics2',
-        },
-        displayName: 'Metrics Two',
-        description: 'describe metrics two',
-        datasetType: DatasetType.DATASET_TRAINING,
-      },
-    ],
+    metricInfos: [],
     name: 'experiment name',
     timeCreatedSecs: 1337,
     user: 'user name',

--- a/tensorboard/webapp/hparams/_redux/hparams_effects.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_effects.ts
@@ -37,7 +37,7 @@ import {HttpErrorResponse} from '../../webapp_data_source/tb_http_client';
 
 import * as hparamsActions from './hparams_actions';
 import {HparamsDataSource} from './hparams_data_source';
-import {HparamAndMetricSpec, SessionGroup} from '../types';
+import {HparamSpec, SessionGroup} from '../types';
 import {RouteKind} from '../../app_routing/types';
 
 /**
@@ -85,13 +85,13 @@ export class HparamsEffects {
   });
 
   private loadHparamsForExperiments(experimentIds: string[]): Observable<{
-    hparamsAndMetricsSpecs: HparamAndMetricSpec;
+    hparamSpecs: HparamSpec[];
     sessionGroups: SessionGroup[];
   }> {
     return this.dataSource.fetchExperimentInfo(experimentIds).pipe(
-      switchMap((hparamsAndMetricsSpecs) => {
+      switchMap((hparamSpecs) => {
         return this.dataSource
-          .fetchSessionGroups(experimentIds, hparamsAndMetricsSpecs)
+          .fetchSessionGroups(experimentIds, hparamSpecs)
           .pipe(
             catchError((error) => {
               // HParam plugin return 400 when there are no hparams
@@ -101,7 +101,7 @@ export class HparamsEffects {
               }
               return throwError(() => error);
             }),
-            map((sessionGroups) => ({hparamsAndMetricsSpecs, sessionGroups}))
+            map((sessionGroups) => ({hparamSpecs, sessionGroups}))
           );
       })
     );

--- a/tensorboard/webapp/hparams/_redux/hparams_effects_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_effects_test.ts
@@ -23,10 +23,9 @@ import {State} from '../../app_state';
 import {provideMockTbStore} from '../../testing/utils';
 import {HparamsDataSource} from './hparams_data_source';
 import {of, ReplaySubject} from 'rxjs';
-import {buildHparamSpec, buildMetricSpec} from './testing';
-import {HparamAndMetricSpec, RunStatus, SessionGroup} from '../types';
+import {buildHparamSpec} from './testing';
+import {HparamSpec, RunStatus, SessionGroup} from '../types';
 import * as selectors from '../../selectors';
-import * as runsActions from '../../runs/actions';
 import * as hparamsActions from './hparams_actions';
 import * as appRoutingActions from '../../app_routing/actions';
 import * as coreActions from '../../core/actions';
@@ -47,7 +46,7 @@ describe('hparams effects', () => {
   let dispatchSpy: jasmine.Spy;
   let actualActions: Action[];
 
-  let mockHparamsAndMetricsSpecs: HparamAndMetricSpec;
+  let mockHparamSpecs: HparamSpec[];
   let mockSessionGroups: SessionGroup[];
 
   beforeEach(async () => {
@@ -74,10 +73,7 @@ describe('hparams effects', () => {
       HparamsDataSource
     ) as jasmine.SpyObj<HparamsDataSource>;
 
-    mockHparamsAndMetricsSpecs = {
-      hparams: [buildHparamSpec({name: 'h1'})],
-      metrics: [buildMetricSpec({tag: 'm1'})],
-    };
+    mockHparamSpecs = [buildHparamSpec({name: 'h1'})];
     mockSessionGroups = [
       {
         name: 'session_group_1',
@@ -99,9 +95,7 @@ describe('hparams effects', () => {
       },
     ];
 
-    dataSource.fetchExperimentInfo.and.returnValue(
-      of(mockHparamsAndMetricsSpecs)
-    );
+    dataSource.fetchExperimentInfo.and.returnValue(of(mockHparamSpecs));
 
     dataSource.fetchSessionGroups.and.returnValue(of(mockSessionGroups));
   });
@@ -141,14 +135,11 @@ describe('hparams effects', () => {
       ]);
       expect(dataSource.fetchSessionGroups).toHaveBeenCalledWith(
         ['expFromRoute'],
-        {
-          hparams: [buildHparamSpec({name: 'h1'})],
-          metrics: [buildMetricSpec({tag: 'm1'})],
-        }
+        [buildHparamSpec({name: 'h1'})]
       );
       expect(actualActions).toEqual([
         hparamsActions.hparamsFetchSessionGroupsSucceeded({
-          hparamsAndMetricsSpecs: mockHparamsAndMetricsSpecs,
+          hparamSpecs: mockHparamSpecs,
           sessionGroups: mockSessionGroups,
         }),
       ]);
@@ -159,7 +150,7 @@ describe('hparams effects', () => {
       action.next(appRoutingActions.navigated({} as any));
       expect(actualActions).toEqual([
         hparamsActions.hparamsFetchSessionGroupsSucceeded({
-          hparamsAndMetricsSpecs: mockHparamsAndMetricsSpecs,
+          hparamSpecs: mockHparamSpecs,
           sessionGroups: mockSessionGroups,
         }),
       ]);
@@ -172,14 +163,11 @@ describe('hparams effects', () => {
       ]);
       expect(dataSource.fetchSessionGroups).toHaveBeenCalledWith(
         ['expFromRoute'],
-        {
-          hparams: [buildHparamSpec({name: 'h1'})],
-          metrics: [buildMetricSpec({tag: 'm1'})],
-        }
+        [buildHparamSpec({name: 'h1'})]
       );
       expect(actualActions).toEqual([
         hparamsActions.hparamsFetchSessionGroupsSucceeded({
-          hparamsAndMetricsSpecs: mockHparamsAndMetricsSpecs,
+          hparamSpecs: mockHparamSpecs,
           sessionGroups: mockSessionGroups,
         }),
       ]);
@@ -192,14 +180,11 @@ describe('hparams effects', () => {
       ]);
       expect(dataSource.fetchSessionGroups).toHaveBeenCalledWith(
         ['expFromRoute'],
-        {
-          hparams: [buildHparamSpec({name: 'h1'})],
-          metrics: [buildMetricSpec({tag: 'm1'})],
-        }
+        [buildHparamSpec({name: 'h1'})]
       );
       expect(actualActions).toEqual([
         hparamsActions.hparamsFetchSessionGroupsSucceeded({
-          hparamsAndMetricsSpecs: mockHparamsAndMetricsSpecs,
+          hparamSpecs: mockHparamSpecs,
           sessionGroups: mockSessionGroups,
         }),
       ]);

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
@@ -20,10 +20,7 @@ import * as actions from './hparams_actions';
 import {HparamsState} from './types';
 
 const initialState: HparamsState = {
-  dashboardSpecs: {
-    hparams: [],
-    metrics: [],
-  },
+  dashboardHparamSpecs: [],
   dashboardSessionGroups: [],
   dashboardFilters: {
     hparams: new Map(),
@@ -45,12 +42,12 @@ const reducer: ActionReducer<HparamsState, Action> = createReducer(
     return state;
   }),
   on(actions.hparamsFetchSessionGroupsSucceeded, (state, action) => {
-    const nextDashboardSpecs = action.hparamsAndMetricsSpecs;
+    const nextDashboardHparamSpecs = action.hparamSpecs;
     const nextDashboardSessionGroups = action.sessionGroups;
 
     return {
       ...state,
-      dashboardSpecs: nextDashboardSpecs,
+      dashboardHparamSpecs: nextDashboardHparamSpecs,
       dashboardSessionGroups: nextDashboardSessionGroups,
     };
   }),

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
@@ -16,7 +16,7 @@ limitations under the License.
 import {DomainType, RunStatus} from '../types';
 import * as actions from './hparams_actions';
 import {reducers} from './hparams_reducers';
-import {buildHparamSpec, buildHparamsState, buildMetricSpec} from './testing';
+import {buildHparamSpec, buildHparamsState} from './testing';
 import {ColumnHeaderType, Side} from '../../widgets/data_table/types';
 import {persistentSettingsLoaded} from '../../persistent_settings';
 import {dataTableUtils} from '../../widgets/data_table/utils';
@@ -95,25 +95,21 @@ describe('hparams/_redux/hparams_reducers_test', () => {
   });
 
   describe('hparamsFetchSessionGroupsSucceeded', () => {
-    it('saves action.hparamsAndMetricsSpecs as dashboardSpecs', () => {
+    it('saves action.hparamSpecs as dashboardHparamSpecs', () => {
       const state = buildHparamsState({
-        dashboardSpecs: {},
+        dashboardHparamSpecs: [],
       });
       const state2 = reducers(
         state,
         actions.hparamsFetchSessionGroupsSucceeded({
-          hparamsAndMetricsSpecs: {
-            hparams: [buildHparamSpec({name: 'foo'})],
-            metrics: [buildMetricSpec({tag: 'bar'})],
-          },
+          hparamSpecs: [buildHparamSpec({name: 'foo'})],
           sessionGroups: [],
         })
       );
 
-      expect(state2.dashboardSpecs).toEqual({
-        hparams: [buildHparamSpec({name: 'foo'})],
-        metrics: [buildMetricSpec({tag: 'bar'})],
-      });
+      expect(state2.dashboardHparamSpecs).toEqual([
+        buildHparamSpec({name: 'foo'}),
+      ]);
     });
 
     it('saves action.sessionGroups as dashboardSessionGroups', () => {
@@ -141,10 +137,7 @@ describe('hparams/_redux/hparams_reducers_test', () => {
       const state2 = reducers(
         state,
         actions.hparamsFetchSessionGroupsSucceeded({
-          hparamsAndMetricsSpecs: {
-            hparams: [],
-            metrics: [],
-          },
+          hparamSpecs: [],
           sessionGroups: [mockSessionGroup],
         })
       );

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
@@ -19,10 +19,10 @@ import {hparamSpecToDefaultFilter} from './utils';
 const getHparamsState =
   createFeatureSelector<HparamsState>(HPARAMS_FEATURE_KEY);
 
-export const getDashboardHparamsAndMetricsSpecs = createSelector(
+export const getDashboardHparamSpecs = createSelector(
   getHparamsState,
   (state: HparamsState) => {
-    return state.dashboardSpecs;
+    return state.dashboardHparamSpecs;
   }
 );
 
@@ -34,10 +34,10 @@ export const getDashboardSessionGroups = createSelector(
 );
 
 export const getDashboardDefaultHparamFilters = createSelector(
-  getDashboardHparamsAndMetricsSpecs,
-  (specs): Map<string, HparamFilter> => {
+  getDashboardHparamSpecs,
+  (hparamSpecs): Map<string, HparamFilter> => {
     const hparams = new Map(
-      specs.hparams.map((hparamSpec) => {
+      hparamSpecs.map((hparamSpec) => {
         return [hparamSpec.name, hparamSpecToDefaultFilter(hparamSpec)];
       })
     );
@@ -47,10 +47,11 @@ export const getDashboardDefaultHparamFilters = createSelector(
 );
 
 export const getDashboardDisplayedHparamColumns = createSelector(
-  getDashboardHparamsAndMetricsSpecs,
   getHparamsState,
-  ({hparams}, state) => {
-    const hparamSet = new Set(hparams.map((hparam) => hparam.name));
+  (state) => {
+    const hparamSet = new Set(
+      state.dashboardHparamSpecs.map((hparamSpec) => hparamSpec.name)
+    );
     return state.dashboardDisplayedHparamColumns.filter((column) =>
       hparamSet.has(column.name)
     );

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
@@ -20,26 +20,21 @@ import * as selectors from './hparams_selectors';
 import {
   buildHparamSpec,
   buildHparamsState,
-  buildMetricSpec,
   buildStateFromHparamsState,
 } from './testing';
 
 describe('hparams/_redux/hparams_selectors_test', () => {
-  describe('#getDashboardHparamsAndMetricsSpecs', () => {
+  describe('#getDashboardHparamSpecs', () => {
     it('returns dashboard specs', () => {
       const state = buildStateFromHparamsState(
         buildHparamsState({
-          dashboardSpecs: {
-            hparams: [buildHparamSpec({name: 'foo'})],
-            metrics: [buildMetricSpec({tag: 'bar'})],
-          },
+          dashboardHparamSpecs: [buildHparamSpec({name: 'foo'})],
         })
       );
 
-      expect(selectors.getDashboardHparamsAndMetricsSpecs(state)).toEqual({
-        hparams: [buildHparamSpec({name: 'foo'})],
-        metrics: [buildMetricSpec({tag: 'bar'})],
-      });
+      expect(selectors.getDashboardHparamSpecs(state)).toEqual([
+        buildHparamSpec({name: 'foo'}),
+      ]);
     });
   });
 
@@ -66,25 +61,23 @@ describe('hparams/_redux/hparams_selectors_test', () => {
     it('generates default filters for all hparam specs', () => {
       const state = buildStateFromHparamsState(
         buildHparamsState({
-          dashboardSpecs: {
-            hparams: [
-              buildHparamSpec({
-                name: 'interval hparam',
-                domain: {
-                  type: DomainType.INTERVAL,
-                  minValue: 2,
-                  maxValue: 5,
-                },
-              }),
-              buildHparamSpec({
-                name: 'discrete hparam',
-                domain: {
-                  type: DomainType.DISCRETE,
-                  values: [2, 4, 6, 8],
-                },
-              }),
-            ],
-          },
+          dashboardHparamSpecs: [
+            buildHparamSpec({
+              name: 'interval hparam',
+              domain: {
+                type: DomainType.INTERVAL,
+                minValue: 2,
+                maxValue: 5,
+              },
+            }),
+            buildHparamSpec({
+              name: 'discrete hparam',
+              domain: {
+                type: DomainType.DISCRETE,
+                values: [2, 4, 6, 8],
+              },
+            }),
+          ],
         })
       );
       expect(selectors.getDashboardDefaultHparamFilters(state)).toEqual(
@@ -118,9 +111,7 @@ describe('hparams/_redux/hparams_selectors_test', () => {
     it('returns no columns if no hparam specs', () => {
       const state = buildStateFromHparamsState(
         buildHparamsState({
-          dashboardSpecs: {
-            hparams: [],
-          },
+          dashboardHparamSpecs: [],
           dashboardDisplayedHparamColumns: [
             {
               type: ColumnHeaderType.HPARAM,
@@ -144,9 +135,7 @@ describe('hparams/_redux/hparams_selectors_test', () => {
     it('returns only hparam columns that have specs', () => {
       const state = buildStateFromHparamsState(
         buildHparamsState({
-          dashboardSpecs: {
-            hparams: [buildHparamSpec({name: 'conv_layers'})],
-          },
+          dashboardHparamSpecs: [buildHparamSpec({name: 'conv_layers'})],
           dashboardDisplayedHparamColumns: [
             {
               type: ColumnHeaderType.HPARAM,

--- a/tensorboard/webapp/hparams/_redux/testing.ts
+++ b/tensorboard/webapp/hparams/_redux/testing.ts
@@ -20,7 +20,6 @@ import {
   HparamSpec,
   HparamValue,
   HparamsValueType,
-  MetricSpec,
   MetricsValue,
   RunStatus,
   Session,
@@ -32,10 +31,7 @@ export function buildHparamsState(
   overrides: DeepPartial<HparamsState> = {}
 ): HparamsState {
   return {
-    dashboardSpecs: {
-      hparams: overrides.dashboardSpecs?.hparams ?? [],
-      metrics: overrides.dashboardSpecs?.metrics ?? [],
-    },
+    dashboardHparamSpecs: overrides.dashboardHparamSpecs ?? [],
     dashboardSessionGroups: overrides.dashboardSessionGroups ?? [],
     dashboardFilters: {
       hparams: overrides.dashboardFilters?.hparams ?? new Map(),
@@ -59,23 +55,6 @@ export function buildHparamSpec(
     domain: {type: DomainType.INTERVAL, minValue: 0, maxValue: 1},
     name: 'sample_param',
     type: HparamsValueType.DATA_TYPE_FLOAT64,
-    ...override,
-  };
-}
-
-export function buildMetricSpec(
-  override: Partial<MetricSpec> = {}
-): MetricSpec {
-  return {
-    name: {
-      ...override?.name,
-      tag: 'metric',
-      group: 'some group',
-    },
-    tag: 'tag',
-    displayName: 'Tag',
-    description: 'This is a tags',
-    datasetType: DatasetType.DATASET_TRAINING,
     ...override,
   };
 }

--- a/tensorboard/webapp/hparams/_redux/types.ts
+++ b/tensorboard/webapp/hparams/_redux/types.ts
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
-  DiscreteFilter,
-  IntervalFilter,
   ColumnHeader,
-  HparamAndMetricSpec,
+  DiscreteFilter,
+  HparamSpec,
+  IntervalFilter,
   SessionGroup,
 } from '../_types';
 
@@ -29,7 +29,7 @@ export type MetricFilter = IntervalFilter;
 export const HPARAMS_FEATURE_KEY = 'hparams';
 
 export interface HparamsState {
-  dashboardSpecs: HparamAndMetricSpec;
+  dashboardHparamSpecs: HparamSpec[];
   dashboardSessionGroups: SessionGroup[];
   dashboardFilters: {
     hparams: Map<string, HparamFilter>;

--- a/tensorboard/webapp/hparams/_types.ts
+++ b/tensorboard/webapp/hparams/_types.ts
@@ -12,11 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {
-  HparamSpec,
-  MetricSpec,
-} from '../runs/data_source/runs_data_source_types';
-
 export {
   DiscreteFilter,
   IntervalFilter,
@@ -30,7 +25,6 @@ export {
   DomainType,
   HparamSpec,
   HparamsValueType,
-  MetricSpec,
   Domain,
   HparamValue,
   RunToHparamsAndMetrics,
@@ -50,8 +44,3 @@ export {
   Session,
   MetricsValue,
 } from '../runs/data_source/runs_backend_types';
-
-export interface HparamAndMetricSpec {
-  hparams: HparamSpec[];
-  metrics: MetricSpec[];
-}

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -1789,12 +1789,10 @@ describe('metrics selectors', () => {
         },
       ];
       hparamsState = {
-        dashboardSpecs: {
-          hparams: [
-            buildHparamSpec({name: 'conv_layers'}),
-            buildHparamSpec({name: 'conv_kernel_size'}),
-          ],
-        },
+        dashboardHparamSpecs: [
+          buildHparamSpec({name: 'conv_layers'}),
+          buildHparamSpec({name: 'conv_kernel_size'}),
+        ],
         dashboardDisplayedHparamColumns: [
           {
             type: ColumnHeaderType.HPARAM,

--- a/tensorboard/webapp/metrics/views/main_view/common_selectors.ts
+++ b/tensorboard/webapp/metrics/views/main_view/common_selectors.ts
@@ -29,11 +29,11 @@ import {
 } from '../../../selectors';
 import {DeepReadonly} from '../../../util/types';
 import {
-  getDashboardMetricsFilterMap,
-  getDashboardHparamsAndMetricsSpecs,
-  getDashboardHparamFilterMap,
   getDashboardDefaultHparamFilters,
   getDashboardDisplayedHparamColumns,
+  getDashboardHparamFilterMap,
+  getDashboardHparamSpecs,
+  getDashboardMetricsFilterMap,
 } from '../../../hparams/_redux/hparams_selectors';
 import {
   DiscreteFilter,
@@ -270,19 +270,19 @@ export const getFilteredRenderableRunsIds = createSelector(
 );
 
 export const getPotentialHparamColumns = createSelector(
-  getDashboardHparamsAndMetricsSpecs,
+  getDashboardHparamSpecs,
   getExperimentIdsFromRoute,
-  ({hparams}, experimentIds): ColumnHeader[] => {
+  (hparamSpecs, experimentIds): ColumnHeader[] => {
     if (!experimentIds) {
       return [];
     }
 
-    return hparams.map((spec) => ({
+    return hparamSpecs.map((hparamSpec) => ({
       type: ColumnHeaderType.HPARAM,
-      name: spec.name,
+      name: hparamSpec.name,
       // According to the api spec when the displayName is empty, the name should
       // be displayed tensorboard/plugins/hparams/api.proto
-      displayName: spec.displayName || spec.name,
+      displayName: hparamSpec.displayName || hparamSpec.name,
       enabled: false,
       removable: true,
       sortable: true,

--- a/tensorboard/webapp/metrics/views/main_view/common_selectors_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/common_selectors_test.ts
@@ -13,10 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {RouteKind} from '../../../app_routing';
-import {
-  buildHparamSpec,
-  buildMetricSpec,
-} from '../../../hparams/_redux/testing';
+import {buildHparamSpec} from '../../../hparams/_redux/testing';
 import {
   buildAppRoutingState,
   buildStateFromAppRoutingState,
@@ -208,21 +205,18 @@ describe('common selectors', () => {
         },
       },
       hparams: {
-        dashboardSpecs: {
-          hparams: [
-            buildHparamSpec({name: 'conv_layers', displayName: 'Conv Layers'}),
-            buildHparamSpec({
-              name: 'conv_kernel_size',
-              displayName: 'Conv Kernel Size',
-            }),
-            buildHparamSpec({
-              name: 'dense_layers',
-              displayName: 'Dense Layers',
-            }),
-            buildHparamSpec({name: 'dropout', displayName: 'Dropout'}),
-          ],
-          metrics: [buildMetricSpec({displayName: 'Bar'})],
-        },
+        dashboardHparamSpecs: [
+          buildHparamSpec({name: 'conv_layers', displayName: 'Conv Layers'}),
+          buildHparamSpec({
+            name: 'conv_kernel_size',
+            displayName: 'Conv Kernel Size',
+          }),
+          buildHparamSpec({
+            name: 'dense_layers',
+            displayName: 'Dense Layers',
+          }),
+          buildHparamSpec({name: 'dropout', displayName: 'Dropout'}),
+        ],
         dashboardSessionGroups: [],
         dashboardDisplayedHparamColumns: [
           {
@@ -1058,7 +1052,7 @@ describe('common selectors', () => {
     });
 
     it('sets name as display name when a display name is not provided', () => {
-      state.hparams!.dashboardSpecs.hparams = [
+      state.hparams!.dashboardHparamSpecs = [
         buildHparamSpec({name: 'conv_layers', displayName: ''}),
       ];
 

--- a/tensorboard/webapp/runs/data_source/runs_data_source_types.ts
+++ b/tensorboard/webapp/runs/data_source/runs_data_source_types.ts
@@ -61,11 +61,6 @@ export interface HparamSpec
   domain: Domain;
 }
 
-// TODO(rileyajones) merge these types by deleting this one.
-export interface MetricSpec extends backendTypes.MetricSpec {
-  tag: string;
-}
-
 export interface Run {
   id: string;
   name: string;

--- a/tensorboard/webapp/runs/store/runs_selectors_test.ts
+++ b/tensorboard/webapp/runs/store/runs_selectors_test.ts
@@ -1120,12 +1120,10 @@ describe('runs_selectors', () => {
         ),
         ...buildStateFromHparamsState(
           buildHparamsState({
-            dashboardSpecs: {
-              hparams: [
-                buildHparamSpec({name: 'conv_layers'}),
-                buildHparamSpec({name: 'conv_kernel_size'}),
-              ],
-            },
+            dashboardHparamSpecs: [
+              buildHparamSpec({name: 'conv_layers'}),
+              buildHparamSpec({name: 'conv_kernel_size'}),
+            ],
             dashboardDisplayedHparamColumns: [
               {
                 type: ColumnHeaderType.HPARAM,

--- a/tensorboard/webapp/runs/views/runs_table/types.ts
+++ b/tensorboard/webapp/runs/views/runs_table/types.ts
@@ -26,7 +26,6 @@ export {
   DomainType,
   HparamSpec,
   HparamValue,
-  MetricSpec,
 } from '../../data_source/runs_data_source_types';
 
 export enum RunsTableColumn {


### PR DESCRIPTION
We no longer surface Hparam-related Metric Values from the server in Angular TensorBoard UI. We therefore remove the MetricSpec and HparamAndMetricSpec types. The latter is replaced with just HparamSpec[] where necessary.
