### PR TITLE
[Global pins] Add clear all pins button

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -277,5 +277,9 @@ export const metricsUnresolvedPinnedCardsFromLocalStorageAdded = createAction(
   props<{cards: CardUniqueInfo[]}>()
 );
 
+export const metricsClearAllPinnedCards = createAction(
+  '[Metrics] Clear all pinned cards'
+);
+
 // TODO(jieweiwu): Delete after internal code is updated.
 export const stepSelectorTimeSelectionChanged = timeSelectionChanged;

--- a/tensorboard/webapp/metrics/data_source/saved_pins_data_source.ts
+++ b/tensorboard/webapp/metrics/data_source/saved_pins_data_source.ts
@@ -45,4 +45,8 @@ export class SavedPinsDataSource {
     }
     return [];
   }
+
+  removeAllScalarPins(): void {
+    window.localStorage.setItem(SAVED_SCALAR_PINS_KEY, JSON.stringify([]));
+  }
 }

--- a/tensorboard/webapp/metrics/data_source/saved_pins_data_source_test.ts
+++ b/tensorboard/webapp/metrics/data_source/saved_pins_data_source_test.ts
@@ -114,4 +114,15 @@ describe('SavedPinsDataSource Test', () => {
       expect(dataSource.getSavedScalarPins()).toEqual(['tag1']);
     });
   });
+
+  describe('removeAllScalarPins', () => {
+    it('removes all existing pins', () => {
+      dataSource.saveScalarPin('tag3');
+      dataSource.saveScalarPin('tag4');
+
+      dataSource.removeAllScalarPins();
+
+      expect(dataSource.getSavedScalarPins().length).toEqual(0);
+    });
+  });
 });

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -316,6 +316,21 @@ export class MetricsEffects implements OnInitEffects {
     })
   );
 
+  private readonly removeAllPins$ = this.actions$.pipe(
+    ofType(actions.metricsClearAllPinnedCards),
+    withLatestFrom(
+      this.store.select(selectors.getEnableGlobalPins),
+      this.store.select(selectors.getShouldPersistSettings)
+    ),
+    filter(
+      ([, enableGlobalPins, shouldPersistSettings]) =>
+        enableGlobalPins && shouldPersistSettings
+    ),
+    tap(() => {
+      this.savedPinsDataSource.removeAllScalarPins();
+    })
+  );
+
   /**
    * In general, this effect dispatch the following actions:
    *
@@ -356,7 +371,11 @@ export class MetricsEffects implements OnInitEffects {
         /**
          * Subscribes to: dashboard shown (initAction).
          */
-        this.loadSavedPins$
+        this.loadSavedPins$,
+        /**
+         * Subscribes to: metricsClearAllPinnedCards.
+         */
+        this.removeAllPins$
       );
     },
     {dispatch: false}

--- a/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
+++ b/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
@@ -985,5 +985,42 @@ describe('metrics effects', () => {
         expect(actualActions).toEqual([]);
       });
     });
