### PR TITLE
Define extract_providers method directly instead of importing from closure

### DIFF
--- a/tensorboard/defs/internal/html.bzl
+++ b/tensorboard/defs/internal/html.bzl
@@ -15,7 +15,10 @@
 """Rule for building the HTML binary."""
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_aspect")
-load("@io_bazel_rules_closure//closure/private:defs.bzl", "WebFilesInfo", "collect_runfiles", "extract_providers", "long_path", "unfurl")  # buildifier: disable=bzl-visibility
+load("@io_bazel_rules_closure//closure/private:defs.bzl", "WebFilesInfo", "collect_runfiles", "long_path", "unfurl")  # buildifier: disable=bzl-visibility
+
+def extract_providers(deps, provider):
+    return [dep[provider] for dep in deps if provider in dep]
 
 def _tb_combine_html_impl(ctx):
     """Compiles HTMLs into one HTML.

--- a/tensorboard/defs/internal/html.bzl
+++ b/tensorboard/defs/internal/html.bzl
@@ -17,6 +17,7 @@
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_aspect")
 load("@io_bazel_rules_closure//closure/private:defs.bzl", "WebFilesInfo", "collect_runfiles", "long_path", "unfurl")  # buildifier: disable=bzl-visibility
 
+# TODO(ytjing): Directly import this function once it's synced from OSS to internal rules_closure repo.
 def extract_providers(deps, provider):
     return [dep[provider] for dep in deps if provider in dep]
 

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -22,7 +22,6 @@ load(
     "@io_bazel_rules_closure//closure/private:defs.bzl",
     "CLOSURE_LIBRARY_BASE_ATTR",
     "CLOSURE_WORKER_ATTR",
-    "ClosureJsLibraryInfo",
     "WebFilesInfo",
     "collect_js",
     "collect_runfiles",

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -31,6 +31,7 @@ load(
 )
 load("//tensorboard/defs/internal:html.bzl", _tb_combine_html = "tb_combine_html")
 
+# TODO(ytjing): Directly import this function once it's synced from OSS to internal rules_closure repo.
 def extract_providers(deps, provider):
     return [dep[provider] for dep in deps if provider in dep]
 

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -27,11 +27,13 @@ load(
     "collect_js",
     "collect_runfiles",
     "difference",
-    "extract_providers",
     "long_path",
     "unfurl",
 )
 load("//tensorboard/defs/internal:html.bzl", _tb_combine_html = "tb_combine_html")
+
+def extract_providers(deps, provider):
+    return [dep[provider] for dep in deps if provider in dep]
 
 def _tf_web_library(ctx):
     if not ctx.attr.srcs:

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -16,6 +16,7 @@
 
 load("@io_bazel_rules_closure//closure/private:defs.bzl", "WebFilesInfo", "collect_runfiles", "unfurl")  # buildifier: disable=bzl-visibility
 
+# TODO(ytjing): Directly import this function once it's synced from OSS to internal rules_closure repo.
 def extract_providers(deps, provider):
     return [dep[provider] for dep in deps if provider in dep]
 

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -14,7 +14,10 @@
 
 """Rule for zipping Webfiles."""
 
-load("@io_bazel_rules_closure//closure/private:defs.bzl", "WebFilesInfo", "collect_runfiles", "extract_providers", "unfurl")
+load("@io_bazel_rules_closure//closure/private:defs.bzl", "WebFilesInfo", "collect_runfiles", "unfurl")  # buildifier: disable=bzl-visibility
+
+def extract_providers(deps, provider):
+    return [dep[provider] for dep in deps if provider in dep]
 
 def _tensorboard_zip_file(ctx):
     deps = extract_providers(ctx.attr.deps, provider = WebFilesInfo)


### PR DESCRIPTION
To fix an internal breakage since `extract_providers` hasn't been imported from OSS to internal rules_closure repo yet. Also fixing a few internal build warnings.

#oncall