### PR TITLE
Fix typos in graph plugin docs and notification actions

### DIFF
--- a/tensorboard/plugins/graph/README.md
+++ b/tensorboard/plugins/graph/README.md
@@ -332,7 +332,7 @@ Note: building a Hierarchy modifies the SlimGraph's OpNodes in place!
     -   Iterate over OpNodes, keep track of device names, XLAClusters,
         opHistograms, TPU Compatibility histograms, library function nodes and
         their associated function name, etc.
-    -   Assume the node's name's '/' occurences indicate its level from the
+    -   Assume the node's name's '/' occurrences indicate its level from the
         root. If node is named 'a/b/c', create metanodes 'a' and 'a/b'.
     -   Update embedding nodes to point to the OpNode they are embedded to:
         `embedding.parentNode = node;`.
@@ -502,7 +502,7 @@ this terminology comes from
     Placeholder=2,Add=9,Pow=1[19]".
 -   **Level**: distance from the node to the artificial root node. Top-level
     `MetaNode`s have level 0, and going deeper increases the level. Can be
-    determined from counting '/' slash occurences in a node's name.
+    determined from counting '/' slash occurrences in a node's name.
 -   **Depth**: distance from the node to its bottom-most leaf descendant. A
     `MetaNode`, containing only 1 child `OpNode`, has depth 1.
 -   **RenderHierarchy / RenderGraphInfo / RenderGraph**: A structure storing

--- a/tensorboard/plugins/graph/tf_graph_common/proto.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/proto.ts
@@ -22,7 +22,7 @@ limitations under the License.
  * When adding a repeated field to this file, make sure to update the
  * GRAPH_REPEATED_FIELDS and METADATA_REPEATED_FIELDS lists within parser.ts.
  * Otherwise, the parser has no way of differentiating between a field with a
- * certain value and a repeated field that has only 1 occurence, resulting in
+ * certain value and a repeated field that has only 1 occurrence, resulting in
  * subtle bugs.
  */
 

--- a/tensorboard/webapp/notification_center/_redux/notification_center_actions.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_actions.ts
@@ -23,7 +23,7 @@ export const notificationBellClicked = createAction(
 );
 
 /**
- * Fires when the response from server is recieved.
+ * Fires when the response from server is received.
  */
 export const fetchNotificationsFailed = createAction(
   '[Notification] Fetch Notification Request Failed'


### PR DESCRIPTION
Fix a few spelling errors:
- `occurences` → `occurrences` (README.md, 2 instances)
- `occurence` → `occurrence` (proto.ts)
- `recieved` → `received` (notification_center_actions.ts)