### PR TITLE
Migrate uses of struct.to_proto

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -112,7 +112,7 @@ def _tf_web_library(ctx):
         ],
     )
     params_file = _new_file(ctx, "-params.pbtxt")
-    ctx.actions.write(output = params_file, content = params.to_proto())
+    ctx.actions.write(output = params_file, content = proto.encode_text(params))
     ctx.actions.write(
         is_executable = True,
         output = ctx.outputs.executable,


### PR DESCRIPTION
Reapplies https://github.com/tensorflow/tensorboard/pull/6778 after https://github.com/tensorflow/tensorboard/pull/6721 inadvertently reverted part of it.

The "to_proto" method on Starlark structs is deprecated and shouldn't be used. Instead, the proto module's "encode_text" function should be used. (https://bazel.build/rules/lib/toplevel/proto)

It, along with "to_json", can be disabled in Bazel using the flag --incompatible_struct_has_no_methods

The underlying implementation is the same, so there should be no observable changes in final outputs.
