### PR TITLE
Adds comment to ignore lints for change in TS 5.8.

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
@@ -508,7 +508,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
     }
     return tf_graph_util.convertUnitsToHumanReadable(
       stats.totalBytes,
-      tf_graph_util.MEMORY_UNITS
+      tf_graph_util.MEMORY_UNITS,
     );
   }
   @computed('_nodeStats')
@@ -519,7 +519,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
     }
     return tf_graph_util.convertUnitsToHumanReadable(
       stats.getTotalMicros(),
-      tf_graph_util.TIME_UNITS
+      tf_graph_util.TIME_UNITS,
     );
   }
   @computed('_nodeStats')
@@ -553,7 +553,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
         attrs = attrs.concat(
           entry.value.list.s.map(function (key) {
             return {key: key, value: 'Too large to show...'};
-          })
+          }),
         );
       } else {
         attrs.push({
@@ -567,6 +567,10 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   @computed('_node')
   get _device(): string {
     var node = this._node;
+    // TODO: go/ts58upgrade - Fix type mismatch caused by improved checking of
+    // returned conditional operators after upgrade
+    //   TS2322: Type 'null' is not assignable to type 'string'.
+    // @ts-ignore
     return node ? node.device : null;
   }
   @computed('_node', 'graphHierarchy')
@@ -580,7 +584,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
     return this._convertEdgeListToEdgeInfoList(
       hierarchy.getSuccessors(node.name),
       false,
-      node.isGroupNode
+      node.isGroupNode,
     );
   }
   @computed('_node', 'graphHierarchy')
@@ -594,7 +598,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
     return this._convertEdgeListToEdgeInfoList(
       hierarchy.getPredecessors(node.name),
       true,
-      node.isGroupNode
+      node.isGroupNode,
     );
   }
   // Only relevant if this is a library function. A list of nodes that
@@ -635,7 +639,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
           node: this._getNode(name, this.graphHierarchy),
           edgeLabel: tf_graph_scene_edge.getLabelForBaseEdge(
             baseEdge,
-            this.renderHierarchy
+            this.renderHierarchy,
           ),
           renderInfo: this._getRenderInfo(name, this.renderHierarchy),
         };
@@ -659,7 +663,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
             node: this._getNode(name, this.graphHierarchy),
             edgeLabel: tf_graph_scene_edge.getLabelForEdge(
               metaedge,
-              this.renderHierarchy
+              this.renderHierarchy,
             ),
             renderInfo: this._getRenderInfo(name, this.renderHierarchy),
           });
@@ -675,6 +679,10 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   @computed('_node')
   get _subnodes(): unknown[] {
     var node = this._node;
+    // TODO: go/ts58upgrade - Fix type mismatch caused by improved checking of
+    // returned conditional operators after upgrade
+    //   TS2322: Type 'null' is not assignable to type 'unknown[]'.
+    // @ts-ignore
     return node && node.metagraph ? node.metagraph.nodes() : null;
   }
   @computed('_predecessors')