+
+    describe('removeAllPins', () => {
+      let removeAllScalarPinsSpy: jasmine.Spy;
+
+      beforeEach(() => {
+        removeAllScalarPinsSpy = spyOn(
+          savedPinsDataSource,
+          'removeAllScalarPins'
+        );
+        store.overrideSelector(selectors.getEnableGlobalPins, true);
+        store.refreshState();
+      });
+
+      it('removes all pins by calling removeAllScalarPins method', () => {
+        actions$.next(actions.metricsClearAllPinnedCards());
+
+        expect(removeAllScalarPinsSpy).toHaveBeenCalled();
+      });
+
+      it('does not remove pins if getEnableGlobalPins is false', () => {
+        store.overrideSelector(selectors.getEnableGlobalPins, false);
+        store.refreshState();
+
+        actions$.next(actions.metricsClearAllPinnedCards());
+
+        expect(removeAllScalarPinsSpy).not.toHaveBeenCalled();
+      });
+
+      it('does not remove pins if getShouldPersistSettings is false', () => {
+        store.overrideSelector(selectors.getShouldPersistSettings, false);
+        store.refreshState();
+
+        actions$.next(actions.metricsClearAllPinnedCards());
+
+        expect(removeAllScalarPinsSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -77,6 +77,8 @@ import {
   TagMetadata,
   TimeSeriesData,
   TimeSeriesLoadable,
+  CardToPinnedCard,
+  PinnedCardToCard,
 } from './metrics_types';
 import {dataTableUtils} from '../../widgets/data_table/utils';
 
@@ -1532,7 +1534,7 @@ const reducer = createReducer(
     let nextCardStateMap = {...state.cardStateMap};
     let nextLastPinnedCardTime = state.lastPinnedCardTime;
 
-    for (const [cardId, _] of state.pinnedCardToOriginal) {
+    for (const cardId of state.pinnedCardToOriginal.keys()) {
       delete nextCardMetadataMap[cardId];
       delete nextCardStepIndexMap[cardId];
       delete nextCardStateMap[cardId];
@@ -1543,9 +1545,9 @@ const reducer = createReducer(
       cardMetadataMap: nextCardMetadataMap,
       cardStateMap: nextCardStateMap,
       cardStepIndex: nextCardStepIndexMap,
-      cardToPinnedCopy: new Map(),
-      cardToPinnedCopyCache: new Map(),
-      pinnedCardToOriginal: new Map(),
+      cardToPinnedCopy: new Map() as CardToPinnedCard,
+      cardToPinnedCopyCache: new Map() as CardToPinnedCard,
+      pinnedCardToOriginal: new Map() as PinnedCardToCard,
       lastPinnedCardTime: nextLastPinnedCardTime,
     };
   })

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1529,14 +1529,13 @@ const reducer = createReducer(
     }
   ),
   on(actions.metricsClearAllPinnedCards, (state) => {
-    let nextCardMetadataMap = {...state.cardMetadataMap};
-    let nextCardStepIndexMap = {...state.cardStepIndex};
-    let nextCardStateMap = {...state.cardStateMap};
-    let nextLastPinnedCardTime = state.lastPinnedCardTime;
+    const nextCardMetadataMap = {...state.cardMetadataMap};
+    const nextCardStepIndex = {...state.cardStepIndex};
+    const nextCardStateMap = {...state.cardStateMap};
 
     for (const cardId of state.pinnedCardToOriginal.keys()) {
       delete nextCardMetadataMap[cardId];
-      delete nextCardStepIndexMap[cardId];
+      delete nextCardStepIndex[cardId];
       delete nextCardStateMap[cardId];
     }
 
@@ -1544,11 +1543,10 @@ const reducer = createReducer(
       ...state,
       cardMetadataMap: nextCardMetadataMap,
       cardStateMap: nextCardStateMap,
-      cardStepIndex: nextCardStepIndexMap,
+      cardStepIndex: nextCardStepIndex,
       cardToPinnedCopy: new Map() as CardToPinnedCard,
       cardToPinnedCopyCache: new Map() as CardToPinnedCard,
       pinnedCardToOriginal: new Map() as PinnedCardToCard,
-      lastPinnedCardTime: nextLastPinnedCardTime,
     };
   })
 );

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -1525,7 +1525,30 @@ const reducer = createReducer(
         ],
       };
     }
-  )
+  ),
+  on(actions.metricsClearAllPinnedCards, (state) => {
+    let nextCardMetadataMap = {...state.cardMetadataMap};
+    let nextCardStepIndexMap = {...state.cardStepIndex};
+    let nextCardStateMap = {...state.cardStateMap};
+    let nextLastPinnedCardTime = state.lastPinnedCardTime;
+
+    for (const [cardId, _] of state.pinnedCardToOriginal) {
+      delete nextCardMetadataMap[cardId];
+      delete nextCardStepIndexMap[cardId];
+      delete nextCardStateMap[cardId];
+    }
+
+    return {
+      ...state,
+      cardMetadataMap: nextCardMetadataMap,
+      cardStateMap: nextCardStateMap,
+      cardStepIndex: nextCardStepIndexMap,
+      cardToPinnedCopy: new Map(),
+      cardToPinnedCopyCache: new Map(),
+      pinnedCardToOriginal: new Map(),
+      lastPinnedCardTime: nextLastPinnedCardTime,
+    };
+  })
 );
 
 export function reducers(state: MetricsState | undefined, action: Action) {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -4488,5 +4488,57 @@ describe('metrics reducers', () => {
         expect(state2.unresolvedImportedPinnedCards).toEqual([fakePinnedCard]);
       });
     });
