### PR TITLE
Preserve white space in text plugin.

### DIFF
--- a/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
+++ b/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
@@ -47,7 +47,7 @@ class TfMarkdownView extends LegacyElementMixin(PolymerElement) {
         margin-bottom: 0.3em;
       }
       #markdown p {
-        white-space: pre;
+        white-space: break-spaces;
       }
 
       /* Pleasant styles for Markdown tables. */

--- a/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
+++ b/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
@@ -47,6 +47,9 @@ class TfMarkdownView extends LegacyElementMixin(PolymerElement) {
         margin-bottom: 0.3em;
       }
       #markdown p {
+        /* Some users include multiple spaces and would like them preserved in
+         * the text visualization in TB. Googlers, see b/335770352.
+         */
         white-space: break-spaces;
       }
 

--- a/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
+++ b/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
@@ -46,6 +46,9 @@ class TfMarkdownView extends LegacyElementMixin(PolymerElement) {
       #markdown > p:last-child {
         margin-bottom: 0.3em;
       }
+      #markdown p {
+        white-space: pre;
+      }
 
       /* Pleasant styles for Markdown tables. */
       #markdown table {


### PR DESCRIPTION
Some users require the spaces to be preserved in the text shown in the text dashboard.

At the moment I can't think of a reason why not to enable this unconditionally. I imagine anybody interested in seeing text logged would be interested in the value *verbatim*, including spaces.

Googlers, see b/335770352