### PR TITLE
Fix demo utils test + clean-ups after PR#7120

### DIFF
--- a/tensorboard/plugins/mesh/BUILD
+++ b/tensorboard/plugins/mesh/BUILD
@@ -163,11 +163,11 @@ py_test(
     srcs = ["demo_utils_test.py"],
     data = [
         ":test_data",
-        "//tensorboard/compat:tensorflow",
     ],
     srcs_version = "PY3",
     deps = [
         ":demo_utils",
+        "//tensorboard/compat:tensorflow",
     ],
 )
 

--- a/third_party/repo.bzl
+++ b/third_party/repo.bzl
@@ -56,7 +56,14 @@ _tb_http_archive = repository_rule(
 )
 
 def tb_http_archive(name, sha256, urls, **kwargs):
-    """Downloads a mirrored archive for TensorBoard-specific repo wiring."""
+    """Downloads a mirrored archive for TensorBoard-specific repo wiring.
+    
+    Args:
+      name: The name of the repository.
+      sha256: The expected SHA-256 hash of the downloaded file.
+      urls: A list of URLs where the file can be downloaded.
+      **kwargs: Additional arguments passed to the underlying rule.
+    """
     if len(urls) < 2:
         fail("tb_http_archive(urls) must have redundant URLs.")
 
@@ -68,6 +75,7 @@ def tb_http_archive(name, sha256, urls, **kwargs):
         fail("The first entry of tb_http_archive(urls) must be a mirror URL.")
 
     if native.existing_rule(name):
+        # buildifier: disable=print
         print("\n\033[1;33mWarning:\033[0m skipping import of repository '" +
               name + "' because it already exists.\n")
         return

--- a/third_party/repo.bzl
+++ b/third_party/repo.bzl
@@ -57,7 +57,7 @@ _tb_http_archive = repository_rule(
 
 def tb_http_archive(name, sha256, urls, **kwargs):
     """Downloads a mirrored archive for TensorBoard-specific repo wiring.
-    
+
     Args:
       name: The name of the repository.
       sha256: The expected SHA-256 hash of the downloaded file.


### PR DESCRIPTION
Move TF dependency to deps in demo_utils_test to fix a linkage issue.

1st and 2nd commit to fix Buildifier internal checks.