### PR TITLE
Updates GH actions upload- and download-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,10 +130,14 @@ jobs:
           bazel run //tensorboard/pip_package:build_pip_package -- /tmp/tb_nightly_pip_package
       - name: 'Upload Pip package as an artifact (master branch TF build only)'
         # Prevent uploads when running on forks or non-master branch.
+        #
+        # Note that upload-artifact GH action, starting in v4, requires the name of the uploaded
+        # file(s) to be unique per workflow run, so make sure that the name is unique for each
+        # "matrix" combination for which this is executed.
         if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@v4.4.3
         with:
-          name: tb-nightly
+          name: tb-nightly_py${{ matrix.python_version }}
           path: /tmp/tb_nightly_pip_package/*
 
   build-data-server-pip:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         # file(s) to be unique per workflow run, so make sure that the name is unique for each
         # "matrix" combination for which this is executed.
         if: matrix.tf_version_id == 'tf' && github.repository == 'tensorflow/tensorboard' && github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: tb-nightly_py${{ matrix.python_version }}
           path: /tmp/tb_nightly_pip_package/*

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -20,9 +20,11 @@ jobs:
     if: github.repository == 'tensorflow/tensorboard'
     steps:
       - name: Download pip package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4.4.3
         with:
-          name: tb-nightly
+          pattern: tb-nightly_py*
+          # Download all matching artifacts in the same directory (specified by path)
+          merge-multiple: true
           path: wheels
       - name: Install Twine
         run: pip install twine

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'tensorflow/tensorboard'
     steps:
       - name: Download pip package
-        uses: actions/download-artifact@v4.4.3
+        uses: actions/download-artifact@v4
         with:
           pattern: tb-nightly_py*
           # Download all matching artifacts in the same directory (specified by path)


### PR DESCRIPTION
As communicated in [this announcement](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), v3 of these actions is deprecated.

I followed [this example](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact) matching our use of these actions.
