### PR TITLE
Custom modal aux click

### DIFF
--- a/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
@@ -16,7 +16,7 @@ import {Injectable, TemplateRef, ViewContainerRef} from '@angular/core';
 import {ConnectedPosition, Overlay, OverlayRef} from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
 import {skipUntil} from 'rxjs/operators';
-import {Subject, Subscription} from 'rxjs';
+import {Subject, Subscription, timer} from 'rxjs';
 import {isMouseEventInElement} from '../../util/dom';
 
 /**

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {Injectable, TemplateRef, ViewContainerRef} from '@angular/core';
 import {ConnectedPosition, Overlay, OverlayRef} from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
-import {delay, pipe, skipUntil, Subject, Subscription, timer} from 'rxjs';
+import {skipUntil, Subject, Subscription, timer} from 'rxjs';
 import {isMouseEventInElement} from '../../util/dom';
 
 /**

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
@@ -16,6 +16,7 @@ import {Injectable, TemplateRef, ViewContainerRef} from '@angular/core';
 import {ConnectedPosition, Overlay, OverlayRef} from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
 import {skipUntil} from 'rxjs/operators';
+import {Subject, Subscription} from 'rxjs';
 import {isMouseEventInElement} from '../../util/dom';
 
 /**

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
@@ -15,8 +15,7 @@ limitations under the License.
 import {Injectable, TemplateRef, ViewContainerRef} from '@angular/core';
 import {ConnectedPosition, Overlay, OverlayRef} from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
-import {skipUntil} from 'rxjs/operators';
-import {Subject, Subscription, timer} from 'rxjs';
+import {Subject, Subscription} from 'rxjs';
 import {isMouseEventInElement} from '../../util/dom';
 
 /**
@@ -112,10 +111,10 @@ export class CustomModal {
 
     const outsidePointerEventsSubscription = overlayRef
       .outsidePointerEvents()
-      .pipe(
-        skipUntil(timer(250)) // prevent closing immediately after modal open.
-      )
       .subscribe((event) => {
+        // Prevent the right click mouseup event from immediately closing the modal.
+        if (event.type === 'auxclick') return;
+
         // Only close when click is outside of every modal
         if (
           this.customModalRefs.every(

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {Injectable, TemplateRef, ViewContainerRef} from '@angular/core';
 import {ConnectedPosition, Overlay, OverlayRef} from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
-import {skipUntil, Subject, Subscription, timer} from 'rxjs';
+import {skipUntil} from 'rxjs/operators';
 import {isMouseEventInElement} from '../../util/dom';
 
 /**


### PR DESCRIPTION
## Motivation for features / changes
On some browsers, the [custom modal close](https://github.com/tensorflow/tensorboard/blob/0627ad5480b309a5f3f69f39e52670496c2e5863/tensorboard/webapp/widgets/custom_modal/custom_modal.ts#L116) logic will be triggered immediately after releasing the right click button, which causes the modal to be closed as soon as it is opened.

## Technical description of changes
The modal close event handler will ignore the `auxclick` (right click) mouseup event. Modals can still be closed with left clicks and the `contextmenu` event.

## Screenshots of UI changes (or N/A)
Status quo: ![image](https://github.com/user-attachments/assets/5b4c0c8f-4878-4cbe-a46a-cd425c188061)

