### PR TITLE
Restricts the protobuf dependency to be < 5.0.0, due to a recent breaking change.

### DIFF
--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,7 +26,7 @@ numpy >= 1.12.0
 # https://github.com/tensorflow/tensorflow/blob/25adc4fccb4b0bb5a933eba1d246380e7b87d7f7/tensorflow/tools/pip_package/setup.py#L101
 # 4.24.0 had an issue that broke our tests, so we should avoid that release:
 # https://github.com/protocolbuffers/protobuf/issues/13485
-protobuf >= 3.19.6, != 4.24.0
+protobuf >= 3.19.6, != 4.24.0, < 5.0.0
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # A dependency of our vendored packages. This lower bound has not been correctly
 # vetted, but I wanted to be the least restrictive we can, since it's not a new

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -26,6 +26,7 @@ numpy >= 1.12.0
 # https://github.com/tensorflow/tensorflow/blob/25adc4fccb4b0bb5a933eba1d246380e7b87d7f7/tensorflow/tools/pip_package/setup.py#L101
 # 4.24.0 had an issue that broke our tests, so we should avoid that release:
 # https://github.com/protocolbuffers/protobuf/issues/13485
+# 5.26.0 introduced a breaking change, so we restricted it for now. See issue #6808 for details.
 protobuf >= 3.19.6, != 4.24.0, < 5.0.0
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # A dependency of our vendored packages. This lower bound has not been correctly


### PR DESCRIPTION
The protobuf release 5.26.x is the first one in the major version 5, which introduces a breaking change.

This change adds a restriction on that dependency. See #6808 for details.