### PR TITLE
[Global Pins] Added a disabling global pins feature

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -281,5 +281,9 @@ export const metricsClearAllPinnedCards = createAction(
   '[Metrics] Clear all pinned cards'
 );
 
+export const metricsEnableSavingPinsToggled = createAction(
+  '[Metrics] Enable Saving Pins Toggled'
+);
+
 // TODO(jieweiwu): Delete after internal code is updated.
 export const stepSelectorTimeSelectionChanged = timeSelectionChanged;

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -333,7 +333,7 @@ export class MetricsEffects implements OnInitEffects {
     })
   );
 
-  private readonly removeAllPins$ = this.actions$.pipe(
+  private readonly removeSavedPinsOnDisable$ = this.actions$.pipe(
     ofType(actions.metricsClearAllPinnedCards),
     withLatestFrom(
       this.store.select(selectors.getEnableGlobalPins),
@@ -423,11 +423,7 @@ export class MetricsEffects implements OnInitEffects {
         /**
          * Subscribes to: metricsClearAllPinnedCards.
          */
-        this.removeAllPins$,
-        /**
-         * Subscribes to: metricsEnableSavingPinsToggled.
-         */
-        this.disableSavingPins$
+        this.removeSavedPinsOnDisable$
       );
     },
     {dispatch: false}

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -35,6 +35,7 @@ import {
   getMetricsScalarSmoothing,
   getMetricsStepSelectorEnabled,
   getMetricsTooltipSort,
+  getMetricsSavingPinsEnabled,
   getRangeSelectionHeaders,
   getSingleSelectionHeaders,
   isMetricsSettingsPaneOpen,
@@ -125,6 +126,12 @@ export function getMetricsTimeSeriesLinkedTimeEnabled() {
   });
 }
 
+export function getMetricsTimeSeriesSavingPinsEnabled() {
+  return createSelector(getMetricsSavingPinsEnabled, (isEnabled) => {
+    return {savingPinsEnabled: isEnabled};
+  });
+}
+
 export function getSingleSelectionHeadersFactory() {
   return createSelector(getSingleSelectionHeaders, (singleSelectionHeaders) => {
     return {singleSelectionHeaders};
@@ -187,6 +194,9 @@ export function getRangeSelectionHeadersFactory() {
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
       getRangeSelectionHeadersFactory
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsTimeSeriesSavingPinsEnabled
     ),
   ],
   providers: [

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -608,6 +608,9 @@ const reducer = createReducer(
     if (typeof partialSettings.scalarSmoothing === 'number') {
       metricsSettings.scalarSmoothing = partialSettings.scalarSmoothing;
     }
+    if (typeof partialSettings.savingPinsEnabled === 'boolean') {
+      metricsSettings.savingPinsEnabled = partialSettings.savingPinsEnabled;
+    }
 
     const isSettingsPaneOpen =
       partialSettings.timeSeriesSettingsPaneOpened ?? state.isSettingsPaneOpen;

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -933,6 +933,19 @@ const reducer = createReducer(
       },
     };
   }),
+  on(actions.metricsEnableSavingPinsToggled, (state) => {
+    const nextSavingPinsEnabled = !(
+      state.settingOverrides.savingPinsEnabled ??
+      state.settings.savingPinsEnabled
+    );
+    return {
+      ...state,
+      settingOverrides: {
+        ...state.settingOverrides,
+        savingPinsEnabled: nextSavingPinsEnabled,
+      },
+    };
+  }),
   on(
     actions.multipleTimeSeriesRequested,
     (

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -3157,6 +3157,7 @@ describe('metrics reducers', () => {
           scalarSmoothing: 0.3,
           ignoreOutliers: false,
           tooltipSort: TooltipSort.ASCENDING,
+          savingPinsEnabled: true,
         }),
         settingOverrides: {
           scalarSmoothing: 0.5,
@@ -3170,6 +3171,7 @@ describe('metrics reducers', () => {
           partialSettings: {
             ignoreOutliers: true,
             tooltipSort: TooltipSort.DESCENDING,
+            savingPinsEnabled: false,
           },
         })
       );
@@ -3177,6 +3179,7 @@ describe('metrics reducers', () => {
       expect(nextState.settings.scalarSmoothing).toBe(0.3);
       expect(nextState.settings.ignoreOutliers).toBe(true);
       expect(nextState.settings.tooltipSort).toBe(TooltipSort.DESCENDING);
+      expect(nextState.settings.savingPinsEnabled).toBe(false);
       expect(nextState.settingOverrides.scalarSmoothing).toBe(0.5);
       expect(nextState.settingOverrides.tooltipSort).toBe(
         TooltipSort.ALPHABETICAL

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1234,18 +1234,22 @@ describe('metrics reducers', () => {
     });
 
     it('changes savingPinsEnabled on metricsEnableSavingPinsToggled', () => {
-      const prevState = buildMetricsState({
-        settings: buildMetricsSettingsState({
-          savingPinsEnabled: true,
-        }),
-        settingOverrides: {},
+      [{value: true}, {value: false}].forEach(({value: initValue}) => {
+        const prevState = buildMetricsState({
+          settings: buildMetricsSettingsState({
+            savingPinsEnabled: initValue,
+          }),
+          settingOverrides: {},
+        });
+
+        const nextState = reducers(
+          prevState,
+          actions.metricsEnableSavingPinsToggled()
+        );
+
+        expect(nextState.settings.savingPinsEnabled).toBe(initValue);
+        expect(nextState.settingOverrides.savingPinsEnabled).toBe(!initValue);
       });
-      const nextState = reducers(
-        prevState,
-        actions.metricsEnableSavingPinsToggled()
-      );
-      expect(nextState.settings.savingPinsEnabled).toBe(true);
-      expect(nextState.settingOverrides.savingPinsEnabled).toBe(false);
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1232,6 +1232,21 @@ describe('metrics reducers', () => {
       expect(thirdState.settings.hideEmptyCards).toBe(false);
       expect(thirdState.settingOverrides.hideEmptyCards).toBe(false);
     });
+
+    it('changes savingPinsEnabled on metricsEnableSavingPinsToggled', () => {
+      const prevState = buildMetricsState({
+        settings: buildMetricsSettingsState({
+          savingPinsEnabled: true,
+        }),
+        settingOverrides: {},
+      });
+      const nextState = reducers(
+        prevState,
+        actions.metricsEnableSavingPinsToggled()
+      );
+      expect(nextState.settings.savingPinsEnabled).toBe(true);
+      expect(nextState.settingOverrides.savingPinsEnabled).toBe(false);
+    });
   });
 
   describe('loading time series data', () => {

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -382,6 +382,11 @@ export const getMetricsImageShowActualSize = createSelector(
   (settings): boolean => settings.imageShowActualSize
 );
 
+export const getMetricsSavingPinsEnabled = createSelector(
+  selectSettings,
+  (settings): boolean => settings.savingPinsEnabled
+);
+
 export const getMetricsTagFilter = createSelector(
   selectMetricsState,
   (state): string => state.tagFilter

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -1298,6 +1298,18 @@ describe('metrics selectors', () => {
       );
       expect(selectors.getMetricsCardMinWidth(state)).toBe(400);
     });
+
+    it('returns savingPinsEnabled when called getMetricsSavingPinsEnabled', () => {
+      selectors.getMetricsSavingPinsEnabled.release();
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          settings: buildMetricsSettingsState({
+            savingPinsEnabled: false,
+          }),
+        })
+      );
+      expect(selectors.getMetricsSavingPinsEnabled(state)).toBe(false);
+    });
   });
 
   describe('getMetricsTagFilter', () => {

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -1300,15 +1300,17 @@ describe('metrics selectors', () => {
     });
 
     it('returns savingPinsEnabled when called getMetricsSavingPinsEnabled', () => {
-      selectors.getMetricsSavingPinsEnabled.release();
-      const state = appStateFromMetricsState(
-        buildMetricsState({
-          settings: buildMetricsSettingsState({
-            savingPinsEnabled: false,
-          }),
-        })
-      );
-      expect(selectors.getMetricsSavingPinsEnabled(state)).toBe(false);
+      [{value: true}, {value: false}].forEach(({value}) => {
+        selectors.getMetricsSavingPinsEnabled.release();
+        const state = appStateFromMetricsState(
+          buildMetricsState({
+            settings: buildMetricsSettingsState({
+              savingPinsEnabled: value,
+            }),
+          })
+        );
+        expect(selectors.getMetricsSavingPinsEnabled(state)).toBe(value);
+      });
     });
   });
 

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -246,6 +246,7 @@ export interface MetricsSettings {
   imageContrastInMilli: number;
   imageShowActualSize: boolean;
   histogramMode: HistogramMode;
+  savingPinsEnabled: boolean;
 }
 
 export interface MetricsNonNamespacedState {
@@ -287,4 +288,5 @@ export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
   imageContrastInMilli: 1000,
   imageShowActualSize: false,
   histogramMode: HistogramMode.OFFSET,
+  savingPinsEnabled: true,
 };

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -64,6 +64,27 @@ export function buildMetricsSettingsState(
   };
 }
 
+// Since Settings proto has missing fields, we need to build a partial of
+// Settings to be used in tests.
+export function buildMetricsSettingsOverrides(
+  overrides?: Partial<MetricsSettings>
+): Partial<MetricsSettings> {
+  return {
+    cardMinWidth: null,
+    tooltipSort: TooltipSort.NEAREST,
+    ignoreOutliers: false,
+    xAxisType: XAxisType.WALL_TIME,
+    scalarSmoothing: 0.3,
+    hideEmptyCards: true,
+    scalarPartitionNonMonotonicX: false,
+    imageBrightnessInMilli: 123,
+    imageContrastInMilli: 123,
+    imageShowActualSize: true,
+    histogramMode: HistogramMode.OFFSET,
+    ...overrides,
+  };
+}
+
 function buildBlankState(): MetricsState {
   return {
     tagMetadataLoadState: {

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -59,6 +59,7 @@ export function buildMetricsSettingsState(
     imageContrastInMilli: 123,
     imageShowActualSize: true,
     histogramMode: HistogramMode.OFFSET,
+    savingPinsEnabled: true,
     ...overrides,
   };
 }

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -548,5 +548,43 @@ describe('metrics right_pane', () => {
         ).toHaveClass('toggle-opened');
       });
     });
+
+    describe('saving pins check box', () => {
+      beforeEach(() => {
+        store.overrideSelector(selectors.getEnableGlobalPins, true);
+        store.overrideSelector(selectors.getMetricsSavingPinsEnabled, false);
+      });
+
+      it('does not render if getEnableGlobalPins feature flag is false', () => {
+        store.overrideSelector(selectors.getEnableGlobalPins, false);
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        expect(select(fixture, '.saving-pins')).toBeFalsy();
+      });
+
+      it('renders checked saving pins check box if isSavingpinsEnabled is true', () => {
+        store.overrideSelector(selectors.getMetricsSavingPinsEnabled, true);
+
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        expect(
+          select(fixture, '.saving-pins input').componentInstance.checked
+        ).toBeTrue();
+      });
+
+      it('dispatches metricsEnableSavingPinsToggled on toggle', () => {
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        const checkbox = select(fixture, '.saving-pins input');
+        checkbox.nativeElement.click();
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+          actions.metricsEnableSavingPinsToggled()
+        );
+      });
+    });
   });
 });

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -103,7 +103,7 @@ limitations under the License.
     <mat-icon
       class="info"
       svgIcon="help_outline_24px"
