### PR TITLE
Fixes regression for issue #5548: Avoid attempting to convert dtypes from "mixed precision" policy types.

### DIFF
--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -114,6 +114,7 @@ py_library(
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/compat/tensorflow_stub",
+        "//tensorboard/util:tb_logging",
     ],
 )
 

--- a/tensorboard/plugins/graph/keras_util.py
+++ b/tensorboard/plugins/graph/keras_util.py
@@ -283,6 +283,10 @@ def keras_model_to_graph_def(keras_layer):
             has_unsupported_value = True
 
         if has_unsupported_value:
+            # There's at least one known case when this happens, which is when
+            # mixed precision dtype policies are used, as described in issue
+            # #5548. (See https://keras.io/api/mixed_precision/).
+            # There might be a better way to handle this, but here we are.
             logger.warning(
                 "Unsupported dtype value in graph model config (json):\n%s",
                 dtype_or_policy,

--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -1043,6 +1043,20 @@ class KerasUtilTest(tf.test.TestCase):
 
         self.assertGraphDefToModel(expected_proto, model)
 
+    def test__keras_model_to_graph_def__does_not_crash_with_mixed_precision_dtype_policy(
+        self,
+    ):
+        # See https://keras.io/api/mixed_precision/ for more info.
+        # Test to avoid regression on issue #5548
+        first_layer = tf.keras.layers.Dense(
+            1, input_shape=(1,), dtype="mixed_float16"
+        )
+        model = tf.keras.Sequential([first_layer])
+
+        model_config = json.loads(model.to_json())
+        # This line should not raise errors:
+        keras_util.keras_model_to_graph_def(model_config)
+
 
 class _DoublingLayer(tf.keras.layers.Layer):
     def call(self, inputs):


### PR DESCRIPTION
Following-up on PR #6857, which seems to have introduced a regression for issue #5548.

This change just gracefully degrades the functionality to avoid crashing on an error (as it was before the recent change in #6857), but it might not be a proper fix for the scenario described in that issue.
