### PR TITLE
Revert "Force tests to use keras 2" after keras-team/keras#19353

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
             grep -v 'external/com_google_protobuf/python: warning: directory' |&\
             grep -v 'INFO: From ProtoCompile ' )
       - name: 'Bazel: test (with TensorFlow support)'
-        run: bazel test //tensorboard/... --test_env=TF_USE_LEGACY_KERAS=true
+        run: bazel test //tensorboard/...
         if: matrix.tf_version_id != 'notf'
       - name: 'Bazel: test (non-TensorFlow only)'
         run: bazel test //tensorboard/... --test_tag_filters="support_notf"


### PR DESCRIPTION
Reverts tensorflow/tensorboard#6804.

keras-team/keras#19353 resolves this on Keras' end.