### PR TITLE
Removes duplicate style specs.

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
@@ -66,11 +66,8 @@ limitations under the License.
   position: absolute;
   right: 40px;
   --mdc-slider-handle-width: 80px;
-  --mat-slider-handle-width: 80px;
   --mdc-slider-handle-height: 16px;
-  --mat-slider-handle-height: 16px;
   --mdc-slider-handle-shape: 5px;
-  --mat-slider-handle-shape: 5px;
 }
 
 ::ng-deep .mat-mdc-focus-indicator {

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -303,13 +303,9 @@ $tb-dark-theme: map_merge(
   body.dark-mode {
     mat-slider {
       --mdc-slider-handle-width: 12px;
-      --mat-slider-handle-width: 12px;
       --mdc-slider-handle-height: 12px;
-      --mat-slider-handle-height: 12px;
       --mdc-slider-active-track-height: 2px;
-      --mat-slider-active-track-height: 2px;
       --mdc-slider-inactive-track-height: 2px;
-      --mat-slider-inactive-track-height: 2px;
     }
 
     a,
@@ -319,13 +315,9 @@ $tb-dark-theme: map_merge(
       --tb-icon-button-width: 40px;
       --tb-icon-button-height: 40px;
       --mdc-text-button-label-text-tracking: normal;
-      --mat-text-button-label-text-tracking: normal;
       --mdc-filled-button-label-text-tracking: normal;
-      --mat-filled-button-label-text-tracking: normal;
       --mdc-outlined-button-label-text-tracking: normal;
-      --mat-outlined-button-label-text-tracking: normal;
       --mdc-protected-button-label-text-tracking: normal;
-      --mat-protected-button-label-text-tracking: normal;
 
       &[mat-icon-button].mat-mdc-icon-button {
         width: var(--tb-icon-button-width);


### PR DESCRIPTION
## Motivation for features / changes
Angular v15, which is the one currently used in the OSS repo, uses styles with format `--mdc-` to style material components.

Later versions of angular migrated to a `--mat-` prefix, and Angular v20 will update some of the names again.

Our internal codebase uses the styles defined internally, so we need to use the new format.

We recently set up translations internally from these "old" `--mdc-` stylings to the newer `--mat-` names, so we don't need them duplicate here, which could potentially be a source for confusion.

Googlers, see cl/744892387 and cl/744895577 for some details.

## Technical description of changes
Remove some scss lines that are unused in the public repo.