### PR TITLE
Add project metadata for uv-managed development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 /bazel-*
 /.idea
+.venv/
 .DS_Store
 *.pyc
 *.egg-info/
 *.swp
 node_modules
+uv.lock

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,6 +23,17 @@ $ source tf/bin/activate
 (tf)$ pip uninstall -y tb-nightly
 ```
 
+If you prefer [uv](https://github.com/astral-sh/uv), you can manage the same
+development environment from the repository root with:
+
+```sh
+$ uv sync --extra tensorflow
+$ uv run bazel run //tensorboard -- --logdir /path/to/logs
+```
+
+This gives `uv` enough project metadata to manage dependencies from the repo
+root, while still using Bazel for the actual TensorBoard build.
+
 TensorBoard builds are done with [Bazel](https://bazel.build), so you may need to [install Bazel](https://docs.bazel.build/versions/master/install.html). The Bazel build will automatically "vulcanize" all the HTML files and generate a "binary" launcher script. When HTML is vulcanized, it means all the script tags and HTML imports are inlined into one big HTML file. Then the Bazel build puts that index.html file inside a static assets zip. The python HTTP server then reads static assets from that zip while serving.
 
 You can build and run TensorBoard via Bazel (from within the TensorFlow nightly virtualenv) as follows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,63 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tensorboard"
+dynamic = ["version", "dependencies"]
+description = "TensorBoard lets you watch Tensors Flow"
+readme = {file = "tensorboard/pip_package/README.rst", content-type = "text/x-rst"}
+requires-python = ">=3.9"
+license = {text = "Apache 2.0"}
+authors = [{name = "Google Inc.", email = "packages@tensorflow.org"}]
+keywords = [
+    "tensorflow",
+    "tensorboard",
+    "tensor",
+    "machine learning",
+    "visualizer",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.scripts]
+tensorboard = "tensorboard.main:run_main"
+
+[project.entry-points."tensorboard_plugins"]
+projector = "tensorboard.plugins.projector.projector_plugin:ProjectorPlugin"
+
+[project.optional-dependencies]
+tensorflow = ["tf-nightly"]
+
+[tool.setuptools.dynamic]
+version = {attr = "tensorboard.version.VERSION"}
+dependencies = {file = ["tensorboard/pip_package/requirements.txt"]}
+
+[tool.setuptools.packages.find]
+include = ["tensorboard", "tensorboard.*"]
+exclude = ["tensorboard.pip_package", "tensorboard.pip_package.*"]
+
+[tool.setuptools.package-data]
+tensorboard = ["webfiles.zip"]
+"tensorboard.plugins.projector" = [
+    "tf_projector_plugin/index.js",
+    "tf_projector_plugin/projector_binary.html",
+    "tf_projector_plugin/projector_binary.js",
+]
+
 [tool.black]
 line-length = 80
 target-version = ["py36", "py37", "py38"]


### PR DESCRIPTION
Fixes #7090.

## Summary

This makes the repository root a valid Python project for tools like Astral `uv` without changing the existing Bazel-based TensorBoard build/run workflow.

Changes:

- add standard setuptools build metadata at the repo root
- add a PEP 621 `project` table in `pyproject.toml`
- source runtime dependencies from `tensorboard/pip_package/requirements.txt`
- add a `tensorflow` optional extra that installs `tf-nightly`
- document the `uv` workflow in `DEVELOPMENT.md`
- ignore common local `uv` artifacts (`.venv/`, `uv.lock`)

## Motivation

Before this change, the repo root had a `pyproject.toml` but no `project` table, so commands like `uv sync` and `uv pip install -e .` failed from a fresh checkout.

This change gives contributors a straightforward way to manage the development environment with `uv`, while still using Bazel to build and run TensorBoard itself.

## Verification

I verified:

- `uv sync`
- `uv sync --extra tensorflow`
- `uv pip install -e .`

I did not verify `uv run bazel run //tensorboard -- --logdir ...` here because Bazel is not installed in this environment.
