### PR TITLE
refactor: drop `ComponentFactoryResolver`

### DIFF
--- a/tensorboard/webapp/app_routing/views/router_outlet_component.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_component.ts
@@ -15,7 +15,6 @@ limitations under the License.
 import {
   ChangeDetectionStrategy,
   Component,
-  ComponentFactoryResolver,
   Input,
   OnChanges,
   SimpleChanges,
@@ -35,20 +34,12 @@ export class RouterOutletComponent implements OnChanges {
 
   @Input() activeNgComponent!: unknown | null;
 
-  constructor(
-    private readonly componentFactoryResolver: ComponentFactoryResolver
-  ) {}
-
   ngOnChanges(changes: SimpleChanges) {
     const activeComponentChange = changes['activeNgComponent'];
     if (activeComponentChange) {
       this.routeContainer.clear();
       if (activeComponentChange.currentValue) {
-        const componentFactory =
-          this.componentFactoryResolver.resolveComponentFactory(
-            activeComponentChange.currentValue
-          );
-        this.routeContainer.createComponent(componentFactory);
+        this.routeContainer.createComponent(activeComponentChange.currentValue);
       }
     }
   }

--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -12,14 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {
-  Component,
-  ComponentFactoryResolver,
-  Input,
-  OnInit,
-  Type,
-  ViewContainerRef,
-} from '@angular/core';
+import {Component, Input, OnInit, Type, ViewContainerRef} from '@angular/core';
 
 /**
  * A Component that defines a customization point. Ideal for use for small
@@ -86,18 +79,13 @@ import {
 export class CustomizableComponent implements OnInit {
   @Input() customizableComponent!: Type<Component> | undefined;
 
-  constructor(
-    private readonly viewContainerRef: ViewContainerRef,
-    private readonly componentFactoryResolver: ComponentFactoryResolver
-  ) {}
+  constructor(private readonly viewContainerRef: ViewContainerRef) {}
 
   ngOnInit() {
     if (this.customizableComponent) {
-      const componentFactory =
-        this.componentFactoryResolver.resolveComponentFactory(
-          this.customizableComponent.constructor as Type<unknown>
-        );
-      this.viewContainerRef.createComponent(componentFactory);
+      this.viewContainerRef.createComponent(
+        this.customizableComponent.constructor as Type<unknown>
+      );
     }
   }
 }

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -21,7 +21,6 @@ limitations under the License.
 import {
   ChangeDetectionStrategy,
   Component,
-  ComponentFactoryResolver,
   ElementRef,
   Input,
   OnChanges,
@@ -64,7 +63,6 @@ export enum PluginLoadState {
 })
 export class PluginsComponent implements OnChanges {
   constructor(
-    private readonly componentFactoryResolver: ComponentFactoryResolver,
     private readonly pluginRegistry: PluginRegistryModule,
     @Optional() private readonly pluginApiHost: PluginApiHostModule
   ) {}
@@ -230,12 +228,8 @@ export class PluginsComponent implements OnChanges {
       case LoadingMechanismType.NG_COMPONENT:
         const ngComponentClass = this.pluginRegistry.getComponent(plugin.id);
         if (ngComponentClass) {
-          const componentFactory =
-            this.componentFactoryResolver.resolveComponentFactory(
-              ngComponentClass
-            );
           const pluginComponent =
-            this.ngPluginContainer.createComponent(componentFactory);
+            this.ngPluginContainer.createComponent(ngComponentClass);
           pluginElement = pluginComponent.location.nativeElement;
         } else {
           console.error(


### PR DESCRIPTION
This API was deprecated in 2022 and can be replaced by passing the component type directly to `createComponent`.

Currently doing a cleanup accross G3 to ideally finally remove `ComponentFactoryResolver` from Angular's public API. 