### PR TITLE
TensorBoard 2.17.1 Release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,11 @@
+# Release 2.17.1
+
+## Bug Fixes
+- Relax restriction on protobuf dependency (#6887)
+- Update usage of numpy to reflect numpy 2.0 changes (#6871)
+- Fix stacking of notification dot (#6875, thanks @crisbeto)
+- Fix setting dialog styling regression (#6885)
+
 # Release 2.17.0
 
 The 2.17 minor series tracks TensorFlow 2.17.

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -485,7 +485,7 @@ py_library(
     srcs = ["data_compat.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_protobuf_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/audio:metadata",
         "//tensorboard/plugins/histogram:metadata",
@@ -584,7 +584,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":context",
-        ":expect_protobuf_installed",
+        "//tensorboard:expect_protobuf_installed",
         "//tensorboard/backend:experiment_id",
         "//tensorboard/util:tb_logging",
         "@org_mozilla_bleach",

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -584,6 +584,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":context",
+        ":expect_protobuf_installed",
         "//tensorboard/backend:experiment_id",
         "//tensorboard/util:tb_logging",
         "@org_mozilla_bleach",

--- a/tensorboard/compat/tensorflow_stub/dtypes.py
+++ b/tensorboard/compat/tensorflow_stub/dtypes.py
@@ -674,7 +674,7 @@ def as_dtype(type_value):
         # dtype with a single constant (np.string does not exist) to decide
         # dtype is a "string" type. We need to compare the dtype.type to be
         # sure it's a string type.
-        if type_value.type == np.string_ or type_value.type == np.unicode_:
+        if type_value.type == np.bytes_ or type_value.type == np.str_:
             return string
 
     if isinstance(type_value, (type, np.dtype)):

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -20,14 +20,18 @@ absl-py >= 0.4
 grpcio >= 1.48.2
 markdown >= 2.6.8
 numpy >= 1.12.0
+# NOTE: The packaging dependency was introduced in order to compare installed
+# package versions and conditionally use different supported kwargs
+# (specifically the protobuf dependency). If we restrict protobuf >= 5.0.0 we
+# can get rid of the packaging dependency.
+packaging
 # NOTE: this version must be >= the protoc version in our WORKSPACE file.
 # At the same time, any constraints we specify here must allow at least some
 # version to be installed that is also compatible with TensorFlow's constraints:
 # https://github.com/tensorflow/tensorflow/blob/25adc4fccb4b0bb5a933eba1d246380e7b87d7f7/tensorflow/tools/pip_package/setup.py#L101
 # 4.24.0 had an issue that broke our tests, so we should avoid that release:
 # https://github.com/protocolbuffers/protobuf/issues/13485
-# 5.26.0 introduced a breaking change, so we restricted it for now. See issue #6808 for details.
-protobuf >= 3.19.6, != 4.24.0, < 5.0.0
+protobuf >= 3.19.6, != 4.24.0
 setuptools >= 41.0.0  # Note: provides pkg_resources as well as setuptools
 # A dependency of our vendored packages. This lower bound has not been correctly
 # vetted, but I wanted to be the least restrictive we can, since it's not a new

--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 """Provides utilities that may be especially useful to plugins."""
 
-
+from google.protobuf import json_format
+from importlib import metadata
+from packaging import version
 import threading
 
 from bleach.sanitizer import Cleaner
@@ -191,6 +193,24 @@ def experiment_id(environ):
       A experiment ID, as a possibly-empty `str`.
     """
     return environ.get(_experiment_id.WSGI_ENVIRON_KEY, "")
+
+
+def proto_to_json(proto):
+    """Utility method to convert proto to JSON, accounting for different version support.
+
+    Args:
+      proto: The proto to convert to JSON.
+    """
+    current_version = metadata.version("protobuf")
+    if version.parse(current_version) >= version.parse("5.0.0"):
+        return json_format.MessageToJson(
+            proto,
+            always_print_fields_with_no_presence=True,
+        )
+    return json_format.MessageToJson(
+        proto,
+        including_default_value_fields=True,
+    )
 
 
 class _MetadataVersionChecker:

--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -201,7 +201,14 @@ def proto_to_json(proto):
     Args:
       proto: The proto to convert to JSON.
     """
-    current_version = metadata.version("protobuf")
+    # Fallback for internal usage, since non third-party code doesn't really
+    # have the concept of "versions" in a monorepo. The package version chosen
+    # below is the minimum value to choose the non-deprecated kwarg to
+    # `MessageToJson`.
+    try:
+        current_version = metadata.version("protobuf")
+    except metadata.PackageNotFoundError:
+        current_version = "5.0.0"
     if version.parse(current_version) >= version.parse("5.0.0"):
         return json_format.MessageToJson(
             proto,

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -21,10 +21,7 @@ See `http_api.md` in this directory for specifications of the routes for
 this plugin.
 """
 
-
 import re
-
-from google.protobuf import json_format
 
 from werkzeug import wrappers
 
@@ -318,9 +315,7 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
                     title_to_category[category.title] = category
 
         if merged_layout:
-            return json_format.MessageToJson(
-                merged_layout, including_default_value_fields=True
-            )
+            return plugin_util.proto_to_json(merged_layout)
         else:
             # No layout was found.
             return {}

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -18,9 +18,7 @@ See `http_api.md` in this directory for specifications of the routes for
 this plugin.
 """
 
-
 import json
-
 
 import werkzeug
 from werkzeug import wrappers
@@ -116,14 +114,16 @@ class HParamsPlugin(base_plugin.TBPlugin):
             request_proto = _parse_request_argument(
                 request, api_pb2.GetExperimentRequest
             )
+            response_proto = get_experiment.Handler(
+                ctx,
+                self._context,
+                experiment_id,
+                request_proto,
+            ).run()
+            response = plugin_util.proto_to_json(response_proto)
             return http_util.Respond(
                 request,
-                json_format.MessageToJson(
-                    get_experiment.Handler(
-                        ctx, self._context, experiment_id, request_proto
-                    ).run(),
-                    including_default_value_fields=True,
-                ),
+                response,
                 "application/json",
             )
         except error.HParamsError as e:
@@ -139,14 +139,16 @@ class HParamsPlugin(base_plugin.TBPlugin):
             request_proto = _parse_request_argument(
                 request, api_pb2.ListSessionGroupsRequest
             )
+            response_proto = list_session_groups.Handler(
+                ctx,
+                self._context,
+                experiment_id,
+                request_proto,
+            ).run()
+            response = plugin_util.proto_to_json(response_proto)
             return http_util.Respond(
                 request,
-                json_format.MessageToJson(
-                    list_session_groups.Handler(
-                        ctx, self._context, experiment_id, request_proto
-                    ).run(),
-                    including_default_value_fields=True,
-                ),
+                response,
                 "application/json",
             )
         except error.HParamsError as e:

--- a/tensorboard/util/tensor_util.py
+++ b/tensorboard/util/tensor_util.py
@@ -137,7 +137,7 @@ def GetNumpyAppendFn(dtype):
     # dtype with a single constant (np.string does not exist) to decide
     # dtype is a "string" type. We need to compare the dtype.type to be
     # sure it's a string type.
-    if dtype.type == np.string_ or dtype.type == np.unicode_:
+    if dtype.type == np.bytes_ or dtype.type == np.str_:
         return SlowAppendObjectArrayToTensorProto
     return GetFromNumpyDTypeDict(_NP_TO_APPEND_FN, dtype)
 

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,7 +15,7 @@
 
 """Contains the version string."""
 
-VERSION = "2.17.0"
+VERSION = "2.17.1"
 
 if __name__ == "__main__":
     print(VERSION)

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -48,7 +48,7 @@ import {
 } from '../types';
 import {AppRoutingEffects, TEST_ONLY} from './app_routing_effects';
 
-@Component({selector: 'test', template: ''})
+@Component({selector: 'test', template: '', jit: true})
 class TestableComponent {}
 
 const testAction = createAction('[TEST] test action');

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
@@ -37,6 +37,7 @@ import {
 @Component({
   selector: 'testable-feature-flag-dialog-container',
   template: '<div>Test</div>',
+  jit: true,
 })
 class TestableFeatureFlagDialogContainer {}
 

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.scss
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.scss
@@ -28,6 +28,7 @@ limitations under the License.
   right: 10px;
   top: 10px;
   width: $_dim;
+  z-index: 2;
 }
 
 ::ng-deep .notification-menu.mat-mdc-menu-panel {

--- a/tensorboard/webapp/plugins/testing/index.ts
+++ b/tensorboard/webapp/plugins/testing/index.ts
@@ -26,5 +26,6 @@ export class ExtraDashboardComponent {}
   imports: [
     PluginRegistryModule.forPlugin('extra-plugin', ExtraDashboardComponent),
   ],
+  jit: true,
 })
 export class ExtraDashboardModule {}

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.css
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.css
@@ -28,3 +28,7 @@ h3 {
 .reload-toggle {
   margin-bottom: 16px;
 }
+
+mat-form-field {
+  width: 100%;
+}

--- a/tensorboard/webapp/testing/integration_test_module.ts
+++ b/tensorboard/webapp/testing/integration_test_module.ts
@@ -62,5 +62,6 @@ export function provideRoute(): RouteDef[] {
   ],
   declarations: [TestableComponent],
   exports: [TestableComponent],
+  jit: true,
 })
 export class IntegrationTestSetupModule {}

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_testing.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_testing.ts
@@ -42,5 +42,6 @@ export class TestingTBFeatureFlagDataSource extends TBFeatureFlagDataSource {
       useExisting: TestingTBFeatureFlagDataSource,
     },
   ],
+  jit: true,
 })
 export class TBFeatureFlagTestingModule {}

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_testing.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_testing.ts
@@ -34,5 +34,6 @@ import {TBHttpClientModule} from './tb_http_client_module';
       ),
     }),
   ],
