### PR TITLE
refactor: remove deprecated Sass wrapper macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
         # Make sure no one depends on Angular material and CDK directly. Please
         # import the indirection in //tensorboard/webapp/angular.
       - run: |
-          ! git grep -E '"@npm//@angular/material"|"@npm//@angular/cdk"' 'tensorboard/*/BUILD' ':!tensorboard/webapp/BUILD' ':!tensorboard/webapp/angular/BUILD' ':!tensorboard/webapp/angular_components/BUILD'
+          ! git grep -E '"@npm//@angular/material"|"@npm//@angular/cdk"' 'tensorboard/*/BUILD' ':!tensorboard/webapp/angular_components/BUILD'
         # Cannot directly depend on d3 in webapp. Must depend on
         # `//tensorboard/webapp/third_party:d3` instead.
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
         # Make sure no one depends on Angular material and CDK directly. Please
         # import the indirection in //tensorboard/webapp/angular.
       - run: |
-          ! git grep -E '"@npm//@angular/material"|"@npm//@angular/cdk"' 'tensorboard/*/BUILD' ':!tensorboard/webapp/BUILD' ':!tensorboard/webapp/angular/BUILD'
+          ! git grep -E '"@npm//@angular/material"|"@npm//@angular/cdk"' 'tensorboard/*/BUILD' ':!tensorboard/webapp/BUILD' ':!tensorboard/webapp/angular/BUILD' ':!tensorboard/webapp/angular_components/BUILD'
         # Cannot directly depend on d3 in webapp. Must depend on
         # `//tensorboard/webapp/third_party:d3` instead.
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
         # Make sure no one depends on Angular material and CDK directly. Please
         # import the indirection in //tensorboard/webapp/angular.
       - run: |
-          ! git grep -E '"@npm//@angular/material"|"@npm//@angular/cdk"' 'tensorboard/*/BUILD' ':!tensorboard/webapp/angular_components/BUILD'
+          ! git grep -E '"@npm//@angular/material"|"@npm//@angular/cdk"' 'tensorboard/*/BUILD' ':!tensorboard/webapp/angular/BUILD' ':!tensorboard/webapp/angular_components/BUILD'
         # Cannot directly depend on d3 in webapp. Must depend on
         # `//tensorboard/webapp/third_party:d3` instead.
       - run: |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,15 +120,15 @@ esbuild_repositories(npm_repository = "npm")
 # rules_sass release information is difficult to find but it does seem to
 # regularly release with same cadence and version as core sass.
 # We typically upgrade this library whenever we upgrade rules_nodejs.
+# The version used here is the most recent release as of 2023-07-11, which is the same version used by rules_nodejs 5.8.1.
 #
