### PR TITLE
[Global Pins] [Quick Fix] Apply theme color to the check box

### DIFF
--- a/tensorboard/webapp/metrics/views/right_pane/saving_pins_checkbox_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/saving_pins_checkbox_component.ts
@@ -28,7 +28,10 @@ import {
   selector: 'saving-pins-checkbox',
   template: `
     <div class="saving-pins-checkbox">
-      <mat-checkbox [checked]="isChecked" (click)="onCheckboxToggled.emit()"
+      <mat-checkbox
+        color="primary"
+        [checked]="isChecked"
+        (click)="onCheckboxToggled.emit()"
         >Enable saving pins (Scalars only)</mat-checkbox
       >
       <mat-icon


### PR DESCRIPTION
## Motivation for features / changes
Theme color was not applied to the checkbox. 
## Technical description of changes
Apply `color="primary"` to the `saving_pins_checkbox_component`

## Screenshots of UI changes (or N/A)
AS-IS
![image](https://github.com/tensorflow/tensorboard/assets/24772412/12ed994a-a3b4-4137-b7b8-7a22b4a9af37)


TO-BE
![image](https://github.com/tensorflow/tensorboard/assets/24772412/2aa3fbd7-b46e-46fd-b365-debc72cf2883)

## Detailed steps to verify changes work correctly (as executed by you)
tested with ` tb_theme=corp`  & TAP presubmit passes


## Alternate designs / implementations considered (or N/A)
