### PR TITLE
Replaces deprecated use of numpy#fromstring method with #frombuffer

### DIFF
--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -209,7 +209,7 @@ class ProjectorAppTest(tf.test.TestCase):
 
     def _AssertTensorResponse(self, tensor_bytes, expected_tensor):
         tensor = np.reshape(
-            np.fromstring(tensor_bytes, dtype=np.float32), expected_tensor.shape
+            np.frombuffer(tensor_bytes, dtype=np.float32), expected_tensor.shape
         )
         self.assertTrue(np.array_equal(tensor, expected_tensor))
 


### PR DESCRIPTION
This method has been deprecated since version 1.14, and it started raising an error in 2.3, according to the [release notes](https://github.com/numpy/numpy/releases/tag/v2.3.0rc1)

A replacement with more appropriate semantics exists, so this change updates that use case to use the appropriate, non-deprecated method `frombuffer`.

Googlers, see b/422161123.