### PR TITLE
:bug: :gear:  Fix settings dialog styling regression

### DIFF
--- a/tensorboard/webapp/settings/_views/settings_dialog_component.css
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.css
@@ -28,3 +28,7 @@ h3 {
 .reload-toggle {
   margin-bottom: 16px;
 }
+
+mat-form-field {
+  width: 100%;
+}


### PR DESCRIPTION
## Motivation for features / changes
When we migrated all the MDC components a year or so ago we missed the size of the fields in the settings dialog changing. This should restore the original intention there.

## Screenshots of UI changes (or N/A)

Before:
![image](https://github.com/user-attachments/assets/e7cb590c-78bd-474f-89da-cef2a74d1a91)

After:
![image](https://github.com/user-attachments/assets/ff12fa0c-27ac-48f8-9817-25c7b5fc0fc8)

