### PR TITLE
Update legacy API usage in get_started.ipynb

### DIFF
--- a/docs/get_started.ipynb
+++ b/docs/get_started.ipynb
@@ -135,7 +135,8 @@
         "\n",
         "def create_model():\n",
         "  return tf.keras.models.Sequential([\n",
-        "    tf.keras.layers.Flatten(input_shape=(28, 28), name='layers_flatten'),\n",
+        "    tf.keras.layers.Input(shape=(28, 28), name='layers_input'),\n",
+        "    tf.keras.layers.Flatten(name='layers_flatten'),\n",
         "    tf.keras.layers.Dense(512, activation='relu', name='layers_dense'),\n",
         "    tf.keras.layers.Dropout(0.2, name='layers_dropout'),\n",
         "    tf.keras.layers.Dense(10, activation='softmax', name='layers_dense_2')\n",
@@ -452,10 +453,10 @@
         "                         test_accuracy.result()*100))\n",
         "\n",
         "  # Reset metrics every epoch\n",
-        "  train_loss.reset_states()\n",
-        "  test_loss.reset_states()\n",
-        "  train_accuracy.reset_states()\n",
-        "  test_accuracy.reset_states()"
+        "  train_loss.reset_state()\n",
+        "  test_loss.reset_state()\n",
+        "  train_accuracy.reset_state()\n",
+        "  test_accuracy.reset_state()"
       ]
     },
     {


### PR DESCRIPTION
## Motivation for features / changes
As title. Current code no longer runs in the newer TF version (2.17.0 on Colab) with the following error / warning:

```
AttributeError                            Traceback (most recent call last)
[<ipython-input-19-f1056f2ad84b>](https://localhost:8080/#) in <cell line: 5>()
     24 
     25   # Reset metrics every epoch
---> 26   train_loss.reset_states()
     27   test_loss.reset_states()
     28   train_accuracy.reset_states()

AttributeError: 'Mean' object has no attribute 'reset_states'
```

```
/usr/local/lib/python3.10/dist-packages/keras/src/layers/reshaping/flatten.py:37: UserWarning: Do not pass an `input_shape`/`input_dim` argument to a layer. When using Sequential models, prefer using an `Input(shape)` object as the first layer in the model instead.
  super().__init__(**kwargs)
```

## Technical description of changes
N/A

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)
Run on Colab

## Alternate designs / implementations considered (or N/A)
N/A
