### PR TITLE
Hparams: Fix regression in column selector.

### DIFF
--- a/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
+++ b/tensorboard/webapp/widgets/data_table/data_table_component.ng.html
@@ -27,7 +27,10 @@ limitations under the License.
 <ng-template #columnSelectorModalTemplate>
   <tb-data-table-column-selector-component
     [selectableColumns]="selectableColumns"
+    [numColumnsLoaded]="numColumnsLoaded"
+    [hasMoreColumnsToLoad]="hasMoreColumnsToLoad"
     (columnSelected)="onColumnAdded($event)"
+    (loadAllColumns)="loadAllColumns.emit()"
   ></tb-data-table-column-selector-component>
 </ng-template>
 


### PR DESCRIPTION
Ensure the following properties are passed to the column selector from the data table:

```
    [numColumnsLoaded]="numColumnsLoaded"
    [hasMoreColumnsToLoad]="hasMoreColumnsToLoad"
    (loadAllColumns)="loadAllColumns.emit()"
```

These were accidentally removed in #6799. Caught by internal tests.