### PR TITLE
New checkbox setting to allow short list in tooltip

### DIFF
--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -125,6 +125,10 @@ export const metricsScalarPartitionNonMonotonicXToggled = createAction(
   '[Metrics] Metrics Setting Partition Non Monotonic X Toggled'
 );
 
+export const metricsToggleLimitTooltipRows = createAction(
+  '[Metrics] Metrics Setting Toggle Limit Tooltip Rows'
+);
+
 export const metricsChangeImageBrightness = createAction(
   '[Metrics] Metrics Setting Change Image Brightness',
   props<{brightnessInMilli: number}>()

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -129,6 +129,11 @@ export const metricsToggleLimitTooltipRows = createAction(
   '[Metrics] Metrics Setting Toggle Limit Tooltip Rows'
 );
 
+export const metricsChangeTooltipRowsLimit = createAction(
+  '[Metrics] Metrics Setting Change Tooltip Rows Limit',
+  props<{tooltipRowsLimit: number}>()
+);
+
 export const metricsChangeImageBrightness = createAction(
   '[Metrics] Metrics Setting Change Image Brightness',
   props<{brightnessInMilli: number}>()

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -125,10 +125,12 @@ export const metricsScalarPartitionNonMonotonicXToggled = createAction(
   '[Metrics] Metrics Setting Partition Non Monotonic X Toggled'
 );
 
+// Toggle the "Limit tooltip rows" checkbox on or off. No payload, just change the current boolean
 export const metricsToggleLimitTooltipRows = createAction(
   '[Metrics] Metrics Setting Toggle Limit Tooltip Rows'
 );
 
+// Set the numeric limit for how many rows to show in the tooltip when limiting is enabled
 export const metricsChangeTooltipRowsLimit = createAction(
   '[Metrics] Metrics Setting Change Tooltip Rows Limit',
   props<{tooltipRowsLimit: number}>()

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -107,7 +107,5 @@ export interface HeaderToggleInfo {
 export const SCALARS_SMOOTHING_MIN = 0;
 export const SCALARS_SMOOTHING_MAX = 0.999;
 
-export const MAX_TOOLTIP_ITEMS = 5;
-
+/** Minimum value for the input: tooltip rows limit setting. */
 export const TOOLTIP_ROWS_LIMIT_MIN = 1;
-export const TOOLTIP_ROWS_LIMIT_MAX = 50;

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -107,8 +107,7 @@ export interface HeaderToggleInfo {
 export const SCALARS_SMOOTHING_MIN = 0;
 export const SCALARS_SMOOTHING_MAX = 0.999;
 
-/**
- * Maximum number of rows shown in the scalar card tooltip when the
- * "Limit tooltip rows" setting is enabled.
- */
 export const MAX_TOOLTIP_ITEMS = 5;
+
+export const TOOLTIP_ROWS_LIMIT_MIN = 1;
+export const TOOLTIP_ROWS_LIMIT_MAX = 50;

--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -106,3 +106,9 @@ export interface HeaderToggleInfo {
 
 export const SCALARS_SMOOTHING_MIN = 0;
 export const SCALARS_SMOOTHING_MAX = 0.999;
+
+/**
+ * Maximum number of rows shown in the scalar card tooltip when the
+ * "Limit tooltip rows" setting is enabled.
+ */
+export const MAX_TOOLTIP_ITEMS = 5;

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -30,6 +30,7 @@ import {MetricsEffects} from './effects';
 import {
   getMetricsCardMinWidth,
   getMetricsIgnoreOutliers,
+  getMetricsLimitTooltipRows,
   getMetricsLinkedTimeEnabled,
   getMetricsRangeSelectionEnabled,
   getMetricsScalarSmoothing,
@@ -132,6 +133,12 @@ export function getMetricsTimeSeriesSavingPinsEnabled() {
   });
 }
 
+export function getMetricsLimitTooltipRowsSettingFactory() {
+  return createSelector(getMetricsLimitTooltipRows, (limitTooltipRows) => {
+    return {limitTooltipRows};
+  });
+}
+
 export function getSingleSelectionHeadersFactory() {
   return createSelector(getSingleSelectionHeaders, (singleSelectionHeaders) => {
     return {singleSelectionHeaders};
@@ -197,6 +204,9 @@ export function getRangeSelectionHeadersFactory() {
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
       getMetricsTimeSeriesSavingPinsEnabled
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsLimitTooltipRowsSettingFactory
     ),
   ],
   providers: [

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -35,6 +35,7 @@ import {
   getMetricsRangeSelectionEnabled,
   getMetricsScalarSmoothing,
   getMetricsStepSelectorEnabled,
+  getMetricsTooltipRowsLimit,
   getMetricsTooltipSort,
   getMetricsSavingPinsEnabled,
   getRangeSelectionHeaders,
@@ -139,6 +140,12 @@ export function getMetricsLimitTooltipRowsSettingFactory() {
   });
 }
 
+export function getMetricsTooltipRowsLimitSettingFactory() {
+  return createSelector(getMetricsTooltipRowsLimit, (tooltipRowsLimit) => {
+    return {tooltipRowsLimit};
+  });
+}
+
 export function getSingleSelectionHeadersFactory() {
   return createSelector(getSingleSelectionHeaders, (singleSelectionHeaders) => {
     return {singleSelectionHeaders};
@@ -207,6 +214,9 @@ export function getRangeSelectionHeadersFactory() {
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
       getMetricsLimitTooltipRowsSettingFactory
+    ),
+    PersistentSettingsConfigModule.defineGlobalSetting(
+      getMetricsTooltipRowsLimitSettingFactory
     ),
   ],
   providers: [

--- a/tensorboard/webapp/metrics/metrics_module.ts
+++ b/tensorboard/webapp/metrics/metrics_module.ts
@@ -30,7 +30,7 @@ import {MetricsEffects} from './effects';
 import {
   getMetricsCardMinWidth,
   getMetricsIgnoreOutliers,
-  getMetricsLimitTooltipRows,
+  getMetricsIsTooltipRowsLimitEnabled,
   getMetricsLinkedTimeEnabled,
   getMetricsRangeSelectionEnabled,
   getMetricsScalarSmoothing,
@@ -134,10 +134,13 @@ export function getMetricsTimeSeriesSavingPinsEnabled() {
   });
 }
 
-export function getMetricsLimitTooltipRowsSettingFactory() {
-  return createSelector(getMetricsLimitTooltipRows, (limitTooltipRows) => {
-    return {limitTooltipRows};
-  });
+export function getMetricsIsTooltipRowsLimitEnabledSettingFactory() {
+  return createSelector(
+    getMetricsIsTooltipRowsLimitEnabled,
+    (isTooltipRowsLimitEnabled) => {
+      return {isTooltipRowsLimitEnabled};
+    }
+  );
 }
 
 export function getMetricsTooltipRowsLimitSettingFactory() {
@@ -213,7 +216,7 @@ export function getRangeSelectionHeadersFactory() {
       getMetricsTimeSeriesSavingPinsEnabled
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
-      getMetricsLimitTooltipRowsSettingFactory
+      getMetricsIsTooltipRowsLimitEnabledSettingFactory
     ),
     PersistentSettingsConfigModule.defineGlobalSetting(
       getMetricsTooltipRowsLimitSettingFactory

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -42,7 +42,6 @@ import {
   CardUniqueInfo,
   SCALARS_SMOOTHING_MAX,
   SCALARS_SMOOTHING_MIN,
-  TOOLTIP_ROWS_LIMIT_MAX,
   TOOLTIP_ROWS_LIMIT_MIN,
   TooltipSort,
   URLDeserializedState,
@@ -867,10 +866,7 @@ const reducer = createReducer(
       ...state,
       settingOverrides: {
         ...state.settingOverrides,
-        tooltipRowsLimit: Math.min(
-          Math.max(tooltipRowsLimit, TOOLTIP_ROWS_LIMIT_MIN),
-          TOOLTIP_ROWS_LIMIT_MAX
-        ),
+        tooltipRowsLimit: Math.max(tooltipRowsLimit, TOOLTIP_ROWS_LIMIT_MIN),
       },
     };
   }),

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -612,8 +612,9 @@ const reducer = createReducer(
     if (typeof partialSettings.savingPinsEnabled === 'boolean') {
       metricsSettings.savingPinsEnabled = partialSettings.savingPinsEnabled;
     }
-    if (typeof partialSettings.limitTooltipRows === 'boolean') {
-      metricsSettings.limitTooltipRows = partialSettings.limitTooltipRows;
+    if (typeof partialSettings.isTooltipRowsLimitEnabled === 'boolean') {
+      metricsSettings.isTooltipRowsLimitEnabled =
+        partialSettings.isTooltipRowsLimitEnabled;
     }
     if (typeof partialSettings.tooltipRowsLimit === 'number') {
       metricsSettings.tooltipRowsLimit = partialSettings.tooltipRowsLimit;
@@ -850,14 +851,15 @@ const reducer = createReducer(
     };
   }),
   on(actions.metricsToggleLimitTooltipRows, (state) => {
-    const nextLimitTooltipRows = !(
-      state.settingOverrides.limitTooltipRows ?? state.settings.limitTooltipRows
+    const nextIsTooltipRowsLimitEnabled = !(
+      state.settingOverrides.isTooltipRowsLimitEnabled ??
+      state.settings.isTooltipRowsLimitEnabled
     );
     return {
       ...state,
       settingOverrides: {
         ...state.settingOverrides,
-        limitTooltipRows: nextLimitTooltipRows,
+        isTooltipRowsLimitEnabled: nextIsTooltipRowsLimitEnabled,
       },
     };
   }),

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -611,6 +611,9 @@ const reducer = createReducer(
     if (typeof partialSettings.savingPinsEnabled === 'boolean') {
       metricsSettings.savingPinsEnabled = partialSettings.savingPinsEnabled;
     }
+    if (typeof partialSettings.limitTooltipRows === 'boolean') {
+      metricsSettings.limitTooltipRows = partialSettings.limitTooltipRows;
+    }
 
     const isSettingsPaneOpen =
       partialSettings.timeSeriesSettingsPaneOpened ?? state.isSettingsPaneOpen;
@@ -839,6 +842,18 @@ const reducer = createReducer(
       settingOverrides: {
         ...state.settingOverrides,
         scalarSmoothing: smoothing,
+      },
+    };
+  }),
+  on(actions.metricsToggleLimitTooltipRows, (state) => {
+    const nextLimitTooltipRows = !(
+      state.settingOverrides.limitTooltipRows ?? state.settings.limitTooltipRows
+    );
+    return {
+      ...state,
+      settingOverrides: {
+        ...state.settingOverrides,
+        limitTooltipRows: nextLimitTooltipRows,
       },
     };
   }),

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -42,6 +42,8 @@ import {
   CardUniqueInfo,
   SCALARS_SMOOTHING_MAX,
   SCALARS_SMOOTHING_MIN,
+  TOOLTIP_ROWS_LIMIT_MAX,
+  TOOLTIP_ROWS_LIMIT_MIN,
   TooltipSort,
   URLDeserializedState,
 } from '../types';
@@ -614,6 +616,9 @@ const reducer = createReducer(
     if (typeof partialSettings.limitTooltipRows === 'boolean') {
       metricsSettings.limitTooltipRows = partialSettings.limitTooltipRows;
     }
+    if (typeof partialSettings.tooltipRowsLimit === 'number') {
+      metricsSettings.tooltipRowsLimit = partialSettings.tooltipRowsLimit;
+    }
 
     const isSettingsPaneOpen =
       partialSettings.timeSeriesSettingsPaneOpened ?? state.isSettingsPaneOpen;
@@ -854,6 +859,18 @@ const reducer = createReducer(
       settingOverrides: {
         ...state.settingOverrides,
         limitTooltipRows: nextLimitTooltipRows,
+      },
+    };
+  }),
+  on(actions.metricsChangeTooltipRowsLimit, (state, {tooltipRowsLimit}) => {
+    return {
+      ...state,
+      settingOverrides: {
+        ...state.settingOverrides,
+        tooltipRowsLimit: Math.min(
+          Math.max(tooltipRowsLimit, TOOLTIP_ROWS_LIMIT_MIN),
+          TOOLTIP_ROWS_LIMIT_MAX
+        ),
       },
     };
   }),

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -372,6 +372,11 @@ export const getMetricsLimitTooltipRows = createSelector(
   (settings): boolean => settings.limitTooltipRows
 );
 
+export const getMetricsTooltipRowsLimit = createSelector(
+  selectSettings,
+  (settings): number => settings.tooltipRowsLimit
+);
+
 export const getMetricsImageBrightnessInMilli = createSelector(
   selectSettings,
   (settings): number => settings.imageBrightnessInMilli

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -367,9 +367,9 @@ export const getMetricsScalarPartitionNonMonotonicX = createSelector(
   (settings): boolean => settings.scalarPartitionNonMonotonicX
 );
 
-export const getMetricsLimitTooltipRows = createSelector(
+export const getMetricsIsTooltipRowsLimitEnabled = createSelector(
   selectSettings,
-  (settings): boolean => settings.limitTooltipRows
+  (settings): boolean => settings.isTooltipRowsLimitEnabled
 );
 
 export const getMetricsTooltipRowsLimit = createSelector(

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -367,6 +367,11 @@ export const getMetricsScalarPartitionNonMonotonicX = createSelector(
   (settings): boolean => settings.scalarPartitionNonMonotonicX
 );
 
+export const getMetricsLimitTooltipRows = createSelector(
+  selectSettings,
+  (settings): boolean => settings.limitTooltipRows
+);
+
 export const getMetricsImageBrightnessInMilli = createSelector(
   selectSettings,
   (settings): number => settings.imageBrightnessInMilli

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -31,6 +31,7 @@ import {
   CardMetadata,
   CardUniqueInfo,
   HistogramMode,
+  MAX_TOOLTIP_ITEMS,
   MinMaxStep,
   NonPinnedCardId,
   PinnedCardId,
@@ -234,11 +235,8 @@ export interface MetricsSettings {
    * future, we may fix this at the log writing, reading, or backend response time.
    */
   scalarPartitionNonMonotonicX: boolean;
-  /**
-   * When enabled, the scalar card tooltip is truncated to MAX_TOOLTIP_ITEMS
-   * rows instead of showing every series.
-   */
   limitTooltipRows: boolean;
+  tooltipRowsLimit: number;
   /**
    * A non-negative, unitless number. A value of 5000 corresponds to 500%
    * increased brightness from normal.
@@ -290,6 +288,7 @@ export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
   scalarSmoothing: 0.6,
   scalarPartitionNonMonotonicX: false,
   limitTooltipRows: false,
+  tooltipRowsLimit: MAX_TOOLTIP_ITEMS,
   imageBrightnessInMilli: 1000,
   imageContrastInMilli: 1000,
   imageShowActualSize: false,

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -31,11 +31,11 @@ import {
   CardMetadata,
   CardUniqueInfo,
   HistogramMode,
-  MAX_TOOLTIP_ITEMS,
   MinMaxStep,
   NonPinnedCardId,
   PinnedCardId,
   TimeSelection,
+  TOOLTIP_ROWS_LIMIT_MIN,
   TooltipSort,
   XAxisType,
 } from '../types';
@@ -235,7 +235,15 @@ export interface MetricsSettings {
    * future, we may fix this at the log writing, reading, or backend response time.
    */
   scalarPartitionNonMonotonicX: boolean;
+  /**
+   * When enabled, the scalar card tooltip is truncated to
+   * `tooltipRowsLimit` rows instead of showing all items.
+   */
   limitTooltipRows: boolean;
+  /**
+   * Number of rows shown in the scalar card tooltip when
+   * `limitTooltipRows` is enabled.
+   */
   tooltipRowsLimit: number;
   /**
    * A non-negative, unitless number. A value of 5000 corresponds to 500%
@@ -288,7 +296,7 @@ export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
   scalarSmoothing: 0.6,
   scalarPartitionNonMonotonicX: false,
   limitTooltipRows: false,
-  tooltipRowsLimit: MAX_TOOLTIP_ITEMS,
+  tooltipRowsLimit: TOOLTIP_ROWS_LIMIT_MIN,
   imageBrightnessInMilli: 1000,
   imageContrastInMilli: 1000,
   imageShowActualSize: false,

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -239,10 +239,10 @@ export interface MetricsSettings {
    * When enabled, the scalar card tooltip is truncated to
    * `tooltipRowsLimit` rows instead of showing all items.
    */
-  limitTooltipRows: boolean;
+  isTooltipRowsLimitEnabled: boolean;
   /**
    * Number of rows shown in the scalar card tooltip when
-   * `limitTooltipRows` is enabled.
+   * `isTooltipRowsLimitEnabled` is enabled.
    */
   tooltipRowsLimit: number;
   /**
@@ -295,7 +295,7 @@ export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
   hideEmptyCards: true,
   scalarSmoothing: 0.6,
   scalarPartitionNonMonotonicX: false,
-  limitTooltipRows: false,
+  isTooltipRowsLimitEnabled: false,
   tooltipRowsLimit: TOOLTIP_ROWS_LIMIT_MIN,
   imageBrightnessInMilli: 1000,
   imageContrastInMilli: 1000,

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -235,6 +235,11 @@ export interface MetricsSettings {
    */
   scalarPartitionNonMonotonicX: boolean;
   /**
+   * When enabled, the scalar card tooltip is truncated to MAX_TOOLTIP_ITEMS
+   * rows instead of showing every series.
+   */
+  limitTooltipRows: boolean;
+  /**
    * A non-negative, unitless number. A value of 5000 corresponds to 500%
    * increased brightness from normal.
    */
@@ -284,6 +289,7 @@ export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
   hideEmptyCards: true,
   scalarSmoothing: 0.6,
   scalarPartitionNonMonotonicX: false,
+  limitTooltipRows: false,
   imageBrightnessInMilli: 1000,
   imageContrastInMilli: 1000,
   imageShowActualSize: false,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -41,7 +41,13 @@ import {
   RunToSeries,
   StepDatum,
 } from './store/metrics_types';
-import {CardId, CardMetadata, TooltipSort, XAxisType} from './types';
+import {
+  CardId,
+  CardMetadata,
+  MAX_TOOLTIP_ITEMS,
+  TooltipSort,
+  XAxisType,
+} from './types';
 import {DataTableMode} from '../widgets/data_table/types';
 
 export function buildMetricsSettingsState(
@@ -56,6 +62,7 @@ export function buildMetricsSettingsState(
     hideEmptyCards: true,
     scalarPartitionNonMonotonicX: false,
     limitTooltipRows: false,
+    tooltipRowsLimit: MAX_TOOLTIP_ITEMS,
     imageBrightnessInMilli: 123,
     imageContrastInMilli: 123,
     imageShowActualSize: true,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -55,6 +55,7 @@ export function buildMetricsSettingsState(
     scalarSmoothing: 0.3,
     hideEmptyCards: true,
     scalarPartitionNonMonotonicX: false,
+    limitTooltipRows: false,
     imageBrightnessInMilli: 123,
     imageContrastInMilli: 123,
     imageShowActualSize: true,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -55,7 +55,7 @@ export function buildMetricsSettingsState(
     scalarSmoothing: 0.3,
     hideEmptyCards: true,
     scalarPartitionNonMonotonicX: false,
-    limitTooltipRows: false,
+    isTooltipRowsLimitEnabled: false,
     tooltipRowsLimit: 4,
     imageBrightnessInMilli: 123,
     imageContrastInMilli: 123,

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -41,13 +41,7 @@ import {
   RunToSeries,
   StepDatum,
 } from './store/metrics_types';
-import {
-  CardId,
-  CardMetadata,
-  MAX_TOOLTIP_ITEMS,
-  TooltipSort,
-  XAxisType,
-} from './types';
+import {CardId, CardMetadata, TooltipSort, XAxisType} from './types';
 import {DataTableMode} from '../widgets/data_table/types';
 
 export function buildMetricsSettingsState(
@@ -62,7 +56,7 @@ export function buildMetricsSettingsState(
     hideEmptyCards: true,
     scalarPartitionNonMonotonicX: false,
     limitTooltipRows: false,
-    tooltipRowsLimit: MAX_TOOLTIP_ITEMS,
+    tooltipRowsLimit: 4,
     imageBrightnessInMilli: 123,
     imageContrastInMilli: 123,
     imageShowActualSize: true,

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -47,6 +47,7 @@ import {CardState} from '../../store';
 import {
   HeaderEditInfo,
   HeaderToggleInfo,
+  MAX_TOOLTIP_ITEMS,
   TooltipSort,
   XAxisType,
 } from '../../types';
@@ -75,8 +76,6 @@ type ScalarTooltipDatum = TooltipDatum<
   }
 >;
 
-const MAX_TOOLTIP_ITEMS = 5;
-
 @Component({
   standalone: false,
   selector: 'scalar-card-component',
@@ -95,6 +94,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() DataDownloadComponent!: ComponentType<Downloader>;
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() ignoreOutliers!: boolean;
+  @Input() limitTooltipRows!: boolean;
   @Input() isCardVisible!: boolean;
   @Input() isPinned!: boolean;
   @Input() loadState!: DataLoadState;
@@ -256,6 +256,11 @@ export class ScalarCardComponent<Downloader> {
           return 0;
         });
         break;
+    }
+
+    if (!this.limitTooltipRows) {
+      this.additionalItemsCount = 0;
+      return scalarTooltipData;
     }
 
     this.additionalItemsCount = Math.max(

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -93,7 +93,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() DataDownloadComponent!: ComponentType<Downloader>;
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() ignoreOutliers!: boolean;
-  @Input() limitTooltipRows!: boolean;
+  @Input() isTooltipRowsLimitEnabled!: boolean;
   @Input() tooltipRowsLimit!: number;
   @Input() isCardVisible!: boolean;
   @Input() isPinned!: boolean;
@@ -258,7 +258,7 @@ export class ScalarCardComponent<Downloader> {
         break;
     }
 
-    if (!this.limitTooltipRows) {
+    if (!this.isTooltipRowsLimitEnabled) {
       this.additionalItemsCount = 0;
       return scalarTooltipData;
     }

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_component.ts
@@ -47,7 +47,6 @@ import {CardState} from '../../store';
 import {
   HeaderEditInfo,
   HeaderToggleInfo,
-  MAX_TOOLTIP_ITEMS,
   TooltipSort,
   XAxisType,
 } from '../../types';
@@ -95,6 +94,7 @@ export class ScalarCardComponent<Downloader> {
   @Input() dataSeries!: ScalarCardDataSeries[];
   @Input() ignoreOutliers!: boolean;
   @Input() limitTooltipRows!: boolean;
+  @Input() tooltipRowsLimit!: number;
   @Input() isCardVisible!: boolean;
   @Input() isPinned!: boolean;
   @Input() loadState!: DataLoadState;
@@ -265,9 +265,9 @@ export class ScalarCardComponent<Downloader> {
 
     this.additionalItemsCount = Math.max(
       0,
-      scalarTooltipData.length - MAX_TOOLTIP_ITEMS
+      scalarTooltipData.length - this.tooltipRowsLimit
     );
-    return scalarTooltipData.slice(0, MAX_TOOLTIP_ITEMS);
+    return scalarTooltipData.slice(0, this.tooltipRowsLimit);
   }
 
   openDataDownloadDialog(): void {

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -95,6 +95,7 @@ import {
   getMetricsLimitTooltipRows,
   getMetricsScalarPartitionNonMonotonicX,
   getMetricsScalarSmoothing,
+  getMetricsTooltipRowsLimit,
   getMetricsTooltipSort,
   getMetricsXAxisType,
   RunToSeries,
@@ -174,6 +175,7 @@ function areSeriesEqual(
       [dataSeries]="dataSeries$ | async"
       [ignoreOutliers]="ignoreOutliers$ | async"
       [limitTooltipRows]="limitTooltipRows$ | async"
+      [tooltipRowsLimit]="tooltipRowsLimit$ | async"
       [isCardVisible]="isVisible"
       [isPinned]="isPinned$ | async"
       [loadState]="loadState$ | async"
@@ -239,6 +241,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     this.useDarkMode$ = this.store.select(getDarkModeEnabled);
     this.ignoreOutliers$ = this.store.select(getMetricsIgnoreOutliers);
     this.limitTooltipRows$ = this.store.select(getMetricsLimitTooltipRows);
+    this.tooltipRowsLimit$ = this.store.select(getMetricsTooltipRowsLimit);
     this.tooltipSort$ = this.store.select(getMetricsTooltipSort);
     this.xAxisType$ = this.store.select(getMetricsXAxisType);
     this.forceSvg$ = this.store.select(getForceSvgFeatureFlag);
@@ -308,6 +311,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
   readonly useDarkMode$;
   readonly ignoreOutliers$;
   readonly limitTooltipRows$;
+  readonly tooltipRowsLimit$;
   readonly tooltipSort$;
   readonly xAxisType$;
   readonly forceSvg$;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -92,7 +92,7 @@ import {
   getCardTimeSeries,
   getMetricsCardMinMax,
   getMetricsIgnoreOutliers,
-  getMetricsLimitTooltipRows,
+  getMetricsIsTooltipRowsLimitEnabled,
   getMetricsScalarPartitionNonMonotonicX,
   getMetricsScalarSmoothing,
   getMetricsTooltipRowsLimit,
@@ -174,7 +174,7 @@ function areSeriesEqual(
       [DataDownloadComponent]="DataDownloadComponent"
       [dataSeries]="dataSeries$ | async"
       [ignoreOutliers]="ignoreOutliers$ | async"
-      [limitTooltipRows]="limitTooltipRows$ | async"
+      [isTooltipRowsLimitEnabled]="isTooltipRowsLimitEnabled$ | async"
       [tooltipRowsLimit]="tooltipRowsLimit$ | async"
       [isCardVisible]="isVisible"
       [isPinned]="isPinned$ | async"
@@ -240,7 +240,9 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     );
     this.useDarkMode$ = this.store.select(getDarkModeEnabled);
     this.ignoreOutliers$ = this.store.select(getMetricsIgnoreOutliers);
-    this.limitTooltipRows$ = this.store.select(getMetricsLimitTooltipRows);
+    this.isTooltipRowsLimitEnabled$ = this.store.select(
+      getMetricsIsTooltipRowsLimitEnabled
+    );
     this.tooltipRowsLimit$ = this.store.select(getMetricsTooltipRowsLimit);
     this.tooltipSort$ = this.store.select(getMetricsTooltipSort);
     this.xAxisType$ = this.store.select(getMetricsXAxisType);
@@ -310,7 +312,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   readonly useDarkMode$;
   readonly ignoreOutliers$;
-  readonly limitTooltipRows$;
+  readonly isTooltipRowsLimitEnabled$;
   readonly tooltipRowsLimit$;
   readonly tooltipSort$;
   readonly xAxisType$;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_container.ts
@@ -92,6 +92,7 @@ import {
   getCardTimeSeries,
   getMetricsCardMinMax,
   getMetricsIgnoreOutliers,
+  getMetricsLimitTooltipRows,
   getMetricsScalarPartitionNonMonotonicX,
   getMetricsScalarSmoothing,
   getMetricsTooltipSort,
@@ -172,6 +173,7 @@ function areSeriesEqual(
       [DataDownloadComponent]="DataDownloadComponent"
       [dataSeries]="dataSeries$ | async"
       [ignoreOutliers]="ignoreOutliers$ | async"
+      [limitTooltipRows]="limitTooltipRows$ | async"
       [isCardVisible]="isVisible"
       [isPinned]="isPinned$ | async"
       [loadState]="loadState$ | async"
@@ -236,6 +238,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
     );
     this.useDarkMode$ = this.store.select(getDarkModeEnabled);
     this.ignoreOutliers$ = this.store.select(getMetricsIgnoreOutliers);
+    this.limitTooltipRows$ = this.store.select(getMetricsLimitTooltipRows);
     this.tooltipSort$ = this.store.select(getMetricsTooltipSort);
     this.xAxisType$ = this.store.select(getMetricsXAxisType);
     this.forceSvg$ = this.store.select(getForceSvgFeatureFlag);
@@ -304,6 +307,7 @@ export class ScalarCardContainer implements CardRenderer, OnInit, OnDestroy {
 
   readonly useDarkMode$;
   readonly ignoreOutliers$;
+  readonly limitTooltipRows$;
   readonly tooltipSort$;
   readonly xAxisType$;
   readonly forceSvg$;

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -1923,7 +1923,10 @@ describe('scalar card', () => {
       }
 
       beforeEach(() => {
-        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        store.overrideSelector(
+          selectors.getMetricsIsTooltipRowsLimitEnabled,
+          true
+        );
         store.overrideSelector(
           selectors.getMetricsTooltipRowsLimit,
           TOOLTIP_ROWS_LIMIT_FOR_TEST
@@ -1931,7 +1934,10 @@ describe('scalar card', () => {
       });
 
       it('test: Shows all rows when the setting Limit Tooltip is unchecked', fakeAsync(() => {
-        store.overrideSelector(selectors.getMetricsLimitTooltipRows, false);
+        store.overrideSelector(
+          selectors.getMetricsIsTooltipRowsLimitEnabled,
+          false
+        );
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
         setTooltipData(fixture, buildTooltipData(TOTAL_TOOLTIP_ITEMS_FOR_TEST));

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -126,7 +126,7 @@ import {
   buildScalarStepData,
   provideMockCardRunToSeriesData,
 } from '../../testing';
-import {TooltipSort, XAxisType} from '../../types';
+import {MAX_TOOLTIP_ITEMS, TooltipSort, XAxisType} from '../../types';
 import * as commonSelectors from '../main_view/common_selectors';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
@@ -1891,6 +1891,8 @@ describe('scalar card', () => {
     }));
 
     describe('tooltip item limiting and legend', () => {
+      const TOTAL_TOOLTIP_ITEMS_FOR_TEST = 12;
+
       const colors = [
         '#00f',
         '#0f0',
@@ -1923,56 +1925,58 @@ describe('scalar card', () => {
         store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
       });
 
-      it('shows every row when the limit tooltip rows setting is off', fakeAsync(() => {
+      it('test: Shows all rows when the setting Limit Tooltip is unchecked', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsLimitTooltipRows, false);
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(8));
+        setTooltipData(fixture, buildTooltipData(TOTAL_TOOLTIP_ITEMS_FOR_TEST));
         fixture.detectChanges();
 
         expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
-          8
+          TOTAL_TOOLTIP_ITEMS_FOR_TEST
         );
         expect(getLegendRow(fixture)).toBeNull();
       }));
 
-      it('limits to 5 rows when the limit tooltip rows setting is on', fakeAsync(() => {
+      it('test: Limits rows to MAX_TOOLTIP_ITEMS when the setting Limit Tooltip rows is checked', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(8));
+        setTooltipData(fixture, buildTooltipData(TOTAL_TOOLTIP_ITEMS_FOR_TEST));
         fixture.detectChanges();
 
         expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
-          5
+          MAX_TOOLTIP_ITEMS
         );
+        const additionalItemsCount =
+          TOTAL_TOOLTIP_ITEMS_FOR_TEST - MAX_TOOLTIP_ITEMS;
         const legendRow = getLegendRow(fixture);
         expect(legendRow).not.toBeNull();
         expect(legendRow.nativeElement.textContent.trim()).toBe(
-          '3 additional items'
+          `${additionalItemsCount} additional items`
         );
       }));
 
-      it('displays all items when there are 5 or fewer', fakeAsync(() => {
+      it('Displays all items when there are 5 or fewer', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(5));
+        setTooltipData(fixture, buildTooltipData(MAX_TOOLTIP_ITEMS));
         fixture.detectChanges();
 
         expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
-          5
+          MAX_TOOLTIP_ITEMS
         );
         expect(getLegendRow(fixture)).toBeNull();
       }));
 
-      it('limits tooltip to 5 items when there are more than 5', fakeAsync(() => {
+      it('Limits tooltip to 5 items when there are more than 5', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(7));
+        setTooltipData(fixture, buildTooltipData(MAX_TOOLTIP_ITEMS + 2));
         fixture.detectChanges();
 
         expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
-          5
+          MAX_TOOLTIP_ITEMS
         );
       }));
 

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -126,7 +126,7 @@ import {
   buildScalarStepData,
   provideMockCardRunToSeriesData,
 } from '../../testing';
-import {MAX_TOOLTIP_ITEMS, TooltipSort, XAxisType} from '../../types';
+import {TooltipSort, XAxisType} from '../../types';
 import * as commonSelectors from '../main_view/common_selectors';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
@@ -1892,6 +1892,7 @@ describe('scalar card', () => {
 
     describe('tooltip item limiting and legend', () => {
       const TOTAL_TOOLTIP_ITEMS_FOR_TEST = 12;
+      const TOOLTIP_ROWS_LIMIT_FOR_TEST = 5;
 
       const colors = [
         '#00f',
@@ -1923,6 +1924,10 @@ describe('scalar card', () => {
 
       beforeEach(() => {
         store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        store.overrideSelector(
+          selectors.getMetricsTooltipRowsLimit,
+          TOOLTIP_ROWS_LIMIT_FOR_TEST
+        );
       });
 
       it('test: Shows all rows when the setting Limit Tooltip is unchecked', fakeAsync(() => {
@@ -1938,18 +1943,17 @@ describe('scalar card', () => {
         expect(getLegendRow(fixture)).toBeNull();
       }));
 
-      it('test: Limits rows to MAX_TOOLTIP_ITEMS when the setting Limit Tooltip rows is checked', fakeAsync(() => {
-        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+      it('test: Limits rows to the configured tooltip rows limit when the setting Limit Tooltip rows is checked', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
         setTooltipData(fixture, buildTooltipData(TOTAL_TOOLTIP_ITEMS_FOR_TEST));
         fixture.detectChanges();
 
         expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
-          MAX_TOOLTIP_ITEMS
+          TOOLTIP_ROWS_LIMIT_FOR_TEST
         );
         const additionalItemsCount =
-          TOTAL_TOOLTIP_ITEMS_FOR_TEST - MAX_TOOLTIP_ITEMS;
+          TOTAL_TOOLTIP_ITEMS_FOR_TEST - TOOLTIP_ROWS_LIMIT_FOR_TEST;
         const legendRow = getLegendRow(fixture);
         expect(legendRow).not.toBeNull();
         expect(legendRow.nativeElement.textContent.trim()).toBe(
@@ -1957,33 +1961,13 @@ describe('scalar card', () => {
         );
       }));
 
-      it('Displays all items when there are 5 or fewer', fakeAsync(() => {
-        store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
-        const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(MAX_TOOLTIP_ITEMS));
-        fixture.detectChanges();
-
-        expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
-          MAX_TOOLTIP_ITEMS
-        );
-        expect(getLegendRow(fixture)).toBeNull();
-      }));
-
-      it('Limits tooltip to 5 items when there are more than 5', fakeAsync(() => {
-        store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
-        const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(MAX_TOOLTIP_ITEMS + 2));
-        fixture.detectChanges();
-
-        expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
-          MAX_TOOLTIP_ITEMS
-        );
-      }));
-
       it('shows legend with singular text for 1 additional item', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(6));
+        setTooltipData(
+          fixture,
+          buildTooltipData(TOOLTIP_ROWS_LIMIT_FOR_TEST + 1)
+        );
         fixture.detectChanges();
 
         const legendRow = getLegendRow(fixture);
@@ -1996,7 +1980,10 @@ describe('scalar card', () => {
       it('shows legend with plural text for multiple additional items', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(8));
+        setTooltipData(
+          fixture,
+          buildTooltipData(TOOLTIP_ROWS_LIMIT_FOR_TEST + 3)
+        );
         fixture.detectChanges();
 
         const legendRow = getLegendRow(fixture);
@@ -2006,10 +1993,10 @@ describe('scalar card', () => {
         );
       }));
 
-      it('does not show legend when there are exactly 5 items', fakeAsync(() => {
+      it('does not show legend when there are exactly the configured limit of items', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(5));
+        setTooltipData(fixture, buildTooltipData(TOOLTIP_ROWS_LIMIT_FOR_TEST));
         fixture.detectChanges();
 
         expect(getLegendRow(fixture)).toBeNull();
@@ -2018,7 +2005,10 @@ describe('scalar card', () => {
       it('shows legend with correct colspan when smoothing is enabled', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0.5);
         const fixture = createComponent('card1');
-        setTooltipData(fixture, buildTooltipData(6));
+        setTooltipData(
+          fixture,
+          buildTooltipData(TOOLTIP_ROWS_LIMIT_FOR_TEST + 1)
+        );
         fixture.detectChanges();
 
         const legendRow = getLegendRow(fixture);

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -1919,6 +1919,40 @@ describe('scalar card', () => {
         return fixture.debugElement.query(By.css('table.tooltip tr.legend'));
       }
 
+      beforeEach(() => {
+        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+      });
+
+      it('shows every row when the limit tooltip rows setting is off', fakeAsync(() => {
+        store.overrideSelector(selectors.getMetricsLimitTooltipRows, false);
+        store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
+        const fixture = createComponent('card1');
+        setTooltipData(fixture, buildTooltipData(8));
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
+          8
+        );
+        expect(getLegendRow(fixture)).toBeNull();
+      }));
+
+      it('limits to 5 rows when the limit tooltip rows setting is on', fakeAsync(() => {
+        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
+        const fixture = createComponent('card1');
+        setTooltipData(fixture, buildTooltipData(8));
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.queryAll(Selector.TOOLTIP_ROW).length).toBe(
+          5
+        );
+        const legendRow = getLegendRow(fixture);
+        expect(legendRow).not.toBeNull();
+        expect(legendRow.nativeElement.textContent.trim()).toBe(
+          '3 additional items'
+        );
+      }));
+
       it('displays all items when there are 5 or fewer', fakeAsync(() => {
         store.overrideSelector(selectors.getMetricsScalarSmoothing, 0);
         const fixture = createComponent('card1');

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -307,7 +307,8 @@ describe('metrics right_pane', () => {
     });
 
     describe('tooltip rows limit input', () => {
-      const TOOLTIP_ROWS_LIMIT_INPUT = '.scalars-limit-tooltip-rows .slider-input';
+      const TOOLTIP_ROWS_LIMIT_INPUT =
+        '.scalars-limit-tooltip-rows .slider-input';
 
       it('renders the current tooltip rows limit', () => {
         store.overrideSelector(selectors.getMetricsTooltipRowsLimit, 8);
@@ -319,7 +320,10 @@ describe('metrics right_pane', () => {
       });
 
       it('disables the input when limit tooltip rows is unchecked', () => {
-        store.overrideSelector(selectors.getMetricsLimitTooltipRows, false);
+        store.overrideSelector(
+          selectors.getMetricsIsTooltipRowsLimitEnabled,
+          false
+        );
         const fixture = TestBed.createComponent(SettingsViewContainer);
         fixture.detectChanges();
 
@@ -328,7 +332,10 @@ describe('metrics right_pane', () => {
       });
 
       it('dispatches the typed value on input', () => {
-        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        store.overrideSelector(
+          selectors.getMetricsIsTooltipRowsLimitEnabled,
+          true
+        );
         const fixture = TestBed.createComponent(SettingsViewContainer);
         fixture.detectChanges();
 
@@ -342,7 +349,10 @@ describe('metrics right_pane', () => {
       });
 
       it('corrects and dispatches the minimum value when input is too low', () => {
-        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        store.overrideSelector(
+          selectors.getMetricsIsTooltipRowsLimitEnabled,
+          true
+        );
         const fixture = TestBed.createComponent(SettingsViewContainer);
         fixture.detectChanges();
 
@@ -361,7 +371,10 @@ describe('metrics right_pane', () => {
       });
 
       it('does not dispatch when the input is cleared', () => {
-        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        store.overrideSelector(
+          selectors.getMetricsIsTooltipRowsLimitEnabled,
+          true
+        );
         const fixture = TestBed.createComponent(SettingsViewContainer);
         fixture.detectChanges();
 

--- a/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -306,6 +306,73 @@ describe('metrics right_pane', () => {
       );
     });
 
+    describe('tooltip rows limit input', () => {
+      const TOOLTIP_ROWS_LIMIT_INPUT = '.scalars-limit-tooltip-rows .slider-input';
+
+      it('renders the current tooltip rows limit', () => {
+        store.overrideSelector(selectors.getMetricsTooltipRowsLimit, 8);
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        const input = select(fixture, TOOLTIP_ROWS_LIMIT_INPUT);
+        expect(input.nativeElement.value).toBe('8');
+      });
+
+      it('disables the input when limit tooltip rows is unchecked', () => {
+        store.overrideSelector(selectors.getMetricsLimitTooltipRows, false);
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        const input = select(fixture, TOOLTIP_ROWS_LIMIT_INPUT);
+        expect(input.nativeElement.disabled).toBeTrue();
+      });
+
+      it('dispatches the typed value on input', () => {
+        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        const input = select(fixture, TOOLTIP_ROWS_LIMIT_INPUT);
+        input.nativeElement.value = '8';
+        input.nativeElement.dispatchEvent(new Event('input'));
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+          actions.metricsChangeTooltipRowsLimit({tooltipRowsLimit: 8})
+        );
+      });
+
+      it('corrects and dispatches the minimum value when input is too low', () => {
+        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        const input = select(fixture, TOOLTIP_ROWS_LIMIT_INPUT);
+        input.nativeElement.value = '0';
+        input.nativeElement.dispatchEvent(new Event('input'));
+
+        expect(input.nativeElement.value).toBe(
+          TEST_ONLY.TOOLTIP_ROWS_LIMIT_MIN.toString()
+        );
+        expect(dispatchSpy).toHaveBeenCalledWith(
+          actions.metricsChangeTooltipRowsLimit({
+            tooltipRowsLimit: TEST_ONLY.TOOLTIP_ROWS_LIMIT_MIN,
+          })
+        );
+      });
+
+      it('does not dispatch when the input is cleared', () => {
+        store.overrideSelector(selectors.getMetricsLimitTooltipRows, true);
+        const fixture = TestBed.createComponent(SettingsViewContainer);
+        fixture.detectChanges();
+
+        const input = select(fixture, TOOLTIP_ROWS_LIMIT_INPUT);
+        input.nativeElement.value = '';
+        input.nativeElement.dispatchEvent(new Event('input'));
+
+        expect(dispatchSpy).not.toHaveBeenCalled();
+      });
+    });
+
     it('dispatches metricsToggleImageShowActualSize on toggle', () => {
       const fixture = TestBed.createComponent(SettingsViewContainer);
       fixture.detectChanges();

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -165,7 +165,6 @@ limitations under the License.
       aria-label="Tooltip rows limit"
       type="number"
       [min]="TOOLTIP_ROWS_LIMIT_MIN"
-      [max]="TOOLTIP_ROWS_LIMIT_MAX"
       step="1"
       [disabled]="!limitTooltipRows"
       [value]="tooltipRowsLimit"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -158,8 +158,19 @@ limitations under the License.
     <mat-checkbox
       [checked]="limitTooltipRows"
       (change)="limitTooltipRowsChanged.emit($event.checked)"
-      >Limit tooltip rows to {{MAX_TOOLTIP_ITEMS}}</mat-checkbox
+      >Limit tooltip rows to</mat-checkbox
     >
+    <input
+      class="slider-input"
+      aria-label="Tooltip rows limit"
+      type="number"
+      [min]="TOOLTIP_ROWS_LIMIT_MIN"
+      [max]="TOOLTIP_ROWS_LIMIT_MAX"
+      step="1"
+      [disabled]="!limitTooltipRows"
+      [value]="tooltipRowsLimit"
+      (input)="onTooltipRowsLimitInput($event)"
+    />
   </div>
 
   <div class="control-row scalars-partition-x">

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -156,8 +156,8 @@ limitations under the License.
 
   <div class="control-row scalars-limit-tooltip-rows">
     <mat-checkbox
-      [checked]="limitTooltipRows"
-      (change)="limitTooltipRowsChanged.emit($event.checked)"
+      [checked]="isTooltipRowsLimitEnabled"
+      (change)="isTooltipRowsLimitEnabledChanged.emit($event.checked)"
       >Limit tooltip rows to</mat-checkbox
     >
     <input
@@ -166,7 +166,7 @@ limitations under the License.
       type="number"
       [min]="TOOLTIP_ROWS_LIMIT_MIN"
       step="1"
-      [disabled]="!limitTooltipRows"
+      [disabled]="!isTooltipRowsLimitEnabled"
       [value]="tooltipRowsLimit"
       (input)="onTooltipRowsLimitInput($event)"
     />

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ng.html
@@ -154,6 +154,14 @@ limitations under the License.
     >
   </div>
 
+  <div class="control-row scalars-limit-tooltip-rows">
+    <mat-checkbox
+      [checked]="limitTooltipRows"
+      (change)="limitTooltipRowsChanged.emit($event.checked)"
+      >Limit tooltip rows to {{MAX_TOOLTIP_ITEMS}}</mat-checkbox
+    >
+  </div>
+
   <div class="control-row scalars-partition-x">
     <mat-checkbox
       [checked]="scalarPartitionX"

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -86,7 +86,7 @@ section .control-row:not(:has(+ .control-row > mat-checkbox)):not(:last-child) {
 
   .slider-input {
     flex: none;
-    width: 2.5em;
+    width: 3.1em;
   }
 }
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.scss
@@ -55,20 +55,20 @@ section .control-row:not(:has(+ .control-row > mat-checkbox)):not(:last-child) {
   .reset-button {
     margin-left: 6px;
   }
+}
 
-  .slider-input {
-    background-color: inherit;
-    border: 1px solid mat.m2-get-color-from-palette($tf-slate, 500);
-    border-radius: 2px;
-    box-sizing: border-box;
-    color: inherit;
-    height: 100%;
-    margin-left: 12px;
-    padding: 0 4px;
+.slider-input {
+  background-color: inherit;
+  border: 1px solid mat.m2-get-color-from-palette($tf-slate, 500);
+  border-radius: 2px;
+  box-sizing: border-box;
+  color: inherit;
+  height: 100%;
+  margin-left: 12px;
+  padding: 0 4px;
 
-    @include tb-dark-theme {
-      border-color: mat.m2-get-color-from-palette($tf-slate, 700);
-    }
+  @include tb-dark-theme {
+    border-color: mat.m2-get-color-from-palette($tf-slate, 700);
   }
 }
 
@@ -77,6 +77,17 @@ section .control-row:not(:has(+ .control-row > mat-checkbox)):not(:last-child) {
   // Wide enough to show 3 digits after a decimal. Required since Firefox does
   // not shrink input fields smaller than some intrinsic size.
   width: 5em;
+}
+
+.scalars-limit-tooltip-rows {
+  align-items: center;
+  display: flex;
+  height: 28px;
+
+  .slider-input {
+    flex: none;
+    width: 2.5em;
+  }
 }
 
 .scalars-partition-x {

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -28,7 +28,6 @@ import {
   HistogramMode,
   SCALARS_SMOOTHING_MAX,
   TimeSelection,
-  TOOLTIP_ROWS_LIMIT_MAX,
   TOOLTIP_ROWS_LIMIT_MIN,
   TooltipSort,
   XAxisType,
@@ -99,7 +98,6 @@ export class SettingsViewComponent {
   @Output() ignoreOutliersChanged = new EventEmitter<void>();
 
   readonly TOOLTIP_ROWS_LIMIT_MIN = TOOLTIP_ROWS_LIMIT_MIN;
-  readonly TOOLTIP_ROWS_LIMIT_MAX = TOOLTIP_ROWS_LIMIT_MAX;
   @Input() limitTooltipRows!: boolean;
   @Output() limitTooltipRowsChanged = new EventEmitter<void>();
   @Input() tooltipRowsLimit!: number;
@@ -110,14 +108,16 @@ export class SettingsViewComponent {
     if (!input.value) {
       return;
     }
-    const nextValue = Math.min(
-      Math.max(TOOLTIP_ROWS_LIMIT_MIN, Math.round(Number(input.value))),
-      TOOLTIP_ROWS_LIMIT_MAX
+    const nextValue = Math.max(
+      TOOLTIP_ROWS_LIMIT_MIN,
+      Math.round(Number(input.value))
     );
 
+    // Fallback in case Angular does not trigger ngOnChanges when expected cause one-way binding.
     if (nextValue !== Number(input.value)) {
       input.value = String(nextValue);
     }
+
     this.tooltipRowsLimitChanged.emit(nextValue);
   }
 
@@ -226,4 +226,5 @@ export const TEST_ONLY = {
   SLIDER_AUDIT_TIME_MS,
   MIN_CARD_WIDTH_SLIDER_VALUE,
   MAX_SMOOTHING_VALUE,
+  TOOLTIP_ROWS_LIMIT_MIN,
 };

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -26,9 +26,10 @@ import {auditTime} from 'rxjs/operators';
 import {DropdownOption} from '../../../widgets/dropdown/dropdown_component';
 import {
   HistogramMode,
-  MAX_TOOLTIP_ITEMS,
   SCALARS_SMOOTHING_MAX,
   TimeSelection,
+  TOOLTIP_ROWS_LIMIT_MAX,
+  TOOLTIP_ROWS_LIMIT_MIN,
   TooltipSort,
   XAxisType,
 } from '../../types';
@@ -97,9 +98,28 @@ export class SettingsViewComponent {
   @Input() ignoreOutliers!: boolean;
   @Output() ignoreOutliersChanged = new EventEmitter<void>();
 
-  readonly MAX_TOOLTIP_ITEMS = MAX_TOOLTIP_ITEMS;
+  readonly TOOLTIP_ROWS_LIMIT_MIN = TOOLTIP_ROWS_LIMIT_MIN;
+  readonly TOOLTIP_ROWS_LIMIT_MAX = TOOLTIP_ROWS_LIMIT_MAX;
   @Input() limitTooltipRows!: boolean;
   @Output() limitTooltipRowsChanged = new EventEmitter<void>();
+  @Input() tooltipRowsLimit!: number;
+  @Output() tooltipRowsLimitChanged = new EventEmitter<number>();
+
+  onTooltipRowsLimitInput(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.value) {
+      return;
+    }
+    const nextValue = Math.min(
+      Math.max(TOOLTIP_ROWS_LIMIT_MIN, Math.round(Number(input.value))),
+      TOOLTIP_ROWS_LIMIT_MAX
+    );
+
+    if (nextValue !== Number(input.value)) {
+      input.value = String(nextValue);
+    }
+    this.tooltipRowsLimitChanged.emit(nextValue);
+  }
 
   readonly XAxisType = XAxisType;
   readonly XAxisTypeDropdownOptions: DropdownOption[] = [

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -98,8 +98,8 @@ export class SettingsViewComponent {
   @Output() ignoreOutliersChanged = new EventEmitter<void>();
 
   readonly TOOLTIP_ROWS_LIMIT_MIN = TOOLTIP_ROWS_LIMIT_MIN;
-  @Input() limitTooltipRows!: boolean;
-  @Output() limitTooltipRowsChanged = new EventEmitter<void>();
+  @Input() isTooltipRowsLimitEnabled!: boolean;
+  @Output() isTooltipRowsLimitEnabledChanged = new EventEmitter<void>();
   @Input() tooltipRowsLimit!: number;
   @Output() tooltipRowsLimitChanged = new EventEmitter<number>();
 

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_component.ts
@@ -26,6 +26,7 @@ import {auditTime} from 'rxjs/operators';
 import {DropdownOption} from '../../../widgets/dropdown/dropdown_component';
 import {
   HistogramMode,
+  MAX_TOOLTIP_ITEMS,
   SCALARS_SMOOTHING_MAX,
   TimeSelection,
   TooltipSort,
@@ -95,6 +96,10 @@ export class SettingsViewComponent {
 
   @Input() ignoreOutliers!: boolean;
   @Output() ignoreOutliersChanged = new EventEmitter<void>();
+
+  readonly MAX_TOOLTIP_ITEMS = MAX_TOOLTIP_ITEMS;
+  @Input() limitTooltipRows!: boolean;
+  @Output() limitTooltipRowsChanged = new EventEmitter<void>();
 
   readonly XAxisType = XAxisType;
   readonly XAxisTypeDropdownOptions: DropdownOption[] = [

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -37,6 +37,7 @@ import {
   metricsSlideoutMenuToggled,
   metricsToggleIgnoreOutliers,
   metricsToggleImageShowActualSize,
+  metricsToggleLimitTooltipRows,
   rangeSelectionToggled,
   stepSelectorToggled,
 } from '../../actions';
@@ -56,6 +57,8 @@ import {
       (tooltipSortChanged)="onTooltipSortChanged($event)"
       [ignoreOutliers]="ignoreOutliers$ | async"
       (ignoreOutliersChanged)="onIgnoreOutliersChanged()"
+      [limitTooltipRows]="limitTooltipRows$ | async"
+      (limitTooltipRowsChanged)="onLimitTooltipRowsChanged()"
       [xAxisType]="xAxisType$ | async"
       (xAxisTypeChanged)="onXAxisTypeChanged($event)"
       [cardMinWidth]="cardMinWidth$ | async"
@@ -138,6 +141,9 @@ export class SettingsViewContainer {
     this.ignoreOutliers$ = this.store.select(
       selectors.getMetricsIgnoreOutliers
     );
+    this.limitTooltipRows$ = this.store.select(
+      selectors.getMetricsLimitTooltipRows
+    );
     this.xAxisType$ = this.store.select(selectors.getMetricsXAxisType);
     this.cardMinWidth$ = this.store.select(selectors.getMetricsCardMinWidth);
     this.histogramMode$ = this.store.select(selectors.getMetricsHistogramMode);
@@ -176,6 +182,7 @@ export class SettingsViewContainer {
 
   readonly tooltipSort$;
   readonly ignoreOutliers$;
+  readonly limitTooltipRows$;
   readonly xAxisType$;
   readonly cardMinWidth$;
   readonly histogramMode$;
@@ -194,6 +201,10 @@ export class SettingsViewContainer {
 
   onIgnoreOutliersChanged() {
     this.store.dispatch(metricsToggleIgnoreOutliers());
+  }
+
+  onLimitTooltipRowsChanged() {
+    this.store.dispatch(metricsToggleLimitTooltipRows());
   }
 
   onXAxisTypeChanged(xAxisType: XAxisType) {

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -34,6 +34,7 @@ import {
   metricsResetImageBrightness,
   metricsResetImageContrast,
   metricsScalarPartitionNonMonotonicXToggled,
+  metricsChangeTooltipRowsLimit,
   metricsSlideoutMenuToggled,
   metricsToggleIgnoreOutliers,
   metricsToggleImageShowActualSize,
@@ -59,6 +60,8 @@ import {
       (ignoreOutliersChanged)="onIgnoreOutliersChanged()"
       [limitTooltipRows]="limitTooltipRows$ | async"
       (limitTooltipRowsChanged)="onLimitTooltipRowsChanged()"
+      [tooltipRowsLimit]="tooltipRowsLimit$ | async"
+      (tooltipRowsLimitChanged)="onTooltipRowsLimitChanged($event)"
       [xAxisType]="xAxisType$ | async"
       (xAxisTypeChanged)="onXAxisTypeChanged($event)"
       [cardMinWidth]="cardMinWidth$ | async"
@@ -144,6 +147,9 @@ export class SettingsViewContainer {
     this.limitTooltipRows$ = this.store.select(
       selectors.getMetricsLimitTooltipRows
     );
+    this.tooltipRowsLimit$ = this.store.select(
+      selectors.getMetricsTooltipRowsLimit
+    );
     this.xAxisType$ = this.store.select(selectors.getMetricsXAxisType);
     this.cardMinWidth$ = this.store.select(selectors.getMetricsCardMinWidth);
     this.histogramMode$ = this.store.select(selectors.getMetricsHistogramMode);
@@ -183,6 +189,7 @@ export class SettingsViewContainer {
   readonly tooltipSort$;
   readonly ignoreOutliers$;
   readonly limitTooltipRows$;
+  readonly tooltipRowsLimit$;
   readonly xAxisType$;
   readonly cardMinWidth$;
   readonly histogramMode$;
@@ -205,6 +212,10 @@ export class SettingsViewContainer {
 
   onLimitTooltipRowsChanged() {
     this.store.dispatch(metricsToggleLimitTooltipRows());
+  }
+
+  onTooltipRowsLimitChanged(tooltipRowsLimit: number) {
+    this.store.dispatch(metricsChangeTooltipRowsLimit({tooltipRowsLimit}));
   }
 
   onXAxisTypeChanged(xAxisType: XAxisType) {

--- a/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/settings_view_container.ts
@@ -58,8 +58,8 @@ import {
       (tooltipSortChanged)="onTooltipSortChanged($event)"
       [ignoreOutliers]="ignoreOutliers$ | async"
       (ignoreOutliersChanged)="onIgnoreOutliersChanged()"
-      [limitTooltipRows]="limitTooltipRows$ | async"
-      (limitTooltipRowsChanged)="onLimitTooltipRowsChanged()"
+      [isTooltipRowsLimitEnabled]="isTooltipRowsLimitEnabled$ | async"
+      (isTooltipRowsLimitEnabledChanged)="onIsTooltipRowsLimitEnabledChanged()"
       [tooltipRowsLimit]="tooltipRowsLimit$ | async"
       (tooltipRowsLimitChanged)="onTooltipRowsLimitChanged($event)"
       [xAxisType]="xAxisType$ | async"
@@ -144,8 +144,8 @@ export class SettingsViewContainer {
     this.ignoreOutliers$ = this.store.select(
       selectors.getMetricsIgnoreOutliers
     );
-    this.limitTooltipRows$ = this.store.select(
-      selectors.getMetricsLimitTooltipRows
+    this.isTooltipRowsLimitEnabled$ = this.store.select(
+      selectors.getMetricsIsTooltipRowsLimitEnabled
     );
     this.tooltipRowsLimit$ = this.store.select(
       selectors.getMetricsTooltipRowsLimit
@@ -188,7 +188,7 @@ export class SettingsViewContainer {
 
   readonly tooltipSort$;
   readonly ignoreOutliers$;
-  readonly limitTooltipRows$;
+  readonly isTooltipRowsLimitEnabled$;
   readonly tooltipRowsLimit$;
   readonly xAxisType$;
   readonly cardMinWidth$;
@@ -210,7 +210,7 @@ export class SettingsViewContainer {
     this.store.dispatch(metricsToggleIgnoreOutliers());
   }
 
-  onLimitTooltipRowsChanged() {
+  onIsTooltipRowsLimitEnabledChanged() {
     this.store.dispatch(metricsToggleLimitTooltipRows());
   }
 

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -128,8 +128,9 @@ export class OSSSettingsConverter extends SettingsConverter<
     if (settings.savingPinsEnabled !== undefined) {
       serializableSettings.savingPinsEnabled = settings.savingPinsEnabled;
     }
-    if (settings.limitTooltipRows !== undefined) {
-      serializableSettings.limitTooltipRows = settings.limitTooltipRows;
+    if (settings.isTooltipRowsLimitEnabled !== undefined) {
+      serializableSettings.isTooltipRowsLimitEnabled =
+        settings.isTooltipRowsLimitEnabled;
     }
     if (settings.tooltipRowsLimit !== undefined) {
       serializableSettings.tooltipRowsLimit = settings.tooltipRowsLimit;
@@ -272,8 +273,9 @@ export class OSSSettingsConverter extends SettingsConverter<
       settings.savingPinsEnabled = backendSettings.savingPinsEnabled;
     }
 
-    if (typeof backendSettings.limitTooltipRows === 'boolean') {
-      settings.limitTooltipRows = backendSettings.limitTooltipRows;
+    if (typeof backendSettings.isTooltipRowsLimitEnabled === 'boolean') {
+      settings.isTooltipRowsLimitEnabled =
+        backendSettings.isTooltipRowsLimitEnabled;
     }
 
     if (typeof backendSettings.tooltipRowsLimit === 'number') {

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -128,6 +128,9 @@ export class OSSSettingsConverter extends SettingsConverter<
     if (settings.savingPinsEnabled !== undefined) {
       serializableSettings.savingPinsEnabled = settings.savingPinsEnabled;
     }
+    if (settings.limitTooltipRows !== undefined) {
+      serializableSettings.limitTooltipRows = settings.limitTooltipRows;
+    }
     return serializableSettings;
   }
 
@@ -264,6 +267,13 @@ export class OSSSettingsConverter extends SettingsConverter<
       typeof backendSettings.savingPinsEnabled === 'boolean'
     ) {
       settings.savingPinsEnabled = backendSettings.savingPinsEnabled;
+    }
+
+    if (
+      backendSettings.hasOwnProperty('limitTooltipRows') &&
+      typeof backendSettings.limitTooltipRows === 'boolean'
+    ) {
+      settings.limitTooltipRows = backendSettings.limitTooltipRows;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -269,10 +269,7 @@ export class OSSSettingsConverter extends SettingsConverter<
       settings.savingPinsEnabled = backendSettings.savingPinsEnabled;
     }
 
-    if (
-      backendSettings.hasOwnProperty('limitTooltipRows') &&
-      typeof backendSettings.limitTooltipRows === 'boolean'
-    ) {
+    if (typeof backendSettings.limitTooltipRows === 'boolean') {
       settings.limitTooltipRows = backendSettings.limitTooltipRows;
     }
 

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source.ts
@@ -131,6 +131,9 @@ export class OSSSettingsConverter extends SettingsConverter<
     if (settings.limitTooltipRows !== undefined) {
       serializableSettings.limitTooltipRows = settings.limitTooltipRows;
     }
+    if (settings.tooltipRowsLimit !== undefined) {
+      serializableSettings.tooltipRowsLimit = settings.tooltipRowsLimit;
+    }
     return serializableSettings;
   }
 
@@ -271,6 +274,10 @@ export class OSSSettingsConverter extends SettingsConverter<
 
     if (typeof backendSettings.limitTooltipRows === 'boolean') {
       settings.limitTooltipRows = backendSettings.limitTooltipRows;
+    }
+
+    if (typeof backendSettings.tooltipRowsLimit === 'number') {
+      settings.tooltipRowsLimit = backendSettings.tooltipRowsLimit;
     }
 
     return settings;

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -186,14 +186,14 @@ describe('persistent_settings data_source test', () => {
       it('loads the limit tooltip rows setting from local storage', async () => {
         getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
           JSON.stringify({
-            limitTooltipRows: true,
+            isTooltipRowsLimitEnabled: true,
           })
         );
 
         const actual = await firstValueFrom(dataSource.getSettings());
 
         expect(actual).toEqual({
-          limitTooltipRows: true,
+          isTooltipRowsLimitEnabled: true,
         });
       });
       it('properly converts singleSelectionHeaders', async () => {
@@ -580,14 +580,14 @@ describe('persistent_settings data_source test', () => {
 
         await firstValueFrom(
           dataSource.setSettings({
-            limitTooltipRows: true,
+            isTooltipRowsLimitEnabled: true,
           })
         );
 
         expect(setItemSpy).toHaveBeenCalledOnceWith(
           TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
           JSON.stringify({
-            limitTooltipRows: true,
+            isTooltipRowsLimitEnabled: true,
           })
         );
       });

--- a/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/persistent_settings_data_source_test.ts
@@ -183,6 +183,19 @@ describe('persistent_settings data_source test', () => {
           linkedTimeEnabled: true,
         });
       });
+      it('loads the limit tooltip rows setting from local storage', async () => {
+        getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
+          JSON.stringify({
+            limitTooltipRows: true,
+          })
+        );
+
+        const actual = await firstValueFrom(dataSource.getSettings());
+
+        expect(actual).toEqual({
+          limitTooltipRows: true,
+        });
+      });
       it('properly converts singleSelectionHeaders', async () => {
         getItemSpy.withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY).and.returnValue(
           JSON.stringify({
@@ -556,6 +569,25 @@ describe('persistent_settings data_source test', () => {
           TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
           JSON.stringify({
             savingPinsEnabled: false,
+          })
+        );
+      });
+
+      it('saves the limit tooltip rows setting to local storage', async () => {
+        getItemSpy
+          .withArgs(TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY)
+          .and.returnValue(null);
+
+        await firstValueFrom(
+          dataSource.setSettings({
+            limitTooltipRows: true,
+          })
+        );
+
+        expect(setItemSpy).toHaveBeenCalledOnceWith(
+          TEST_ONLY.GLOBAL_LOCAL_STORAGE_KEY,
+          JSON.stringify({
+            limitTooltipRows: true,
           })
         );
       });

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -48,6 +48,7 @@ export declare interface BackendSettings {
   rangeSelectionHeaders?: ColumnHeader[];
   dashboardDisplayedHparamColumns?: ColumnHeader[];
   savingPinsEnabled?: boolean;
+  limitTooltipRows?: boolean;
 }
 
 /**
@@ -74,4 +75,5 @@ export interface PersistableSettings {
   rangeSelectionHeaders?: ColumnHeader[];
   dashboardDisplayedHparamColumns?: ColumnHeader[];
   savingPinsEnabled?: boolean;
+  limitTooltipRows?: boolean;
 }

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -48,7 +48,7 @@ export declare interface BackendSettings {
   rangeSelectionHeaders?: ColumnHeader[];
   dashboardDisplayedHparamColumns?: ColumnHeader[];
   savingPinsEnabled?: boolean;
-  limitTooltipRows?: boolean;
+  isTooltipRowsLimitEnabled?: boolean;
   tooltipRowsLimit?: number;
 }
 
@@ -76,6 +76,6 @@ export interface PersistableSettings {
   rangeSelectionHeaders?: ColumnHeader[];
   dashboardDisplayedHparamColumns?: ColumnHeader[];
   savingPinsEnabled?: boolean;
-  limitTooltipRows?: boolean;
+  isTooltipRowsLimitEnabled?: boolean;
   tooltipRowsLimit?: number;
 }

--- a/tensorboard/webapp/persistent_settings/_data_source/types.ts
+++ b/tensorboard/webapp/persistent_settings/_data_source/types.ts
@@ -49,6 +49,7 @@ export declare interface BackendSettings {
   dashboardDisplayedHparamColumns?: ColumnHeader[];
   savingPinsEnabled?: boolean;
   limitTooltipRows?: boolean;
+  tooltipRowsLimit?: number;
 }
 
 /**
@@ -76,4 +77,5 @@ export interface PersistableSettings {
   dashboardDisplayedHparamColumns?: ColumnHeader[];
   savingPinsEnabled?: boolean;
   limitTooltipRows?: boolean;
+  tooltipRowsLimit?: number;
 }


### PR DESCRIPTION
## Motivation for features / changes

We wrapped a previous functionality to reduce redundancy of data in the tooltip for Scalar Chart into a checkbox so users can choose either to display the tooltip with the full list or short list for exploring data. 

## Technical description of changes
- Added a new limitTooltipRows setting. As redux setting like the other controls in panel settings: action → reducer → selector → container → presentational component input.
- New checkbox added to the metrics settings panel; defaults to unchecked box (full tooltip shown).
 - When on, the scalar card tooltip caps at MAX_TOOLTIP_ITEMS rows and shows a "N additional items" legend for the overflow.
 - Setting persists to localStorage, so it sticks across reloads, same pattern as the other metrics settings.
 - Added unit tests covering the on/off behavior of the tooltip and persistance.


## Detailed steps to verify changes work correctly (as executed by you)
- Ran the full frontend Karma suite `bazel test ... tensorboard/webapp:karma_test_chromium-local`
- Verified the new functionality tests
- Verified the new persistence tests

## Screenshots of UI changes (or N/A)
<img width="845" height="380" alt="Screenshot 2026-06-23 at 2 59 19 p m" src="https://github.com/user-attachments/assets/18218c4d-b506-44f7-95d9-68843e645a08" />

<img width="847" height="750" alt="Screenshot 2026-06-23 at 2 59 52 p m" src="https://github.com/user-attachments/assets/d73e368e-b55f-44e1-b639-589319574d92" />


