### PR TITLE
Update visibility of `lib_init_only` target

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -103,7 +103,7 @@ py_library(
     name = "lib_init_only",
     srcs = ["__init__.py"],
     srcs_version = "PY3",
-    visibility = ["//tensorboard:internal"],
+    visibility = ["//visibility:public"],
     deps = [
         ":lazy",
         ":version",


### PR DESCRIPTION
This is updating our OSS code with a change made in cl/678434606, to prevent that change being reverted next time we sync our code to the internal code base.

This target is intended to expose part of the public API of TensorBoard, but it does not include all the underlying dependencies, so it could lead to issues if other dependencies are not included otherwise.

I expect the explicit naming of `lib_init_only` should be enough to note this, so the visibility was changed to allow a new client to include it as a dependency.