### PR TITLE
Bump black from 22.6.0 to 24.3.0

### DIFF
--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -152,13 +152,13 @@ class MultiplexerDataProvider(provider.DataProvider):
             plugin_name, run_tag_filter, summary_pb2.DATA_CLASS_SCALAR
         )
         run_tag_to_last_scalar_datum = collections.defaultdict(dict)
-        for (run, tags_for_run) in index.items():
-            for (tag, metadata) in tags_for_run.items():
+        for run, tags_for_run in index.items():
+            for tag, metadata in tags_for_run.items():
                 events = self._multiplexer.Tensors(run, tag)
                 if events:
-                    run_tag_to_last_scalar_datum[run][
-                        tag
-                    ] = _convert_scalar_event(events[-1])
+                    run_tag_to_last_scalar_datum[run][tag] = (
+                        _convert_scalar_event(events[-1])
+                    )
 
         return run_tag_to_last_scalar_datum
 
@@ -222,11 +222,11 @@ class MultiplexerDataProvider(provider.DataProvider):
             all_metadata = self._multiplexer.AllSummaryMetadata()
 
         result = {}
-        for (run, tag_to_metadata) in all_metadata.items():
+        for run, tag_to_metadata in all_metadata.items():
             if runs is not None and run not in runs:
                 continue
             result_for_run = {}
-            for (tag, metadata) in tag_to_metadata.items():
+            for tag, metadata in tag_to_metadata.items():
                 if tags is not None and tag not in tags:
                     continue
                 if metadata.data_class != data_class_filter:
@@ -250,10 +250,10 @@ class MultiplexerDataProvider(provider.DataProvider):
           suitable to be returned from `list_scalars` or `list_tensors`.
         """
         result = {}
-        for (run, tag_to_metadata) in index.items():
+        for run, tag_to_metadata in index.items():
             result_for_run = {}
             result[run] = result_for_run
-            for (tag, summary_metadata) in tag_to_metadata.items():
+            for tag, summary_metadata in tag_to_metadata.items():
                 max_step = None
                 max_wall_time = None
                 for event in self._multiplexer.Tensors(run, tag):
@@ -286,10 +286,10 @@ class MultiplexerDataProvider(provider.DataProvider):
           suitable to be returned from `read_scalars` or `read_tensors`.
         """
         result = {}
-        for (run, tags_for_run) in index.items():
+        for run, tags_for_run in index.items():
             result_for_run = {}
             result[run] = result_for_run
-            for (tag, metadata) in tags_for_run.items():
+            for tag, metadata in tags_for_run.items():
                 events = self._multiplexer.Tensors(run, tag)
                 data = [convert_event(e) for e in events]
                 result_for_run[tag] = _downsample(data, downsample)
@@ -304,10 +304,10 @@ class MultiplexerDataProvider(provider.DataProvider):
             plugin_name, run_tag_filter, summary_pb2.DATA_CLASS_BLOB_SEQUENCE
         )
         result = {}
-        for (run, tag_to_metadata) in index.items():
+        for run, tag_to_metadata in index.items():
             result_for_run = {}
             result[run] = result_for_run
-            for (tag, metadata) in tag_to_metadata.items():
+            for tag, metadata in tag_to_metadata.items():
                 max_step = None
                 max_wall_time = None
                 max_length = None
@@ -345,7 +345,7 @@ class MultiplexerDataProvider(provider.DataProvider):
             plugin_name, run_tag_filter, summary_pb2.DATA_CLASS_BLOB_SEQUENCE
         )
         result = {}
-        for (run, tags) in index.items():
+        for run, tags in index.items():
             result_for_run = {}
             result[run] = result_for_run
             for tag in tags:

--- a/tensorboard/backend/event_processing/data_provider_test.py
+++ b/tensorboard/backend/event_processing/data_provider_test.py
@@ -83,7 +83,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
                 ("very smooth", (0.0, 0.25, 0.5, 0.75, 1.0), "uniform"),
                 ("very smoothn't", (0.0, 0.01, 0.99, 1.0), "bimodal"),
             ]