-# rules_sass 1.55.0: https://github.com/bazelbuild/rules_sass/tree/1.55.0
+# rules_sass: https://github.com/bazelbuild/rules_sass/tags
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "1ea0103fa6adcb7d43ff26373b5082efe1d4b2e09c4f34f8a8f8b351e9a8a9b0",
-    strip_prefix = "rules_sass-1.55.0",
+    sha256 = "4285781b24dfd07cb01fcc2324faec87818d0f2174b02e0ed9038f6f809de80a",
+    strip_prefix = "rules_sass-1.69.5",
     urls = [
-        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_sass/archive/1.55.0.zip",
-        "https://github.com/bazelbuild/rules_sass/archive/1.55.0.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/refs/tags/1.69.5.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,7 +122,7 @@ esbuild_repositories(npm_repository = "npm")
 # We typically upgrade this library whenever we upgrade rules_nodejs.
 # This rules_sass version is the compatible with rules_nodejs 5.8.1
 #
-# rules_sass: https://github.com/bazelbuild/rules_sass/tags
+# rules_sass: https://github.com/bazelbuild/rules_sass/releases/tag/1.69.5
 http_archive(
     name = "io_bazel_rules_sass",
     sha256 = "4285781b24dfd07cb01fcc2324faec87818d0f2174b02e0ed9038f6f809de80a",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,7 +120,7 @@ esbuild_repositories(npm_repository = "npm")
 # rules_sass release information is difficult to find but it does seem to
 # regularly release with same cadence and version as core sass.
 # We typically upgrade this library whenever we upgrade rules_nodejs.
-# The version used here is the most recent release as of 2023-07-11, which is the same version used by rules_nodejs 5.8.1.
+# This rules_sass version is the compatible with rules_nodejs 5.8.1
 #
 # rules_sass: https://github.com/bazelbuild/rules_sass/tags
 http_archive(

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -249,45 +249,6 @@ def tf_svg_bundle(name, srcs, out):
         ],
     )
 
-def tf_sass_binary(deps = [], include_paths = [], strict_deps = True, **kwargs):
-    """TensorBoard wrap for declaring SASS binary.
-
-    It adds dependency on theme by default then add include Angular material
-    theme library paths for better node_modules library resolution.
-
-    strict_deps is included here and intentionally ignored so it can be used
-    internally.
-    """
-    sass_binary(
-        deps = deps,
-        include_paths = include_paths + [
-            "external/npm/node_modules",
-        ],
-        sourcemap = False,
-        **kwargs
-    )
-
-def tf_sass_library(**kwargs):
-    """TensorBoard wrap for declaring SASS library.
-
-    It re-exports the sass_libray symbol so users do not have to depend on
-    "@io_bazel_rules_sass//:defs.bzl".
-    """
-    sass_library(
-        **kwargs
-    )
-
-def tf_external_sass_libray(**kwargs):
-    """TensorBoard wrapper for declaring external SASS dependency.
-
-    When an external (NPM) package have SASS files that has `import` statements,
-    TensorBoard has to depdend on them very specifically. This rule allows SASS
-    modules in NPM packages to be built properly.
-    """
-    npm_sass_library(
-        **kwargs
-    )
-
 def tf_ng_module(assets = [], **kwargs):
     """TensorBoard wrapper for Angular modules."""
     tf_ts_library(

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -14,7 +14,9 @@
 """External-only delegates for various BUILD rules."""
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library", "sass_binary", "sass_library")
+# TODO(@cdavalos7): upgrade rules_sass to >=1.86 + sass >=1.71 to use `pkg:` package importer
+# and drop the per-target `include_paths = ["external/npm/node_modules"]`.
+load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library", "sass_library")
 load("@npm//@angular/build-tooling/bazel/app-bundling:index.bzl", "app_bundle")
 load("@npm//@angular/build-tooling/bazel/spec-bundling:index.bzl", "spec_bundle")
 load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -14,12 +14,9 @@
 """External-only delegates for various BUILD rules."""
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-# TODO(@cdavalos7): upgrade rules_sass to >=1.86 + sass >=1.71 to use `pkg:` package importer
-# and drop the per-target `include_paths = ["external/npm/node_modules"]`.
-load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library", "sass_library")
+load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 load("@npm//@angular/build-tooling/bazel/app-bundling:index.bzl", "app_bundle")
 load("@npm//@angular/build-tooling/bazel/spec-bundling:index.bzl", "spec_bundle")
-load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 load("@npm//@bazel/concatjs:index.bzl", "karma_web_test_suite", "ts_library")
 load("@npm//@bazel/esbuild:index.bzl", "esbuild")
 load("@npm//@bazel/typescript:index.bzl", "ts_config")

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -1,13 +1,15 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_web_test_suite", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("@rules_python//python:py_binary.bzl", "py_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_web_test_suite", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "debugger_component_style",
     src = "debugger_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/BUILD
@@ -1,10 +1,10 @@
-load("//tensorboard/defs:defs.bzl", "tf_sass_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_library(
+sass_library(
     name = "style_lib",
     srcs = ["_lib.scss"],
     deps = ["//tensorboard/webapp:angular_material_sass_deps"],

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common/BUILD
@@ -7,5 +7,5 @@ licenses(["notice"])
 sass_library(
     name = "style_lib",
     srcs = ["_lib.scss"],
-    deps = ["//tensorboard/webapp:angular_material_sass_deps"],
+    deps = ["//tensorboard/webapp/angular_components:material_sass"],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "execution_data_styles",
     src = "execution_data_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
@@ -10,7 +10,7 @@ sass_binary(
     src = "execution_data_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
@@ -1,21 +1,24 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "graph_styles",
     src = "graph_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "graph_op_styles",
     src = "graph_op_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp:angular_material_sass_deps",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
@@ -21,7 +21,7 @@ sass_binary(
     include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "graph_executions_styles",
     src = "graph_executions_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp/theme",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "source_files_component_style",
     src = "source_files_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "stack_trace_styles",
     src = "stack_trace_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/common:style_lib",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library", "sass_binary", "sass_library")
+load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library", "sass_binary")
 load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_prod_js_binary", "tf_ng_web_test_suite", "tf_svg_bundle", "tf_ts_library")
 load("//tensorboard/defs:js.bzl", "tf_resource_digest_suffixer")
 load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -1,4 +1,5 @@
-load("//tensorboard/defs:defs.bzl", "tf_external_sass_libray", "tf_ng_module", "tf_ng_prod_js_binary", "tf_ng_web_test_suite", "tf_sass_binary", "tf_svg_bundle", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library", "sass_binary", "sass_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_prod_js_binary", "tf_ng_web_test_suite", "tf_svg_bundle", "tf_ts_library")
 load("//tensorboard/defs:js.bzl", "tf_resource_digest_suffixer")
 load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
 
@@ -86,9 +87,10 @@ tf_ts_library(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "app_styles",
     src = "app_container.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 
@@ -379,13 +381,14 @@ tf_svg_bundle(
     out = "icon_bundle.svg",
 )
 
-tf_external_sass_libray(
+npm_sass_library(
     name = "angular_material_sass_deps",
     deps = ["@npm//@angular/material"],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "styles",
     src = "styles.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library", "sass_binary")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ng_prod_js_binary", "tf_ng_web_test_suite", "tf_svg_bundle", "tf_ts_library")
 load("//tensorboard/defs:js.bzl", "tf_resource_digest_suffixer")
 load("//tensorboard/defs:web.bzl", "tb_combine_html", "tf_web_library")
@@ -379,11 +379,6 @@ tf_svg_bundle(
         "@com_google_material_design_icon//:warning_24px.svg",
     ],
     out = "icon_bundle.svg",
-)
-
-npm_sass_library(
-    name = "angular_material_sass_deps",
-    deps = ["@npm//@angular/material"],
 )
 
 sass_binary(

--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -1,10 +1,12 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "alert_display_snackbar_styles",
     src = "alert_display_snackbar_container.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/angular_components/BUILD
+++ b/tensorboard/webapp/angular_components/BUILD
@@ -1,3 +1,5 @@
+# Open-source-only file (synced as BUILD.OPENSOURCE). Internally this dependency
+# is managed directly by Blaze, so npm_sass_library is not needed.
 load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library")
 
 package(default_visibility = ["//tensorboard:internal"])

--- a/tensorboard/webapp/angular_components/BUILD
+++ b/tensorboard/webapp/angular_components/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_sass//:defs.bzl", "npm_sass_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+npm_sass_library(
+    name = "material_sass",
+    deps = ["@npm//@angular/material"],
+)

--- a/tensorboard/webapp/core/views/BUILD
+++ b/tensorboard/webapp/core/views/BUILD
@@ -1,10 +1,12 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "layout_styles",
     src = "layout_container.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/feature_flag/views/BUILD
+++ b/tensorboard/webapp/feature_flag/views/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "style",
     src = "feature_flag_dialog_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/feature_flag/views/BUILD
+++ b/tensorboard/webapp/feature_flag/views/BUILD
@@ -10,7 +10,7 @@ sass_binary(
     src = "feature_flag_dialog_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/header/BUILD
+++ b/tensorboard/webapp/header/BUILD
@@ -1,18 +1,21 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "plugin_selector_styles",
     src = "plugin_selector_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "header_styles",
     src = "header_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/metrics/views/BUILD
+++ b/tensorboard/webapp/metrics/views/BUILD
@@ -1,17 +1,19 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_sass_library", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary", "sass_library")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_library(
+sass_library(
     name = "metrics_common_styles",
     srcs = [
         "_common.scss",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "metrics_container_styles",
     src = "metrics_container.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/BUILD
+++ b/tensorboard/webapp/metrics/views/BUILD
@@ -15,7 +15,7 @@ sass_binary(
     src = "metrics_container.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -1,10 +1,12 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "card_view_styles",
     src = "card_view_container.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 
@@ -39,9 +41,10 @@ tf_ng_module(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "data_download_dialog_styles",
     src = "data_download_dialog_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 
@@ -76,9 +79,10 @@ tf_ng_module(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "histogram_card_styles",
     src = "histogram_card_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
@@ -124,9 +128,10 @@ tf_ng_module(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "image_card_styles",
     src = "image_card_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -171,9 +176,10 @@ tf_ng_module(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "run_name_styles",
     src = "run_name_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 
@@ -200,9 +206,10 @@ tf_ng_module(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "vis_linked_time_selection_warning_styles",
     src = "vis_linked_time_selection_warning_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
@@ -251,9 +258,10 @@ tf_ts_library(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "scalar_card_styles",
     src = "scalar_card_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -261,14 +269,16 @@ tf_sass_binary(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "scalar_card_fob_controller_styles",
     src = "scalar_card_fob_controller.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "scalar_card_data_table_styles",
     src = "scalar_card_data_table.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
 tf_ng_module(
@@ -358,9 +368,10 @@ tf_ng_module(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "scalar_card_line_chart_styles",
     src = "scalar_card_line_chart_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/metrics/views/card_renderer/BUILD
+++ b/tensorboard/webapp/metrics/views/card_renderer/BUILD
@@ -133,7 +133,7 @@ sass_binary(
     src = "image_card_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
     ],
@@ -211,7 +211,7 @@ sass_binary(
     src = "vis_linked_time_selection_warning_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )
@@ -263,7 +263,7 @@ sass_binary(
     src = "scalar_card_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
     ],

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -1,10 +1,12 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "main_view_styles",
     src = "main_view_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -12,27 +14,30 @@ tf_sass_binary(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "filter_input_component_styles",
     src = "filter_input_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "filtered_view_component_styles",
     src = "filtered_view_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "pinned_view_component_styles",
     src = "pinned_view_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
@@ -40,27 +45,30 @@ tf_sass_binary(
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "card_grid_component_styles",
     src = "card_grid_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "card_groups_component_styles",
     src = "card_groups_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "card_group_toolbar_component_styles",
     src = "card_group_toolbar_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/main_view/BUILD
+++ b/tensorboard/webapp/metrics/views/main_view/BUILD
@@ -8,7 +8,7 @@ sass_binary(
     src = "main_view_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
     ],
@@ -19,7 +19,7 @@ sass_binary(
     src = "filter_input_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )
@@ -39,7 +39,7 @@ sass_binary(
     src = "pinned_view_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/metrics/views:metrics_common_styles",
         "//tensorboard/webapp/theme",
     ],

--- a/tensorboard/webapp/metrics/views/right_pane/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/BUILD
@@ -1,19 +1,22 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "settings_view_styles",
     src = "settings_view_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "saving_pins_checkbox_styles",
     src = "saving_pins_checkbox_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/right_pane/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/BUILD
@@ -8,7 +8,7 @@ sass_binary(
     src = "settings_view_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )
@@ -18,7 +18,7 @@ sass_binary(
     src = "saving_pins_checkbox_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/metrics/views/right_pane/saving_pins_dialog/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/saving_pins_dialog/BUILD
@@ -1,10 +1,12 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "saving_pins_dialog_component_styles",
     src = "saving_pins_dialog_component.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
@@ -1,10 +1,12 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "scalar_column_editor_styles",
     src = "scalar_column_editor_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/BUILD
@@ -8,7 +8,7 @@ sass_binary(
     src = "scalar_column_editor_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/notification_center/_views/BUILD
+++ b/tensorboard/webapp/notification_center/_views/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard/webapp/notification_center:__subpackages__"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "notification_center_styles",
     src = "notification_center_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/notification_center/_views/BUILD
+++ b/tensorboard/webapp/notification_center/_views/BUILD
@@ -10,7 +10,7 @@ sass_binary(
     src = "notification_center_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "plugins_component_styles",
     src = "plugins_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -1,33 +1,38 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "runs_group_menu_button_styles",
     src = "runs_group_menu_button_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "regex_edit_dialog_styles",
     src = "regex_edit_dialog_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "filterbar_styles",
     src = "filterbar_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "runs_data_table_styles",
     src = "runs_data_table.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -10,7 +10,7 @@ sass_binary(
     src = "runs_group_menu_button_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )
@@ -34,7 +34,7 @@ sass_binary(
     src = "runs_data_table.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/theme/BUILD
+++ b/tensorboard/webapp/theme/BUILD
@@ -1,10 +1,10 @@
-load("//tensorboard/defs:defs.bzl", "tf_sass_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_library(
+sass_library(
     name = "theme",
     srcs = [
         "_tb_palette.scss",

--- a/tensorboard/webapp/theme/BUILD
+++ b/tensorboard/webapp/theme/BUILD
@@ -11,7 +11,7 @@ sass_library(
         "_tb_theme.scss",
     ],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
     ],
 )
 

--- a/tensorboard/webapp/widgets/card_fob/BUILD
+++ b/tensorboard/webapp/widgets/card_fob/BUILD
@@ -1,19 +1,22 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "card_fob_styles",
     src = "card_fob_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "card_fob_controller_styles",
     src = "card_fob_controller_component.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/widgets/card_fob/BUILD
+++ b/tensorboard/webapp/widgets/card_fob/BUILD
@@ -8,7 +8,7 @@ sass_binary(
     src = "card_fob_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/widgets/content_wrapping_input/BUILD
+++ b/tensorboard/webapp/widgets/content_wrapping_input/BUILD
@@ -1,10 +1,12 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "content_wrapping_input_component_styles",
     src = "content_wrapping_input_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/content_wrapping_input/BUILD
+++ b/tensorboard/webapp/widgets/content_wrapping_input/BUILD
@@ -8,7 +8,7 @@ sass_binary(
     src = "content_wrapping_input_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -1,56 +1,64 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "data_table_styles",
     src = "data_table_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "header_cell_styles",
     src = "header_cell_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "content_cell_styles",
     src = "content_cell_component.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "data_table_header_styles",
     src = "data_table_header_component.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "column_selector_component_styles",
     src = "column_selector_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "context_menu_component_styles",
     src = "context_menu_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "filter_dialog_styles",
     src = "filter_dialog_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/data_table/BUILD
+++ b/tensorboard/webapp/widgets/data_table/BUILD
@@ -8,7 +8,7 @@ sass_binary(
     src = "data_table_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )
@@ -18,7 +18,7 @@ sass_binary(
     src = "header_cell_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )
@@ -40,7 +40,7 @@ sass_binary(
     src = "column_selector_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )
@@ -50,7 +50,7 @@ sass_binary(
     src = "context_menu_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )
@@ -60,7 +60,7 @@ sass_binary(
     src = "filter_dialog_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "dropdown_styles",
     src = "dropdown_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/dropdown/BUILD
+++ b/tensorboard/webapp/widgets/dropdown/BUILD
@@ -10,7 +10,7 @@ sass_binary(
     src = "dropdown_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/widgets/experiment_alias/BUILD
+++ b/tensorboard/webapp/widgets/experiment_alias/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "experiment_alias_component_styles",
     src = "experiment_alias_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/filter_input/BUILD
+++ b/tensorboard/webapp/widgets/filter_input/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "filter_input_component_styles",
     src = "filter_input_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/histogram/BUILD
+++ b/tensorboard/webapp/widgets/histogram/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "histogram_styles",
     src = "histogram_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "line_chart_styles",
     src = "line_chart_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = ["//tensorboard/webapp/theme"],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -1,19 +1,22 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "line_chart_axis_view_styles",
     src = "line_chart_axis_view.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",
     ],
 )
 
-tf_sass_binary(
+sass_binary(
     name = "line_chart_interactive_view_styles",
     src = "line_chart_interactive_view.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
 tf_ng_module(

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -8,7 +8,7 @@ sass_binary(
     src = "line_chart_axis_view.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/widgets/range_input/BUILD
+++ b/tensorboard/webapp/widgets/range_input/BUILD
@@ -1,10 +1,12 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary", "tf_ts_library")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-tf_sass_binary(
+sass_binary(
     name = "range_input_styles",
     src = "range_input_component.scss",
+    include_paths = ["external/npm/node_modules"],
     deps = [
         "//tensorboard/webapp:angular_material_sass_deps",
         "//tensorboard/webapp/theme",

--- a/tensorboard/webapp/widgets/range_input/BUILD
+++ b/tensorboard/webapp/widgets/range_input/BUILD
@@ -8,7 +8,7 @@ sass_binary(
     src = "range_input_component.scss",
     include_paths = ["external/npm/node_modules"],
     deps = [
-        "//tensorboard/webapp:angular_material_sass_deps",
+        "//tensorboard/webapp/angular_components:material_sass",
         "//tensorboard/webapp/theme",
     ],
 )

--- a/tensorboard/webapp/widgets/text/BUILD
+++ b/tensorboard/webapp/widgets/text/BUILD
@@ -1,12 +1,14 @@
-load("//tensorboard/defs:defs.bzl", "tf_ng_module", "tf_sass_binary")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tensorboard/defs:defs.bzl", "tf_ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-tf_sass_binary(
+sass_binary(
     name = "truncated_path_styles",
     src = "truncated_path_component.scss",
+    include_paths = ["external/npm/node_modules"],
 )
 
 tf_ng_module(


### PR DESCRIPTION

## Motivation for features / changes
Unblock internal LSC intended to remove workarounds for Sass and bad practices. Internal issue: b/508363660. This PR removes the wrappers for Sass build rules. Sass rules must directly declare their dependencies.

Per Sass build rules guidelines, wrapper macros are discouraged, and tf_external_sass_libray was relying on a loophole (passing a sass_library to another sass_library's srcs) that is being closed.    

## Technical description of changes
- Replace `tf_sass_binary`,`tf_sass_library`,  and `tf_external_sass_libray` wrappers with direct calls to `sass_binary`, `sass_library`, and  `npm_sass_library` from `@io_bazel_rules_sass`.  
- Updated hash version rules_sass from 1.55.0 to 1.69.5 
- Replaces the angular_material_sass_deps target  with a direct npm_sass_library call. This produces a SassInfo provider consumed via deps, complying with the rule that sass libraries must declare deps directly rather than passing one library to another's srcs.                                                                                                                                                                                                 
 - Added `include_paths = ["external/npm/node_modules"]` to each sass_binary so dart-sass can resolve `@use '@angular/material'`. The old wrapper set this automatically, now it has to be set per target.                                                                                                                                                                           
                                                                                                                                                                                                                                           

## Detailed steps to verify changes work correctly (as executed by you)
- BUILD
- Standalone running
- No console errors

