### PR TITLE
Post release 2.18.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,15 @@
+# Release 2.18.0
+
+The 2.18 minor series tracks TensorFlow 2.18.
+
+## Features
+- Compatibility updates for changes in Numpy 2.0 (#6871)
+- Relax `protobuf` restriction to work with versions < 5.0.0 (in addition to >= 5.0.0) (#6888)
+
+## Bug Fixes
+- Fixes a floating menu disappearing immediately after right-clicking on the trigger point. (#6891)
+
+
 # Release 2.17.1
 
 ## Bug Fixes

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,7 +15,7 @@
 
 """Contains the version string."""
 
-VERSION = "2.18.0a0"
+VERSION = "2.19.0a0"
 
 if __name__ == "__main__":
     print(VERSION)


### PR DESCRIPTION
Two commits to round out the 2.18.0 release process:

- Bump tb-nightly version to 2.19.0a0
- Cherrypick of 2.18.0 relnotes added to RELEASE.md