### PR TITLE
Update usage of numpy to reflect numpy 2.0 changes

### DIFF
--- a/tensorboard/compat/tensorflow_stub/dtypes.py
+++ b/tensorboard/compat/tensorflow_stub/dtypes.py
@@ -674,7 +674,7 @@ def as_dtype(type_value):
         # dtype with a single constant (np.string does not exist) to decide
         # dtype is a "string" type. We need to compare the dtype.type to be
         # sure it's a string type.
-        if type_value.type == np.string_ or type_value.type == np.unicode_:
+        if type_value.type == np.bytes_ or type_value.type == np.str_:
             return string
 
     if isinstance(type_value, (type, np.dtype)):

--- a/tensorboard/util/tensor_util.py
+++ b/tensorboard/util/tensor_util.py
@@ -137,7 +137,7 @@ def GetNumpyAppendFn(dtype):
     # dtype with a single constant (np.string does not exist) to decide
     # dtype is a "string" type. We need to compare the dtype.type to be
     # sure it's a string type.
-    if dtype.type == np.string_ or dtype.type == np.unicode_:
+    if dtype.type == np.bytes_ or dtype.type == np.str_:
         return SlowAppendObjectArrayToTensorProto
     return GetFromNumpyDTypeDict(_NP_TO_APPEND_FN, dtype)
 


### PR DESCRIPTION
## Motivation for features / changes
Nightlies are failing due to new numpy release(one example: https://github.com/tensorflow/tensorboard/actions/runs/9546526095/job/26309613783)

## Technical description of changes
The new numpy replaced np.string_ with np.bytes_ and np.unicode_ with np.str_

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)
I ran tests that were failing and they passed.

## Alternate designs / implementations considered (or N/A)
Locking numpy version < 2 was considered. However, this will eventually get us very out of date and should be avoided.