### PR TITLE
Relax pandas dev dependency

### DIFF
--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -17,7 +17,7 @@
 
 # For tests
 grpcio-testing==1.24.3
-pandas~=1.0
+pandas~=2.0
 # For gfile S3 test
 boto3==1.9.86
 moto==1.3.7


### PR DESCRIPTION
This avoids issues during test due to incompatibility between the installed pandas and numpy versions:

`ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject`