### PR TITLE
[Global pins] enable globalpins by default

### DIFF
--- a/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_metadata.ts
@@ -121,7 +121,7 @@ export const FeatureFlagMetadataMap: FeatureFlagMetadataMapType<FeatureFlags> =
       parseValue: parseBoolean,
     },
     enableGlobalPins: {
-      defaultValue: false,
+      defaultValue: true,
       queryParamOverride: 'enableGlobalPins',
       parseValue: parseBoolean,
     },


### PR DESCRIPTION
## Motivation for features / changes
launch global pins feature by enabling the feature by default 
## Technical description of changes

## Screenshots of UI changes (or N/A)
### Light mode
![image](https://github.com/tensorflow/tensorboard/assets/24772412/c5163d74-a5ef-4ba0-969b-4a87111d55c7)

### Dark mode
![image](https://github.com/tensorflow/tensorboard/assets/24772412/d568f957-9d55-4b93-bb65-7bca50e6c39f)
#### pop up
![image](https://github.com/tensorflow/tensorboard/assets/24772412/9ce2939c-390f-4d2a-b464-a92ab7c4a52b)

### Corp theme
<img width="237" alt="image" src="https://github.com/tensorflow/tensorboard/assets/24772412/231a68f1-4ab0-4c6e-ab82-15ec1f17181c">


https://screenshot.googleplex.com/7WaVHXBFfAfHYUk
## Detailed steps to verify changes work correctly (as executed by you)
* Needs to update scuba test images after this PR is merged

## Alternate designs / implementations considered (or N/A)
