### PR TITLE
Relax development `virtualenv` dependency versioning

### DIFF
--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -30,4 +30,4 @@ flake8==3.7.8
 yamllint==1.17.0
 
 # For building Pip package
-virtualenv==20.0.31
+virtualenv


### PR DESCRIPTION
We're seeing issues when trying to build our wheels which resolve when upgrading to a newer virtualenv version.