### PR TITLE
disable precompiled libraries for incompatible tensorboard js_binaries

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -36,6 +36,7 @@ tf_js_binary(
     ],
     compile = 1,
     entry_point = ":tensor-widget-interop.ts",
+    use_precompiled_libraries = False,
     deps = [
         ":tensor_widget_binary_lib",
     ],


### PR DESCRIPTION
Opt out breaking targets from using precompiled libraries. This is apart of the LSC to make precompiled libraries the default for js_binary and js_module_binary in google3. This is a no op, we are just moving the flag from the .bzl to the users BUILD file
