### PR TITLE
Migrate uses of struct.to_proto

### DIFF
--- a/tensorboard/defs/internal/html.bzl
+++ b/tensorboard/defs/internal/html.bzl
@@ -77,10 +77,10 @@ def _tb_combine_html_impl(ctx):
     manifest = ctx.actions.declare_file("%s.pbtxt" % ctx.label.name)
     ctx.actions.write(
         output = manifest,
-        content = struct(
+        content = proto.encode_text(struct(
             label = str(ctx.label),
             src = manifest_srcs,
-        ).to_proto(),
+        )),
     )
     manifests = depset([manifest], transitive = [manifests])
 

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -104,7 +104,7 @@ def _tf_web_library(ctx):
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])
   params_file = _new_file(ctx, "-params.pbtxt")
-  ctx.actions.write(output=params_file, content=params.to_proto())
+  ctx.actions.write(output=params_file, content=proto.encode_text(params))
   ctx.actions.write(
       is_executable=True,
       output=ctx.outputs.executable,
@@ -150,9 +150,9 @@ def _make_manifest(ctx, src_list):
   manifest = _new_file(ctx, "-webfiles.pbtxt")
   ctx.actions.write(
       output=manifest,
-      content=struct(
+      content=proto.encode_text(struct(
           label=str(ctx.label),
-          src=src_list).to_proto())
+          src=src_list)))
   return manifest
 
 def _run_webfiles_validator(ctx, srcs, deps, manifest):


### PR DESCRIPTION
The "to_proto" method on Starlark structs is deprecated and shouldn't be used. Instead, the proto module's "encode_text" function should be used. (https://bazel.build/rules/lib/toplevel/proto)

It, along with "to_json", can be disabled in Bazel using the flag --incompatible_struct_has_no_methods

The underlying implementation is the same, so there should be no observable changes in final outputs.