-            for (description, distribution, name) in data:
+            for description, distribution, name in data:
                 tensor = tf.constant([distribution], dtype=tf.float64)
                 for i in range(1, 11):
                     histogram_summary.histogram(
@@ -97,7 +97,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
                 ("blue", (1, 91, 158), "bottom-left"),
                 ("yellow", (239, 220, 111), "bottom-right"),
             ]
-            for (name, color, description) in data:
+            for name, color, description in data:
                 image_1x1 = tf.constant([[[color]]], dtype=tf.uint8)
                 for i in range(1, 11):
                     # Use a non-monotonic sequence of sample sizes to
@@ -289,7 +289,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             for tag in result[run]:
                 tensor_events = multiplexer.Tensors(run, tag)
                 self.assertLen(result[run][tag], len(tensor_events))
-                for (datum, event) in zip(result[run][tag], tensor_events):
+                for datum, event in zip(result[run][tag], tensor_events):
                     self.assertEqual(datum.step, event.step)
                     self.assertEqual(datum.wall_time, event.wall_time)
                     self.assertEqual(
@@ -424,7 +424,7 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
             for tag in result[run]:
                 tensor_events = multiplexer.Tensors(run, tag)
                 self.assertLen(result[run][tag], len(tensor_events))
-                for (datum, event) in zip(result[run][tag], tensor_events):
+                for datum, event in zip(result[run][tag], tensor_events):
                     self.assertEqual(datum.step, event.step)
                     self.assertEqual(datum.wall_time, event.wall_time)
                     np.testing.assert_equal(

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -96,7 +96,7 @@ class EventMultiplexer:
                 "Event Multplexer doing initialization load for %s",
                 run_path_map,
             )
-            for (run, path) in run_path_map.items():
+            for run, path in run_path_map.items():
                 self.AddRun(path, run)
         logger.info("Event Multiplexer done initializing")
 

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -122,7 +122,7 @@ class EventMultiplexer:
                 "Event Multplexer doing initialization load for %s",
                 run_path_map,
             )
-            for (run, path) in run_path_map.items():
+            for run, path in run_path_map.items():
                 self.AddRun(path, run)
         logger.info("Event Multiplexer done initializing")
 

--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -602,9 +602,11 @@ class FSSpecFileSystem:
         prefix = self._get_chain_protocol_prefix(filename)
 
         return [
-            file
-            if (self.SEPARATOR in file or self.CHAIN_SEPARATOR in file)
-            else prefix + file
+            (
+                file
+                if (self.SEPARATOR in file or self.CHAIN_SEPARATOR in file)
+                else prefix + file
+            )
             for file in files
         ]
 

--- a/tensorboard/compat/tensorflow_stub/io/gfile_tf_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_tf_test.py
@@ -158,7 +158,7 @@ class FileIoTest(tb_test.TestCase):
         all_dirs = []
         all_subdirs = []
         all_files = []
-        for (w_dir, w_subdirs, w_files) in gfile.walk(dir_path, topdown=True):
+        for w_dir, w_subdirs, w_files in gfile.walk(dir_path, topdown=True):
             all_dirs.append(w_dir)
             all_subdirs.append(w_subdirs)
             all_files.append(w_files)
@@ -198,7 +198,7 @@ class FileIoTest(tb_test.TestCase):
         all_dirs = []
         all_subdirs = []
         all_files = []
-        for (w_dir, w_subdirs, w_files) in gfile.walk(dir_path, topdown=False):
+        for w_dir, w_subdirs, w_files in gfile.walk(dir_path, topdown=False):
             all_dirs.append(w_dir)
             all_subdirs.append(w_subdirs)
             all_files.append(w_files)
@@ -237,7 +237,7 @@ class FileIoTest(tb_test.TestCase):
         all_dirs = []
         all_subdirs = []
         all_files = []