-      title="When saving pins are enabled, pinned cards will be shared across multiple experiments."
+      title="When saving pins are enabled, pinned cards will be visible across multiple experiments."
     ></mat-icon>
   </div>
 </section>

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -93,6 +93,19 @@ limitations under the License.
       </button>
     </div>
   </div>
+
+  <div class="control-row saving-pins" *ngIf="globalPinsFeatureEnabled">
+    <mat-checkbox
+      [checked]="isSavingPinsEnabled"
+      (change)="onEnableSavingPinsToggled.emit()"
+      >Enable saving pins (Scalars only)</mat-checkbox
+    >
+    <mat-icon
+      class="info"
+      svgIcon="help_outline_24px"
+      title="When saving pins are enabled, pinned cards will be shared across multiple experiments."
+    ></mat-icon>
+  </div>
 </section>
 
 <section class="scalars">

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -146,3 +146,16 @@ tb-dropdown {
     margin-left: 28px;
   }
 }
+
+.saving-pins {
+  align-items: center;
+  display: flex;
+
+  .info {
+    $_dim: 15px;
+    height: $_dim;
+    margin-left: 5px;
+    width: $_dim;
+    min-width: $_dim;
+  }
+}

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -79,7 +79,8 @@ section .control-row:not(:has(+ .control-row > mat-checkbox)):not(:last-child) {
   width: 5em;
 }
 
