### PR TITLE
Fix Projector Plugin vulnerability

### DIFF
--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -217,13 +217,15 @@ def _rel_to_abs_asset_path(fpath, config_fpath):
     if not os.path.isabs(candidate):
         candidate = os.path.join(config_dir, candidate)
     candidate = os.path.realpath(candidate)
+    error_message = 'Asset path "%s" resolves outside the config directory' % (
+        fpath
+    )
     try:
-        if os.path.commonpath([config_dir, candidate]) != config_dir:
-            raise ValueError()
+        common_path = os.path.commonpath([config_dir, candidate])
     except ValueError as e:
-        raise ValueError(
-            'Asset path "%s" resolves outside the config directory' % fpath
-        ) from e
+        raise ValueError(error_message) from e
+    if common_path != config_dir:
+        raise ValueError(error_message)
     return candidate
 
 

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -210,10 +210,22 @@ def _parse_positive_int_param(request, param_name):
 
 
 def _rel_to_abs_asset_path(fpath, config_fpath):
-    fpath = os.path.expanduser(fpath)
-    if not os.path.isabs(fpath):
-        return os.path.join(os.path.dirname(config_fpath), fpath)
-    return fpath
+    config_dir = os.path.realpath(
+        os.path.dirname(os.path.expanduser(config_fpath))
+    )
+    candidate = os.path.expanduser(fpath)
+    if not os.path.isabs(candidate):
+        candidate = os.path.join(config_dir, candidate)
+    candidate = os.path.realpath(candidate)
+    try:
+        if os.path.commonpath([config_dir, candidate]) != config_dir:
+            raise ValueError()
+    except ValueError as e:
+        raise ValueError(
+            'Asset path "%s" resolves outside the config directory'
+            % fpath
+        ) from e
+    return candidate
 
 
 def _using_tf():
@@ -363,9 +375,18 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                     embedding.tensor_name = embedding.tensor_name[:-2]
                 # Find the size of embeddings associated with a tensors file.
                 if embedding.tensor_path:
-                    fpath = _rel_to_abs_asset_path(
-                        embedding.tensor_path, self.config_fpaths[run]
-                    )
+                    try:
+                        fpath = _rel_to_abs_asset_path(
+                            embedding.tensor_path, self.config_fpaths[run]
+                        )
+                    except ValueError as e:
+                        logger.warning(
+                            'Skipping tensor path "%s" for run "%s": %s',
+                            embedding.tensor_path,
+                            run,
+                            e,
+                        )
+                        continue
                     tensor = self.tensor_cache.get((run, embedding.tensor_name))
                     if tensor is None:
                         try:
@@ -594,7 +615,10 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                 "text/plain",
                 400,
             )
