### PR TITLE
Support LSC with explicit inclusion of dependency bazel:java_proto_library.bzl

### DIFF
--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -2,6 +2,7 @@
 # TensorBoard, a dashboard for investigating TensorFlow
 
 load("@rules_python//python:py_test.bzl", "py_test")
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])


### PR DESCRIPTION
Support LSC with explicit inclusion of dependency bazel:java_proto_library.bzl

## Motivation for features / changes
This is intended to help support cl/693803990

## Technical description of changes
Adds an explicit dependency to  bazel:java_proto_library.bzl in the context BUILD file

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
N/A