### PR TITLE
Adds comment to ignore lints for change in TS 5.8

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
@@ -567,6 +567,10 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   @computed('_node')
   get _device(): string {
     var node = this._node;
+    // TODO: go/ts58upgrade - Fix type mismatch caused by improved checking of
+    // returned conditional operators after upgrade
+    //   TS2322: Type 'null' is not assignable to type 'string'.
+    // @ts-ignore
     return node ? node.device : null;
   }
   @computed('_node', 'graphHierarchy')
@@ -675,6 +679,10 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
   @computed('_node')
   get _subnodes(): unknown[] {
     var node = this._node;
+    // TODO: go/ts58upgrade - Fix type mismatch caused by improved checking of
+    // returned conditional operators after upgrade
+    //   TS2322: Type 'null' is not assignable to type 'unknown[]'.
+    // @ts-ignore
     return node && node.metagraph ? node.metagraph.nodes() : null;
   }
   @computed('_predecessors')

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
@@ -509,7 +509,11 @@ export class AxesCollection {
   public getAxisPosition(colIndex: number): number {
     return this._draggedAxis !== null &&
       this._draggedAxis.colIndex() === colIndex
-      ? this._draggedAxisPosition
+      ? // TODO: go/ts58upgrade - Fix type mismatch caused by improved checking
+        // of returned conditional operators after upgrade
+        //   TS2322: Type 'number | null' is not assignable to type 'number'.
+        // @ts-ignore
+        this._draggedAxisPosition
       : this._stationaryAxesPositions(colIndex);
   }
   /**


### PR DESCRIPTION
This replicates an LSC from [cl/744890759](http://cl/744890759), so we would not override those changes when syncing our repo into the internal code base.

(This also replicates several changes from the formatter.)