### PR TITLE
"Fix" an issue with pytype timeouts

### DIFF
--- a/tensorboard/compat/tensorflow_stub/tensor_shape.py
+++ b/tensorboard/compat/tensorflow_stub/tensor_shape.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Helper classes for tensor shape inference."""
 
+# pytype: skip-file
+
 from . import compat, dtypes
 from tensorboard.compat.proto import tensor_shape_pb2
 


### PR DESCRIPTION
The TensorBoard python codebase does not have any type checking. Apparently this has lead to issues with the typechecker internally the "fix" for this is to simply skip the file.

Googlers see b/419318203
