### PR TITLE
Re-disables enableScalarColumnContextMenus flag

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -111,7 +111,7 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       parseValue: parseBoolean,
     },
     enableScalarColumnContextMenus: {
-      defaultValue: true,
+      defaultValue: false,
       queryParamOverride: 'enableScalarColumnContextMenus',
       parseValue: parseBoolean,
     },


### PR DESCRIPTION
## Motivation for features / changes
In 3p, enabling standard (non-hparam column) hide is currently dangerous as there is currently no way to re-show them. Enabling for 3p will have to wait until we add an affordance other than the 1p-only column customizer.

Affected users can clear localStorage for the page, or add the `enableScalarColumnCustomization=true` flag to enable the column customizer in the settings menu and re-add hidden columns.

## Technical description of changes
Sets `enableScalarColumnContextMenus` default to `false`. (Reverts #6817)
