### PR TITLE
mailmap: update info for wchargin

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Willow Chargin <wchargin@gmail.com>
+Willow Chargin <wchargin@gmail.com> <github@wchargin.com>
+Willow Chargin <wchargin@gmail.com> <wchargin@google.com>


### PR DESCRIPTION
Hello! I used to work on TensorBoard full time. Then I changed my name. (👋!) I still consult this repo sometimes, so I'd like for my name to be updated and correct.

This patch adds a [Git mailmap], which is a plain text file that teaches Git to correct errors or duplication in user information. It transparently fixes the output of commands like `git shortlog` and `git show`, without needing to rewrite old hashes or destroy any information. I've initialized the mailmap with my name and also unified the email addresses to the one that I used most commonly (99.2% of the time).

Test Plan:
`git shortlog -nse | head` and see that my name is [spelled right now][wc].

[Git mailmap]: https://git-scm.com/docs/gitmailmap
[wc]: https://wchargin.com
