### PR TITLE
Adds import that was used via a transitive dependency.

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -154,6 +154,7 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_material_menu",
         "//tensorboard/webapp/angular:expect_angular_material_paginator",
         "//tensorboard/webapp/angular:expect_angular_material_progress_spinner",
+        "//tensorboard/webapp/angular:expect_angular_material_select",
         "//tensorboard/webapp/angular:expect_angular_material_sort",
         "//tensorboard/webapp/angular:expect_angular_material_table",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",


### PR DESCRIPTION
This was missing when #6847 was merged, but it's causing some build errors in internal repo due to more strict dependency checks (this target is currently used via transitive dependencies).