### PR TITLE
Sets defaultvalue of enableScalarColumnContextMenus to true

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -111,7 +111,7 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       parseValue: parseBoolean,
     },
     enableScalarColumnContextMenus: {
-      defaultValue: false,
+      defaultValue: true,
       queryParamOverride: 'enableScalarColumnContextMenus',
       parseValue: parseBoolean,
     },


### PR DESCRIPTION
## Motivation for features / changes
Context menus in Time series scalar tables are ready for use

## Technical description of changes
Removes the enableScalarColumnContextMenus feature flag and associated code

## Detailed steps to verify changes work correctly (as executed by you)
Manually tested context menus in runs table, filterbar, scalar tables