### PR TITLE
Update macos13 reference to macos15 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
-        platform: ['ubuntu-22.04', 'macos-13']
+        platform: ['ubuntu-22.04', 'macos-15']
         rust_version: ['1.65.0']
         include:
           - mode: 'universal'


### PR DESCRIPTION
The previous version is deprecated, as announced in [action/runner/images/issues/13046](https://github.com/actions/runner-images/issues/13046), and the workflow started to fail.