-        fpath = _rel_to_abs_asset_path(fpath, self.config_fpaths[run])
+        try:
+            fpath = _rel_to_abs_asset_path(fpath, self.config_fpaths[run])
+        except ValueError as e:
+            return Respond(request, str(e), "text/plain", 400)
         if not tf.io.gfile.exists(fpath) or tf.io.gfile.isdir(fpath):
             return Respond(
                 request,
@@ -651,9 +675,12 @@ class ProjectorPlugin(base_plugin.TBPlugin):
             embedding = self._get_embedding(name, config)
 
             if embedding and embedding.tensor_path:
-                fpath = _rel_to_abs_asset_path(
-                    embedding.tensor_path, self.config_fpaths[run]
-                )
+                try:
+                    fpath = _rel_to_abs_asset_path(
+                        embedding.tensor_path, self.config_fpaths[run]
+                    )
+                except ValueError as e:
+                    return Respond(request, str(e), "text/plain", 400)
                 if not tf.io.gfile.exists(fpath):
                     return Respond(
                         request,
@@ -720,7 +747,10 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                 "text/plain",
                 400,
             )
-        fpath = _rel_to_abs_asset_path(fpath, self.config_fpaths[run])
+        try:
+            fpath = _rel_to_abs_asset_path(fpath, self.config_fpaths[run])
+        except ValueError as e:
+            return Respond(request, str(e), "text/plain", 400)
         if not tf.io.gfile.exists(fpath) or tf.io.gfile.isdir(fpath):
             return Respond(
                 request,
@@ -766,7 +796,10 @@ class ProjectorPlugin(base_plugin.TBPlugin):
             )
 
         fpath = os.path.expanduser(embedding_info.sprite.image_path)
-        fpath = _rel_to_abs_asset_path(fpath, self.config_fpaths[run])
+        try:
+            fpath = _rel_to_abs_asset_path(fpath, self.config_fpaths[run])
+        except ValueError as e:
+            return Respond(request, str(e), "text/plain", 400)
         if not tf.io.gfile.exists(fpath) or tf.io.gfile.isdir(fpath):
             return Respond(
                 request,

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -222,8 +222,7 @@ def _rel_to_abs_asset_path(fpath, config_fpath):
             raise ValueError()
     except ValueError as e:
         raise ValueError(
-            'Asset path "%s" resolves outside the config directory'
-            % fpath
+            'Asset path "%s" resolves outside the config directory' % fpath
         ) from e
     return candidate
 

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -55,7 +55,11 @@ class ProjectorAppTest(tf.test.TestCase):
         self.server = None
 
     def setUp(self):
-        self.log_dir = self.get_temp_dir()
+        self.test_dir = self.get_temp_dir()
+        self.log_dir = os.path.join(self.test_dir, "log_dir")
+        self.restricted_dir = os.path.join(self.test_dir, "restricted_dir")
+        tf.io.gfile.makedirs(self.log_dir)
+        tf.io.gfile.makedirs(self.restricted_dir)
 
     def testRunsWithValidCheckpoint(self):
         self._GenerateProjectorTestData()
@@ -197,11 +201,24 @@ class ProjectorAppTest(tf.test.TestCase):
         bookmark = self._GetJson(url)
         self.assertEqual(bookmark, {"a": "b"})
 
+    def testMetadataServesRelativeFileWithinLogdir(self):
+        self._GenerateProjectorAssetsTestData(metadata_path="metadata.tsv")
+        self._WriteTextFile(
+            os.path.join(self.log_dir, "metadata.tsv"), "label\nvalue\n"
+        )
+        self._SetupWSGIApp()
+
+        response = self._Get(
+            "/data/plugin/projector/metadata?run=.&name=embedding"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, b"label\nvalue\n")
+
     def testMetadataRejectsTraversalOutsideLogdir(self):
         outside_metadata_path = os.path.join(
-            os.path.dirname(self.log_dir), "outside_metadata.tsv"
+            self.restricted_dir, "outside_metadata.tsv"
         )
-        traversal_path = os.path.relpath(outside_metadata_path, self.log_dir)
+        traversal_path = "../restricted_dir/outside_metadata.tsv"
         self._WriteTextFile(outside_metadata_path, "secret\n")
         self._GenerateProjectorAssetsTestData(metadata_path=traversal_path)
         self._SetupWSGIApp()
@@ -211,9 +228,27 @@ class ProjectorAppTest(tf.test.TestCase):
         )
         self._AssertOutsideConfigDirResponse(response)
 
+    def testMetadataRejectsSymlinkOutsideLogdir(self):
+        outside_metadata_path = os.path.join(
+            self.restricted_dir, "outside_metadata.tsv"
+        )
+        symlink_path = os.path.join(self.log_dir, "metadata-link.tsv")
+        self._WriteTextFile(outside_metadata_path, "secret\n")
+        try:
+            os.symlink(outside_metadata_path, symlink_path)
+        except (AttributeError, NotImplementedError, OSError) as e:
+            self.skipTest("symlinks unavailable: %s" % e)
+        self._GenerateProjectorAssetsTestData(metadata_path="metadata-link.tsv")
+        self._SetupWSGIApp()
+
+        response = self._Get(
+            "/data/plugin/projector/metadata?run=.&name=embedding"
+        )
+        self._AssertOutsideConfigDirResponse(response)
+
     def testTensorRejectsAbsolutePathOutsideLogdir(self):
         outside_tensor_path = os.path.join(
-            os.path.dirname(self.log_dir), "outside_tensor.tsv"
+            self.restricted_dir, "outside_tensor.tsv"
         )
         self._WriteTextFile(outside_tensor_path, "1.0\t2.0\n")
         self._GenerateProjectorAssetsTestData(tensor_path=outside_tensor_path)
@@ -226,7 +261,7 @@ class ProjectorAppTest(tf.test.TestCase):
 
     def testBookmarksRejectAbsolutePathOutsideLogdir(self):
         outside_bookmarks_path = os.path.join(
-            os.path.dirname(self.log_dir), "outside_bookmarks.json"
+            self.restricted_dir, "outside_bookmarks.json"
         )
         self._WriteTextFile(outside_bookmarks_path, '{"label": "secret"}')
         self._GenerateProjectorAssetsTestData(
@@ -241,9 +276,9 @@ class ProjectorAppTest(tf.test.TestCase):
 
     def testSpriteImageRejectsTraversalOutsideLogdir(self):
         outside_sprite_path = os.path.join(
-            os.path.dirname(self.log_dir), "outside_sprite.png"
+            self.restricted_dir, "outside_sprite.png"
         )
-        traversal_path = os.path.relpath(outside_sprite_path, self.log_dir)
+        traversal_path = "../restricted_dir/outside_sprite.png"
         self._WriteTextFile(outside_sprite_path, "not-an-image")
         self._GenerateProjectorAssetsTestData(sprite_image_path=traversal_path)
         self._SetupWSGIApp()

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -219,7 +219,9 @@ class ProjectorAppTest(tf.test.TestCase):
         self._GenerateProjectorAssetsTestData(tensor_path=outside_tensor_path)
         self._SetupWSGIApp()
 
-        response = self._Get("/data/plugin/projector/tensor?run=.&name=embedding")
+        response = self._Get(
+            "/data/plugin/projector/tensor?run=.&name=embedding"
+        )
         self._AssertOutsideConfigDirResponse(response)
 
     def testBookmarksRejectAbsolutePathOutsideLogdir(self):
@@ -269,9 +271,7 @@ class ProjectorAppTest(tf.test.TestCase):
 
     def _AssertOutsideConfigDirResponse(self, response):
         self.assertEqual(response.status_code, 400)
-        self.assertIn(
-            b"resolves outside the config directory", response.data
-        )
+        self.assertIn(b"resolves outside the config directory", response.data)
 
     # TODO(#2007): Cleanly separate out projector tests that require real TF
     @unittest.skipUnless(USING_REAL_TF, "Test only passes when using real TF")
@@ -403,9 +403,7 @@ class ProjectorAppTest(tf.test.TestCase):
         bookmarks_path=None,
         sprite_image_path=None,
     ):
-        self._WriteTextFile(
-            self._ResolveAssetPath(tensor_path), "1.0\t2.0\n"
-        )
+        self._WriteTextFile(self._ResolveAssetPath(tensor_path), "1.0\t2.0\n")
 
         config = projector_config_pb2.ProjectorConfig()
         embedding = config.embeddings.add()

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -197,6 +197,60 @@ class ProjectorAppTest(tf.test.TestCase):
         bookmark = self._GetJson(url)
         self.assertEqual(bookmark, {"a": "b"})
 
+    def testMetadataRejectsTraversalOutsideLogdir(self):
+        outside_metadata_path = os.path.join(
+            os.path.dirname(self.log_dir), "outside_metadata.tsv"
+        )
+        traversal_path = os.path.relpath(outside_metadata_path, self.log_dir)
+        self._WriteTextFile(outside_metadata_path, "secret\n")
+        self._GenerateProjectorAssetsTestData(metadata_path=traversal_path)
+        self._SetupWSGIApp()
+
+        response = self._Get(
+            "/data/plugin/projector/metadata?run=.&name=embedding"
+        )
+        self._AssertOutsideConfigDirResponse(response)
+
+    def testTensorRejectsAbsolutePathOutsideLogdir(self):
+        outside_tensor_path = os.path.join(
+            os.path.dirname(self.log_dir), "outside_tensor.tsv"
+        )
+        self._WriteTextFile(outside_tensor_path, "1.0\t2.0\n")
+        self._GenerateProjectorAssetsTestData(tensor_path=outside_tensor_path)
+        self._SetupWSGIApp()
+
+        response = self._Get("/data/plugin/projector/tensor?run=.&name=embedding")
+        self._AssertOutsideConfigDirResponse(response)
+
+    def testBookmarksRejectAbsolutePathOutsideLogdir(self):
+        outside_bookmarks_path = os.path.join(
+            os.path.dirname(self.log_dir), "outside_bookmarks.json"
+        )
+        self._WriteTextFile(outside_bookmarks_path, '{"label": "secret"}')
+        self._GenerateProjectorAssetsTestData(
+            bookmarks_path=outside_bookmarks_path
+        )
+        self._SetupWSGIApp()
+
+        response = self._Get(
+            "/data/plugin/projector/bookmarks?run=.&name=embedding"
+        )
+        self._AssertOutsideConfigDirResponse(response)
+
+    def testSpriteImageRejectsTraversalOutsideLogdir(self):
+        outside_sprite_path = os.path.join(
+            os.path.dirname(self.log_dir), "outside_sprite.png"
+        )
+        traversal_path = os.path.relpath(outside_sprite_path, self.log_dir)
+        self._WriteTextFile(outside_sprite_path, "not-an-image")
+        self._GenerateProjectorAssetsTestData(sprite_image_path=traversal_path)
+        self._SetupWSGIApp()
+
+        response = self._Get(
+            "/data/plugin/projector/sprite_image?run=.&name=embedding"
+        )
+        self._AssertOutsideConfigDirResponse(response)
+
     def testEndpointsNoAssets(self):
         g = tf.Graph()
 
@@ -212,6 +266,12 @@ class ProjectorAppTest(tf.test.TestCase):
             np.frombuffer(tensor_bytes, dtype=np.float32), expected_tensor.shape
         )
         self.assertTrue(np.array_equal(tensor, expected_tensor))
