### PR TITLE
Tooltip settings input - default value to 5

### DIFF
--- a/tensorboard/webapp/metrics/internal_types.ts
+++ b/tensorboard/webapp/metrics/internal_types.ts
@@ -109,3 +109,6 @@ export const SCALARS_SMOOTHING_MAX = 0.999;
 
 /** Minimum value for the input: tooltip rows limit setting. */
 export const TOOLTIP_ROWS_LIMIT_MIN = 1;
+
+/** Default number of rows shown in the tooltip when limiting is enabled. */
+export const TOOLTIP_ROWS_LIMIT_DEFAULT = 5;

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -46,9 +46,11 @@ import {
   HistogramMode,
   MinMaxStep,
   NonPinnedCardId,
+  TOOLTIP_ROWS_LIMIT_DEFAULT,
   TooltipSort,
   XAxisType,
 } from '../types';
+import {METRICS_SETTINGS_DEFAULT} from './metrics_types';
 import {ColumnHeaderType, DataTableMode} from '../../widgets/data_table/types';
 import {reducers} from './metrics_reducers';
 import {getCardId, getPinnedCardId} from './metrics_store_internal_utils';
@@ -1032,6 +1034,29 @@ describe('metrics reducers', () => {
       );
       expect(nextState.settings.ignoreOutliers).toBe(true);
       expect(nextState.settingOverrides.ignoreOutliers).toBe(false);
+    });
+
+    it('uses TOOLTIP_ROWS_LIMIT_DEFAULT as the default tooltipRowsLimit', () => {
+      expect(METRICS_SETTINGS_DEFAULT.tooltipRowsLimit).toBe(
+        TOOLTIP_ROWS_LIMIT_DEFAULT
+      );
+    });
+
+    it('updates tooltipRowsLimit on metricsChangeTooltipRowsLimit', () => {
+      const prevState = buildMetricsState({
+        settings: buildMetricsSettingsState({
+          tooltipRowsLimit: TOOLTIP_ROWS_LIMIT_DEFAULT,
+        }),
+        settingOverrides: {},
+      });
+      const nextState = reducers(
+        prevState,
+        actions.metricsChangeTooltipRowsLimit({tooltipRowsLimit: 10})
+      );
+      expect(nextState.settings.tooltipRowsLimit).toBe(
+        TOOLTIP_ROWS_LIMIT_DEFAULT
+      );
+      expect(nextState.settingOverrides.tooltipRowsLimit).toBe(10);
     });
 
     it('changes xAxisType on metricsChangeXAxisType', () => {

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -35,7 +35,7 @@ import {
   NonPinnedCardId,
   PinnedCardId,
   TimeSelection,
-  TOOLTIP_ROWS_LIMIT_MIN,
+  TOOLTIP_ROWS_LIMIT_DEFAULT,
   TooltipSort,
   XAxisType,
 } from '../types';
@@ -296,7 +296,7 @@ export const METRICS_SETTINGS_DEFAULT: MetricsSettings = {
   scalarSmoothing: 0.6,
   scalarPartitionNonMonotonicX: false,
   isTooltipRowsLimitEnabled: false,
-  tooltipRowsLimit: TOOLTIP_ROWS_LIMIT_MIN,
+  tooltipRowsLimit: TOOLTIP_ROWS_LIMIT_DEFAULT,
   imageBrightnessInMilli: 1000,
   imageContrastInMilli: 1000,
   imageShowActualSize: false,


### PR DESCRIPTION
## Motivation for features / changes
Added TOOLTIP_ROWS_LIMIT_DEFAULT = 5 constant to internal_types.ts and replaced the inline 5 in METRICS_SETTINGS_DEFAULT with it. 

Full details: https://github.com/tensorflow/tensorboard/pull/7133