-        for (w_dir, w_subdirs, w_files) in gfile.walk(dir_path, topdown=False):
+        for w_dir, w_subdirs, w_files in gfile.walk(dir_path, topdown=False):
             all_dirs.append(w_dir)
             all_subdirs.append(w_subdirs)
             all_files.append(w_files)

--- a/tensorboard/data/grpc_provider.py
+++ b/tensorboard/data/grpc_provider.py
@@ -140,7 +140,7 @@ class GrpcDataProvider(provider.DataProvider):
                     series = []
                     tags[tag_entry.tag_name] = series
                     d = tag_entry.data
-                    for (step, wt, value) in zip(d.step, d.wall_time, d.value):
+                    for step, wt, value in zip(d.step, d.wall_time, d.value):
                         point = provider.ScalarDatum(
                             step=step,
                             wall_time=wt,
@@ -177,13 +177,13 @@ class GrpcDataProvider(provider.DataProvider):
                     d = tag_entry.data
                     # There should be no more than one datum in
                     # `tag_entry.data` since downsample was set to 1.
-                    for (step, wt, value) in zip(d.step, d.wall_time, d.value):
-                        result[run_name][
-                            tag_entry.tag_name
-                        ] = provider.ScalarDatum(
-                            step=step,
-                            wall_time=wt,
-                            value=value,
+                    for step, wt, value in zip(d.step, d.wall_time, d.value):
+                        result[run_name][tag_entry.tag_name] = (
+                            provider.ScalarDatum(
+                                step=step,
+                                wall_time=wt,
+                                value=value,
+                            )
                         )
             return result
 
@@ -243,7 +243,7 @@ class GrpcDataProvider(provider.DataProvider):
                     series = []
                     tags[tag_entry.tag_name] = series
                     d = tag_entry.data
-                    for (step, wt, value) in zip(d.step, d.wall_time, d.value):
+                    for step, wt, value in zip(d.step, d.wall_time, d.value):
                         point = provider.TensorDatum(
                             step=step,
                             wall_time=wt,
@@ -308,7 +308,7 @@ class GrpcDataProvider(provider.DataProvider):
                     series = []
                     tags[tag_entry.tag_name] = series
                     d = tag_entry.data
-                    for (step, wt, blob_sequence) in zip(
+                    for step, wt, blob_sequence in zip(
                         d.step, d.wall_time, d.values
                     ):
                         values = []

--- a/tensorboard/data/grpc_provider_test.py
+++ b/tensorboard/data/grpc_provider_test.py
@@ -513,7 +513,7 @@ class GrpcDataProviderTest(tb_test.TestCase):
             (grpc.StatusCode.NOT_FOUND, errors.NotFoundError),
             (grpc.StatusCode.PERMISSION_DENIED, errors.PermissionDeniedError),
         ]
-        for (code, error_type) in cases:
+        for code, error_type in cases:
             with self.subTest(code.name):
                 msg = "my favorite cause"
                 e = _grpc_error(code, msg)

--- a/tensorboard/data/server_ingester_test.py
+++ b/tensorboard/data/server_ingester_test.py
@@ -64,6 +64,7 @@ class SubprocessServerDataIngesterTest(tb_test.TestCase):
         error_file = os.path.join(tmpdir.name, "startup_error")
 
         real_popen = subprocess.Popen
+
         # Stub out `subprocess.Popen` to write the port file.
         def fake_popen(subprocess_args, *args, **kwargs):
             def target():

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
@@ -74,8 +74,8 @@ class ExamplePlugin(base_plugin.TBPlugin):
         )
 
         result = {run: {} for run in mapping}
-        for (run, tag_to_timeseries) in mapping.items():
-            for (tag, timeseries) in tag_to_timeseries.items():
+        for run, tag_to_timeseries in mapping.items():
+            for tag, timeseries in tag_to_timeseries.items():
                 result[run][tag] = {
                     "description": timeseries.description,
                 }

--- a/tensorboard/functionaltests/core_test.py
+++ b/tensorboard/functionaltests/core_test.py
@@ -116,7 +116,7 @@ class DashboardsTest(BasicTest):
             "reload_button": "paper-icon-button#reload-button",
         }
         elements = {}
-        for (name, selector) in selectors.items():
+        for name, selector in selectors.items():
             locator = (by.By.CSS_SELECTOR, selector)
             self.wait.until(
                 expected_conditions.presence_of_element_located(locator)

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -349,7 +349,7 @@ def _display_colab(port, height, display_handle):
         ("%PORT%", "%d" % port),
         ("%HEIGHT%", "%d" % height),
     ]
-    for (k, v) in replacements:
+    for k, v in replacements:
         shell = shell.replace(k, v)
     script = IPython.display.Javascript(shell)
 
@@ -398,7 +398,7 @@ def _display_ipython(port, height, display_handle):
             ("%URL%", json.dumps("/")),
         ]
 
