### PR TITLE
Updates CI workflow to run on self-hosted runner

### DIFF
--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -125,7 +125,6 @@ class WerkzeugServerTest(tb_test.TestCase):
             self._StubApplication(), self.make_flags(port=0, path_prefix="")
         )
         self.assertStartsWith(server.get_url(), "http://")
-        server.shutdown()
 
     def testPathPrefixSlash(self):
         # Test that checks the path prefix ends with one trailing slash
@@ -134,14 +133,12 @@ class WerkzeugServerTest(tb_test.TestCase):
             self.make_flags(port=0, path_prefix="/test"),
         )
         self.assertEndsWith(server.get_url(), "/test/")
-        server.shutdown()
 
         server = program.WerkzeugServer(
             self._StubApplication(),
             self.make_flags(port=0, path_prefix="/test/"),
         )
         self.assertEndsWith(server.get_url(), "/test/")
-        server.shutdown()
 
     def testSpecifiedHost(self):
         one_passed = False
@@ -151,7 +148,6 @@ class WerkzeugServerTest(tb_test.TestCase):
                 self.make_flags(host="127.0.0.1", port=0, path_prefix=""),
             )
             self.assertStartsWith(server.get_url(), "http://127.0.0.1:")
-            server.shutdown()
             one_passed = True
         except program.TensorBoardServerException:
             # IPv4 is not supported
@@ -162,7 +158,6 @@ class WerkzeugServerTest(tb_test.TestCase):
                 self.make_flags(host="::1", port=0, path_prefix=""),
             )
             self.assertStartsWith(server.get_url(), "http://[::1]:")
-            server.shutdown()
             one_passed = True
         except program.TensorBoardServerException:
             # IPv6 is not supported


### PR DESCRIPTION
## Motivation for features / changes
The standard runners provided by GitHub started running out of space, so we set up self-hosted runners.

By internal policy, these runners cannot publish artifacts, e.g. to PyPI, so the nightly workflows will need to  be update to be produced by separate infra, but at least this unblocks CI runs for PRs and such.

This change also removes the BUILD cache that was not actually used before due to misconfiguration issue. To reduce maintenance burden related to internal security policy and processes, the storage bucket that was used for this purpose had public access removed, so we're simply not using this anymore either way.
