### PR TITLE
Removes enableScalarColumnContextMenus flag

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -110,11 +110,6 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       queryParamOverride: 'enableScalarColumnCustomization',
       parseValue: parseBoolean,
     },
-    enableScalarColumnContextMenus: {
-      defaultValue: false,
-      queryParamOverride: 'enableScalarColumnContextMenus',
-      parseValue: parseBoolean,
-    },
     enableSuggestedCards: {
       defaultValue: false,
       queryParamOverride: 'enableSuggestedCards',

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -146,10 +146,3 @@ export const getIsScalarColumnCustomizationEnabled = createSelector(
     return flags.enableScalarColumnCustomization;
   }
 );
-
-export const getIsScalarColumnContextMenusEnabled = createSelector(
-  getFeatureFlags,
-  (flags: FeatureFlags): boolean => {
-    return flags.enableScalarColumnContextMenus;
-  }
-);

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -45,8 +45,6 @@ export interface FeatureFlags {
   // Adds affordance for users to select and reorder the columns in the Scalar
   // Card Data Table
   enableScalarColumnCustomization: boolean;
-  // Allows users to manipulate Scalar Card Table columns using context menus.
-  enableScalarColumnContextMenus: boolean;
   // Adds a new section at the top of the time series metrics view
   // containing suggested cards based on the users previous interactions.
   enableSuggestedCards: boolean;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -198,7 +198,6 @@ limitations under the License.
       [columnHeaders]="columnHeaders"
       [sortingInfo]="sortingInfo"
       [columnCustomizationEnabled]="columnCustomizationEnabled"
-      [columnContextMenusEnabled]="columnContextMenusEnabled"
       [smoothingEnabled]="smoothingEnabled"
       [columnFilters]="columnFilters"
       [runToHparamMap]="runToHparamMap"

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -105,7 +105,6 @@ export class ScalarCardComponent<Downloader> {
   @Input() useDarkMode!: boolean;
   @Input() forceSvg!: boolean;
   @Input() columnCustomizationEnabled!: boolean;
-  @Input() columnContextMenusEnabled!: boolean;
   @Input() linkedTimeSelection: TimeSelectionView | undefined;
   @Input() stepOrLinkedTimeSelection: TimeSelection | undefined;
   @Input() minMaxStep!: MinMaxStep;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -43,7 +43,6 @@ import {
 } from '../../../hparams';
 import {
   getForceSvgFeatureFlag,
-  getIsScalarColumnContextMenusEnabled,
   getIsScalarColumnCustomizationEnabled,
 } from '../../../feature_flag/store/feature_flag_selectors';
 import {
@@ -187,7 +186,6 @@ function areSeriesEqual(
       [stepOrLinkedTimeSelection]="stepOrLinkedTimeSelection$ | async"
       [forceSvg]="forceSvg$ | async"
       [columnCustomizationEnabled]="columnCustomizationEnabled$ | async"
-      [columnContextMenusEnabled]="columnContextMenusEnabled$ | async"
       [minMaxStep]="minMaxSteps$ | async"
       [userViewBox]="userViewBox$ | async"
       [columnHeaders]="columnHeaders$ | async"
@@ -272,9 +270,6 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   readonly forceSvg$ = this.store.select(getForceSvgFeatureFlag);
   readonly columnCustomizationEnabled$ = this.store.select(
     getIsScalarColumnCustomizationEnabled
-  );
-  readonly columnContextMenusEnabled$ = this.store.select(
-    getIsScalarColumnContextMenusEnabled
   );
   readonly xScaleType$ = this.store.select(getMetricsXAxisType).pipe(
     map((xAxisType) => {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ng.html
@@ -35,7 +35,6 @@ limitations under the License.
         *ngIf="header.enabled && (header.type !== ColumnHeaderType.SMOOTHED || smoothingEnabled)"
         [header]="header"
         [sortingInfo]="sortingInfo"
-        [disableContextMenu]="!columnContextMenusEnabled"
       ></tb-data-table-header-cell> </ng-container
   ></ng-container>
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_data_table.ts
@@ -57,7 +57,6 @@ export class ScalarCardDataTable {
   @Input() columnHeaders!: ColumnHeader[];
   @Input() sortingInfo!: SortingInfo;
   @Input() columnCustomizationEnabled!: boolean;
-  @Input() columnContextMenusEnabled!: boolean;
   @Input() smoothingEnabled!: boolean;
   @Input() columnFilters!: Map<string, DiscreteFilter | IntervalFilter>;
   @Input() selectableColumns!: ColumnHeader[];

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -136,7 +136,6 @@ import {HparamFilter} from '../../../hparams/_redux/types';
 import * as hparamsSelectors from '../../../hparams/_redux/hparams_selectors';
 import * as hparamsActions from '../../../hparams/_redux/hparams_actions';
 import * as runsSelectors from '../../../runs/store/runs_selectors';
-import {getIsScalarColumnContextMenusEnabled} from '../../../selectors';
 
 @Component({
   selector: 'line-chart',
@@ -392,10 +391,6 @@ describe('scalar card', () => {
     store.overrideSelector(selectors.getForceSvgFeatureFlag, false);
     store.overrideSelector(
       selectors.getIsScalarColumnCustomizationEnabled,
-      false
-    );
-    store.overrideSelector(
-      selectors.getIsScalarColumnContextMenusEnabled,
       false
     );
     store.overrideSelector(selectors.getMetricsStepSelectorEnabled, false);
@@ -4648,33 +4643,7 @@ describe('scalar card', () => {
         expect(dataTableComponent).toBeFalsy();
       }));
 
-      it('disables context menus if columnContextMenusEnabled is not set', fakeAsync(() => {
-        store.overrideSelector(getIsScalarColumnContextMenusEnabled, false);
-        store.overrideSelector(getCardStateMap, {
-          card1: {
-            dataMinMax: {
-              minStep: 0,
-              maxStep: 100,
-            },
-          },
-        });
-        store.overrideSelector(getMetricsCardTimeSelection, {
-          start: {step: 0},
-          end: {step: 100},
-        });
-        store.overrideSelector(selectors.getMetricsStepSelectorEnabled, true);
-        const fixture = createComponent('card1');
-        fixture.detectChanges();
-
-        const headerCellComponentInstance = fixture.debugElement.query(
-          By.directive(HeaderCellComponent)
-        ).componentInstance;
-
-        expect(headerCellComponentInstance.disableContextMenu).toBeTrue();
-      }));
-
-      it('enables context menus if columnContextMenusEnabled is set', fakeAsync(() => {
-        store.overrideSelector(getIsScalarColumnContextMenusEnabled, true);
+      it('shows context menus', fakeAsync(() => {
         store.overrideSelector(getCardStateMap, {
           card1: {
             dataMinMax: {


### PR DESCRIPTION
## Motivation for features / changes
Context menus in Time series scalar tables are ready for use!

## Technical description of changes
Removes the enableScalarColumnContextMenus feature flag and associated code

## Detailed steps to verify changes work correctly (as executed by you)
Manually tested context menus in runs table, filterbar, scalar tables