-.scalars-partition-x {
+.scalars-partition-x,
+.saving-pins {
   align-items: center;
   display: flex;
 
@@ -144,18 +145,5 @@ tb-dropdown {
 .control-row {
   .indent {
     margin-left: 28px;
-  }
-}
-
-.saving-pins {
-  align-items: center;
-  display: flex;
-
-  .info {
-    $_dim: 15px;
-    height: $_dim;
-    margin-left: 5px;
-    width: $_dim;
-    min-width: $_dim;
   }
 }

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -70,12 +70,15 @@ export class SettingsViewComponent {
   @Input() linkedTimeSelection!: TimeSelection | null;
   @Input() stepMinMax!: {min: number; max: number};
   @Input() isSlideOutMenuOpen!: boolean;
+  @Input() isSavingPinsEnabled!: boolean;
+  @Input() globalPinsFeatureEnabled: boolean = false;
 
   @Output() linkedTimeToggled = new EventEmitter<void>();
 
   @Output() stepSelectorToggled = new EventEmitter<void>();
   @Output() rangeSelectionToggled = new EventEmitter<void>();
   @Output() onSlideOutToggled = new EventEmitter<void>();
+  @Output() onEnableSavingPinsToggled = new EventEmitter<void>();
 
   @Input() isImageSupportEnabled!: boolean;
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -28,6 +28,7 @@ import {
   metricsChangeScalarSmoothing,
   metricsChangeTooltipSort,
   metricsChangeXAxisType,
+  metricsEnableSavingPinsToggled,
   metricsResetCardWidth,
   metricsResetImageBrightness,
   metricsResetImageContrast,
@@ -83,6 +84,9 @@ import {HistogramMode, TooltipSort, XAxisType} from '../../types';
       (stepSelectorToggled)="onStepSelectorToggled()"
       (rangeSelectionToggled)="onRangeSelectionToggled()"
       (onSlideOutToggled)="onSlideOutToggled()"
+      [isSavingPinsEnabled]="isSavingPinsEnabled$ | async"
+      (onEnableSavingPinsToggled)="onEnableSavingPinsToggled()"
+      [globalPinsFeatureEnabled]="globalPinsFeatureEnabled$ | async"
     >
     </metrics-dashboard-settings-component>
   `,
@@ -145,6 +149,13 @@ export class SettingsViewContainer {
   );
   readonly imageShowActualSize$ = this.store.select(
     selectors.getMetricsImageShowActualSize
+  );
+  readonly isSavingPinsEnabled$ = this.store.select(
+    selectors.getMetricsSavingPinsEnabled
+  );
+  // Feature flag for global pins.
+  readonly globalPinsFeatureEnabled$ = this.store.select(
+    selectors.getEnableGlobalPins
   );
 
   onTooltipSortChanged(sort: TooltipSort) {
@@ -221,5 +232,9 @@ export class SettingsViewContainer {
 
   onSlideOutToggled() {
     this.store.dispatch(metricsSlideoutMenuToggled());
+  }
+
+  onEnableSavingPinsToggled() {
+    this.store.dispatch(metricsEnableSavingPinsToggled());
   }
 }

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -125,6 +125,9 @@ export class OSSSettingsConverter extends SettingsConverter<
       serializableSettings.dashboardDisplayedHparamColumns =
         settings.dashboardDisplayedHparamColumns;
     }
+    if (settings.savingPinsEnabled !== undefined) {
+      serializableSettings.savingPinsEnabled = settings.savingPinsEnabled;
+    }
     return serializableSettings;
   }
 
@@ -254,6 +257,13 @@ export class OSSSettingsConverter extends SettingsConverter<
     if (Array.isArray(backendSettings.dashboardDisplayedHparamColumns)) {
       settings.dashboardDisplayedHparamColumns =
         backendSettings.dashboardDisplayedHparamColumns;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('savingPinsEnabled') &&
+      typeof backendSettings.savingPinsEnabled === 'boolean'
+    ) {
+      settings.savingPinsEnabled = backendSettings.savingPinsEnabled;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -398,6 +398,20 @@ describe('persistent_settings data_source test', () => {
           ],
         });
       });
+
+      it('properly converts savingPinsEnabled', async () => {
+        getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
+          JSON.stringify({
+            savingPinsEnabled: false,
+          })
+        );
+
+        const actual = await firstValueFrom(dataSource.getSettings());
+
+        expect(actual).toEqual({
+          savingPinsEnabled: false,
+        });
+      });
     });
 
     describe('#setSettings', () => {
@@ -523,6 +537,25 @@ describe('persistent_settings data_source test', () => {
                 enabled: true,
               },
             ],
+          })
+        );
+      });
+
+      it('properly converts savingPinsEnabled', async () => {
+        getItemSpy
+          .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
+          .and.returnValue(null);
+
+        await firstValueFrom(
+          dataSource.setSettings({
+            savingPinsEnabled: false,
+          })
+        );
+
+        expect(setItemSpy).toHaveBeenCalledOnceWith(
+          TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
+          JSON.stringify({
+            savingPinsEnabled: false,
           })
         );
       });

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -47,6 +47,7 @@ export declare interface BackendSettings {
   singleSelectionHeaders?: ColumnHeader[];
   rangeSelectionHeaders?: ColumnHeader[];
   dashboardDisplayedHparamColumns?: ColumnHeader[];
+  savingPinsEnabled?: boolean;
 }
 
 /**
@@ -72,4 +73,5 @@ export interface PersistableSettings {
   singleSelectionHeaders?: ColumnHeader[];
   rangeSelectionHeaders?: ColumnHeader[];
   dashboardDisplayedHparamColumns?: ColumnHeader[];
+  savingPinsEnabled?: boolean;
 }


### PR DESCRIPTION
## Motivation for features / changes
Following #6828,

Since global pins are applied automatically, this PR allows users disable the global pin feature.

## Technical description of changes
2cf2b11 Added `savingPinsEnabled` in the `MetricsSettings`
  * Also added a selector getting `settings.savingPinsEnabled` value from the store.

dec6a63 Introduced new action `metricsEnableSavingPinsToggled`
  * If `metricsEnableSavingPinsToggled` is dispatched, it toggles the `savingPinsEnabled` store value.

6ea22fd Added a checkbox UI to the settings view component.
  * Also added a feature flag guard to the component. If check box is clicked, it dispatched  `metricsEnableSavingPinsToggled` action.

568febf Added a new effect `disableSavingPins`
  * When `metricsEnableSavingPinsToggled` action is called, this effect will call `removeAllScalarPins` method if `savingPinsEnabled` value is false.
 
bbf9050 Added  saving pins feature in persistent settings to preserve user preferences.

3ff7cd2 Add buildMetricsSettingsOverrides util in the testing to use in tbcorp

## Screenshots of UI changes (or N/A)
![image](https://github.com/tensorflow/tensorboard/assets/24772412/874dbc2b-f01f-4112-b34b-6b07330ea31f)

## Detailed steps to verify changes work correctly (as executed by you)
Unit test passes + created a cl/625208577 to pass TAP Presubmit tests
## Alternate designs / implementations considered (or N/A)
N/A

## Action Items in the next PR
In the next PR, I'll add a "confirmation dialog" that appears when the user unchecks the checkbox to make the user aware that local storage is disappearing.

- [ ] Add the confirmation dialog