-    for (k, v) in replacements:
+    for k, v in replacements:
         shell = shell.replace(k, v)
     iframe = IPython.display.HTML(shell)
     if display_handle:

--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -25,7 +25,7 @@ moto==1.3.7
 fsspec>=2021.06.0
 
 # For linting
-black==22.6.0
+black==24.3.0
 flake8==3.7.8
 yamllint==1.17.0
 

--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -60,6 +60,7 @@ _ALLOWED_TAGS = [
     "th",
 ]
 
+
 # Cache Markdown converter to avoid expensive initialization at each
 # call to `markdown_to_safe_html`. Cache a different instance per thread.
 class _MarkdownStore(threading.local):

--- a/tensorboard/plugins/audio/audio_plugin.py
+++ b/tensorboard/plugins/audio/audio_plugin.py
@@ -101,8 +101,8 @@ class AudioPlugin(base_plugin.TBPlugin):
             plugin_name=metadata.PLUGIN_NAME,
         )
         result = {run: {} for run in mapping}
-        for (run, tag_to_time_series) in mapping.items():
-            for (tag, time_series) in tag_to_time_series.items():
+        for run, tag_to_time_series in mapping.items():
+            for tag, time_series in tag_to_time_series.items():
                 md = metadata.parse_plugin_metadata(time_series.plugin_content)
                 if not self._version_checker.ok(md.version, run, tag):
                     continue

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -177,9 +177,9 @@ class CustomScalarsPluginTest(tf.test.TestCase):
             custom_scalars_plugin_instance,
         ]
         for plugin_instance in plugin_instances:
-            plugin_name_to_instance[
-                plugin_instance.plugin_name
-            ] = plugin_instance
+            plugin_name_to_instance[plugin_instance.plugin_name] = (
+                plugin_instance
+            )
         return custom_scalars_plugin_instance
 
     def test_download_url_json(self):

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -116,6 +116,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.plugin = debugger_v2_plugin.DebuggerV2Plugin(context)
         wsgi_app = application.TensorBoardWSGI([self.plugin])
         self.server = werkzeug_test.Client(wsgi_app, wrappers.Response)
+
         # The multiplexer reads data asynchronously on a separate thread, so
         # as not to block the main thread of the TensorBoard backend. During
         # unit test, we disable the asynchronous behavior, so that we can

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -108,8 +108,8 @@ class GraphsPlugin(base_plugin.TBPlugin):
             experiment_id=experiment,
             plugin_name=metadata.PLUGIN_NAME_RUN_METADATA_WITH_GRAPH,
         )
-        for (run_name, tags) in mapping.items():
-            for (tag, tag_data) in tags.items():
+        for run_name, tags in mapping.items():
+            for tag, tag_data in tags.items():
                 # The Summary op is defined in TensorFlow and does not use a stringified proto
                 # as a content of plugin data. It contains single string that denotes a version.
                 # https://github.com/tensorflow/tensorflow/blob/11f4ecb54708865ec757ca64e4805957b05d7570/tensorflow/python/ops/summary_ops_v2.py#L789-L790
@@ -128,8 +128,8 @@ class GraphsPlugin(base_plugin.TBPlugin):
             experiment_id=experiment,
             plugin_name=metadata.PLUGIN_NAME_RUN_METADATA,
         )
