### PR TITLE
Hparams: Limit number of Hparams retrieved by default.

### DIFF
--- a/tensorboard/webapp/hparams/_redux/BUILD
+++ b/tensorboard/webapp/hparams/_redux/BUILD
@@ -111,6 +111,7 @@ tf_ng_module(
     deps = [
         ":hparams_actions",
         ":hparams_data_source",
+        ":hparams_selectors",
         ":types",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/app_routing:types",

--- a/tensorboard/webapp/hparams/_redux/hparams_data_source.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_data_source.ts
@@ -87,11 +87,15 @@ export class HparamsDataSource {
     return experimentIds.map((eid, index) => `${index}:${eid}`).join(',');
   }
 
-  fetchExperimentInfo(experimentIds: string[]): Observable<HparamSpec[]> {
+  fetchExperimentInfo(
+    experimentIds: string[],
+    hparamsLimit: number
+  ): Observable<HparamSpec[]> {
     const formattedExperimentIds = this.formatExperimentIds(experimentIds);
 
     const experimentRequest: BackendHparamsExperimentRequest = {
       experimentName: formattedExperimentIds,
+      hparamsLimit,
       // The hparams feature generates its own metric data and does not require
       // the backend to calculate it.
       includeMetrics: false,
@@ -132,7 +136,7 @@ export class HparamsDataSource {
     const colParams: BackendListSessionGroupRequest['colParams'] = [];
 
     for (const hparamSpec of hparamSpecs) {
-      colParams.push({hparam: hparamSpec.name});
+      colParams.push({hparam: hparamSpec.name, includeInResult: true});
     }
 
     const listSessionRequestParams: BackendListSessionGroupRequest = {

--- a/tensorboard/webapp/hparams/_redux/hparams_data_source_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_data_source_test.ts
@@ -28,6 +28,7 @@ import {
   BackendListSessionGroupResponse,
   RunStatus,
 } from '../types';
+import {buildHparamSpec} from './testing';
 
 describe('HparamsDataSource Test', () => {
   let httpMock: HttpTestingController;
@@ -46,7 +47,7 @@ describe('HparamsDataSource Test', () => {
   describe('fetchExperimentInfo', () => {
     it('uses /experiment when a single experiment id is provided', () => {
       const returnValue = jasmine.createSpy();
-      dataSource.fetchExperimentInfo(['eid']).subscribe(returnValue);
+      dataSource.fetchExperimentInfo(['eid'], 0).subscribe(returnValue);
       httpMock
         .expectOne('/experiment/eid/data/plugin/hparams/experiment')
         .flush(createHparamsExperimentResponse());
@@ -55,7 +56,9 @@ describe('HparamsDataSource Test', () => {
 
     it('uses /compare when a multiple experiment ids are provided', () => {
       const returnValue = jasmine.createSpy();
-      dataSource.fetchExperimentInfo(['eid1', 'eid2']).subscribe(returnValue);
+      dataSource
+        .fetchExperimentInfo(['eid1', 'eid2'], 0)
+        .subscribe(returnValue);
       httpMock
         .expectOne('/compare/0:eid1,1:eid2/data/plugin/hparams/experiment')
         .flush(createHparamsExperimentResponse());
@@ -64,7 +67,7 @@ describe('HparamsDataSource Test', () => {
 
     it('maps interval and discrete domains to domain', () => {
       const returnValue = jasmine.createSpy();
-      dataSource.fetchExperimentInfo(['eid']).subscribe(returnValue);
+      dataSource.fetchExperimentInfo(['eid'], 0).subscribe(returnValue);
       httpMock
         .expectOne('/experiment/eid/data/plugin/hparams/experiment')
         .flush(createHparamsExperimentResponse());
@@ -95,7 +98,7 @@ describe('HparamsDataSource Test', () => {
 
     it('treats missing domains as discrete domains', () => {
       const returnValue = jasmine.createSpy();
-      dataSource.fetchExperimentInfo(['eid']).subscribe(returnValue);
+      dataSource.fetchExperimentInfo(['eid'], 0).subscribe(returnValue);
       httpMock
         .expectOne('/experiment/eid/data/plugin/hparams/experiment')
         .flush(createHparamsExperimentNoDomainResponse());
@@ -121,6 +124,15 @@ describe('HparamsDataSource Test', () => {
           },
         },
       ]);
+    });
+
+    it('sets hparamsLimit and includeMetrics', () => {
+      dataSource.fetchExperimentInfo(['eid'], 100).subscribe();
+      const actual = httpMock.expectOne(
+        '/experiment/eid/data/plugin/hparams/experiment'
+      );
+      expect(actual.request.body.hparamsLimit).toEqual(100);
+      expect(actual.request.body.includeMetrics).toBeFalse();
     });
   });
 
@@ -175,6 +187,25 @@ describe('HparamsDataSource Test', () => {
       expect(sessionGroups.length).toEqual(2);
       expect(sessionGroups[0].sessions[0].name).toEqual('eid1/run_name_1');
       expect(sessionGroups[1].sessions[0].name).toEqual('eid2/run_name_2');
+    });
+
+    it('adds hparams as colParams', () => {
+      dataSource
+        .fetchSessionGroups(
+          ['eid'],
+          [
+            buildHparamSpec({name: 'hparam1'}),
+            buildHparamSpec({name: 'hparam2'}),
+          ]
+        )
+        .subscribe();
+      const actual = httpMock.expectOne(
+        '/experiment/eid/data/plugin/hparams/session_groups'
+      );
+      expect(actual.request.body.colParams).toEqual([
+        {hparam: 'hparam1', includeInResult: true},
+        {hparam: 'hparam2', includeInResult: true},
+      ]);
     });
   });
 });

--- a/tensorboard/webapp/hparams/_redux/hparams_effects_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_effects_test.ts
@@ -27,6 +27,7 @@ import {buildHparamSpec} from './testing';
 import {HparamSpec, RunStatus, SessionGroup} from '../types';
 import * as selectors from '../../selectors';
 import * as hparamsActions from './hparams_actions';
+import * as hparamsSelectors from './hparams_selectors';
 import * as appRoutingActions from '../../app_routing/actions';
 import * as coreActions from '../../core/actions';
 import {RouteKind} from '../../app_routing/types';
@@ -112,6 +113,10 @@ describe('hparams effects', () => {
       store.overrideSelector(selectors.getExperimentIdsFromRoute, [
         'expFromRoute',
       ]);
+      store.overrideSelector(
+        hparamsSelectors.getNumDashboardHparamsToLoad,
+        1111
+      );
       store.refreshState();
     });
 
@@ -130,9 +135,10 @@ describe('hparams effects', () => {
 
     it('fetches data after navigation', () => {
       action.next(appRoutingActions.navigated({} as any));
-      expect(dataSource.fetchExperimentInfo).toHaveBeenCalledWith([
-        'expFromRoute',
-      ]);
+      expect(dataSource.fetchExperimentInfo).toHaveBeenCalledWith(
+        ['expFromRoute'],
+        1111
+      );
       expect(dataSource.fetchSessionGroups).toHaveBeenCalledWith(
         ['expFromRoute'],
         [buildHparamSpec({name: 'h1'})]
@@ -158,9 +164,10 @@ describe('hparams effects', () => {
 
     it('fetches data on reload', () => {
       action.next(coreActions.reload());
-      expect(dataSource.fetchExperimentInfo).toHaveBeenCalledWith([
-        'expFromRoute',
-      ]);
+      expect(dataSource.fetchExperimentInfo).toHaveBeenCalledWith(
+        ['expFromRoute'],
+        1111
+      );
       expect(dataSource.fetchSessionGroups).toHaveBeenCalledWith(
         ['expFromRoute'],
         [buildHparamSpec({name: 'h1'})]
@@ -175,9 +182,10 @@ describe('hparams effects', () => {
 
     it('fetches data on manualReload', () => {
       action.next(coreActions.manualReload());
-      expect(dataSource.fetchExperimentInfo).toHaveBeenCalledWith([
-        'expFromRoute',
-      ]);
+      expect(dataSource.fetchExperimentInfo).toHaveBeenCalledWith(
+        ['expFromRoute'],
+        1111
+      );
       expect(dataSource.fetchSessionGroups).toHaveBeenCalledWith(
         ['expFromRoute'],
         [buildHparamSpec({name: 'h1'})]

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers.ts
@@ -19,6 +19,8 @@ import {Side} from '../../widgets/data_table/types';
 import * as actions from './hparams_actions';
 import {HparamsState} from './types';
 
+const INITIAL_NUM_HPARAMS_TO_LOAD = 1000;
+
 const initialState: HparamsState = {
   dashboardHparamSpecs: [],
   dashboardSessionGroups: [],
@@ -27,6 +29,8 @@ const initialState: HparamsState = {
     metrics: new Map(),
   },
   dashboardDisplayedHparamColumns: [],
+  numDashboardHparamsToLoad: INITIAL_NUM_HPARAMS_TO_LOAD,
+  numDashboardHparamsLoaded: 0,
 };
 
 const reducer: ActionReducer<HparamsState, Action> = createReducer(
@@ -49,6 +53,7 @@ const reducer: ActionReducer<HparamsState, Action> = createReducer(
       ...state,
       dashboardHparamSpecs: nextDashboardHparamSpecs,
       dashboardSessionGroups: nextDashboardSessionGroups,
+      numDashboardHparamsLoaded: nextDashboardHparamSpecs.length,
     };
   }),
   on(actions.dashboardHparamFilterAdded, (state, action) => {

--- a/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_reducers_test.ts
@@ -144,6 +144,25 @@ describe('hparams/_redux/hparams_reducers_test', () => {
 
       expect(state2.dashboardSessionGroups).toEqual([mockSessionGroup]);
     });
+
+    it('calculates numDashboardHparamsLoaded from action.hparamSpecs', () => {
+      const state = buildHparamsState({
+        numDashboardHparamsLoaded: 0,
+      });
+      const state2 = reducers(
+        state,
+        actions.hparamsFetchSessionGroupsSucceeded({
+          hparamSpecs: [
+            buildHparamSpec(),
+            buildHparamSpec(),
+            buildHparamSpec(),
+          ],
+          sessionGroups: [],
+        })
+      );
+
+      expect(state2.numDashboardHparamsLoaded).toEqual(3);
+    });
   });
 
   describe('dashboardHparamFilterAdded', () => {

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors.ts
@@ -71,3 +71,17 @@ export const getDashboardMetricsFilterMap = createSelector(
     return state.dashboardFilters.metrics;
   }
 );
+
+export const getNumDashboardHparamsToLoad = createSelector(
+  getHparamsState,
+  (state) => {
+    return state.numDashboardHparamsToLoad;
+  }
+);
+
+export const getNumDashboardHparamsLoaded = createSelector(
+  getHparamsState,
+  (state) => {
+    return state.numDashboardHparamsLoaded;
+  }
+);

--- a/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_selectors_test.ts
@@ -163,4 +163,28 @@ describe('hparams/_redux/hparams_selectors_test', () => {
       ]);
     });
   });
+
+  describe('#getNumDashboardHparamsToLoad', () => {
+    it('returns dashboard specs', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          numDashboardHparamsToLoad: 5,
+        })
+      );
+
+      expect(selectors.getNumDashboardHparamsToLoad(state)).toEqual(5);
+    });
+  });
+
+  describe('#getNumDashboardHparamsToLoad', () => {
+    it('returns dashboard specs', () => {
+      const state = buildStateFromHparamsState(
+        buildHparamsState({
+          numDashboardHparamsLoaded: 22,
+        })
+      );
+
+      expect(selectors.getNumDashboardHparamsLoaded(state)).toEqual(22);
+    });
+  });
 });

--- a/tensorboard/webapp/hparams/_redux/testing.ts
+++ b/tensorboard/webapp/hparams/_redux/testing.ts
@@ -39,6 +39,8 @@ export function buildHparamsState(
     },
     dashboardDisplayedHparamColumns:
       overrides.dashboardDisplayedHparamColumns ?? [],
+    numDashboardHparamsLoaded: overrides.numDashboardHparamsLoaded ?? 0,
+    numDashboardHparamsToLoad: overrides.numDashboardHparamsToLoad ?? 0,
   } as HparamsState;
 }
 

--- a/tensorboard/webapp/hparams/_redux/types.ts
+++ b/tensorboard/webapp/hparams/_redux/types.ts
@@ -36,6 +36,9 @@ export interface HparamsState {
     metrics: Map<string, MetricFilter>;
   };
   dashboardDisplayedHparamColumns: ColumnHeader[];
+  // 0 means load "all".
+  numDashboardHparamsToLoad: number;
+  numDashboardHparamsLoaded: number;
 }
 
 export interface State {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -203,6 +203,8 @@ limitations under the License.
       [columnFilters]="columnFilters"
       [runToHparamMap]="runToHparamMap"
       [selectableColumns]="selectableColumns"
+      [numColumnsLoaded]="numColumnsLoaded"
+      [numColumnsToLoad]="numColumnsToLoad"
       (sortDataBy)="sortDataBy($event)"
       (editColumnHeaders)="editColumnHeaders.emit($event)"
       (addColumn)="addColumn.emit($event)"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -114,6 +114,8 @@ export class ScalarCardComponent<Downloader> {
   @Input() rangeEnabled!: boolean;
   @Input() columnFilters!: Map<string, DiscreteFilter | IntervalFilter>;
   @Input() selectableColumns!: ColumnHeader[];
+  @Input() numColumnsLoaded!: number;
+  @Input() numColumnsToLoad!: number;
   @Input() runToHparamMap!: RunToHparamMap;
 
   @Output() onFullSizeToggle = new EventEmitter<void>();

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -37,7 +37,10 @@ import {
 } from 'rxjs/operators';
 import {State} from '../../../app_state';
 import {ExperimentAlias} from '../../../experiments/types';
-import {actions as hparamsActions} from '../../../hparams';
+import {
+  actions as hparamsActions,
+  selectors as hparamsSelectors,
+} from '../../../hparams';
 import {
   getForceSvgFeatureFlag,
   getIsScalarColumnContextMenusEnabled,
@@ -192,6 +195,8 @@ function areSeriesEqual(
       [columnFilters]="columnFilters$ | async"
       [runToHparamMap]="runToHparamMap$ | async"
       [selectableColumns]="selectableColumns$ | async"
+      [numColumnsLoaded]="numColumnsLoaded$ | async"
+      [numColumnsToLoad]="numColumnsToLoad$ | async"
       (onFullSizeToggle)="onFullSizeToggle()"
       (onPinClicked)="pinStateChanged.emit($event)"
       observeIntersection
@@ -248,6 +253,12 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   columnFilters$ = this.store.select(getCurrentColumnFilters);
   runToHparamMap$?: Observable<RunToHparamMap>;
   selectableColumns$?: Observable<ColumnHeader[]>;
+  numColumnsLoaded$ = this.store.select(
+    hparamsSelectors.getNumDashboardHparamsLoaded
+  );
+  numColumnsToLoad$ = this.store.select(
+    hparamsSelectors.getNumDashboardHparamsToLoad
+  );
 
   onVisibilityChange({visible}: {visible: boolean}) {
     this.isVisible = visible;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
@@ -20,6 +20,8 @@ limitations under the License.
   [sortingInfo]="sortingInfo"
   [columnFilters]="columnFilters"
   [selectableColumns]="selectableColumns"
+  [numColumnsLoaded]="numColumnsLoaded"
+  [hasMoreColumnsToLoad]="numColumnsLoaded == numColumnsToLoad"
   (sortDataBy)="sortDataBy.emit($event)"
   (orderColumns)="onOrderColumns($event)"
   (addColumn)="addColumn.emit($event)"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
@@ -21,7 +21,7 @@ limitations under the License.
   [columnFilters]="columnFilters"
   [selectableColumns]="selectableColumns"
   [numColumnsLoaded]="numColumnsLoaded"
-  [hasMoreColumnsToLoad]="numColumnsLoaded == numColumnsToLoad"
+  [hasMoreColumnsToLoad]="numColumnsLoaded === numColumnsToLoad"
   (sortDataBy)="sortDataBy.emit($event)"
   (orderColumns)="onOrderColumns($event)"
   (addColumn)="addColumn.emit($event)"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -61,6 +61,8 @@ export class ScalarCardDataTable {
   @Input() smoothingEnabled!: boolean;
   @Input() columnFilters!: Map<string, DiscreteFilter | IntervalFilter>;
   @Input() selectableColumns!: ColumnHeader[];
+  @Input() numColumnsLoaded!: number;
+  @Input() numColumnsToLoad!: number;
   @Input() runToHparamMap!: RunToHparamMap;
 
   @Output() sortDataBy = new EventEmitter<SortingInfo>();

--- a/tensorboard/webapp/runs/data_source/runs_backend_types.ts
+++ b/tensorboard/webapp/runs/data_source/runs_backend_types.ts
@@ -87,7 +87,8 @@ export function isDiscreteDomainHparamSpec(
 
 export interface BackendHparamsExperimentRequest {
   experimentName: string;
-  includeMetrics?: boolean;
+  hparamsLimit: number;
+  includeMetrics: boolean;
 }
 
 export interface BackendHparamsExperimentResponse {
@@ -101,10 +102,12 @@ export interface BackendHparamsExperimentResponse {
 
 interface HparamsColFilterParams {
   hparam: string;
+  includeInResult: boolean;
 }
 
 interface MetricsColFilterParams {
   metric: MetricName;
+  includeInResult: boolean;
 }
 
 export interface BackendListSessionGroupRequest {

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -30,7 +30,7 @@ limitations under the License.
     [sortingInfo]="sortingInfo"
     [selectableColumns]="selectableColumns"
     [numColumnsLoaded]="numColumnsLoaded"
-    [hasMoreColumnsToLoad]="numColumnsLoaded == numColumnsToLoad"
+    [hasMoreColumnsToLoad]="numColumnsLoaded === numColumnsToLoad"
     [columnFilters]="columnFilters"
     [loading]="loading"
     (sortDataBy)="sortDataBy.emit($event)"

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ng.html
@@ -29,6 +29,8 @@ limitations under the License.
     [headers]="headers"
     [sortingInfo]="sortingInfo"
     [selectableColumns]="selectableColumns"
+    [numColumnsLoaded]="numColumnsLoaded"
+    [hasMoreColumnsToLoad]="numColumnsLoaded == numColumnsToLoad"
     [columnFilters]="columnFilters"
     [loading]="loading"
     (sortDataBy)="sortDataBy.emit($event)"

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table.ts
@@ -44,6 +44,8 @@ export class RunsDataTable {
   @Input() regexFilter!: string;
   @Input() isFullScreen!: boolean;
   @Input() selectableColumns!: ColumnHeader[];
+  @Input() numColumnsLoaded!: number;
+  @Input() numColumnsToLoad!: number;
   @Input() loading!: boolean;
   @Input() columnFilters!: Map<string, DiscreteFilter | IntervalFilter>;
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_container.ts
@@ -32,7 +32,10 @@ import {
 import * as alertActions from '../../../alert/actions';
 import {areSameRouteKindAndExperiments} from '../../../app_routing';
 import {State} from '../../../app_state';
-import {actions as hparamsActions} from '../../../hparams';
+import {
+  actions as hparamsActions,
+  selectors as hparamsSelectors,
+} from '../../../hparams';
 import {
   getActiveRoute,
   getCurrentRouteRunSelection,
@@ -93,6 +96,8 @@ const getRunsLoading = createSelector<
       [headers]="runsColumns$ | async"
       [data]="sortedRunsTableData$ | async"
       [selectableColumns]="selectableColumns$ | async"
+      [numColumnsLoaded]="numColumnsLoaded$ | async"
+      [numColumnsToLoad]="numColumnsToLoad$ | async"
       [columnFilters]="columnFilters$ | async"
       [sortingInfo]="sortingInfo$ | async"
       [experimentIds]="experimentIds"
@@ -143,6 +148,12 @@ export class RunsTableContainer implements OnInit, OnDestroy {
   runsColumns$ = this.store.select(getGroupedRunsTableHeaders);
   runsTableFullScreen$ = this.store.select(getRunsTableFullScreen);
   selectableColumns$ = this.store.select(getSelectableColumns);
+  numColumnsLoaded$ = this.store.select(
+    hparamsSelectors.getNumDashboardHparamsLoaded
+  );
+  numColumnsToLoad$ = this.store.select(
+    hparamsSelectors.getNumDashboardHparamsToLoad
+  );
 
   columnFilters$ = this.store.select(getCurrentColumnFilters);
 

--- a/tensorboard/webapp/widgets/data_table/column_selector_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/column_selector_component.ng.html
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="contents">
-  <mat-form-field class="search-area">
+  <mat-form-field class="search-area" subscriptSizing="dynamic">
     <mat-icon matPrefix class="search-icon" svgIcon="search_24px"></mat-icon>
     <mat-label>Search</mat-label>
     <input
@@ -22,6 +22,13 @@ limitations under the License.
       (ngModelChange)="searchInputChanged()"
     />
   </mat-form-field>
+
+  <div class="column-load-info">
+    <label>{{ numColumnsLoaded }} columns loaded.</label>
+    <label *ngIf="hasMoreColumnsToLoad">
+      Warning: There were too many columns to load all of them.
+    </label>
+  </div>
 
   <div #columnList class="column-list">
     <button

--- a/tensorboard/webapp/widgets/data_table/column_selector_component.scss
+++ b/tensorboard/webapp/widgets/data_table/column_selector_component.scss
@@ -37,7 +37,15 @@ limitations under the License.
   }
 
   .search-area {
-    margin-bottom: 4px;
+    margin-bottom: 12px;
+  }
+
+  .column-load-info {
+    display: flex;
+    flex-direction: column;
+    font-size: 13px;
+    font-style: italic;
+    margin-bottom: 12px;
   }
 
   .column-list {

--- a/tensorboard/webapp/widgets/data_table/column_selector_component.ts
+++ b/tensorboard/webapp/widgets/data_table/column_selector_component.ts
@@ -35,6 +35,8 @@ import {BehaviorSubject} from 'rxjs';
 })
 export class ColumnSelectorComponent implements OnInit, AfterViewInit {
   @Input() selectableColumns: ColumnHeader[] = [];
+  @Input() numColumnsLoaded!: number;
+  @Input() hasMoreColumnsToLoad!: boolean;
   @Output() columnSelected = new EventEmitter<ColumnHeader>();
 
   @ViewChild('search')

--- a/tensorboard/webapp/widgets/data_table/column_selector_test.ts
+++ b/tensorboard/webapp/widgets/data_table/column_selector_test.ts
@@ -197,7 +197,7 @@ describe('column selector', () => {
     });
   });
 
-  it('selects a column when the it is clicked', fakeAsync(() => {
+  it('selects a column when it is clicked', fakeAsync(() => {
     let selectedColumn: ColumnHeader;
     fixture.componentInstance.columnSelected.subscribe((column) => {
       selectedColumn = column;
@@ -206,5 +206,24 @@ describe('column selector', () => {
     flush();
 
     expect(selectedColumn!.name).toEqual('runs');
+  }));
+
+  it('renders number of loaded columns', fakeAsync(() => {
+    fixture.componentInstance.numColumnsLoaded = 100;
+    fixture.detectChanges();
+
+    const numColumns = fixture.debugElement.query(By.css('.column-load-info'));
+    expect(numColumns.nativeElement.textContent).toEqual('100 columns loaded.');
+  }));
+
+  it('renders too many columns warning', fakeAsync(() => {
+    fixture.componentInstance.numColumnsLoaded = 100;
+    fixture.componentInstance.hasMoreColumnsToLoad = true;
+    fixture.detectChanges();
+
+    const numColumns = fixture.debugElement.query(By.css('.column-load-info'));
+    expect(numColumns.nativeElement.textContent).toContain(
+      'Warning: There were too many columns to load all of them.'
+    );
   }));
 });

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -80,6 +80,8 @@ limitations under the License.
 >
   <tb-data-table-column-selector-component
     [selectableColumns]="selectableColumns"
+    [numColumnsLoaded]="numColumnsLoaded"
+    [hasMoreColumnsToLoad]="hasMoreColumnsToLoad"
     (columnSelected)="onColumnAdded($event)"
   ></tb-data-table-column-selector-component>
 </custom-modal>

--- a/tensorboard/webapp/widgets/data_table/data_table_component.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ts
@@ -62,6 +62,8 @@ export class DataTableComponent implements OnDestroy, AfterContentInit {
   @Input() headers!: ColumnHeader[];
   @Input() sortingInfo!: SortingInfo;
   @Input() selectableColumns?: ColumnHeader[];
+  @Input() numColumnsLoaded!: number;
+  @Input() hasMoreColumnsToLoad!: boolean;
   @Input() columnFilters!: Map<string, DiscreteFilter | IntervalFilter>;
   @Input() loading: boolean = false;
 


### PR DESCRIPTION
Limit the number of hparams retrieved by default to 1000 for display in Time Series. Print retrieval information: # of columns loaded and whether there could be more.

This is to address performance issues with loading 1000s of hparams from the backend and trying to render them all.

In a future PR we will add abitlity to "Load All" if user wants to nonetheless load them all.

Screenshot (with default set to 2 instead of 1000):
![image](https://github.com/tensorflow/tensorboard/assets/17152369/b0f2c4e6-bda0-4ed7-bead-9f1ef6eaaca7)
