### PR TITLE
Replaces uses of deprecated  library `pipes` with `shlex`

### DIFF
--- a/tensorboard/manager_e2e_test.py
+++ b/tensorboard/manager_e2e_test.py
@@ -20,9 +20,9 @@ import datetime
 import errno
 import json
 import os
-import pipes
-import signal
+import shlex
 import shutil
+import signal
 import subprocess
 import tempfile
 import textwrap
@@ -275,7 +275,7 @@ class ManagerEndToEndTest(tf.test.TestCase):
                 rm -r %s
                 exit 22
                 """
-                % pipes.quote(self.tmproot),
+                % shlex.quote(self.tmproot),
             ).lstrip(),
         )
         start_result = manager.start(["--logdir=./logs", "--port=0"])
@@ -305,7 +305,7 @@ class ManagerEndToEndTest(tf.test.TestCase):
                 printf >&2 'warn: I am tired\n'
                 sleep 60
                 """
-                % pipes.quote(os.path.realpath(pid_file)),
+                % shlex.quote(os.path.realpath(pid_file)),
             ).lstrip(),
         )
         start_result = manager.start(

--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -29,7 +29,6 @@ import hashlib
 import inspect
 import logging
 import os
-import pipes
 import shlex
 import socket
 import subprocess
@@ -394,8 +393,7 @@ def stat_tensorboardinfo():
         )
         # This error should only appear on Unices, so it's okay to use
         # Unix-specific utilities and shell syntax.
-        quote = getattr(shlex, "quote", None) or pipes.quote  # Python <3.3
-        command = "chmod 777 %s" % quote(path)
+        command = "chmod 777 %s" % shlex.quote(path)
         message = "%s\n\n\t%s" % (preamble, command)
         yield Suggestion('Fix permissions on "%s"' % path, message)
 


### PR DESCRIPTION
The `pipes` standard library was deprecated in python 3.11 and removed in python 3.13. (See https://docs.python.org/3/library/pipes.html)

This replacement enables running CI with python 3.13 (unless I find more blockers later).

The affected files are only for testing or diagnosing, not part of the actual TB package.