### PR TITLE
Allow embedding Perfetto UI in Tensorboard pages

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -36,7 +36,7 @@ _DISALLOWED_CHAR_IN_DOMAIN = re.compile(r"\s")
 # @vaadin/vaadin-lumo-styles/font-icons(via vaadin-grid) uses data URI for
 # loading font icons.
 _CSP_FONT_DOMAINS_WHITELIST = ["data:"]
-_CSP_FRAME_DOMAINS_WHITELIST = []
+_CSP_FRAME_DOMAINS_WHITELIST = ["https://ui.perfetto.dev"]
 _CSP_IMG_DOMAINS_WHITELIST = []
 _CSP_SCRIPT_DOMAINS_WHITELIST = []
 _CSP_CONNECT_DOMAINS_WHITELIST = []


### PR DESCRIPTION
## Motivation for features / changes
This is a required step for open sourcing the new Megascale Perfetto tool in xprof.

Googlers see b/476134328

## Technical description of changes
Adds https://ui.perfetto.dev to the whitelist of domains that are allowed to be embedded in a frame on the page. A follow up change will embed this UI in the xprof (Profiler) plugin.

## Screenshots of UI changes (or N/A)
N/A

## Detailed steps to verify changes work correctly (as executed by you)
Tested on Tensorboard (in combination with other necessary changes) and verified that it works as expected.

## Alternate designs / implementations considered (or N/A)
N/A
