### PR TITLE
Fix histogram bin redistribution dropping counts at the range boundary

### DIFF
--- a/tensorboard/webapp/widgets/histogram/histogram_util.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util.ts
@@ -119,8 +119,14 @@ function rebuildBins(bins: Bin[], range: Range, binCount: number): Bin[] {
   let nextBinContribution = 0;
   for (let i = 0; i < binCount; i++) {
     const resultLeft = left + i * dx;
-    const resultRight = resultLeft + dx;
     const isLastResultBin = i === binCount - 1;
+    // The last result bin must extend exactly to `range.right`. Computing it as
+    // `resultLeft + dx` accumulates floating-point error in the repeated `i * dx`
+    // sum and can land just below `range.right`; an input bin whose right edge
+    // sits exactly on `range.right` then satisfies `bin.x + bin.dx > resultRight`
+    // and is skipped without being consumed, dropping its counts. Clamp the last
+    // result bin's right edge to `range.right` so those counts are preserved.
+    const resultRight = isLastResultBin ? right : resultLeft + dx;
 
     let resultY = nextBinContribution;
     nextBinContribution = 0;

--- a/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_util_test.ts
@@ -54,6 +54,38 @@ describe('histogram util', () => {
       });
     });
 
+    describe('count conservation at the range boundary', () => {
+      function totalCount(bins: Bin[]): number {
+        return bins.reduce((sum, bin) => sum + bin.y, 0);
+      }
+
+      it('preserves a bin whose right edge sits on range.right', () => {
+        // A zero-width bin at x=1 sits exactly on the range's right edge (the
+        // widest histogram spans [0, 1]). It must not be dropped when the bins
+        // are redistributed into `binCount` result bins.
+        const input: Bin[] = [
+          {x: 0, dx: 1, y: 1},
+          {x: 1, dx: 0, y: 5},
+        ];
+        const [result] = histogramsToBins(
+          buildNormalizedHistograms([binsToHistogram(input)], 6)
+        );
+        expect(totalCount(result)).toBeCloseTo(totalCount(input), 6);
+      });
+
+      it('preserves counts when the final normal bin ends on range.right', () => {
+        const input: Bin[] = [
+          {x: 0, dx: 1, y: 2},
+          {x: 1, dx: 1, y: 3},
+          {x: 2, dx: 1, y: 4},
+        ];
+        const [result] = histogramsToBins(
+          buildNormalizedHistograms([binsToHistogram(input)], 7)
+        );
+        expect(totalCount(result)).toBeCloseTo(totalCount(input), 6);
+      });
+    });
+
     describe('single histogram', () => {
       it('converts a 0 width bin into a default bin', () => {
         expect(


### PR DESCRIPTION
### Problem

`buildNormalizedHistograms` (in `tensorboard/webapp/widgets/histogram/histogram_util.ts`) redistributes input bins into `binCount` equal-width result bins. In `rebuildBins`, the last result bin's right edge was computed as:

```ts
const resultLeft = left + i * dx;
const resultRight = resultLeft + dx;   // == left + (binCount-1)*dx + dx
```

Because `dx = (right - left) / binCount` is generally not exactly representable, this sum accumulates floating-point error and can land *just below* `range.right`. For `range = [0, 1]` with `binCount = 6`, the last `resultRight` is `0.9999999999999999`.

An input bin whose right edge sits exactly on `range.right` (for example a zero-width bin at the maximum value, or the final normal bin's edge) then satisfies the inner-loop guard `bin.x + bin.dx > resultRight` (`1 > 0.9999999999999999`), so the loop `break`s **without consuming that bin** — and its `y` counts are silently dropped from the normalized histogram shown to the user.

Minimal reproduction (through the public API):

```ts
buildNormalizedHistograms(
  [{step: 0, wallTime: 0, bins: [{x: 0, dx: 1, y: 1}, {x: 1, dx: 0, y: 5}]}],
  6,
)
// total y in output: 1  (expected 6 — the 5 counts on the x=1 bin vanish)
```

### Fix

The last result bin must extend exactly to `range.right`, which is by construction the true upper bound of all input data. Clamp it:

```ts
const resultLeft = left + i * dx;
const isLastResultBin = i === binCount - 1;
const resultRight = isLastResultBin ? right : resultLeft + dx;
```

This is a general fix (not a special-case hack) and leaves all interior bins unchanged. After it, the reproduction above conserves all 6 counts, and normal inputs are unaffected.

### Tests

Added a `count conservation at the range boundary` block to `histogram_util_test.ts` asserting that total counts are preserved when a bin's right edge sits on `range.right` (both a zero-width boundary bin and a final normal bin). These fail on the current code and pass with the fix.