@@ -704,7 +712,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
     this._openedControlSucc = false;
     this.set(
       '_groupButtonText',
-      tf_graph_scene_node.getGroupSettingLabel(this._node)
+      tf_graph_scene_node.getGroupSettingLabel(this._node),
     );
   }
   _resizeList(selector) {
@@ -732,7 +740,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   }
   _isInSeries(node) {
     return tf_graph_scene_node.canBeInSeries(node);
-  }
+  },
   @observe('graphHierarchy')
   _graphHierarchyChanged() {
     this._templateIndex = this.graphHierarchy.getTemplateIndex();

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
@@ -740,7 +740,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   }
   _isInSeries(node) {
     return tf_graph_scene_node.canBeInSeries(node);
-  },
+  }
   @observe('graphHierarchy')
   _graphHierarchyChanged() {
     this._templateIndex = this.graphHierarchy.getTemplateIndex();
@@ -748,7 +748,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
       tf_graph_hierarchy.HierarchyEvent.TEMPLATES_UPDATED,
       () => {
         this._templateIndex = this.graphHierarchy.getTemplateIndex();
-      }
+      },
     );
   }
 }

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
@@ -59,7 +59,7 @@ class IntervalBrushFilter implements AxisBrushFilter {
     lower: number,
     upper: number,
     lowerOpen: boolean,
-    upperOpen: boolean
+    upperOpen: boolean,
   ) {
     this._lower = lower;
     this._upper = upper;
@@ -121,7 +121,7 @@ export class Axis {
     svgProps: tf_hparams_parallel_coords_plot_interaction_manager.SVGProperties,
     schema: Schema,
     interactionManager: tf_hparams_parallel_coords_plot_interaction_manager.InteractionManager,
-    colIndex: number
+    colIndex: number,
   ) {
     this._svgProps = svgProps;
     this._schema = schema;
@@ -152,7 +152,7 @@ export class Axis {
     this._brushFilter = this._buildBrushFilter(
       this.brushSelection()!,
       this.scaleType()!,
-      this.yScale()
+      this.yScale(),
     );
   }
   /**
@@ -165,7 +165,7 @@ export class Axis {
       // Pass a copy since createAxisScale may permute the domainValues array.
       domainValues.slice(),
       this._svgProps.height,
-      this.scaleType()
+      this.scaleType(),
     );
     // TODO(erez): Try to modify the brush selection so that it selects
     // the same subset of the axis domain which was selected before
@@ -181,7 +181,7 @@ export class Axis {
     this._brushFilter = this._buildBrushFilter(
       this.brushSelection()!,
       this.scaleType()!,
-      this.yScale()
+      this.yScale(),
     );
   }
   public brushFilter(): AxisBrushFilter {
@@ -216,7 +216,7 @@ export class Axis {
       .style('text-anchor', 'middle')
       .attr('y', -9)
       .text((colIndex) =>
-        tf_hparams_utils.schemaColumnName(this._schema, colIndex)
+        tf_hparams_utils.schemaColumnName(this._schema, colIndex),
       );
     // Add dragging event handlers.
     axisParentSel.call(
@@ -233,7 +233,7 @@ export class Axis {
         .on('end', () => {
           this._interactionManager.onDragEnd();
           axisParent.removeAttribute('is-dragging');
-        })
+        }),
     );
     // Add the brush.
     const d3Brush = d3
@@ -259,7 +259,7 @@ export class Axis {
         axisParent.setAttribute('is-brushing', '');
         this._interactionManager.onBrushChanged(
           this.colIndex(),
-          d3.event.selection
+          d3.event.selection,
         );
       })
       .on('brush', () => {
@@ -268,7 +268,7 @@ export class Axis {
         }
         this._interactionManager.onBrushChanged(
           this.colIndex(),
-          d3.event.selection
+          d3.event.selection,
         );
       })
       .on('end', () => {
@@ -277,7 +277,7 @@ export class Axis {
         }
         this._interactionManager.onBrushChanged(
           this.colIndex(),
-          d3.event.selection
+          d3.event.selection,
         );
         axisParent.removeAttribute('is-brushing');
       });
@@ -301,7 +301,7 @@ export class Axis {
   private _buildBrushFilter(
     brushSelection: d3.BrushSelection,
     scaleType: ScaleType,
-    yScale: any /* D3 scale */
+    yScale: any /* D3 scale */,
   ) {
     if (brushSelection === null) {
       return new AlwaysPassingBrushFilter();
@@ -309,7 +309,7 @@ export class Axis {
     if (scaleType === null) {
       console.error(
         "Scale type is null, but brushSelection isn't: ",
-        brushSelection
+        brushSelection,
       );
       return new AlwaysPassingBrushFilter();
     }
@@ -321,13 +321,13 @@ export class Axis {
           tf_hparams_parallel_coords_plot_utils.continuousScaleInverseImage(
             yScale,
             brushSelection[0],
-            brushSelection[1]
+            brushSelection[1],
           );
         return new IntervalBrushFilter(
           lower,
           upper,
           /*lowerOpen=*/ false,
-          /*upperOpen=*/ false
+          /*upperOpen=*/ false,
         );
       }
       case ScaleType.QUANTILE: {
@@ -335,13 +335,13 @@ export class Axis {
           tf_hparams_parallel_coords_plot_utils.quantileScaleInverseImage(
             yScale,
             brushSelection[0],
-            brushSelection[1]
+            brushSelection[1],
           );
         return new IntervalBrushFilter(
           lower as number,
           upper as number,
           /*lowerOpen=*/ false,
-          /*upperOpen=*/ true
+          /*upperOpen=*/ true,
         );
       }
       case ScaleType.NON_NUMERIC:
@@ -349,8 +349,8 @@ export class Axis {
           tf_hparams_parallel_coords_plot_utils.pointScaleInverseImage(
             yScale,
             brushSelection[0],
-            brushSelection[1]
-          )
+            brushSelection[1],
+          ),
         );
     }
     console.error('Unknown scale type: ', scaleType);
@@ -375,7 +375,7 @@ export class AxesCollection {
   public constructor(
     svgProps: tf_hparams_parallel_coords_plot_interaction_manager.SVGProperties,
     schema: Schema,
-    interactionManager: tf_hparams_parallel_coords_plot_interaction_manager.InteractionManager
+    interactionManager: tf_hparams_parallel_coords_plot_interaction_manager.InteractionManager,
   ) {
     this._svgProps = svgProps;
     this._schema = schema;
@@ -396,7 +396,7 @@ export class AxesCollection {
    */
   public updateAxes(
     options: any,
-    sessionGroups: tf_hparams_api.SessionGroup[]
+    sessionGroups: tf_hparams_api.SessionGroup[],
   ) {
     console.assert(!this.isAxisDragging());
     // Traverse options.columns, and update each corresponding axis.
@@ -406,7 +406,7 @@ export class AxesCollection {
       let axis = this._axes[colIndex];
       axis.setDisplayed(true);
       const domainValues = sessionGroups.map((sg) =>
-        tf_hparams_utils.columnValueByIndex(this._schema, sg, colIndex)
+        tf_hparams_utils.columnValueByIndex(this._schema, sg, colIndex),
       );
       axis.setDomainAndScale(domainValues, column.scale);
       visibleColIndices.add(colIndex);
@@ -421,7 +421,7 @@ export class AxesCollection {
     // Update the DOM.
     this._parentsSel = this._parentsSel.data(
       Array.from(visibleColIndices),
-      /*key=*/ (colIndex) => colIndex
+      /*key=*/ (colIndex) => colIndex,
     );
     this._parentsSel.exit().remove();
     this._parentsSel = this._parentsSel
@@ -447,7 +447,7 @@ export class AxesCollection {
     return this._stationaryAxesPositions
       .domain()
       .map((colIndex) =>
-        mapFunction(this.getAxisPosition(colIndex), this._axes[colIndex])
+        mapFunction(this.getAxisPosition(colIndex), this._axes[colIndex]),
       );
   }
   /**
@@ -456,12 +456,12 @@ export class AxesCollection {
    *     the first time it returns false.
    */
   public allVisibleAxesSatisfy(
-    predicate: (xPosition, axis) => boolean
+    predicate: (xPosition, axis) => boolean,
   ): boolean {
     return this._stationaryAxesPositions
       .domain()
       .every((colIndex) =>
-        predicate(this.getAxisPosition(colIndex), this._axes[colIndex])
+        predicate(this.getAxisPosition(colIndex), this._axes[colIndex]),
       );
   }
   public getAxisForColIndex(colIndex: number): Axis {
@@ -490,7 +490,7 @@ export class AxesCollection {
     this._draggedAxisPosition = newX;
     let visibleColIndices = this._stationaryAxesPositions.domain();
     visibleColIndices.sort(
-      (ci1, ci2) => this.getAxisPosition(ci1) - this.getAxisPosition(ci2)
+      (ci1, ci2) => this.getAxisPosition(ci1) - this.getAxisPosition(ci2),
     );
     this._stationaryAxesPositions.domain(visibleColIndices);
     this._updateAxesPositionsInDOM(this._parentsSel);
@@ -500,7 +500,7 @@ export class AxesCollection {
     this._draggedAxisPosition = null;
     this._draggedAxis = null;
     this._updateAxesPositionsInDOM(
-      this._parentsSel.transition().duration(duration)
+      this._parentsSel.transition().duration(duration),
     );
   }
   public isAxisDragging(): boolean {
@@ -509,7 +509,11 @@ export class AxesCollection {
   public getAxisPosition(colIndex: number): number {
     return this._draggedAxis !== null &&
       this._draggedAxis.colIndex() === colIndex
-      ? this._draggedAxisPosition
+      ? // TODO: go/ts58upgrade - Fix type mismatch caused by improved checking
+        // of returned conditional operators after upgrade
+        //   TS2322: Type 'number | null' is not assignable to type 'number'.
+        // @ts-ignore
+        this._draggedAxisPosition
       : this._stationaryAxesPositions(colIndex);
   }
   /**
@@ -531,23 +535,23 @@ export class AxesCollection {
       .domain()
       .filter((colIndex) => visibleColIndices.has(colIndex));
     const newDomain = Array.from(
-      new Set([...visibleDomain, ...Array.from(visibleColIndices)])
+      new Set([...visibleDomain, ...Array.from(visibleColIndices)]),
     );
     this._stationaryAxesPositions.domain(newDomain);
   }
   private _updateAxesPositionsInDOM(selectionOrTransition) {
     selectionOrTransition.attr('transform', (colIndex) =>
-      tf_hparams_utils.translateStr(this.getAxisPosition(colIndex))
+      tf_hparams_utils.translateStr(this.getAxisPosition(colIndex)),
     );
   }
   private _createAxes(
-    interactionManager: tf_hparams_parallel_coords_plot_interaction_manager.InteractionManager
+    interactionManager: tf_hparams_parallel_coords_plot_interaction_manager.InteractionManager,
   ): Axis[] {
     return d3
       .range(tf_hparams_utils.numColumns(this._schema))
       .map(
         (colIndex) =>
-          new Axis(this._svgProps, this._schema, interactionManager, colIndex)
+          new Axis(this._svgProps, this._schema, interactionManager, colIndex),
       );
   }
   private _svgProps: tf_hparams_parallel_coords_plot_interaction_manager.SVGProperties;


### PR DESCRIPTION
This replicates an LSC from cl/744890759, so we would not override those changes when syncing our repo into the internal code base.

(This also replicates several changes from the formatter.)