### PR TITLE
Removed mac version not supported anymore to avoid unnecessary CI tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         mode: ['native']
+        platform: ['ubuntu-22.04']
         rust_version: ['1.65.0']
         include:
           - mode: 'universal'


### PR DESCRIPTION
## Motivation for features / changes
This MacOS version is not supported anymore as we intend to reduce maintenance we opt for removing this task.

## Technical description of changes
This line defines the platforms on which the job runs.
