### PR TITLE
Allow CI workflow to access the secrets when run from the nightly_release workflow.

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -14,6 +14,7 @@ jobs:
   ci:
     uses: ./.github/workflows/ci.yml
     # Allow the reused workflow to access the secrets.
+    # See: https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-inputs-and-secrets-to-a-reusable-workflow
     secrets: inherit
 
   nightly-release:


### PR DESCRIPTION
All our nightly release runs print the message `Using read-only cache (no credentials)` when it should be using the secret to use the cache build in [this step of the workflow](https://github.com/tensorflow/tensorboard/blob/ab697c38f84146b8c2fa4269cc936906060ea05b/.github/workflows/ci.yml#L56), even tho the secret is set.

<img width="393" height="120" alt="image" src="https://github.com/user-attachments/assets/18ec99b6-bc70-4db1-ab4b-2be1c7aba8d1" />

The reason seems to be that this CI workflow is called from another workflow, and in such cases, the parent workflow must explicitly allow child workflows to access the secrets, as noted in the GitHub documentation [here](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-inputs-and-secrets-to-a-reusable-workflow).