### PR TITLE
Fixes documentation from projector plugin when running in standalone mode.

### DIFF
--- a/tensorboard/plugins/projector/README.md
+++ b/tensorboard/plugins/projector/README.md
@@ -5,7 +5,7 @@ To develop the Embedding Projector, launch it in standalone mode:
 bazel run tensorboard/plugins/projector/vz_projector:standalone
 ```
 
-And open <http://localhost:6006/index.html>. The projector points to the local
+And open <http://localhost:6006/standalone.html>. The projector points to the local
 `standalone_projector_config.json` file, which configures it with a set of
 public datasets (word2vec, mnist, iris) that are useful for development
 and are hosted on Google Cloud Storage.


### PR DESCRIPTION
The output file for the standalone version was changed from generating an `index.html` file to generating a `standalone.html` file in #3933, but the README file was not updated with the new url.

Reported in #6795.