+  jit: true,
 })
 export class TBHttpClientTestingModule {}

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal.ts
@@ -109,23 +109,23 @@ export class CustomModal {
     const customModalRef = new CustomModalRef(overlayRef);
     this.customModalRefs.push(customModalRef);
 
-    // setTimeout to prevent closing immediately after modal open.
-    setTimeout(() => {
-      const outsidePointerEventsSubscription = overlayRef
-        .outsidePointerEvents()
-        .subscribe((event) => {
-          // Only close when click is outside of every modal
-          if (
-            this.customModalRefs.every(
-              (ref) =>
-                !isMouseEventInElement(event, ref.overlayRef.overlayElement)
-            )
-          ) {
-            this.closeAll();
-          }
-        });
-      customModalRef.subscriptions.push(outsidePointerEventsSubscription);
-    });
+    const outsidePointerEventsSubscription = overlayRef
+      .outsidePointerEvents()
+      .subscribe((event) => {
+        // Prevent the right click mouseup event from immediately closing the modal.
+        if (event.type === 'auxclick') return;
+
+        // Only close when click is outside of every modal
+        if (
+          this.customModalRefs.every(
+            (ref) =>
+              !isMouseEventInElement(event, ref.overlayRef.overlayElement)
+          )
+        ) {
+          this.closeAll();
+        }
+      });
+    customModalRef.subscriptions.push(outsidePointerEventsSubscription);
 
     const keydownEventsSubscription = overlayRef
       .keydownEvents()

--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_testing_module.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_testing_module.ts
@@ -16,7 +16,7 @@ import {Directive, EventEmitter, NgModule, Output} from '@angular/core';
 import {ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
-@Directive({selector: '[observeIntersection]'})
+@Directive({selector: '[observeIntersection]', jit: true})
 class IntersectionObserverTestingDirective {
   @Output() onVisibilityChange = new EventEmitter<{visible: boolean}>();
 
@@ -28,6 +28,7 @@ class IntersectionObserverTestingDirective {
 @NgModule({
   exports: [IntersectionObserverTestingDirective],
   declarations: [IntersectionObserverTestingDirective],
+  jit: true,
 })
 export class IntersectionObserverTestingModule {
   simulateVisibilityChange<T>(fixture: ComponentFixture<T>, visible: boolean) {

--- a/tensorboard/webapp/widgets/resize_detector_testing_module.ts
+++ b/tensorboard/webapp/widgets/resize_detector_testing_module.ts
@@ -29,6 +29,7 @@ class ResizeDetectorTestingDirective {
 @NgModule({
   exports: [ResizeDetectorTestingDirective],
   declarations: [ResizeDetectorTestingDirective],
+  jit: true,
 })
 export class ResizeDetectorTestingModule {
   simulateResize<T>(fixture: ComponentFixture<T>) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4830,11 +4830,11 @@ brace-expansion@^2.0.1:
     balanced-match "^1.0.0"
 
 braces@^3.0.2, braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
-    fill-range "^7.0.1"
+    fill-range "^7.1.1"
 
 browser-sync-client@^2.27.10:
   version "2.27.10"
@@ -6743,10 +6743,10 @@ figures@^3.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -10221,7 +10221,16 @@ string-argv@~0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10253,7 +10262,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10266,6 +10275,13 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -10982,7 +10998,7 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10995,6 +11011,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6073,6 +6073,13 @@ debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@~4.3.4:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
+  integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -6304,10 +6311,15 @@ engine.io-parser@~5.0.3:
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.4.tgz#0b13f704fa9271b3ec4f33112410d8f3f41d0fc0"
   integrity sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==
 
-engine.io@~6.2.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.2.1.tgz#e3f7826ebc4140db9bbaa9021ad6b1efb175878f"
-  integrity sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==
+engine.io-parser@~5.2.1:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.2.3.tgz#00dc5b97b1f233a23c9398d0209504cf5f94d92f"
+  integrity sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==
+
+engine.io@~6.5.2:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.5.5.tgz#430b80d8840caab91a50e9e23cb551455195fc93"
+  integrity sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==
   dependencies:
     "@types/cookie" "^0.4.1"
     "@types/cors" "^2.8.12"
@@ -6317,8 +6329,8 @@ engine.io@~6.2.0:
     cookie "~0.4.1"
     cors "~2.8.5"
     debug "~4.3.1"
-    engine.io-parser "~5.0.3"
-    ws "~8.2.3"
+    engine.io-parser "~5.2.1"
+    ws "~8.17.1"
 
 enhanced-resolve@^5.10.0:
   version "5.10.0"
@@ -9983,10 +9995,13 @@ smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socket.io-adapter@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz#b50a4a9ecdd00c34d4c8c808224daa1a786152a6"
-  integrity sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==
+socket.io-adapter@~2.5.2:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz#c7a1f9c703d7756844751b6ff9abfc1780664082"
+  integrity sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==
+  dependencies:
+    debug "~4.3.4"
+    ws "~8.17.1"
 
 socket.io-client@^4.4.1:
   version "4.5.3"
@@ -10006,17 +10021,26 @@ socket.io-parser@~4.2.0:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
+socket.io-parser@~4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.4.tgz#c806966cf7270601e47469ddeec30fbdfda44c83"
+  integrity sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+
 socket.io@^4.2.0, socket.io@^4.4.1:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.5.3.tgz#44dffea48d7f5aa41df4a66377c386b953bc521c"
-  integrity sha512-zdpnnKU+H6mOp7nYRXH4GNv1ux6HL6+lHL8g7Ds7Lj8CkdK1jJK/dlwsKDculbyOHifcJ0Pr/yeXnZQ5GeFrcg==
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.5.tgz#56eb2d976aef9d1445f373a62d781a41c7add8f8"
+  integrity sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==
   dependencies:
     accepts "~1.3.4"
     base64id "~2.0.0"
+    cors "~2.8.5"
     debug "~4.3.2"
-    engine.io "~6.2.0"
-    socket.io-adapter "~2.4.0"
-    socket.io-parser "~4.2.0"
+    engine.io "~6.5.2"
+    socket.io-adapter "~2.5.2"
+    socket.io-parser "~4.2.4"
 
 sockjs@^0.3.24:
   version "0.3.24"
@@ -11043,6 +11067,11 @@ ws@>=8.7.0, ws@^8.4.2:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+
+ws@~8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 ws@~8.2.3:
   version "8.2.3"


### PR DESCRIPTION
This patch release resolves some underlying dependency issues, most notably:
* Relaxing protobuf dependency restrictions
* Numpy 2.0 compatibility updates

These commits prepare for the release. I will rebase and merge them.