### PR TITLE
Build: Import 'first' from 'rxjs/operators' (again).

### DIFF
--- a/tensorboard/webapp/widgets/custom_modal/custom_modal_test.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal_test.ts
@@ -28,7 +28,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import {Overlay, OverlayModule, OverlayRef} from '@angular/cdk/overlay';
-import {first} from 'rxjs';
+import {first} from 'rxjs/operators';
 
 @Component({
   selector: 'fake-modal-view-container',


### PR DESCRIPTION
Similar to #6810 but for a test file. This is not strictly necessary for the internal import (these tests are not run internally) but I figured it would be good to do for completeness.