### PR TITLE
Remove deprecated call to flatDoc.normalize

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
@@ -17,7 +17,7 @@ java_binary(
         "@com_google_protobuf//:protobuf_java",
         "@io_bazel_rules_closure//java/io/bazel/rules/closure:webpath",
         "@io_bazel_rules_closure//java/io/bazel/rules/closure/webfiles:build_info_java_proto",
-        "@org_jsoup",
+        "@org_jsoup_external",
     ],
 )
 

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -460,9 +460,6 @@ public final class Vulcanize {
       }
     }
 
-    // Create `<html>`, `<head>` and `<body>`.
-    flatDoc.normalise();
-
     document.traverse(new FlatDocumentCopier(flatDoc));
 
     for (Element subdoc : flatDoc.getElementsByTag("#root")) {

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -138,3 +138,12 @@ def tensorboard_workspace(name = ""):
         ],
         licenses = ["notice"],  # Apache 2.0
     )
+
+    java_import_external(
+        name = "org_jsoup_external",
+        jar_sha256 = "436adf71fe9f326e04fe134cd2785b261f0f4b9b60876adda1de3b6919463394",
+        jar_urls = [
+            "https://jsoup.org/packages/jsoup-1.21.1.jar",
+        ],
+        licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
+    )

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -143,7 +143,9 @@ def tensorboard_workspace(name = ""):
         name = "org_jsoup_external",
         jar_sha256 = "436adf71fe9f326e04fe134cd2785b261f0f4b9b60876adda1de3b6919463394",
         jar_urls = [
+            "https://storage.googleapis.com/mirror.tensorflow.org/jsoup.org/packages/jsoup-1.21.1.jar",
+            "https://repo1.maven.org/maven2/org/jsoup/jsoup/1.21.1/jsoup-1.21.1.jar",
             "https://jsoup.org/packages/jsoup-1.21.1.jar",
         ],
-        licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
+        licenses = ["notice"],  # MIT
     )


### PR DESCRIPTION
## Motivation for features / changes
This was a deprecated call to a no-op function. The function has now been removed in a newer version of the library. We need to support this newer library version to unblock an internal lsc Googlers see cl/771125806

I also needed to add a new source for the jsoup dependency. Previously this was being provided by the operating system (CI currently uses ubuntu 22.04 lts), but that version is now 3 years out of date.