### PR TITLE
Remove stale whitespace hygiene exception

### DIFF
--- a/tensorboard/tools/whitespace_hygiene_test.py
+++ b/tensorboard/tools/whitespace_hygiene_test.py
@@ -25,14 +25,9 @@ import subprocess
 import sys
 
 
-# @TODO(@cdavalos7): Remove this exception when the patch file is no longer needed.
-# Patch files use a trailing space on blank lines to mark them as context.
-# This is required by patch-package and cannot be removed.
-exceptions = frozenset(
-    [
-        "patches/@angular+build-tooling+0.0.0-2113cd7f66a089ac0208ea84eee672b2529f4f6c.patch",
-    ]
-)
+# Patch files should not carry trailing whitespace unless a specific patch
+# format requires it.
+exceptions = frozenset()
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
## Summary

This PR removes a stale exception from `tensorboard/tools/whitespace_hygiene_test.py`.

The referenced patch file no longer contains trailing whitespace, so the exception now causes the whitespace hygiene check itself to fail with a stale-exception error.

## What changed

- removed the obsolete exception entry for:
  - `patches/@angular+build-tooling+0.0.0-2113cd7f66a089ac0208ea84eee672b2529f4f6c.patch`

## Validation

Validated by running:

```bash
./tensorboard/tools/whitespace_hygiene_test.py