### PR TITLE
Allow Custom File Systems To Override The Walk Method

### DIFF
--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -928,6 +928,12 @@ def walk(top, topdown=True, onerror=None):
     """
     top = compat.as_str_any(top)
     fs = get_filesystem(top)
+    
+    if hasattr(fs, 'walk'):
+        for item in fs.walk(top, onerror=onerror):
+            yield item
+        return
+
     try:
         listing = listdir(top)
     except errors.NotFoundError as err:


### PR DESCRIPTION
## Motivation for features / changes
When registering a file system, we would like to be to use our custom walk method. This is useful for using multi-threading in the walk and other file system specifics.  

## Technical description of changes
Instead of using the `gfile` implementation of `walk`, it will check first if the file system has its own implementation. 

## Detailed steps to verify changes work correctly (as executed by you)
Tested locally with a custom file system. Used custom walk method when it existed. Used old logic when file system didn't have an override.
