### PR TITLE
Fix initializer of instance members that reference identifiers declar…

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
@@ -37,87 +37,104 @@ export class ExecutionDataContainer {
   @Input()
   focusedExecutionIndex!: number;
 
-  readonly focusedExecutionData$ = this.store.pipe(
-    select(getFocusedExecutionData)
-  );
+  readonly focusedExecutionData$;
 
-  readonly tensorDebugMode$ = this.store.pipe(
-    select(
-      createSelector(getFocusedExecutionData, (execution: Execution | null) => {
-        if (execution === null) {
-          return TensorDebugMode.UNSPECIFIED;
-        } else {
-          return execution.tensor_debug_mode;
-        }
-      })
-    )
-  );
+  readonly tensorDebugMode$;
 
-  readonly hasDebugTensorValues$ = this.store.pipe(
-    select(
-      createSelector(getFocusedExecutionData, (execution: Execution | null) => {
-        if (execution === null || execution.debug_tensor_values === null) {
-          return false;
-        } else {
-          for (const singleDebugTensorValues of execution.debug_tensor_values) {
-            if (
-              singleDebugTensorValues !== null &&
-              singleDebugTensorValues.length > 0
-            ) {
-              return true;
-            }
-          }
-          return false;
-        }
-      })
-    )
-  );
+  readonly hasDebugTensorValues$;
 
-  readonly debugTensorValues$ = this.store.pipe(
-    select(
-      createSelector(getFocusedExecutionData, (execution: Execution | null) => {
-        if (execution === null) {
-          return null;
-        } else {
-          return execution.debug_tensor_values;
-        }
-      })
-    )
-  );
+  readonly debugTensorValues$;
 
-  readonly debugTensorDtypes$ = this.store.pipe(
-    select(
-      createSelector(
-        getFocusedExecutionData,
-        (execution: Execution | null): string[] | null => {
-          if (execution === null || execution.debug_tensor_values === null) {
-            return null;
-          }
-          if (
-            execution.tensor_debug_mode !== TensorDebugMode.FULL_HEALTH &&
-            execution.tensor_debug_mode !== TensorDebugMode.SHAPE
-          ) {
-            // TODO(cais): Add logic for other TensorDebugModes with dtype info.
-            return null;
-          }
-          const dtypes: string[] = [];
-          for (const tensorValue of execution.debug_tensor_values) {
-            if (tensorValue === null) {
-              dtypes.push(UNKNOWN_DTYPE_NAME);
+  readonly debugTensorDtypes$;
+
+  constructor(private readonly store: Store<State>) {
+      this.focusedExecutionData$ = this.store.pipe(
+      select(getFocusedExecutionData),
+    );
+    this.tensorDebugMode$ = this.store.pipe(
+      select(
+        createSelector(
+          getFocusedExecutionData,
+          (execution: Execution | null) => {
+            if (execution === null) {
+              return TensorDebugMode.UNSPECIFIED;
             } else {
-              const dtypeEnum = String(
-                execution.tensor_debug_mode === TensorDebugMode.FULL_HEALTH
-                  ? tensorValue[2] // tensor_debug_mode: FULL_HEALTH
-                  : tensorValue[1] // tensor_debug_mode: SHAPE
-              );
-              dtypes.push(DTYPE_ENUM_TO_NAME[dtypeEnum] || UNKNOWN_DTYPE_NAME);
+              return execution.tensor_debug_mode;
             }
-          }
-          return dtypes;
-        }
-      )
-    )
-  );
-
-  constructor(private readonly store: Store<State>) {}
+          },
+        ),
+      ),
+    );
+    this.hasDebugTensorValues$ = this.store.pipe(
+      select(
+        createSelector(
+          getFocusedExecutionData,
+          (execution: Execution | null) => {
+            if (execution === null || execution.debug_tensor_values === null) {
+              return false;
+            } else {
+              for (const singleDebugTensorValues of execution.debug_tensor_values) {
+                if (
+                  singleDebugTensorValues !== null &&
+                  singleDebugTensorValues.length > 0
+                ) {
+                  return true;
+                }
+              }
+              return false;
+            }
+          },
+        ),
+      ),
+    );
+    this.debugTensorValues$ = this.store.pipe(
+      select(
+        createSelector(
+          getFocusedExecutionData,
+          (execution: Execution | null) => {
+            if (execution === null) {
+              return null;
+            } else {
+              return execution.debug_tensor_values;
+            }
+          },
+        ),
+      ),
+    );
+    this.debugTensorDtypes$ = this.store.pipe(
+      select(
+        createSelector(
+          getFocusedExecutionData,
+          (execution: Execution | null): string[] | null => {
+            if (execution === null || execution.debug_tensor_values === null) {
+              return null;
+            }
+            if (
+              execution.tensor_debug_mode !== TensorDebugMode.FULL_HEALTH &&
+              execution.tensor_debug_mode !== TensorDebugMode.SHAPE
+            ) {
+              // TODO(cais): Add logic for other TensorDebugModes with dtype info.
+              return null;
+            }
+            const dtypes: string[] = [];
+            for (const tensorValue of execution.debug_tensor_values) {
+              if (tensorValue === null) {
+                dtypes.push(UNKNOWN_DTYPE_NAME);
+              } else {
+                const dtypeEnum = String(
+                  execution.tensor_debug_mode === TensorDebugMode.FULL_HEALTH
+                    ? tensorValue[2] // tensor_debug_mode: FULL_HEALTH
+                    : tensorValue[1], // tensor_debug_mode: SHAPE
+                );
+                dtypes.push(
+                  DTYPE_ENUM_TO_NAME[dtypeEnum] || UNKNOWN_DTYPE_NAME,
+                );
+              }
+            }
+            return dtypes;
+          },
+        ),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
…ed in the constructor.

## Motivation for features / changes
When public class fields are enabled, such cases throw a TS error similar to this.

```
third_party/javascript/angular_components/src/cdk/platform/platform.ts:37:29 - error TS2729: Property '_platformId' is used before its initialization.

37   isBrowser: boolean = this._platformId
                               ~~~~~~~~~~~

  third_party/javascript/angular_components/src/cdk/platform/platform.ts:87:15
    87   constructor(@Inject(PLATFORM_ID) private _platformId: Object) {}
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    '_platformId' is declared here.
```

This error is fixed by moving the initializer of such class members into the constructor.

This is a no-op change 

See go/lsc-fix-properties-used-before-initialization

## Technical description of changes
Fix initializer of instance members that reference identifiers declared in the constructor.

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)
This is a no-op change

## Alternate designs / implementations considered (or N/A)
N/A
