### PR TITLE
Purge pip cache after build step in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,10 @@ jobs:
             bazel build //tensorboard/... |&\
             grep -v 'external/com_google_protobuf/python: warning: directory' |&\
             grep -v 'INFO: From ProtoCompile ' )
+      - name: 'Purge pip cache'
+        # The provisioned VM is running out of space, so we attempt to
+        # delete cached package info to release some disk space.
+        run: pip cache purge
       - name: 'Bazel: test (with TensorFlow support)'
         run: bazel test //tensorboard/...
         if: matrix.tf_version_id != 'notf'


### PR DESCRIPTION
## Motivation for features / changes
Our CI runs (including for our nightly releases) are failing.

## Technical description of changes
The error reads `ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device`.

It seems the provisioned virtual machine is running out of space. Our code hasn't had many changes, but it's possible that some of our dependencies have grown and/or the provisioned machine has less available space from the beginning, compared to before, for some reason (e.g. it comes with more things preinstalled).

## Detailed steps to verify changes work correctly (as executed by you)
Due to security reasons, the CI workflow is read from submitted code/files, so we'll need to somehow merge this even if CI is not passing, and then see if this allows CI runs to pass.

EDIT: It seems this change was actually executed in the CI run for this PR. I'm not sure if I did something different in a previous attempt or where I got confused. Unfortunately, tho, this didn't seem to solve the problem.

## Alternate designs / implementations considered (or N/A)
Alternatively, we'll need to figure out what we can delete from the provisioned machine, as suggested in https://github.com/orgs/community/discussions/25678