### PR TITLE
[Global Pins] Saves all currently pinned cards if the user has enabled global pins.

### DIFF
--- a/tensorboard/webapp/metrics/data_source/saved_pins_data_source.ts
+++ b/tensorboard/webapp/metrics/data_source/saved_pins_data_source.ts
@@ -30,6 +30,16 @@ export class SavedPinsDataSource {
     );
   }
 
+  saveScalarPins(tags: Tag[]): void {
+    const existingPins = this.getSavedScalarPins();
+    const newTags = tags.filter((v) => !existingPins.includes(v));
+    existingPins.push(...newTags);
+    window.localStorage.setItem(
+      SAVED_SCALAR_PINS_KEY,
+      JSON.stringify(existingPins)
+    );
+  }
+
   removeScalarPin(tag: Tag): void {
     const existingPins = this.getSavedScalarPins();
     window.localStorage.setItem(

--- a/tensorboard/webapp/metrics/data_source/saved_pins_data_source_test.ts
+++ b/tensorboard/webapp/metrics/data_source/saved_pins_data_source_test.ts
@@ -85,7 +85,7 @@ describe('SavedPinsDataSource Test', () => {
       expect(dataSource.getSavedScalarPins()).toEqual(['tag1', 'tag2']);
     });
 
-    it('does not addd the provided tag if it already exists', () => {
+    it('does not add the provided tag if it already exists', () => {
       window.localStorage.setItem(
         SAVED_SCALAR_PINS_KEY,
         JSON.stringify(['tag1', 'tag2'])
@@ -94,6 +94,36 @@ describe('SavedPinsDataSource Test', () => {
       dataSource.saveScalarPin('tag2');
 
       expect(dataSource.getSavedScalarPins()).toEqual(['tag1', 'tag2']);
+    });
+  });
+
+  describe('saveScalarPins', () => {
+    it('stores the provided tags in the local storage', () => {
+      dataSource.saveScalarPins(['tag1', 'tag2']);
+
+      expect(dataSource.getSavedScalarPins()).toEqual(['tag1', 'tag2']);
+    });
+
+    it('adds the provided tags to the existing list', () => {
+      window.localStorage.setItem(
+        SAVED_SCALAR_PINS_KEY,
+        JSON.stringify(['tag1'])
+      );
+
+      dataSource.saveScalarPins(['tag2']);
+
+      expect(dataSource.getSavedScalarPins()).toEqual(['tag1', 'tag2']);
+    });
+
+    it('does not add the tag if it already exists', () => {
+      window.localStorage.setItem(
+        SAVED_SCALAR_PINS_KEY,
+        JSON.stringify(['tag1', 'tag2'])
+      );
+
+      dataSource.saveScalarPins(['tag2', 'tag3']);
+
+      expect(dataSource.getSavedScalarPins()).toEqual(['tag1', 'tag2', 'tag3']);
     });
   });
 

--- a/tensorboard/webapp/metrics/effects/index.ts
+++ b/tensorboard/webapp/metrics/effects/index.ts
@@ -371,11 +371,11 @@ export class MetricsEffects implements OnInitEffects {
     ),
     tap(([, pinnedCards, , , getMetricsSavingPinsEnabled]) => {
       if (getMetricsSavingPinsEnabled) {
-        const tags = pinnedCards
+        const tags: Tag[] = pinnedCards
           .map((card) => {
             return card.plugin === PluginType.SCALARS ? card.tag : null;
           })
-          .filter((v) => v) as Tag[];
+          .filter((v): v is Tag => v !== null);
         this.savedPinsDataSource.saveScalarPins(tags);
       } else {
         this.savedPinsDataSource.removeAllScalarPins();

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -422,6 +422,8 @@ export function buildStepIndexMetadata(
 export class TestingSavedPinsDataSource {
   saveScalarPin(tag: Tag) {}
 
+  saveScalarPins(tag: Tag[]) {}
+
   removeScalarPin(tag: Tag) {}
 
   getSavedScalarPins() {


### PR DESCRIPTION
## Motivation for features / changes

Feature request during the teamfood: `Clicking disable pins -> pinning a card -> clicking enable pins` doesn't save the currently pinned card. It seems reasonable to save all currently pinned cards when the setting is activated.

This PR saves all currently pinned cards when user clicks enable global pins.

## Technical description of changes

* 97c6324389e1a9a5f51b89e5e33b0665ead533a4 Added `saveScalarPins` to the data source

* c6be93b Modified `addOrRemovePinsOnToggle` logic to include adding pins logic
  *  Previously, if a user disabled the global pin feature, all pins would be removed. 
  *  This PR added logic that will cause all currently pinned cards to be saved to local storage when the user activates the feature.

## Screenshots of UI changes (or N/A)
N/A
## Detailed steps to verify changes work correctly (as executed by you)
Unit test passes
## Alternate designs / implementations considered (or N/A)
N/A
