### PR TITLE
Move the initializer into the constructor for instance members that r…

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -41,33 +41,19 @@ import {State} from '../../store/debugger_types';
   `,
 })
 export class GraphExecutionsContainer {
-  readonly numGraphExecutions$ = this.store.pipe(select(getNumGraphExecutions));
+  readonly numGraphExecutions$;
 
-  readonly graphExecutionData$ = this.store.pipe(select(getGraphExecutionData));
+  readonly graphExecutionData$;
 
-  readonly graphExecutionIndices$ = this.store.pipe(
-    select(
-      createSelector(
-        getNumGraphExecutions,
-        (numGraphExecution: number): number[] | null => {
-          if (numGraphExecution === 0) {
-            return null;
-          }
-          return Array.from({length: numGraphExecution}).map((_, i) => i);
-        }
-      )
-    )
-  );
+  readonly graphExecutionIndices$;
 
-  readonly focusIndex$ = this.store.pipe(select(getGraphExecutionFocusIndex));
+  readonly focusIndex$;
 
   /**
    * Inferred graph-execution indices that belong to the immediate inputs
    * to the currently-focused graph op.
    */
-  readonly focusInputIndices$ = this.store.pipe(
-    select(getFocusedGraphExecutionInputIndices)
-  );
+  readonly focusInputIndices$;
 
   onScrolledIndexChange(scrolledIndex: number) {
     this.store.dispatch(graphExecutionScrollToIndex({index: scrolledIndex}));
@@ -77,5 +63,25 @@ export class GraphExecutionsContainer {
     this.store.dispatch(graphExecutionFocused(event));
   }
 
-  constructor(private readonly store: Store<State>) {}
+  constructor(private readonly store: Store<State>) {
+    this.numGraphExecutions$ = this.store.pipe(select(getNumGraphExecutions));
+    this.graphExecutionData$ = this.store.pipe(select(getGraphExecutionData));
+    this.graphExecutionIndices$ = this.store.pipe(
+      select(
+        createSelector(
+          getNumGraphExecutions,
+          (numGraphExecution: number): number[] | null => {
+            if (numGraphExecution === 0) {
+              return null;
+            }
+            return Array.from({length: numGraphExecution}).map((_, i) => i);
+          }
+        )
+      )
+    );
+    this.focusIndex$ = this.store.pipe(select(getGraphExecutionFocusIndex));
+    this.focusInputIndices$ = this.store.pipe(
+      select(getFocusedGraphExecutionInputIndices)
+    );
+  }
 }

--- a/tensorboard/webapp/app_routing/views/router_outlet_container.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_container.ts
@@ -34,25 +34,27 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RouterOutletContainer {
-  activeNgComponent$ = combineLatest([
-    this.store.select(getActiveRoute),
-    this.store.select(getNextRouteForRouterOutletOnly),
-  ]).pipe(
-    map(([activeRoute, nextRoute]) => {
-      if (!activeRoute) {
-        return null;
-      }
-      const isRouteTransitioning =
-        nextRoute !== null &&
-        !areSameRouteKindAndExperiments(activeRoute, nextRoute);
-      return isRouteTransitioning
-        ? null
-        : this.registry.getNgComponentByRouteKind(activeRoute.routeKind);
-    })
-  );
+  activeNgComponent$;
 
   constructor(
     private readonly store: Store<State>,
     private readonly registry: RouteRegistryModule
-  ) {}
+  ) {
+    this.activeNgComponent$ = combineLatest([
+      this.store.select(getActiveRoute),
+      this.store.select(getNextRouteForRouterOutletOnly),
+    ]).pipe(
+      map(([activeRoute, nextRoute]) => {
+        if (!activeRoute) {
+          return null;
+        }
+        const isRouteTransitioning =
+          nextRoute !== null &&
+          !areSameRouteKindAndExperiments(activeRoute, nextRoute);
+        return isRouteTransitioning
+          ? null
+          : this.registry.getNgComponentByRouteKind(activeRoute.routeKind);
+      })
+    );
+  }
 }

--- a/tensorboard/webapp/core/views/layout_container.ts
+++ b/tensorboard/webapp/core/views/layout_container.ts
@@ -79,21 +79,22 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LayoutContainer implements OnDestroy {
-  readonly runsTableFullScreen$ = this.store.select(getRunsTableFullScreen);
-  readonly width$: Observable<number> = this.store
-    .select(getSideBarWidthInPercent)
-    .pipe(
-      combineLatestWith(this.runsTableFullScreen$),
-      map(([percentageWidth, fullScreen]) => {
-        return fullScreen ? 100 : percentageWidth;
-      })
-    );
-  private readonly ngUnsubscribe = new Subject<void>();
+  readonly runsTableFullScreen$;
+  readonly width$: Observable<number>;
+  private readonly ngUnsubscribe;
   private resizing: boolean = false;
 
   readonly MINIMUM_SIDEBAR_WIDTH_IN_PX = 75;
 
   constructor(private readonly store: Store<State>, hostElRef: ElementRef) {
+    this.runsTableFullScreen$ = this.store.select(getRunsTableFullScreen);
+    this.width$ = this.store.select(getSideBarWidthInPercent).pipe(
+      combineLatestWith(this.runsTableFullScreen$),
+      map(([percentageWidth, fullScreen]) => {
+        return fullScreen ? 100 : percentageWidth;
+      })
+    );
+    this.ngUnsubscribe = new Subject<void>();
     fromEvent<MouseEvent>(hostElRef.nativeElement, 'mousemove')
       .pipe(
         takeUntil(this.ngUnsubscribe),

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
@@ -57,24 +57,8 @@ const RUN_COLOR_UPDATE_THROTTLE_TIME_IN_MS = 350;
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CardViewContainer {
-  constructor(private readonly store: Store<State>) {}
-
-  isEverVisible = false;
-
-  @Input() cardId!: CardId;
-  @Input() groupName!: string | null;
-  @Input() pluginType!: PluginType;
-
-  @Output() fullWidthChanged = new EventEmitter<boolean>();
-  @Output() fullHeightChanged = new EventEmitter<boolean>();
-
-  onVisibilityChange({visible}: {visible: boolean}) {
-    this.isEverVisible = this.isEverVisible || visible;
-  }
-
-  readonly runColorScale$: Observable<RunColorScale> = this.store
-    .select(selectors.getRunColorMap)
-    .pipe(
+  constructor(private readonly store: Store<State>) {
+    this.runColorScale$ = this.store.select(selectors.getRunColorMap).pipe(
       throttleTime(RUN_COLOR_UPDATE_THROTTLE_TIME_IN_MS, undefined, {
         leading: true,
         trailing: true,
@@ -90,6 +74,22 @@ export class CardViewContainer {
         };
       })
     );
+  }
+
+  isEverVisible = false;
+
+  @Input() cardId!: CardId;
+  @Input() groupName!: string | null;
+  @Input() pluginType!: PluginType;
+
+  @Output() fullWidthChanged = new EventEmitter<boolean>();
+  @Output() fullHeightChanged = new EventEmitter<boolean>();
+
+  onVisibilityChange({visible}: {visible: boolean}) {
+    this.isEverVisible = this.isEverVisible || visible;
+  }
+
+  readonly runColorScale$: Observable<RunColorScale>;
 
   onFullWidthChanged(showFullWidth: boolean) {
     this.fullWidthChanged.emit(showFullWidth);

--- a/tensorboard/webapp/metrics/views/main_view/filtered_view_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/filtered_view_container.ts
@@ -50,49 +50,54 @@ export const FILTER_VIEW_DEBOUNCE_IN_MS = 200;
 export class FilteredViewContainer {
   @Input() cardObserver!: CardObserver;
 
-  constructor(private readonly store: Store<State>) {}
+  constructor(private readonly store: Store<State>) {
+    this.cardIdsWithMetadata$ = this.store
+      .select(getSortedRenderableCardIdsWithMetadata)
+      .pipe(
+        combineLatestWith(this.store.select(getMetricsFilteredPluginTypes)),
+        map(([cardList, filteredPluginTypes]) => {
+          if (!filteredPluginTypes.size) return cardList;
+          return cardList.filter((card) =>
+            filteredPluginTypes.has(card.plugin)
+          );
+        }),
+        combineLatestWith(this.store.select(getMetricsTagFilter)),
+        debounceTime(FILTER_VIEW_DEBOUNCE_IN_MS),
+        map(([cardList, tagFilter]) => {
+          try {
+            return {cardList, regex: new RegExp(tagFilter, 'i')};
+          } catch (e) {
+            return {cardList, regex: null};
+          }
+        }),
+        filter(({regex}) => regex !== null),
+        map(({cardList, regex}) => {
+          return cardList.filter(({tag}) => regex!.test(tag));
+        }),
+        distinctUntilChanged<DeepReadonly<CardIdWithMetadata>[]>(
+          (prev, updated) => {
+            if (prev.length !== updated.length) {
+              return false;
+            }
+            return prev.every((prevVal, index) => {
+              return prevVal.cardId === updated[index].cardId;
+            });
+          }
+        ),
+        share(),
+        startWith([])
+      ) as Observable<DeepReadonly<CardIdWithMetadata>[]>;
+    this.isEmptyMatch$ = this.cardIdsWithMetadata$.pipe(
+      combineLatestWith(
+        this.store.select(getSortedRenderableCardIdsWithMetadata)
+      ),
+      map(([filteredCardList, fullCardList]) => {
+        return Boolean(fullCardList.length) && filteredCardList.length === 0;
+      })
+    );
+  }
 
-  readonly cardIdsWithMetadata$: Observable<
-    DeepReadonly<CardIdWithMetadata>[]
-  > = this.store.select(getSortedRenderableCardIdsWithMetadata).pipe(
-    combineLatestWith(this.store.select(getMetricsFilteredPluginTypes)),
-    map(([cardList, filteredPluginTypes]) => {
-      if (!filteredPluginTypes.size) return cardList;
-      return cardList.filter((card) => filteredPluginTypes.has(card.plugin));
-    }),
-    combineLatestWith(this.store.select(getMetricsTagFilter)),
-    debounceTime(FILTER_VIEW_DEBOUNCE_IN_MS),
-    map(([cardList, tagFilter]) => {
-      try {
-        return {cardList, regex: new RegExp(tagFilter, 'i')};
-      } catch (e) {
-        return {cardList, regex: null};
-      }
-    }),
-    filter(({regex}) => regex !== null),
-    map(({cardList, regex}) => {
-      return cardList.filter(({tag}) => regex!.test(tag));
-    }),
-    distinctUntilChanged<DeepReadonly<CardIdWithMetadata>[]>(
-      (prev, updated) => {
-        if (prev.length !== updated.length) {
-          return false;
-        }
-        return prev.every((prevVal, index) => {
-          return prevVal.cardId === updated[index].cardId;
-        });
-      }
-    ),
-    share(),
-    startWith([])
-  ) as Observable<DeepReadonly<CardIdWithMetadata>[]>;
+  readonly cardIdsWithMetadata$: Observable<DeepReadonly<CardIdWithMetadata>[]>;
 
-  readonly isEmptyMatch$: Observable<boolean> = this.cardIdsWithMetadata$.pipe(
-    combineLatestWith(
-      this.store.select(getSortedRenderableCardIdsWithMetadata)
-    ),
-    map(([filteredCardList, fullCardList]) => {
-      return Boolean(fullCardList.length) && filteredCardList.length === 0;
-    })
-  );
+  readonly isEmptyMatch$: Observable<boolean>;
 }

--- a/tensorboard/webapp/metrics/views/main_view/pinned_view_container.ts
+++ b/tensorboard/webapp/metrics/views/main_view/pinned_view_container.ts
@@ -17,12 +17,12 @@ import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {skip, startWith} from 'rxjs/operators';
 import {State} from '../../../app_state';
+import {getEnableGlobalPins} from '../../../selectors';
 import {DeepReadonly} from '../../../util/types';
+import {metricsClearAllPinnedCards} from '../../actions';
 import {getLastPinnedCardTime, getPinnedCardsWithMetadata} from '../../store';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
-import {metricsClearAllPinnedCards} from '../../actions';
-import {getEnableGlobalPins} from '../../../selectors';
 
 @Component({
   selector: 'metrics-pinned-view',
@@ -40,19 +40,23 @@ import {getEnableGlobalPins} from '../../../selectors';
 export class PinnedViewContainer {
   @Input() cardObserver!: CardObserver;
 
-  constructor(private readonly store: Store<State>) {}
+  constructor(private readonly store: Store<State>) {
+    this.cardIdsWithMetadata$ = this.store
+      .select(getPinnedCardsWithMetadata)
+      .pipe(startWith([]));
+    this.lastPinnedCardTime$ = this.store.select(getLastPinnedCardTime).pipe(
+      // Ignore the first value on component load, only reacting to new
+      // pins after page load.
+      skip(1)
+    );
+    this.globalPinsEnabled$ = this.store.select(getEnableGlobalPins);
+  }
 
-  readonly cardIdsWithMetadata$: Observable<
-    DeepReadonly<CardIdWithMetadata[]>
-  > = this.store.select(getPinnedCardsWithMetadata).pipe(startWith([]));
+  readonly cardIdsWithMetadata$: Observable<DeepReadonly<CardIdWithMetadata[]>>;
 
-  readonly lastPinnedCardTime$ = this.store.select(getLastPinnedCardTime).pipe(
-    // Ignore the first value on component load, only reacting to new
-    // pins after page load.
-    skip(1)
-  );
+  readonly lastPinnedCardTime$;
 
-  readonly globalPinsEnabled$ = this.store.select(getEnableGlobalPins);
+  readonly globalPinsEnabled$;
 
   onClearAllPinsClicked() {
     this.store.dispatch(metricsClearAllPinnedCards());

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_container.ts
@@ -14,7 +14,12 @@ limitations under the License.
 ==============================================================================*/
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
+import {map} from 'rxjs/operators';
 import {State} from '../../../../app_state';
+import {
+  ColumnHeader,
+  DataTableMode,
+} from '../../../../widgets/data_table/types';
 import {
   dataTableColumnOrderChanged,
   dataTableColumnToggled,
@@ -27,11 +32,6 @@ import {
   getTableEditorSelectedTab,
 } from '../../../store/metrics_selectors';
 import {HeaderEditInfo, HeaderToggleInfo} from '../../../types';
-import {
-  ColumnHeader,
-  DataTableMode,
-} from '../../../../widgets/data_table/types';
-import {map} from 'rxjs/operators';
 
 function headersWithoutRuns(headers: ColumnHeader[]) {
   return headers.filter((header) => header.type !== 'RUN');
@@ -54,15 +54,19 @@ function headersWithoutRuns(headers: ColumnHeader[]) {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScalarColumnEditorContainer {
-  constructor(private readonly store: Store<State>) {}
+  constructor(private readonly store: Store<State>) {
+    this.singleHeaders$ = this.store
+      .select(getSingleSelectionHeaders)
+      .pipe(map(headersWithoutRuns));
+    this.rangeHeaders$ = this.store
+      .select(getRangeSelectionHeaders)
+      .pipe(map(headersWithoutRuns));
+    this.selectedTab$ = this.store.select(getTableEditorSelectedTab);
+  }
 
-  readonly singleHeaders$ = this.store
-    .select(getSingleSelectionHeaders)
-    .pipe(map(headersWithoutRuns));
-  readonly rangeHeaders$ = this.store
-    .select(getRangeSelectionHeaders)
-    .pipe(map(headersWithoutRuns));
-  readonly selectedTab$ = this.store.select(getTableEditorSelectedTab);
+  readonly singleHeaders$;
+  readonly rangeHeaders$;
+  readonly selectedTab$;
 
   onScalarTableColumnToggled(toggleInfo: HeaderToggleInfo) {
     this.store.dispatch(dataTableColumnToggled(toggleInfo));

--- a/tensorboard/webapp/notification_center/_views/notification_center_container.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_container.ts
@@ -38,8 +38,12 @@ const iconMap = new Map([[CategoryEnum.WHATS_NEW, 'info_outline_24px']]);
   `,
 })
 export class NotificationCenterContainer {
-  readonly notificationNotes$: Observable<ViewNotificationExt[]> =
-    combineLatest([
+  readonly notificationNotes$: Observable<ViewNotificationExt[]>;
+
+  readonly hasUnreadMessages$;
+
+  constructor(private readonly store: Store<State>) {
+    this.notificationNotes$ = combineLatest([
       this.store.select(getNotifications),
       this.store.select(getLastReadTime),
     ]).pipe(
@@ -54,14 +58,12 @@ export class NotificationCenterContainer {
       }),
       shareReplay()
     );
-
-  readonly hasUnreadMessages$ = this.notificationNotes$.pipe(
-    map((notifications) => {
-      return notifications.some(({hasRead}) => !hasRead);
-    })
-  );
-
-  constructor(private readonly store: Store<State>) {}
+    this.hasUnreadMessages$ = this.notificationNotes$.pipe(
+      map((notifications) => {
+        return notifications.some(({hasRead}) => !hasRead);
+      })
+    );
+  }
 
   onBellButtonClicked() {
     this.store.dispatch(actions.notificationBellClicked());

--- a/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_group_menu_button_container.ts
@@ -15,13 +15,13 @@ limitations under the License.
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
-import {map, take, filter, startWith, shareReplay} from 'rxjs/operators';
+import {filter, map, shareReplay, startWith, take} from 'rxjs/operators';
 import {RouteKind} from '../../../app_routing/types';
 import {State} from '../../../app_state';
 import {
-  getRegisteredRouteKinds,
   getDashboardExperimentNames,
   getEnableColorByExperiment,
+  getRegisteredRouteKinds,
 } from '../../../selectors';
 import {runGroupByChanged} from '../../actions';
 import {
@@ -50,35 +50,35 @@ import {GroupBy, GroupByKey} from '../../types';
 export class RunsGroupMenuButtonContainer {
   @Input() experimentIds!: string[];
 
-  constructor(private readonly store: Store<State>) {}
-
-  readonly showExperimentsGroupBy$: Observable<boolean> = this.store
-    .select(getRegisteredRouteKinds)
-    .pipe(
-      map((registeredRouteKinds) => {
-        return registeredRouteKinds.has(RouteKind.COMPARE_EXPERIMENT);
-      })
-    );
-
-  readonly selectedGroupBy$: Observable<GroupBy> =
-    this.store.select(getRunGroupBy);
-
-  readonly lastRegexGroupByKey$: Observable<GroupByKey> = this.store
-    .select(getRunGroupBy)
-    .pipe(
+  constructor(private readonly store: Store<State>) {
+    this.showExperimentsGroupBy$ = this.store
+      .select(getRegisteredRouteKinds)
+      .pipe(
+        map((registeredRouteKinds) => {
+          return registeredRouteKinds.has(RouteKind.COMPARE_EXPERIMENT);
+        })
+      );
+    this.selectedGroupBy$ = this.store.select(getRunGroupBy);
+    this.lastRegexGroupByKey$ = this.store.select(getRunGroupBy).pipe(
       map((group) => group.key),
       filter(
         (key) => key === GroupByKey.REGEX || key === GroupByKey.REGEX_BY_EXP
       ),
       startWith(GroupByKey.REGEX)
     );
+    this.groupByRegexString$ = this.store.select(getColorGroupRegexString);
+    this.expNameByExpId$ = this.store.select(getDashboardExperimentNames);
+  }
 
-  readonly groupByRegexString$: Observable<string> = this.store.select(
-    getColorGroupRegexString
-  );
+  readonly showExperimentsGroupBy$: Observable<boolean>;
 
-  readonly expNameByExpId$: Observable<Record<string, string>> =
-    this.store.select(getDashboardExperimentNames);
+  readonly selectedGroupBy$: Observable<GroupBy>;
+
+  readonly lastRegexGroupByKey$: Observable<GroupByKey>;
+
+  readonly groupByRegexString$: Observable<string>;
+
+  readonly expNameByExpId$: Observable<Record<string, string>>;
 
   onGroupByChange(groupBy: GroupBy) {
     this.expNameByExpId$.pipe(take(1)).subscribe((expNameByExpId) => {


### PR DESCRIPTION
…eference identifiers declared in the constructor.

This updates our OSS code with a change made in cl/678990911, to prevent the change being reverted the next time we sync into our internal code base.

When TypeScript outputs modern language features, the below case throws an TS error.

```
class C {
  a = this.x; // TS2729: Property 'x' is used before its initialization.

  constructor(public x:number){}
}
```

This error is fixed by moving the initializer of such class members into the constructor.