-        for (run_name, tags) in mapping.items():
-            for (tag, tag_data) in tags.items():
+        for run_name, tags in mapping.items():
+            for tag, tag_data in tags.items():
                 if tag_data.plugin_content != b"1":
                     logger.warning(
                         "Ignoring unrecognizable version of RunMetadata."
@@ -146,8 +146,8 @@ class GraphsPlugin(base_plugin.TBPlugin):
             experiment_id=experiment,
             plugin_name=metadata.PLUGIN_NAME_KERAS_MODEL,
         )
-        for (run_name, tags) in mapping.items():
-            for (tag, tag_data) in tags.items():
+        for run_name, tags in mapping.items():
+            for tag, tag_data in tags.items():
                 if tag_data.plugin_content != b"1":
                     logger.warning(
                         "Ignoring unrecognizable version of RunMetadata."
@@ -161,7 +161,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
             experiment_id=experiment,
             plugin_name=metadata.PLUGIN_NAME,
         )
-        for (run_name, tags) in mapping.items():
+        for run_name, tags in mapping.items():
             if metadata.RUN_GRAPH_NAME in tags:
                 (run_item, _) = add_row_item(run_name, None)
                 run_item["run_graph"] = True
@@ -172,7 +172,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
             experiment_id=experiment,
             plugin_name=metadata.PLUGIN_NAME_TAGGED_RUN_METADATA,
         )
-        for (run_name, tags) in mapping.items():
+        for run_name, tags in mapping.items():
             for tag in tags:
                 (_, tag_item) = add_row_item(run_name, tag)
                 tag_item["profile"] = True

--- a/tensorboard/plugins/graph/keras_util.py
+++ b/tensorboard/plugins/graph/keras_util.py
@@ -60,7 +60,7 @@ def _walk_layers(keras_layer):
     if keras_layer.get("config").get("layers"):
         name_scope = keras_layer.get("config").get("name")
         for layer in keras_layer.get("config").get("layers"):
