### PR TITLE
Hparams: fix metrics loading when group name is "."

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -487,12 +487,8 @@ class Context:
             if session is None:
                 continue
             group = os.path.relpath(run, session)
-            # Do not normalize the path since the run name could be ".", note that 
-            # `os.path.relpath` would remove the the trailing "/.".
-            if run.endswith("/."):
-                group += "/."
             # relpath() returns "." for the 'session' directory, we use an empty
-            # string, unless the run name ends with ".".
+            # string, unless the run name actually ends with ".".
             if group == "." and not run.endswith("."):
                 group = ""
             metric_names_set.update((tag, group) for tag in tags)

--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -185,19 +185,12 @@ class Context:
           value, with keys only for runs and tags that actually had
           data, which may be a subset of what was requested.
         """
-        last_scalars = self._tb_context.data_provider.read_last_scalars(
+        return self._tb_context.data_provider.read_last_scalars(
             ctx,
             experiment_id=experiment_id,
             plugin_name=scalar_metadata.PLUGIN_NAME,
             run_tag_filter=run_tag_filter,
         )
-        # Transform keys from the data provider using some of the same os-level
-        # filesystem operations used to generate metric names elsewhere.
-        # This will, for example, translate runs with name 'SOMETHING/.' to
-        # 'SOMETHING'.
-        return {
-            os.path.normpath(key): value for key, value in last_scalars.items()
-        }
 
     def hparams_from_data_provider(self, ctx, experiment_id, limit):
         """Calls DataProvider.list_hyperparameters() and returns the result."""
@@ -494,9 +487,13 @@ class Context:
             if session is None:
                 continue
             group = os.path.relpath(run, session)
+            # Do not normalize the path since the run name could be ".", note that 
+            # `os.path.relpath` would remove the the trailing "/.".
+            if run.endswith("/."):
+                group += "/."
             # relpath() returns "." for the 'session' directory, we use an empty
-            # string.
-            if group == ".":
+            # string, unless the run name ends with ".".
+            if group == "." and not run.endswith("."):
                 group = ""
             metric_names_set.update((tag, group) for tag in tags)
         metric_names_list = list(metric_names_set)

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -129,7 +129,7 @@ class BackendContextTest(tf.test.TestCase):
             "exp/session_3xyz/": {
                 "loss2": b"",
             },
-            "exp/session_4/.": {
+            ".": {
                 "entropy": b"",
             },
         }
@@ -905,7 +905,7 @@ class BackendContextTest(tf.test.TestCase):
             }
             metric_infos {
               name {
-                group: "exp/session_4/."
+                group: "."
                 tag: "entropy"
               }
             }

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -129,6 +129,9 @@ class BackendContextTest(tf.test.TestCase):
             "exp/session_3xyz/": {
                 "loss2": b"",
             },
+            "exp/session_4/.": {
+                "entropy": b"",
+            },
         }
         result = {}
         for run, tag_to_content in scalars_content.items():
@@ -898,6 +901,12 @@ class BackendContextTest(tf.test.TestCase):
               name {
                 group: "exp/session_3"
                 tag: "accuracy"
+              }
+            }
+            metric_infos {
+              name {
+                group: "exp/session_4/."
+                tag: "entropy"
               }
             }
             metric_infos {

--- a/tensorboard/plugins/hparams/metrics.py
+++ b/tensorboard/plugins/hparams/metrics.py
@@ -32,10 +32,12 @@ def run_tag_from_session_and_metric(session_name, metric_name):
     """
     assert isinstance(session_name, str)
     assert isinstance(metric_name, api_pb2.MetricName)
+    run = os.path.join(session_name, metric_name.group)
     # os.path.join() will append a final slash if the group is empty; it seems
     # like multiplexer.Tensors won't recognize paths that end with a '/' so
     # we normalize the result of os.path.join() to remove the final '/' in that
     # case.
-    run = os.path.normpath(os.path.join(session_name, metric_name.group))
+    if run.endswith("/"):
+        run = run[:-1]
     tag = metric_name.tag
     return run, tag

--- a/tensorboard/plugins/hparams/metrics.py
+++ b/tensorboard/plugins/hparams/metrics.py
@@ -32,11 +32,10 @@ def run_tag_from_session_and_metric(session_name, metric_name):
     """
     assert isinstance(session_name, str)
     assert isinstance(metric_name, api_pb2.MetricName)
-    run = os.path.join(session_name, metric_name.group)
     # os.path.join() will append a final slash if the group is empty; it seems
     # like multiplexer.Tensors won't recognize paths that end with a '/' so
-    # we normalize the result of os.path.join() to remove the final '/' in that
-    # case.
+    # we remove the final '/' in that case.
+    run = os.path.join(session_name, metric_name.group)
     if run.endswith("/"):
         run = run[:-1]
     tag = metric_name.tag

--- a/tensorboard/plugins/hparams/tf_hparams_utils/tf-hparams-utils.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_utils/tf-hparams-utils.ts
@@ -75,7 +75,7 @@ export function metricName(metricInfo) {
   if (tag === undefined) {
     tag = '';
   }
-  if (group === '') {
+  if (group === '' || group === '.') {
     return tag;
   }
   return group + '.' + tag;


### PR DESCRIPTION
In the Hparams plugin, when fetching metrics (scalar data) for multiple experiments in the comparison view, we can't replace group name `.` with an empty string. 

Googlers, see b/332308243 for more details.

Tested internally: cl/582334596

#hparams #oncall
