### PR TITLE
Updates version of urllib3 used by bazel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
       fail-fast: false
       matrix:
         tf_version_id: ['tf', 'notf']
-        python_version: ['3.9']
+        # Lower and upper bounds for python versions that we're intending to support.
+        python_version: ['3.9', 3.13]
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         tf_version_id: ['tf', 'notf']
-        # Lower and upper bounds for python versions that we're intending to support.
-        python_version: ['3.9', 3.13]
+        python_version: ['3.9']
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -50,8 +50,9 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pythonhosted_urllib3",
         urls = [
-            "http://mirror.tensorflow.org/files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz"
-            "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz"
+            # Will upload to mirror after CI passes.
+            # "http://mirror.tensorflow.org/files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz",
+            "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz",
         ],
         sha256 = "be35dfb571d8e1baefbf909756fa6526d000fd4e",
         strip_prefix = "urllib3-1.26.20/src",

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -44,6 +44,9 @@ def tensorboard_python_workspace():
         build_file = str(Label("//third_party:markdown.BUILD")),
     )
 
+    # urllib3 is a transitive dependency from TF (or perhaps other
+    # dependencies), not directly used in TB code. We use a specific version to
+    # have a controlled environment, e.g. for CI.
     http_archive(
         name = "org_pythonhosted_urllib3",
         urls = [

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -13,7 +13,19 @@
 # limitations under the License.
 
 # TensorBoard external dependencies that are used on the python side.
-# Protobuf and six were deliberately left in the top-level workspace, as they
+#
+# A couple of these are "vendored" with our package, see:
+# https://github.com/tensorflow/tensorboard/blob/b94d9294eeb29ff5a673ef21843e060461ac78c2/tensorboard/pip_package/build_pip_package.sh#L87
+#
+# When building from source (i.e. whenever `bazel run` / `bazel test`
+# is used, including for CI), these are the dependencies used, rather than
+# whatever is already present (installed) in the system or runtime used.
+#
+# When not using bazel, but rather a "distributed" package of TB
+# (e.g. the one installed with pip), the non-vendored dependencies must be
+# already installed.
+#
+# Protobuf is deliberately left in the top-level workspace, as they
 # are used in TensorFlow as well.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -35,12 +47,11 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pythonhosted_urllib3",
         urls = [
-            "http://mirror.tensorflow.org/pypi.python.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
-            "https://pypi.python.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
-            "https://files.pythonhosted.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
+            "http://mirror.tensorflow.org/files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz"
+            "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz"
         ],
-        sha256 = "f03eeb431c77b88cf8747d47e94233a91d0e0fdae1cf09e0b21405a885700266",
-        strip_prefix = "urllib3-1.25/src",
+        sha256 = "be35dfb571d8e1baefbf909756fa6526d000fd4e",
+        strip_prefix = "urllib3-1.26.20/src",
         build_file = str(Label("//third_party:urllib3.BUILD")),
     )
 

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -50,8 +50,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pythonhosted_urllib3",
         urls = [
-            # Will upload to mirror after CI passes.
-            # "http://mirror.tensorflow.org/files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz",
+            "http://mirror.tensorflow.org/files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz",
             "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz",
         ],
         sha256 = "be35dfb571d8e1baefbf909756fa6526d000fd4e",


### PR DESCRIPTION
## Motivation for features / changes

`urllib3` is a transitive dependency that "vendors" the `six` library in it, but the version of `six` vendored within the version of urllib3 that our code was using is not compatible with python >= 3.12.

This newer version is still within the major version number, but [after 1.26.5, which updated the vendored version of `six`](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#1265-2021-05-26) to one that runs with python >= 3.12.
