### PR TITLE
Updates missed GH upload-artifact action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,9 +211,9 @@ jobs:
             --out-dir /tmp/pip_package \
             ;
       - name: 'Upload'
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        uses: actions/upload-artifact@v4
         with:
-          name: tensorboard-data-server
+          name: tensorboard-data-server_${{ matrix.mode }}_${{ matrix.platform }}_${{ matrix.rust_version }}
           path: /tmp/pip_package/*
 
   lint-python-flake8:


### PR DESCRIPTION
Follow-up to #6936, where I missed one occurrence of this deprecated action.

As noted in the [migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact), the upload action can no longer be called with the same name more than once within the same workflow, so the matrix values needs to be included in the name.