### PR TITLE
Fix initializer of instance members that reference identifiers declar…

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/card_groups_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_groups_container.ts
@@ -36,18 +36,20 @@ import {getSortedRenderableCardIdsWithMetadata} from './common_selectors';
 export class CardGroupsContainer {
   @Input() cardObserver!: CardObserver;
 
-  constructor(private readonly store: Store<State>) {}
+  constructor(private readonly store: Store<State>) {
+      this.cardGroups$ = this.store
+          .select(getSortedRenderableCardIdsWithMetadata)
+          .pipe(
+              combineLatestWith(this.store.select(getMetricsFilteredPluginTypes)),
+              map(([cardList, filteredPlugins]) => {
+                  if (!filteredPlugins.size) return cardList;
+                  return cardList.filter((card) => {
+                      return filteredPlugins.has(card.plugin);
+                  });
+              }),
+              map((cardList) => groupCardIdWithMetdata(cardList))
+          );
+  }
 
-  readonly cardGroups$: Observable<CardGroup[]> = this.store
-    .select(getSortedRenderableCardIdsWithMetadata)
-    .pipe(
-      combineLatestWith(this.store.select(getMetricsFilteredPluginTypes)),
-      map(([cardList, filteredPlugins]) => {
-        if (!filteredPlugins.size) return cardList;
-        return cardList.filter((card) => {
-          return filteredPlugins.has(card.plugin);
-        });
-      }),
-      map((cardList) => groupCardIdWithMetdata(cardList))
-    );
+  readonly cardGroups$: Observable<CardGroup[]>;
 }


### PR DESCRIPTION
…ed in the constructor

When public class fields are enabled, such cases throw a TS error similar to this.

```
third_party/javascript/angular_components/src/cdk/platform/platform.ts:37:29 - error TS2729: Property '_platformId' is used before its initialization.

37   isBrowser: boolean = this._platformId
                               ~~~~~~~~~~~

  third_party/javascript/angular_components/src/cdk/platform/platform.ts:87:15
    87   constructor(@Inject(PLATFORM_ID) private _platformId: Object) {}
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    '_platformId' is declared here.
```

This error is fixed by moving the initializer of such class members into the constructor.

This is a no-op change 

See go/lsc-fix-properties-used-before-initialization

## Motivation for features / changes

## Technical description of changes

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
