### PR TITLE
Remove python_version & srcs_version from build files

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -24,7 +24,6 @@ py_binary(
     name = "tensorboard",
     srcs = ["main.py"],
     main = "main.py",
-    srcs_version = "PY3",
     deps = [
         ":assets_lib",  # link dep for webfiles assets
         ":default",
@@ -42,7 +41,6 @@ py_binary(
 py_library(
     name = "main_lib",
     srcs = ["main_lib.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_absl_logging_installed",
         "//tensorboard/compat",
@@ -55,7 +53,6 @@ py_binary(
     srcs = ["main_dev.py"],
     data = ["dev_webfiles.zip"],
     main = "main_dev.py",
-    srcs_version = "PY3",
     deps = [
         ":default",
         ":dynamic_plugins",  # loads internal dynamic plugin like projector
@@ -81,7 +78,6 @@ py_repl(
 py_library(
     name = "lib",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     visibility = ["//tensorboard:internal"],
     deps = [
         ":errors",
@@ -103,7 +99,6 @@ py_library(
 py_library(
     name = "lib_init_only",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":lazy",
@@ -115,7 +110,6 @@ py_test(
     name = "lib_test",
     size = "small",
     srcs = ["lib_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     visibility = ["//tensorboard:internal"],
     deps = [":lib"],
@@ -125,7 +119,6 @@ py_library(
     name = "assets_lib",
     srcs = ["assets.py"],
     data = ["webfiles.zip"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/util:tb_logging",
     ],
@@ -135,7 +128,6 @@ py_test(
     name = "assets_lib_test",
     srcs = ["assets_test.py"],
     main = "assets_test.py",
-    srcs_version = "PY3",
     deps = [
         ":assets_lib",
         "//tensorboard:test",
@@ -145,14 +137,12 @@ py_test(
 py_library(
     name = "auth",
     srcs = ["auth.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "auth_test",
     size = "small",
     srcs = ["auth_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":auth",
@@ -163,7 +153,6 @@ py_test(
 py_library(
     name = "context",
     srcs = ["context.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":auth",
@@ -174,7 +163,6 @@ py_test(
     name = "context_test",
     size = "small",
     srcs = ["context_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":auth",
@@ -186,13 +174,11 @@ py_test(
 py_library(
     name = "errors",
     srcs = ["errors.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "errors_test",
     srcs = ["errors_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":errors",
         ":test",
@@ -202,7 +188,6 @@ py_test(
 py_library(
     name = "manager",
     srcs = ["manager.py"],
-    srcs_version = "PY3",
     visibility = ["//tensorboard:internal"],
     deps = [
         ":version",
@@ -214,7 +199,6 @@ py_test(
     name = "manager_test",
     size = "large",
     srcs = ["manager_test.py"],
-    srcs_version = "PY3",
     tags = [
         "exclusive",
         "support_notf",
@@ -240,7 +224,6 @@ py_test(
     # high parallelism; TensorBoard subprocess time out instead of
     # launching successfully.
     flaky = True,
-    srcs_version = "PY3",
     visibility = ["//tensorboard:internal"],
     deps = [
         ":manager",
@@ -251,7 +234,6 @@ py_test(
 py_library(
     name = "notebook",
     srcs = ["notebook.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":manager",
@@ -261,7 +243,6 @@ py_library(
 py_library(
     name = "program",
     srcs = ["program.py"],
-    srcs_version = "PY3",
     deps = [
         ":manager",
         ":version",
@@ -279,7 +260,6 @@ py_test(
     name = "program_test",
     size = "large",
     srcs = ["program_test.py"],
-    srcs_version = "PY3",
     tags = [
         "exclusive",
         "support_notf",
@@ -298,7 +278,6 @@ py_library(
     name = "test",
     testonly = 1,
     srcs = ["test.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_absl_testing_absltest_installed",
         "//tensorboard/util:tb_logging",
@@ -308,7 +287,6 @@ py_library(
 py_library(
     name = "default",
     srcs = ["default.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/backend:experimental_plugin",
         "//tensorboard/plugins/audio:audio_plugin",
@@ -332,7 +310,6 @@ py_library(
 
 py_library(
     name = "dynamic_plugins",
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/plugins/projector:projector_plugin",
     ],
@@ -342,7 +319,6 @@ py_test(
     name = "default_test",
     size = "small",
     srcs = ["default_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":default",
@@ -354,14 +330,12 @@ py_test(
 py_library(
     name = "version",
     srcs = ["version.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "version_test",
     size = "small",
     srcs = ["version_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":test",
@@ -493,7 +467,6 @@ py_library(name = "expect_protobuf_installed")
 py_library(
     name = "data_compat",
     srcs = ["data_compat.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_protobuf_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -509,7 +482,6 @@ py_test(
     name = "data_compat_test",
     size = "small",
     srcs = ["data_compat_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":data_compat",
         "//tensorboard:expect_numpy_installed",
@@ -530,7 +502,6 @@ py_test(
 py_library(
     name = "dataclass_compat",
     srcs = ["dataclass_compat.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/audio:metadata",
@@ -551,7 +522,6 @@ py_test(
     name = "dataclass_compat_test",
     size = "small",
     srcs = ["dataclass_compat_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":dataclass_compat",
         "//tensorboard:expect_numpy_installed",
@@ -577,7 +547,6 @@ py_test(
 py_binary(
     name = "encode_png_benchmark",
     srcs = ["encode_png_benchmark.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_absl_logging_installed",
         "//tensorboard:expect_numpy_installed",
@@ -590,7 +559,6 @@ py_binary(
 py_library(
     name = "plugin_util",
     srcs = ["plugin_util.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":context",
@@ -606,7 +574,6 @@ py_test(
     name = "plugin_util_test",
     size = "small",
     srcs = ["plugin_util_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":context",
@@ -625,14 +592,12 @@ alias(
 py_library(
     name = "lazy",
     srcs = ["lazy.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "lazy_test",
     size = "small",
     srcs = ["lazy_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [":lazy"],
 )

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -11,7 +11,6 @@ licenses(["notice"])
 py_library(
     name = "http_util",
     srcs = ["http_util.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":json_util",
@@ -23,7 +22,6 @@ py_test(
     name = "http_util_test",
     size = "small",
     srcs = ["http_util_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":http_util",
@@ -35,14 +33,12 @@ py_test(
 py_library(
     name = "json_util",
     srcs = ["json_util.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "json_util_test",
     size = "small",
     srcs = ["json_util_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":json_util",
@@ -53,7 +49,6 @@ py_test(
 py_library(
     name = "application",
     srcs = ["application.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":auth_context_middleware",
@@ -76,7 +71,6 @@ py_test(
     name = "application_test",
     size = "small",
     srcs = ["application_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":application",
@@ -93,7 +87,6 @@ py_test(
 py_library(
     name = "auth_context_middleware",
     srcs = ["auth_context_middleware.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:auth",
         "//tensorboard:context",
@@ -104,7 +97,6 @@ py_test(
     name = "auth_context_middleware_test",
     size = "small",
     srcs = ["auth_context_middleware_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":auth_context_middleware",
@@ -118,14 +110,12 @@ py_test(
 py_library(
     name = "empty_path_redirect",
     srcs = ["empty_path_redirect.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "empty_path_redirect_test",
     size = "small",
     srcs = ["empty_path_redirect_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":empty_path_redirect",
@@ -137,13 +127,11 @@ py_test(
 py_library(
     name = "experiment_id",
     srcs = ["experiment_id.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "experiment_id_test",
     srcs = ["experiment_id_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":experiment_id",
         "//tensorboard:test",
@@ -154,13 +142,11 @@ py_test(
 py_library(
     name = "experimental_plugin",
     srcs = ["experimental_plugin.py"],
-    srcs_version = "PY3",
 )
 
 py_library(
     name = "path_prefix",
     srcs = ["path_prefix.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:errors",
     ],
@@ -170,7 +156,6 @@ py_test(
     name = "path_prefix_test",
     size = "small",
     srcs = ["path_prefix_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":path_prefix",
@@ -183,14 +168,12 @@ py_test(
 py_library(
     name = "process_graph",
     srcs = ["process_graph.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )
 
 py_library(
     name = "security_validator",
     srcs = ["security_validator.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
@@ -201,7 +184,6 @@ py_test(
     name = "security_validator_test",
     size = "small",
     srcs = ["security_validator_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":security_validator",
@@ -214,7 +196,6 @@ py_test(
 py_library(
     name = "client_feature_flags",
     srcs = ["client_feature_flags.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:context",
         "//tensorboard:errors",
@@ -225,7 +206,6 @@ py_test(
     name = "client_feature_flags_test",
     size = "small",
     srcs = ["client_feature_flags_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":client_feature_flags",

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -10,7 +10,6 @@ licenses(["notice"])
 py_library(
     name = "io_wrapper",
     srcs = ["io_wrapper.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat",
@@ -24,7 +23,6 @@ py_test(
     name = "io_wrapper_test",
     size = "small",
     srcs = ["io_wrapper_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":io_wrapper",
         "//tensorboard:expect_tensorflow_installed",
@@ -34,7 +32,6 @@ py_test(
 py_library(
     name = "data_ingester",
     srcs = ["data_ingester.py"],
-    srcs_version = "PY3",
     deps = [
         ":data_provider",
         ":event_multiplexer",
@@ -54,8 +51,6 @@ py_library(
 py_test(
     name = "data_ingester_test",
     srcs = ["data_ingester_test.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":data_ingester",
         "//tensorboard:expect_tensorflow_installed",
@@ -67,7 +62,6 @@ py_test(
 py_library(
     name = "data_provider",
     srcs = ["data_provider.py"],
-    srcs_version = "PY3",
     deps = [
         ":event_accumulator",
         "//tensorboard:errors",
@@ -80,7 +74,6 @@ py_library(
 py_test(
     name = "data_provider_test",
     srcs = ["data_provider_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":data_provider",
         ":event_multiplexer",
@@ -102,7 +95,6 @@ py_test(
 py_library(
     name = "directory_loader",
     srcs = ["directory_loader.py"],
-    srcs_version = "PY3",
     deps = [
         ":directory_watcher",
         ":io_wrapper",
@@ -116,7 +108,6 @@ py_test(
     name = "directory_loader_test",
     size = "small",
     srcs = ["directory_loader_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":directory_loader",
         ":directory_watcher",
@@ -129,7 +120,6 @@ py_test(
 py_library(
     name = "directory_watcher",
     srcs = ["directory_watcher.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":io_wrapper",
@@ -144,7 +134,6 @@ py_test(
     name = "directory_watcher_test",
     size = "small",
     srcs = ["directory_watcher_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":directory_watcher",
         "//tensorboard:expect_tensorflow_installed",
@@ -154,14 +143,12 @@ py_test(
 py_library(
     name = "reservoir",
     srcs = ["reservoir.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "reservoir_test",
     size = "small",
     srcs = ["reservoir_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":reservoir",
         "//tensorboard:expect_tensorflow_installed",
@@ -171,7 +158,6 @@ py_test(
 py_library(
     name = "event_file_loader",
     srcs = ["event_file_loader.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:data_compat",
@@ -188,7 +174,6 @@ py_test(
     name = "event_file_loader_test",
     size = "small",
     srcs = ["event_file_loader_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":event_file_loader",
         "//tensorboard:expect_tensorflow_installed",
@@ -204,7 +189,6 @@ py_test(
     size = "small",
     srcs = ["event_file_loader_test.py"],
     main = "event_file_loader_test.py",
-    srcs_version = "PY3",
     deps = [
         ":event_file_loader",
         "//tensorboard:test",
@@ -218,7 +202,6 @@ py_test(
 py_library(
     name = "event_util",
     srcs = ["event_util.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -230,7 +213,6 @@ py_test(
     name = "event_util_test",
     size = "small",
     srcs = ["event_util_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":event_util",
         "//tensorboard:test",
@@ -242,7 +224,6 @@ py_test(
 py_library(
     name = "tag_types",
     srcs = ["tag_types.py"],
-    srcs_version = "PY3",
 )
 
 py_library(
@@ -251,7 +232,6 @@ py_library(
         "event_accumulator.py",
         "plugin_event_accumulator.py",
     ],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":directory_loader",
@@ -272,7 +252,6 @@ py_test(
     name = "event_accumulator_test",
     size = "small",
     srcs = ["event_accumulator_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":event_accumulator",
         "//tensorboard:data_compat",
@@ -295,7 +274,6 @@ py_test(
     name = "plugin_event_accumulator_test",
     size = "small",
     srcs = ["plugin_event_accumulator_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":event_accumulator",
         "//tensorboard:expect_tensorflow_installed",
@@ -317,7 +295,6 @@ py_library(
         "event_multiplexer.py",
         "plugin_event_multiplexer.py",
     ],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":directory_watcher",
@@ -331,7 +308,6 @@ py_test(
     name = "event_multiplexer_test",
     size = "small",
     srcs = ["event_multiplexer_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":event_accumulator",
         ":event_multiplexer",
@@ -344,7 +320,6 @@ py_test(
     name = "plugin_event_multiplexer_test",
     size = "small",
     srcs = ["plugin_event_multiplexer_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":event_accumulator",
         ":event_multiplexer",
@@ -356,7 +331,6 @@ py_test(
 py_library(
     name = "plugin_asset_util",
     srcs = ["plugin_asset_util.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat",
@@ -367,7 +341,6 @@ py_library(
 py_library(
     name = "event_file_inspector",
     srcs = ["event_file_inspector.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":event_accumulator",
@@ -382,7 +355,6 @@ py_test(
     name = "event_file_inspector_test",
     size = "small",
     srcs = ["event_file_inspector_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":event_file_inspector",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/compat/BUILD
+++ b/tensorboard/compat/BUILD
@@ -21,7 +21,6 @@ licenses(["notice"])
 py_library(
     name = "compat",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = ["//tensorboard:lazy"],
 )
@@ -29,7 +28,6 @@ py_library(
 py_test(
     name = "compat_test",
     srcs = ["compat_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":compat",
         "//tensorboard:expect_tensorflow_installed",
@@ -48,7 +46,6 @@ py_test(
 py_library(
     name = "tensorflow",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     # Keep the package's real __init__.py on this target instead of depending
     # on :compat so Bazel test/binary runfiles expose the lazy tf/tf2 exports from
     # the actual package init rather than a synthesized empty package.
@@ -67,7 +64,6 @@ py_library(
         "__init__.py",
         "notf.py",
     ],
-    srcs_version = "PY3",
     # Mirror :tensorflow's package layout so the no-TF variant still exposes
     # the compat package exports while forcing the sentinel import.
     deps = [

--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -17,7 +17,6 @@ py_test(
     name = "proto_test",
     size = "small",
     srcs = ["proto_test.py"],
-    srcs_version = "PY3",
     tags = [
         "manual",
         "notap",

--- a/tensorboard/compat/tensorflow_stub/BUILD
+++ b/tensorboard/compat/tensorflow_stub/BUILD
@@ -15,7 +15,6 @@ py_library(
         "io/__init__.py",
         "io/gfile.py",
     ],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_absl_flags_installed",
         "//tensorboard:expect_fsspec_installed",
@@ -28,7 +27,6 @@ py_test(
     name = "gfile_test",
     size = "small",
     srcs = ["io/gfile_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":tensorflow_stub",
@@ -40,7 +38,6 @@ py_test(
     name = "gfile_tf_test",
     size = "small",
     srcs = ["io/gfile_tf_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":tensorflow_stub",
@@ -52,7 +49,6 @@ py_test(
     name = "gfile_s3_test",
     size = "small",
     srcs = ["io/gfile_s3_test.py"],
-    srcs_version = "PY3",
     tags = [
         "manual",
         "notap",
@@ -67,7 +63,6 @@ py_test(
     name = "gfile_fsspec_test",
     size = "small",
     srcs = ["io/gfile_fsspec_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":tensorflow_stub",

--- a/tensorboard/data/BUILD
+++ b/tensorboard/data/BUILD
@@ -11,7 +11,6 @@ licenses(["notice"])
 py_library(
     name = "provider",
     srcs = ["provider.py"],
-    srcs_version = "PY3",
     deps = ["//tensorboard:expect_numpy_installed"],
 )
 
@@ -19,7 +18,6 @@ py_test(
     name = "provider_test",
     size = "small",
     srcs = ["provider_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":provider",
@@ -31,14 +29,12 @@ py_test(
 py_library(
     name = "ingester",
     srcs = ["ingester.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "ingester_test",
     size = "small",
     srcs = ["ingester_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":ingester",
@@ -57,7 +53,6 @@ py_library(
         ":link_data_server": ["//tensorboard/data/server"],
         "//conditions:default": [],
     }),
-    srcs_version = "PY3",
     deps = [
         ":grpc_provider",
         ":ingester",
@@ -73,7 +68,6 @@ py_test(
     size = "medium",  # time.sleep
     timeout = "short",
     srcs = ["server_ingester_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":grpc_provider",
@@ -87,7 +81,6 @@ py_test(
 py_library(
     name = "grpc_provider",
     srcs = ["grpc_provider.py"],
-    srcs_version = "PY3",
     deps = [
         ":provider",
         "//tensorboard:errors",
@@ -103,7 +96,6 @@ py_test(
     name = "grpc_provider_test",
     size = "small",
     srcs = ["grpc_provider_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":grpc_provider",

--- a/tensorboard/data/server/BUILD
+++ b/tensorboard/data/server/BUILD
@@ -134,8 +134,6 @@ py_binary(
     name = "rustboard_core_doc_server",
     srcs = ["rustboard_core_doc_server.py"],
     data = [":rustboard_core_doc.zip"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     tags = ["manual"],  # https://github.com/bazelbuild/rules_rust/issues/689
     deps = [
         "@org_pocoo_werkzeug",
@@ -202,8 +200,6 @@ py_binary(
     srcs = ["update_protos.py"],
     args = ["--update"] + _proto_packages + ["descriptor.bin"],
     data = _genproto_files + [_generated_file_descriptor_set],
-    python_version = "PY3",
-    srcs_version = "PY3",
 )
 
 py_test(
@@ -215,6 +211,4 @@ py_test(
         _checked_in_file_descriptor_set,
     ],
     main = "update_protos.py",
-    python_version = "PY3",
-    srcs_version = "PY3",
 )

--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -11,8 +11,6 @@ licenses(["notice"])
 py_binary(
     name = "inline_images",
     srcs = ["inline_images.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
 )
 
 py_test(

--- a/tensorboard/examples/plugins/example_raw_scalars/BUILD
+++ b/tensorboard/examples/plugins/example_raw_scalars/BUILD
@@ -39,7 +39,6 @@ py_test(
         "test.py",
     ],
     main = "test.py",
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         "//tensorboard",

--- a/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/BUILD
+++ b/tensorboard/examples/plugins/example_raw_scalars/tensorboard_plugin_example_raw_scalars/BUILD
@@ -9,6 +9,5 @@ licenses(["notice"])
 py_library(
     name = "plugin",
     srcs = ["plugin.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )

--- a/tensorboard/functionaltests/BUILD
+++ b/tensorboard/functionaltests/BUILD
@@ -13,7 +13,6 @@ py_web_test_suite(
     ],
     # TODO(@jart): Make this fast and not flaky.
     flaky = True,
-    srcs_version = "PY3",
     tags = [
         "manual",
         "webtest",

--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -62,7 +62,6 @@ sh_binary(
 py_binary(
     name = "deterministic_tar_gz",
     srcs = ["deterministic_tar_gz.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
@@ -73,7 +72,6 @@ py_test(
     data = [
         ":deterministic_tar_gz",  # invoked as subprocess
     ],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:test",
     ],

--- a/tensorboard/plugins/BUILD
+++ b/tensorboard/plugins/BUILD
@@ -10,14 +10,12 @@ licenses(["notice"])
 py_library(
     name = "base_plugin",
     srcs = ["base_plugin.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )
 
 py_test(
     name = "base_plugin_test",
     srcs = ["base_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":base_plugin",
         "//tensorboard:test",

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -17,7 +17,6 @@ filegroup(
 py_library(
     name = "audio_plugin",
     srcs = ["audio_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         "//tensorboard:errors",
@@ -33,7 +32,6 @@ py_test(
     name = "audio_plugin_test",
     size = "small",
     srcs = ["audio_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":audio_plugin",
         ":summary",
@@ -54,7 +52,6 @@ py_test(
     size = "small",
     srcs = ["audio_plugin_test.py"],
     main = "audio_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":audio_plugin",
         ":summary",
@@ -73,7 +70,6 @@ py_test(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":summary_v2",
@@ -85,7 +81,6 @@ py_library(
 py_library(
     name = "summary_v2",
     srcs = ["summary_v2.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],
@@ -101,7 +96,6 @@ py_test(
     name = "summary_test",
     size = "medium",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":summary",
@@ -115,7 +109,6 @@ py_test(
 py_binary(
     name = "audio_demo",
     srcs = ["audio_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
@@ -125,7 +118,6 @@ py_binary(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -10,7 +10,6 @@ licenses(["notice"])
 py_library(
     name = "core_plugin",
     srcs = ["core_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:plugin_util",
         "//tensorboard:version",
@@ -26,7 +25,6 @@ py_test(
     name = "core_plugin_test",
     size = "small",
     srcs = ["core_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":core_plugin",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -13,7 +13,6 @@ licenses(["notice"])
 py_library(
     name = "custom_scalars_plugin",
     srcs = ["custom_scalars_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
@@ -32,7 +31,6 @@ py_library(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -42,7 +40,6 @@ py_library(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
@@ -54,7 +51,6 @@ py_test(
     name = "summary_test",
     size = "small",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
@@ -70,7 +66,6 @@ py_test(
     name = "custom_scalars_plugin_test",
     size = "small",
     srcs = ["custom_scalars_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":custom_scalars_plugin",
         ":protos_all_py_pb2",
@@ -96,7 +91,6 @@ py_test(
     size = "small",
     srcs = ["custom_scalars_plugin_test.py"],
     main = "custom_scalars_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":custom_scalars_plugin",
         ":protos_all_py_pb2",
@@ -126,7 +120,6 @@ tb_proto_library(
 py_binary(
     name = "custom_scalar_demo",
     srcs = ["custom_scalar_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/plugins/debugger_v2/BUILD
+++ b/tensorboard/plugins/debugger_v2/BUILD
@@ -12,7 +12,6 @@ licenses(["notice"])
 py_library(
     name = "debug_data_multiplexer",
     srcs = ["debug_data_multiplexer.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:errors",
         "//tensorboard:expect_tensorflow_installed",
@@ -22,7 +21,6 @@ py_library(
 py_library(
     name = "debug_data_provider",
     srcs = ["debug_data_provider.py"],
-    srcs_version = "PY3",
     deps = [
         ":debug_data_multiplexer",
         "//tensorboard/data:provider",
@@ -32,7 +30,6 @@ py_library(
 py_library(
     name = "debugger_v2_plugin",
     srcs = ["debugger_v2_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":debug_data_provider",
         "//tensorboard:errors",
@@ -47,7 +44,6 @@ py_test(
     name = "debug_data_multiplexer_test",
     size = "small",
     srcs = ["debug_data_multiplexer_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":debug_data_multiplexer",
         "//tensorboard:expect_tensorflow_installed",
@@ -58,7 +54,6 @@ py_test(
     name = "debugger_v2_plugin_test",
     size = "medium",
     srcs = ["debugger_v2_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":debug_data_multiplexer",
         ":debugger_v2_plugin",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -108,8 +108,6 @@ tf_ng_web_test_suite(
 py_binary(
     name = "extract_dtypes_from_python",
     srcs = ["extract_dtypes_from_python.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/compat/tensorflow_stub",
     ],

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -11,7 +11,6 @@ licenses(["notice"])
 py_library(
     name = "distributions_plugin",
     srcs = ["distributions_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":compressor",
         ":metadata",
@@ -28,7 +27,6 @@ py_test(
     size = "small",
     srcs = ["distributions_plugin_test.py"],
     main = "distributions_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":compressor",
         ":distributions_plugin",
@@ -51,7 +49,6 @@ py_test(
     size = "small",
     srcs = ["distributions_plugin_test.py"],
     main = "distributions_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":compressor",
         ":distributions_plugin",
@@ -72,7 +69,6 @@ py_test(
 py_library(
     name = "compressor",
     srcs = ["compressor.py"],
-    srcs_version = "PY3",
     deps = ["//tensorboard:expect_numpy_installed"],
 )
 
@@ -80,7 +76,6 @@ py_test(
     name = "compressor_test",
     size = "small",
     srcs = ["compressor_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":compressor",
         "//tensorboard:expect_tensorflow_installed",
@@ -90,5 +85,4 @@ py_test(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
 )

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -12,7 +12,6 @@ licenses(["notice"])
 py_library(
     name = "graphs_plugin",
     srcs = ["graphs_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":graph_util",
         ":keras_util",
@@ -32,7 +31,6 @@ py_test(
     name = "graphs_plugin_test",
     size = "small",
     srcs = ["graphs_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":graphs_plugin_test_lib",
         "//tensorboard:expect_protobuf_installed",
@@ -43,7 +41,6 @@ py_library(
     name = "graphs_plugin_test_lib",
     testonly = True,
     srcs = ["graphs_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":graphs_plugin",
         "//tensorboard:context",
@@ -63,7 +60,6 @@ py_test(
     size = "small",
     srcs = ["graphs_plugin_v2_test.py"],
     main = "graphs_plugin_v2_test.py",
-    srcs_version = "PY3",
     deps = [
         ":graphs_plugin",
         ":graphs_plugin_test_lib",
@@ -81,7 +77,6 @@ py_test(
     size = "small",
     srcs = ["graphs_plugin_test.py"],
     main = "graphs_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":graphs_plugin",
         "//tensorboard:expect_protobuf_installed",
@@ -99,7 +94,6 @@ py_test(
 py_binary(
     name = "graphs_demo",
     srcs = ["graphs_demo.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
@@ -109,7 +103,6 @@ py_binary(
 py_library(
     name = "keras_util",
     srcs = ["keras_util.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:private"],
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -123,7 +116,6 @@ py_test(
     size = "small",
     srcs = ["keras_util_test.py"],
     main = "keras_util_test.py",
-    srcs_version = "PY3",
     deps = [
         ":keras_util",
         "//tensorboard:expect_protobuf_installed",
@@ -135,7 +127,6 @@ py_test(
 py_library(
     name = "graph_util",
     srcs = ["graph_util.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:private"],
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -147,7 +138,6 @@ py_test(
     size = "small",
     srcs = ["graph_util_test.py"],
     main = "graph_util_test.py",
-    srcs_version = "PY3",
     deps = [
         ":graph_util",
         "//tensorboard:expect_protobuf_installed",
@@ -159,7 +149,6 @@ py_test(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
 )
 
 # This test suite is disabled as lodash does not seem to get properly bundled

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -14,7 +14,6 @@ licenses(["notice"])
 py_library(
     name = "histograms_plugin",
     srcs = ["histograms_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         "//tensorboard:errors",
@@ -31,7 +30,6 @@ py_test(
     size = "medium",
     srcs = ["histograms_plugin_test.py"],
     main = "histograms_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":histograms_plugin",
         ":summary",
@@ -54,7 +52,6 @@ py_test(
     size = "small",
     srcs = ["histograms_plugin_test.py"],
     main = "histograms_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":histograms_plugin",
         ":summary",
@@ -75,7 +72,6 @@ py_test(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],
@@ -88,7 +84,6 @@ py_library(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":summary_v2",
@@ -99,7 +94,6 @@ py_library(
 py_library(
     name = "summary_v2",
     srcs = ["summary_v2.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],
@@ -120,7 +114,6 @@ py_test(
     size = "small",
     srcs = ["summary_test.py"],
     main = "summary_test.py",
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
@@ -139,7 +132,6 @@ py_test(
         "test_with_large_counts",
     ],
     main = "summary_test.py",
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
@@ -151,7 +143,6 @@ py_test(
 py_binary(
     name = "histograms_demo",
     srcs = ["histograms_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -16,7 +16,6 @@ licenses(["notice"])
 py_library(
     name = "hparams",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":api",
@@ -37,7 +36,6 @@ py_library(
         "list_session_groups.py",
         "metrics.py",
     ],
-    srcs_version = "PY3",
     deps = [
         ":error",
         ":metadata",
@@ -134,7 +132,6 @@ py_test(
 py_binary(
     name = "hparams_demo",
     srcs = ["hparams_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":api",
         ":protos_all_py_pb2",
@@ -150,7 +147,6 @@ py_binary(
 py_binary(
     name = "hparams_minimal_demo",
     srcs = ["hparams_minimal_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":protos_all_py_pb2",
         ":summary",
@@ -165,7 +161,6 @@ py_binary(
 py_binary(
     name = "hparams_util",
     srcs = ["hparams_util.py"],
-    srcs_version = "PY3",
     visibility = [
         "//visibility:public",
     ],
@@ -190,7 +185,6 @@ sh_test(
 py_library(
     name = "api",
     srcs = ["api.py"],
-    srcs_version = "PY3",
     visibility = [
         "//visibility:public",
     ],
@@ -204,7 +198,6 @@ py_test(
     name = "api_test",
     size = "small",
     srcs = ["api_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":api",
         ":keras",
@@ -216,7 +209,6 @@ py_test(
 py_library(
     name = "keras",
     srcs = ["_keras.py"],
-    srcs_version = "PY3",
     deps = [
         ":protos_all_py_pb2",
         ":summary",
@@ -230,7 +222,6 @@ py_test(
     size = "small",
     srcs = ["_keras_test.py"],
     main = "_keras_test.py",
-    srcs_version = "PY3",
     deps = [
         ":api",
         ":keras",
@@ -245,7 +236,6 @@ py_test(
 py_library(
     name = "summary_v2",
     srcs = ["summary_v2.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
@@ -260,7 +250,6 @@ py_test(
     name = "summary_v2_test",
     size = "small",
     srcs = ["summary_v2_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
@@ -278,7 +267,6 @@ py_test(
     size = "small",
     srcs = ["summary_v2_test.py"],
     main = "summary_v2_test.py",
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":metadata",
@@ -295,7 +283,6 @@ py_test(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     visibility = [
         "//visibility:public",
     ],
@@ -310,7 +297,6 @@ py_library(
 py_test(
     name = "summary_test",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":protos_all_py_pb2",
         ":summary",
@@ -322,7 +308,6 @@ py_test(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     deps = [
         ":error",
         ":protos_all_py_pb2",
@@ -334,7 +319,6 @@ py_library(
 py_library(
     name = "error",
     srcs = ["error.py"],
-    srcs_version = "PY3",
 )
 
 tb_proto_library(

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -18,7 +18,6 @@ filegroup(
 py_library(
     name = "images_plugin",
     srcs = ["images_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         "//tensorboard:expect_numpy_installed",
@@ -33,7 +32,6 @@ py_library(
 py_binary(
     name = "images_demo",
     srcs = ["images_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
@@ -44,7 +42,6 @@ py_test(
     name = "images_plugin_test",
     size = "small",
     srcs = ["images_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":images_plugin",
         ":summary",
@@ -65,7 +62,6 @@ py_test(
     size = "small",
     srcs = ["images_plugin_test.py"],
     main = "images_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":images_plugin",
         ":summary",
@@ -84,7 +80,6 @@ py_test(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":summary_v2",
@@ -96,7 +91,6 @@ py_library(
 py_library(
     name = "summary_v2",
     srcs = ["summary_v2.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],
@@ -113,7 +107,6 @@ py_test(
     name = "summary_test",
     size = "small",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":summary",
@@ -126,7 +119,6 @@ py_test(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],

--- a/tensorboard/plugins/mesh/BUILD
+++ b/tensorboard/plugins/mesh/BUILD
@@ -11,7 +11,6 @@ licenses(["notice"])
 py_library(
     name = "mesh",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":summary",
@@ -21,7 +20,6 @@ py_library(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -32,7 +30,6 @@ py_test(
     name = "metadata_test",
     size = "small",
     srcs = ["metadata_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         "//tensorboard:expect_tensorflow_installed",
@@ -42,7 +39,6 @@ py_test(
 py_library(
     name = "mesh_plugin",
     srcs = ["mesh_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
@@ -59,7 +55,6 @@ py_library(
     name = "test_utils",
     testonly = 1,
     srcs = ["test_utils.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard/backend/event_processing:event_multiplexer",
@@ -71,7 +66,6 @@ py_test(
     name = "mesh_plugin_test",
     size = "small",
     srcs = ["mesh_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":mesh_plugin",
         ":summary",
@@ -90,7 +84,6 @@ py_test(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     visibility = [
         "//visibility:public",
     ],
@@ -105,7 +98,6 @@ py_library(
 py_library(
     name = "summary_v2",
     srcs = ["summary_v2.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         "//tensorboard/compat",
@@ -119,7 +111,6 @@ py_test(
     name = "summary_test",
     size = "small",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         ":test_utils",
@@ -131,7 +122,6 @@ py_test(
     name = "summary_v2_test",
     size = "small",
     srcs = ["summary_v2_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
@@ -149,7 +139,6 @@ tb_proto_library(
 py_library(
     name = "demo_utils",
     srcs = ["demo_utils.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_numpy_installed",
         "//tensorboard/compat",
@@ -165,7 +154,6 @@ py_test(
         ":test_data",
         "//tensorboard/compat:tensorflow",
     ],
-    srcs_version = "PY3",
     deps = [
         ":demo_utils",
     ],
@@ -177,7 +165,6 @@ py_binary(
     data = [
         ":test_data",
     ],
-    srcs_version = "PY3",
     deps = [
         ":demo_utils",
         ":summary_v2",

--- a/tensorboard/plugins/metrics/BUILD
+++ b/tensorboard/plugins/metrics/BUILD
@@ -14,7 +14,6 @@ py_library(
         "metadata.py",
         "metrics_plugin.py",
     ],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:errors",
         "//tensorboard:plugin_util",
@@ -32,7 +31,6 @@ py_library(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
@@ -40,8 +38,6 @@ py_test(
     size = "medium",
     srcs = ["metrics_plugin_test.py"],
     main = "metrics_plugin_test.py",
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":metrics_plugin",
         "//tensorboard:context",

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -13,7 +13,6 @@ licenses(["notice"])
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -23,7 +22,6 @@ py_library(
 py_library(
     name = "pr_curves_plugin",
     srcs = ["pr_curves_plugin.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":metadata",
@@ -40,7 +38,6 @@ py_test(
     name = "pr_curves_plugin_test",
     size = "medium",  # tf integration test
     srcs = ["pr_curves_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":pr_curve_demo_lib",
@@ -61,7 +58,6 @@ py_test(
     size = "medium",  # tf integration test
     srcs = ["pr_curves_plugin_test.py"],
     main = "pr_curves_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":pr_curve_demo_lib",
@@ -80,7 +76,6 @@ py_test(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":metadata",
@@ -94,7 +89,6 @@ py_test(
     name = "summary_test",
     size = "small",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_numpy_installed",
@@ -115,14 +109,12 @@ tb_proto_library(
 py_binary(
     name = "pr_curve_demo",
     srcs = ["pr_curve_demo.py"],
-    srcs_version = "PY3",
     deps = [":pr_curve_demo_lib"],
 )
 
 py_library(
     name = "pr_curve_demo_lib",
     srcs = ["pr_curve_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/plugins/profile_redirect/BUILD
+++ b/tensorboard/plugins/profile_redirect/BUILD
@@ -11,7 +11,6 @@ licenses(["notice"])
 py_library(
     name = "profile_redirect_plugin",
     srcs = ["profile_redirect_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/plugins:base_plugin",
     ],
@@ -20,7 +19,6 @@ py_library(
 py_test(
     name = "profile_redirect_plugin_test",
     srcs = ["profile_redirect_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":profile_redirect_plugin",
         "//tensorboard:test",

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -15,7 +15,6 @@ py_library(
     data = [
         "//tensorboard/plugins/projector/tf_projector_plugin:projector_assets",
     ],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
@@ -36,7 +35,6 @@ py_library(
 py_library(
     name = "projector",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":metadata",
@@ -52,7 +50,6 @@ py_test(
     size = "small",
     srcs = ["projector_api_test.py"],
     main = "projector_api_test.py",
-    srcs_version = "PY3",
     deps = [
         ":projector",
         "//tensorboard:expect_protobuf_installed",
@@ -66,7 +63,6 @@ py_test(
     size = "small",
     srcs = ["projector_plugin_test.py"],
     main = "projector_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":projector_plugin",
         "//tensorboard:expect_numpy_installed",
@@ -88,7 +84,6 @@ py_test(
     size = "small",
     srcs = ["projector_plugin_test.py"],
     main = "projector_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":projector_plugin",
         "//tensorboard:expect_numpy_installed",
@@ -108,7 +103,6 @@ py_test(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
 )
 
 tb_proto_library(
@@ -120,7 +114,6 @@ tb_proto_library(
 py_binary(
     name = "projector_demo",
     srcs = ["projector_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":projector",
     ],

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -14,7 +14,6 @@ licenses(["notice"])
 py_library(
     name = "scalars_plugin",
     srcs = ["scalars_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         "//tensorboard:errors",
@@ -31,7 +30,6 @@ py_test(
     size = "medium",
     srcs = ["scalars_plugin_test.py"],
     main = "scalars_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":scalars_plugin",
         ":summary",
@@ -53,7 +51,6 @@ py_test(
     size = "small",
     srcs = ["scalars_plugin_test.py"],
     main = "scalars_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":scalars_plugin",
         ":summary",
@@ -73,7 +70,6 @@ py_test(
 py_binary(
     name = "scalars_demo",
     srcs = ["scalars_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
@@ -83,7 +79,6 @@ py_binary(
 py_binary(
     name = "scalars_demo_eager",
     srcs = ["scalars_demo_eager.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
@@ -93,7 +88,6 @@ py_binary(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":summary_v2",
@@ -104,7 +98,6 @@ py_library(
 py_library(
     name = "summary_v2",
     srcs = ["summary_v2.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],
@@ -121,7 +114,6 @@ py_test(
     name = "summary_test",
     size = "small",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":summary",
@@ -135,7 +127,6 @@ py_test(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -14,7 +14,6 @@ licenses(["notice"])
 py_library(
     name = "text_plugin",
     srcs = ["text_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         "//tensorboard:plugin_util",
@@ -31,7 +30,6 @@ py_test(
     size = "small",
     srcs = ["text_plugin_test.py"],
     main = "text_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":text_plugin",
         "//tensorboard:context",
@@ -51,7 +49,6 @@ py_test(
     size = "small",
     srcs = ["text_plugin_test.py"],
     main = "text_plugin_test.py",
-    srcs_version = "PY3",
     deps = [
         ":text_plugin",
         "//tensorboard:context",
@@ -69,7 +66,6 @@ py_test(
 py_binary(
     name = "text_demo",
     srcs = ["text_demo.py"],
-    srcs_version = "PY3",
     deps = [
         ":summary_v2",
         "//tensorboard:expect_absl_logging_installed",
@@ -80,7 +76,6 @@ py_binary(
 py_library(
     name = "summary",
     srcs = ["summary.py"],
-    srcs_version = "PY3",
     visibility = [
         "//visibility:public",
     ],
@@ -94,7 +89,6 @@ py_library(
 py_library(
     name = "summary_v2",
     srcs = ["summary_v2.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],
@@ -111,7 +105,6 @@ py_test(
     name = "summary_test",
     size = "small",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":metadata",
         ":summary",
@@ -125,7 +118,6 @@ py_test(
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],

--- a/tensorboard/plugins/wit_redirect/BUILD
+++ b/tensorboard/plugins/wit_redirect/BUILD
@@ -10,7 +10,6 @@ licenses(["notice"])
 py_library(
     name = "wit_redirect_plugin",
     srcs = ["wit_redirect_plugin.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/plugins:base_plugin",
     ],
@@ -19,7 +18,6 @@ py_library(
 py_test(
     name = "wit_redirect_plugin_test",
     srcs = ["wit_redirect_plugin_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":wit_redirect_plugin",
         "//tensorboard:test",

--- a/tensorboard/scripts/BUILD
+++ b/tensorboard/scripts/BUILD
@@ -9,7 +9,6 @@ licenses(["notice"])
 py_binary(
     name = "generate_testdata",
     srcs = ["generate_testdata.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
@@ -19,6 +18,5 @@ py_binary(
 py_binary(
     name = "execrooter",
     srcs = ["execrooter.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )

--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -25,7 +25,6 @@ py_library(
 py_library(
     name = "summary_minimal",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     deps = [
         ":writer",
     ],
@@ -36,7 +35,6 @@ py_library(
     srcs = [
         "_writer.py",
     ],
-    srcs_version = "PY3",
     deps = [
         ":output",
         "//tensorboard:expect_numpy_installed",
@@ -48,7 +46,6 @@ py_test(
     name = "writer_test",
     srcs = ["_writer_test.py"],
     main = "_writer_test.py",
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":test_util",
@@ -65,7 +62,6 @@ py_library(
     srcs = [
         "_output.py",
     ],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/summary/writer",
@@ -77,7 +73,6 @@ py_test(
     name = "output_test",
     srcs = ["_output_test.py"],
     main = "_output_test.py",
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":output",
@@ -94,7 +89,6 @@ py_library(
     srcs = [
         "v1.py",
     ],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":summary_minimal",
@@ -113,7 +107,6 @@ py_library(
     srcs = [
         "v2.py",
     ],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":summary_minimal",
@@ -129,7 +122,6 @@ py_test(
     name = "summary_test",
     size = "small",
     srcs = ["summary_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":summary",
@@ -142,7 +134,6 @@ py_library(
     name = "test_util",
     testonly = 1,
     srcs = ["_test_util.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/compat/tensorflow_stub",
@@ -163,7 +154,6 @@ py_library(
         "_tf/__init__.py",
         "_tf/summary/__init__.py",
     ],
-    srcs_version = "PY3",
     visibility = [
         "//tensorboard:internal",
     ],
@@ -176,7 +166,6 @@ py_test(
     name = "tf_summary_test",
     size = "small",
     srcs = ["tf_summary_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":tf_summary",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/summary/writer/BUILD
+++ b/tensorboard/summary/writer/BUILD
@@ -14,7 +14,6 @@ py_library(
         "event_file_writer.py",
         "record_writer.py",
     ],
-    srcs_version = "PY3",
     # This target depends directly on //tensorboard/compat and on the TF stub to
     # ensure it doesn't pick up a TF build dependency, which may happen when using
     # //tensorboard/compat:tensorflow when the code is synced internally.
@@ -34,7 +33,6 @@ py_test(
     size = "small",
     srcs = ["event_file_writer_test.py"],
     main = "event_file_writer_test.py",
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":writer",
@@ -47,7 +45,6 @@ py_test(
     size = "small",
     srcs = ["event_file_writer_s3_test.py"],
     main = "event_file_writer_s3_test.py",
-    srcs_version = "PY3",
     tags = [
         "manual",
         "notap",
@@ -64,7 +61,6 @@ py_test(
     size = "small",
     srcs = ["event_file_writer_fsspec_test.py"],
     main = "event_file_writer_fsspec_test.py",
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":writer",
@@ -78,7 +74,6 @@ py_test(
     size = "small",
     srcs = ["record_writer_test.py"],
     main = "record_writer_test.py",
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":writer",

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -11,13 +11,11 @@ licenses(["notice"])
 py_library(
     name = "upload_tracker",
     srcs = ["upload_tracker.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "upload_tracker_test",
     srcs = ["upload_tracker_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":upload_tracker",
         "//tensorboard:test",
@@ -27,7 +25,6 @@ py_test(
 py_library(
     name = "logdir_loader",
     srcs = ["logdir_loader.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/backend/event_processing:directory_watcher",
         "//tensorboard/backend/event_processing:io_wrapper",
@@ -51,7 +48,6 @@ py_test(
 py_library(
     name = "util",
     srcs = ["util.py"],
-    srcs_version = "PY3",
 )
 
 py_test(

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -9,7 +9,6 @@ licenses(["notice"])
 py_library(
     name = "encoder",
     srcs = ["encoder.py"],
-    srcs_version = "PY3",
     deps = [
         ":op_evaluator",
         "//tensorboard:expect_numpy_installed",
@@ -21,7 +20,6 @@ py_test(
     name = "encoder_test",
     size = "small",
     srcs = ["encoder_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":encoder",
         "//tensorboard:expect_numpy_installed",
@@ -32,7 +30,6 @@ py_test(
 py_library(
     name = "grpc_util",
     srcs = ["grpc_util.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:version",
@@ -44,7 +41,6 @@ py_test(
     name = "grpc_util_test",
     size = "small",
     srcs = ["grpc_util_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":grpc_util",
         ":grpc_util_test_proto_py_pb2",
@@ -66,7 +62,6 @@ tb_proto_library(
 py_library(
     name = "lazy_tensor_creator",
     srcs = ["lazy_tensor_creator.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/compat",
         "//tensorboard/compat:tensorflow",
@@ -77,7 +72,6 @@ py_test(
     name = "lazy_tensor_creator_test",
     size = "small",
     srcs = ["lazy_tensor_creator_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":lazy_tensor_creator",
         "//tensorboard:expect_tensorflow_installed",
@@ -87,7 +81,6 @@ py_test(
 py_library(
     name = "op_evaluator",
     srcs = ["op_evaluator.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_tensorflow_installed",
     ],
@@ -97,7 +90,6 @@ py_test(
     name = "op_evaluator_test",
     size = "small",
     srcs = ["op_evaluator_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":op_evaluator",
         "//tensorboard:expect_tensorflow_installed",
@@ -115,14 +107,12 @@ py_library(
 py_library(
     name = "io_util",
     srcs = ["io_util.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "io_util_test",
     size = "small",
     srcs = ["io_util_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":io_util",
@@ -133,14 +123,12 @@ py_test(
 py_library(
     name = "platform_util",
     srcs = ["platform_util.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
     name = "platform_util_test",
     size = "small",
     srcs = ["platform_util_test.py"],
-    srcs_version = "PY3",
     tags = ["support_notf"],
     deps = [
         ":platform_util",
@@ -151,13 +139,11 @@ py_test(
 py_library(
     name = "tb_logging",
     srcs = ["tb_logging.py"],
-    srcs_version = "PY3",
 )
 
 py_library(
     name = "tensor_util",
     srcs = ["tensor_util.py"],
-    srcs_version = "PY3",
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/compat/tensorflow_stub",
@@ -168,7 +154,6 @@ py_library(
     name = "test_util",
     testonly = 1,
     srcs = ["test_util.py"],
-    srcs_version = "PY3",
     deps = [
         ":tb_logging",
         "//tensorboard:expect_absl_logging_installed",
@@ -180,7 +165,6 @@ py_library(
 py_library(
     name = "timing",
     srcs = ["timing.py"],
-    srcs_version = "PY3",
     deps = [
         ":tb_logging",
     ],
@@ -190,7 +174,6 @@ py_test(
     name = "timing_test",
     size = "small",
     srcs = ["timing_test.py"],
-    srcs_version = "PY3",
     deps = [
         ":tb_logging",
         ":timing",

--- a/third_party/markdown.BUILD
+++ b/third_party/markdown.BUILD
@@ -13,5 +13,4 @@ exports_files(["LICENSE.md"])
 py_library(
     name = "org_pythonhosted_markdown",
     srcs = glob(["markdown/**/*.py"]),
-    srcs_version = "PY3",
 )

--- a/third_party/urllib3.BUILD
+++ b/third_party/urllib3.BUILD
@@ -12,5 +12,4 @@ exports_files(["LICENSE.md"])
 py_library(
     name = "org_pythonhosted_urllib3",
     srcs = glob(["urllib3/**/*.py"]),
-    srcs_version = "PY3",
 )

--- a/third_party/webencodings.BUILD
+++ b/third_party/webencodings.BUILD
@@ -15,6 +15,5 @@ py_library(
         "webencodings/mklabels.py",
         "webencodings/x_user_defined.py",
     ],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )

--- a/third_party/werkzeug.BUILD
+++ b/third_party/werkzeug.BUILD
@@ -14,6 +14,5 @@ py_library(
     # Expose the extracted root as an import path so `import werkzeug...`
     # resolves from the vendored package layout under Bazel.
     imports = ["."],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Removing the following attributes in BUILD files:

python_version = "PY3",
srcs_version = "PY3",

Python rules already defaults to PY3