### PR TITLE
Hparams: Workaround problem with '/.' in run names.

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -185,12 +185,19 @@ class Context:
           value, with keys only for runs and tags that actually had
           data, which may be a subset of what was requested.
         """
-        return self._tb_context.data_provider.read_last_scalars(
+        last_scalars = self._tb_context.data_provider.read_last_scalars(
             ctx,
             experiment_id=experiment_id,
             plugin_name=scalar_metadata.PLUGIN_NAME,
             run_tag_filter=run_tag_filter,
         )
+        # Transform keys from the data provider using some of the same os-level
+        # filesystem operations used to generate metric names elsewhere.
+        # This will, for example, translate runs with name 'SOMETHING/.' to
+        # 'SOMETHING'.
+        return {
+            os.path.normpath(key): value for key, value in last_scalars.items()
+        }
 
     def hparams_from_data_provider(self, ctx, experiment_id, limit):
         """Calls DataProvider.list_hyperparameters() and returns the result."""


### PR DESCRIPTION
Some responses from data_provider.read_last_scalars() may contain run names of the following form: 'SOME_EXPERIMENT_OR_SOMETHING/.', with a trailing '/.' at the end. 

'.' always behaves sort of weird with Hparams and this is no exception. The problem in this case is that sessions of this sort could not be matched with metric values. No metric values would appear for them in the hparams dashboard.

This is because the logic to generate metric names drops the '/.' and so we could not match. That code relies on some os-level path operations and we know that '.' has special meaning for filesystems:

https://github.com/tensorflow/tensorboard/blob/23073c55c03f2f1a9da8c7e0bb9db3349dc15c90/tensorboard/plugins/hparams/metrics.py#L39

We fix the problem by transforming the result of data_provider.read_last_scalars() to apply the same os-level path operations to the run names (ie the keys of the result).


