### PR TITLE
Use macos-13 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-20.04', 'macos-12']
+        platform: ['ubuntu-20.04', 'macos-13']
         rust_version: ['1.65.0']
         include:
           - mode: 'universal'


### PR DESCRIPTION
## Motivation for features / changes
macos 12 is deprecated so nightly PIP release is failing