### PR TITLE
Handle undefiled unknown query params gracefully

### DIFF
--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -177,7 +177,7 @@ const reducer = createReducer(
     };
   }),
   on(stateRehydratedFromUrl, (state, {partialState}) => {
-    const {unknownQueryParams} = partialState as URLDeserializedState;
+    const {unknownQueryParams = {}} = partialState as URLDeserializedState;
     return {
       ...state,
       unknownQueryParams,

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -674,5 +674,19 @@ describe('core reducer', () => {
         foo: 'bar',
       });
     });
+
+    it('stores an empty object when no value is provided', () => {
+      const state = createCoreState({
+        unknownQueryParams: {foo: 'bar'},
+      });
+      const state2 = reducers(
+        state,
+        stateRehydratedFromUrl({
+          routeKind: RouteKind.EXPERIMENT,
+          partialState: {},
+        })
+      );
+      expect(state2.unknownQueryParams).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
## Motivation for features / changes
The internal deeplink provider doesn't know about `unknownQueryParams` yet and as such dispatches `stateRehydratedFromUrl` without defining a value for `unknownQueryParams`. This leads to a null pointer being thrown when loading in from the experiment list view. By defining a default value this null state can never occur.