+
+    def _AssertOutsideConfigDirResponse(self, response):
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            b"resolves outside the config directory", response.data
+        )
 
     # TODO(#2007): Cleanly separate out projector tests that require real TF
     @unittest.skipUnless(USING_REAL_TF, "Test only passes when using real TF")
@@ -335,6 +395,46 @@ class ProjectorAppTest(tf.test.TestCase):
                 write_version=tf.compat.v1.train.SaverDef.V1
             )
             saver.save(sess, checkpoint_path)
+
+    def _GenerateProjectorAssetsTestData(
+        self,
+        tensor_path="tensor.tsv",
+        metadata_path=None,
+        bookmarks_path=None,
+        sprite_image_path=None,
+    ):
+        self._WriteTextFile(
+            self._ResolveAssetPath(tensor_path), "1.0\t2.0\n"
+        )
+
+        config = projector_config_pb2.ProjectorConfig()
+        embedding = config.embeddings.add()
+        embedding.tensor_name = "embedding"
+        embedding.tensor_path = tensor_path
+        if metadata_path is not None:
+            embedding.metadata_path = metadata_path
+        if bookmarks_path is not None:
+            embedding.bookmarks_path = bookmarks_path
+        if sprite_image_path is not None:
+            embedding.sprite.image_path = sprite_image_path
+
+        with tf.io.gfile.GFile(
+            os.path.join(self.log_dir, "projector_config.pbtxt"), "w"
+        ) as f:
+            f.write(text_format.MessageToString(config))
+
+    def _ResolveAssetPath(self, path):
+        path = os.path.expanduser(path)
+        if os.path.isabs(path):
+            return os.path.realpath(path)
+        return os.path.realpath(os.path.join(self.log_dir, path))
+
+    def _WriteTextFile(self, path, contents):
+        parent = os.path.dirname(path)
+        if parent:
+            tf.io.gfile.makedirs(parent)
+        with tf.io.gfile.GFile(path, "w") as f:
+            f.write(contents)
 
 
 class MetadataColumnsTest(tf.test.TestCase):


