### PR TITLE
Material 2 migration fixes 2 the fixening

### DIFF
--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -61,7 +61,7 @@ $tb-foreground: map_merge(
   )
 );
 $tb-background: map_merge(
-  matm2.$light-theme-background-palette,
+  matm2var.$light-theme-background-palette,
   (
     app-bar: $tb-app-bar-color,
     // Default is `map.get($grey-palette, 50)`.

--- a/tensorboard/webapp/widgets/data_table/column_selector_component.scss
+++ b/tensorboard/webapp/widgets/data_table/column_selector_component.scss
@@ -82,10 +82,16 @@ limitations under the License.
     width: 100%;
 
     &.selected {
-      background-color: matm2.get-color-from-palette(mat.$grey-palette, 200);
+      background-color: matm2.get-color-from-palette(
+        matm2var.$grey-palette,
+        200
+      );
 
       @include tb-dark-theme {
-        background-color: matm2.get-color-from-palette(mat.$grey-palette, 400);
+        background-color: matm2.get-color-from-palette(
+          matm2var.$grey-palette,
+          400
+        );
       }
     }
   }


### PR DESCRIPTION
## Motivation for features / changes
When I authored #6998 I replaced all the existing comments with aliases then updated the sync rules. What I missed was that there were a few places where there SHOULD have been comments before but weren't. This adds the correct aliases.

Googlers see cl/762084033 for an example of a fixed sync