-            for (sub_name_scope, sublayer) in _walk_layers(layer):
+            for sub_name_scope, sublayer in _walk_layers(layer):
                 sub_name_scope = (
                     "%s/%s" % (name_scope, sub_name_scope)
                     if sub_name_scope
@@ -157,7 +157,7 @@ def _update_dicts(
     is_parent_functional_model = bool(inbound_nodes)
 
     if is_parent_functional_model and is_functional_model:
-        for (input_layer, inbound_node) in zip(input_layers, inbound_nodes):
+        for input_layer, inbound_node in zip(input_layers, inbound_nodes):
             input_layer_name = _scoped_name(node_name, input_layer)
             inbound_node_name = _scoped_name(name_scope, inbound_node[0])
             input_to_in_layer[input_layer_name] = inbound_node_name
@@ -209,7 +209,7 @@ def keras_model_to_graph_def(keras_layer):
     # instead are defined implicitly via order of layers.
     prev_node_name = None
 
-    for (name_scope, layer) in _walk_layers(keras_layer):
+    for name_scope, layer in _walk_layers(keras_layer):
         if _is_model(layer):
             (
                 input_to_layer,

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -80,8 +80,8 @@ class HistogramsPlugin(base_plugin.TBPlugin):
             plugin_name=metadata.PLUGIN_NAME,
         )
         result = {run: {} for run in mapping}
-        for (run, tag_to_content) in mapping.items():
-            for (tag, metadatum) in tag_to_content.items():
+        for run, tag_to_content in mapping.items():
+            for tag, metadatum in tag_to_content.items():
                 description = plugin_util.markdown_to_safe_html(
                     metadatum.description
                 )

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -190,7 +190,7 @@ class HistogramsPluginTest(tf.test.TestCase):
             % (expected_length, len(data), downsample),
         )
         last_step_seen = None
-        for (i, datum) in enumerate(data):
+        for i, datum in enumerate(data):
             [_unused_wall_time, step, buckets] = datum
             if last_step_seen is not None:
                 self.assertGreater(step, last_step_seen)

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -286,13 +286,13 @@ class Context:
             start_info = metadata.parse_session_start_info_plugin_data(
                 tag_to_content[metadata.SESSION_START_INFO_TAG]
             )
-            for (name, value) in start_info.hparams.items():
+            for name, value in start_info.hparams.items():
                 hparams[name].append(value)
 
         # Try to construct an HParamInfo for each hparam from its name and list
         # of values.
         result = []
-        for (name, values) in hparams.items():
+        for name, values in hparams.items():
             hparam_info = self._compute_hparam_info_from_values(name, values)
             if hparam_info is not None:
                 result.append(hparam_info)

--- a/tensorboard/plugins/hparams/list_session_groups.py
+++ b/tensorboard/plugins/hparams/list_session_groups.py
@@ -329,7 +329,7 @@ class Handler:
             # hyperparameter values) into result.
             # There doesn't seem to be a way to initialize a protobuffer map in the
             # constructor.
-            for (key, value) in start_info.hparams.items():
+            for key, value in start_info.hparams.items():
                 if not json_format_compat.is_serializable_value(value):
                     # NaN number_value cannot be serialized by higher level layers
                     # that are using json_format.MessageToJson(). To workaround
@@ -811,7 +811,7 @@ def _set_avg_session_metrics(session_group):
             stats.total_wall_time_secs += metric_value.wall_time_secs
 
     del session_group.metric_values[:]
-    for (metric_name, stats) in metric_stats.items():
+    for metric_name, stats in metric_stats.items():
         session_group.metric_values.add(
             name=api_pb2.MetricName(
                 group=metric_name.group, tag=metric_name.tag
@@ -1037,5 +1037,5 @@ def _reduce_to_hparams_to_include(session_groups, col_params):
         }
 
         session_group.ClearField("hparams")
-        for (hparam, value) in new_hparams.items():
+        for hparam, value in new_hparams.items():
             session_group.hparams[hparam].CopyFrom(value)

--- a/tensorboard/plugins/hparams/list_session_groups_test.py
+++ b/tensorboard/plugins/hparams/list_session_groups_test.py
@@ -205,9 +205,9 @@ class ListSessionGroupsTest(tf.test.TestCase):
             },
         }
         result = {}
-        for (run, tag_to_content) in hparams_content.items():
+        for run, tag_to_content in hparams_content.items():
             result.setdefault(run, {})
-            for (tag, content) in tag_to_content.items():
+            for tag, content in tag_to_content.items():
                 t = provider.TensorTimeSeries(
                     max_step=0,
                     max_wall_time=0,
@@ -1242,9 +1242,9 @@ class ListSessionGroupsTest(tf.test.TestCase):
             },
         }
         result = {}
-        for (run, tag_to_content) in hparams_content.items():
+        for run, tag_to_content in hparams_content.items():
             result.setdefault(run, {})
