### PR TITLE
Skip linter issues. Add TODOs and ts-ignores that will be removed in …

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/common_test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common_test.ts
@@ -568,6 +568,9 @@ async function slimGraphToHierarchy(
 
 async function pbtxtToGraphDef(text: string): Promise<tf_graph_proto.GraphDef> {
   const encoder = new TextEncoder();
+  // TODO: go/ts59upgrade - Remove this suppression after TS 5.9.2 upgrade
+  // TS2345: Argument of type 'Uint8Array<ArrayBuffer>' is not assignable to parameter of type 'ArrayBuffer'.
+  // @ts-ignore
   return tf_graph_parser.parseGraphPbTxt(encoder.encode(text));
 }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/compact_data_series_test.ts
@@ -141,6 +141,9 @@ describe('line_chart_v2/lib/compact_data_series', () => {
             length: 2,
           },
         ],
+        // TODO: go/ts59upgrade - Remove this suppression after TS 5.9.2 upgrade
+        // TS2322: Type 'Float32Array<ArrayBuffer>' is not assignable to type 'ArrayBuffer'.
+        // @ts-ignore
         flattenedSeries: new Float32Array([1, 2, 3]),
       };
 


### PR DESCRIPTION
> These comments temporarily suppress TypeScript warnings that will be fixed after upgrading to TypeScript 5.9.2 and should be removed at that point.

> Googlers: see http://b/471057679
