### PR TITLE
Fix azure logging

### DIFF
--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -602,9 +602,11 @@ class FSSpecFileSystem:
         prefix = self._get_chain_protocol_prefix(filename)
 
         return [
-            file
-            if (self.SEPARATOR in file or self.CHAIN_SEPARATOR in file)
-            else prefix + file
+            (
+                file
+                if (self.SEPARATOR in file or self.CHAIN_SEPARATOR in file)
+                else prefix + file
+            )
             for file in files
         ]
 


### PR DESCRIPTION
## Motivation for features / changes

When using the TensorboardLogger in Pytorch lightning to log to an Azure blob storage location, the following error is thrown: 

```
ErrorCode:InvalidBlobType
Content: <?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidBlobType</Code><Message>The blob type is invalid for this operation.

```

This is due to the assumption that if the filesystem supports append opperations, these will automatically be available for any file in the blob storage, see this code snippet from gfile.py: 

```
if self.fs_supports_append:
    if not self.write_started:
        # write the first chunk to truncate file if it already exists
        self.fs.write(self.filename, file_content, self.binary_mode)
        self.write_started = True

    else:
        # append the later chunks
        self.fs.append(self.filename, file_content, self.binary_mode)
```

However, in Azure, if a file is created by opening it in write mode, it will not permit append operations later on. 


## Technical description of changes

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