-            for (tag, content) in tag_to_content.items():
+            for tag, content in tag_to_content.items():
                 t = provider.TensorTimeSeries(
                     max_step=0,
                     max_wall_time=0,

--- a/tensorboard/plugins/hparams/summary.py
+++ b/tensorboard/plugins/hparams/summary.py
@@ -125,7 +125,7 @@ def session_start_pb(
         group_name=group_name,
         start_time_secs=start_time_secs,
     )
-    for (hp_name, hp_val) in hparams.items():
+    for hp_name, hp_val in hparams.items():
         # Boolean typed values need to be checked before integers since in Python
         # isinstance(True/False, int) returns True.
         if isinstance(hp_val, bool):

--- a/tensorboard/plugins/hparams/summary_v2.py
+++ b/tensorboard/plugins/hparams/summary_v2.py
@@ -196,7 +196,7 @@ def _normalize_hparams(hparams):
         hyperparameter name.
     """
     result = {}
-    for (k, v) in hparams.items():
+    for k, v in hparams.items():
         if isinstance(k, HParam):
             k = k.name
         if k in result:

--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -91,8 +91,8 @@ class ImagesPlugin(base_plugin.TBPlugin):
             plugin_name=metadata.PLUGIN_NAME,
         )
         result = {run: {} for run in mapping}
-        for (run, tag_to_content) in mapping.items():
-            for (tag, metadatum) in tag_to_content.items():
+        for run, tag_to_content in mapping.items():
+            for tag, metadatum in tag_to_content.items():
                 md = metadata.parse_plugin_metadata(metadatum.plugin_content)
                 if not self._version_checker.ok(md.version, run, tag):
                     continue

--- a/tensorboard/plugins/mesh/mesh_plugin.py
+++ b/tensorboard/plugins/mesh/mesh_plugin.py
@@ -108,7 +108,7 @@ class MeshPlugin(base_plugin.TBPlugin):
         response = dict()
         for run, tags in all_runs.items():
             response[run] = dict()
-            for (instance_tag, metadatum) in tags.items():
+            for instance_tag, metadatum in tags.items():
                 md = metadata.parse_plugin_metadata(metadatum.plugin_content)
                 if not self._version_checker.ok(md.version, run, instance_tag):
                     continue

--- a/tensorboard/plugins/metrics/metrics_plugin.py
+++ b/tensorboard/plugins/metrics/metrics_plugin.py
@@ -65,8 +65,8 @@ def _get_tag_description_info(mapping):
     """
     tag_to_descriptions = collections.defaultdict(set)
     description_to_runs = collections.defaultdict(set)
-    for (run, tag_to_content) in mapping.items():
-        for (tag, metadatum) in tag_to_content.items():
+    for run, tag_to_content in mapping.items():
+        for tag, metadatum in tag_to_content.items():
             description = metadatum.description
             if len(description):
                 tag_to_descriptions[tag].add(description)
@@ -216,8 +216,8 @@ def _get_tag_run_image_info(mapping):
         }
     """
     tag_run_image_info = collections.defaultdict(dict)
-    for (run, tag_to_content) in mapping.items():
-        for (tag, metadatum) in tag_to_content.items():
+    for run, tag_to_content in mapping.items():
+        for tag, metadatum in tag_to_content.items():
             tag_run_image_info[tag][run] = {
                 "maxSamplesPerStep": metadatum.max_length - 2  # width, height
             }
@@ -365,8 +365,8 @@ class MetricsPlugin(base_plugin.TBPlugin):
     def _filter_by_version(self, mapping, parse_metadata, version_checker):
         """Filter `DataProvider.list_*` output by summary metadata version."""
         result = {run: {} for run in mapping}
-        for (run, tag_to_content) in mapping.items():
-            for (tag, metadatum) in tag_to_content.items():
+        for run, tag_to_content in mapping.items():
+            for tag, metadatum in tag_to_content.items():
                 md = parse_metadata(metadatum.plugin_content)
                 if not version_checker.ok(md.version, run, tag):
                     continue
@@ -509,7 +509,7 @@ class MetricsPlugin(base_plugin.TBPlugin):
         )
 
         run_to_series = {}
-        for (result_run, tag_data) in mapping.items():
+        for result_run, tag_data in mapping.items():
             if tag not in tag_data:
                 continue
             values = [
@@ -558,7 +558,7 @@ class MetricsPlugin(base_plugin.TBPlugin):
         )
 
         run_to_series = {}
-        for (result_run, tag_data) in mapping.items():
+        for result_run, tag_data in mapping.items():
             if tag not in tag_data:
                 continue
             values = [
@@ -595,7 +595,7 @@ class MetricsPlugin(base_plugin.TBPlugin):
         )
 
         run_to_series = {}
-        for (result_run, tag_data) in mapping.items():
+        for result_run, tag_data in mapping.items():
             if tag not in tag_data:
                 continue
             blob_sequence_datum_list = tag_data[tag]

--- a/tensorboard/plugins/metrics/metrics_plugin_test.py
+++ b/tensorboard/plugins/metrics/metrics_plugin_test.py
@@ -131,14 +131,14 @@ class MetricsPluginTest(tf.test.TestCase):
         place."""
         for response in responses:
             run_to_series = response.get("runToSeries", {})
