### PR TITLE
Fix stacking of notification dot

### DIFF
--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -28,6 +28,7 @@ limitations under the License.
   right: 10px;
   top: 10px;
   width: $_dim;
+  z-index: 2;
 }
 
 ::ng-deep .notification-menu.mat-mdc-menu-panel {


### PR DESCRIPTION
An upcoming change in Angular Material (https://github.com/angular/components/pull/29291) changes the `z-index` of icons which ended up putting it behind the notification dot.

This change adds an explicit `z-index` to the dot to ensure that it's on top of the icon.
