### PR TITLE
Adding load for pytest in compat build

### DIFF
--- a/tensorboard/compat/BUILD
+++ b/tensorboard/compat/BUILD
@@ -1,6 +1,7 @@
 # Description:
 # Compatibility interfaces for TensorBoard.
 load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 
 package(default_visibility = ["//tensorboard:internal"])
 


### PR DESCRIPTION
This Fix should resolve the multiple errors of "no such attribue" of in the internal build of TB.

Note: Current open-source software is not testing for this properly; it should be considered a task to write appropriate tests so that this goes unnoticed.