### PR TITLE
Removed deprecated testing dependency

### DIFF
--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -347,12 +347,12 @@ tf_ts_library(
     deps = ["@npm//@angular/platform-browser"],
 )
 
-# This is a dummy rule used as a @angular/platform-browser-dynamic/testing dependency.
-# This is not a replacement for @angular/platform-browser-dynamic dependency.
+# This is a dummy rule used as a @angular/platform-browser/testing dependency.
+# This is not a replacement for @angular/platform-browser dependency.
 tf_ts_library(
-    name = "expect_angular_platform_browser_dynamic_testing",
+    name = "expect_angular_platform_browser_testing",
     srcs = [],
-    deps = ["@npm//@angular/platform-browser-dynamic"],
+    deps = ["@npm//@angular/platform-browser"],
 )
 
 # This is a dummy rule used as a @angular/cdk/drag_drop dependency.

--- a/tensorboard/webapp/app_routing/views/BUILD
+++ b/tensorboard/webapp/app_routing/views/BUILD
@@ -40,7 +40,7 @@ tf_ts_library(
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
-        "//tensorboard/webapp/angular:expect_angular_platform_browser_dynamic_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/app_routing:app_root",
         "//tensorboard/webapp/app_routing:location",

--- a/tensorboard/webapp/app_routing/views/router_outlet_test.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_test.ts
@@ -20,7 +20,6 @@ import {
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {BrowserDynamicTestingModule} from '@angular/platform-browser-dynamic/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Store} from '@ngrx/store';
 import {MockStore} from '@ngrx/store/testing';

--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -109,7 +109,7 @@ tf_ts_library(
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
-        "//tensorboard/webapp/angular:expect_angular_platform_browser_dynamic_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_testing",
         "//tensorboard/webapp/feature_flag",
         "//tensorboard/webapp/metrics/store:metrics_initial_state_provider",
         "//tensorboard/webapp/metrics/store:types",

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -163,7 +163,7 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_material_sort",
         "//tensorboard/webapp/angular:expect_angular_material_table",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
-        "//tensorboard/webapp/angular:expect_angular_platform_browser_dynamic_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/app_routing:testing",
         "//tensorboard/webapp/app_routing:types",

--- a/tensorboard/webapp/settings/_views/BUILD
+++ b/tensorboard/webapp/settings/_views/BUILD
@@ -50,7 +50,7 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_material_input",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
-        "//tensorboard/webapp/angular:expect_angular_platform_browser_dynamic_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/settings:testing",
         "//tensorboard/webapp/settings/_redux",

--- a/tensorboard/webapp/settings/_views/settings_test.ts
+++ b/tensorboard/webapp/settings/_views/settings_test.ts
@@ -20,7 +20,6 @@ import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatDialogModule} from '@angular/material/dialog';
 import {MatInputModule} from '@angular/material/input';
 import {By} from '@angular/platform-browser';
-import {BrowserDynamicTestingModule} from '@angular/platform-browser-dynamic/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -14,7 +14,8 @@ tf_ts_library(
     ],
     deps = [
         "//tensorboard/webapp/angular:expect_angular_core_testing",
-        "//tensorboard/webapp/angular:expect_angular_platform_browser_dynamic_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_testing",
+        "@npm//@angular/core",
         "@npm//@angular/localize",
     ],
 )
@@ -107,7 +108,6 @@ tf_ng_module(
         "//tensorboard/webapp:reducer_config",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
-        "//tensorboard/webapp/angular:expect_angular_platform_browser_dynamic_testing",
         "//tensorboard/webapp/app_routing",
         "//tensorboard/webapp/app_routing:route_config",
         "//tensorboard/webapp/app_routing:route_registry",

--- a/tensorboard/webapp/testing/initialize_testbed.ts
+++ b/tensorboard/webapp/testing/initialize_testbed.ts
@@ -16,9 +16,9 @@ import {NgModule, provideZoneChangeDetection} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import '@angular/localize/init';
 import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing';
 
 @NgModule({
   providers: [provideZoneChangeDetection()],
@@ -26,6 +26,6 @@ import {
 class ZoneChangeDetectionTestingModule {}
 
 TestBed.initTestEnvironment(
-  [BrowserDynamicTestingModule, ZoneChangeDetectionTestingModule],
-  platformBrowserDynamicTesting()
+  [BrowserTestingModule, ZoneChangeDetectionTestingModule],
+  platformBrowserTesting()
 );


### PR DESCRIPTION
## Motivation for features / changes

`@angular/platform-browser-dynamic/testing` was deprecated in Angular 21. The
OSS build still accepts it, but the internal build no longer does, so it has to
go.

The internal build also reported a strictDeps error on `initialize_testbed.ts`:

    `error TS2307: [strictDeps] transitive dependency on .../core/index.d.ts
    not allowed. Please add the BUILD target to your rule's deps.`


## Technical description of changes

1. `testing/initialize_testbed.ts`: removed the 2 deprecated symbols for their `@angular/platform-browser/testing` equivalents,  dropped dynamic from `platformBrowserDynamicTesting` and `BrowserDynamicTestingModule`.
2. `angular/BUILD`: rename `expect_angular_platform_browser_dynamic_testing` `expect_angular_platform_browser_testing`, now pointing at `@npm//@angular/platform-browser`. Its four consumer BUILD files were updated to match.
3. `testing/BUILD`: add `@npm//@angular/core` to `initialize_testbed`, which is the `strictDeps` fix.

Some references were removed rather than renamed, because they were not used:

4. `settings/_views/settings_test.ts` and`app_routing/views/router_outlet_test.ts` imported `BrowserDynamicTestingModule` without ever using it, so the import lines were removed.
5. `integration_test_module` in `testing/BUILD` declared the dependency although none of its sources import the package.