-            for (run, series) in run_to_series.items():
+            for run, series in run_to_series.items():
                 for datum in series:
                     if "wallTime" in datum:
                         datum["wallTime"] = "<wall_time>"
 
             # Clean images.
             run_to_image_series = response.get("runToSeries", {})
-            for (run, series) in run_to_image_series.items():
+            for run, series in run_to_image_series.items():
                 for datum in series:
                     if "wallTime" in datum:
                         datum["wallTime"] = "<wall_time>"

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -148,8 +148,8 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
             ctx, experiment_id=experiment, plugin_name=metadata.PLUGIN_NAME
         )
         result = {run: {} for run in mapping}
-        for (run, tag_to_time_series) in mapping.items():
-            for (tag, time_series) in tag_to_time_series.items():
+        for run, tag_to_time_series in mapping.items():
+            for tag, time_series in tag_to_time_series.items():
                 md = metadata.parse_plugin_metadata(time_series.plugin_content)
                 if not self._version_checker.ok(md.version, run, tag):
                     continue

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -523,7 +523,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     def _append_plugin_asset_directories(self, run_path_pairs):
         extra = []
         plugin_assets_name = metadata.PLUGIN_ASSETS_NAME
-        for (run, logdir) in run_path_pairs:
+        for run, logdir in run_path_pairs:
             assets = plugin_asset_util.ListAssets(logdir, plugin_assets_name)
             if metadata.PROJECTOR_FILENAME not in assets:
                 continue

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -84,8 +84,8 @@ class ScalarsPlugin(base_plugin.TBPlugin):
             plugin_name=metadata.PLUGIN_NAME,
         )
         result = {run: {} for run in mapping}
-        for (run, tag_to_content) in mapping.items():
-            for (tag, metadatum) in tag_to_content.items():
+        for run, tag_to_content in mapping.items():
+            for tag, metadatum in tag_to_content.items():
                 md = metadata.parse_plugin_metadata(metadatum.plugin_content)
                 if not self._version_checker.ok(md.version, run, tag):
                     continue

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -240,8 +240,8 @@ class TextPlugin(base_plugin.TBPlugin):
             plugin_name=metadata.PLUGIN_NAME,
         )
         result = {run: [] for run in mapping}
-        for (run, tag_to_content) in mapping.items():
-            for (tag, metadatum) in tag_to_content.items():
+        for run, tag_to_content in mapping.items():
+            for tag, metadatum in tag_to_content.items():
                 md = metadata.parse_plugin_metadata(metadatum.plugin_content)
                 if not self._version_checker.ok(md.version, run, tag):
                     continue

--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -503,7 +503,7 @@ def main():
     markdown_code_fence = "``````"  # seems likely to be sufficient
     print(markdown_code_fence)
     suggestions = []
-    for (i, check) in enumerate(CHECKS):
+    for i, check in enumerate(CHECKS):
         if i > 0:
             print()
         print("--- check: %s" % check.__name__)

--- a/tensorboard/util/grpc_util.py
+++ b/tensorboard/util/grpc_util.py
@@ -189,9 +189,7 @@ def _compute_backoff_seconds(num_attempts):
     jitter_factor = random.uniform(
         _GRPC_RETRY_JITTER_FACTOR_MIN, _GRPC_RETRY_JITTER_FACTOR_MAX
     )
-    backoff_secs = (
-        _GRPC_RETRY_EXPONENTIAL_BASE**num_attempts
-    ) * jitter_factor
+    backoff_secs = (_GRPC_RETRY_EXPONENTIAL_BASE**num_attempts) * jitter_factor
     return backoff_secs
 
 


### PR DESCRIPTION
Dependabot upgrade https://github.com/tensorflow/tensorboard/pull/6802 failed since Python files need to be reformatted after `black` upgrade, bumping `black` version and linting the Python files in this PR.

#oncall