### PR DESCRIPTION
## Summary

Fixes an arbitrary file read issue in the TensorBoard Projector plugin by restricting asset paths to the directory that contains `projector_config.pbtxt`.

Previously, user-controlled fields such as `metadata_path`, `tensor_path`, `bookmarks_path`, and `sprite.image_path` could resolve to absolute paths or traversal paths outside the intended logdir/config directory. That allowed a malicious config to make TensorBoard read and return arbitrary local files from the host.

## What Changed

- Hardened projector asset path resolution to:
  - expand and normalize candidate paths
  - resolve them against the directory containing `projector_config.pbtxt`
  - reject any path that escapes that directory boundary
- Returned a clean `400` response when a requested asset path is invalid
- Applied this validation consistently across:
  - metadata loading
  - tensor loading
  - bookmarks loading
  - sprite image loading
- Updated config augmentation logic to safely skip invalid external tensor paths instead of trying to read them

## Security Impact

This closes a path traversal / arbitrary local file read vector in the Projector plugin for deployments where an attacker can write or influence `projector_config.pbtxt` contents under a scanned logdir.

## Tests

Added projector integration coverage for:
- `metadata_path` using traversal outside the logdir
- `tensor_path` using an absolute path outside the logdir
- `bookmarks_path` using an absolute path outside the logdir
- `sprite.image_path` using traversal outside the logdir

## Validation

Verified:
- `python -m py_compile tensorboard/plugins/projector/projector_plugin.py tensorboard/plugins/projector/projector_plugin_test.py`
- `bazel test //tensorboard/plugins/projector:projector_plugin_test`
- Full build and test suite

## Risk / Compatibility

Low risk for valid configurations.

This change may reject projector configs that previously referenced assets outside the config directory, but that behavior is now considered unsafe and is intentionally blocked.