### PR TITLE
Fixes type in recent test changes for regex search in runs table.

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -146,7 +146,7 @@ describe('regex_edit_dialog', () => {
     expect(dispatchSpy).toHaveBeenCalledWith(
       runGroupByChanged({
         experimentIds: ['rose'],
-        expNameByExpId: {rose: 'exp_name_rose'},
+        expNameByExpId: {'rose': 'exp_name_rose'},
         groupBy: {key: GroupByKey.REGEX, regexString: 'test(\\d+)'},
       })
     );
@@ -172,7 +172,7 @@ describe('regex_edit_dialog', () => {
     expect(dispatchSpy).toHaveBeenCalledWith(
       runGroupByChanged({
         experimentIds: ['rose'],
-        expNameByExpId: {rose: 'exp_name_rose'},
+        expNameByExpId: {'rose': 'exp_name_rose'},
         groupBy: {key: GroupByKey.REGEX, regexString: 'test'},
       })
     );
@@ -202,7 +202,7 @@ describe('regex_edit_dialog', () => {
     expect(dispatchSpy).toHaveBeenCalledWith(
       runGroupByChanged({
         experimentIds: ['rose'],
-        expNameByExpId: {rose: 'exp_name_rose'},
+        expNameByExpId: {'rose': 'exp_name_rose'},
         groupBy: {key: GroupByKey.REGEX_BY_EXP, regexString: 'test'},
       })
     );
@@ -282,7 +282,7 @@ describe('regex_edit_dialog', () => {
     expect(dispatchSpy).toHaveBeenCalledWith(
       runGroupByChanged({
         experimentIds: ['rose'],
-        expNameByExpId: {rose: 'exp_name_rose'},
+        expNameByExpId: {'rose': 'exp_name_rose'},
         groupBy: {key: GroupByKey.REGEX, regexString: 'test'},
       })
     );
@@ -304,7 +304,7 @@ describe('regex_edit_dialog', () => {
     expect(dispatchSpy).toHaveBeenCalledWith(
       runGroupByChanged({
         experimentIds: ['rose'],
-        expNameByExpId: {rose: 'exp_name_rose'},
+        expNameByExpId: {'rose': 'exp_name_rose'},
         groupBy: {key: GroupByKey.REGEX, regexString: 'test regex string'},
       })
     );


### PR DESCRIPTION
Our internal static analysis tools show a message like:

`Property 'rose' comes from an index signature on type (Record<string, string> | undefined). Check if this property should be consistently quoted.`

This change makes the value used match the expected type and remove those warnings.