+
+    describe('#metricsClearAllPinnedCards', () => {
+      it('unpins all pinned cards', () => {
+        const beforeState = buildMetricsState({
+          cardMetadataMap: {
+            card1: createScalarCardMetadata(),
+            pinnedCopy1: createScalarCardMetadata(),
+            card2: createScalarCardMetadata(),
+            pinnedCopy2: createScalarCardMetadata(),
+          },
+          cardList: ['card1', 'card2'],
+          cardStepIndex: {
+            card1: buildStepIndexMetadata({index: 10}),
+            pinnedCopy1: buildStepIndexMetadata({index: 20}),
+            card2: buildStepIndexMetadata({index: 11}),
+            pinnedCopy2: buildStepIndexMetadata({index: 21}),
+          },
+          cardToPinnedCopy: new Map([
+            ['card1', 'pinnedCopy1'],
+            ['card2', 'pinnedCopy2'],
+          ]),
+          cardToPinnedCopyCache: new Map([
+            ['card1', 'pinnedCopy1'],
+            ['card2', 'pinnedCopy2'],
+          ]),
+          pinnedCardToOriginal: new Map([
+            ['pinnedCopy1', 'card1'],
+            ['pinnedCopy2', 'card2'],
+          ]),
+        });
+        const nextState = reducers(
+          beforeState,
+          actions.metricsClearAllPinnedCards()
+        );
+
+        const expectedState = buildMetricsState({
+          cardMetadataMap: {
+            card1: createScalarCardMetadata(),
+            card2: createScalarCardMetadata(),
+          },
+          cardList: ['card1', 'card2'],
+          cardStepIndex: {
+            card1: buildStepIndexMetadata({index: 10}),
+            card2: buildStepIndexMetadata({index: 11}),
+          },
+          cardToPinnedCopy: new Map(),
+          cardToPinnedCopyCache: new Map(),
+          pinnedCardToOriginal: new Map(),
+        });
+        expect(nextState).toEqual(expectedState);
+      });
+    });
   });
 });

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -405,6 +405,8 @@ export class TestingSavedPinsDataSource {
   getSavedScalarPins() {
     return [];
   }
+
+  removeAllScalarPins() {}
 }
 
 export function provideTestingSavedPinsDataSource() {

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.scss
@@ -26,6 +26,25 @@ mat-icon {
   margin-right: 5px;
 }
 
+.group-toolbar {
+  justify-content: space-between;
+}
+
+.left-items {
+  display: flex;
+  align-items: center;
+}
+
+.right-items {
+  button {
+    $_height: 25px;
+    font-size: 12px;
+    font-weight: normal;
+    height: $_height;
+    line-height: $_height;
+  }
+}
+
 .group-text {
   display: flex;
   align-items: baseline;

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 
@@ -20,23 +26,30 @@ import {CardIdWithMetadata} from '../metrics_view_types';
   selector: 'metrics-pinned-view-component',
   template: `
     <div class="group-toolbar">
-      <mat-icon svgIcon="keep_24px"></mat-icon>
-      <span class="group-text">
-        <span class="group-title" aria-role="heading" aria-level="3"
-          >Pinned</span
-        >
-        <span *ngIf="cardIdsWithMetadata.length > 1" class="group-card-count"
-          >{{ cardIdsWithMetadata.length }} cards</span
-        >
-        <span *ngIf="lastPinnedCardTime">
-          <span
-            *ngFor="let id of [lastPinnedCardTime]"
-            [attr.data-id]="id"
-            class="new-card-pinned"
-            >New card pinned</span
+      <div class="left-items">
+        <mat-icon svgIcon="keep_24px"></mat-icon>
+        <span class="group-text">
+          <span class="group-title" aria-role="heading" aria-level="3"
+            >Pinned</span
           >
+          <span *ngIf="cardIdsWithMetadata.length > 1" class="group-card-count"
+            >{{ cardIdsWithMetadata.length }} cards</span
+          >
+          <span *ngIf="lastPinnedCardTime">
+            <span
+              *ngFor="let id of [lastPinnedCardTime]"
+              [attr.data-id]="id"
+              class="new-card-pinned"
+              >New card pinned</span
+            >
+          </span>
         </span>
-      </span>
+      </div>
+      <div class="right-items" *ngIf="cardIdsWithMetadata.length > 0">
+        <button mat-stroked-button (click)="onClearAllPinsClicked.emit()">
+          Clear all pins
+        </button>
+      </div>
     </div>
     <metrics-card-grid
       *ngIf="cardIdsWithMetadata.length; else emptyPinnedView"
@@ -54,4 +67,5 @@ export class PinnedViewComponent {
   @Input() cardObserver!: CardObserver;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
   @Input() lastPinnedCardTime!: number;
+  @Output() onClearAllPinsClicked = new EventEmitter<void>();
 }

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_component.ts
@@ -45,8 +45,15 @@ import {CardIdWithMetadata} from '../metrics_view_types';
           </span>
         </span>
       </div>
-      <div class="right-items" *ngIf="cardIdsWithMetadata.length > 0">
-        <button mat-stroked-button (click)="onClearAllPinsClicked.emit()">
+      <div
+        class="right-items"
+        *ngIf="cardIdsWithMetadata.length > 0 && globalPinsEnabled"
+      >
+        <button
+          mat-stroked-button
+          aria-label="Clear all pinned cards"
+          (click)="onClearAllPinsClicked.emit()"
+        >
           Clear all pins
         </button>
       </div>
@@ -67,5 +74,6 @@ export class PinnedViewComponent {
   @Input() cardObserver!: CardObserver;
   @Input() cardIdsWithMetadata!: CardIdWithMetadata[];
   @Input() lastPinnedCardTime!: number;
+  @Input() globalPinsEnabled: boolean = false;
   @Output() onClearAllPinsClicked = new EventEmitter<void>();
 }

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_container.ts
@@ -21,6 +21,7 @@ import {DeepReadonly} from '../../../util/types';
 import {getLastPinnedCardTime, getPinnedCardsWithMetadata} from '../../store';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
+import {metricsClearAllPinnedCards} from '../../actions';
 
 @Component({
   selector: 'metrics-pinned-view',
@@ -29,6 +30,7 @@ import {CardIdWithMetadata} from '../metrics_view_types';
       [cardIdsWithMetadata]="cardIdsWithMetadata$ | async"
       [lastPinnedCardTime]="lastPinnedCardTime$ | async"
       [cardObserver]="cardObserver"
+      (onClearAllPinsClicked)="onClearAllPinsClicked()"
     ></metrics-pinned-view-component>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -47,4 +49,8 @@ export class PinnedViewContainer {
     // pins after page load.
     skip(1)
   );
+
+  onClearAllPinsClicked() {
+    this.store.dispatch(metricsClearAllPinnedCards());
+  }
 }

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_container.ts
@@ -22,6 +22,7 @@ import {getLastPinnedCardTime, getPinnedCardsWithMetadata} from '../../store';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 import {metricsClearAllPinnedCards} from '../../actions';
+import {getEnableGlobalPins} from '../../../selectors';
 
 @Component({
   selector: 'metrics-pinned-view',
@@ -30,6 +31,7 @@ import {metricsClearAllPinnedCards} from '../../actions';
       [cardIdsWithMetadata]="cardIdsWithMetadata$ | async"
       [lastPinnedCardTime]="lastPinnedCardTime$ | async"
       [cardObserver]="cardObserver"
+      [globalPinsEnabled]="globalPinsEnabled$ | async"
       (onClearAllPinsClicked)="onClearAllPinsClicked()"
     ></metrics-pinned-view-component>
   `,
@@ -49,6 +51,8 @@ export class PinnedViewContainer {
     // pins after page load.
     skip(1)
   );
+
+  readonly globalPinsEnabled$ = this.store.select(getEnableGlobalPins);
 
   onClearAllPinsClicked() {
     this.store.dispatch(metricsClearAllPinnedCards());


### PR DESCRIPTION
## Motivation for features / changes
Following #6821 As pin data is accumulated, unwanted pins can easily crowd the dashboard. Therefore, this PR adds a button that allows users to conveniently clear all pins at once.

## Technical description of changes
* 57c6a47 Introduced new action called `metricsClearAllPinnedCards`
  * When `metricsClearAllPinnedCards` is dispatched, the reducer removed all pinned cards in the state.

* a04c2d7 Added `clear all pins` button in the pinned view container.
  * The button will be shown if there's at least one pinned card.

* f0c3a54 Implemented `removeAllScalarPins` method in the saved pins data source.
  * This method removes stored pins from local storage.

* e97b110 Added `removeAllPins` effect in the `metrics/effects/index.ts`
  * When `metricsClearAllPinnedCards` action is called, this effect will call `removeAllScalarPins` method defined in the saved pin data source.

* c0edd37 guarded UI feature  (button) with feature flag and added related tests.

## Screenshots of UI changes (or N/A)
### Light mode
![image](https://github.com/tensorflow/tensorboard/assets/24772412/a0793e8b-7fea-45f0-b2d8-4e742ca40918)


### Dark mode
![image](https://github.com/tensorflow/tensorboard/assets/24772412/581468a1-1a9c-4ab4-b70a-13c5a5b168f6)

## Detailed steps to verify changes work correctly (as executed by you)
Unit test pass  & cl TAP presubmit pass
## Alternate designs / implementations considered (or N/A)
I also considered a feature to select a pinned card and remove the selected pinned card, but I thought that this would be the same as pressing the 'unpin' button individually from the user's perspective. So I implemented a 'clear all pins' button that removes all pinned cards. Any feedback is appreciated!