### PR TITLE
Update tests to be compatible with recent keras update.

### DIFF
--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -982,12 +982,13 @@ class KerasUtilTest(tf.test.TestCase):
 
         self.assertGraphDefToModel(expected_proto, model)
 
-    def test_keras_model_to_graph_def_functional_multiple_inbound_nodes_from_same_node(
+    # Enable after next sync to internal repo from Keras team.
+    def DISABLED_test_keras_model_to_graph_def_functional_multiple_inbound_nodes_from_same_node(
         self,
     ):
         expected_proto = """
             node {
-              name: "functional_1/input_layer"
+              name: "functional/input_layer"
               attr {
                 key: "keras_class"
                 value {
@@ -1002,8 +1003,8 @@ class KerasUtilTest(tf.test.TestCase):
               }
             }
             node {
-              name: "functional_1/__doubling_layer"
-              input: "functional_1/input_layer"
+              name: "functional/__doubling_layer"
+              input: "functional/input_layer"
               attr {
                 key: "keras_class"
                 value {
@@ -1018,9 +1019,9 @@ class KerasUtilTest(tf.test.TestCase):
               }
             }
             node {
-              name: "functional_1/add"
-              input: "functional_1/__doubling_layer"
-              input: "functional_1/__doubling_layer"
+              name: "functional/add"
+              input: "functional/__doubling_layer"
+              input: "functional/__doubling_layer"
               attr {
                 key: "keras_class"
                 value {


### PR DESCRIPTION
## Motivation for features / changes
A recent change in Keras broke these tests. I believe it's related to keras-team/keras#19805, which caused a name change in the names of the nodes in the graph, but not too sure.

## Technical description of changes
Updates the affected test, but leaves it commented out, because when this code is imported into the internal repository on our side, before the keras update does, our project would break, as the keras change would not be synced internally yet.
Once this is sycned to our internal repo, and keras is able to sync theirs (without breaking us), we can enable the test and it should work fine.

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)
Ran tests with keras-nightly before and after the change, and they pass. Then commented out the test for the reason noted above.

## Alternate designs / implementations considered (or N/A)
N/A
